### PR TITLE
Rewrote "Stamp Hunt" quest in Bastok. Was having issues.

### DIFF
--- a/scripts/zones/Bastok_Markets/npcs/Arawn.lua
+++ b/scripts/zones/Bastok_Markets/npcs/Arawn.lua
@@ -25,20 +25,19 @@ end;
 -----------------------------------
 
 function onTrigger(player,npc)
-    
-	local StampHunt = player:getQuestStatus(BASTOK,STAMP_HUNT);
-	local WildcatBastok = player:getVar("WildcatBastok");
-	
-	if (player:getQuestStatus(BASTOK,LURE_OF_THE_WILDCAT_BASTOK) == QUEST_ACCEPTED and player:getMaskBit(WildcatBastok,11) == false) then
-		player:startEvent(0x01ad);
-	elseif (StampHunt == 0) then
-		player:startEvent(0x00e1);
-	elseif (StampHunt == 1 and player:getVar("StampHunt_Event") == 0x7F) then
-		player:startEvent(0x00e2);
+    local StampHunt = player:getQuestStatus(BASTOK,STAMP_HUNT);
+    local WildcatBastok = player:getVar("WildcatBastok");
+
+    if (player:getQuestStatus(BASTOK,LURE_OF_THE_WILDCAT_BASTOK) == QUEST_ACCEPTED and player:getMaskBit(WildcatBastok,11) == false) then
+        player:startEvent(0x01ad);
+    elseif (StampHunt == QUEST_AVAILABLE) then
+        player:startEvent(0x00e1);
+    elseif (StampHunt == QUEST_ACCEPTED and player:isMaskFull(player:getVar("StampHunt_Mask"),7) == true) then
+        player:startEvent(0x00e2);
     else
         player:startEvent(0x0072);
     end
-	
+
 end;
 
 -----------------------------------
@@ -46,8 +45,8 @@ end;
 -----------------------------------
 
 function onEventUpdate(player,csid,option)
---printf("CSID: %u",csid);
---printf("RESULT: %u",option);
+    -- printf("CSID: %u",csid);
+    -- printf("RESULT: %u",option);
 end;
 
 -----------------------------------
@@ -55,8 +54,8 @@ end;
 -----------------------------------
 
 function onEventFinish(player,csid,option)
---printf("CSID: %u",csid);
---printf("RESULT: %u",option);
+    -- printf("CSID: %u",csid);
+    -- printf("RESULT: %u",option);
 
     if (csid == 0x00e1 and option == 0) then
         player:addQuest(BASTOK,STAMP_HUNT);
@@ -68,14 +67,14 @@ function onEventFinish(player,csid,option)
             player:addItem(13081);
             player:messageSpecial(ITEM_OBTAINED,13081); -- Leather Gorget
             player:delKeyItem(STAMP_SHEET);
-            player:setVar("StampHunt_Event",0);
-			player:addFame(BASTOK,BAS_FAME*50);
-			player:completeQuest(BASTOK,STAMP_HUNT);
+            player:setVar("StampHunt_Mask",0);
+            player:addFame(BASTOK,BAS_FAME*50);
+            player:completeQuest(BASTOK,STAMP_HUNT);
         else
-           player:messageSpecial(ITEM_CANNOT_BE_OBTAINED, LEATHER_GORGET);
+           player:messageSpecial(ITEM_CANNOT_BE_OBTAINED, 13081);
         end
-	elseif (csid == 0x01ad) then
-		player:setMaskBit(player:getVar("WildcatBastok"),"WildcatBastok",11,true);
+    elseif (csid == 0x01ad) then
+        player:setMaskBit(player:getVar("WildcatBastok"),"WildcatBastok",11,true);
     end
-	
+
 end;

--- a/scripts/zones/Bastok_Markets/npcs/Pavel.lua
+++ b/scripts/zones/Bastok_Markets/npcs/Pavel.lua
@@ -22,24 +22,17 @@ end;
 -----------------------------------
 
 function onTrigger(player,npc)
-	function testflag(set,flag)
-		return (set % (2*flag) >= flag)
-	end
-
+    local WildcatBastok = player:getVar("WildcatBastok");
     local StampHunt = player:getQuestStatus(BASTOK,STAMP_HUNT);
