### PR TITLE
more abysystuffs

### DIFF
--- a/scripts/globals/quests.lua
+++ b/scripts/globals/quests.lua
@@ -732,7 +732,6 @@ CRYSTAL_GUARDIAN                 = 96;
 ENDINGS_AND_BEGINNINGS           = 97;
 AD_INFINITUM                     = 98;
 
-
 -----------------------------------
 --  Abyssea
 -----------------------------------
@@ -899,7 +898,7 @@ A_MIGHTIER_MARTELLO_ALTEPA      = 157;
 A_MIGHTIER_MARTELLO_ULEGUERAND  = 158;
 A_MIGHTIER_MARTELLO_GRAUBERG    = 159;
 A_JOURNEY_BEGINS                = 160; -- + --
-THE_TRUTH_BECKONS               = 161;
+THE_TRUTH_BECKONS               = 161; -- + --
 DAWN_OF_DEATH                   = 162;
 A_GOLDSTRUCK_GIGAS              = 163;
 TO_PASTE_A_PEISTE               = 164;

--- a/scripts/zones/Abyssea-Altepa/Zone.lua
+++ b/scripts/zones/Abyssea-Altepa/Zone.lua
@@ -1,11 +1,13 @@
 -----------------------------------
--- 
--- Zone: Abyssea-Altepa
--- 
+--
+-- Zone: Abyssea - Altepa
+--
+-----------------------------------
+package.loaded["scripts/zones/Abyssea-Altepa/TextIDs"] = nil;
 -----------------------------------
 
 require("scripts/globals/settings");
-package.loaded["scripts/zones/Abyssea-Altepa/TextIDs"] = nil;
+require("scripts/globals/quests");
 require("scripts/zones/Abyssea-Altepa/TextIDs");
 
 -----------------------------------
@@ -20,15 +22,22 @@ end;
 -----------------------------------
 
 function onZoneIn(player,prevZone)
-cs = -1;
-if ((player:getXPos() == 0) and (player:getYPos() == 0) and (player:getZPos() == 0)) then	
-		player:setPos(435 ,0 ,320 ,136)
-	end	
-return cs;
+    local cs = -1;
+
+    if (player:getXPos() == 0 and player:getYPos() == 0 and player:getZPos() == 0) then
+        player:setPos(435 ,0 ,320 ,136)
+    end
+
+    if (player:getQuestStatus(ABYSSEA, THE_TRUTH_BECKONS) == QUEST_ACCEPTED
+    and player:getVar("1stTimeAyssea") == 0) then
+        player:setVar("1stTimeAyssea",1);
+    end
+
+    return cs;
 end;
 
 -----------------------------------
--- onRegionEnter          
+-- onRegionEnter
 -----------------------------------
 
 function onRegionEnter(player,region)
@@ -39,8 +48,8 @@ end;
 -----------------------------------
 
 function onEventUpdate(player,csid,option)
---printf("CSID: %u",csid);
---printf("RESULT: %u",option);
+    -- printf("CSID: %u",csid);
+    -- printf("RESULT: %u",option);
 end;
 
 -----------------------------------
@@ -48,9 +57,6 @@ end;
 -----------------------------------
 
 function onEventFinish(player,csid,option)
---printf("CSID: %u",csid);
---printf("RESULT: %u",option);
+    -- printf("CSID: %u",csid);
+    -- printf("RESULT: %u",option);
 end;
-
-
-

--- a/scripts/zones/Abyssea-Attohwa/Zone.lua
+++ b/scripts/zones/Abyssea-Attohwa/Zone.lua
@@ -1,11 +1,13 @@
 -----------------------------------
 -- 
--- Zone: Abyssea-Attohwa
+-- Zone: Abyssea - Attohwa
 -- 
+-----------------------------------
+package.loaded["scripts/zones/Abyssea-Attohwa/TextIDs"] = nil;
 -----------------------------------
 
 require("scripts/globals/settings");
-package.loaded["scripts/zones/Abyssea-Attohwa/TextIDs"] = nil;
+require("scripts/globals/quests");
 require("scripts/zones/Abyssea-Attohwa/TextIDs");
 
 -----------------------------------
@@ -20,9 +22,18 @@ end;
 -----------------------------------
 
 function onZoneIn(player,prevZone)
-cs = -1;
+    local cs = -1;
 
