### PR TITLE
Rock door in Kuftal Tunnel now opens or closes based on current weather

### DIFF
--- a/scripts/zones/Kuftal_Tunnel/Zone.lua
+++ b/scripts/zones/Kuftal_Tunnel/Zone.lua
@@ -8,6 +8,7 @@ package.loaded["scripts/zones/Kuftal_Tunnel/TextIDs"] = nil;
 
 require("scripts/globals/settings");
 require("scripts/zones/Kuftal_Tunnel/TextIDs");
+require("scripts/globals/weather");
 
 -----------------------------------
 -- onInitialize
@@ -52,3 +53,17 @@ function onEventFinish(player,csid,option)
 	--printf("CSID: %u",csid);
 	--printf("RESULT: %u",option);
 end;	
+
+-----------------------------------	
+-- OnZoneWeatherChange	
+-----------------------------------	
+
+function OnZoneWeatherChange(weather)
+
+	if(weather == WEATHER_WIND or weather == WEATHER_GALES) then
+		GetNPCByID(17490276):setAnimation(9); -- Rock Up
+	else
+		GetNPCByID(17490276):setAnimation(8); -- Rock Down
+	end
+	
+end;


### PR DESCRIPTION
A working implementation of the Rock Door as described in:  Kuftal Tunnel rock https://github.com/DarkstarProject/darkstar/issues/365

I used info from [FFXI wiki](http://wiki.ffxiclopedia.org/wiki/Talk:Kuftal_Tunnel) to set the rock to come up during wind and gale weather and to be down for everything else
