### PR TITLE
Fix non-portable zlib compression/decompression code.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -125,51 +125,6 @@ AC_ARG_ENABLE(
   [ enable_rdtsc=0 ]
 )
 
-### Compile for a 64-bit target
-AC_ARG_ENABLE(
-        [64bit],
-        AC_HELP_STRING(
-                [--enable-64bit],
-                [
-                        Don't force 32bit. (disable by default)
-                        64bit support is still being tested, not recommended for production servers.
-                ]
-        ),
-        [
-                enable_64bit="$enableval"
-                case $enableval in
-                        "no");;
-                        "yes");;
-                        *) AC_MSG_ERROR([[ invalid argumen --enable-64bit = $enableval ... stopping]]);;
-                esac
-        ],
-        [ enable_64bit="no" ]
-)
-
-### Make sure pointers will fit in int when using 64-bit target
-if test "$enable_64bit" = "no" ; then
-        AC_MSG_CHECKING([whether pointers can be stored in ints (old code)])
-        pointers_fit_in_ints="no"
-        AC_COMPILE_IFELSE(
-                [AC_LANG_PROGRAM([[static int test_array[((long int)sizeof(int)) == ((long int)sizeof(void*))? 1 : -1];]])],
-                [pointers_fit_in_ints="yes"],
-                []
-        )
-        if test "$pointers_fit_in_ints" = "no" ; then
-                DARKSTAR_CXXFLAGS="$DARKSTAR_CXXFLAGS -m32"
-                DARKSTAR_LDFLAGS="$DARKSTAR_LDFLAGS -m32"
-                AC_COMPILE_IFELSE(
-                        [AC_LANG_PROGRAM([[static int test_array[((long int)sizeof(int)) == ((long int)sizeof(void*))? 1: -1];]])],
-                        [pointers_fit_in_ints="yes (with -m32)"],
-                        []
-                )
-        fi
-        AC_MSG_RESULT($pointers_fit_in_ints)
-        if test "$pointers_fit_in_ints" = "no" ; then
-                AC_MSG_ERROR([pointers cannot be stored in ints, required for old code... stopping])
-        fi
-fi
-
 AC_MSG_CHECKING([whether $CXX supports -Wno-unused-parameter])
 OLD_DARKSTAR_CXXFLAGS="$DARKSTAR_CXXFLAGS"
 DARKSTAR_CXXFLAGS="$DARKSTAR_CXXFLAGS -Wno-unused-parameter"

--- a/src/common/cbasetypes.h
+++ b/src/common/cbasetypes.h
@@ -37,6 +37,10 @@
 #define CYGWIN
 #endif
 
+#if !defined(__64BIT__) && defined(__x86_64__)
+#define __64BIT__
+#endif
+
 // debug mode
 #if defined(_DEBUG) && !defined(DEBUG)
 #define DEBUG
@@ -57,7 +61,7 @@
 #if !defined(__GNUC__) && !defined(MINGW)
 #  define  __attribute__(x)
 #endif
- 
+
 // define a break macro for debugging.
 #if defined(DEBUG)
 #if defined(_MSC_VER)

--- a/src/common/zlib.cpp
+++ b/src/common/zlib.cpp
@@ -4,18 +4,21 @@
 #include <stdlib.h>
 #include <string.h>
 
-ppuint32 zlib_compress_table[512];
-char*    zlib_decompress_table[2556];
+uint32 zlib_compress_table[512];
+uint32 zlib_decompress_table[2556];
 
 int32   zlib_init()
 {
 	FILE * fp;
 	long size, i;
 
+	memset(zlib_compress_table, 0, sizeof(zlib_compress_table));
+	memset(zlib_decompress_table, 0, sizeof(zlib_decompress_table));
+
 	fp = fopen("compress.dat", "rb");
 	if( fp == NULL )
 		ShowFatalError("zlib_init: can't open file <compress.dat> \n");
-	fread(zlib_compress_table, sizeof(ppuint32),512, fp);
+	fread(zlib_compress_table, sizeof(uint32), 512, fp);
 	fclose(fp);
 
 	fp = fopen("decompress.dat","rb");
@@ -28,13 +31,14 @@ int32   zlib_init()
 	fclose(fp);
 
 	for(i = 0; i < size/4; i++)
-		if(zlib_decompress_table[i] > (char *)255)
-			zlib_decompress_table[i] = zlib_decompress_table[i] - 0x15b3aaa0 + (unsigned long)zlib_decompress_table;
+		if(zlib_decompress_table[i] > 0xff)
+			zlib_decompress_table[i] = zlib_decompress_table[i] - 0x15b3aaa0 + (uintptr)zlib_decompress_table;
+
 
 	return 0;
 }
 
