### PR TITLE
Add merit bonuses for Protectra V & Shellra V

### DIFF
--- a/scripts/globals/spells/protectra_v.lua
+++ b/scripts/globals/spells/protectra_v.lua
@@ -14,19 +14,12 @@ function OnMagicCastingCheck(caster,target,spell)
 end;
 
 function onSpellCast(caster,target,spell)
-    local power = 175;
+    local meritBonus = caster:getMerit(MERIT_PROTECTRA_V);
     local duration = 1800;
-
-    --printf("Protectra V Base Power: %d", power);
-
-    local meritBonus = caster:getMerit(MERIT_PROTECTRA_V) - 5;
-    --printf("Protectra V Merit Bonus: %d", meritBonus);
+    --Base Power is actually 175, but you have to have at least 1 merit and they're each +5
     
-    if(meritBonus > 0) then
-        power = power + meritBonus;
-    end
-    
-    --printf("Protectra V Final Power: %d", power);
+    local power = 170 + meritBonus;
+    --printf("Protectra V Power: %d", power);
     
     duration = calculateDurationForLvl(duration, 75, target:getMainLvl());
 

--- a/scripts/globals/spells/shellra_v.lua
+++ b/scripts/globals/spells/shellra_v.lua
@@ -14,19 +14,12 @@ function OnMagicCastingCheck(caster,target,spell)
 end;
 
 function onSpellCast(caster,target,spell)
-    local power = 62;
+    local meritBonus = caster:getMerit(MERIT_SHELLRA_V);
     local duration = 1800;
-
-    --printf("Shellra V Base Power: %d", power);
-
-    local meritBonus = caster:getMerit(MERIT_SHELLRA_V) - 1;
-    --printf("Shellra V Merit Bonus: %d", meritBonus);
     
-    if(meritBonus > 0) then
-        power = power + meritBonus;
-    end
-    
-    --printf("Shellra V Final Power: %d", power);
+    --Base Power is actually 62, but you will always have atleast 1 merit
+    local power = 60 + meritBonus;
+    --printf("Shellra V Power: %d", power);
     
     duration = calculateDurationForLvl(duration, 75, target:getMainLvl());
 


### PR DESCRIPTION
Added the merit bonuses for Protectra V & Shellra V, as they were not factored into the current scripts.

Protectra V: Each additional merit point beyond the 1st is supposed to boost the power by 5
Shellra V: Each additional merit point beyond the 1st is supposed to boost the power by 1

With this change & the Martyr #103 & Devotion #101 changes, White Mage Group 2 Merits should be fully functional :-)

Let me know if there is anything I need to adjust

-SLK