-return cs;
+    if (player:getXPos() == 0 and player:getYPos() == 0 and player:getZPos() == 0) then
+        player:setPos(-134,-20,-182,108);
+    end
+
+    if (player:getQuestStatus(ABYSSEA, THE_TRUTH_BECKONS) == QUEST_ACCEPTED
+    and player:getVar("1stTimeAyssea") == 0) then
+        player:setVar("1stTimeAyssea",1);
+    end
+
+    return cs;
 end;
 
 -----------------------------------
@@ -37,8 +48,8 @@ end;
 -----------------------------------
 
 function onEventUpdate(player,csid,option)
---printf("CSID: %u",csid);
---printf("RESULT: %u",option);
+    -- printf("CSID: %u",csid);
+    -- printf("RESULT: %u",option);
 end;
 
 -----------------------------------
@@ -46,9 +57,6 @@ end;
 -----------------------------------
 
 function onEventFinish(player,csid,option)
---printf("CSID: %u",csid);
---printf("RESULT: %u",option);
+    -- printf("CSID: %u",csid);
+    -- printf("RESULT: %u",option);
 end;
-
-
-

--- a/scripts/zones/Abyssea-Empyreal_Paradox/Zone.lua
+++ b/scripts/zones/Abyssea-Empyreal_Paradox/Zone.lua
@@ -1,11 +1,13 @@
 -----------------------------------
--- 
--- Zone: Abyssea-Empyreal_Paradox
--- 
+--
+-- Zone: Abyssea - Empyreal_Paradox
+--
+-----------------------------------
+package.loaded["scripts/zones/Abyssea-Empyreal_Paradox/TextIDs"] = nil;
 -----------------------------------
 
 require("scripts/globals/settings");
-package.loaded["scripts/zones/Abyssea-Empyreal_Paradox/TextIDs"] = nil;
+require("scripts/globals/quests");
 require("scripts/zones/Abyssea-Empyreal_Paradox/TextIDs");
 
 -----------------------------------
@@ -20,13 +22,18 @@ end;
 -----------------------------------
 
 function onZoneIn(player,prevZone)
-cs = -1;
+    local cs = -1;
 
-return cs;
+    if (player:getXPos() == 0 and player:getYPos() == 0 and player:getZPos() == 0) then
+        --player:setPos(-495,0,483,205); -- BC Area
+        player:setPos(540,-500,-565,64);
+    end
+
+    return cs;
 end;
 
 -----------------------------------
--- onRegionEnter          
+-- onRegionEnter
 -----------------------------------
 
 function onRegionEnter(player,region)
@@ -37,8 +44,8 @@ end;
 -----------------------------------
 
 function onEventUpdate(player,csid,option)
---printf("CSID: %u",csid);
---printf("RESULT: %u",option);
+    -- printf("CSID: %u",csid);
+    -- printf("RESULT: %u",option);
 end;
 
 -----------------------------------
@@ -46,9 +53,6 @@ end;
 -----------------------------------
 
 function onEventFinish(player,csid,option)
---printf("CSID: %u",csid);
---printf("RESULT: %u",option);
+    -- printf("CSID: %u",csid);
+    -- printf("RESULT: %u",option);
 end;
-
-
-

--- a/scripts/zones/Abyssea-Grauberg/Zone.lua
+++ b/scripts/zones/Abyssea-Grauberg/Zone.lua
@@ -1,11 +1,13 @@
 -----------------------------------
 -- 
--- Zone: Abyssea-Grauberg
+-- Zone: Abyssea - Grauberg
 -- 
+-----------------------------------
+package.loaded["scripts/zones/Abyssea-Grauberg/TextIDs"] = nil;
 -----------------------------------
 
 require("scripts/globals/settings");
-package.loaded["scripts/zones/Abyssea-Grauberg/TextIDs"] = nil;
+require("scripts/globals/quests");
 require("scripts/zones/Abyssea-Grauberg/TextIDs");
 
 -----------------------------------
@@ -20,9 +22,18 @@ end;
 -----------------------------------
 
 function onZoneIn(player,prevZone)
-cs = -1;
+    local cs = -1;
 
-return cs;
+    if (player:getXPos() == 0 and player:getYPos() == 0 and player:getZPos() == 0) then
+        player:setPos(-555,31,-760,0); 
+    end
+
+    if (player:getQuestStatus(ABYSSEA, THE_TRUTH_BECKONS) == QUEST_ACCEPTED
+    and player:getVar("1stTimeAyssea") == 0) then
+        player:setVar("1stTimeAyssea",1);
+    end
+
+    return cs;
 end;
 
 -----------------------------------
