### PR TITLE
Fix missing require("scripts/globals/titles") in newly the updated title npc scripts...

### DIFF
--- a/scripts/globals/npc_util.lua
+++ b/scripts/globals/npc_util.lua
@@ -189,12 +189,15 @@ function npcUtil.tradeHas(trade, items, gil)
 
 	return true;
 end
+
 function npcUtil.genTmask(player,title)
 	local val1 = 0
+
 	for i = 1, #title do
 		if(title[i] == 0 or player:hasTitle(title[i]) ~= true)then
 			val1 = bit.bor(val1, bit.lshift(1, i))
-		end			
+		end
 	end
+
 	return val1
 end

--- a/scripts/zones/Aht_Urhgan_Whitegate/npcs/Koyol-Futenol.lua
+++ b/scripts/zones/Aht_Urhgan_Whitegate/npcs/Koyol-Futenol.lua
@@ -4,10 +4,9 @@
 -- Title Change NPC
 -- @pos -129 2 -20 50
 -----------------------------------
-package.loaded["scripts/zones/Aht_Urhgan_Whitegate/TextIDs"] = nil;
------------------------------------
 
-require("scripts/zones/Aht_Urhgan_Whitegate/TextIDs");	
+require("scripts/globals/titles");
+
 local title2 = { DARK_RESISTANT , BEARER_OF_THE_MARK_OF_ZAHAK  , SEAGULL_PHRATRIE_CREW_MEMBER , PROUD_AUTOMATON_OWNER , WILDCAT_PUBLICIST ,
 				SCENIC_SNAPSHOTTER , BRANDED_BY_THE_FIVE_SERPENTS , IMMORTAL_LION , PARAGON_OF_BLUE_MAGE_EXCELLENCE , PARAGON_OF_CORSAIR_EXCELLENCE , PARAGON_OF_PUPPETMASTER_EXCELLENCE ,
 				MASTER_OF_AMBITION , MASTER_OF_CHANCE , SKYSERPENT_AGGRANDIZER , GALESERPENT_GUARDIAN , STONESERPENT_SHOCKTROOPER , PHOTOPTICATOR_OPERATOR ,
@@ -22,14 +21,14 @@ local title4 = { SUBDUER_OF_THE_MAMOOL_JA , SUBDUER_OF_THE_TROLLS , SUBDUER_OF_T
 				0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 }
 local title5 = { 0 , SUPERNAL_SAVANT , SOLAR_SAGE , BOLIDE_BARON , MOON_MAVEN  , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 }
 local title6 = { 0 , 0 , 0 , 0 , 0  , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 }
-local title7 = { 0 , 0 , 0 , 0 , 0  , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 }	
+local title7 = { 0 , 0 , 0 , 0 , 0  , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 }
 
 -----------------------------------
 -- onTrade Action
 -----------------------------------
 
 function onTrade(player,npc,trade)
-end; 
+end;
 
 -----------------------------------
 -- onTrigger Action
@@ -37,15 +36,15 @@ end;
 
 function onTrigger(player,npc)
 	player:startEvent(0x0284,npcUtil.genTmask(player,title2),npcUtil.genTmask(player,title3),npcUtil.genTmask(player,title4),npcUtil.genTmask(player,title5),npcUtil.genTmask(player,title6),npcUtil.genTmask(player,title7),1   ,player:getGil());
-end;-- 																					 							 													Last Title
+end;
 
 -----------------------------------
 -- onEventUpdate
 -----------------------------------
 
 function onEventUpdate(player,csid,option)
---printf("CSID: %u",csid);
---printf("RESULT: %u",option);
+	-- printf("CSID: %u",csid);
+	-- printf("RESULT: %u",option);
 end;
 
 -----------------------------------
@@ -53,25 +52,25 @@ end;
 -----------------------------------
 
 function onEventFinish(player,csid,option)
---printf("CSID: %u",csid);
---printf("RESULT: %u",option);
-	 if(csid==0x0284)then
-		if(option > 0 and option <29)then
-			if (player:delGil(200))then
+	-- printf("CSID: %u",csid);
+	-- printf("RESULT: %u",option);
+	if (csid==0x0284) then
+		if(option > 0 and option <29) then
+			if (player:delGil(200)) then
 				player:setTitle( title2[option] )
-			end				
-		elseif(option > 256 and option <285)then
-			if (player:delGil(300))then
+			end
+		elseif(option > 256 and option <285) then
+			if (player:delGil(300)) then
 				player:setTitle( title3[option - 256] )
 			end
-		elseif(option > 512 and option < 541)then
-			if (player:delGil(400))then
+		elseif(option > 512 and option < 541) then
+			if (player:delGil(400)) then
 				player:setTitle( title4[option - 512] )
 			end
-		elseif(option > 768 and option <797)then
-			if (player:delGil(500))then
+		elseif(option > 768 and option <797) then
+			if (player:delGil(500)) then
 				player:setTitle( title5[option - 768] )
 			end
 		end
-	end		
+	end
 end;

--- a/scripts/zones/Kazham/npcs/Eron-Tomaron.lua
+++ b/scripts/zones/Kazham/npcs/Eron-Tomaron.lua
@@ -5,9 +5,8 @@
 -- @pos -22 -4 -24 250
 -----------------------------------
 
-package.loaded["scripts/zones/Kazham/TextIDs"] = nil;
-require("scripts/zones/Kazham/TextIDs");
 require("scripts/globals/titles");
+
 local title2 = { DISCERNING_INDIVIDUAL , VERY_DISCERNING_INDIVIDUAL , EXTREMELY_DISCERNING_INDIVIDUAL , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 }
 local title3 = { HEIR_OF_THE_GREAT_FIRE  , YA_DONE_GOOD , GULLIBLES_TRAVELS , KAZHAM_CALLER , EXCOMMUNICATE_OF_KAZHAM , EVEN_MORE_GULLIBLES_TRAVELS ,
 				KING_OF_THE_OPOOPOS , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 }
@@ -15,19 +14,19 @@ local title4 = { FODDERCHIEF_FLAYER , WARCHIEF_WRECKER , DREAD_DRAGON_SLAYER , O
 				ADAMANTKING_KILLER  , BLACK_DRAGON_SLAYER , MANIFEST_MAULER , BEHEMOTHS_BANE , ARCHMAGE_ASSASSIN , HELLSBANE , GIANT_KILLER ,
 				LICH_BANISHER , JELLYBANE , BOGEYDOWNER , BEAKBENDER , SKULLCRUSHER , MORBOLBANE , GOLIATH_KILLER , MARYS_GUIDE , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 }
 local title5 = { SIMURGH_POACHER , ROC_STAR , SERKET_BREAKER  , CASSIENOVA , THE_HORNSPLITTER , TORTOISE_TORTURER , MON_CHERRY ,
-				BEHEMOTH_DETHRONER , THE_VIVISECTOR , DRAGON_ASHER , EXPEDITIONARY_TROOPER , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 }																
+				BEHEMOTH_DETHRONER , THE_VIVISECTOR , DRAGON_ASHER , EXPEDITIONARY_TROOPER , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 }
 local title6 = { ADAMANTKING_USURPER , OVERLORD_OVERTHROWER , DEITY_DEBUNKER , FAFNIR_SLAYER , ASPIDOCHELONE_SINKER , NIDHOGG_SLAYER ,
 				MAAT_MASHER , KIRIN_CAPTIVATOR , CACTROT_DESACELERADOR , LIFTER_OF_SHADOWS , TIAMAT_TROUNCER , VRTRA_VANQUISHER , WORLD_SERPENT_SLAYER ,
 				XOLOTL_XTRAPOLATOR , BOROKA_BELEAGUERER , OURYU_OVERWHELMER , VINEGAR_EVAPORATOR , VIRTUOUS_SAINT , BYEBYE_TAISAI , TEMENOS_LIBERATOR ,
 				APOLLYON_RAVAGER , WYRM_ASTONISHER , NIGHTMARE_AWAKENER , 0 , 0 , 0 , 0 , 0 }
