### PR TITLE
Fix text IDs for the various San'dOria zones (Fixes Bug 1309)

### DIFF
--- a/scripts/zones/Chateau_dOraguille/TextIDs.lua
+++ b/scripts/zones/Chateau_dOraguille/TextIDs.lua
@@ -8,7 +8,7 @@
               KEYITEM_LOST = 6583; -- Lost key item: << >>.
 
 -- Other Dialog
-TOMBSTONE = 7130; -- Here lies the beloved Queen Leaute. May Her Majesty's soul find Paradise.
+TOMBSTONE = 7132; -- Here lies the beloved Queen Leaute. May Her Majesty's soul find Paradise.
 
 -- Mission dialog
-HALVER_OFFSET = 6751; -- The princess is always speaking of your deeds for the Kingdom. Everyone here is counting on you, <<<Player Name>>>.
+HALVER_OFFSET = 6753; -- The princess is always speaking of your deeds for the Kingdom. Everyone here is counting on you, <<<Player Name>>>.

--- a/scripts/zones/Northern_San_dOria/TextIDs.lua
+++ b/scripts/zones/Northern_San_dOria/TextIDs.lua
@@ -9,102 +9,102 @@
              HOMEPOINT_SET =   188;  -- Home point set!
              IMAGE_SUPPORT =  6883;  -- Your ≺Multiple Choice (Parameter 1)≻[fishing/woodworking/smithing/goldsmithing/clothcraft/leatherworking/bonecraft/alchemy/cooking] skills went up ...
     FISHING_MESSAGE_OFFSET =  7343;  -- You can't fish here.
-             MOGHOUSE_EXIT = 12268;  -- You have learned your way through the back alleys of San d'Oria! Now you can exit to any area from your residence.
+             MOGHOUSE_EXIT = 12270;  -- You have learned your way through the back alleys of San d'Oria! Now you can exit to any area from your residence.
 
 -- Conquest System
-CONQUEST = 11622; -- You've earned conquest points!
+CONQUEST = 11624; -- You've earned conquest points!
       
 -- Mission Dialogs
 ORIGINAL_MISSION_OFFSET = 16; -- Bring me one of those axes, and your mission will be a success. No running away now; we've a proud country to defend!
  YOU_ACCEPT_THE_MISSION = 5;  -- You accept the mission.
 
 -- Quest Dialog
-   OLBERGIEUT_DIALOG = 11187; -- Friar Faurbellant is on retreat at the Crag of Holla. Please give 
-       FLYER_REFUSED = 11435; -- Your flyer is refused.
-      FLYER_ACCEPTED = 11974; -- Your flyer is accepted!
-       FLYER_ALREADY = 11975; -- This person already has a flyer.
-      SHIVA_UNLOCKED = 12713; -- You are now able to summon <<<Multiple Choice (Parameter 2)>>>
+   OLBERGIEUT_DIALOG = 11189; -- Friar Faurbellant is on retreat at the Crag of Holla. Please give 
+       FLYER_REFUSED = 11437; -- Your flyer is refused.
+      FLYER_ACCEPTED = 11976; -- Your flyer is accepted!
+       FLYER_ALREADY = 11977; -- This person already has a flyer.
+      SHIVA_UNLOCKED = 12715; -- You are now able to summon <<<Multiple Choice (Parameter 2)>>>
 
 -- Other Dialog
- GUILBERDRIER_DIALOG = 11063; -- A magic shop, you say? A bit of magic would come in handy... I know! I'll have my daughter study it for me!
-    ABIOLEGET_DIALOG = 11139; -- All of Altana's children are welcome here.
-     PELLIMIE_DIALOG = 11140; -- Is this your first time here? Join us in prayer!
-   FITTESEGAT_DIALOG = 11141; -- Paradise is a place without fear, without death!
-      MAURINE_DIALOG = 11142; -- Papsque Shamonde sometimes addresses the city from the balcony, you know. I long for his blessing, if but once!
-     PRERIVON_DIALOG = 11143; -- With each sermon, I take another step closer to Paradise.
-      MALFINE_DIALOG = 11144; -- Truly fortunate are we that words of sacrament are read every day!
-     COULLENE_DIALOG = 11145; -- Goddess above, deliver us to Paradise!
+ GUILBERDRIER_DIALOG = 11065; -- A magic shop, you say? A bit of magic would come in handy... I know! I'll have my daughter study it for me!
+    ABIOLEGET_DIALOG = 11141; -- All of Altana's children are welcome here.
+     PELLIMIE_DIALOG = 11142; -- Is this your first time here? Join us in prayer!
+   FITTESEGAT_DIALOG = 11143; -- Paradise is a place without fear, without death!
+      MAURINE_DIALOG = 11144; -- Papsque Shamonde sometimes addresses the city from the balcony, you know. I long for his blessing, if but once!
+     PRERIVON_DIALOG = 11145; -- With each sermon, I take another step closer to Paradise.
+      MALFINE_DIALOG = 11146; -- Truly fortunate are we that words of sacrament are read every day!
+     COULLENE_DIALOG = 11147; -- Goddess above, deliver us to Paradise!
 
