### PR TITLE
White Mage: Implement Bar Spell Merit Bonus

### DIFF
--- a/scripts/globals/magic.lua
+++ b/scripts/globals/magic.lua
@@ -1209,11 +1209,14 @@ function calculateDurationForLvl(duration, spellLvl, targetLvl)
 end
 
 function calculateBarspellPower(caster,enhanceSkill)
+	local meritBonus = caster:getMerit(MERIT_BAR_SPELL_EFFECT);	
+	--printf("Barspell: Merit Bonus +%d", meritBonus);
+	
 	if (enhanceSkill == nil or enhanceSkill < 0) then
 		enhanceSkill = 0;
 	end
 
-	local power = 40 + 0.2 * enchanceSkill;
+	local power = 40 + 0.2 * enchanceSkill + meritBonus;
 	
 	local equippedLegs = caster:getEquipID(SLOT_LEGS);
 	if(equippedLegs == 15119) then

--- a/scripts/globals/spells/barblind.lua
+++ b/scripts/globals/spells/barblind.lua
@@ -13,11 +13,14 @@ function OnMagicCastingCheck(caster,target,spell)
 end;
 
 function onSpellCast(caster,target,spell)
+    local meritBonus = caster:getMerit(MERIT_BAR_SPELL_EFFECT);	
+    --printf("Barspell: Merit Bonus +%d", meritBonus);
+    
     local enchanceSkill = caster:getSkillLevel(34);
 
     local duration = 150;
 
-    local power = 1 + 0.02 * enchanceSkill;
+    local power = 1 + 0.02 * enchanceSkill + meritBonus;
 
     if(enchanceSkill >180)then
         duration = 150 + 0.8 * (enchanceSkill - 180);

--- a/scripts/globals/spells/barblindra.lua
+++ b/scripts/globals/spells/barblindra.lua
@@ -13,9 +13,12 @@ function OnMagicCastingCheck(caster,target,spell)
 end;
 
 function onSpellCast(caster,target,spell)
+    local meritBonus = caster:getMerit(MERIT_BAR_SPELL_EFFECT);	
+    --printf("Barspell: Merit Bonus +%d", meritBonus);
+    
 	local enchanceSkill = caster:getSkillLevel(34);
-
-    local power = 1 + 0.02 * enchanceSkill;
+    
+    local power = 1 + 0.02 * enchanceSkill + meritBonus;
 
 	local duration = 150;
 

--- a/scripts/globals/spells/barparalyze.lua
+++ b/scripts/globals/spells/barparalyze.lua
@@ -13,9 +13,12 @@ function OnMagicCastingCheck(caster,target,spell)
 end;
 
 function onSpellCast(caster,target,spell)
+    local meritBonus = caster:getMerit(MERIT_BAR_SPELL_EFFECT);	
+    --printf("Barspell: Merit Bonus +%d", meritBonus);
+    
     local enchanceSkill = caster:getSkillLevel(34);
 
-    local power = 1 + 0.02 * enchanceSkill;
+    local power = 1 + 0.02 * enchanceSkill + meritBonus;
 
     local duration = 150;
 

--- a/scripts/globals/spells/barparalyzra.lua
+++ b/scripts/globals/spells/barparalyzra.lua
@@ -13,9 +13,12 @@ function OnMagicCastingCheck(caster,target,spell)
 end;
 
 function onSpellCast(caster,target,spell)
+    local meritBonus = caster:getMerit(MERIT_BAR_SPELL_EFFECT);	
+    --printf("Barspell: Merit Bonus +%d", meritBonus);
+    
 	local enchanceSkill = caster:getSkillLevel(34);
 
-    local power = 1 + 0.02 * enchanceSkill;
+    local power = 1 + 0.02 * enchanceSkill + meritBonus;
 
 	local duration = 150;
 

--- a/scripts/globals/spells/barpetra.lua
+++ b/scripts/globals/spells/barpetra.lua
@@ -13,9 +13,12 @@ function OnMagicCastingCheck(caster,target,spell)
 end;
 
 function onSpellCast(caster,target,spell)
+    local meritBonus = caster:getMerit(MERIT_BAR_SPELL_EFFECT);	
+    --printf("Barspell: Merit Bonus +%d", meritBonus);
+    
 	local enchanceSkill = caster:getSkillLevel(34);
 
-    local power = 1 + 0.02 * enchanceSkill;
+    local power = 1 + 0.02 * enchanceSkill + meritBonus;
 
 	local duration = 150;
 

--- a/scripts/globals/spells/barpetrify.lua
+++ b/scripts/globals/spells/barpetrify.lua
@@ -13,9 +13,12 @@ function OnMagicCastingCheck(caster,target,spell)
 end;
 
 function onSpellCast(caster,target,spell)
+    local meritBonus = caster:getMerit(MERIT_BAR_SPELL_EFFECT);	
+    --printf("Barspell: Merit Bonus +%d", meritBonus);
+    
     local enchanceSkill = caster:getSkillLevel(34);
 
-    local power = 1 + 0.02 * enchanceSkill;
+    local power = 1 + 0.02 * enchanceSkill + meritBonus;
 
     local duration = 150;
 

--- a/scripts/globals/spells/barpoison.lua
+++ b/scripts/globals/spells/barpoison.lua
@@ -13,9 +13,12 @@ function OnMagicCastingCheck(caster,target,spell)
 end;
 
 function onSpellCast(caster,target,spell)
