### PR TITLE
Implement PlayTime function and fix tractor spell

### DIFF
--- a/scripts/globals/spells/tractor.lua
+++ b/scripts/globals/spells/tractor.lua
@@ -10,12 +10,14 @@ require("scripts/globals/magic");
 -----------------------------------------
 
 function OnMagicCastingCheck(caster,target,spell)
-	return 0;
+    return 0;
 end;
 
 function onSpellCast(caster,target,spell)
+printf("Caster Zone: %u",caster:getZone());
+    target:sendTractor(caster:getXPos(), caster:getYPos(), caster:getZPos(), target:getRotPos());
 
-    -- target:setPos(caster:getXPos(), caster:getYPos(), caster:getZPos());
+    spell:setMsg(309);
 
-    return 0;
+    return 1;
 end;

--- a/scripts/zones/Bastok_Markets/Zone.lua
+++ b/scripts/zones/Bastok_Markets/Zone.lua
@@ -23,7 +23,7 @@ end;
 function onZoneIn(player,prevZone)			
 	cs = -1;		
 	-- FIRST LOGIN (START CS)		
-	if (prevZone == 0) then		
+	if (player:getPlaytime(false) == 0) then		
 		if (OPENING_CUTSCENE_ENABLE == 1) then	
 			--cs = 0x00;
 		end	

--- a/scripts/zones/Bastok_Mines/Zone.lua
+++ b/scripts/zones/Bastok_Mines/Zone.lua
@@ -24,7 +24,7 @@ end;
 function onZoneIn(player,prevZone)			
 	cs = -1;		
 	-- FIRST LOGIN (START CS)		
-	if (prevZone == 0) then		
+	if (player:getPlaytime(false) == 0) then		
 		if (OPENING_CUTSCENE_ENABLE == 1) then	
 			cs = 0x01;
 		end	

--- a/scripts/zones/Northern_San_dOria/Zone.lua
+++ b/scripts/zones/Northern_San_dOria/Zone.lua
@@ -26,7 +26,7 @@ end;
 function onZoneIn(player,prevZone)	
 	cs = -1;		
 	-- FIRST LOGIN (START CS)		
-	if(prevZone == 0) then		
+	if(player:getPlaytime(false) == 0) then		
 		if(OPENING_CUTSCENE_ENABLE == 1) then	
 			cs = 0x0217;
 		end	

--- a/scripts/zones/Port_Bastok/Zone.lua
+++ b/scripts/zones/Port_Bastok/Zone.lua
@@ -25,7 +25,7 @@ end;
 function onZoneIn(player,prevZone)
 	cs = -1;
 	-- FIRST LOGIN (START CS)
-	if (prevZone == 0) then
+	if (player:getPlaytime(false) == 0) then
 		if (OPENING_CUTSCENE_ENABLE == 1) then
 			cs = 0x0001;
 		end	

--- a/scripts/zones/Port_San_dOria/Zone.lua
+++ b/scripts/zones/Port_San_dOria/Zone.lua
@@ -23,7 +23,7 @@ end;
 function onZoneIn(player,prevZone)			
 	cs = -1;		
 	-- FIRST LOGIN (START CS)		
-	if (prevZone == 0) then		
+	if (player:getPlaytime(false) == 0) then		
 		if (OPENING_CUTSCENE_ENABLE == 1) then	
 			cs = 0x01F4;
 		end	

--- a/scripts/zones/Port_Windurst/Zone.lua
+++ b/scripts/zones/Port_Windurst/Zone.lua
@@ -23,7 +23,7 @@ end;
 function onZoneIn(player,prevZone)			
 	cs = -1;		
 	-- FIRST LOGIN (START CS)		
-	if (prevZone == 0) then		
+	if (player:getPlaytime(false) == 0) then		
 		if (OPENING_CUTSCENE_ENABLE == 1) then	
 			cs = 0x0131;
 		end	

--- a/scripts/zones/Southern_San_dOria/Zone.lua
+++ b/scripts/zones/Southern_San_dOria/Zone.lua
@@ -24,7 +24,7 @@ end;
 function onZoneIn(player,prevZone)			
 	cs = -1;		
 	-- FIRST LOGIN (START CS)		