-     GUILERME_DIALOG = 11259; -- Behold Chateau d'Oraguille, the greatest fortress in the realm!
+     GUILERME_DIALOG = 11261; -- Behold Chateau d'Oraguille, the greatest fortress in the realm!
 
-     PHAVIANE_DIALOG = 11263; -- This is Victory Arch. Beyond lies Southern San d'Oria.
-     SOCHIENE_DIALOG = 11264; -- You stand before Victory Arch. Southern San d'Oria is on the other side.
-     PEPIGORT_DIALOG = 11265; -- This gate leads to Port San d'Oria.
-   RODAILLECE_DIALOG = 11266; -- This is Ranperre Gate. Fiends lurk in the lands beyond, so take caution!
+     PHAVIANE_DIALOG = 11265; -- This is Victory Arch. Beyond lies Southern San d'Oria.
+     SOCHIENE_DIALOG = 11266; -- You stand before Victory Arch. Southern San d'Oria is on the other side.
+     PEPIGORT_DIALOG = 11267; -- This gate leads to Port San d'Oria.
+   RODAILLECE_DIALOG = 11268; -- This is Ranperre Gate. Fiends lurk in the lands beyond, so take caution!
    
-      GALAHAD_DIALOG = 11279; -- Welcome to the Consulate of Jeuno. I am Galahad, Consul to San d'Oria.
-       ISHWAR_DIALOG = 11280; -- May I assist you?
-       ARIENH_DIALOG = 11281; -- If you have business with Consul Galahad, you'll find him inside.
-       EMILIA_DIALOG = 11282; -- Welcome to the Consulate of Jeuno.
+      GALAHAD_DIALOG = 11281; -- Welcome to the Consulate of Jeuno. I am Galahad, Consul to San d'Oria.
+       ISHWAR_DIALOG = 11282; -- May I assist you?
+       ARIENH_DIALOG = 11283; -- If you have business with Consul Galahad, you'll find him inside.
+       EMILIA_DIALOG = 11284; -- Welcome to the Consulate of Jeuno.
 	   
-       HELAKU_DIALOG = 11311; -- Leave this building, and you'll see a great fortress to the right. That's Chateau d'Oraguille. And be polite; San d'Orians can be quite touchy.
+       HELAKU_DIALOG = 11313; -- Leave this building, and you'll see a great fortress to the right. That's Chateau d'Oraguille. And be polite; San d'Orians can be quite touchy.
 
-     KASARORO_DIALOG = 11350; -- Step right outside, and you'll see a big castle on the left. That's Chateau d'Oraguille. They're a little touchy in there, so mind your manners!
+     KASARORO_DIALOG = 11352; -- Step right outside, and you'll see a big castle on the left. That's Chateau d'Oraguille. They're a little touchy in there, so mind your manners!
 
-     MAURINNE_DIALOG = 11387; -- This part of town is so lively, I like watching everybody just go about their business.
+     MAURINNE_DIALOG = 11389; -- This part of town is so lively, I like watching everybody just go about their business.
 
-     AIVEDOIR_DIALOG = 11421; -- That's funny. I could have sworn she asked me to meet her here...
-      CAPIRIA_DIALOG = 11422; -- He's late! I do hope he hasn't forgotten.
-    BERTENONT_DIALOG = 11423; -- Stars are more beautiful up close. Don't you agree?
+     AIVEDOIR_DIALOG = 11423; -- That's funny. I could have sworn she asked me to meet her here...
+      CAPIRIA_DIALOG = 11424; -- He's late! I do hope he hasn't forgotten.
+    BERTENONT_DIALOG = 11425; -- Stars are more beautiful up close. Don't you agree?
 
-     GILIPESE_DIALOG = 11444; -- Nothing to report!
+     GILIPESE_DIALOG = 11446; -- Nothing to report!
 
-      BONCORT_DIALOG = 11970; -- Hmm... With magic, I could get hold of materials a mite easier. I'll have to check this ^"omart^"c out.
-      CAPIRIA_DIALOG = 11971; -- A flyer? For me? Some reading material would be a welcome change of pace, indeed!
-      VILLION_DIALOG = 11972; -- Opening a shop of magic, without consulting me first? I must pay this Regine a visit!
-     COULLENE_DIALOG = 11973; -- Magic could be of use on my journey to Paradise. Thank you so much!
+      BONCORT_DIALOG = 11972; -- Hmm... With magic, I could get hold of materials a mite easier. I'll have to check this ^"omart^"c out.
+      CAPIRIA_DIALOG = 11973; -- A flyer? For me? Some reading material would be a welcome change of pace, indeed!
+      VILLION_DIALOG = 11974; -- Opening a shop of magic, without consulting me first? I must pay this Regine a visit!
+     COULLENE_DIALOG = 11975; -- Magic could be of use on my journey to Paradise. Thank you so much!
 
