### PR TITLE
Added message handling code for cruor drops in abyssea.

### DIFF
--- a/src/map/utils/charutils.cpp
+++ b/src/map/utils/charutils.cpp
@@ -3447,7 +3447,28 @@ void AddExperiencePoints(bool expFromRaise, CCharEntity* PChar, CBaseEntity* PMo
         }
     }
 
-	//player levels up
+        // Cruor Drops in Abyssea zones.
+        uint16 Pzone = PChar->getZone();
+        if (zoneutils::GetCurrentRegion(Pzone) == REGION_ABYSSEA)
+        {
+            int32 TextID = luautils::GetTextIDVariable(Pzone, "CRUOR_OBTAINED");
+            uint16 Total = PChar->m_currency.cruor;
+            uint32 Cruor = 0; // Need to work out how to do cruor chains, until then no cruor will drop unless this line is customized for non retail play.
+
+            if (TextID == 0)
+            {
+                ShowWarning(CL_YELLOW"Failed to fetch Cruor Message ID for zone: %i\n" CL_RESET, Pzone);
+            }
+
+            if (Cruor >= 1)
+            {
+                PChar->pushPacket(new CMessageSpecialPacket(PChar, TextID, Cruor, Total, 0, 0));
+                PChar->m_currency.cruor += Cruor;
+            }
+        }
+    }
+
+    // Player levels up
     if ((currentExp + exp) >= GetExpNEXTLevel(PChar->jobs.job[PChar->GetMJob()]) && onLimitMode == false)
     {
         if (PChar->jobs.job[PChar->GetMJob()] >= PChar->jobs.genkai)


### PR DESCRIPTION
This won't make cruor drop till someone creates code to handle cruor chaining or edits their copy for non retail amounts however. As long as the text IDs I added in ea9724b07cf310476d1ba1a838f386c6ea42d734 a few days ago stay updated, this will work properly.
