### PR TITLE
CORE: disable custom time offset, remove CVanaTime::getSysTime() which w...

### DIFF
--- a/src/map/packet_system.cpp
+++ b/src/map/packet_system.cpp
@@ -2252,7 +2252,7 @@ void SmallPacket0x04E(map_session_data_t* session, CCharEntity* PChar, int8* dat
                               quantity == 0,
                               PChar->id,
                               PChar->GetName(),
-                              CVanaTime::getInstance()->getSysTime(),
+                              (uint32)time(NULL),
                               price) == SQL_ERROR)
 			    {
 				    ShowError(CL_RED"SmallPacket0x04E::AuctionHouse: Cannot insert item to database\n" CL_RESET);
@@ -2307,7 +2307,7 @@ void SmallPacket0x04E(map_session_data_t* session, CCharEntity* PChar, int8* dat
                                       fmtQuery,
                                       PChar->GetName(),
                                       price,
-                                      CVanaTime::getInstance()->getSysTime(),
+                                      (uint32)time(NULL),
                                       itemid,
                                       quantity == 0,
                                       price) != SQL_ERROR &&

--- a/src/map/packets/zone_in.cpp
+++ b/src/map/packets/zone_in.cpp
@@ -130,7 +130,7 @@ CZoneInPacket::CZoneInPacket(CCharEntity * PChar, int16 csid)
 	WBUFB(data,(0x1E)-4) = PChar->GetHPP();
 	WBUFB(data,(0x1F)-4) = PChar->animation;
 
-	WBUFL(data,(0x38)-4) = CVanaTime::getInstance()->getSysTime();
+	WBUFL(data,(0x38)-4) = (uint32)time(NULL);
     WBUFL(data,(0x3C)-4) = CVanaTime::getInstance()->getVanaTime();
 
 	WBUFB(data,(0x44)-4) = PChar->look.face;

--- a/src/map/utils/charutils.cpp
+++ b/src/map/utils/charutils.cpp
@@ -4163,8 +4163,7 @@ bool hasMogLockerAccess(CCharEntity* PChar) {
 	if(Sql_NextRow(SqlHandle) == SQL_SUCCESS)
 	{
 		int32 tstamp  = (int32)Sql_GetIntData(SqlHandle,0);
-		uint32 now = time(NULL) - 1009810800;
-		if (now < tstamp) {
+		if (CVanaTime::getInstance()->getVanaTime() < tstamp) {
 			return true;
 		}
 	}

--- a/src/map/vana_time.cpp
+++ b/src/map/vana_time.cpp
@@ -29,7 +29,7 @@
 #include "vana_time.h"
 #include "utils/zoneutils.h"
 
-#define VTIME_BASEDATE		1009810800		// Real starting date for Vana time - used to be 1024844400?
+#define VTIME_BASEDATE		1009810800		// unix epoch - 1009810800 = se epoch (in earth seconds)
 #define VTIME_YEAR			518400			// 360 * GameDay
 #define VTIME_MONTH			43200			// 30 * GameDay
 #define VTIME_WEEK			11520			// 8 * GameDay
@@ -91,11 +91,6 @@ uint32 CVanaTime::getWeekday()
 	return m_vDay;
 }
 
-uint32 CVanaTime::getSysTime()
-{
-	return (uint32)(time(NULL) + m_customOffset * 2.4f);
-}
-
 uint32 CVanaTime::getSysHour()
 {
 	time_t now = time(0);
@@ -136,11 +131,11 @@ uint32 CVanaTime::getSysYearDay()
 	return ltm->tm_yday;
 }
 
-
-
 uint32 CVanaTime::getVanaTime()
 {
-    return getSysTime() - VTIME_BASEDATE;
+    //if custom offset is re-implemented here is the place to put it
+    //all functions/variables for in game time should be derived from this
+    return (uint32)time(NULL) - VTIME_BASEDATE;
 }
 
 int32 CVanaTime::getCustomOffset()
@@ -151,15 +146,7 @@ int32 CVanaTime::getCustomOffset()
 void CVanaTime::setCustomOffset(int32 offset)
 {
 	m_customOffset = offset;
-
-	SyncTime();
-
-	if (m_vHour >= 20)      m_TimeType = TIME_NIGHT;
-	else if (m_vHour >= 18) m_TimeType = TIME_EVENING;
-	else if (m_vHour >= 17) m_TimeType = TIME_DUSK;
-	else if (m_vHour >=  7) m_TimeType = TIME_DAY;
-	else if (m_vHour >=  6) m_TimeType = TIME_DAWN;
-	else if (m_vHour >=  4) m_TimeType = TIME_NEWDAY;
+	m_TimeType = SyncTime();
 }
 
 TIMETYPE CVanaTime::GetCurrentTOTD()
@@ -170,9 +157,7 @@ TIMETYPE CVanaTime::GetCurrentTOTD()
 uint32 CVanaTime::getMoonPhase()
 {
 	int32  phase = 0;
-	uint32 rawtime = this->getSysTime();
-
-	int32  game_days = (int32)(rawtime - VTIME_BASEDATE) / 3456;
+	int32  game_days = (int32)this->getVanaTime() / 3456;
 	double daysmod   = (int32)(game_days - 22) % 84;
 
 	if (daysmod >= 42){
@@ -187,9 +172,7 @@ uint32 CVanaTime::getMoonPhase()
 uint8 CVanaTime::getMoonDirection()
 {
 	int32  phase = 0;
-	uint32 rawtime = this->getSysTime();
-
-	int32  game_days = (int32)(rawtime - VTIME_BASEDATE) / 3456;
+	int32  game_days = (int32)this->getVanaTime() / 3456;
 	double daysmod   = (int32)(game_days - 22) % 84;
 
 	if (daysmod == 42 || daysmod == 0){
@@ -203,12 +186,7 @@ uint8 CVanaTime::getMoonDirection()
 
 TIMETYPE CVanaTime::SyncTime()
 {
-	timeb SysTime;
-	ftime(&SysTime);
-
-	//Convert real time into Vana minutes
-
-	m_vanaDate  = (uint32)((SysTime.time + 92514960 ) / 60.0 * 25 );
+	m_vanaDate  = (uint32)(this->getVanaTime() / 60.0 * 25) + 886 * VTIME_YEAR; //convert vana time (from SE epoch in earth seconds) to vanadiel minutes and add 886 vana years
 
 	m_vYear = (uint32)( m_vanaDate / VTIME_YEAR);
 	m_vMon  = (uint32)((m_vanaDate / VTIME_MONTH) % 12) + 1;

--- a/src/map/vana_time.h
+++ b/src/map/vana_time.h
@@ -69,7 +69,6 @@ public:
 	uint32	 getWeekday();
 	uint32	 getMoonPhase();
 	uint8	 getMoonDirection();
-	uint32	 getSysTime();							// Timestamp of the system time
 	uint32	 getSysHour();
 	uint32	 getSysMinute();
 	uint32	 getSysSecond();


### PR DESCRIPTION
...as applying it - all calls to getSysTime() redirected to built-in time(), derive all vanadiel time related variables from getVanaTime()

the formula in CVanaTime::SyncTime() for m_vanaDate looks way different but it yields the exact same result as before, I just rearranged it to derive from getVanaTime() and to be more understandable