-    local stampCount = player:getVar("StampHunt_Event");
-	local checkStamp = testflag(tonumber(stampCount),0x1);
-	
-	local WildcatBastok = player:getVar("WildcatBastok");
-	
-	if (player:getQuestStatus(BASTOK,LURE_OF_THE_WILDCAT_BASTOK) == QUEST_ACCEPTED and player:getMaskBit(WildcatBastok,14) == false) then
-		player:startEvent(0x01af);
-    elseif (StampHunt == 1 and checkStamp == false) then
-        player:setVar("StampHunt_Event",stampCount+0x1);
+
+    if (player:getQuestStatus(BASTOK,LURE_OF_THE_WILDCAT_BASTOK) == QUEST_ACCEPTED and player:getMaskBit(WildcatBastok,14) == false) then
+        player:startEvent(0x01af);
+    elseif (StampHunt == QUEST_ACCEPTED and player:getMaskBit(player:getVar("StampHunt_Mask"),2) == false) then
         player:startEvent(0x00e3);
     else
         player:startEvent(0x0080);
     end
+
 end;
 
 -----------------------------------
@@ -47,8 +40,8 @@ end;
 -----------------------------------
 
 function onEventUpdate(player,csid,option)
---printf("CSID: %u",csid);
---printf("RESULT: %u",option);
+    -- printf("CSID: %u",csid);
+    -- printf("RESULT: %u",option);
 end;
 
 -----------------------------------
@@ -56,15 +49,13 @@ end;
 -----------------------------------
 
 function onEventFinish(player,csid,option)
---printf("CSID: %u",csid);
---printf("RESULT: %u",option);
+    -- printf("CSID: %u",csid);
+    -- printf("RESULT: %u",option);
 
-	if (csid == 0x01af) then
-		player:setMaskBit(player:getVar("WildcatBastok"),"WildcatBastok",14,true);
+    if (csid == 0x01af) then
+        player:setMaskBit(player:getVar("WildcatBastok"),"WildcatBastok",14,true);
+    elseif (csid == 0x00e3) then
+        player:setMaskBit(player:getVar("StampHunt_Mask"),"StampHunt_Mask",2,true);
     end
 
 end;
-
-
-
-

--- a/scripts/zones/Bastok_Mines/npcs/Deadly_Spider.lua
+++ b/scripts/zones/Bastok_Mines/npcs/Deadly_Spider.lua
@@ -21,20 +21,14 @@ end;
 -----------------------------------
 
 function onTrigger(player,npc)
-	function testflag(set,flag)
-		return (set % (2*flag) >= flag)
-	end
+    local StampHunt = player:getQuestStatus(BASTOK,STAMP_HUNT);
 
-    StampHunt = player:getQuestStatus(BASTOK,STAMP_HUNT);
-    stampCount = player:getVar("StampHunt_Event");
-	checkStamp = testflag(tonumber(stampCount),0x2);
-
-    if (StampHunt == 1 and checkStamp == false) then
-        player:setVar("StampHunt_Event",stampCount+0x2);
+    if (StampHunt == QUEST_ACCEPTED and player:getMaskBit(player:getVar("StampHunt_Mask"),0) == false) then
         player:startEvent(0x0056);
     else
         player:startEvent(0x0011);
     end
+
 end;
 
 -----------------------------------
@@ -42,8 +36,8 @@ end;
 -----------------------------------
 
 function onEventUpdate(player,csid,option)
---printf("CSID: %u",csid);
---printf("RESULT: %u",option);
+    -- printf("CSID: %u",csid);
+    -- printf("RESULT: %u",option);
 end;
 
 -----------------------------------
@@ -51,10 +45,11 @@ end;
 -----------------------------------
 
 function onEventFinish(player,csid,option)
---printf("CSID: %u",csid);
---printf("RESULT: %u",option);
+    -- printf("CSID: %u",csid);
+    -- printf("RESULT: %u",option);
+
+    if (csid == 0x0056) then
+        player:setMaskBit(player:getVar("StampHunt_Mask"),"StampHunt_Mask",0,true);
+    end
+
 end;
-
-
-
-

--- a/scripts/zones/Bastok_Mines/npcs/Tall_Mountain.lua
+++ b/scripts/zones/Bastok_Mines/npcs/Tall_Mountain.lua
@@ -25,22 +25,16 @@ end;
 -----------------------------------
 
 function onTrigger(player,npc)
-	
-	function testflag(set,flag)
-		return (set % (2*flag) >= flag)
-	end
+    local StampHunt = player:getQuestStatus(BASTOK,STAMP_HUNT);
 
-	local checkStamp = testflag(tonumber(player:getVar("StampHunt_Event")),0x4);
-	
-	if(player:getCurrentMission(BASTOK) == RETURN_OF_THE_TALEKEEPER and player:getVar("MissionStatus") == 3) then
-		player:startEvent(0x00b6);
-    elseif(player:getQuestStatus(BASTOK,STAMP_HUNT) == QUEST_ACCEPTED and checkStamp == false) then
-        player:setVar("StampHunt_Event",stampCount+0x4);
+    if(player:getCurrentMission(BASTOK) == RETURN_OF_THE_TALEKEEPER and player:getVar("MissionStatus") == 3) then
+        player:startEvent(0x00b6);
+    elseif (StampHunt == QUEST_ACCEPTED and player:getMaskBit(player:getVar("StampHunt_Mask"),1) == false) then
         player:startEvent(0x0055);
     else
         player:startEvent(0x0037);
     end
