### PR TITLE
Fix the SQL for the Palborough Mines Elevator (Fixes Bug 952)

### DIFF
--- a/sql/elevators.sql
+++ b/sql/elevators.sql
@@ -54,7 +54,7 @@ INSERT INTO `elevators` VALUES ('18', 'Pso\'Xja_Dspprng_Tls_4', '16814514', '0',
 INSERT INTO `elevators` VALUES ('19', 'Pso\'Xja_Dspprng_Tls_1', '16814515', '0', '0', '1', '1');
 INSERT INTO `elevators` VALUES ('20', 'Pso\'Xja_Dspprng_Tls_2', '16814516', '0', '0', '1', '1');
 INSERT INTO `elevators` VALUES ('21', 'Fort_Ghelsba_Elvtr', '17354988', '17354990', '17354989', '0', '0');
-INSERT INTO `elevators` VALUES ('22', 'Palborough_Mines_Elvtr', '17363339', '17363333', '17363332', '0', '0');
+INSERT INTO `elevators` VALUES ('22', 'Palborough_Mines_Elvtr', '17363340', '17363334', '17363333', '0', '0');
 INSERT INTO `elevators` VALUES ('23', 'Davoi_Elvtr', '17387993', '17387996', '17387994', '0', '0');
 INSERT INTO `elevators` VALUES ('24', 'Kuftal_Tunnel_Dspprng_Rck', '17490275', '0', '0', '1', '1');
 INSERT INTO `elevators` VALUES ('25', 'Port_Bastok_Drwbrdg', '17743962', '17743963', '17743964', '1', '1');


### PR DESCRIPTION
Fixes long standing bug 952, which is a mission blocker:
http://bugs.dspt.info/show_bug.cgi?id=952

After much debugging, I was pretty sure it was trying to move the wrong NPC, but I didn't know how to fix that.

Apparently that was indeed the issue, and special thanks to forgottenandlost from the forums for responding to my debugging topic in the bugs section and showing me how to adjust the SQL.
