### PR TITLE
Scripts: Add Regen IV Script

### DIFF
--- a/scripts/globals/spells/regen_iv.lua
+++ b/scripts/globals/spells/regen_iv.lua
@@ -1,0 +1,48 @@
+-----------------------------------------
+-- Spell: Regen IV
+-- Gradually restores target's HP.
+-----------------------------------------
+-- Cleric's Briault enhances the effect
+-- Scale down duration based on level
+-- Composure increases duration 3x
+-----------------------------------------
+
+require("scripts/globals/status");
+require("scripts/globals/magic");
+
+-----------------------------------------
+-- OnSpellCast
+-----------------------------------------
+
+function OnMagicCastingCheck(caster,target,spell)
+	return 0;
+end;
+
+function onSpellCast(caster,target,spell)
+
+	local hp = 30;
+	local meritBonus = caster:getMerit(MERIT_REGEN_EFFECT);
+
+	--printf("Regen IV: Merit Bonus = Extra +%d", meritBonus);	
+
+	local body = caster:getEquipID(SLOT_BODY);
+	if (body == 15089 or body == 14502) then
+		hp = hp+4;
+	end
+
+	hp = hp + caster:getMod(MOD_REGEN_EFFECT) + meritBonus;
+
+	local duration = 60;
+
+	duration = duration + caster:getMod(MOD_REGEN_DURATION);
+
+	duration = calculateDurationForLvl(duration, 86, target:getMainLvl());
+
+	if(target:addStatusEffect(EFFECT_REGEN,hp,3,duration)) then
+		spell:setMsg(230);
+	else
+		spell:setMsg(75); -- no effect
+	end
+
+	return EFFECT_REGEN;
+end;


### PR DESCRIPTION
Spell was already learnable and you could cast it, but it didn't do anything since it didn't have a script, so I added the script for it.

Modeled after the other regen scripts. Wiki says the base heal is 30 for this one and the cleric's briault bonus is +4

http://wiki.ffxiclopedia.org/wiki/Regen_IV