-	
+
 end;
 
 -- 0x7fb5  0x0037  0x0055  0x00b0  0x00b4  0x00b6  0x024f  0x0251
@@ -50,8 +44,8 @@ end;
 -----------------------------------
 
 function onEventUpdate(player,csid,option)
---printf("CSID: %u",csid);
---printf("RESULT: %u",option);
+    -- printf("CSID: %u",csid);
+    -- printf("RESULT: %u",option);
 end;
 
 -----------------------------------
@@ -59,11 +53,13 @@ end;
 -----------------------------------
 
 function onEventFinish(player,csid,option)
---printf("CSID: %u",csid);
---printf("RESULT: %u",option);
-	
-	if(csid == 0x00b6) then
-		finishMissionTimeline(player,1,csid,option);
-	end
-	
+    -- printf("CSID: %u",csid);
+    -- printf("RESULT: %u",option);
+
+    if (csid == 0x00b6) then
+        finishMissionTimeline(player,1,csid,option);
+    elseif (csid == 0x0055) then
+        player:setMaskBit(player:getVar("StampHunt_Mask"),"StampHunt_Mask",1,true);
+    end
+
 end;

--- a/scripts/zones/Metalworks/npcs/Elayne.lua
+++ b/scripts/zones/Metalworks/npcs/Elayne.lua
@@ -21,16 +21,9 @@ end;
 -----------------------------------
 
 function onTrigger(player,npc)
-	function testflag(set,flag)
-		return (set % (2*flag) >= flag)
-	end
+    local StampHunt = player:getQuestStatus(BASTOK,STAMP_HUNT);
 
-    StampHunt = player:getQuestStatus(BASTOK,STAMP_HUNT);
-    stampCount = player:getVar("StampHunt_Event");
-	checkStamp = testflag(tonumber(stampCount),0x10);
-
-    if (StampHunt == 1 and checkStamp == false) then
-        player:setVar("StampHunt_Event",stampCount+0x10);
+    if (StampHunt == QUEST_ACCEPTED and player:getMaskBit(player:getVar("StampHunt_Mask"),3) == false) then
         player:startEvent(0x02d5);
     else
         player:startEvent(0x02c0);
@@ -42,8 +35,8 @@ end;
 -----------------------------------
 
 function onEventUpdate(player,csid,option)
---printf("CSID: %u",csid);
---printf("RESULT: %u",option);
+    -- printf("CSID: %u",csid);
+    -- printf("RESULT: %u",option);
 end;
 
 -----------------------------------
@@ -51,10 +44,11 @@ end;
 -----------------------------------
 
 function onEventFinish(player,csid,option)
---printf("CSID: %u",csid);
---printf("RESULT: %u",option);
+    -- printf("CSID: %u",csid);
+    -- printf("RESULT: %u",option);
+
+    if (csid == 0x02d5) then
+        player:setMaskBit(player:getVar("StampHunt_Mask"),"StampHunt_Mask",3,true);
+    end
+
 end;
-
-
-
-

--- a/scripts/zones/Metalworks/npcs/Romualdo.lua
+++ b/scripts/zones/Metalworks/npcs/Romualdo.lua
@@ -21,16 +21,9 @@ end;
 -----------------------------------
 
 function onTrigger(player,npc)
-	function testflag(set,flag)
-		return (set % (2*flag) >= flag)
-	end
+    local StampHunt = player:getQuestStatus(BASTOK,STAMP_HUNT);
 
-	local StampHunt = player:getQuestStatus(BASTOK,STAMP_HUNT);
-	local stampCount = player:getVar("StampHunt_Event");
-	local checkStamp = testflag(tonumber(stampCount),0x8);
-
-    if (StampHunt == 1 and checkStamp == false) then
-        player:setVar("StampHunt_Event",stampCount+0x8);
+    if (StampHunt == QUEST_ACCEPTED and player:getMaskBit(player:getVar("StampHunt_Mask"),4) == false) then
         player:startEvent(0x02d6);
     else
         player:startEvent(0x02c1);
@@ -42,8 +35,8 @@ end;
 -----------------------------------
 
 function onEventUpdate(player,csid,option)
---printf("CSID: %u",csid);
---printf("RESULT: %u",option);
+    -- printf("CSID: %u",csid);
+    -- printf("RESULT: %u",option);
 end;
 
 -----------------------------------