@@ -37,8 +48,8 @@ end;
 -----------------------------------
 
 function onEventUpdate(player,csid,option)
---printf("CSID: %u",csid);
---printf("RESULT: %u",option);
+    -- printf("CSID: %u",csid);
+    -- printf("RESULT: %u",option);
 end;
 
 -----------------------------------
@@ -46,9 +57,6 @@ end;
 -----------------------------------
 
 function onEventFinish(player,csid,option)
---printf("CSID: %u",csid);
---printf("RESULT: %u",option);
+    -- printf("CSID: %u",csid);
+    -- printf("RESULT: %u",option);
 end;
-
-
-

--- a/scripts/zones/Abyssea-Konschtat/Zone.lua
+++ b/scripts/zones/Abyssea-Konschtat/Zone.lua
@@ -1,11 +1,19 @@
 -----------------------------------
 -- 
--- Zone: Abyssea-Konschtat
+-- Zone: Abyssea - Konschtat
 -- 
+-----------------------------------
+-- Research
+-- EventID 0x0400-0x0405 aura of boundless rage
+-- EventID 0x0800-0x0883 The treasure chest will disappear is 180 seconds menu.
+-- EventID 0x0884 Teleport?
+-- EventID 0x0885 DEBUG Menu
+-----------------------------------
+package.loaded["scripts/zones/Abyssea-Konschtat/TextIDs"] = nil;
 -----------------------------------
 
 require("scripts/globals/settings");
-package.loaded["scripts/zones/Abyssea-Konschtat/TextIDs"] = nil;
+require("scripts/globals/quests");
 require("scripts/zones/Abyssea-Konschtat/TextIDs");
 
 -----------------------------------
@@ -20,13 +28,22 @@ end;
 -----------------------------------
 
 function onZoneIn(player,prevZone)
-cs = -1;
+    local cs = -1;
+    -- Note: in retail even tractor lands you back at searing ward, will handle later.
+    if (player:getXPos() == 0 and player:getYPos() == 0 and player:getZPos() == 0) then
+        player:setPos(153,-72,-840,140);
+    end
 
-return cs;
+    if (player:getQuestStatus(ABYSSEA, THE_TRUTH_BECKONS) == QUEST_ACCEPTED
+    and player:getVar("1stTimeAyssea") == 0) then
+        player:setVar("1stTimeAyssea",1);
+    end
+
+    return cs;
 end;
 
 -----------------------------------
--- onRegionEnter          
+-- onRegionEnter
 -----------------------------------
 
 function onRegionEnter(player,region)
@@ -37,8 +54,8 @@ end;
 -----------------------------------
 
 function onEventUpdate(player,csid,option)
---printf("CSID: %u",csid);
---printf("RESULT: %u",option);
+    -- printf("CSID: %u",csid);
+    -- printf("RESULT: %u",option);
 end;
 
 -----------------------------------
@@ -46,9 +63,6 @@ end;
 -----------------------------------
 
 function onEventFinish(player,csid,option)
---printf("CSID: %u",csid);
---printf("RESULT: %u",option);
+    -- printf("CSID: %u",csid);
+    -- printf("RESULT: %u",option);
 end;
-
-
-

--- a/scripts/zones/Abyssea-Konschtat/npcs/Cavernous_Maw.lua
+++ b/scripts/zones/Abyssea-Konschtat/npcs/Cavernous_Maw.lua
@@ -7,7 +7,6 @@
 package.loaded["scripts/zones/Abyssea-Konschtat/TextIDs"] = nil;
 -----------------------------------
 
-require("scripts/globals/teleports");
 require("scripts/zones/Abyssea-Konschtat/TextIDs");
 
 -----------------------------------

--- a/scripts/zones/Abyssea-La_Theine/Zone.lua
+++ b/scripts/zones/Abyssea-La_Theine/Zone.lua
@@ -1,11 +1,13 @@
 -----------------------------------
--- 
--- Zone: Abyssea-La_Theine
--- 
+--
+-- Zone: Abyssea - La_Theine
+--
+-----------------------------------
+package.loaded["scripts/zones/Abyssea-La_Theine/TextIDs"] = nil;
 -----------------------------------
 
 require("scripts/globals/settings");
