### PR TITLE
These leeches had an incorrect behavior/link setting - they spawned already in an aggressive state.

### DIFF
--- a/scripts/zones/Korroloka_Tunnel/npcs/qm2.lua
+++ b/scripts/zones/Korroloka_Tunnel/npcs/qm2.lua
@@ -24,47 +24,47 @@ end;
 -----------------------------------
 
 function onTrigger(player,npc)
-	
-	if(player:getQuestStatus(BASTOK,AYAME_AND_KAEDE) == QUEST_ACCEPTED) then
-		if(player:getVar("AyameAndKaede_Event") == 2 and player:hasKeyItem(STRANGELY_SHAPED_CORAL) == false) then
-			local leechesDespawned = (GetMobAction(17486187) == 0 and GetMobAction(17486188) == 0 and GetMobAction(17486189) == 0);
-			local spawnTime = player:getVar("KorrolokaLeeches_Spawned");
-			local canSpawn = (leechesDespawned and (os.time() - spawnTime) > 30);
-			local killedLeeches = player:getVar("KorrolokaLeeches");
 
-			if(killedLeeches >= 1) then
-				if((killedLeeches == 3 and (os.time() - player:getVar("KorrolokaLeeches_Timer") < 30)) or (killedLeeches < 3 and leechesDespawned and (os.time() - spawnTime) < 30)) then
-					player:addKeyItem(STRANGELY_SHAPED_CORAL);
-					player:messageSpecial(KEYITEM_OBTAINED,STRANGELY_SHAPED_CORAL);
-					player:setVar("KorrolokaLeeches",0);
-					player:setVar("KorrolokaLeeches_Spawned",0);
-					player:setVar("KorrolokaLeeches_Timer",0);
-				elseif(leechesDespawned) then
-					SpawnMob(17486187,168):updateEnmity(player); -- Despawn after 3 minutes (-12 seconds for despawn delay).
-					SpawnMob(17486188,168):updateEnmity(player);
-					SpawnMob(17486189,168):updateEnmity(player);
-					player:setVar("KorrolokaLeeches",0);
-					player:setVar("KorrolokaLeeches_Spawned",os.time()+180);
-					player:messageSpecial(SENSE_OF_BOREBODING);
-				else
-					player:messageSpecial(NOTHING_OUT_OF_ORDINARY);
-				end
-			elseif(canSpawn) then
-				SpawnMob(17486187,168):updateEnmity(player); -- Despawn after 3 minutes (-12 seconds for despawn delay).
-				SpawnMob(17486188,168):updateEnmity(player);
-				SpawnMob(17486189,168):updateEnmity(player);
-				player:setVar("KorrolokaLeeches_Spawned",os.time()+180);
-				player:messageSpecial(SENSE_OF_BOREBODING);
-			else
-				player:messageSpecial(NOTHING_OUT_OF_ORDINARY);
-			end
-		else
-			player:messageSpecial(NOTHING_OUT_OF_ORDINARY);
-		end
-	else
-		player:messageSpecial(NOTHING_OUT_OF_ORDINARY);
-	end
-	
+    if(player:getQuestStatus(BASTOK,AYAME_AND_KAEDE) == QUEST_ACCEPTED) then
+        if(player:getVar("AyameAndKaede_Event") == 2 and player:hasKeyItem(STRANGELY_SHAPED_CORAL) == false) then
+            local leechesDespawned = (GetMobAction(17486187) == 0 and GetMobAction(17486188) == 0 and GetMobAction(17486189) == 0);
+            local spawnTime = player:getVar("KorrolokaLeeches_Spawned");
+            local canSpawn = (leechesDespawned and (os.time() - spawnTime) > 30);
+            local killedLeeches = player:getVar("KorrolokaLeeches");
+
+            if(killedLeeches >= 1) then
+                if((killedLeeches == 3 and (os.time() - player:getVar("KorrolokaLeeches_Timer") < 30)) or (killedLeeches < 3 and leechesDespawned and (os.time() - spawnTime) < 30)) then
+                    player:addKeyItem(STRANGELY_SHAPED_CORAL);
+                    player:messageSpecial(KEYITEM_OBTAINED,STRANGELY_SHAPED_CORAL);
+                    player:setVar("KorrolokaLeeches",0);
+                    player:setVar("KorrolokaLeeches_Spawned",0);
+                    player:setVar("KorrolokaLeeches_Timer",0);
+                elseif(leechesDespawned) then
+                    SpawnMob(17486187,168); -- Despawn after 3 minutes (-12 seconds for despawn delay).
+                    SpawnMob(17486188,168);
+                    SpawnMob(17486189,168);
+                    player:setVar("KorrolokaLeeches",0);
+                    player:setVar("KorrolokaLeeches_Spawned",os.time()+180);
+                    player:messageSpecial(SENSE_OF_BOREBODING);
+                else
+                    player:messageSpecial(NOTHING_OUT_OF_ORDINARY);
+                end
+            elseif(canSpawn) then
+                SpawnMob(17486187,168); -- Despawn after 3 minutes (-12 seconds for despawn delay).
+                SpawnMob(17486188,168);
+                SpawnMob(17486189,168);
+                player:setVar("KorrolokaLeeches_Spawned",os.time()+180);
+                player:messageSpecial(SENSE_OF_BOREBODING);
+            else
+                player:messageSpecial(NOTHING_OUT_OF_ORDINARY);
+            end
+        else
+            player:messageSpecial(NOTHING_OUT_OF_ORDINARY);
+        end
+    else
+        player:messageSpecial(NOTHING_OUT_OF_ORDINARY);
+    end
+
 end;
 
 -----------------------------------
@@ -72,8 +72,8 @@ end;
 -----------------------------------
 
 function onEventUpdate(player,csid,option)
---printf("CSID: %u",csid);
---printf("RESULT: %u",option);
+    -- printf("CSID: %u",csid);
+    -- printf("RESULT: %u",option);
 end;
 
 -----------------------------------
@@ -81,6 +81,6 @@ end;
 -----------------------------------
 
 function onEventFinish(player,csid,option)
---printf("CSID: %u",csid);
---printf("RESULT: %u",option);
+    -- printf("CSID: %u",csid);
+    -- printf("RESULT: %u",option);
 end;


### PR DESCRIPTION
Only change I made was to spawn them non agro'd. If the player is low enough lv and does not have sneak effect on, they will still agro.

They will also still link, I have not changed that in the SQL. But I am not sure the Korroloka Leeches for NIN unlock quest really do link in retail despite what wiki says. I've helped many people get their ninja unlock over the years, and we always sneak popped and pulled a single leach.

It may be that they do link, but the they were far enough a part to pull safely. I've left it alone in any case.

One of the multiple examples from ffxiclopedia's talk page showing they don't spawn agro and sneak pull works:
"Soloable by BST 40/ WHM 20. Caled pet (Tiger familiar) and used sneak. When I popped the leaches they didn't aggro. I then continued to use my pet to kill the first one. They do not link. After the first one was dead I sent my tiger to kill another while I soloed the last leech. Relatively easy, had to cast a few cures. -Heillon-Fairy(Sylph) Server."

Just ran a test char through entire quest, no script errors everything went flawless.
