### PR TITLE
CORE: synthutils: fix for HQ calculation on subcraft synths. hq rate is ...

### DIFF
--- a/src/map/utils/synthutils.cpp
+++ b/src/map/utils/synthutils.cpp
@@ -315,8 +315,11 @@ uint8 getGeneralCraft(CCharEntity* PChar)
 uint8 calcSynthResult(CCharEntity* PChar)
 {
 	uint8 count  = 0;
-	uint8 result = 0;
+	uint8 result = 1;
 	uint8 hqtier = 0;
+	uint8 mainID = 0;
+	uint8 mainlvl = 0;
+	bool canHQsubsynth = true;
 
 	double success = 0;
 	double chance  = 0;
@@ -325,6 +328,15 @@ uint8 calcSynthResult(CCharEntity* PChar)
 	uint8  crystalElement = PChar->CraftContainer->getType();
 	uint8  strongElement[8] = {2,3,5,4,0,1,7,6};
 	
+    for(uint8 skillID = 49; skillID < 57; ++skillID)
+    {
+        uint8 checkSkill = PChar->CraftContainer->getQuantity(skillID-40);
+        if(checkSkill > mainlvl)
+        {
+            mainlvl = checkSkill;
+            mainID = skillID;
+        }
+    }   
 
 	for(uint8 skillID = 49; skillID < 57; ++skillID)
 	{
@@ -354,8 +366,13 @@ uint8 calcSynthResult(CCharEntity* PChar)
 			else
 			{
 				success = 0.95 - (synthDiff / 10) - (double)(PChar->CraftContainer->getType() == ELEMENT_LIGHTNING) * 0.2;
+				canHQsubsynth = false;
 				if(success < 0.05)
 					success = 0.05;
+
+				#ifdef _DSP_SYNTH_DEBUG_MESSAGES_
+				ShowDebug(CL_CYAN"SkillID %u: difficulty > 0\n" CL_RESET, skillID);
+				#endif
 			}
 
 			double random = WELL512::drand();
@@ -365,8 +382,11 @@ uint8 calcSynthResult(CCharEntity* PChar)
 
 			if(random < success)
 			{
-				for(int32 i = 0; i < 3; ++i)
+				for(uint8 i = 0; i < 3; ++i)
 				{
+					if(mainID != skillID)
+					    break;
+					
 					random = WELL512::drand();
 					
 					switch(hqtier)
@@ -399,7 +419,7 @@ uint8 calcSynthResult(CCharEntity* PChar)
 					    chance = 0.500;
 					
 					#ifdef _DSP_SYNTH_DEBUG_MESSAGES_
-					ShowDebug(CL_CYAN"HQ Tier: %i  HQ Chance: %g  Random: %g\n" CL_RESET, hqtier, chance, random);
+					ShowDebug(CL_CYAN"HQ Tier: %i HQ Chance: %g Random: %g SkillID: %u\n" CL_RESET, hqtier, chance, random, skillID);
 					#endif
 					
 					if(chance < random)
@@ -411,18 +431,14 @@ uint8 calcSynthResult(CCharEntity* PChar)
 				// сохраняем умение, из-за которого синтез провалился.
 				// используем slotID ячейки кристалла, т.к. он был удален еще в начале синтеза
 				PChar->CraftContainer->setInvSlotID(0,skillID);
-				result = -1;
+				result = 0;
 				break;
 			}
 		}
 	}
 
-	result = (count == 0 ? SYNTHESIS_SUCCESS : (result == 0xFF ? SYNTHESIS_FAIL : (result/count+1)));
-
-	if ((result > SYNTHESIS_SUCCESS) && (!canSynthesizeHQ(PChar,getGeneralCraft(PChar))))
-	{
+	if(result > SYNTHESIS_SUCCESS && (!canSynthesizeHQ(PChar,getGeneralCraft(PChar)) || !canHQsubsynth))
 		result = SYNTHESIS_SUCCESS;
-	}
 
 	// результат синтеза записываем в поле quantity ячейки кристалла.
 	PChar->CraftContainer->setQuantity(0, result);


### PR DESCRIPTION
...now only determined by the player's main craft skill level, provided the subcraft skill levels are at or above that of the recipe
