### PR TITLE
Implement Thief Ambush Ability

### DIFF
--- a/src/map/utils/battleutils.cpp
+++ b/src/map/utils/battleutils.cpp
@@ -1577,8 +1577,8 @@ uint8 GetRangedHitRate(CBattleEntity* PAttacker, CBattleEntity* PDefender, bool 
 		}
 	}
 	
-	   //Check For Ambush Merit -Ranged
-    	if (PAttacker->objtype == TYPE_PC && (charutils::hasTrait((CCharEntity*)PAttacker, TRAIT_AMBUSH)) && ((abs(m_victim->loc.p.rotation - m_attacker->loc.p.rotation) < 23) {
+	   //Check For Ambush Merit - Ranged
+    	if (PAttacker->objtype == TYPE_PC && (charutils::hasTrait((CCharEntity*)PAttacker, TRAIT_AMBUSH)) && ((abs(m_victim->loc.p.rotation - m_attacker->loc.p.rotation) < 23))) {
     		acc += ((CCharEntity*)PAttacker)->PMeritPoints->GetMeritValue(MERIT_AMBUSH,(CCharEntity*)PAttacker);
     	}
 


### PR DESCRIPTION
Resubmitting as a pull request that will ONLY be Ambush this time.  Implemented in both the ranged and melee accuracy checks.  Ambush adds 3 accuracy for each point when the thief is behind the target.  I used the same formula as was used for checking sneak attack.  
