### PR TITLE
Fix issue with merit bonus for Devotion

### DIFF
--- a/scripts/globals/abilities/devotion.lua
+++ b/scripts/globals/abilities/devotion.lua
@@ -19,7 +19,7 @@ end;
 
 function OnUseAbility(player, target, ability)
     --Plus 5 percent mp recovers per extra devotion merit
-    local meritBonus = player:getMerit(MERIT_DEVOTION);
+    local meritBonus = player:getMerit(MERIT_DEVOTION) - 5;
     --printf("Devotion Merit Bonus: %d", meritBonus);
     
     local mpPercent = (25 + meritBonus) / 100;


### PR DESCRIPTION
You only get an extra 5% bonus for each merit point after the first. The script was giving you a 5% bonus for the first point as well. Thanks to @maxtherabbit for pointing this out.

Sorry for the mistake :-(

-SLK
