### PR TITLE
CORE: set SPECEFFECT_NONE for mob skills missed/anticipated/taken by sha...

### DIFF
--- a/src/map/ai/ai_mob_dummy.cpp
+++ b/src/map/ai/ai_mob_dummy.cpp
@@ -983,6 +983,7 @@ void CAIMobDummy::ActionAbilityFinish()
 		if(m_PMobSkill->hasMissMsg())
 		{
 		    Action.reaction   = REACTION_MISS;
+            Action.speceffect = SPECEFFECT_NONE;
             if (msg = m_PMobSkill->getAoEMsg())
                 msg = 282;
 		} else {


### PR DESCRIPTION
...dows

this was NOT being set, missed TP moves were tested making the player recoil and causing knockback if the move has it
