### PR TITLE
New GM commands

### DIFF
--- a/scripts/commands/raise.lua
+++ b/scripts/commands/raise.lua
@@ -1,0 +1,34 @@
+-----------------------------------------------------------------------
+-- func: raise
+-- auth: Forgottenandlost
+-- desc: @raise <power> <player>
+-- Sends raise menu to GM or target player.
+-----------------------------------------------------------------------
+
+cmdprops =
+{
+	permission = 1,
+	parameters = "is"
+};
+
+function onTrigger(player,power,target)
+
+	if (power == nil or power >3) then
+		power = 3;
+	else
+		if (power <1) then
+			power = 1;
+		end
+	end
+	
+	if (target == nil) then
+		player:sendRaise(power);
+	else
+		local targ = GetPlayerByName(target);
+		if (targ ~= nil) then
+			targ:sendRaise(power);
+		else
+			player:PrintToPlayer( string.format( "Player named '%s' not found!", target ) );
+		end
+	end
+end;

--- a/scripts/commands/return.lua
+++ b/scripts/commands/return.lua
@@ -1,0 +1,31 @@
+---------------------------------------------------------------------------------------------------
+-- func: return
+-- auth: Forgottenandlost
+-- desc: @return <player>
+-- Warps GM or target player to their previous zone
+---------------------------------------------------------------------------------------------------
+
+cmdprops =
+{
+	permission = 1,
+	parameters = "s"
+};
+
+function onTrigger(player, target)
+	local ZoneID = 0
+	if (target == nil) then
+		target = player:getName();
+	end
+
+	local targ = GetPlayerByName( target );
+	if (targ ~= nil) then
+		ZoneID = targ:getPreviousZone();
+		if (ZoneID == nil or ZoneID == 0) then
+			player:PrintToPlayer( "Previous Zone was a Mog House or there was a problem fetching the ID.");
+		else
+			targ:setPos( 0, 0, 0, 0, ZoneID );
+		end
+	else
+		player:PrintToPlayer( string.format( "Player named '%s' not found!", target ) );
+	end
+end


### PR DESCRIPTION
@raise - Allows GM to command line raise target player or self. Can send any tier of raise.
@return - Sends target player or GM to previous zone, rather than homepointing them.