+    local meritBonus = caster:getMerit(MERIT_BAR_SPELL_EFFECT);	
+    --printf("Barspell: Merit Bonus +%d", meritBonus);
+    
     local enchanceSkill = caster:getSkillLevel(34);
 
-    local power = 1 + 0.02 * enchanceSkill;
+    local power = 1 + 0.02 * enchanceSkill + meritBonus;
 
     local duration = 150;
 

--- a/scripts/globals/spells/barpoisonra.lua
+++ b/scripts/globals/spells/barpoisonra.lua
@@ -13,9 +13,12 @@ function OnMagicCastingCheck(caster,target,spell)
 end;
 
 function onSpellCast(caster,target,spell)
+    local meritBonus = caster:getMerit(MERIT_BAR_SPELL_EFFECT);	
+    --printf("Barspell: Merit Bonus +%d", meritBonus);
+    
 	local enchanceSkill = caster:getSkillLevel(34);
 
-    local power = 1 + 0.02 * enchanceSkill;
+    local power = 1 + 0.02 * enchanceSkill + meritBonus;
 
 	local duration = 150;
 

--- a/scripts/globals/spells/barsilence.lua
+++ b/scripts/globals/spells/barsilence.lua
@@ -13,11 +13,14 @@ function OnMagicCastingCheck(caster,target,spell)
 end;
 
 function onSpellCast(caster,target,spell)
+    local meritBonus = caster:getMerit(MERIT_BAR_SPELL_EFFECT);	
+    --printf("Barspell: Merit Bonus +%d", meritBonus);
+    
     local enchanceSkill = caster:getSkillLevel(34);
 
     local duration = 150;
 
-    local power = 1 + 0.02 * enchanceSkill;
+    local power = 1 + 0.02 * enchanceSkill + meritBonus;
 
     if(enchanceSkill >180)then
         duration = 150 + 0.8 * (enchanceSkill - 180);

--- a/scripts/globals/spells/barsilencera.lua
+++ b/scripts/globals/spells/barsilencera.lua
@@ -13,9 +13,12 @@ function OnMagicCastingCheck(caster,target,spell)
 end;
 
 function onSpellCast(caster,target,spell)
+    local meritBonus = caster:getMerit(MERIT_BAR_SPELL_EFFECT);	
+    --printf("Barspell: Merit Bonus +%d", meritBonus);
+    
 	local enchanceSkill = caster:getSkillLevel(34);
 
-    local power = 1 + 0.02 * enchanceSkill;
+    local power = 1 + 0.02 * enchanceSkill + meritBonus;
 
 	local duration = 150;
 

--- a/scripts/globals/spells/barsleep.lua
+++ b/scripts/globals/spells/barsleep.lua
@@ -13,9 +13,12 @@ function OnMagicCastingCheck(caster,target,spell)
 end;
 
 function onSpellCast(caster,target,spell)
+    local meritBonus = caster:getMerit(MERIT_BAR_SPELL_EFFECT);	
+    --printf("Barspell: Merit Bonus +%d", meritBonus);
+    
     local enchanceSkill = caster:getSkillLevel(34);
 
-    local power = 1 + 0.02 * enchanceSkill;
+    local power = 1 + 0.02 * enchanceSkill + meritBonus;
 
     local duration = 150;
 

--- a/scripts/globals/spells/barsleepra.lua
+++ b/scripts/globals/spells/barsleepra.lua
@@ -13,9 +13,12 @@ function OnMagicCastingCheck(caster,target,spell)
 end;
 
 function onSpellCast(caster,target,spell)
+    local meritBonus = caster:getMerit(MERIT_BAR_SPELL_EFFECT);	
+    --printf("Barspell: Merit Bonus +%d", meritBonus);
+    
 	local enchanceSkill = caster:getSkillLevel(34);
 
-    local power = 1 + 0.02 * enchanceSkill;
+    local power = 1 + 0.02 * enchanceSkill + meritBonus;
 
 	local duration = 150;
 

--- a/scripts/globals/spells/barvira.lua
+++ b/scripts/globals/spells/barvira.lua
@@ -13,9 +13,12 @@ function OnMagicCastingCheck(caster,target,spell)
 end;
 
 function onSpellCast(caster,target,spell)
+    local meritBonus = caster:getMerit(MERIT_BAR_SPELL_EFFECT);	
+    --printf("Barspell: Merit Bonus +%d", meritBonus);
+    
     local enchanceSkill = caster:getSkillLevel(34);
 
-    local power = 1 + 0.02 * enchanceSkill;
+    local power = 1 + 0.02 * enchanceSkill + meritBonus;
 
     local duration = 150;
 

--- a/scripts/globals/spells/barvirus.lua
+++ b/scripts/globals/spells/barvirus.lua
@@ -13,9 +13,12 @@ function OnMagicCastingCheck(caster,target,spell)
 end;
 
 function onSpellCast(caster,target,spell)
+    local meritBonus = caster:getMerit(MERIT_BAR_SPELL_EFFECT);	
+    --printf("Barspell: Merit Bonus +%d", meritBonus);
+    
     local enchanceSkill = caster:getSkillLevel(34);
 
-    local power = 1 + 0.02 * enchanceSkill;
+    local power = 1 + 0.02 * enchanceSkill + meritBonus;
 
     local duration = 150;
 


### PR DESCRIPTION
Implemented the bar spell merit bonuses for White Mage. Each bar spell merit gives a +2 bonus to all bar spells