-    COULLENE_MESSAGE = 13276; -- Coullene looks over curiously for a moment.
-GUILBERDRIER_MESSAGE = 13277; -- Guilberdrier looks over curiously for a moment.
-     BONCORT_MESSAGE = 13278; -- Boncort looks over curiously for a moment.
-     CAPIRIA_MESSAGE = 13279; -- Capiria looks over curiously for a moment.
-     VILLION_MESSAGE = 13280; -- Villion looks over curiously for a moment.
+    COULLENE_MESSAGE = 13282; -- Coullene looks over curiously for a moment.
+GUILBERDRIER_MESSAGE = 13283; -- Guilberdrier looks over curiously for a moment.
+     BONCORT_MESSAGE = 13284; -- Boncort looks over curiously for a moment.
+     CAPIRIA_MESSAGE = 13285; -- Capiria looks over curiously for a moment.
+     VILLION_MESSAGE = 13286; -- Villion looks over curiously for a moment.
 
 -- Shop Texts
-   DOGGOMEHR_SHOP_DIALOG = 11457; -- Welcome to the Blacksmiths' Guild shop.
-    LUCRETIA_SHOP_DIALOG = 11458; -- Blacksmiths' Guild shop, at your service!
+   DOGGOMEHR_SHOP_DIALOG = 11459; -- Welcome to the Blacksmiths' Guild shop.
+    LUCRETIA_SHOP_DIALOG = 11460; -- Blacksmiths' Guild shop, at your service!
 
-  CAUZERISTE_SHOP_DIALOG = 11525; -- Welcome! San d'Oria Carpenters' Guild shop, at your service.
+  CAUZERISTE_SHOP_DIALOG = 11527; -- Welcome! San d'Oria Carpenters' Guild shop, at your service.
   
-    ANTONIAN_OPEN_DIALOG = 11540; -- Interested in goods from Aragoneu?
-     BONCORT_SHOP_DIALOG = 11541; -- Welcome to the Phoenix Perch!
- PIRVIDIAUCE_SHOP_DIALOG = 11542; -- Care to see what I have?
-  PALGUEVION_OPEN_DIALOG = 11543; -- I've got a shipment straight from Valdeaunia!
-     VICHUEL_OPEN_DIALOG = 11544; -- Fauregandi produce for sale!
-     ARLENNE_SHOP_DIALOG = 11545; -- Welcome to the Royal Armory!
-   TAVOURINE_SHOP_DIALOG = 11546; -- Looking for a weapon? We've got many in stock!
+    ANTONIAN_OPEN_DIALOG = 11542; -- Interested in goods from Aragoneu?
+     BONCORT_SHOP_DIALOG = 11543; -- Welcome to the Phoenix Perch!
+ PIRVIDIAUCE_SHOP_DIALOG = 11544; -- Care to see what I have?
+  PALGUEVION_OPEN_DIALOG = 11545; -- I've got a shipment straight from Valdeaunia!
+     VICHUEL_OPEN_DIALOG = 11546; -- Fauregandi produce for sale!
+     ARLENNE_SHOP_DIALOG = 11547; -- Welcome to the Royal Armory!
+   TAVOURINE_SHOP_DIALOG = 11548; -- Looking for a weapon? We've got many in stock!
    
-  ANTONIAN_CLOSED_DIALOG = 11550; -- The Kingdom's influence is waning in Aragoneu. I cannot import goods from that region, though I long to.
-PALGUEVION_CLOSED_DIALOG = 11551; -- Would that Valdeaunia came again under San d'Orian dominion, I could then import its goods!
-   VICHUEL_CLOSED_DIALOG = 11552; -- I'd make a killing selling Fauregandi produce here, but that region's not under San d'Orian control!
-  ATTARENA_CLOSED_DIALOG = 11553; -- Once all of Li'Telor is back under San d'Orian influence, I'll fill my stock with unique goods from there!
-EUGBALLION_CLOSED_DIALOG = 11554; -- I'd be making a fortune selling goods from Qufim Island...if it were only under San d'Orian control!
-  EUGBALLION_OPEN_DIALOG = 11555; -- Have a look at these goods imported direct from Qufim Island!
-    CHAUPIRE_SHOP_DIALOG = 11556; -- San d'Orian woodcraft is the finest in the land!
+  ANTONIAN_CLOSED_DIALOG = 11552; -- The Kingdom's influence is waning in Aragoneu. I cannot import goods from that region, though I long to.
+PALGUEVION_CLOSED_DIALOG = 11553; -- Would that Valdeaunia came again under San d'Orian dominion, I could then import its goods!
+   VICHUEL_CLOSED_DIALOG = 11554; -- I'd make a killing selling Fauregandi produce here, but that region's not under San d'Orian control!
+  ATTARENA_CLOSED_DIALOG = 11555; -- Once all of Li'Telor is back under San d'Orian influence, I'll fill my stock with unique goods from there!
+EUGBALLION_CLOSED_DIALOG = 11556; -- I'd be making a fortune selling goods from Qufim Island...if it were only under San d'Orian control!
+  EUGBALLION_OPEN_DIALOG = 11557; -- Have a look at these goods imported direct from Qufim Island!
+    CHAUPIRE_SHOP_DIALOG = 11558; -- San d'Orian woodcraft is the finest in the land!
 