-	if (prevZone == 0) then		
+	if (player:getPlaytime(false) == 0) then		
 		if (OPENING_CUTSCENE_ENABLE == 1) then	
 			cs = 0x1f7;
 		end	

--- a/scripts/zones/Windurst_Waters/Zone.lua
+++ b/scripts/zones/Windurst_Waters/Zone.lua
@@ -26,7 +26,7 @@ end;
 function onZoneIn(player,prevZone)			
 	cs = -1;		
 	-- FIRST LOGIN (START CS)		
-	if (prevZone == 0) then		
+	if (player:getPlaytime(false) == 0) then		
 		if (OPENING_CUTSCENE_ENABLE == 1) then	
 			cs = 0x213;
 		end	

--- a/scripts/zones/Windurst_Woods/Zone.lua
+++ b/scripts/zones/Windurst_Woods/Zone.lua
@@ -23,7 +23,7 @@ end;
 function onZoneIn(player,prevZone)			
 	cs = -1;		
 	-- FIRST LOGIN (START CS)		
-	if (prevZone == 0) then		
+	if (player:getPlaytime(false) == 0) then		
 		if (OPENING_CUTSCENE_ENABLE == 1) then	
 			cs = 0x016F;
 		end	

--- a/src/map/entities/charentity.cpp
+++ b/src/map/entities/charentity.cpp
@@ -22,6 +22,7 @@
 */
 
 #include "../../common/showmsg.h"
+#include "../../common/timer.h"
 #include "../../common/utils.h"
 
 #include <string.h>
@@ -137,7 +138,8 @@ CCharEntity::CCharEntity()
 	petZoningInfo.petHP = 0;
 	petZoningInfo.petTP = 0;
 
-
+	m_PlayTime = 0;
+	m_SaveTime = 0;
 }
 
 CCharEntity::~CCharEntity()
@@ -343,4 +345,23 @@ bool CCharEntity::getMijinGakure()
 void CCharEntity::setMijinGakure(bool isMijinGakure)
 {
 	m_isMijinGakure = isMijinGakure;
+}
+
+void CCharEntity::SetPlayTime(uint32 playTime)
+{
+	m_PlayTime = playTime;
+	m_SaveTime = gettick() / 1000;
+}
+
+uint32 CCharEntity::GetPlayTime(bool needUpdate)
+{
+	if (needUpdate)
+	{
+		uint32 currentTime = gettick() / 1000;
+
+		m_PlayTime += currentTime - m_SaveTime;
+		m_SaveTime = currentTime;
+	}
+
+	return m_PlayTime;
 }

--- a/src/map/entities/charentity.h
+++ b/src/map/entities/charentity.h
@@ -344,6 +344,9 @@ public:
     uint8             m_hasAutoTarget;              // возможность использования AutoTarget функции
 	position_t		  m_StartActionPos;				// позиция начала действия (использование предмета, начало стрельбы, позиция tractor)
 
+	uint32			  m_PlayTime;
+	uint32			  m_SaveTime;
+
 	uint8			  m_GMlevel;                    // Level of the GM flag assigned to this character
 
 	int8			  getShieldSize();
@@ -366,6 +369,9 @@ public:
 
 	std::vector<GearSetMod_t> m_GearSetMods;		// The list of gear set mods currently applied to the character.
     std::vector<AuctionHistory_t> m_ah_history;		// AH history list (в будущем нужно использовать UContainer)
+
+	void SetPlayTime(uint32 playTime);				// Set playtime
+	uint32 GetPlayTime(bool needUpdate = true);		// Get playtime
 
 	 CCharEntity();									// конструктор
 	~CCharEntity();									// деструктор

--- a/src/map/lua/lua_baseentity.cpp
+++ b/src/map/lua/lua_baseentity.cpp
@@ -3897,23 +3897,21 @@ inline int32 CLuaBaseEntity::sendTractor(lua_State *L)
     DSP_DEBUG_BREAK_IF(m_PBaseEntity == NULL);
     DSP_DEBUG_BREAK_IF(m_PBaseEntity->objtype != TYPE_PC);
 
