### PR TITLE
SCRIPTS: Fix Spatial Displacements in Riverne Sites

### DIFF
--- a/scripts/zones/Riverne-Site_A01/npcs/Spatial_Displacement.lua
+++ b/scripts/zones/Riverne-Site_A01/npcs/Spatial_Displacement.lua
@@ -17,7 +17,7 @@ end;
 function onTrigger(player,npc)
 	
 	local id = npc:getID();
-	local base = 16900332; -- (First Spacial Displacement in NPC_LIST)
+	local base = 16900333; -- (First Spacial Displacement in NPC_LIST)
 
 	if(id == base) then 
 		player:startEvent(0x2);

--- a/scripts/zones/Riverne-Site_B01/npcs/Spatial_Displacement.lua
+++ b/scripts/zones/Riverne-Site_B01/npcs/Spatial_Displacement.lua
@@ -16,7 +16,7 @@ end;
 
 function onTrigger(player,npc)
 
-	local base = 16896181; -- First Spacial Displacement in NPC_LIST
+	local base = 16896182; -- First Spacial Displacement in NPC_LIST
 	local id = npc:getID();
 
 	if(id == base) then --  L-9 porter


### PR DESCRIPTION
The base id in these scripts was off by one since the updates, so they did not port you to the correct locations.