-    GAUDYLOX_SHOP_DIALOG = 12528; -- You never see Goblinshhh from underworld? Me no bad. Me sell chipshhh. You buy. Use with shhhtone heart. You get lucky!
-MILLECHUCA_CLOSED_DIALOG = 12529; -- I've been trying to import goods from Vollbow, but it's so hard to get items from areas that aren't under San d'Orian control.
+    GAUDYLOX_SHOP_DIALOG = 12530; -- You never see Goblinshhh from underworld? Me no bad. Me sell chipshhh. You buy. Use with shhhtone heart. You get lucky!
+MILLECHUCA_CLOSED_DIALOG = 12531; -- I've been trying to import goods from Vollbow, but it's so hard to get items from areas that aren't under San d'Orian control.
 
-    ATTARENA_OPEN_DIALOG = 12614; -- Good day! Take a look at my selection from Li'Telor!
-  MILLECHUCA_OPEN_DIALOG = 12615; -- Specialty goods from Vollbow! Specialty goods from Vollbow!
+    ATTARENA_OPEN_DIALOG = 12616; -- Good day! Take a look at my selection from Li'Telor!
+  MILLECHUCA_OPEN_DIALOG = 12617; -- Specialty goods from Vollbow! Specialty goods from Vollbow!
   
-  ARACHAGNON_SHOP_DIALOG = 12817; -- Would you be interested in purchasing some adventurer-issue armor? Be careful when selecting, as we accept no refunds.
+  ARACHAGNON_SHOP_DIALOG = 12819; -- Would you be interested in purchasing some adventurer-issue armor? Be careful when selecting, as we accept no refunds.
 
-       JUSTI_SHOP_DIALOG = 11425; -- Hello!
+       JUSTI_SHOP_DIALOG = 13472; -- Hello!
 	   
 -- Harvest Festival
-      TRICK_OR_TREAT = 12960; -- Trick or treat...
-     THANK_YOU_TREAT = 12961; -- And now for your treat...
-      HERE_TAKE_THIS = 12962; -- Here, take this...
-    IF_YOU_WEAR_THIS = 12963; -- If you put this on and walk around, something...unexpected might happen...
-           THANK_YOU = 12964; -- Thank you...<<<Prompt>>>
+      TRICK_OR_TREAT = 12962; -- Trick or treat...
+     THANK_YOU_TREAT = 12963; -- And now for your treat...
+      HERE_TAKE_THIS = 12964; -- Here, take this...
+    IF_YOU_WEAR_THIS = 12965; -- If you put this on and walk around, something...unexpected might happen...
+           THANK_YOU = 12966; -- Thank you...<<<Prompt>>>

--- a/scripts/zones/Port_San_dOria/TextIDs.lua
+++ b/scripts/zones/Port_San_dOria/TextIDs.lua
@@ -9,53 +9,53 @@ FULL_INVENTORY_AFTER_TRADE =  6414; -- You cannot obtain the <<<Possible Special
               GIL_OBTAINED =  6416; -- Obtained <<<Numeric Parameter 0>>> gil.
           KEYITEM_OBTAINED =  6418; -- Obtained key item: <<<Unknown Parameter (Type: 80) 1>>><<<Possible Special Code: 01>>><<<Possible Special Code: 05>>>3<<<BAD CHAR: 8280>>><<<BAD CHAR: 80>>><<<BAD CHAR: 80>>>.
              HOMEPOINT_SET =  24; 	-- Home point set!
-    FISHING_MESSAGE_OFFSET =  7161; -- You can't fish here.
+    FISHING_MESSAGE_OFFSET =  7163; -- You can't fish here.
 
-      ITEM_DELIVERY_DIALOG =  7873; -- Now delivering parcels to rooms everywhere!
+      ITEM_DELIVERY_DIALOG =  7875; -- Now delivering parcels to rooms everywhere!
 
 -- Dialogs
-   FLYER_REFUSED =  7485; -- This person isn't interested.
-   FLYER_ALREADY =  7486; -- This person already has a flyer.
-  FLYER_ACCEPTED =  7487; -- Your flyer is accepted!
-   FLYERS_HANDED =  7488; -- You've handed out <<<Numeric Parameter 0>>> flyer(s).
+   FLYER_REFUSED =  7487; -- This person isn't interested.
+   FLYER_ALREADY =  7488; -- This person already has a flyer.
+  FLYER_ACCEPTED =  7489; -- Your flyer is accepted!
+   FLYERS_HANDED =  7490; -- You've handed out <<<Numeric Parameter 0>>> flyer(s).
 
- PORTAURE_DIALOG =  7750; -- What's this? A magic shop? Hmm...I could use a new line of work, and magic just might be the ticket!
+ PORTAURE_DIALOG =  7752; -- What's this? A magic shop? Hmm...I could use a new line of work, and magic just might be the ticket!
 