@@ -51,10 +44,11 @@ end;
 -----------------------------------
 
 function onEventFinish(player,csid,option)
---printf("CSID: %u",csid);
---printf("RESULT: %u",option);
+    -- printf("CSID: %u",csid);
+    -- printf("RESULT: %u",option);
+
+    if (csid == 0x02d6) then
+        player:setMaskBit(player:getVar("StampHunt_Mask"),"StampHunt_Mask",4,true);
+    end
+
 end;
-
-
-
-

--- a/scripts/zones/Port_Bastok/npcs/Ehrhard.lua
+++ b/scripts/zones/Port_Bastok/npcs/Ehrhard.lua
@@ -21,16 +21,9 @@ end;
 -----------------------------------
 
 function onTrigger(player,npc)
-	function testflag(set,flag)
-		return (set % (2*flag) >= flag)
-	end
+    local StampHunt = player:getQuestStatus(BASTOK,STAMP_HUNT);
 
-    StampHunt = player:getQuestStatus(BASTOK,STAMP_HUNT);
-    stampCount = player:getVar("StampHunt_Event");
-	checkStamp = testflag(tonumber(stampCount),0x20);
-
-    if(StampHunt == 1 and checkStamp == false) then
-        player:setVar("StampHunt_Event",stampCount+0x20);
+    if (StampHunt == QUEST_ACCEPTED and player:getMaskBit(player:getVar("StampHunt_Mask"),5) == false) then
         player:startEvent(0x0079);
     else
         player:startEvent(0x002f);
@@ -42,8 +35,8 @@ end;
 -----------------------------------
 
 function onEventUpdate(player,csid,option)
---printf("CSID: %u",csid);
---printf("RESULT: %u",option);
+    -- printf("CSID: %u",csid);
+    -- printf("RESULT: %u",option);
 end;
 
 -----------------------------------
@@ -51,6 +44,11 @@ end;
 -----------------------------------
 
 function onEventFinish(player,csid,option)
---printf("CSID: %u",csid);
---printf("RESULT: %u",option);
+    -- printf("CSID: %u",csid);
+    -- printf("RESULT: %u",option);
+
+    if (csid == 0x0079) then
+        player:setMaskBit(player:getVar("StampHunt_Mask"),"StampHunt_Mask",5,true);
+    end
+
 end;

--- a/scripts/zones/Port_Bastok/npcs/Latifah.lua
+++ b/scripts/zones/Port_Bastok/npcs/Latifah.lua
@@ -18,16 +18,9 @@ end;
 -----------------------------------
 
 function onTrigger(player,npc)
-	function testflag(set,flag)
-		return (set % (2*flag) >= flag)
-	end
+    local StampHunt = player:getQuestStatus(BASTOK,STAMP_HUNT);
 
-    StampHunt = player:getQuestStatus(BASTOK,STAMP_HUNT);
-    stampCount = player:getVar("StampHunt_Event");
-	checkStamp = testflag(tonumber(stampCount),0x40);
-
-    if(StampHunt == QUEST_ACCEPTED and checkStamp == false) then
-        player:setVar("StampHunt_Event",stampCount+0x40);
+    if (StampHunt == QUEST_ACCEPTED and player:getMaskBit(player:getVar("StampHunt_Mask"),6) == false) then
         player:startEvent(0x0078);
     else
         player:startEvent(0x000d);
@@ -39,8 +32,8 @@ end;
 -----------------------------------
 
 function onEventUpdate(player,csid,option)
---printf("CSID: %u",csid);
---printf("RESULT: %u",option);
+    -- printf("CSID: %u",csid);
+    -- printf("RESULT: %u",option);
 end;
 
 -----------------------------------
@@ -48,6 +41,11 @@ end;
 -----------------------------------
 
 function onEventFinish(player,csid,option)
---printf("CSID: %u",csid);
---printf("RESULT: %u",option);
+    -- printf("CSID: %u",csid);
+    -- printf("RESULT: %u",option);
+
+    if (csid == 0x0078) then
+        player:setMaskBit(player:getVar("StampHunt_Mask"),"StampHunt_Mask",6,true);
+    end
+
 end;


### PR DESCRIPTION
Sometimes it worked fine, but sometimes a character would hit all 7 NPC's get all 7 messages saying the "received a stamp!" and then the quest wouldn't finish. Now it works every time.

Was faster to rewrite the scripts than figure out exactly what went wrong. If setMaskBit was good enough for lure of the wildcat (80 NPCs, 20 per town), it is good enough for stamp hunt (7 NPCs).

Used a new variable instead of recycling the old one to store the mask to avoid any conflicts with whatever might be in the old var on existing players.

Players who were mid quest only need to recheck the NPCs and they'll be fine. Old var can be nuked from table.