-    DSP_DEBUG_BREAK_IF(lua_isnil(L,-1) || !lua_isnumber(L,-1));
-    DSP_DEBUG_BREAK_IF(lua_isnil(L,-2) || !lua_isnumber(L,-2));
-    DSP_DEBUG_BREAK_IF(lua_isnil(L,-3) || !lua_isnumber(L,-3));
-    DSP_DEBUG_BREAK_IF(lua_isnil(L,-4) || !lua_isnumber(L,-4));
-
-	// недостаточно условий, tractor можно читать только на мертвую цель
+    DSP_DEBUG_BREAK_IF(lua_isnil(L,1) || !lua_isnumber(L,1));
+    DSP_DEBUG_BREAK_IF(lua_isnil(L,2) || !lua_isnumber(L,2));
+    DSP_DEBUG_BREAK_IF(lua_isnil(L,3) || !lua_isnumber(L,3));
+    DSP_DEBUG_BREAK_IF(lua_isnil(L,4) || !lua_isnumber(L,4));
 
     CCharEntity* PChar = (CCharEntity*)m_PBaseEntity;
 
-	if(PChar->m_hasTractor == 0)
-    {
+	if (PChar->m_hasTractor == 0)
+	{
 		PChar->m_hasTractor = 1;
 
-		PChar->m_StartActionPos.x = (float)lua_tonumber(L, -1);
-		PChar->m_StartActionPos.y = (float)lua_tonumber(L, -2);
-		PChar->m_StartActionPos.z = (float)lua_tonumber(L, -3);
-		PChar->m_StartActionPos.rotation = (int8)lua_tonumber(L, -4);
+		PChar->m_StartActionPos.x = (float)lua_tonumber(L,1);
+		PChar->m_StartActionPos.y = (float)lua_tonumber(L,2);
+		PChar->m_StartActionPos.z = (float)lua_tonumber(L,3);
+		PChar->m_StartActionPos.rotation = (uint8)lua_tointeger(L,4);
 
 		PChar->pushPacket(new CRaiseTractorMenuPacket(PChar, TYPE_TRACTOR));
 	}
@@ -4975,6 +4973,24 @@ inline int32 CLuaBaseEntity::getMerit(lua_State *L)
 
 		lua_pushinteger(L, PChar->PMeritPoints->GetMeritValue((MERIT_TYPE)lua_tointeger(L,1), PChar));
 	}
+
+	return 1;
+}
+
+//==========================================================//
+
+inline int32 CLuaBaseEntity::getPlaytime(lua_State *L)
+{
+	DSP_DEBUG_BREAK_IF(m_PBaseEntity == NULL);
+    DSP_DEBUG_BREAK_IF(m_PBaseEntity->objtype != TYPE_PC);
+
+	bool update = true;
+    if(!lua_isnil(L,1) && lua_isboolean(L,1))
+		update = lua_toboolean(L, 1);
+
+	CCharEntity* PChar = (CCharEntity*)m_PBaseEntity;
+
+	lua_pushinteger(L, PChar->GetPlayTime(update));
 
 	return 1;
 }
@@ -8480,6 +8496,7 @@ Lunar<CLuaBaseEntity>::Register_t CLuaBaseEntity::methods[] =
 	LUNAR_DECLARE_METHOD(CLuaBaseEntity,changesJob),
 	LUNAR_DECLARE_METHOD(CLuaBaseEntity,setMerits),
 	LUNAR_DECLARE_METHOD(CLuaBaseEntity,getMerit),
+	LUNAR_DECLARE_METHOD(CLuaBaseEntity,getPlaytime),
 	LUNAR_DECLARE_METHOD(CLuaBaseEntity,getWeaponDmg),
 	LUNAR_DECLARE_METHOD(CLuaBaseEntity,getOffhandDmg),
 	LUNAR_DECLARE_METHOD(CLuaBaseEntity,getWeaponDmgRank),

--- a/src/map/lua/lua_baseentity.h
+++ b/src/map/lua/lua_baseentity.h
@@ -399,6 +399,7 @@ public:
 	int32 changeJob(lua_State*);			// changes the job of a char (testing only!)
 	int32 setMerits(lua_State*);			// set merits (testing only!)
 	int32 getMerit(lua_State*);
