### PR TITLE
Fix issue #144

### DIFF
--- a/src/map/ai/ai_char_normal.cpp
+++ b/src/map/ai/ai_char_normal.cpp
@@ -389,7 +389,8 @@ void CAICharNormal::ActionFall()
     m_PChar->UContainer->Clean();
 
 	m_PChar->animation = ANIMATION_DEATH;
-    m_PChar->m_DeathTimestamp = 0; //so char update packet will send the full homepoint timer 
+    m_PChar->m_DeathCounter = 0; //so char update packet will send the full homepoint timer
+    m_PChar->m_DeathTimestamp = (uint32)time(NULL);
 	m_PChar->pushPacket(new CCharUpdatePacket(m_PChar));
     m_PChar->pushPacket(new CRaiseTractorMenuPacket(m_PChar,TYPE_HOMEPOINT));
 
@@ -400,7 +401,6 @@ void CAICharNormal::ActionFall()
 
 	if (!m_PChar->getMijinGakure() && !m_PChar->m_PVPFlag)
 		charutils::DelExperiencePoints(m_PChar,map_config.exp_retain);
-
 
 	charutils::SaveDeathTime(m_PChar);
 

--- a/src/map/entities/charentity.cpp
+++ b/src/map/entities/charentity.cpp
@@ -111,7 +111,8 @@ CCharEntity::CCharEntity()
 	m_insideBCNM = false;
 	m_lastBcnmTimePrompt = 0;
 	m_AHHistoryTimestamp = 0;
-	m_DeathTimestamp = 0;
+    m_DeathCounter = 0;
+    m_DeathTimestamp = 0;
 
 	m_EquipFlag  = 0;
     m_EquipBlock = 0;

--- a/src/map/entities/charentity.h
+++ b/src/map/entities/charentity.h
@@ -337,7 +337,8 @@ public:
 	uint8			  m_LevelRestriction;			// ограничение уровня персонажа
     uint16            m_Costum;                     // карнавальный костюм персонажа (модель)
 	uint32			  m_AHHistoryTimestamp;			// Timestamp when last asked to view history
-	uint32			  m_DeathTimestamp;				// Timestamp when you last died. This is set when you first login.
+    uint32            m_DeathCounter;               // Counter when you last died. This is set when you first login
+    uint32            m_DeathTimestamp;             // Timestamp when death counter has been saved to database
 
     uint8             m_PVPFlag;                    // pvp
 	uint8			  m_hasTractor;					// checks if player has tractor already

--- a/src/map/map.cpp
+++ b/src/map/map.cpp
@@ -689,6 +689,10 @@ int32 map_close_session(uint32 tick, CTaskMgr::CTask* PTask)
 		map_session_data->PChar != NULL)					// crash occured when both server_packet_data & PChar were NULL
 	{
 		charutils::SavePlayTime(map_session_data->PChar);
+        if (map_session_data->PChar->isDead())
+        {
+            charutils::SaveDeathTime(map_session_data->PChar);
+        }
 
 		Sql_Query(SqlHandle, "DELETE FROM accounts_sessions WHERE charid = %u", map_session_data->PChar->id);
 

--- a/src/map/packet_system.cpp
+++ b/src/map/packet_system.cpp
@@ -263,9 +263,11 @@ void SmallPacket0x00A(map_session_data_t* session, CCharEntity* PChar, int8* dat
 
 		const int8* deathTsQuery = "SELECT death FROM char_stats where charid = %u;";
 		int32 ret = Sql_Query(SqlHandle,deathTsQuery, PChar->id);
-		if (Sql_NextRow(SqlHandle) == SQL_SUCCESS) {
-			PChar->m_DeathTimestamp = (uint32)Sql_GetUIntData(SqlHandle,0);
-		}
+        if (Sql_NextRow(SqlHandle) == SQL_SUCCESS)
+        {
+            PChar->m_DeathCounter = (uint32)Sql_GetUIntData(SqlHandle, 0);
+            PChar->m_DeathTimestamp = (uint32)time(NULL);
+        }
         
         if (firstLogin)
             PChar->PMeritPoints->SaveMeritPoints(PChar->id, true);

--- a/src/map/packets/char_update.cpp
+++ b/src/map/packets/char_update.cpp
@@ -86,7 +86,7 @@ CCharUpdatePacket::CCharUpdatePacket(CCharEntity* PChar)
         flag |= 0x08;
     WBUFB(data,(0x36)-4) = flag;
 
-    if (!PChar->isDead() || PChar->m_DeathTimestamp == 0) //prevent this packet from resetting the homepoint timer after tractor
+    if (!PChar->isDead() || PChar->m_DeathCounter == 0) //prevent this packet from resetting the homepoint timer after tractor
         WBUFL(data,(0x3C)-4) = 0x0003A020;
 
     WBUFL(data,(0x40)-4) = CVanaTime::getInstance()->getVanaTime();

--- a/src/map/packets/zone_in.cpp
+++ b/src/map/packets/zone_in.cpp
@@ -188,8 +188,8 @@ CZoneInPacket::CZoneInPacket(CCharEntity * PChar, int16 csid)
 
 	// current death timestamp is less than an hour ago and the player is dead.
     // 60min starts at 0x03A020 (66 min) and ventures down to 0x5460 (6 min)
-    if (((pktTime + VTIME_BASEDATE) - PChar->m_DeathTimestamp) < 3600 && PChar->isDead()) 
-        WBUFL(data,(0xA4)-4) = 0x03A020 - (60*((pktTime + VTIME_BASEDATE) - PChar->m_DeathTimestamp));
+    if (PChar->m_DeathCounter < 3600 && PChar->isDead())
+        WBUFL(data,(0xA4)-4) = 0x03A020 - (60 * PChar->m_DeathCounter);
 
 	memcpy(data+(0xCC)-4, &PChar->stats, 14);
 

--- a/src/map/utils/charutils.cpp
+++ b/src/map/utils/charutils.cpp
@@ -4354,8 +4354,12 @@ void saveCharWsPoints(CCharEntity* PChar, uint16 indexid, int32 points)
 
 void SaveDeathTime(CCharEntity* PChar)
 {
-	const int8* fmtQuery = "UPDATE char_stats SET death = %u WHERE charid = %u LIMIT 1;";
-	Sql_Query(SqlHandle, fmtQuery, (uint32)time(NULL), PChar->id);
+    uint32 currentTime = (uint32)time(NULL);
+    PChar->m_DeathCounter += (currentTime - PChar->m_DeathTimestamp);
+    PChar->m_DeathTimestamp = currentTime;
+
+    const int8* fmtQuery = "UPDATE char_stats SET death = %u WHERE charid = %u LIMIT 1;";
+    Sql_Query(SqlHandle, fmtQuery, PChar->m_DeathCounter, PChar->id);
 }
 
 void SavePlayTime(CCharEntity* PChar)


### PR DESCRIPTION
Fix the death timer when player have a d/c.

Change the death timestamp to death counter for freeze the timer when
player have a d/c. The timestamp used only to update the counter when
saved to database
