### PR TITLE
Fixed slash in path in map/latent_effect.cpp.

### DIFF
--- a/src/map/latent_effect.cpp
+++ b/src/map/latent_effect.cpp
@@ -24,7 +24,7 @@
 #include "entities/battleentity.h"
 
 #include "latent_effect.h"
-#include "entities\charentity.h"
+#include "entities/charentity.h"
 
 CLatentEffect::CLatentEffect(LATENT conditionsId, uint16 conditionsValue, uint8 slot, uint16 modValue, int16 modPower)
 {


### PR DESCRIPTION
Include with the wrong slash in the path was causing build on linux to fail.