+	int32 getPlaytime(lua_State*);
 	int32 changesJob(lua_State*);			// changes the sub job of a char (testing only!)
 	int32 getWeaponDmg(lua_State*);			// gets the current equipped weapons' DMG rating
 	int32 getOffhandDmg(lua_State*);		// gets the current equipped offhand's DMG rating (used in WS calcs)

--- a/src/map/lua/luautils.cpp
+++ b/src/map/lua/luautils.cpp
@@ -949,7 +949,7 @@ int32 OnGameIn(CCharEntity* PChar)
 	CLuaBaseEntity LuaBaseEntity(PChar);
 	Lunar<CLuaBaseEntity>::push(LuaHandle,&LuaBaseEntity);
 
-	lua_pushboolean(LuaHandle, PChar->loc.prevzone == 0); // first login
+	lua_pushboolean(LuaHandle, PChar->GetPlayTime(false) == 0); // first login
 
 	if( lua_pcall(LuaHandle,2,LUA_MULTRET,0) )
 	{

--- a/src/map/map.cpp
+++ b/src/map/map.cpp
@@ -677,7 +677,9 @@ int32 map_close_session(uint32 tick, CTaskMgr::CTask* PTask)
 		map_session_data->server_packet_data != NULL &&		// bad pointer crashed here, might need dia to look at this one
 		map_session_data->PChar != NULL)					// crash occured when both server_packet_data & PChar were NULL
 	{
-		Sql_Query(SqlHandle,"DELETE FROM accounts_sessions WHERE charid = %u",map_session_data->PChar->id);
+		charutils::SavePlayTime(map_session_data->PChar);
+
+		Sql_Query(SqlHandle, "DELETE FROM accounts_sessions WHERE charid = %u", map_session_data->PChar->id);
 
 		uint64 port64 = map_session_data->client_port;
 		uint64 ipp	  = map_session_data->client_addr;

--- a/src/map/packets/zone_in.cpp
+++ b/src/map/packets/zone_in.cpp
@@ -181,7 +181,7 @@ CZoneInPacket::CZoneInPacket(CCharEntity * PChar, int16 csid)
 		WBUFB(data,(0xAF)-4) = PChar->loc.zone->CanUseMisc(MISC_MOGMENU);	// флаг, позволяет использовать mog menu за пределами mog house
 	}
 
-	WBUFL(data,(0xA0)-4) = 0x00000000;							// время, проведенное персонажем в игре с момента создания
+	WBUFL(data,(0xA0)-4) = PChar->GetPlayTime();				// время, проведенное персонажем в игре с момента создания
 
 	// current death timestamp is less than an hour ago and the player is dead.
 	if (PChar->m_DeathTimestamp > 0 && ((time(NULL)-PChar->m_DeathTimestamp) < (60*60)) && PChar->isDead()) 

--- a/src/map/time_server.cpp
+++ b/src/map/time_server.cpp
@@ -84,6 +84,7 @@ int32 time_server(uint32 tick,CTaskMgr::CTask* PTask)
             guildutils::UpdateGuildsStock();
 			luautils::OnGameDayAutomatisation();
 			conquest::UpdateConquestSystem();
+			zoneutils::SavePlayTime();
 
             // weekly update for conquest (monday at midnight)
 	        if (CVanaTime::getInstance()->getSysWeekDay() == 1)

--- a/src/map/utils/charutils.cpp
+++ b/src/map/utils/charutils.cpp
@@ -403,6 +403,7 @@ void LoadChar(CCharEntity* PChar)
 		Sql_GetData(SqlHandle,20,&missions,&length);
 		memcpy(PChar->m_missionLog, missions, (length > sizeof(PChar->m_missionLog) ? sizeof(PChar->m_missionLog) : length));
 
+		PChar->SetPlayTime(Sql_GetUIntData(SqlHandle, 21));
 	}
 
 
