### PR TITLE
SCRIPTS: Fix Curing Waltz III to Be Usable by /DNC

### DIFF
--- a/scripts/globals/abilities/curing_waltz_iii.lua
+++ b/scripts/globals/abilities/curing_waltz_iii.lua
@@ -35,6 +35,8 @@ function OnUseAbility(player, target, ability)
 	--Performing mj check.
 	if(mjob == 19) then
 		cure = (vit+chr)*0.75+270;
+	else
+		cure = (vit+chr)*0.375+270;
 	end
 
 	--Reducing TP.


### PR DESCRIPTION
According to FFXIclopedia, Curing Waltz III is usable by /DNC, but the amount of HP healed is calculated slightly differently. The current script healed 0 hp is dancer was not your main job.

Formula (for DNC): Amount Healed = floor(((Target's VIT+Caster's CHR)*0.750) + 270,1)

Formula (for /DNC): Amount Healed = floor(((Target's VIT+Caster's CHR)*0.375) + 270,1)

http://wiki.ffxiclopedia.org/wiki/Curing_Waltz_III
