### PR TITLE
Skip checkRegime if killer is null

### DIFF
--- a/scripts/globals/fieldsofvalor.lua
+++ b/scripts/globals/fieldsofvalor.lua
@@ -388,7 +388,7 @@ end
 
 function checkRegime(killer,mob,rid,index)
     -- dead people get no point
-    if(killer:getHP() == 0) then
+    if(killer == nil or killer:getHP() == 0) then
         return;
     end
 


### PR DESCRIPTION
Killer can be nil, caused by ai_mob_dummy.cpp:517