-package.loaded["scripts/zones/Abyssea-La_Theine/TextIDs"] = nil;
+require("scripts/globals/quests");
 require("scripts/zones/Abyssea-La_Theine/TextIDs");
 
 -----------------------------------
@@ -20,13 +22,22 @@ end;
 -----------------------------------
 
 function onZoneIn(player,prevZone)
-cs = -1;
+    local cs = -1;
 
-return cs;
+    if (player:getXPos() == 0 and player:getYPos() == 0 and player:getZPos() == 0) then
+        player:setPos(-480.5,-0.5,794,62);
+    end
+
+    if (player:getQuestStatus(ABYSSEA, THE_TRUTH_BECKONS) == QUEST_ACCEPTED
+    and player:getVar("1stTimeAyssea") == 0) then
+        player:setVar("1stTimeAyssea",1);
+    end
+
+    return cs;
 end;
 
 -----------------------------------
--- onRegionEnter          
+-- onRegionEnter
 -----------------------------------
 
 function onRegionEnter(player,region)
@@ -37,8 +48,8 @@ end;
 -----------------------------------
 
 function onEventUpdate(player,csid,option)
---printf("CSID: %u",csid);
---printf("RESULT: %u",option);
+    -- printf("CSID: %u",csid);
+    -- printf("RESULT: %u",option);
 end;
 
 -----------------------------------
@@ -46,9 +57,6 @@ end;
 -----------------------------------
 
 function onEventFinish(player,csid,option)
---printf("CSID: %u",csid);
---printf("RESULT: %u",option);
+    -- printf("CSID: %u",csid);
+    -- printf("RESULT: %u",option);
 end;
-
-
-

--- a/scripts/zones/Abyssea-Misareaux/Zone.lua
+++ b/scripts/zones/Abyssea-Misareaux/Zone.lua
@@ -1,11 +1,13 @@
 -----------------------------------
--- 
--- Zone: Abyssea-Misareaux
--- 
+--
+-- Zone: Abyssea - Misareaux
+--
+-----------------------------------
+package.loaded["scripts/zones/Abyssea-Misareaux/TextIDs"] = nil;
 -----------------------------------
 
 require("scripts/globals/settings");
-package.loaded["scripts/zones/Abyssea-Misareaux/TextIDs"] = nil;
+require("scripts/globals/quests");
 require("scripts/zones/Abyssea-Misareaux/TextIDs");
 
 -----------------------------------
@@ -20,13 +22,22 @@ end;
 -----------------------------------
 
 function onZoneIn(player,prevZone)
-cs = -1;
+    local cs = -1;
 
-return cs;
+    if (player:getXPos() == 0 and player:getYPos() == 0 and player:getZPos() == 0) then
+        -- player:setPos(670,-15,318,119);
+    end
+
+    if (player:getQuestStatus(ABYSSEA, THE_TRUTH_BECKONS) == QUEST_ACCEPTED
+    and player:getVar("1stTimeAyssea") == 0) then
+        player:setVar("1stTimeAyssea",1);
+    end
+
+    return cs;
 end;
 
 -----------------------------------
--- onRegionEnter          
+-- onRegionEnter
 -----------------------------------
 
 function onRegionEnter(player,region)
@@ -37,8 +48,8 @@ end;
 -----------------------------------
 
 function onEventUpdate(player,csid,option)
---printf("CSID: %u",csid);
---printf("RESULT: %u",option);
+    -- printf("CSID: %u",csid);
+    -- printf("RESULT: %u",option);
 end;
 
 -----------------------------------
@@ -46,9 +57,6 @@ end;
 -----------------------------------
 
 function onEventFinish(player,csid,option)
---printf("CSID: %u",csid);
---printf("RESULT: %u",option);
+    -- printf("CSID: %u",csid);
+    -- printf("RESULT: %u",option);
 end;
-
-
-

--- a/scripts/zones/Abyssea-Tahrongi/Zone.lua
+++ b/scripts/zones/Abyssea-Tahrongi/Zone.lua
@@ -1,11 +1,13 @@
 -----------------------------------
--- 
--- Zone: Abyssea-Tahrongi
--- 
+--
+-- Zone: Abyssea - Tahrongi
+--
+-----------------------------------
+package.loaded["scripts/zones/Abyssea-Tahrongi/TextIDs"] = nil;
 -----------------------------------
 
 require("scripts/globals/settings");