-  ANSWALD_DIALOG =  7770; -- A magic shop? Oh, it's right near here. I'll go check it out sometime.
+  ANSWALD_DIALOG =  7772; -- A magic shop? Oh, it's right near here. I'll go check it out sometime.
 
-  PRIETTA_DIALOG =  7794; -- This is the first I've heard of a magic shop here in San d'Oria. Such arts have never been popular in the Kingdom.
+  PRIETTA_DIALOG =  7796; -- This is the first I've heard of a magic shop here in San d'Oria. Such arts have never been popular in the Kingdom.
 
-   AUVARE_DIALOG =  7801; -- What have I got here? Look, I can't read, but I takes what I gets, and you ain't getting it back!
+   AUVARE_DIALOG =  7803; -- What have I got here? Look, I can't read, but I takes what I gets, and you ain't getting it back!
 
-    MIENE_DIALOG =  7854; -- Oh, a magic shop... Here in San d'Oria? I'd take a look if I got more allowance.
+    MIENE_DIALOG =  7856; -- Oh, a magic shop... Here in San d'Oria? I'd take a look if I got more allowance.
 
- ANSWALD_MESSAGE =  8347; -- Answald looks over curiously for a moment.
- PRIETTA_MESSAGE =  8348; -- Prietta looks over curiously for a moment.
-   MIENE_MESSAGE =  8349; -- Miene looks over curiously for a moment.
-PORTAURE_MESSAGE =  8350; -- Portaure looks over curiously for a moment.
-  AUVARE_MESSAGE =  8351; -- Auvare looks over curiously for a moment.
+ ANSWALD_MESSAGE =  8349; -- Answald looks over curiously for a moment.
+ PRIETTA_MESSAGE =  8350; -- Prietta looks over curiously for a moment.
+   MIENE_MESSAGE =  8351; -- Miene looks over curiously for a moment.
+PORTAURE_MESSAGE =  8352; -- Portaure looks over curiously for a moment.
+  AUVARE_MESSAGE =  8353; -- Auvare looks over curiously for a moment.
 
 -- Shop Texts
-           ALBINIE_SHOP_DIALOG = 7814; -- Welcome to my simple shop.
+           ALBINIE_SHOP_DIALOG = 7816; -- Welcome to my simple shop.
 
-          COULLAVE_SHOP_DIALOG = 7860; -- Can I help you?
-        CROUMANGUE_SHOP_DIALOG = 7861; -- Can't fight on an empty stomach. How about some nourishment?
+          COULLAVE_SHOP_DIALOG = 7862; -- Can I help you?
+        CROUMANGUE_SHOP_DIALOG = 7863; -- Can't fight on an empty stomach. How about some nourishment?
 
-          VENDAVOQ_OPEN_DIALOG = 7868; -- Vandoolin! Vendavoq vring voods vack vrom Vovalpolos! Vuy! Vuy!
-        VENDAVOQ_CLOSED_DIALOG = 7869; -- Vandoolin... Vendavoq's vream vo vell voods vrom vometown vf Vovalpolos...
+          VENDAVOQ_OPEN_DIALOG = 7870; -- Vandoolin! Vendavoq vring voods vack vrom Vovalpolos! Vuy! Vuy!
+        VENDAVOQ_CLOSED_DIALOG = 7871; -- Vandoolin... Vendavoq's vream vo vell voods vrom vometown vf Vovalpolos...
 
-              FIVA_OPEN_DIALOG = 7862; -- I've got imports from Kolshushu!
-             MILVA_OPEN_DIALOG = 7863; -- How about some produce from Sarutabaruta?
-            FIVA_CLOSED_DIALOG = 7864; -- I'm trying to sell goods from Kolshushu. But I can't because we don't have enough influence there.
-           MILVA_CLOSED_DIALOG = 7865; -- I want to import produce from Sarutabaruta... But I can't do anything until we control that region!
-           NIMIA_CLOSED_DIALOG = 7866; -- I can't sell goods from the lowlands of Elshimo because it's under foreign control.
-         PATOLLE_CLOSED_DIALOG = 7867; -- I'm trying to find goods from Kuzotz. But how can I when it's under foreign control?
+              FIVA_OPEN_DIALOG = 7864; -- I've got imports from Kolshushu!
+             MILVA_OPEN_DIALOG = 7865; -- How about some produce from Sarutabaruta?
+            FIVA_CLOSED_DIALOG = 7866; -- I'm trying to sell goods from Kolshushu. But I can't because we don't have enough influence there.
+           MILVA_CLOSED_DIALOG = 7867; -- I want to import produce from Sarutabaruta... But I can't do anything until we control that region!
+           NIMIA_CLOSED_DIALOG = 7868; -- I can't sell goods from the lowlands of Elshimo because it's under foreign control.
+         PATOLLE_CLOSED_DIALOG = 7869; -- I'm trying to find goods from Kuzotz. But how can I when it's under foreign control?
 
