### PR TITLE
CORE: Add Flames for the Dead to the list of BCNMs that checks CoP_Battle_cap

### DIFF
--- a/src/map/instance.cpp
+++ b/src/map/instance.cpp
@@ -185,7 +185,7 @@ void CInstance::capPlayerToBCNM(){ //adjust player's level to the appropriate ca
 	{	// Other missions lines and things like dragoon quest battle can be done similarly to CoP_Battle_cap.
 		// Might be better to add a type flag to the sql to tell bcnm/isnm/which expantions mission than doing by bcnmID like this.
 		if((map_config.CoP_Battle_cap == 0) && (m_BcnmID == 768 || m_BcnmID == 800 || m_BcnmID == 832 || m_BcnmID == 960
-		|| m_BcnmID == 704 || m_BcnmID == 961 || m_BcnmID == 864 || m_BcnmID == 672 || m_BcnmID == 736 || m_BcnmID == 992))
+		|| m_BcnmID == 704 || m_BcnmID == 961 || m_BcnmID == 864 || m_BcnmID == 672 || m_BcnmID == 736 || m_BcnmID == 992 || m_BcnmID == 640))
 		{
 		cap = 99;
 		}


### PR DESCRIPTION
Since this BCNM (the Snoll Tzar BCNM) was not on the list players would get capped at 60 despite server setting