-package.loaded["scripts/zones/Abyssea-Tahrongi/TextIDs"] = nil;
+require("scripts/globals/quests");
 require("scripts/zones/Abyssea-Tahrongi/TextIDs");
 
 -----------------------------------
@@ -20,13 +22,22 @@ end;
 -----------------------------------
 
 function onZoneIn(player,prevZone)
-cs = -1;
+    local cs = -1;
 
-return cs;
+    if (player:getXPos() == 0 and player:getYPos() == 0 and player:getZPos() == 0) then
+        player:setPos(-24,44,-678,240);
+    end
+
+    if (player:getQuestStatus(ABYSSEA, THE_TRUTH_BECKONS) == QUEST_ACCEPTED
+    and player:getVar("1stTimeAyssea") == 0) then
+        player:setVar("1stTimeAyssea",1);
+    end
+
+    return cs;
 end;
 
 -----------------------------------
--- onRegionEnter          
+-- onRegionEnter
 -----------------------------------
 
 function onRegionEnter(player,region)
@@ -37,8 +48,8 @@ end;
 -----------------------------------
 
 function onEventUpdate(player,csid,option)
---printf("CSID: %u",csid);
---printf("RESULT: %u",option);
+    -- printf("CSID: %u",csid);
+    -- printf("RESULT: %u",option);
 end;
 
 -----------------------------------
@@ -46,9 +57,6 @@ end;
 -----------------------------------
 
 function onEventFinish(player,csid,option)
---printf("CSID: %u",csid);
---printf("RESULT: %u",option);
+    -- printf("CSID: %u",csid);
+    -- printf("RESULT: %u",option);
 end;
-
-
-

--- a/scripts/zones/Abyssea-Uleguerand/Zone.lua
+++ b/scripts/zones/Abyssea-Uleguerand/Zone.lua
@@ -1,11 +1,13 @@
 -----------------------------------
--- 
--- Zone: Abyssea-Uleguerand
--- 
+--
+-- Zone: Abyssea - Uleguerand
+--
+-----------------------------------
+package.loaded["scripts/zones/Abyssea-Uleguerand/TextIDs"] = nil;
 -----------------------------------
 
 require("scripts/globals/settings");
-package.loaded["scripts/zones/Abyssea-Uleguerand/TextIDs"] = nil;
+require("scripts/globals/quests");
 require("scripts/zones/Abyssea-Uleguerand/TextIDs");
 
 -----------------------------------
@@ -20,13 +22,22 @@ end;
 -----------------------------------
 
 function onZoneIn(player,prevZone)
-cs = -1;
+    local cs = -1;
 
-return cs;
+    if (player:getXPos() == 0 and player:getYPos() == 0 and player:getZPos() == 0) then
+        player:setPos(-238, -40, -520.5, 0);
+    end
+
+    if (player:getQuestStatus(ABYSSEA, THE_TRUTH_BECKONS) == QUEST_ACCEPTED
+    and player:getVar("1stTimeAyssea") == 0) then
+        player:setVar("1stTimeAyssea",1);
+    end
+
+    return cs;
 end;
 
 -----------------------------------
--- onRegionEnter          
+-- onRegionEnter
 -----------------------------------
 
 function onRegionEnter(player,region)
@@ -37,8 +48,8 @@ end;
 -----------------------------------
 
 function onEventUpdate(player,csid,option)
---printf("CSID: %u",csid);
---printf("RESULT: %u",option);
+    -- printf("CSID: %u",csid);
+    -- printf("RESULT: %u",option);
 end;
 
 -----------------------------------
@@ -46,9 +57,6 @@ end;
 -----------------------------------
 
 function onEventFinish(player,csid,option)
---printf("CSID: %u",csid);
---printf("RESULT: %u",option);
+    -- printf("CSID: %u",csid);
+    -- printf("RESULT: %u",option);
 end;
-
-
-

--- a/scripts/zones/Abyssea-Vunkerl/Zone.lua
+++ b/scripts/zones/Abyssea-Vunkerl/Zone.lua
@@ -1,11 +1,13 @@
 -----------------------------------
 -- 
--- Zone: Abyssea-Vunkerl
+-- Zone: Abyssea - Vunkerl
 -- 
+-----------------------------------
+package.loaded["scripts/zones/Abyssea-Vunkerl/TextIDs"] = nil;
 -----------------------------------
 
 require("scripts/globals/settings");
