### PR TITLE
Add require bits as lua51-bitop is not usually compiled in linux packages

### DIFF
--- a/scripts/globals/magic_maps.lua
+++ b/scripts/globals/magic_maps.lua
@@ -4,6 +4,7 @@
 --	SE updated the map NPCs to sell maps from the normal areas, RoZ, and CoP areas (Update was in Nov 5, 2013)
 ---------------------------------------------
 
+local bit = require("bit")
 require("scripts/globals/keyitems");
 
 local Maps = {MAP_OF_THE_SAN_DORIA_AREA, MAP_OF_THE_BASTOK_AREA, MAP_OF_THE_WINDURST_AREA, MAP_OF_THE_JEUNO_AREA, MAP_OF_ORDELLES_CAVES, MAP_OF_GHELSBA, MAP_OF_DAVOI, MAP_OF_CARPENTERS_LANDING, MAP_OF_THE_ZERUHN_MINES,

--- a/scripts/globals/mobskills/Horrid_Roar_1.lua
+++ b/scripts/globals/mobskills/Horrid_Roar_1.lua
@@ -3,6 +3,7 @@
 -- Dispels a single buff at random which could be food.  Lowers Enmity.
 ---------------------------------------------------
 
+local bit = require("bit")
 require("/scripts/globals/settings");
 require("/scripts/globals/status");
 require("/scripts/globals/monstertpmoves");

--- a/scripts/globals/mobskills/Horrid_Roar_2.lua
+++ b/scripts/globals/mobskills/Horrid_Roar_2.lua
@@ -3,6 +3,7 @@
 -- Dispels all buffs including food. Lowers Enmity.
 ---------------------------------------------------
 
+local bit = require("bit")
 require("/scripts/globals/settings");
 require("/scripts/globals/status");
 require("/scripts/globals/monstertpmoves");

--- a/scripts/globals/mobskills/Horrid_Roar_3.lua
+++ b/scripts/globals/mobskills/Horrid_Roar_3.lua
@@ -3,6 +3,7 @@
 -- Dispels all buffs including food. Lowers Enmity.
 ---------------------------------------------------
 
+local bit = require("bit")
 require("/scripts/globals/settings");
 require("/scripts/globals/status");
 require("/scripts/globals/monstertpmoves");

--- a/scripts/globals/mobskills/Tortoise_Song.lua
+++ b/scripts/globals/mobskills/Tortoise_Song.lua
@@ -7,6 +7,8 @@
 --  Range: 20' radial
 --  Notes:
 ---------------------------------------------
+
+local bit = require("bit")
 require("/scripts/globals/settings");
 require("/scripts/globals/status");
 require("/scripts/globals/monstertpmoves");

--- a/scripts/zones/Aht_Urhgan_Whitegate/npcs/Abda-Lurabda.lua
+++ b/scripts/zones/Aht_Urhgan_Whitegate/npcs/Abda-Lurabda.lua
@@ -4,6 +4,7 @@
 -- Standard Info NPC
 -----------------------------------
 
+local bit = require("bit")
 require("scripts/globals/status");
 require("scripts/globals/pets");
 

--- a/scripts/zones/Aht_Urhgan_Whitegate/npcs/Famad.lua
+++ b/scripts/zones/Aht_Urhgan_Whitegate/npcs/Famad.lua
@@ -7,6 +7,7 @@
 package.loaded["scripts/zones/Aht_Urhgan_Whitegate/TextIDs"] = nil;
 -----------------------------------
 
+local bit = require("bit")
 require("scripts/globals/keyitems");
 require("scripts/zones/Aht_Urhgan_Whitegate/TextIDs");
 require("scripts/globals/besieged");

--- a/scripts/zones/Aht_Urhgan_Whitegate/npcs/Ugrihd.lua
+++ b/scripts/zones/Aht_Urhgan_Whitegate/npcs/Ugrihd.lua
@@ -7,6 +7,7 @@
 package.loaded["scripts/zones/Aht_Urhgan_Whitegate/TextIDs"] = nil;
 -----------------------------------
 
+local bit = require("bit")
 require("scripts/globals/status");
 require("scripts/globals/besieged");
 require("scripts/zones/Aht_Urhgan_Whitegate/TextIDs");

--- a/scripts/zones/Balgas_Dais/bcnms/shattering_stars.lua
+++ b/scripts/zones/Balgas_Dais/bcnms/shattering_stars.lua
@@ -6,6 +6,7 @@
 package.loaded["scripts/zones/Balgas_Dais/TextIDs"] = nil;
 -------------------------------------
 
+local bit = require("bit")
 require("scripts/globals/titles");
 require("scripts/globals/quests");
 require("scripts/zones/Balgas_Dais/TextIDs");

--- a/scripts/zones/Chamber_of_Oracles/bcnms/shattering_stars.lua
+++ b/scripts/zones/Chamber_of_Oracles/bcnms/shattering_stars.lua
@@ -6,6 +6,7 @@
 package.loaded["scripts/zones/Sacrificial_Chamber/TextIDs"] = nil;
 -------------------------------------
 
+local bit = require("bit")
 require("scripts/zones/Sacrificial_Chamber/TextIDs");
 
 -----------------------------------

--- a/scripts/zones/Empyreal_Paradox/mobs/Prishe.lua
+++ b/scripts/zones/Empyreal_Paradox/mobs/Prishe.lua
@@ -4,6 +4,7 @@
 -- Chains of Promathia 8-4 BCNM Fight
 -----------------------------------
 
+local bit = require("bit")
 require("scripts/globals/status");
 require("scripts/globals/magic");
 require("/scripts/zones/Empyreal_Paradox/TextIDs");

--- a/scripts/zones/Empyreal_Paradox/mobs/Promathia.lua
+++ b/scripts/zones/Empyreal_Paradox/mobs/Promathia.lua
@@ -3,6 +3,7 @@
 -- NPC:  Promathia
 -----------------------------------
 
+local bit = require("bit")
 require("scripts/globals/titles");
 require("scripts/globals/status");
 require("/scripts/zones/Empyreal_Paradox/TextIDs");

--- a/scripts/zones/Empyreal_Paradox/mobs/Promathia_2.lua
+++ b/scripts/zones/Empyreal_Paradox/mobs/Promathia_2.lua
@@ -3,6 +3,7 @@
 -- NPC:  Promathia (phase 2)
 -----------------------------------
 
+local bit = require("bit")
 require("scripts/globals/titles");
 require("scripts/globals/status");
 require("/scripts/zones/Empyreal_Paradox/TextIDs");

--- a/scripts/zones/Horlais_Peak/bcnms/shattering_stars.lua
+++ b/scripts/zones/Horlais_Peak/bcnms/shattering_stars.lua
@@ -6,6 +6,7 @@
 package.loaded["scripts/zones/Horlais_Peak/TextIDs"] = nil;
 -----------------------------------
 
+local bit = require("bit")
 require("scripts/globals/titles");
 require("scripts/globals/quests");
 require("scripts/zones/Horlais_Peak/TextIDs");

--- a/scripts/zones/Lebros_Cavern/instances/wamoura_farm_raid.lua
+++ b/scripts/zones/Lebros_Cavern/instances/wamoura_farm_raid.lua
@@ -4,6 +4,7 @@
 -- 
 -----------------------------------
 
+local bit = require("bit")
 require("scripts/zones/Lebros_Cavern/IDs");
 
 -----------------------------------

--- a/scripts/zones/Mount_Zhayolm/npcs/_1p3.lua
+++ b/scripts/zones/Mount_Zhayolm/npcs/_1p3.lua
@@ -7,6 +7,7 @@
 package.loaded["scripts/zones/Mount_Zhayolm/TextIDs"] = nil;
 -----------------------------------
 
+local bit = require("bit")
 require("scripts/globals/keyitems");
 require("scripts/globals/missions");
 require("scripts/globals/besieged");

--- a/scripts/zones/Norg/npcs/_700.lua
+++ b/scripts/zones/Norg/npcs/_700.lua
@@ -4,6 +4,7 @@
 --	@pos 97 -7 -12 252
 -----------------------------------
 
+local bit = require("bit")
 require("scripts/globals/missions");
 require("scripts/globals/settings")
 

--- a/scripts/zones/QuBia_Arena/bcnms/shattering_stars.lua
+++ b/scripts/zones/QuBia_Arena/bcnms/shattering_stars.lua
@@ -6,6 +6,7 @@
 package.loaded["scripts/zones/QuBia_Arena/TextIDs"] = nil;
 -----------------------------------
 
+local bit = require("bit")
 require("scripts/zones/QuBia_Arena/TextIDs");
 
 -----------------------------------

--- a/scripts/zones/Waughroon_Shrine/bcnms/shattering_stars.lua
+++ b/scripts/zones/Waughroon_Shrine/bcnms/shattering_stars.lua
@@ -6,6 +6,7 @@
 package.loaded["scripts/zones/Waughroon_Shrine/TextIDs"] = nil;
 -----------------------------------
 
+local bit = require("bit")
 require("scripts/zones/Waughroon_Shrine/TextIDs");
 
 -----------------------------------


### PR DESCRIPTION
This will become unnecessary, if we move to luajit or lua52.
I'm not sure if those require() lines break precompiled windows lua library.
Testing is needed.
