### PR TITLE
SCRIPTS: Fix Server Crash When Using Runic Portal

### DIFF
--- a/scripts/globals/besieged.lua
+++ b/scripts/globals/besieged.lua
@@ -47,7 +47,7 @@ function hasAssaultOrders(player)
 	
 	if(player:hasKeyItem(LEUJAOAM_ASSAULT_ORDERS)) then -- assault @ Azouph Isle
 		event = 0x0078;
-	elseif(player:hasKeyItem(MAMMOOL_JA_ASSAULT_ORDERS)) then -- assault @ Mamool Ja 
+	elseif(player:hasKeyItem(MAMOOL_JA_ASSAULT_ORDERS)) then -- assault @ Mamool Ja 
 		event = 0x0079;
 	elseif(player:hasKeyItem(LEBROS_ASSAULT_ORDERS)) then -- assault @ Halvung	
 		event = 0x007A;


### PR DESCRIPTION
The constant for MAMOOL_JA_STAGING_POINT was spelled wrong in hasAssaultOrders(), making it an invalid variable.

This caused a crash for me when I clicked on the runic portal, since it checks that function.
