### PR TITLE
Update slow.lua

### DIFF
--- a/scripts/globals/spells/slow.lua
+++ b/scripts/globals/spells/slow.lua
@@ -26,6 +26,8 @@ function onSpellCast(caster,target,spell)
 		if(power > 300) then
 			power = 300;
 		end
+		
+		power = power / 1024;
 
 		--Duration, including resistance.
 		local duration = 120 * applyResistance(caster,spell,target,dMND,35,bonus);


### PR DESCRIPTION
power is never divided by 1024

"Slow's potency is calculated with the formula (150 + dMND*2)/1024, and caps at 300/1024 (~29.3%)."

 --- http://wiki.ffxiclopedia.org/wiki/Slow
