### PR TITLE
Default in map.cpp didn't match default in conf, so people who didn't update their conf were getting uncapped CoP battles. 

### DIFF
--- a/src/map/map.cpp
+++ b/src/map/map.cpp
@@ -854,7 +854,7 @@ int32 map_config_default()
     map_config.max_time_lastupdate = 60000;
     map_config.newstyle_skillups = 7;
     map_config.Battle_cap_tweak = 0;
-    map_config.CoP_Battle_cap = 0;
+    map_config.CoP_Battle_cap = 1;
     map_config.max_merit_points = 30;
     map_config.audit_chat = 0;
     map_config.audit_say = 0;


### PR DESCRIPTION
Was going to leave it be till next time I had to edit the map settings, but multiple people have mentioned it so I made the quick 0 to 1 change for them. Default in conf was oldschool, but in map.cpp was retail.