-      DEGUERENDARS_OPEN_DIALOG = 7870; -- Welcome! Have a look at these rare goods from Tavnazia!
-    DEGUERENDARS_CLOSED_DIALOG = 7871; -- With that other nation in control of the region, there is no way for me to import goods from Tavnazia...
-DEGUERENDARS_COP_NOT_COMPLETED = 7872; -- Why must I wait for the Kingdom to issue a permit allowing me to set up shop? How am I to feed my children in the meantime!?
+      DEGUERENDARS_OPEN_DIALOG = 7872; -- Welcome! Have a look at these rare goods from Tavnazia!
+    DEGUERENDARS_CLOSED_DIALOG = 7873; -- With that other nation in control of the region, there is no way for me to import goods from Tavnazia...
+DEGUERENDARS_COP_NOT_COMPLETED = 7874; -- Why must I wait for the Kingdom to issue a permit allowing me to set up shop? How am I to feed my children in the meantime!?
 
-     BONMAURIEUT_CLOSED_DIALOG = 8207; -- I would like to sell goods from the Elshimo Uplands, but I cannot, as it's under foreign control.
-             NIMIA_OPEN_DIALOG = 8208; -- Hello, friend! Can I interest you in specialty goods from the Elshimo Lowlands?
-           PATOLLE_OPEN_DIALOG = 8209; -- How about some specialty goods from Kuzotz?
-       BONMAURIEUT_OPEN_DIALOG = 8210; -- My shipment is in! Would you like to see what has just arrived from the Elshimo Uplands?
+     BONMAURIEUT_CLOSED_DIALOG = 8209; -- I would like to sell goods from the Elshimo Uplands, but I cannot, as it's under foreign control.
+             NIMIA_OPEN_DIALOG = 8210; -- Hello, friend! Can I interest you in specialty goods from the Elshimo Lowlands?
+           PATOLLE_OPEN_DIALOG = 8211; -- How about some specialty goods from Kuzotz?
+       BONMAURIEUT_OPEN_DIALOG = 8212; -- My shipment is in! Would you like to see what has just arrived from the Elshimo Uplands?

--- a/scripts/zones/Southern_San_dOria/TextIDs.lua
+++ b/scripts/zones/Southern_San_dOria/TextIDs.lua
@@ -12,80 +12,80 @@ FULL_INVENTORY_AFTER_TRADE = 6414; -- Try trading again after sorting your inven
            LEATHER_SUPPORT = 6705; -- Your ≺Multiple Choice (Parameter 1)≻[fishing/woodworking/smithing/goldsmithing/clothcraft/leatherworking/bonecraft/alchemy/cooking] skills went up ...
 
 -- Conquest System
-CONQUEST =  8405; -- You've earned conquest points!
+CONQUEST =  8411; -- You've earned conquest points!
 
 -- Mission Dialogs
- YOU_ACCEPT_THE_MISSION = 7122; -- You accept the mission.
-ORIGINAL_MISSION_OFFSET = 7133; -- Bring me one of those axes, and your mission will be a success. No running away now; we've a proud country to defend!
+ YOU_ACCEPT_THE_MISSION = 7124; -- You accept the mission.
+ORIGINAL_MISSION_OFFSET = 7135; -- Bring me one of those axes, and your mission will be a success. No running away now; we've a proud country to defend!
  
 -- Dynamis dialogs
-      YOU_CANNOT_ENTER_DYNAMIS = 7334; -- You cannot enter Dynamis - <<<Multiple Choice (Parameter 1)>>>
-PLAYERS_HAVE_NOT_REACHED_LEVEL = 7336; -- Players who have not reached level <<<Numeric Parameter 0>>> are prohibited from entering Dynamis.
-  UNUSUAL_ARRANGEMENT_BRANCHES = 7347; -- There is an unusual arrangement of branches here.
+      YOU_CANNOT_ENTER_DYNAMIS = 7341; -- You cannot enter Dynamis - <<<Multiple Choice (Parameter 1)>>>
+PLAYERS_HAVE_NOT_REACHED_LEVEL = 7343; -- Players who have not reached level <<<Numeric Parameter 0>>> are prohibited from entering Dynamis.
+  UNUSUAL_ARRANGEMENT_BRANCHES = 7353; -- There is an unusual arrangement of branches here.
 
 -- Quest Dialogs
-      UNLOCK_PALADIN = 7930; -- You can now become a paladin!
-       FLYER_REFUSED = 8101; -- Your flyer is refused.
-      FLYER_ACCEPTED = 8750; -- The flyer is accepted.
-       FLYER_ALREADY = 8751; -- This person already has a flyer.
+      UNLOCK_PALADIN = 7936; -- You can now become a paladin!
+       FLYER_REFUSED = 8107; -- Your flyer is refused.
+      FLYER_ACCEPTED = 8756; -- The flyer is accepted.
+       FLYER_ALREADY = 8757; -- This person already has a flyer.
 
 -- Harvest Festival