-local title7 = { 0 , 0 , 0 , 0 , 0  , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 }	
-	
+local title7 = { 0 , 0 , 0 , 0 , 0  , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 }
+
 -----------------------------------
 -- onTrade Action
 -----------------------------------
 
 function onTrade(player,npc,trade)
-end; 
+end;
 
 -----------------------------------
 -- onTrigger Action
@@ -42,8 +41,8 @@ end;
 -----------------------------------
 
 function onEventUpdate(player,csid,option)
---printf("CSID: %u",csid);
---printf("RESULT: %u",option);
+	-- printf("CSID: %u",csid);
+	-- printf("RESULT: %u",option);
 end;
 
 -----------------------------------
@@ -51,27 +50,27 @@ end;
 -----------------------------------
 
 function onEventFinish(player,csid,option)
---printf("CSID: %u",csid);
---printf("RESULT: %u",option);
-	 if(csid==0x271D)then
-		if(option > 0 and option <29)then
-			if (player:delGil(200))then
+	-- printf("CSID: %u",csid);
+	-- printf("RESULT: %u",option);
+	if (csid==0x271D) then
+		if(option > 0 and option <29) then
+			if (player:delGil(200)) then
 				player:setTitle( title2[option] )
-			end				
-		elseif(option > 256 and option <285)then
-			if (player:delGil(300))then
+			end
+		elseif(option > 256 and option <285) then
+			if (player:delGil(300)) then
 				player:setTitle( title3[option - 256] )
 			end
-		elseif(option > 512 and option < 541)then
-			if (player:delGil(400))then
+		elseif(option > 512 and option < 541) then
+			if (player:delGil(400)) then
 				player:setTitle( title4[option - 512] )
 			end
-		elseif(option > 768 and option <797)then
-			if (player:delGil(500))then
+		elseif(option > 768 and option <797) then
+			if (player:delGil(500)) then
 				player:setTitle( title5[option - 768] )
 			end
-		elseif(option > 1024 and option < 1053)then
-			if (player:delGil(600))then
+		elseif(option > 1024 and option < 1053) then
+			if (player:delGil(600)) then
 				player:setTitle( title6[option - 1024] )
 			end
 		end

--- a/scripts/zones/Lower_Jeuno/npcs/Tuh_Almobankha.lua
+++ b/scripts/zones/Lower_Jeuno/npcs/Tuh_Almobankha.lua
@@ -5,8 +5,8 @@
 -- @pos -14 0 -61 245
 -----------------------------------
 
-package.loaded["scripts/zones/Lower_Jeuno/TextIDs"] = nil;
-require("scripts/zones/Lower_Jeuno/TextIDs");
+require("scripts/globals/titles");
+
 local title2 = { BROWN_MAGE_GUINEA_PIG , BROWN_MAGIC_BYPRODUCT , RESEARCHER_OF_CLASSICS , TORCHBEARER , FORTUNETELLER_IN_TRAINING ,
 				CHOCOBO_TRAINER , CLOCK_TOWER_PRESERVATIONIST , LIFE_SAVER , CARD_COLLECTOR , TWOS_COMPANY , TRADER_OF_ANTIQUITIES , GOBLINS_EXCLUSIVE_FASHION_MANNEQUIN ,
 				TENSHODO_MEMBER , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 }
@@ -23,14 +23,14 @@ local title5 = { PARAGON_OF_BEASTMASTER_EXCELLENCE , PARAGON_OF_BARD_EXCELLENCE 
 				DYNAMISQUFIM_INTERLOPER , CONQUEROR_OF_FATE , SUPERHERO , SUPERHEROINE , ELEGANT_DANCER , DAZZLING_DANCE_DIVA , GRIMOIRE_BEARER ,
 				FELLOW_FORTIFIER , BUSHIN_ASPIRANT , BUSHIN_RYU_INHERITOR , 0 , 0 , 0 , 0 , 0 , 0 , 0 }
 local title6 = { GRAND_GREEDALOX , SILENCER_OF_THE_ECHO , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 }
-local title7 = { 0 , 0 , 0 , 0 , 0  , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 }																				
+local title7 = { 0 , 0 , 0 , 0 , 0  , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 }
 
 -----------------------------------
 -- onTrade Action
 -----------------------------------
 
 function onTrade(player,npc,trade)
-end; 
+end;
 
 -----------------------------------
 -- onTrigger Action
@@ -38,15 +38,15 @@ end;
 
 function onTrigger(player,npc)
 	player:startEvent(0x271E,npcUtil.genTmask(player,title2),npcUtil.genTmask(player,title3),npcUtil.genTmask(player,title4),npcUtil.genTmask(player,title5),npcUtil.genTmask(player,title6),npcUtil.genTmask(player,title7),1   ,player:getGil());
-end; 
+end;
 
 -----------------------------------
 -- onEventUpdate
 -----------------------------------
 
 function onEventUpdate(player,csid,option)
---printf("CSID: %u",csid);
---printf("RESULT: %u",option);
+	-- printf("CSID: %u",csid);
+	-- printf("RESULT: %u",option);
 end;
 
 -----------------------------------
@@ -54,29 +54,29 @@ end;
 -----------------------------------
 
 function onEventFinish(player,csid,option)
---printf("CSID: %u",csid);
---printf("RESULT: %u",option);
-	 if(csid==0x271E)then
-		if(option > 0 and option <29)then
-			if (player:delGil(400))then
+	-- printf("CSID: %u",csid);
+	-- printf("RESULT: %u",option);
+	if (csid==0x271E) then
+		if(option > 0 and option <29) then
+			if (player:delGil(400)) then
 				player:setTitle( title2[option] )
-			end				
-		elseif(option > 256 and option <285)then
-			if (player:delGil(500))then
+			end
+		elseif(option > 256 and option <285) then
+			if (player:delGil(500)) then
 				player:setTitle(  title3[option - 256] )
 			end
-		elseif(option > 512 and option < 541)then
-			if (player:delGil(600))then
+		elseif(option > 512 and option < 541) then
+			if (player:delGil(600)) then
 				player:setTitle( title4[option - 512] )
 			end
-		elseif(option > 768 and option <797)then
-			if (player:delGil(700))then
+		elseif(option > 768 and option <797) then
+			if (player:delGil(700)) then
 				player:setTitle( title5[option - 768] )
 			end
-		elseif(option > 1024 and option < 1053)then
-			if (player:delGil(800))then
+		elseif(option > 1024 and option < 1053) then
+			if (player:delGil(800)) then
 				player:setTitle( title6[option - 1024] )
 			end
 		end
-	end			
+	end
 end;

--- a/scripts/zones/Mhaura/npcs/Willah_Maratahya.lua
+++ b/scripts/zones/Mhaura/npcs/Willah_Maratahya.lua
@@ -4,10 +4,9 @@
 --	Title Change NPC
 --  @pos 23 -8 63 249
 -----------------------------------
-package.loaded["scripts/zones/Mhaura/TextIDs"] = nil;
------------------------------------
 
