### PR TITLE
added check for bat hunt mission repeat.

### DIFF
--- a/scripts/zones/King_Ranperres_Tomb/npcs/Tombstone.lua
+++ b/scripts/zones/King_Ranperres_Tomb/npcs/Tombstone.lua
@@ -32,11 +32,12 @@ end;
 function onTrigger(player,npc) 
 	local currentMission = player:getCurrentMission(SANDORIA);
 	local MissionStatus = player:getVar("MissionStatus");	
+	local BatHuntCompleted = player:hasCompletedMission(SANDORIA,BAT_HUNT); -- quest repeatable and clicking tombstone should not produce cutscene on repeat
 	local X = npc:getXPos();
 	local Z = npc:getZPos();
 	
 	if(X >= -1 and X <= 1 and Z >= -106 and Z <= -102) then
-		if(player:getCurrentMission(SANDORIA) == BAT_HUNT and MissionStatus <= 1) then -- Bug caused players to have MissionStatus 1 at start, so self-healing is necessary.
+		if(player:getCurrentMission(SANDORIA) == BAT_HUNT and MissionStatus <= 1 and BatHuntCompleted == false) then -- Bug caused players to have MissionStatus 1 at start, so self-healing is necessary.
 			player:startEvent(0x0004);
 		else
 			player:startEvent(0x0002);


### PR DESCRIPTION
tombstone should only produce cut-scene on first run of bat hunt. a check for bat hunt completion needed to prevent cut-scene repeat.
