### PR TITLE
Update qm8.lua

### DIFF
--- a/scripts/zones/Crawlers_Nest/npcs/qm8.lua
+++ b/scripts/zones/Crawlers_Nest/npcs/qm8.lua
@@ -72,6 +72,7 @@ function onEventFinish(player,csid,option)
 			player:messageSpecial(ITEM_OBTAINED, 14093); -- Warlock's Boots
 			player:setVar("theCrimsonTrial_date",0);
 			player:setVar("theCrimsonTrial_prog",0);
+			player:setVar("needs_crawler_blood",2); -- Fixed being unable start next quest
 			player:addFame(SANDORIA,AF2_FAME);
 			player:completeQuest(SANDORIA,ENVELOPED_IN_DARKNESS);
 		end


### PR DESCRIPTION
Players were unable to start the next quest after receiving Warlock's Boots.

Also see:
https://github.com/DarkstarProject/darkstar/pull/435