-require("scripts/zones/Mhaura/TextIDs");
+require("scripts/globals/titles");
+
 local title2 = { PURVEYOR_IN_TRAINING , ONESTAR_PURVEYOR , TWOSTAR_PURVEYOR , THREESTAR_PURVEYOR , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 }
 local title3 = { FOURSTAR_PURVEYOR , FIVESTAR_PURVEYOR , HEIR_OF_THE_GREAT_LIGHTNING , ORCISH_SERJEANT , BRONZE_QUADAV , YAGUDO_INITIATE ,
 				MOBLIN_KINSMAN , DYNAMISBUBURIMU_INTERLOPER , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 }
@@ -20,14 +19,14 @@ local title6 = { ADAMANTKING_USURPER , OVERLORD_OVERTHROWER , DEITY_DEBUNKER , F
 				MAAT_MASHER , KIRIN_CAPTIVATOR , CACTROT_DESACELERADOR , LIFTER_OF_SHADOWS , TIAMAT_TROUNCER , VRTRA_VANQUISHER , WORLD_SERPENT_SLAYER ,
 				XOLOTL_XTRAPOLATOR , BOROKA_BELEAGUERER , OURYU_OVERWHELMER , VINEGAR_EVAPORATOR , VIRTUOUS_SAINT , BYEBYE_TAISAI , TEMENOS_LIBERATOR ,
 				APOLLYON_RAVAGER , WYRM_ASTONISHER , NIGHTMARE_AWAKENER , 0 , 0 , 0 , 0 , 0 }
-local title7 = { 0 , 0 , 0 , 0 , 0  , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 }																				
+local title7 = { 0 , 0 , 0 , 0 , 0  , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 }
 
 -----------------------------------
 -- onTrade Action
 -----------------------------------
 
 function onTrade(player,npc,trade)
-end; 
+end;
 
 -----------------------------------
 -- onTrigger Action
@@ -42,8 +41,8 @@ end;
 -----------------------------------
 
 function onEventUpdate(player,csid,option)
---printf("CSID: %u",csid);
---printf("RESULT: %u",option);
+	-- printf("CSID: %u",csid);
+	-- printf("RESULT: %u",option);
 end;
 
 -----------------------------------
@@ -51,29 +50,29 @@ end;
 -----------------------------------
 
 function onEventFinish(player,csid,option)
---printf("CSID: %u",csid);
---printf("RESULT: %u",option);
-	 if(csid==0x2711)then
-		if(option > 0 and option <29)then
-			if (player:delGil(200))then
+	-- printf("CSID: %u",csid);
+	-- printf("RESULT: %u",option);
+	if (csid==0x2711) then
+		if(option > 0 and option <29) then
+			if (player:delGil(200)) then
 				player:setTitle( title2[option] )
-			end				
-		elseif(option > 256 and option <285)then
-			if (player:delGil(300))then
+			end
+		elseif(option > 256 and option <285) then
+			if (player:delGil(300)) then
 				player:setTitle( title3[option - 256] )
 			end
-		elseif(option > 512 and option < 541)then
-			if (player:delGil(400))then
+		elseif(option > 512 and option < 541) then
+			if (player:delGil(400)) then
 				player:setTitle( title4[option - 512] )
 			end
-		elseif(option > 768 and option <797)then
-			if (player:delGil(500))then
+		elseif(option > 768 and option <797) then
+			if (player:delGil(500)) then
 				player:setTitle( title5[option - 768] )
 			end
-		elseif(option > 1024 and option < 1053)then
-			if (player:delGil(600))then
+		elseif(option > 1024 and option < 1053) then
+			if (player:delGil(600)) then
 				player:setTitle( title6[option - 1024] )
 			end
 		end
-	end			
+	end
 end;

--- a/scripts/zones/Norg/npcs/Quntsu-Nointsu.lua
+++ b/scripts/zones/Norg/npcs/Quntsu-Nointsu.lua
@@ -4,6 +4,9 @@
 -- Title Change NPC
 -- @pos -67 -1 34 252
 -----------------------------------
