### PR TITLE
SCRIPTS: Fix Pso'Xja Stone Doors

### DIFF
--- a/scripts/zones/PsoXja/mobs/Gargoyle.lua
+++ b/scripts/zones/PsoXja/mobs/Gargoyle.lua
@@ -21,7 +21,7 @@ function onMobDeath(mob, killer)
 	for i = 0, 16, 1 do
 	
 	local GargoyleOffset = 16814081 + (i-1);
-	local DoorOffset = 16814443 + (i-1);
+	local DoorOffset = 16814444 + (i-1);
 	
 		if(mob:getID() == GargoyleOffset) then
 			GetNPCByID(DoorOffset):openDoor(30);


### PR DESCRIPTION
NPC Id Offset was off by one. Fixes blocker on CoP: The Three Paths (Tenzen's Path)