@@ -4308,6 +4309,11 @@ void SaveDeathTime(CCharEntity* PChar)
 {
 	const int8* fmtQuery = "UPDATE char_stats SET death = %u WHERE charid = %u LIMIT 1;";
 	Sql_Query(SqlHandle, fmtQuery, (uint32)time(NULL), PChar->id);
+}
+
+void SavePlayTime(CCharEntity* PChar)
+{
+	Sql_Query(SqlHandle, "UPDATE chars SET playtime = '%u' WHERE charid = '%u' LIMIT 1;", PChar->GetPlayTime(), PChar->id);
 }
 
 /************************************************************************

--- a/src/map/utils/charutils.h
+++ b/src/map/utils/charutils.h
@@ -139,6 +139,7 @@ namespace charutils
 	void	SaveCharSkills(CCharEntity* PChar, uint8 skillID);	        // сохраняем указанный skill персонажа
 	void	SaveCharPoints(CCharEntity* PChar);							// Conquest point, Nation TP
 	void	SaveDeathTime(CCharEntity* PChar);							// Saves when this character last died.
+	void	SavePlayTime(CCharEntity* PChar);							// Saves this characters total play time.
 	bool	hasMogLockerAccess(CCharEntity* PChar);						// true if have access, false otherwise.
 
     uint32  AddExpBonus(CCharEntity* PChar, uint32 exp);

--- a/src/map/utils/zoneutils.cpp
+++ b/src/map/utils/zoneutils.cpp
@@ -124,6 +124,15 @@ void UpdateWeather()
     ShowDebug(CL_CYAN"UpdateWeather Finished\n" CL_RESET);
 }
 
+void SavePlayTime()
+{
+	for(int32 ZoneID = 0; ZoneID < MAX_ZONEID; ZoneID++)
+	{
+		g_PZoneList[ZoneID]->SavePlayTime();
+	}
+	ShowDebug(CL_CYAN"Player playtime saving finished\n" CL_RESET);
+}
+
 /************************************************************************
 *																		*
 *  Возвращаем указатель на класс зоны с указанным ID.					*

--- a/src/map/utils/zoneutils.h
+++ b/src/map/utils/zoneutils.h
@@ -47,6 +47,7 @@ namespace zoneutils
   void UpdateTreasureSpawnPoint(uint32 npcid, uint32 respawnTime = 300000);
     void UpdateWeather();                                                           // обновляем погоду в зонах
 	void TOTDCharnge(TIMETYPE TOTD);                                                // реакция мира на смену времени суток
+	void SavePlayTime();
 
     REGIONTYPE    GetCurrentRegion(uint16 ZoneID);
     CONTINENTTYPE GetCurrentContinent(uint16 ZoneID);

--- a/src/map/zone.cpp
+++ b/src/map/zone.cpp
@@ -1345,6 +1345,18 @@ void CZone::TOTDChange(TIMETYPE TOTD)
     luautils::OnTOTDChange(m_zoneID, TOTD);
 }
 
+void CZone::SavePlayTime()
+{
+	if(!m_charList.empty())
+	{
+		for(EntityList_t::const_iterator it = m_charList.begin(); it != m_charList.end(); ++it)
+		{
+			CCharEntity* PChar = (CCharEntity*)it->second;
+			charutils::SavePlayTime(PChar);
+		}
+	}
+}
+
 /************************************************************************
 *                                                                       *
 *                                                                       *

--- a/src/map/zone.h
+++ b/src/map/zone.h
@@ -508,6 +508,7 @@ public:
 	void			SpawnNPCs(CCharEntity* PChar);									// отображаем NPCs в зоне
 	void			SpawnMoogle(CCharEntity* PChar);								// отображаем Moogle в MogHouse
     void            SpawnTransport(CCharEntity* PChar);                             // отображаем транспорт
+	void			SavePlayTime();
 
 	void			WideScan(CCharEntity* PChar, uint16 radius);					// сканирование местности с заданным радиусом
 


### PR DESCRIPTION
PlayTime function solved the bug of warp to homepoint on death. The
problem is in the packet zone_in, when the pj death, send this packet
with playtime set to 0, the client doesn't understand that a player
whith a platime of 0 has 0 hp and warp to homepoint.

Tractor now working after fixed the bug of warp to homepoint at death

I've tested on my private test server.
