### PR TITLE
Fixes issue where dying pet can possibly crash server

### DIFF
--- a/src/map/ai/ai_pet_dummy.cpp
+++ b/src/map/ai/ai_pet_dummy.cpp
@@ -894,14 +894,19 @@ void CAIPetDummy::ActionDisengage()
 
 void CAIPetDummy::ActionFall()
 {
-    // remove master from pet
-    if(m_PPet->PMaster != NULL){
-        petutils::DetachPet(m_PPet->PMaster);
-    }
+        bool isMob = m_PPet->objtype == TYPE_MOB;
+        // remove master from pet
+        if(m_PPet->PMaster != NULL){
+            petutils::DetachPet(m_PPet->PMaster);
+        }
 
-    if(m_PPet->objtype != TYPE_MOB){
+        // detach pet just deleted this
+        // so break out of here
+        if(isMob){
+            return;
+        }
+
         m_PPet->health.hp = 0;
-    }
 
 	m_PPet->loc.zone->PushPacket(m_PPet, CHAR_INRANGE, new CEntityUpdatePacket(m_PPet, ENTITY_UPDATE, UPDATE_COMBAT));
 


### PR DESCRIPTION
When a bst pet dies the current pet ai gets deleted and replaced with a mob AI. Problem is the ai gets deleted in detachpet and then jumps back into the deleted pet ai. This will jump out of the pet ai early if its a mob pet.