-package.loaded["scripts/zones/Abyssea-Vunkerl/TextIDs"] = nil;
+require("scripts/globals/quests");
 require("scripts/zones/Abyssea-Vunkerl/TextIDs");
 
 -----------------------------------
@@ -20,9 +22,18 @@ end;
 -----------------------------------
 
 function onZoneIn(player,prevZone)
-cs = -1;
+    local cs = -1;
 
-return cs;
+    if (player:getXPos() == 0 and player:getYPos() == 0 and player:getZPos() == 0) then
+        player:setPos(-351,-46.750,699.5,10);
+    end
+
+    if (player:getQuestStatus(ABYSSEA, THE_TRUTH_BECKONS) == QUEST_ACCEPTED
+    and player:getVar("1stTimeAyssea") == 0) then
+        player:setVar("1stTimeAyssea",1);
+    end
+
+    return cs;
 end;
 
 -----------------------------------
@@ -37,8 +48,8 @@ end;
 -----------------------------------
 
 function onEventUpdate(player,csid,option)
---printf("CSID: %u",csid);
---printf("RESULT: %u",option);
+    -- printf("CSID: %u",csid);
+    -- printf("RESULT: %u",option);
 end;
 
 -----------------------------------
@@ -46,9 +57,6 @@ end;
 -----------------------------------
 
 function onEventFinish(player,csid,option)
---printf("CSID: %u",csid);
---printf("RESULT: %u",option);
+    -- printf("CSID: %u",csid);
+    -- printf("RESULT: %u",option);
 end;
-
-
-

--- a/scripts/zones/Konschtat_Highlands/npcs/Cavernous_Maw.lua
+++ b/scripts/zones/Konschtat_Highlands/npcs/Cavernous_Maw.lua
@@ -1,0 +1,64 @@
+-----------------------------------
+-- Area: Konschtat Highlands
+--  NPC: Cavernous Maw
+-- Teleports Players to Abyssea - Konschtat
+-- @pos 96.344, -69.080, -580.008 108
+-----------------------------------
+package.loaded["scripts/zones/Konschtat_Highlands/TextIDs"] = nil;
+-----------------------------------
+
+require("scripts/globals/settings");
+require("scripts/globals/keyitems");
+require("scripts/globals/quests");
+require("scripts/globals/abyssea");
+require("scripts/zones/Konschtat_Highlands/TextIDs");
+
+-----------------------------------
+-- onTrade Action
+-----------------------------------
+
+function onTrade(player,npc,trade)
+end;
+
+-----------------------------------
+-- onTrigger Action
+-----------------------------------
+
+function onTrigger(player,npc)
+    if (ENABLE_ABYSSEA == 1 and player:getMainLvl() >= 30) then
+        local HasStone = getTravStonesTotal(player);
+        if (HasStone >= 1 and player:getQuestStatus(ABYSSEA, DAWN_OF_DEATH) == QUEST_ACCEPTED
+        and player:getQuestStatus(ABYSSEA, TO_PASTE_A_PEISTE) == QUEST_AVAILABLE) then
+            player:startEvent(0);
+        else
+            player:startEvent(0x006B,0,1); -- No param = no entry.
+        end
+    else
+        player:messageSpecial(NOTHING_HAPPENS);
+    end
+end;
+
+-----------------------------------
+-- onEventUpdate
+-----------------------------------
+
+function onEventUpdate(player,csid,option)
+    -- printf("CSID: %u",csid);
+    -- printf("RESULT: %u",option);
+end;
+
+-----------------------------------
+-- onEventFinish
+-----------------------------------
+
+function onEventFinish(player,csid,option)
+    -- printf("CSID: %u",csid);
+    -- printf("RESULT: %u",option);
+    if (csid == 0) then
+        player:addQuest(ABYSSEA, TO_PASTE_A_PEISTE);
+    elseif (csid ==1) then
+        -- Killed Kukulkan
+    elseif(csid == 0x006B and option == 1) then
+        player:setPos(153,-72,-840,140,15);
+    end
+end;

--- a/scripts/zones/Port_Jeuno/Zone.lua
+++ b/scripts/zones/Port_Jeuno/Zone.lua
@@ -37,7 +37,7 @@ function onZoneIn(player,prevZone)
 			cs = 0x2725;
 			player:setPos(-24.000, 12.000, 116.000, 128);
 		else
