### PR TITLE
Add missing mob scripts in Zeruhn Mines.

### DIFF
--- a/scripts/globals/regimeinfo.lua
+++ b/scripts/globals/regimeinfo.lua
@@ -1456,7 +1456,7 @@ function getRegimeInfo(regimeid)
                     a.sl = 75;
                     a.el = 79;
                     return a;
-                elseif (regimeid == 620) then
+                elseif (regimeid == 630) then
                     a.n1 = 5;
                     a.n2 = 2;
                     a.n3 = 0;
@@ -1538,7 +1538,7 @@ function getRegimeInfo(regimeid)
                     a.sl = 3;
                     a.el = 8;
                     return a;
-                elseif (regimeid == 630) then
+                elseif (regimeid == 640) then
                     a.n1 = 3;
                     a.n2 = 2;
                     a.n3 = 0;
@@ -1555,7 +1555,7 @@ function getRegimeInfo(regimeid)
                     a.el = 14;
                     return a;
                 end
-            else -- 641-651
+            else -- 642-651
                 if (regimeid == 642) then
                     a.n1 = 4;
                     a.n2 = 2;

--- a/scripts/zones/Zeruhn_Mines/mobs/Burrower_Worm.lua
+++ b/scripts/zones/Zeruhn_Mines/mobs/Burrower_Worm.lua
@@ -1,0 +1,21 @@
+----------------------------------
+--  Area: Zeruhn Mines (172)
+--   Mob: Burrower Worm
+-----------------------------------
+
+require("scripts/globals/groundsofvalor");
+
+-----------------------------------
+-- onMobInitialize
+-----------------------------------
+
+function onMobInitialize(mob)
+end;
+
+-----------------------------------
+-- onMobDeath
+-----------------------------------
+
+function onMobDeath(mob,killer)
+    checkGoVregime(killer,mob,629,2);
+end;

--- a/scripts/zones/Zeruhn_Mines/mobs/Colliery_Bat.lua
+++ b/scripts/zones/Zeruhn_Mines/mobs/Colliery_Bat.lua
@@ -1,0 +1,23 @@
+-----------------------------------
+--  Area: Zeruhn Mines (172)
+--   Mob: Colliery Bat
+-----------------------------------
+
+require("scripts/globals/groundsofvalor");
+
+-----------------------------------
+-- onMobInitialize
+-----------------------------------
+
+function onMobInitialize(mob)
+end;
+
+-----------------------------------
+-- onMobDeath
+-----------------------------------
+
+function onMobDeath(mob,killer)
+    checkGoVregime(killer,mob,628,1);
+    checkGoVregime(killer,mob,629,1);
+    checkGoVregime(killer,mob,630,1);
+end;

--- a/scripts/zones/Zeruhn_Mines/mobs/Ding_Bats.lua
+++ b/scripts/zones/Zeruhn_Mines/mobs/Ding_Bats.lua
@@ -1,0 +1,21 @@
+-----------------------------------
+--  Area: Zeruhn Mines (172)
+--   Mob: Ding_Bats
+-----------------------------------
+
+require("scripts/globals/groundsofvalor");
+
+-----------------------------------
+-- onMobInitialize
+-----------------------------------
+
+function onMobInitialize(mob)
+end;
+
+-----------------------------------
+-- onMobDeath
+-----------------------------------
+
+function onMobDeath(mob,killer)
+    checkGoVregime(killer,mob,626,1);
+end;

--- a/scripts/zones/Zeruhn_Mines/mobs/River_Crab.lua
+++ b/scripts/zones/Zeruhn_Mines/mobs/River_Crab.lua
@@ -1,0 +1,21 @@
+-----------------------------------
+--  Area: Zeruhn Mines (172)
+--   Mob: River_Crab
+-----------------------------------
+
+require("scripts/globals/groundsofvalor");
+
+-----------------------------------
+-- onMobInitialize
+-----------------------------------
+
+function onMobInitialize(mob)
+end;
+
+-----------------------------------
+-- onMobDeath
+-----------------------------------
+
+function onMobDeath(mob,killer)
+    checkGoVregime(killer,mob,627,1);
+end;

--- a/scripts/zones/Zeruhn_Mines/mobs/Soot_Crab.lua
+++ b/scripts/zones/Zeruhn_Mines/mobs/Soot_Crab.lua
@@ -1,0 +1,21 @@
+-----------------------------------
+--  Area: Zeruhn Mines (172)
+--   Mob: Soot Crab
+-----------------------------------
+
+require("scripts/globals/groundsofvalor");
+
+-----------------------------------
+-- onMobInitialize
+-----------------------------------
+
+function onMobInitialize(mob)
+end;
+
+-----------------------------------
+-- onMobDeath
+-----------------------------------
+
+function onMobDeath(mob,killer)
+    checkGoVregime(killer,mob,628,2);
+end;

--- a/scripts/zones/Zeruhn_Mines/mobs/Veindigger_Leech.lua
+++ b/scripts/zones/Zeruhn_Mines/mobs/Veindigger_Leech.lua
@@ -1,0 +1,21 @@
+-----------------------------------
+--  Area: Zeruhn Mines (172)
+--   Mob: Veindigger Leech
+-----------------------------------
+
+require("scripts/globals/groundsofvalor");
+
+-----------------------------------
+-- onMobInitialize
+-----------------------------------
+
+function onMobInitialize(mob)
+end;
+
+-----------------------------------
+-- onMobDeath
+-----------------------------------
+
+function onMobDeath(mob,killer)
+    checkGoVregime(killer,mob,630,2);
+end;


### PR DESCRIPTION
Still some problems related to incorrect pool/group IDs, will toss those into a separate pull request if nobody else does it before I get around to it.

Basically server thinks the Burrower Worm is the Tunnel Worm that used to be there back before SE slapped lv 80 mobs in old zones.
