### PR TITLE
April Update: ZM6 - Fix Quicksands Caves Weight Door

### DIFF
--- a/scripts/zones/Quicksand_Caves/Zone.lua
+++ b/scripts/zones/Quicksand_Caves/Zone.lua
@@ -10,7 +10,7 @@ require("scripts/globals/settings");
 require("scripts/globals/keyitems");
 require("scripts/zones/Quicksand_Caves/TextIDs");
 
-base_id = 17629680;
+base_id = 17629681;
 
 -----------------------------------
 -- onInitialize


### PR DESCRIPTION
NPC ID in the Lua Script was off by one post update; this was preventing access to the Chamber of Oracles for ZM6