+
+require("scripts/globals/titles");
+
 local title2 = { HONORARY_DOCTORATE_MAJORING_IN_TONBERRIES , BUSHIDO_BLADE , BLACK_MARKETEER , CRACKER_OF_THE_SECRET_CODE ,
 				LOOKS_SUBLIME_IN_A_SUBLIGAR , LOOKS_GOOD_IN_LEGGINGS , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 }
 local title3 = { APPRENTICE_SOMMELIER , TREASUREHOUSE_RANSACKER , HEIR_OF_THE_GREAT_WATER , PARAGON_OF_SAMURAI_EXCELLENCE ,
@@ -13,14 +16,14 @@ local title4 = { BEARER_OF_THE_WISEWOMANS_HOPE , BEARER_OF_THE_EIGHT_PRAYERS , L
 				BURIER_OF_THE_ILLUSION , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 }
 local title5 = { 0 , 0 , 0 , 0 , 0  , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 }
 local title6 = { 0 , 0 , 0 , 0 , 0  , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 }
-local title7 = { 0 , 0 , 0 , 0 , 0  , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 }												
+local title7 = { 0 , 0 , 0 , 0 , 0  , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 }
 
 -----------------------------------
 -- onTrade Action
 -----------------------------------
 
 function onTrade(player,npc,trade)
-end; 
+end;
 
 -----------------------------------
 -- onTrigger Action
@@ -28,15 +31,15 @@ end;
 
 function onTrigger(player,npc)
 	player:startEvent(0x03F3,npcUtil.genTmask(player,title2),npcUtil.genTmask(player,title3),npcUtil.genTmask(player,title4),npcUtil.genTmask(player,title5),npcUtil.genTmask(player,title6),npcUtil.genTmask(player,title7),1   ,player:getGil());
-end; 
+end;
 
 -----------------------------------
 -- onEventUpdate
 -----------------------------------
 
 function onEventUpdate(player,csid,option)
---printf("CSID: %u",csid);
---printf("RESULT: %u",option);
+	-- printf("CSID: %u",csid);
+	-- printf("RESULT: %u",option);
 end;
 
 -----------------------------------
@@ -44,19 +47,19 @@ end;
 -----------------------------------
 
 function onEventFinish(player,csid,option)
---printf("CSID: %u",csid);
---printf("RESULT: %u",option);
-	 if(csid==0x03F3)then
-		if(option > 0 and option <29)then
-			if (player:delGil(200))then
+	-- printf("CSID: %u",csid);
+	-- printf("RESULT: %u",option);
+	if (csid==0x03F3) then
+		if(option > 0 and option <29) then
+			if (player:delGil(200)) then
 				player:setTitle( title2[option] )
-			end				
-		elseif(option > 256 and option <285)then
-			if (player:delGil(300))then
+			end
+		elseif(option > 256 and option <285) then
+			if (player:delGil(300)) then
 				player:setTitle(  title3[option - 256] )
 			end
-		elseif(option > 512 and option < 541)then
-			if (player:delGil(400))then
+		elseif(option > 512 and option < 541) then
+			if (player:delGil(400)) then
 				player:setTitle( title4[option - 512] )
 			end
 		end

--- a/scripts/zones/Port_Bastok/npcs/Styi_Palneh.lua
+++ b/scripts/zones/Port_Bastok/npcs/Styi_Palneh.lua
@@ -5,9 +5,8 @@
 -- @pos 28 4 -15 236
 -----------------------------------
 
+require("scripts/globals/titles");
 
-package.loaded["scripts/zones/Port_Bastok/TextIDs"] = nil;
-require("scripts/zones/Port_Bastok/TextIDs");
 local title2 = { NEW_ADVENTURER , BASTOK_WELCOMING_COMMITTEE , BUCKET_FISHER , PURSUER_OF_THE_PAST , MOMMYS_HELPER , HOT_DOG ,
 				STAMPEDER , RINGBEARER , ZERUHN_SWEEPER , TEARJERKER , CRAB_CRUSHER , BRYGIDAPPROVED , GUSTABERG_TOURIST , MOGS_MASTER , CERULEAN_SOLDIER ,
 				DISCERNING_INDIVIDUAL , VERY_DISCERNING_INDIVIDUAL , EXTREMELY_DISCERNING_INDIVIDUAL , APOSTATE_FOR_HIRE , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 }
@@ -30,23 +29,23 @@ local title7 = { MOG_HOUSE_HANDYPERSON , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 ,
 -----------------------------------
 
 function onTrade(player,npc,trade)
-end; 
+end;
 
 -----------------------------------
 -- onTrigger Action
 -----------------------------------
 
-function onTrigger(player,npc)																								
+function onTrigger(player,npc)
 	player:startEvent(0x00C8,npcUtil.genTmask(player,title2),npcUtil.genTmask(player,title3),npcUtil.genTmask(player,title4),npcUtil.genTmask(player,title5),npcUtil.genTmask(player,title6),npcUtil.genTmask(player,title7),1   ,player:getGil());
-end; 
+end;
 
 -----------------------------------
 -- onEventUpdate
 -----------------------------------
 
 function onEventUpdate(player,csid,option)
---printf("CSID: %u",csid);
---printf("RESULT: %u",option);
+	-- printf("CSID: %u",csid);
+	-- printf("RESULT: %u",option);
 end;
 
 -----------------------------------
@@ -54,33 +53,33 @@ end;
 -----------------------------------
 
 function onEventFinish(player,csid,option)
---printf("CSID: %u",csid);
---printf("RESULT: %u",option);
-	 if(csid==0x00C8)then
-		if(option > 0 and option <29)then
-			if (player:delGil(200))then
+	-- printf("CSID: %u",csid);
+	-- printf("RESULT: %u",option);
+	if (csid==0x00C8) then
+		if(option > 0 and option <29) then
+			if (player:delGil(200)) then
 				player:setTitle( title2[option] )
-			end				
-		elseif(option > 256 and option <285)then
-			if (player:delGil(300))then
+			end
+		elseif(option > 256 and option <285) then
+			if (player:delGil(300)) then
 				player:setTitle( title3[option - 256] )
 			end
-		elseif(option > 512 and option < 541)then
-			if (player:delGil(400))then
+		elseif(option > 512 and option < 541) then
+			if (player:delGil(400)) then
 				player:setTitle( title5[option - 512] )
 			end
-		elseif(option > 768 and option <797)then
-			if (player:delGil(500))then
+		elseif(option > 768 and option <797) then
+			if (player:delGil(500)) then
 				player:setTitle( title5[option - 768] )
 			end
-		elseif(option > 1024 and option < 1053)then
-			if (player:delGil(600))then
+		elseif(option > 1024 and option < 1053) then
+			if (player:delGil(600)) then
 				player:setTitle( title6[option - 1024] )
 			end
-		elseif(option > 1280 and option < 1309)then
-			if (player:delGil(700))then
-				player:setTitle(  title7[option - 1280]7) 
+		elseif(option > 1280 and option < 1309) then
+			if (player:delGil(700)) then
+				player:setTitle(  title7[option - 1280]7)
 			end
 		end
-	end			
+	end
 end;

--- a/scripts/zones/Port_Jeuno/npcs/Zuah_Lepahnyu.lua
+++ b/scripts/zones/Port_Jeuno/npcs/Zuah_Lepahnyu.lua
@@ -5,7 +5,8 @@
 -- @pos 0 0 8 246
 -----------------------------------
 
-require("scripts/zones/Port_Jeuno/TextIDs");
+require("scripts/globals/titles");
+
 local title2 = { VISITOR_TO_ABYSSEA , FRIEND_OF_ABYSSEA , WARRIOR_OF_ABYSSEA , STORMER_OF_ABYSSEA , DEVASTATOR_OF_ABYSSEA ,
 				HERO_OF_ABYSSEA , CHAMPION_OF_ABYSSEA , CONQUEROR_OF_ABYSSEA , SAVIOR_OF_ABYSSEA , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 }
 local title3 = { GOLDWING_SQUASHER , SILAGILITH_DETONATOR , SURTR_SMOTHERER , DREYRUK_PREDOMINATOR , SAMURSK_VITIATOR ,
@@ -18,17 +19,17 @@ local title5 = { TITLACAUAN_DISMEMBERER , SMOK_DEFOGGER , AMHULUK_INUNDATER , PU
 				0 , 0 , 0 , 0 , 0 , TEMENOS_EMANCIPATOR , APOLLYON_RAZER , UMAGRHK_MANEMANGLER , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 }
 local title6 = { KARKINOS_CLAWCRUSHER , CARABOSSE_QUASHER , OVNI_OBLITERATOR , RUMINATOR_CONFOUNDER , FISTULE_DRAINER , TURUL_GROUNDER ,
 				BLOODEYE_BANISHER , SATIATOR_DEPRIVER , CHLORIS_UPROOTER , MYRMECOLEON_TAMER , GLAVOID_STAMPEDER , USURPER_DEPOSER , ULHUADSHI_DESICCATOR ,
-				ITZPAPALOTL_DECLAWER , SOBEK_MUMMIFIER , CIREINCROIN_HARPOONER , BUKHIS_TETHERER , SEDNA_TUSKBREAKER , CLEAVER_DISMANTLER , 
-				EXECUTIONER_DISMANTLER , SEVERER_DISMANTLER , 0 , 0 , 0 , 0 , 0 , 0 , 0 }																				
+				ITZPAPALOTL_DECLAWER , SOBEK_MUMMIFIER , CIREINCROIN_HARPOONER , BUKHIS_TETHERER , SEDNA_TUSKBREAKER , CLEAVER_DISMANTLER ,
+				EXECUTIONER_DISMANTLER , SEVERER_DISMANTLER , 0 , 0 , 0 , 0 , 0 , 0 , 0 }
 local title7 = { HADHAYOSH_HALTERER , BRIAREUS_FELLER , ECCENTRICITY_EXPUNGER , KUKULKAN_DEFANGER , IRATHAM_CAPTURER , LACOVIE_CAPSIZER ,
-				LUSCA_DEBUNKER , TRISTITIA_DELIVERER , KETEA_BEACHER , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 }				
+				LUSCA_DEBUNKER , TRISTITIA_DELIVERER , KETEA_BEACHER , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 }
 
 -----------------------------------
 -- onTrade Action
 -----------------------------------
 
 function onTrade(player,npc,trade)
-end; 
+end;
 
 -----------------------------------
 -- onTrigger Action
@@ -36,15 +37,15 @@ end;
 
 function onTrigger(player,npc)
 	player:startEvent(0x014A,npcUtil.genTmask(player,title2),npcUtil.genTmask(player,title3),npcUtil.genTmask(player,title4),npcUtil.genTmask(player,title5),npcUtil.genTmask(player,title6),npcUtil.genTmask(player,title7),1   ,player:getGil());
-end; 
+end;
 
 -----------------------------------
 -- onEventUpdate
 -----------------------------------
 
 function onEventUpdate(player,csid,option)
---printf("CSID: %u",csid);
---printf("RESULT: %u",option);
+	-- printf("CSID: %u",csid);
+	-- printf("RESULT: %u",option);
 end;
 
 -----------------------------------
@@ -52,33 +53,33 @@ end;
 -----------------------------------
 
 function onEventFinish(player,csid,option)
---printf("CSID: %u",csid);
---printf("RESULT: %u",option);
-	 if(csid==0x014A)then
-		if(option > 0 and option <29)then
-			if (player:delGil(200))then
+	-- printf("CSID: %u",csid);
+	-- printf("RESULT: %u",option);
+	if (csid==0x014A) then
+		if(option > 0 and option <29) then
+			if (player:delGil(200)) then
 				player:setTitle( title2[option] )
-			end				
-		elseif(option > 256 and option <285)then
-			if (player:delGil(300))then
+			end
+		elseif(option > 256 and option <285) then
+			if (player:delGil(300)) then
 				player:setTitle( title3[option - 256] )
 			end
-		elseif(option > 512 and option < 541)then
-			if (player:delGil(400))then
+		elseif(option > 512 and option < 541) then
+			if (player:delGil(400)) then
 				player:setTitle( title4[option - 512] )
 			end
-		elseif(option > 768 and option <797)then
-			if (player:delGil(500))then
+		elseif(option > 768 and option <797) then
+			if (player:delGil(500)) then
 				player:setTitle( title5[option - 768] )
 			end
-		elseif(option > 1024 and option < 1053)then
-			if (player:delGil(600))then
+		elseif(option > 1024 and option < 1053) then
+			if (player:delGil(600)) then
 				player:setTitle( title6[option - 1024] )
 			end
-		elseif(option > 1280 and option < 1309)then
-			if (player:delGil(700))then
-				player:setTitle(  title7[option - 1280] ) 
-			end				
+		elseif(option > 1280 and option < 1309) then
+			if (player:delGil(700)) then
+				player:setTitle(  title7[option - 1280] )
+			end
 		end
 	end
 end;

--- a/scripts/zones/Rabao/npcs/Shupah_Mujuuk.lua
+++ b/scripts/zones/Rabao/npcs/Shupah_Mujuuk.lua
@@ -4,6 +4,9 @@
 -- Title Change NPC
 -- @pos 12 8 20 247
 -----------------------------------
+
+require("scripts/globals/titles");
+
 local title2 = { THE_IMMORTAL_FISHER_LU_SHANG , INDOMITABLE_FISHER , KUFTAL_TOURIST , ACQUIRER_OF_ANCIENT_ARCANUM , DESERT_HUNTER ,
 				ROOKIE_HERO_INSTRUCTOR , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 }
 local title3 = { HEIR_OF_THE_GREAT_WIND , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 }
@@ -16,14 +19,14 @@ local title6 = { ADAMANTKING_USURPER , OVERLORD_OVERTHROWER , DEITY_DEBUNKER , F
 				MAAT_MASHER , KIRIN_CAPTIVATOR , CACTROT_DESACELERADOR , LIFTER_OF_SHADOWS , TIAMAT_TROUNCER , VRTRA_VANQUISHER , WORLD_SERPENT_SLAYER ,
 				XOLOTL_XTRAPOLATOR , BOROKA_BELEAGUERER , OURYU_OVERWHELMER , VINEGAR_EVAPORATOR , VIRTUOUS_SAINT , BYEBYE_TAISAI , TEMENOS_LIBERATOR ,
 				APOLLYON_RAVAGER , WYRM_ASTONISHER , NIGHTMARE_AWAKENER , 0 , 0 , 0 , 0 , 0 }
-local title7 = { 0 , 0 , 0 , 0 , 0  , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 }																			
-	
+local title7 = { 0 , 0 , 0 , 0 , 0  , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 }
+
 -----------------------------------
 -- onTrade Action
 -----------------------------------
 
 function onTrade(player,npc,trade)
-end; 
+end;
 
 -----------------------------------
 -- onTrigger Action
@@ -31,15 +34,15 @@ end;
 
 function onTrigger(player,npc)
 	player:startEvent(0x03F3,npcUtil.genTmask(player,title2),npcUtil.genTmask(player,title3),npcUtil.genTmask(player,title4),npcUtil.genTmask(player,title5),npcUtil.genTmask(player,title6),npcUtil.genTmask(player,title7),1   ,player:getGil());
-end; 
+end;
 
 -----------------------------------
 -- onEventUpdate
 -----------------------------------
 
 function onEventUpdate(player,csid,option)
---printf("CSID: %u",csid);
---printf("RESULT: %u",option);
+	-- printf("CSID: %u",csid);
+	-- printf("RESULT: %u",option);
 end;
 
 -----------------------------------
@@ -47,27 +50,27 @@ end;
 -----------------------------------
 
 function onEventFinish(player,csid,option)
---printf("CSID: %u",csid);
---printf("RESULT: %u",option);
-	 if(csid==0x03F3)then
-		if(option > 0 and option <29)then
-			if (player:delGil(200))then
+	-- printf("CSID: %u",csid);
+	-- printf("RESULT: %u",option);
+	if (csid==0x03F3) then
+		if(option > 0 and option <29) then
+			if (player:delGil(200)) then
 				player:setTitle( title2[option] )
-			end				
-		elseif(option > 256 and option <285)then
-			if (player:delGil(300))then
+			end
+		elseif(option > 256 and option <285) then
+			if (player:delGil(300)) then
 				player:setTitle( title3[option - 256] )
 			end
-		elseif(option > 512 and option < 541)then
-			if (player:delGil(400))then
+		elseif(option > 512 and option < 541) then
+			if (player:delGil(400)) then
 				player:setTitle( title4[option - 512] )
 			end
-		elseif(option > 768 and option <797)then
-			if (player:delGil(500))then
+		elseif(option > 768 and option <797) then
+			if (player:delGil(500)) then
 				player:setTitle( title5[option - 768] )
 			end
-		elseif(option > 1024 and option < 1053)then
-			if (player:delGil(600))then
+		elseif(option > 1024 and option < 1053) then
+			if (player:delGil(600)) then
 				player:setTitle( title6[option - 1024] )
 			end
 		end

--- a/scripts/zones/Selbina/npcs/Yulon-Polon.lua
+++ b/scripts/zones/Selbina/npcs/Yulon-Polon.lua
@@ -4,10 +4,9 @@
 --  Type: Title Change NPC
 --  @pos 45.998 -16.273 15.739 248
 -----------------------------------
-package.loaded["scripts/zones/Selbina/TextIDs"] = nil;
------------------------------------
 
-require("scripts/zones/Selbina/TextIDs");
+require("scripts/globals/titles");
+
 local title2 = { CORDON_BLEU_FISHER , ECOLOGIST , LIL_CUPID , ACE_ANGLER , GOLD_HOOK , MYTHRIL_HOOK , SILVER_HOOK , COPPER_HOOK ,
 				0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 }
 local title3 = { SAVIOR_OF_LOVE , HONORARY_CITIZEN_OF_SELBINA , THE_LOVE_DOCTOR , LU_SHANGLIKE_FISHER_KING , ORCISH_SERJEANT , BRONZE_QUADAV ,
@@ -22,8 +21,8 @@ local title6 = { ADAMANTKING_USURPER , OVERLORD_OVERTHROWER , DEITY_DEBUNKER , F
 				MAAT_MASHER , KIRIN_CAPTIVATOR , CACTROT_DESACELERADOR , LIFTER_OF_SHADOWS , TIAMAT_TROUNCER , VRTRA_VANQUISHER , WORLD_SERPENT_SLAYER ,
 				XOLOTL_XTRAPOLATOR , BOROKA_BELEAGUERER , OURYU_OVERWHELMER , VINEGAR_EVAPORATOR , VIRTUOUS_SAINT , BYEBYE_TAISAI , TEMENOS_LIBERATOR ,
 				APOLLYON_RAVAGER , WYRM_ASTONISHER , NIGHTMARE_AWAKENER , 0 , 0 , 0 , 0 , 0 }
-local title7 = { 0 , 0 , 0 , 0 , 0  , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 }																				
-	
+local title7 = { 0 , 0 , 0 , 0 , 0  , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 }
+
 -----------------------------------
 -- onTrade Action
 -----------------------------------
@@ -55,27 +54,27 @@ end;
 function onEventFinish(player,csid,option)
 	-- printf("CSID: %u",csid);
 	-- printf("RESULT: %u",option);
-	 if(csid==0x2711)then
-		if(option > 0 and option <29)then
-			if (player:delGil(200))then
+	if (csid==0x2711) then
+		if(option > 0 and option <29) then
+			if (player:delGil(200)) then
 				player:setTitle( title2[option] )
-			end				
-		elseif(option > 256 and option <285)then
-			if (player:delGil(300))then
+			end
+		elseif(option > 256 and option <285) then
+			if (player:delGil(300)) then
 				player:setTitle(  title3[option - 256] )
-			end		
-		elseif(option > 512 and option < 541)then
-			if (player:delGil(400))then
+			end
+		elseif(option > 512 and option < 541) then
+			if (player:delGil(400)) then
 				player:setTitle( title4[option - 512] )
 			end
-		elseif(option > 768 and option <797)then
-			if (player:delGil(500))then
+		elseif(option > 768 and option <797) then
+			if (player:delGil(500)) then
 				player:setTitle( title5[option - 768] )
 			end
-		elseif(option > 1024 and option < 1053)then
-			if (player:delGil(600))then
+		elseif(option > 1024 and option < 1053) then
+			if (player:delGil(600)) then
 				player:setTitle( title6[option - 1024] )
 			end
 		end
-	end	
+	end
 end;

--- a/scripts/zones/Southern_San_dOria/npcs/Moozo-Koozo.lua
+++ b/scripts/zones/Southern_San_dOria/npcs/Moozo-Koozo.lua
@@ -7,9 +7,10 @@
 package.loaded["scripts/zones/Southern_San_dOria/TextIDs"] = nil;
 -----------------------------------
 
-require("scripts/globals/settings");
+require("scripts/globals/titles");
 require("scripts/globals/quests");
 require("scripts/zones/Southern_San_dOria/TextIDs");
+
 local title2 = { NEW_ADVENTURER , BEAN_CUISINE_SALTER , DAYBREAK_GAMBLER , ENTRANCE_DENIED , RABBITER , ROYAL_GRAVE_KEEPER ,
 				COURIER_EXTRAORDINAIRE , RONFAURIAN_RESCUER , PICKPOCKET_PINCHER , THE_PURE_ONE , LOST_CHILD_OFFICER , SILENCER_OF_THE_LAMBS ,
 				LOST_AMP_FOUND_OFFICER , GREEN_GROCER , THE_BENEVOLENT_ONE , KNIGHT_IN_TRAINING , ADVERTISING_EXECUTIVE , FAMILY_COUNSELOR ,
@@ -22,7 +23,7 @@ local title4 = { FIRSTRATE_ORGANIZER , PILGRIM_TO_HOLLA , TRIED_AND_TESTED_KNIGH
 				TALKS_WITH_TONBERRIES , SHADOW_BANISHER , MOGS_EXCEPTIONALLY_KIND_MASTER , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 }
 local title5 = { SEARING_STAR , STRIKING_STAR , SOOTHING_STAR , SABLE_STAR , SCARLET_STAR , SONIC_STAR , SAINTLY_STAR , SHADOWY_STAR ,
 				SAVAGE_STAR , SINGING_STAR , SNIPING_STAR , SLICING_STAR , SNEAKING_STAR , SPEARING_STAR , SUMMONING_STAR , SAPPHIRE_STAR ,
-				SURGING_STAR , SWAYING_STAR , SPRIGHTLY_STAR , SAGACIOUS_STAR , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 }												
+				SURGING_STAR , SWAYING_STAR , SPRIGHTLY_STAR , SAGACIOUS_STAR , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 }
 local title6 = { ROOK_BUSTER , BANNERET , GOLD_BALLI_STAR , MYTHRIL_BALLI_STAR , SILVER_BALLI_STAR , BRONZE_BALLI_STAR , BALLISTAGER ,
 				FINAL_BALLI_STAR , BALLI_STAR_ROYALE , PARAGON_OF_RED_MAGE_EXCELLENCE , PARAGON_OF_WHITE_MAGE_EXCELLENCE , PARAGON_OF_PALADIN_EXCELLENCE ,
 				PARAGON_OF_DRAGOON_EXCELLENCE , HEIR_OF_THE_GREAT_ICE , MOGS_LOVING_MASTER , SAN_DORIAN_ROYAL_HEIR , DYNAMISSAN_DORIA_INTERLOPER , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 }
@@ -30,10 +31,10 @@ local title7 = { ROYAL_ARCHER , ROYAL_SPEARMAN , ROYAL_SQUIRE , ROYAL_SWORDSMAN 
 				GRAND_TEMPLE_KNIGHT , RESERVE_KNIGHT_CAPTAIN , ELITE_ROYAL_GUARD , WOOD_WORSHIPER , LUMBER_LATHER , ACCOMPLISHED_CARPENTER ,
 				ANVIL_ADVOCATE , FORGE_FANATIC , ACCOMPLISHED_BLACKSMITH , ARMORY_OWNER , HIDE_HANDLER , LEATHER_LAUDER , ACCOMPLISHED_TANNER ,
 				SHOESHOP_OWNER , MOG_HOUSE_HANDYPERSON , 0 , 0 , 0 , 0 , 0 , 0 }
-				
------------------------------------ 
--- onTrade Action 
------------------------------------ 
+
+-----------------------------------
+-- onTrade Action
+-----------------------------------
 
 function onTrade(player,npc,trade)
 -- "Flyers for Regine" conditional script
@@ -48,21 +49,21 @@ function onTrade(player,npc,trade)
 	end
 end;
 
------------------------------------ 
--- onTrigger Action 
 -----------------------------------
- 
-function onTrigger(player,npc)																												 
+-- onTrigger Action
+-----------------------------------
+
+function onTrigger(player,npc)
 	player:startEvent(0x2A3,npcUtil.genTmask(player,title2),npcUtil.genTmask(player,title3),npcUtil.genTmask(player,title4),npcUtil.genTmask(player,title5),0,npcUtil.genTmask(player,title7),1   ,player:getGil());
-end; 
+end;
 
 -----------------------------------
 -- onEventUpdate
 -----------------------------------
 
 function onEventUpdate(player,csid,option)
---printf("CSID: %u",csid);
---printf("RESULT: %u",option);
+	-- printf("CSID: %u",csid);
+	-- printf("RESULT: %u",option);
 end;
 
 -----------------------------------
@@ -70,32 +71,32 @@ end;
 -----------------------------------
 
 function onEventFinish(player,csid,option)
---printf("CSID: %u",csid);
---printf("RESULT: %u",option);
-	 if(csid==0x2A3)then
-		if(option > 0 and option <29)then
-			if (player:delGil(200))then
+	-- printf("CSID: %u",csid);
+	-- printf("RESULT: %u",option);
+	if (csid==0x2A3) then
+		if(option > 0 and option <29) then
+			if (player:delGil(200)) then
 				player:setTitle( title2[option] )
-			end				
-		elseif(option > 256 and option <285)then
-			if (player:delGil(300))then
+			end
+		elseif(option > 256 and option <285) then
+			if (player:delGil(300)) then
 				player:setTitle(  title3[option - 256] )
 			end
-		elseif(option > 512 and option < 541)then
-			if (player:delGil(400))then
+		elseif(option > 512 and option < 541) then
+			if (player:delGil(400)) then
 				player:setTitle( title4[option - 512] )
 			end
-		elseif(option > 768 and option <797)then
-			if (player:delGil(500))then
+		elseif(option > 768 and option <797) then
+			if (player:delGil(500)) then
 				player:setTitle( title5[option - 768] )
 			end
-		elseif(option > 1024 and option < 1053)then
-			if (player:delGil(600))then
+		elseif(option > 1024 and option < 1053) then
+			if (player:delGil(600)) then
 				player:setTitle( title6[option - 1024] )
 			end
-		elseif(option > 1280 and option < 1309)then
-			if (player:delGil(700))then
-				player:setTitle(  title7[option - 1280] ) 
+		elseif(option > 1280 and option < 1309) then
+			if (player:delGil(700)) then
+				player:setTitle(  title7[option - 1280] )
 			end
 		end
 	end

--- a/scripts/zones/Tavnazian_Safehold/npcs/Aligi-Kufongi.lua
+++ b/scripts/zones/Tavnazian_Safehold/npcs/Aligi-Kufongi.lua
@@ -4,10 +4,12 @@
 -- Title Change NPC
 -- @pos -23 -21 15 26
 -----------------------------------
+
 require("scripts/globals/titles");
+
 local title2 = { TAVNAZIAN_SQUIRE ,PUTRID_PURVEYOR_OF_PUNGENT_PETALS , MONARCH_LINN_PATROL_GUARD , SIN_HUNTER_HUNTER , DISCIPLE_OF_JUSTICE , DYNAMISTAVNAZIA_INTERLOPER ,
 				CONFRONTER_OF_NIGHTMARES , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 }
-local title3 = { DEAD_BODY , FROZEN_DEAD_BODY , DREAMBREAKER , MIST_MELTER , DELTA_ENFORCER , OMEGA_OSTRACIZER , ULTIMA_UNDERTAKER , 
+local title3 = { DEAD_BODY , FROZEN_DEAD_BODY , DREAMBREAKER , MIST_MELTER , DELTA_ENFORCER , OMEGA_OSTRACIZER , ULTIMA_UNDERTAKER ,
 				ULMIAS_SOULMATE , TENZENS_ALLY , COMPANION_OF_LOUVERANCE , TRUE_COMPANION_OF_LOUVERANCE  , PRISHES_BUDDY  , NAGMOLADAS_UNDERLING ,
 				ESHANTARLS_COMRADE_IN_ARMS , THE_CHEBUKKIS_WORST_NIGHTMARE , UNQUENCHABLE_LIGHT , WARRIOR_OF_THE_CRYSTAL  , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 }
 local title4 = { ANCIENT_FLAME_FOLLOWER , TAVNAZIAN_TRAVELER , TRANSIENT_DREAMER , THE_LOST_ONE , TREADER_OF_AN_ICY_PAST , BRANDED_BY_LIGHTNING ,
@@ -21,23 +23,23 @@ local title7 = { 0 , 0 , 0 , 0 , 0  , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 
 -----------------------------------
 
 function onTrade(player,npc,trade)
-end; 
+end;
 
 -----------------------------------
 -- onTrigger Action
 -----------------------------------
 
-function onTrigger(player,npc)												
+function onTrigger(player,npc)
 	player:startEvent(0x0156,npcUtil.genTmask(player,title2),npcUtil.genTmask(player,title3),npcUtil.genTmask(player,title4),npcUtil.genTmask(player,title5),npcUtil.genTmask(player,title6),npcUtil.genTmask(player,title7),1   ,player:getGil());
-end; 
+end;
 
 -----------------------------------
 -- onEventUpdate
 -----------------------------------
 
 function onEventUpdate(player,csid,option)
---printf("CSID: %u",csid);
---printf("RESULT: %u",option);
+	-- printf("CSID: %u",csid);
+	-- printf("RESULT: %u",option);
 end;
 
 -----------------------------------
@@ -45,19 +47,19 @@ end;
 -----------------------------------
 
 function onEventFinish(player,csid,option)
---printf("CSID: %u",csid)
---printf("RESULT: %u",option)
-	if(csid == 0x0156)then
-		if(option > 0 and option <29)then
-			if (player:delGil(200))then	
+	-- printf("CSID: %u",csid)
+	-- printf("RESULT: %u",option)
+	if(csid == 0x0156) then
+		if(option > 0 and option <29) then
+			if (player:delGil(200)) then
 				player:setTitle( title2[option] )
 			end
-		elseif(option > 256 and option <285)then
-			if (player:delGil(300))then
+		elseif(option > 256 and option <285) then
+			if (player:delGil(300)) then
 				player:setTitle( title3[option - 256] )
 			end
-		elseif(option > 512 and option < 541)then
-			if (player:delGil(400))then
+		elseif(option > 512 and option < 541) then
+			if (player:delGil(400)) then
 				player:setTitle( title4[option - 512] )
 			end
 		end

--- a/scripts/zones/Windurst_Walls/npcs/Burute-Sorute.lua
+++ b/scripts/zones/Windurst_Walls/npcs/Burute-Sorute.lua
@@ -7,11 +7,10 @@
 --
 -- Auto-Script: Requires Verification (Verfied by Brawndo)
 -----------------------------------
-package.loaded["scripts/zones/Windurst_Walls/TextIDs"] = nil;
-require("scripts/globals/titles");
------------------------------------
 
-local title2 = { NEW_ADVENTURER , CAT_BURGLAR_GROUPIE , CRAWLER_CULLER , STAR_ONION_BRIGADE_MEMBER , SOB_SUPER_HERO , 
+require("scripts/globals/titles");
+
+local title2 = { NEW_ADVENTURER , CAT_BURGLAR_GROUPIE , CRAWLER_CULLER , STAR_ONION_BRIGADE_MEMBER , SOB_SUPER_HERO ,
 			EDITORS_HATCHET_MAN , SUPER_MODEL , FAST_FOOD_DELIVERER , CARDIAN_TUTOR , KISSER_MAKEUPPER , LOWER_THAN_THE_LOWEST_TUNNEL_WORM ,
 			FRESH_NORTH_WINDS_RECRUIT , HEAVENS_TOWER_GATEHOUSE_RECRUIT , NEW_BEST_OF_THE_WEST_RECRUIT , NEW_BUUMAS_BOOMERS_RECRUIT ,
 			MOGS_MASTER, EMERALD_EXTERMINATOR , DISCERNING_INDIVIDUAL , VERY_DISCERNING_INDIVIDUAL , EXTREMELY_DISCERNING_INDIVIDUAL ,
@@ -19,23 +18,23 @@ local title2 = { NEW_ADVENTURER , CAT_BURGLAR_GROUPIE , CRAWLER_CULLER , STAR_ON
 local title3 = { SAVIOR_OF_KNOWLEDGE , STAR_ONION_BRIGADIER , QUICK_FIXER , FAKEMOUSTACHED_INVESTIGATOR , CUPIDS_FLORIST ,
 			TARUTARU_MURDER_SUSPECT , HEXER_VEXER , GREAT_GRAPPLER_SCORPIO , CERTIFIED_ADVENTURER , BOND_FIXER , FOSSILIZED_SEA_FARER ,
 			MOGS_KIND_MASTER , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0}
-local title4 = { HAKKURURINKURUS_BENEFACTOR , SPOILSPORT , PILGRIM_TO_MEA , TOTAL_LOSER , DOCTOR_SHANTOTTOS_FLAVOR_OF_THE_MONTH , 
-			THE_FANGED_ONE , RAINBOW_WEAVER , FINE_TUNER , DOCTOR_SHANTOTTOS_GUINEA_PIG , GHOSTIE_BUSTER , NIGHT_SKY_NAVIGATOR , 
-			DELIVERER_OF_TEARFUL_NEWS , DOWN_PIPER_PIPEUPPERER , DOCTOR_YORANORAN_SUPPORTER , DOCTOR_SHANTOTTO_SUPPORTER , 
+local title4 = { HAKKURURINKURUS_BENEFACTOR , SPOILSPORT , PILGRIM_TO_MEA , TOTAL_LOSER , DOCTOR_SHANTOTTOS_FLAVOR_OF_THE_MONTH ,
+			THE_FANGED_ONE , RAINBOW_WEAVER , FINE_TUNER , DOCTOR_SHANTOTTOS_GUINEA_PIG , GHOSTIE_BUSTER , NIGHT_SKY_NAVIGATOR ,
+			DELIVERER_OF_TEARFUL_NEWS , DOWN_PIPER_PIPEUPPERER , DOCTOR_YORANORAN_SUPPORTER , DOCTOR_SHANTOTTO_SUPPORTER ,
 			PROFESSOR_KORUMORU_SUPPORTER , STARORDAINED_WARRIOR  , SHADOW_BANISHER , MOGS_EXCEPTIONALLY_KIND_MASTER , FRIEND_OF_THE_HELMED ,
 			DEED_VERIFIER , 0 , 0 , 0 , 0 , 0 , 0 , 0 }
-local title5 = { PARAGON_OF_THIEF_EXCELLENCE , PARAGON_OF_BLACK_MAGE_EXCELLENCE , PARAGON_OF_RANGER_EXCELLENCE , PARAGON_OF_SUMMONER_EXCELLENCE  , 
-			CERTIFIED_RHINOSTERY_VENTURER , DREAM_DWELLER , HERO_ON_BEHALF_OF_WINDURST , VICTOR_OF_THE_BALGA_CONTEST , MOGS_LOVING_MASTER , 
-			HEIR_OF_THE_NEW_MOON , SEEKER_OF_TRUTH  , FUGITIVE_MINISTER_BOUNTY_HUNTER , GUIDING_STAR , VESTAL_CHAMBERLAIN , 
+local title5 = { PARAGON_OF_THIEF_EXCELLENCE , PARAGON_OF_BLACK_MAGE_EXCELLENCE , PARAGON_OF_RANGER_EXCELLENCE , PARAGON_OF_SUMMONER_EXCELLENCE  ,
+			CERTIFIED_RHINOSTERY_VENTURER , DREAM_DWELLER , HERO_ON_BEHALF_OF_WINDURST , VICTOR_OF_THE_BALGA_CONTEST , MOGS_LOVING_MASTER ,
+			HEIR_OF_THE_NEW_MOON , SEEKER_OF_TRUTH  , FUGITIVE_MINISTER_BOUNTY_HUNTER , GUIDING_STAR , VESTAL_CHAMBERLAIN ,
 			DYNAMISWINDURST_INTERLOPER  , HEIR_TO_THE_REALM_OF_DREAMS , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0, 0 , 0 }
 local title6 = { FREESWORD , MERCENARY , MERCENARY_CAPTAIN , COMBAT_CASTER , TACTICIAN_MAGICIAN , WISE_WIZARD  ,
-			PATRIARCH_PROTECTOR , CASTER_CAPTAIN , MASTER_CASTER , MERCENARY_MAJOR , KNITTING_KNOWITALL , LOOM_LUNATIC , 
+			PATRIARCH_PROTECTOR , CASTER_CAPTAIN , MASTER_CASTER , MERCENARY_MAJOR , KNITTING_KNOWITALL , LOOM_LUNATIC ,
 			ACCOMPLISHED_WEAVER , BOUTIQUE_OWNER , BONE_BEAUTIFIER , SHELL_SCRIMSHANDER , ACCOMPLISHED_BONEWORKER , CURIOSITY_SHOP_OWNER ,
-			FASTRIVER_FISHER , COASTLINE_CASTER , ACCOMPLISHED_ANGLER , FISHMONGER_OWNER , GOURMAND_GRATIFIER , BANQUET_BESTOWER , 
+			FASTRIVER_FISHER , COASTLINE_CASTER , ACCOMPLISHED_ANGLER , FISHMONGER_OWNER , GOURMAND_GRATIFIER , BANQUET_BESTOWER ,
 			ACCOMPLISHED_CHEF , RESTAURANT_OWNER , 0 , 0 }
-local title7 = { MOG_HOUSE_HANDYPERSON , ARRESTER_OF_THE_ASCENSION , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 
+local title7 = { MOG_HOUSE_HANDYPERSON , ARRESTER_OF_THE_ASCENSION , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 ,
 			0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 }
-			
+
 -----------------------------------
 -- onTrade Action
 -----------------------------------
@@ -47,17 +46,17 @@ end;
 -- onTrigger Action
 -----------------------------------
 
-function onTrigger(player,npc)														    			
+function onTrigger(player,npc)
 	player:startEvent(0x2714,npcUtil.genTmask(player,title2),npcUtil.genTmask(player,title3),npcUtil.genTmask(player,title4),npcUtil.genTmask(player,title5),npcUtil.genTmask(player,title6),npcUtil.genTmask(player,title7),1   ,player:getGil());
-end;					   
+end;
 
 -----------------------------------
 -- onEventUpdate
 -----------------------------------
 
 function onEventUpdate(player,csid,option)
-	 --printf("CSID: %u",csid);
-	 --printf("RESULT: %u",option);
+	-- printf("CSID: %u",csid);
+	-- printf("RESULT: %u",option);
 end;
 
 -----------------------------------
@@ -65,32 +64,32 @@ end;
 -----------------------------------
 
 function onEventFinish(player,csid,option)
-	 --printf("CSID: %u",csid)
-	 --printf("RESULT: %u",option)
-	 if(csid==0x2714)then
-		if(option > 0 and option <29)then
-			if (player:delGil(200))then
+	-- printf("CSID: %u",csid)
+	-- printf("RESULT: %u",option)
+	if (csid==0x2714) then
+		if(option > 0 and option <29) then
+			if (player:delGil(200)) then
 				player:setTitle( title2[option] )
-			end				
-		elseif(option > 256 and option <285)then
-			if (player:delGil(300))then
+			end
+		elseif(option > 256 and option <285) then
+			if (player:delGil(300)) then
 				player:setTitle(  title3[option - 256] )
 			end
-		elseif(option > 512 and option < 541)then
-			if (player:delGil(400))then
+		elseif(option > 512 and option < 541) then
+			if (player:delGil(400)) then
 				player:setTitle( title4[option - 512] )
 			end
-		elseif(option > 768 and option <797)then
-			if (player:delGil(500))then
+		elseif(option > 768 and option <797) then
+			if (player:delGil(500)) then
 				player:setTitle( title5[option - 768] )
 			end
-		elseif(option > 1024 and option < 1053)then
-			if (player:delGil(600))then
+		elseif(option > 1024 and option < 1053) then
+			if (player:delGil(600)) then
 				player:setTitle( title6[option - 1024] )
 			end
-		elseif(option > 1280 and option < 1309)then
-			if (player:delGil(700))then
-				player:setTitle(  title7[option - 1280] ) 
+		elseif(option > 1280 and option < 1309) then
+			if (player:delGil(700)) then
+				player:setTitle(  title7[option - 1280] )
 			end
 		end
 	end


### PR DESCRIPTION
Also removed unused requires, most of these don't so much as call a single text ID. And trimmed trailing space...Left your tabs alone. To view the diffs without those whitespace changes, append ?w=1 to the url.