-      TRICK_OR_TREAT = 7281; -- Trick or treat...
-     THANK_YOU_TREAT = 7282; -- And now for your treat...
-      HERE_TAKE_THIS = 7283; -- Here, take this...
-    IF_YOU_WEAR_THIS = 7284; -- If you put this on and walk around, something...unexpected might happen...
-           THANK_YOU = 7285; -- Thank you...<<<Prompt>>>
+      TRICK_OR_TREAT = 7283; -- Trick or treat...
+     THANK_YOU_TREAT = 7284; -- And now for your treat...
+      HERE_TAKE_THIS = 7285; -- Here, take this...
+    IF_YOU_WEAR_THIS = 7286; -- If you put this on and walk around, something...unexpected might happen...
+           THANK_YOU = 7287; -- Thank you...<<<Prompt>>>
 		   
 -- Other dialog
-ITEM_DELIVERY_DIALOG = 8330; -- Parcels delivered to rooms anywhere in Vana'diel!
-        ROSEL_DIALOG = 7707; -- Hrmm... Now, this is interesting! It pays to keep an eye on the competition. Thanks for letting me know!
+ITEM_DELIVERY_DIALOG = 8336; -- Parcels delivered to rooms anywhere in Vana'diel!
+        ROSEL_DIALOG = 7713; -- Hrmm... Now, this is interesting! It pays to keep an eye on the competition. Thanks for letting me know!
 
-     BLENDARE_DIALOG = 8014; -- Wait! If I had magic, maybe I could keep my brother's hands off my sweets...
+     BLENDARE_DIALOG = 8020; -- Wait! If I had magic, maybe I could keep my brother's hands off my sweets...
 
-    BLENDARE_MESSAGE = 8752; -- Blendare looks over curiously for a moment.
-       ROSEL_MESSAGE = 8753; -- Rosel looks over curiously for a moment.
-       MAUGIE_DIALOG = 8754; -- A magic shop, eh? Hmm... A little magic could go a long way for making a leisurely retirement! Ho ho ho!
-      MAUGIE_MESSAGE = 8755; -- Maugie looks over curiously for a moment.
-      ADAUNEL_DIALOG = 8756; -- A magic shop? Maybe I'll check it out one of these days. Could help with my work, even...
-     ADAUNEL_MESSAGE = 8757; -- Adaunel looks over curiously for a moment.
-     LEUVERET_DIALOG = 8758; -- A magic shop? That'd be a fine place to peddle my wares. I smell a profit! I'll be up to my gills in gil, I will!
-    LEUVERET_MESSAGE = 8759; -- Leuveret looks over curiously for a moment.
+    BLENDARE_MESSAGE = 8758; -- Blendare looks over curiously for a moment.
+       ROSEL_MESSAGE = 8759; -- Rosel looks over curiously for a moment.
+       MAUGIE_DIALOG = 8760; -- A magic shop, eh? Hmm... A little magic could go a long way for making a leisurely retirement! Ho ho ho!
+      MAUGIE_MESSAGE = 8761; -- Maugie looks over curiously for a moment.
+      ADAUNEL_DIALOG = 8762; -- A magic shop? Maybe I'll check it out one of these days. Could help with my work, even...
+     ADAUNEL_MESSAGE = 8763; -- Adaunel looks over curiously for a moment.
+     LEUVERET_DIALOG = 8764; -- A magic shop? That'd be a fine place to peddle my wares. I smell a profit! I'll be up to my gills in gil, I will!
+    LEUVERET_MESSAGE = 8765; -- Leuveret looks over curiously for a moment.
 
-     PAUNELIE_DIALOG = 8230; -- I'm sorry, can I help you?
+     PAUNELIE_DIALOG = 8236; -- I'm sorry, can I help you?
 
 -- Shop Texts
-      LUSIANE_SHOP_DIALOG = 7881; -- Hello! Let Taumila's handle all your sundry needs!
-      OSTALIE_SHOP_DIALOG = 7882; -- Welcome, customer. Please have a look.
+      LUSIANE_SHOP_DIALOG = 7887; -- Hello! Let Taumila's handle all your sundry needs!
+      OSTALIE_SHOP_DIALOG = 7888; -- Welcome, customer. Please have a look.
 
-ASH_THADI_ENE_SHOP_DIALOG = 7903; -- Welcome to Helbort's Blades!
+ASH_THADI_ENE_SHOP_DIALOG = 7909; -- Welcome to Helbort's Blades!
 
-       SHILAH_SHOP_DIALOG = 8035; -- Welcome, weary traveler. Make yourself at home!
+       SHILAH_SHOP_DIALOG = 8041; -- Welcome, weary traveler. Make yourself at home!
 
-            CLETAE_DIALOG = 8121; -- Why, hello. All our skins are guild-approved.
-   KUEH_IGUNAHMORI_DIALOG = 8122; -- Good day! We have lots in stock today.
+            CLETAE_DIALOG = 8127; -- Why, hello. All our skins are guild-approved.
+   KUEH_IGUNAHMORI_DIALOG = 8128; -- Good day! We have lots in stock today.
 
