### PR TITLE
Fix packet exploit in job change

### DIFF
--- a/src/map/packet_system.cpp
+++ b/src/map/packet_system.cpp
@@ -4833,7 +4833,7 @@ void SmallPacket0x100(map_session_data_t* session, CCharEntity* PChar, int8* dat
 			}
 		}
 
-		if ((sjob > 0x00) && (sjob < MAX_JOBTYPE) && (PChar->jobs.unlocked & (1 << mjob)))
+		if ((sjob > 0x00) && (sjob < MAX_JOBTYPE) && (PChar->jobs.unlocked & (1 << sjob)))
 		{
 			JOBTYPE prevsjob = PChar->GetSJob();
 


### PR DESCRIPTION
Stop players from switching to lvl0 jobs/not unlocked jobs via packets
