### PR TITLE
Fix Syntax Error in Besieged.lua

### DIFF
--- a/scripts/globals/besieged.lua
+++ b/scripts/globals/besieged.lua
@@ -219,6 +219,7 @@ function geteRecommendedAssaultLevel(assaultid)
         return 75;
     elseif assaultid == 52 then
         return 99;
+    end;
 end;
 
 -----------------------------------------------------------------------------------


### PR DESCRIPTION
There was an error in closing the assault function after the merging of the instancing branch. This made the file fail to compile, which broke other stuff.