-FERDOULEMIONT_SHOP_DIALOG = 8334; -- Hello!
-      AVELINE_SHOP_DIALOG = 8340; -- Welcome to Raimbroy's Grocery!
-      BENAIGE_SHOP_DIALOG = 8341; -- Looking for something in particular?
+FERDOULEMIONT_SHOP_DIALOG = 8340; -- Hello!
+      AVELINE_SHOP_DIALOG = 8346; -- Welcome to Raimbroy's Grocery!
+      BENAIGE_SHOP_DIALOG = 8347; -- Looking for something in particular?
 
-    MACHIELLE_OPEN_DIALOG = 8336; -- Might I interest you in produce from Norvallen?
-        CORUA_OPEN_DIALOG = 8337; -- Ronfaure produce for sale!
-    PHAMELISE_OPEN_DIALOG = 8338; -- I've got fresh produce from Zulkheim!
-   APAIREMANT_OPEN_DIALOG = 8339; -- Might you be interested in produce from Gustaberg
+    MACHIELLE_OPEN_DIALOG = 8342; -- Might I interest you in produce from Norvallen?
+        CORUA_OPEN_DIALOG = 8343; -- Ronfaure produce for sale!
+    PHAMELISE_OPEN_DIALOG = 8344; -- I've got fresh produce from Zulkheim!
+   APAIREMANT_OPEN_DIALOG = 8345; -- Might you be interested in produce from Gustaberg
 
-     PAUNELIE_SHOP_DIALOG = 8235; -- These magic shells are full of mysteries...
+     PAUNELIE_SHOP_DIALOG = 8241; -- These magic shells are full of mysteries...
 	 
-  MACHIELLE_CLOSED_DIALOG = 8343; -- We want to sell produce from Norvallen, but the entire region is under foreign control!
-      CORUA_CLOSED_DIALOG = 8344; -- We specialize in Ronfaure produce, but we cannot import from that region without a strong San d'Orian presence there.
-  PHAMELISE_CLOSED_DIALOG = 8345; -- I'd be making a killing selling produce from Zulkheim, but the region's under foreign control!
- APAIREMANT_CLOSED_DIALOG = 8346; -- I'd love to import produce from Gustaberg, but the foreign powers in control there make me feel unsafe!
-     POURETTE_OPEN_DIALOG = 8347; -- Derfland produce for sale!
-   POURETTE_CLOSED_DIALOG = 8348; -- Listen, adventurer... I can't import from Derfland until the region knows San d'Orian power!
+  MACHIELLE_CLOSED_DIALOG = 8349; -- We want to sell produce from Norvallen, but the entire region is under foreign control!
+      CORUA_CLOSED_DIALOG = 8350; -- We specialize in Ronfaure produce, but we cannot import from that region without a strong San d'Orian presence there.
+  PHAMELISE_CLOSED_DIALOG = 8351; -- I'd be making a killing selling produce from Zulkheim, but the region's under foreign control!
+ APAIREMANT_CLOSED_DIALOG = 8352; -- I'd love to import produce from Gustaberg, but the foreign powers in control there make me feel unsafe!
+     POURETTE_OPEN_DIALOG = 8353; -- Derfland produce for sale!
+   POURETTE_CLOSED_DIALOG = 8354; -- Listen, adventurer... I can't import from Derfland until the region knows San d'Orian power!
 
-     MIOGIQUE_SHOP_DIALOG = 8341; -- Looking for something in particular?   
-     CARAUTIA_SHOP_DIALOG = 8342; -- Well, what sort of armor would you like?
-    VALERIANO_SHOP_DIALOG = 8053; -- Oh, a fellow outsider! We are Troupe Valeriano. I am Valeriano, at your service!
+     MIOGIQUE_SHOP_DIALOG = 8347; -- Looking for something in particular?   
+     CARAUTIA_SHOP_DIALOG = 8348; -- Well, what sort of armor would you like?
+    VALERIANO_SHOP_DIALOG = 8059; -- Oh, a fellow outsider! We are Troupe Valeriano. I am Valeriano, at your service!
 
-		RAMINEL_DELIVERY  = 8018; -- Here's your delivery!
-			LUSIANE_THANK = 8019; -- Thank you!<<<Prompt>>>
-	   RAMINEL_DELIVERIES = 8020; -- Sorry, I have deliveries to make!
+		RAMINEL_DELIVERY  = 8024; -- Here's your delivery!
+			LUSIANE_THANK = 8025; -- Thank you!<<<Prompt>>>
+	   RAMINEL_DELIVERIES = 8026; -- Sorry, I have deliveries to make!


### PR DESCRIPTION
These seemed to have shifted by 2 in a lot of places, mostly ids > 6000. Fixes various crashes and incorrect text, including crashes when accepting a mission and when receiving conquest points from turning in crystals for rank points

Fixes bug 1309: http://bugs.dspt.info/show_bug.cgi?id=1309

Thanks to @xdemolish for pointing in the right direction for troubleshooting this. This is now in line with client id 30140319_0