-			position = math.random(1,3) - 2;
+			local position = math.random(1,3) - 2;
 			player:setPos(-192.5 ,-5,position,0);
 			if (player:getMainJob() ~= player:getVar("PlayerMainJob")) then
 				cs = 0x7534;
@@ -49,21 +49,24 @@ function onZoneIn(player,prevZone)
 		cs = 0x0144;
 	end
 
------------------------------------		
--- onConquestUpdate		
------------------------------------		
+	return cs
+end;
+
+-----------------------------------
+-- onConquestUpdate
+-----------------------------------
 
 function onConquestUpdate(zone, updatetype)
     local players = zone:getPlayers();
-    
+
     for name, player in pairs(players) do
         conquestUpdate(zone, player, updatetype, CONQUEST_BASE);
     end
 end;
 
------------------------------------		
--- onTransportEvent		
------------------------------------		
+-----------------------------------
+-- onTransportEvent
+-----------------------------------
 
 -----------------------------------
 -- onTransportEvent
@@ -86,8 +89,8 @@ end;
 -----------------------------------
 
 function onEventUpdate(player,csid,option)
-	--printf("CSID: %u",csid);
-	--printf("RESULT: %u",option);
+	-- printf("CSID: %u",csid);
+	-- printf("RESULT: %u",option);
 end;
 
 -----------------------------------
@@ -95,8 +98,8 @@ end;
 -----------------------------------
 
 function onEventFinish(player,csid,option)
-	--printf("CSID: %u",csid);
-	--printf("RESULT: %u",option);
+	-- printf("CSID: %u",csid);
+	-- printf("RESULT: %u",option);
 	if (csid == 0x271A) then
 		player:setPos(0,0,0,0,223);
 	elseif (csid == 0x271B) then

--- a/scripts/zones/Port_Jeuno/npcs/Horst.lua
+++ b/scripts/zones/Port_Jeuno/npcs/Horst.lua
@@ -22,7 +22,9 @@ end;
 
 function onTrigger(player,npc)
     local CRUOR = player:getCruor();
-    if (ENABLE ABYSSEA == 1 and player:getQuestStatus(ABYSSEA, THE_TRUTH_BECKONS) == QUEST_COMPLETED) then
+    if (player:getQuestStatus(ABYSSEA, THE_TRUTH_BECKONS) == QUEST_ACCEPTED) then
+        player:startEvent(0x0153,1,CRUOR,7,7,7); -- Temp activated all locations till param handling sorted out.
+    elseif (player:getQuestStatus(ABYSSEA, THE_TRUTH_BECKONS) == QUEST_COMPLETED) then
         player:startEvent(0x0153,2,CRUOR,7,7,7); -- Temp activated all locations till param handling sorted out.
     else
         player:startEvent(0x0153, 0);
@@ -46,48 +48,48 @@ function onEventFinish(player,csid,option)
     -- printf("CSID: %u",csid);
     -- printf("RESULT: %u",option);
     local CRUOR = player:getCruor();
-    if(csid == 0x0153)then
-        if(option == 260)then
+    if (csid == 0x0153)then
+        if (option == 260)then
             if (CRUOR >= 200) then
                 player:delCruor(200);
                 player:setPos(-562,0.001,640,26,102); -- La Theine Plateau
             end
-        elseif(option == 264)then
+        elseif (option == 264)then
             if (CRUOR >= 200) then
                 player:delCruor(200);
                 player:setPos(91,-68,-582,237,108); -- Konshtat Highlands
             end
-        elseif(option == 268)then
+        elseif (option == 268)then
             if (CRUOR >= 200) then
                 player:delCruor(200);
                 player:setPos(-28,46,-680,76,117); -- Tahrongi Canyon
             end
-        elseif(option == 272)then
+        elseif (option == 272)then
             if (CRUOR >= 200) then
                 player:delCruor(200);
                 player:setPos(241,0.001,11,42,104); -- Jugner Forest
             end
-        elseif(option == 276)then
+        elseif (option == 276)then
             if (CRUOR >= 200) then
                 player:delCruor(200);
                 player:setPos(362,0.001,-119,4,103); -- Valkrum
             end
-        elseif(option == 280)then
+        elseif (option == 280)then
             if (CRUOR >= 200) then
                 player:delCruor(200);
                 player:setPos(-338,-23,47,167,118); -- Buburimu Peninsula
             end
