### PR TITLE
CORE: prevent loading mobs with '0' familyid

### DIFF
--- a/src/map/utils/zoneutils.cpp
+++ b/src/map/utils/zoneutils.cpp
@@ -294,7 +294,7 @@ void LoadMOBList()
 			FROM mob_groups LEFT JOIN mob_pools ON mob_groups.poolid = mob_pools.poolid \
 			LEFT JOIN mob_spawn_points ON mob_groups.groupid = mob_spawn_points.groupid \
 			LEFT JOIN mob_family_system ON mob_pools.familyid = mob_family_system.familyid \
-			WHERE NOT (pos_x = 0 AND pos_y = 0 AND pos_z = 0);";
+			WHERE NOT (mob_pools.familyid = 0 OR (pos_x = 0 AND pos_y = 0 AND pos_z = 0));";
 
     int32 ret = Sql_Query(SqlHandle, Query);
 


### PR DESCRIPTION
fixes #240
