### PR TITLE
Fix Temonos Gates

### DIFF
--- a/scripts/zones/Temenos/npcs/Particle_Gate.lua
+++ b/scripts/zones/Temenos/npcs/Particle_Gate.lua
@@ -22,8 +22,7 @@ end;
 -----------------------------------
 
 function onTrigger(player,npc)
-  GateID =  (npc:getID())-16928768;
-  
+  GateID =  (npc:getID())-16928770;  
   -- print("GateID" ..GateID);
   
   


### PR DESCRIPTION
GateID's were off by 2 which caused players to be sent to wrong location.
