### PR TITLE
CoP 7-1: Chains & Bonds - Fix Mismatched Cutscenes

### DIFF
--- a/scripts/zones/Tavnazian_Safehold/npcs/_0q1.lua
+++ b/scripts/zones/Tavnazian_Safehold/npcs/_0q1.lua
@@ -25,8 +25,8 @@ function onTrigger(player,npc)
 	
 	if(player:getCurrentMission(COP) == THE_LOST_CITY and player:getVar("PromathiaStatus") > 0)then
 		player:startEvent(0x0067);	
-    elseif(player:getCurrentMission(COP) == CHAINS_AND_BONDS and player:getVar("PromathiaStatus")==3)then
-	    player:startEvent(0x0073);
+    	elseif(player:getCurrentMission(COP) == CHAINS_AND_BONDS and player:getVar("PromathiaStatus")==3)then
+		player:startEvent(0x0074);
 	elseif(player:getCurrentMission(COP) >= DISTANT_BELIEFS or hasCompletedMission(COP,THE_LAST_VERSE))then
 		player:startEvent(0x01f6);
 	else
@@ -57,7 +57,7 @@ function onEventFinish(player,csid,option)
 		player:setVar("PromathiaStatus",0);
 		player:completeMission(COP,THE_LOST_CITY);
 		player:addMission(COP,DISTANT_BELIEFS);
-	elseif(csid == 0x0073)then
+	elseif(csid == 0x0074)then
 	    player:setVar("PromathiaStatus",4);
 	elseif(csid == 0x01f6 and option == 1)then
 		player:setPos(260.068,0,-283.568,190,27); -- To Phomiuna Aqueducts {R}

--- a/scripts/zones/Tavnazian_Safehold/npcs/_0qa.lua
+++ b/scripts/zones/Tavnazian_Safehold/npcs/_0qa.lua
@@ -29,7 +29,7 @@ function onTrigger(player,npc)
 	elseif(player:getCurrentMission(COP) == THE_SECRETS_OF_WORSHIP and player:getVar("PromathiaStatus") == 0) then 	
 	    player:startEvent(0x006F);
 	elseif(player:getCurrentMission(COP) == CHAINS_AND_BONDS and player:getVar("PromathiaStatus")==4)then
-	    player:startEvent(0x0074);	
+	    player:startEvent(0x0073);	
 	elseif(player:getCurrentMission(COP) == DAWN and player:getVar("PromathiaStatus")==5)then		
 		player:startEvent(0x021F);
 	end
@@ -55,7 +55,7 @@ function onEventFinish(player,csid,option)
 	
 	if(csid == 0x0068 or csid == 0x006F)then
 		player:setVar("PromathiaStatus",1);
-	elseif(csid == 0x0074)then
+	elseif(csid == 0x0073)then
 	    player:setVar("PromathiaStatus",0);
 		player:completeMission(COP,CHAINS_AND_BONDS);
 		player:addMission(COP,FLAMES_IN_THE_DARKNESS);


### PR DESCRIPTION
The Ulmia/Prishe Cutscene is supposed to happen at the Walnut Door, while the Louverance Cutscene is supposed to happen at the gate to Aquaducts.

These were mixed up, leading to awkward scenarios where you click the walnut door and are suddenly at the gate to aquaducts in a cs, or click the gate to aquaducts and walk into a room.
