### PR TITLE
SCRIPTS: Fix Conquest Lua Script

### DIFF
--- a/scripts/globals/conquest.lua
+++ b/scripts/globals/conquest.lua
@@ -582,7 +582,7 @@ switch (region): caseof {
   ---------------------------------
 	--print("RONFAURE");
 
-	local Doladepaiton = 17187518;
+	local Doladepaiton = 17187519;
 	
 	npc  = {
 	--
@@ -613,7 +613,7 @@ switch (region): caseof {
   ---------------------------------
 	--print("ZULKHEIM");
 
-	local Quanteilleron = 17199699;
+	local Quanteilleron = 17199700;
 	
 	npc  = {
 	--
@@ -644,7 +644,7 @@ switch (region): caseof {
   ---------------------------------
 	--print("NORVALLEN");
 
-	local Chaplion = 17203838;
+	local Chaplion = 17203839;
 	
 	npc  = {
 	--
@@ -706,7 +706,7 @@ switch (region): caseof {
   ---------------------------------
 	--print("DERFLAND");
 
-	local Mesachedeau = 17224316;
+	local Mesachedeau = 17224317;
 	
 	npc  = {
 	--
@@ -737,7 +737,7 @@ switch (region): caseof {
   ---------------------------------
 	--print("SARUTABARUTA");
 
-	local Naguipeillont = 17248818; 
+	local Naguipeillont = 17248819; 
 	
 	npc  = {
 	--
@@ -768,7 +768,7 @@ switch (region): caseof {
   ---------------------------------
 	--print("KOLSHUSHU");
 
-	local Bonbavour = 17261140; 
+	local Bonbavour = 17261141; 
 	
 	npc  = {
 	--
@@ -799,7 +799,7 @@ switch (region): caseof {
   ---------------------------------
 	--print("ARAGONEU");
 
-	local Chegourt = 17265261;
+	local Chegourt = 17265262;
 	
 	npc  = {
 	--
@@ -830,7 +830,7 @@ switch (region): caseof {
   ---------------------------------
 	--print("FAUREGANDI");
 
-	local Parledaire = 17232199;	
+	local Parledaire = 17232200;	
 	
 	npc  = {
 	--
@@ -861,7 +861,7 @@ switch (region): caseof {
   ---------------------------------
 	--print("VALDEAUNIA");
 
-	local Jeantelas = 17236280;	
+	local Jeantelas = 17236281;	
 	
 	npc  = {
 	--
@@ -892,7 +892,7 @@ switch (region): caseof {
   ---------------------------------
 	--print("QUFIMISLAND");
 
-	local Pitoire = 17293704; 
+	local Pitoire = 17293705; 
 	
 	npc  = {
 	--
@@ -923,7 +923,7 @@ switch (region): caseof {
   ---------------------------------
 	--print("LITELOR");
 
-	local Credaurion = 17273359;	
+	local Credaurion = 17273360;	
 	
 	npc  = {
 	--
@@ -954,7 +954,7 @@ switch (region): caseof {
   ---------------------------------
 	--print("KUZOTZ");
 
-	local Eaulevisat = 17244621;
+	local Eaulevisat = 17244622;
 	
 	npc  = {
 	--
@@ -985,7 +985,7 @@ switch (region): caseof {
   ---------------------------------
 	--print("VOLLBOW");
 
-	local Salimardi = 17240464;
+	local Salimardi = 17240465;
 	
 	npc  = {
 	--
@@ -1016,7 +1016,7 @@ switch (region): caseof {
   ---------------------------------
 	--print("ELSHIMOLOWLANDS");
 
-	local Zorchorevi = 17281587; 
+	local Zorchorevi = 17281588; 
 	
 	npc  = {
 	--
@@ -1047,7 +1047,7 @@ switch (region): caseof {
   ---------------------------------
 	--print("ELSHIMOUPLANDS");
 
-	local Ilieumort = 17285642;
+	local Ilieumort = 17285643;
 	
 	npc  ={
 	--
@@ -1078,7 +1078,7 @@ switch (region): caseof {
   ---------------------------------
 	--print("TULIA");
 	
-	local RuAun_Banner = 17310074;
+	local RuAun_Banner = 17310075;
 
 	npc  = {
 	--
@@ -1097,7 +1097,7 @@ switch (region): caseof {
   ---------------------------------
 	--print("MOVALPOLOS");
 
-	local Oldton_Banner_Offset = 16822507; 
+	local Oldton_Banner_Offset = 16822508; 
 	
 	
 	npc  = {
@@ -1117,7 +1117,7 @@ switch (region): caseof {
   ---------------------------------
 	--print("TAVNAZIA");
 
-	local Jemmoquel = 16875826;
+	local Jemmoquel = 16875827;
 	
 	npc  = {
 	--


### PR DESCRIPTION
This had a bunch of NPC IDs off since the April update. This fixes the error on startup

This also had downstream effects that were mission blockers for CoP: because this broke the OnServerStart function before it finished processing, Old Prof. Mariselle's spawn location never got set, leaving players unable to finish the Sacrarium mission.
