### PR TITLE
Savagery merits were not being used in warcry script. Also changed item ID check into a modifier. Editied item_mods.sql data is from http://wiki.bluegartr.com/bg/Warcry

### DIFF
--- a/scripts/globals/abilities/warcry.lua
+++ b/scripts/globals/abilities/warcry.lua
@@ -9,23 +9,23 @@ require("scripts/globals/status");
 -----------------------------------
 
 function OnAbilityCheck(player,target,ability)
-	return 0,0;
+    return 0,0;
 end;
 
 function OnUseAbility(player, target, ability)
-	local power = 0;
-	local duration = 30;
-	local sHead = player:getEquipID(SLOT_HEAD)
-	if(sHead == 15072 or sHead == 15245) then
-		duration = duration + 10;
-	elseif(sHead == 10650) then
-		duration = duration + 20;
-	end
-	if player:getMainJob() == 1 then
-		power = math.floor((player:getMainLvl()/4)+4.75)/256;
-	else
-		power = math.floor((player:getSubLvl()/4)+4.75)/256;
-	end
-	power = power * 100;
-	target:addStatusEffect(EFFECT_WARCRY,power,0,30);
+    local merit = target:getMerit(MERIT_SAVAGERY);
+    local power = 0;
+    local duration = 30;
+
+    if player:getMainJob() == 1 then
+        power = math.floor((player:getMainLvl()/4)+4.75)/256;
+    else
+        power = math.floor((player:getSubLvl()/4)+4.75)/256;
+    end
+
+    power = power * 100;
+    duration = duration + player:getStat(MOD_WARCRY_DURATION);
+
+
+    player:addStatusEffect(EFFECT_WARCRY,power,0,duration,0,merit);
 end;

--- a/scripts/globals/effects/warcry.lua
+++ b/scripts/globals/effects/warcry.lua
@@ -2,6 +2,10 @@
 --
 -- 	EFFECT_WARCRY
 --
+-- Notes:
+-- Savagery TP bonus not cut in half like ffxclopedia says.
+-- ffxiclopedia is wrong, bg wiki right. See link where testing was done.
+-- http://www.bluegartr.com/threads/108199-Random-Facts-Thread-Other?p=5367464&viewfull=1#post5367464
 -----------------------------------
 
 require("scripts/globals/settings");
@@ -12,7 +16,8 @@ require("scripts/globals/status");
 -----------------------------------
 
 function onEffectGain(target,effect)
-	target:addMod(MOD_ATTP,effect:getPower());
+    target:addMod(MOD_ATTP,effect:getPower());
+    target:addMod(MOD_TP_BONUS,effect:getSubPower());
 end;
 
 -----------------------------------
@@ -27,5 +32,6 @@ end;
 -----------------------------------
 
 function onEffectLose(target,effect)
-	target:delMod(MOD_ATTP,effect:getPower());
+    target:delMod(MOD_ATTP,effect:getPower());
+    target:delMod(MOD_TP_BONUS,effect:getSubPower());
 end;

--- a/scripts/globals/status.lua
+++ b/scripts/globals/status.lua
@@ -1024,6 +1024,9 @@ MOD_DARK_NULL                 =0x1DA -- (modId = 474)
 
 MOD_MAGIC_ABSORB              =0x1DB -- (modId = 475)
 MOD_MAGIC_NULL                =0x1DC -- (modId = 476)
+
+MOD_WARCRY_DURATION           =0x1E3 -- Warcy duration bonus from gear
+
 -----------------------------------
 -- Merit Definitions
 -----------------------------------

--- a/sql/item_mods.sql
+++ b/sql/item_mods.sql
@@ -37,6 +37,11 @@ CREATE TABLE IF NOT EXISTS `item_mods` (
 -- Contenu de la table `item_mods`
 --
 
+INSERT INTO `item_mods` VALUES(10650, 1, 36);
+INSERT INTO `item_mods` VALUES(10650, 8, 8);
+INSERT INTO `item_mods` VALUES(10650, 9, 8);
+INSERT INTO `item_mods` VALUES(10650, 110, 9);
+INSERT INTO `item_mods` VALUES(10650, 483, 20);
 INSERT INTO `item_mods` VALUES(11265, 1, 1);
 INSERT INTO `item_mods` VALUES(11266, 1, 1);
 INSERT INTO `item_mods` VALUES(11267, 1, 1);
@@ -9175,6 +9180,7 @@ INSERT INTO `item_mods` VALUES(15072, 1, 28);
 INSERT INTO `item_mods` VALUES(15072, 9, 5);
 INSERT INTO `item_mods` VALUES(15072, 27, 1);
 INSERT INTO `item_mods` VALUES(15072, 110, 5);
+INSERT INTO `item_mods` VALUES(15072, 483, 10);
 INSERT INTO `item_mods` VALUES(15073, 1, 23);
 INSERT INTO `item_mods` VALUES(15073, 3, 5);
 INSERT INTO `item_mods` VALUES(15073, 8, 5);
@@ -9898,6 +9904,7 @@ INSERT INTO `item_mods` VALUES(15245, 1, 29);
 INSERT INTO `item_mods` VALUES(15245, 9, 6);
 INSERT INTO `item_mods` VALUES(15245, 27, 1);
 INSERT INTO `item_mods` VALUES(15245, 110, 7);
+INSERT INTO `item_mods` VALUES(15245, 483, 10);
 INSERT INTO `item_mods` VALUES(15246, 1, 24);
 INSERT INTO `item_mods` VALUES(15246, 3, 5);
 INSERT INTO `item_mods` VALUES(15246, 8, 6);

--- a/src/map/modifier.h
+++ b/src/map/modifier.h
@@ -283,6 +283,7 @@ enum MODIFIER
 
 	// Warrior
 	MOD_DOUBLE_ATTACK             =0x120,// Percent chance to proc (modId = 288)
+    MOD_WARCRY_DURATION           =0x1E3,// Warcy duration bonus from gear
 
 	// Monk
 	MOD_SUBTLE_BLOW               =0x121,// How much TP to reduce. (modId = 289)
@@ -527,7 +528,6 @@ enum MODIFIER
     MOD_MAGIC_ABSORB              =0x1DB,// (modId = 475)
     MOD_MAGIC_NULL                =0x1DC,// (modId = 476)
 
-	// MOD_SPARE	=0x1E3,// (modId = 483)
 	// MOD_SPARE	=0x1E4,// (modId = 484)
 	// MOD_SPARE	=0x1E5,// (modId = 485)
 	// MOD_SPARE	=0x1E6,// (modId = 486)
@@ -540,7 +540,7 @@ enum MODIFIER
 	MOD_EAT_RAW_MEAT			  =0x19A, // not implemented (modId = 410)
 };
 
-#define MAX_MODIFIER	       483
+#define MAX_MODIFIER	       484
 
 
 


### PR DESCRIPTION
Did I do this right?

And no idea why the diff insists a crapton of identical lines for subeffects are "changed" when I never touched'em. Didn't even mess with whitespace.
