### PR TITLE
Tortoise Song now only dispels songs and rolls, food no longer removed when entering battlefield or level sync

### DIFF
--- a/scripts/globals/mobskills/Tortoise_Song.lua
+++ b/scripts/globals/mobskills/Tortoise_Song.lua
@@ -19,7 +19,7 @@ end;
 
 function OnMobWeaponSkill(target, mob, skill)
 
-    local count = target:dispelAllStatusEffect();
+    local count = target:dispelAllStatusEffect(bit.bor(EFFECTFLAG_SONG, EFFECTFLAG_ROLL));
 
     if(count == 0) then
         skill:setMsg(MSG_NO_EFFECT);

--- a/scripts/globals/status.lua
+++ b/scripts/globals/status.lua
@@ -616,6 +616,8 @@ EFFECTFLAG_NO_REST 		= 0x1000
 EFFECTFLAG_PREVENT_ACTION   = 0x2000
 EFFECTFLAG_WALTZABLE        = 0x4000
 EFFECTFLAG_FOOD                 = 0x8000
+EFFECTFLAG_SONG             = 0x10000
+EFFECTFLAG_ROLL             = 0x20000
 
 function removeSleepEffects(target)
 	target:delStatusEffect(EFFECT_SLEEP_I);

--- a/sql/status_effects.sql
+++ b/sql/status_effects.sql
@@ -285,7 +285,7 @@ INSERT INTO `status_effects` VALUES (247,'(imagery)',32,244,0,0,0,0,0);
 INSERT INTO `status_effects` VALUES (248,'(imagery)',32,244,0,0,0,0,0);
 INSERT INTO `status_effects` VALUES (249,'dedication',0,0,0,0,0,0,0);
 INSERT INTO `status_effects` VALUES (250,'ef_badge',32,0,0,0,0,0,0);
-INSERT INTO `status_effects` VALUES (251,'food',32800,0,0,2,0,0,0);
+INSERT INTO `status_effects` VALUES (251,'food',32768,0,0,2,0,0,0);
 INSERT INTO `status_effects` VALUES (252,'chocobo',164,0,0,0,0,0,0);
 INSERT INTO `status_effects` VALUES (253,'signet',0,0,0,0,0,0,0);
 INSERT INTO `status_effects` VALUES (254,'battlefield',0,0,0,0,0,0,0);

--- a/src/map/ai/ai_char_normal.cpp
+++ b/src/map/ai/ai_char_normal.cpp
@@ -415,7 +415,7 @@ void CAICharNormal::ActionDeath()
     // без задержки удаление эффектов не всегда правильно обрабатывается клиентом
     if (m_Tick >= m_LastActionTime + 1000)
     {
-        m_PChar->StatusEffectContainer->DelStatusEffectsByFlag(EFFECTFLAG_DEATH, true);
+        m_PChar->StatusEffectContainer->DelStatusEffectsByFlag(EFFECTFLAG_DEATH | EFFECTFLAG_FOOD, true);
 
         if(m_PChar->m_PVPFlag)
         {

--- a/src/map/status_effect.h
+++ b/src/map/status_effect.h
@@ -58,7 +58,9 @@ enum EFFECTFLAG
     EFFECTFLAG_NO_REST 		= 0x1000,  // prevents resting, curse II, plague, disease
     EFFECTFLAG_PREVENT_ACTION   = 0x2000,    // sleep, lullaby, stun, petro. Not implemented
     EFFECTFLAG_WALTZABLE        = 0x4000,   //for healing waltzable spells
-    EFFECTFLAG_FOOD             = 0x8000
+    EFFECTFLAG_FOOD             = 0x8000,
+    EFFECTFLAG_SONG             = 0x10000,  //bard songs
+    EFFECTFLAG_ROLL             = 0x20000   //corsair rolls
 };
 
 enum EFFECT


### PR DESCRIPTION
tortoise song now only dispels status effects flagged with EFFECTFLAG_SONG or EFFECTFLAG_ROLL - this is retail behavior

created new EFFECTFLAG_SONG and ROLL in status.lua and status_effect.h

removed EFFECTFLAG_DEATH from the 'food' status effect and added EFFECTFLAG_FOOD to the flags of deleted status effects on player death in the ActionDeath() function 

having the 'food' effect flagged with the 'DEATH' flag was causing food effects to be removed upon level sync and entering a battlefield (non-retail behavior)

TODO: flag all bard songs and cor rolls in sql
