### PR TITLE
Do not downcast from 16 bit precision to 8 bit precision.

### DIFF
--- a/src/map/ai/ai_char_normal.cpp
+++ b/src/map/ai/ai_char_normal.cpp
@@ -1089,7 +1089,7 @@ void CAICharNormal::ActionRangedFinish()
 				}
 
 				// check for recycle chance
-				uint8 recycleChance = m_PChar->getMod(MOD_RECYCLE);
+				uint16 recycleChance = m_PChar->getMod(MOD_RECYCLE);
 				if (charutils::hasTrait(m_PChar,TRAIT_RECYCLE))
 				{
 					recycleChance += m_PChar->PMeritPoints->GetMeritValue(MERIT_RECYCLE,m_PChar);
@@ -1199,7 +1199,7 @@ void CAICharNormal::ActionRangedFinish()
 		// Will instantly trigger another ranged attack
 		if (m_PChar->StatusEffectContainer->HasStatusEffect(EFFECT_DOUBLE_SHOT,0) && !m_PChar->secondDoubleShotTaken &&	!isBarrage && !isSange)
 		{
-			uint8 doubleShotChance = m_PChar->getMod(MOD_DOUBLE_SHOT_RATE);
+			uint16 doubleShotChance = m_PChar->getMod(MOD_DOUBLE_SHOT_RATE);
 			if (WELL512::irand()%100 < doubleShotChance)
 			{
 				m_PChar->secondDoubleShotTaken = true;
@@ -1943,7 +1943,7 @@ void CAICharNormal::ActionJobAbilityFinish()
 
     		// check for recycle chance
     		CItemWeapon* PAmmo = (CItemWeapon*)m_PChar->getEquip(SLOT_AMMO);
-    		uint8 recycleChance = m_PChar->getMod(MOD_RECYCLE);
+    		uint16 recycleChance = m_PChar->getMod(MOD_RECYCLE);
 
     		if (charutils::hasTrait(m_PChar,TRAIT_RECYCLE))
     			recycleChance += m_PChar->PMeritPoints->GetMeritValue(MERIT_RECYCLE,m_PChar);
@@ -2621,7 +2621,7 @@ void CAICharNormal::ActionWeaponSkillFinish()
 		//ranged WS IDs
 		CItemWeapon* PAmmo = (CItemWeapon*)m_PChar->getEquip(SLOT_AMMO);
 
-        uint8 recycleChance = m_PChar->getMod(MOD_RECYCLE) + m_PChar->PMeritPoints->GetMeritValue(MERIT_RECYCLE,m_PChar);
+        uint16 recycleChance = m_PChar->getMod(MOD_RECYCLE) + m_PChar->PMeritPoints->GetMeritValue(MERIT_RECYCLE,m_PChar);
 
         if(m_PChar->StatusEffectContainer->HasStatusEffect(EFFECT_UNLIMITED_SHOT))
         {

--- a/src/map/ai/states/magic_state.cpp
+++ b/src/map/ai/states/magic_state.cpp
@@ -254,8 +254,8 @@ uint32 CMagicState::CalculateCastTime(CSpell* PSpell)
         cast = cast * (1.0f - ((songcasting > 50 ? 50 : songcasting) / 100.0f));
     }
 
-    int8 fastCast = dsp_cap(m_PEntity->getMod(MOD_FASTCAST),-100,50);
-    int8 uncappedFastCast = dsp_cap(m_PEntity->getMod(MOD_UFASTCAST),-100,100);
+    int16 fastCast = dsp_cap(m_PEntity->getMod(MOD_FASTCAST),-100,50);
+    int16 uncappedFastCast = dsp_cap(m_PEntity->getMod(MOD_UFASTCAST),-100,100);
     float sumFastCast = dsp_cap(fastCast + uncappedFastCast, -100, 100);
 
     return cast * ((100.0f - sumFastCast)/100.0f);

--- a/src/map/attackround.cpp
+++ b/src/map/attackround.cpp
@@ -249,9 +249,9 @@ void CAttackRound::CreateAttacks(CItemWeapon* PWeapon, PHYSICAL_ATTACK_DIRECTION
 	AddAttackSwing(ATTACK_NORMAL, direction, num);
 
 	// Checking the players triple, double and quadruple attack
-	int8 tripleAttack = m_attacker->getMod(MOD_TRIPLE_ATTACK);
-	int8 doubleAttack = m_attacker->getMod(MOD_DOUBLE_ATTACK);
-	int8 quadAttack = m_attacker->getMod(MOD_QUAD_ATTACK);
+	int16 tripleAttack = m_attacker->getMod(MOD_TRIPLE_ATTACK);
+	int16 doubleAttack = m_attacker->getMod(MOD_DOUBLE_ATTACK);
+	int16 quadAttack = m_attacker->getMod(MOD_QUAD_ATTACK);
 
 	//check for merit upgrades
 	if (m_attacker->objtype == TYPE_PC)
@@ -309,7 +309,7 @@ void CAttackRound::CreateKickAttacks()
 	if (m_attacker->objtype == TYPE_PC)
 	{
 		// kick attack mod (All jobs)
-		uint8 kickAttack = m_attacker->getMod(MOD_KICK_ATTACK); 
+		uint16 kickAttack = m_attacker->getMod(MOD_KICK_ATTACK); 
 
 		if (m_attacker->GetMJob() == JOB_MNK) // MNK (Main job)
 		{
@@ -349,7 +349,7 @@ void CAttackRound::CreateZanshinAttacks()
 		!m_quadAttackOccured &&
 		m_attackSwings.at(0)->GetAttackType() != ZANSHIN_ATTACK)
 	{
-		uint8 zanshinChance = m_attacker->getMod(MOD_ZANSHIN) + ((CCharEntity*)m_attacker)->PMeritPoints->GetMeritValue(MERIT_ZASHIN_ATTACK_RATE, (CCharEntity*)m_attacker);
+		uint16 zanshinChance = m_attacker->getMod(MOD_ZANSHIN) + ((CCharEntity*)m_attacker)->PMeritPoints->GetMeritValue(MERIT_ZASHIN_ATTACK_RATE, (CCharEntity*)m_attacker);
 		zanshinChance = dsp_cap(zanshinChance, 0, 100);
 
 		if (rand()%100 < zanshinChance)

--- a/src/map/status_effect_container.cpp
+++ b/src/map/status_effect_container.cpp
@@ -1235,9 +1235,9 @@ void CStatusEffectContainer::CheckRegen(uint32 tick)
 
 		m_RegenCheckTime = tick;
 
-        int8 regen = m_POwner->getMod(MOD_REGEN);
-        int8 poison = m_POwner->getMod(MOD_REGEN_DOWN);
-        int8 refresh = m_POwner->getMod(MOD_REFRESH) - m_POwner->getMod(MOD_REFRESH_DOWN);
+        int16 regen = m_POwner->getMod(MOD_REGEN);
+        int16 poison = m_POwner->getMod(MOD_REGEN_DOWN);
+        int16 refresh = m_POwner->getMod(MOD_REFRESH) - m_POwner->getMod(MOD_REFRESH_DOWN);
         int16 regain = m_POwner->getMod(MOD_REGAIN) - m_POwner->getMod(MOD_REGAIN_DOWN);
 
 		m_POwner->addHP(regen);
@@ -1256,7 +1256,7 @@ void CStatusEffectContainer::CheckRegen(uint32 tick)
 
 		if (m_POwner->getMod(MOD_AVATAR_PERPETUATION) > 0 && (m_POwner->objtype == TYPE_PC))
 		{
-			int8 perpetuation = m_POwner->getMod(MOD_AVATAR_PERPETUATION);
+			int16 perpetuation = m_POwner->getMod(MOD_AVATAR_PERPETUATION);
 
 			if (m_POwner->StatusEffectContainer->HasStatusEffect(EFFECT_ASTRAL_FLOW))
 				perpetuation = 0;

--- a/src/map/utils/battleutils.cpp
+++ b/src/map/utils/battleutils.cpp
@@ -2170,8 +2170,8 @@ uint8 CheckMobMultiHits(CBattleEntity* PEntity)
 				break;
 		}
 
-		int8 tripleAttack = PEntity->getMod(MOD_TRIPLE_ATTACK);
-		int8 doubleAttack = PEntity->getMod(MOD_DOUBLE_ATTACK);
+		int16 tripleAttack = PEntity->getMod(MOD_TRIPLE_ATTACK);
+		int16 doubleAttack = PEntity->getMod(MOD_DOUBLE_ATTACK);
 		doubleAttack = dsp_cap(doubleAttack,0,100);
 		tripleAttack = dsp_cap(tripleAttack,0,100);
 		if (WELL512::irand()%100 < tripleAttack)
@@ -2198,8 +2198,8 @@ uint8 CheckMultiHits(CBattleEntity* PEntity, CItemWeapon* PWeapon)
 	//checking players weapon hit count
 	uint8 num = PWeapon->getHitCount();
 
-	int8 tripleAttack = PEntity->getMod(MOD_TRIPLE_ATTACK);
-	int8 doubleAttack = PEntity->getMod(MOD_DOUBLE_ATTACK);
+	int16 tripleAttack = PEntity->getMod(MOD_TRIPLE_ATTACK);
+	int16 doubleAttack = PEntity->getMod(MOD_DOUBLE_ATTACK);
 
 	//check for merit upgrades
 	if (PEntity->objtype == TYPE_PC)
@@ -2231,7 +2231,7 @@ uint8 CheckMultiHits(CBattleEntity* PEntity, CItemWeapon* PWeapon)
 	{
 		if (PEntity->StatusEffectContainer->HasStatusEffect(EFFECT_HASSO))
 		{
-			uint8 zanshin = PEntity->getMod(MOD_ZANSHIN);
+			uint16 zanshin = PEntity->getMod(MOD_ZANSHIN);
 			if (PEntity->objtype == TYPE_PC)
 				zanshin += ((CCharEntity*)PEntity)->PMeritPoints->GetMeritValue(MERIT_ZASHIN_ATTACK_RATE, (CCharEntity*)PEntity);
 
@@ -3602,7 +3602,7 @@ void tryToCharm(CBattleEntity* PCharmer, CBattleEntity* PVictim)
 		}
 
 		//apply charm time extension from gear
-		uint8 charmModValue = (PCharmer->getMod(MOD_CHARM_TIME));
+		uint16 charmModValue = (PCharmer->getMod(MOD_CHARM_TIME));
 		// adds 5% increase
 		float extraCharmTime = (float)(CharmTime*(charmModValue * 0.5f)/10);
 		CharmTime += extraCharmTime;

--- a/src/map/utils/charutils.cpp
+++ b/src/map/utils/charutils.cpp
@@ -4260,9 +4260,9 @@ bool hasMogLockerAccess(CCharEntity* PChar) {
 *                                                                       *
 ************************************************************************/
 
-uint8 AvatarPerpetuationReduction(CCharEntity* PChar)
+uint16 AvatarPerpetuationReduction(CCharEntity* PChar)
 {
-	uint8 reduction = PChar->getMod(MOD_PERPETUATION_REDUCTION);
+	uint16 reduction = PChar->getMod(MOD_PERPETUATION_REDUCTION);
 
 	static const MODIFIER strong[8] = {
         MOD_FIRE_AFFINITY,
@@ -4298,7 +4298,7 @@ uint8 AvatarPerpetuationReduction(CCharEntity* PChar)
 
     DSP_DEBUG_BREAK_IF(element > 7);
 
-	int8 affinity = PChar->getMod(strong[element]);
+	int16 affinity = PChar->getMod(strong[element]);
 
     // TODO: don't use ItemIDs in CORE. it must be MOD
 

--- a/src/map/utils/charutils.h
+++ b/src/map/utils/charutils.h
@@ -146,7 +146,7 @@ namespace charutils
 
     void    RemoveAllEquipment(CCharEntity* PChar);
 
-	uint8	AvatarPerpetuationReduction(CCharEntity* PChar);
+	uint16	AvatarPerpetuationReduction(CCharEntity* PChar);
 
 	void	SaveCharUnlockedWeapons(CCharEntity* PChar);
 	void	LoadCharUnlockedWeapons(CCharEntity* PChar);


### PR DESCRIPTION
This for example makes Vrtra take damage instead of regen health every
tick due to overflow of regen mod.

Not sure why this downcasting is done, it just most likely makes overflowing/underflowing very easy (unless that is wanted).

getMod actually returns uint16.
