### PR TITLE
Loot Cooldown Implementation

### DIFF
--- a/src/map/ai/ai_mob_dummy.cpp
+++ b/src/map/ai/ai_mob_dummy.cpp
@@ -444,18 +444,36 @@ void CAIMobDummy::ActionDropItems()
 				*/
 
 				uint8 Pzone = PChar->getZone();
+
 				bool validZone = ((Pzone > 0 && Pzone < 39) || (Pzone > 42 && Pzone < 134) || (Pzone > 135 && Pzone < 185) || (Pzone > 188 && Pzone < 255));
 
 				if(validZone && charutils::GetRealExp(PChar->GetMLevel(),m_PMob->GetMLevel())>0 && m_PMob->m_Type == MOBTYPE_NORMAL){ //exp-yielding monster and drop is successful
-					//TODO: The drop is actually based on a 5 minute timer, and not a probability of dropping!
 
 					if (PChar->StatusEffectContainer->HasStatusEffect(EFFECT_SIGNET) && m_PMob->m_Element > 0 && WELL512::irand()%100 < 20) // Need to move to SIGNET_CHANCE constant
 					{
 						PChar->PTreasurePool->AddItem(4095 + m_PMob->m_Element, m_PMob);
+						
 					}
-					if(WELL512::irand()%100 < 20)
-					{
 
+					//Check if seal cool down is up, if it is remove it from the list
+					PChar->PRecastContainer->Check(m_Tick);	
+
+					if (!PChar->PRecastContainer->Has(RECASTTYPE::RECAST_LOOT, 1) && WELL512::irand() % 100 < 20)
+					{
+									
+						if (PChar->PParty != NULL && PChar->PParty->GetPartyType() == PARTY_PCS)
+						{
+							for (uint8 i = 0; i < PChar->PParty->members.size(); ++i)
+							{
+								PChar = (CCharEntity*)PChar->PParty->members.at(i);
+
+								PChar->PRecastContainer->Add(RECASTTYPE::RECAST_LOOT, 1, 300000); //300000 = 5 min cooldown
+							}
+						}
+						else {
+							PChar->PRecastContainer->Add(RECASTTYPE::RECAST_LOOT, 1, 300000); //300000 = 5 min cooldown
+						}
+						
 						//RULES: Only 1 kind may drop per mob
 						if(m_PMob->GetMLevel() < 50){ //b.seal only
 							PChar->PTreasurePool->AddItem(1126, m_PMob);

--- a/src/map/party.cpp
+++ b/src/map/party.cpp
@@ -407,6 +407,18 @@ CBattleEntity* CParty::GetQuaterMaster()
 	return m_PQuaterMaster;
 }
 
+/************************************************************************
+*																		*
+*	Used to access private variable m_PartyType							*
+*																		*
+************************************************************************/
+
+
+PARTYTYPE CParty::GetPartyType()
+{
+	return m_PartyType;
+}
+
 
 
 /************************************************************************

--- a/src/map/party.h
+++ b/src/map/party.h
@@ -68,6 +68,8 @@ public:
     CBattleEntity* GetLeader();                         // узнаем лидера группы
     CBattleEntity* GetSyncTarget();                     // узнаем цель синхронизации
     CBattleEntity* GetQuaterMaster();                   // узнаем владельца сокровищ
+	
+	PARTYTYPE GetPartyType();							//Access private variable m_PartyType
 
 	void DisbandParty();								// распускаем группу
 	void ReloadParty();                                 // перезагружаем карту группы для всех участников группы

--- a/src/map/recast_container.cpp
+++ b/src/map/recast_container.cpp
@@ -68,6 +68,7 @@ std::vector<Recast_t*>* CRecastContainer::GetRecastList(RECASTTYPE type)
         case RECAST_MAGIC:   return &RecastMagicList;
         case RECAST_ABILITY: return &RecastAbilityList;
         case RECAST_ITEM:    return &RecastItemList;
+		case RECAST_LOOT:    return &RecastLootList;
     }
     //Unhandled Scenario
 	DSP_DEBUG_BREAK_IF(true);
@@ -268,7 +269,7 @@ void CRecastContainer::Check(uint32 tick)
                     m_PChar->pushPacket(new CInventoryItemPacket(PItem, LOC_INVENTORY, recast->ID));
 	                m_PChar->pushPacket(new CInventoryFinishPacket());
                 }
-                if (type == RECAST_ITEM || type == RECAST_MAGIC)
+                if (type == RECAST_ITEM || type == RECAST_MAGIC || type == RECAST_LOOT)
                 {
                     PRecastList->erase(PRecastList->begin() + i--);
                     delete recast;

--- a/src/map/recast_container.h
+++ b/src/map/recast_container.h
@@ -33,9 +33,10 @@ enum RECASTTYPE
 {
     RECAST_ITEM     = 0,
     RECAST_MAGIC    = 1,
-    RECAST_ABILITY  = 2
+    RECAST_ABILITY  = 2,
+	RECAST_LOOT     = 3
 };
-#define MAX_RECASTTPE_SIZE   3
+#define MAX_RECASTTPE_SIZE   4
 
 struct Recast_t 
 {
@@ -92,6 +93,7 @@ class CRecastContainer
     RecastList_t RecastItemList;
     RecastList_t RecastMagicList;
     RecastList_t RecastAbilityList;
+	RecastList_t RecastLootList;
 };
 
 #endif


### PR DESCRIPTION
Added a RECAST_LOOT enumeration that tracks the cooldown between looting an item (such as beastmen's seals in this case).

Added a method that stamps all party members (or solo players) when they loot a beastmen's seal.
Method checks for the stamp and if the cooldown (default 5 mins) isn't up, they cannot loot a beastmen's seal.