-int32   zlib_compress_sub(char * output,ppuint32 var1,ppuint32 cume, char * lookup1,ppuint32 var2,ppuint32 var3,ppuint32 lookup2)
+int32   zlib_compress_sub(char * output,uint32 var1,uint32 cume, char * lookup1,uint32 var2,uint32 var3,uint32 lookup2)
 {
 	if((cume + lookup2 + 7)/8 > var1)
 		return -1;
@@ -49,10 +53,10 @@ int32   zlib_compress_sub(char * output,ppuint32 var1,ppuint32 cume, char * look
 	return 0;
 }
 
-int32   zlib_compress(char * input,ppuint32 var1, char * output, ppuint32 var2, ppuint32 * lookup)
+int32   zlib_compress(char * input,uint32 var1, char * output, uint32 var2, uint32 * lookup)
 {
-	unsigned int i, cume = 0, tmp;
-	unsigned long * ptr;
+	uint32 i, cume = 0, tmp;
+	uint32 * ptr;
 
 	tmp = (var2-1)*8;
 	for(i = 0; i < var1 && var1; i++){
@@ -73,10 +77,10 @@ int32   zlib_compress(char * input,ppuint32 var1, char * output, ppuint32 var2, 
 	return (cume+8);
 };
 
-ppuint32 zlib_decompress(char *in,ppuint32 inSize, char *out, ppuint32 outSize, char **table)
+uint32 zlib_decompress(char *in,uint32 inSize, char *out, uint32 outSize, uint32 *table)
 {
-	unsigned int ** follow = (unsigned int **)table[0];
-	unsigned long i, j=0;
+	uint32 * follow = (uint32*)(uintptr)table[0];
+	uint32 i, j=0;
 
 	if(in[0] != 1)
 		return -1;
@@ -84,16 +88,16 @@ ppuint32 zlib_decompress(char *in,ppuint32 inSize, char *out, ppuint32 outSize, 
 
 	for(i = 0; i < inSize ;i++){
 		if((in[i/8]>>(i&7))&1)
-			follow = (unsigned int **)follow[1];
+			follow = (uint32*)(uintptr)follow[1];
 		else
-			follow = (unsigned int **)follow[0];
+			follow = (uint32*)(uintptr)follow[0];
 		if(follow[0] == 0){
 			if(follow[1]==0){
-				void* ptr = follow[3];
-				out[j] = (uintptr_t)(ptr) & 255;
+				void *ptr = (void*)(uintptr)follow[3];
+				out[j] = (uintptr)(ptr) & 255;
 				if(++j >= outSize)
 					return -1;
-				follow = (unsigned int **)table[0];
+				follow = (uint32*)(uintptr)table[0];
 			}
 		}
 	}

--- a/src/common/zlib.h
+++ b/src/common/zlib.h
@@ -4,15 +4,15 @@
 
 #include "../common/cbasetypes.h"
 
-extern ppuint32 zlib_compress_table[];
-extern char*    zlib_decompress_table[];
+extern uint32 zlib_compress_table[];
+extern uint32 zlib_decompress_table[];
 
 int32   zlib_init();
 
-int32   zlib_compress_sub(char * output,ppuint32 var1,ppuint32 cume, char * lookup1,ppuint32 var2,ppuint32 var3,ppuint32 lookup2);
-int32   zlib_compress(char * input,ppuint32 var1, char * output, ppuint32 var2, ppuint32 * lookup);
+int32   zlib_compress_sub(char * output,uint32 var1,uint32 cume, char * lookup1,uint32 var2,uint32 var3,uint32 lookup2);
+int32   zlib_compress(char * input,uint32 var1, char * output, uint32 var2, uint32 * lookup);
 
-ppuint32 zlib_decompress(char *in,ppuint32 inSize, char *out, ppuint32 outSize, char **table);
+uint32  zlib_decompress(char *in,uint32 inSize, char *out, uint32 outSize, uint32 *table);
 
 
-#endif 
+#endif


### PR DESCRIPTION
This will make 64bit host work.
By getting rid of the "Client cannot receive packet or key is invalid".

Tested on x86_64 arch linux, looking for somebody to test 64bit on
windows and 32bit too for regressions if any.