-        elseif(option == 288)then
+        elseif (option == 288)then
             if (CRUOR >= 200) then
                 player:delCruor(200);
                 player:setPos(269,-7,-75,192,112); -- Xarcabard
             end
-        elseif(option == 284)then
+        elseif (option == 284)then
             if (CRUOR >= 200) then
                 player:delCruor(200);
                 player:setPos(337,0.001,-675,52,107);  -- South Gustaberg
             end
-        elseif(option == 292)then
+        elseif (option == 292)then
             if (CRUOR >= 200) then
                 player:delCruor(200);
                 player:setPos(-71,0.001,601,126,106); -- North Gustaberg

--- a/scripts/zones/Port_Jeuno/npcs/Joachim.lua
+++ b/scripts/zones/Port_Jeuno/npcs/Joachim.lua
@@ -56,11 +56,11 @@ function onTrigger(player,npc)
 
     if (player:getQuestStatus(ABYSSEA, A_JOURNEY_BEGINS) == QUEST_ACCEPTED) then
         player:startEvent(0x0145);
-     elseif (player:getQuestStatus(ABYSSEA, THE_TRUTH_BECKONS) == QUEST_ACCEPTED) then
+    elseif (player:getQuestStatus(ABYSSEA, THE_TRUTH_BECKONS) == QUEST_ACCEPTED and player:getVar("1stTimeAyssea") == 1) then
+        player:startEvent(0x0147,0,0,MaxKI); -- cs for "The Truth Beckons" completion
+    elseif (player:getQuestStatus(ABYSSEA, THE_TRUTH_BECKONS) ~= QUEST_COMPLETED) then
         player:startEvent(0x0146); -- Pre "The Truth Beckons" Menu
-    elseif (player:getQuestStatus(ABYSSEA, THE_TRUTH_BECKONS) == QUEST_COMPLETED) then
-        --player:startEvent(0x0147); -- cs after "The Truth Beckons" completed
-    --elseif (player:getQuestStatus(ABYSSEA, DAWN_OF_DEATH) == QUEST_ACCEPTED) then
+    elseif (player:getQuestStatus(ABYSSEA, DAWN_OF_DEATH) == QUEST_ACCEPTED) then
         player:startEvent(0x0148,0,StonesStock,StonesKI,isCap,1,1,1,3); -- Post "The Truth Beckons" Menu
     -- elseif
         -- player:startEvent(0x014C);
@@ -88,6 +88,10 @@ function onEventFinish(player,csid,option)
         player:addKeyItem(TRAVERSER_STONE1)
         player:completeQuest(ABYSSEA, A_JOURNEY_BEGINS);
         player:addQuest(ABYSSEA, THE_TRUTH_BECKONS);
+    elseif (csid == 0x0147) then
+        player:completeQuest(ABYSSEA, THE_TRUTH_BECKONS);
+        player:addQuest(ABYSSEA, DAWN_OF_DEATH);
+        player:setVar("1stTimeAyssea",0);
     elseif (csid == 0x0148 and option == 6) then
         local StonesKI = getTravStonesTotal(player);
         if (StonesKI == 5) then


### PR DESCRIPTION
Implemented quest "The Truth Beckons", and the start of "Dawn of Death"
Added script for the maw in Konschtat Highlands.
Repaired busted zone.lua in Port Jeuno.
Added a default position to every Abyssea zone so we'd stop zoning into empty space using GM command during testing.

Looking over scripts offered by @LegionXI
Some of it can be reworked to not rely on NPC IDs as a trigger condition since updates can break those and will fit with what I had already started working on for treasure boxes outside abyssea (roughly same system, abyssea just has more box types to deal with). 

Regarding the future of magian trials: 
I really want to avoid having to add a check in on death for every mob in every zone for some things though, so I will need to work out how to handle checking the trial objectives and if the mobs meet those in core to avoid that. I'm also thinking of moving the info for said trials into a db table instead of those huge lua tables I started on. Any feedback about how you think any of that should go are appreciated.

...Could do the same to those big FoV/GoV info tables eventually. GoV began as a hack to FoV, and I had to split them up because the lua file was to large, but a single db table could hold all the regime info for FoV GoV Hunts and Dominion OPs. I think I'd still need to keep the onDeath checks for those however, because they aren't neatly divided into mob families and weather conditions like magian trials are.
