### PR TITLE
change Save My Son to match retail prerequisites

### DIFF
--- a/scripts/zones/Lower_Jeuno/npcs/_6t2.lua
+++ b/scripts/zones/Lower_Jeuno/npcs/_6t2.lua
@@ -58,7 +58,7 @@ function onTrigger(player,npc)
 		player:startEvent(0x0000); 
 	
 	-- Save My Son
-	elseif(player:getQuestStatus(JEUNO, SAVE_MY_SON) == QUEST_AVAILABLE and ChocobosWounds == QUEST_COMPLETED) then
+	elseif(player:getQuestStatus(JEUNO, SAVE_MY_SON) == QUEST_AVAILABLE and mLvl >= 30) then
 		player:startEvent(0x00a4);
 	elseif(player:getQuestStatus(JEUNO, SAVE_MY_SON) == QUEST_ACCEPTED) then
 		if(SaveMySon == 0) then


### PR DESCRIPTION
While Save My Son quest is after Chocobo Wounds quest, it does not require it's completion. Save My Son only requires the character is at least level 30.  Removed Chocobo Wounds requirement and added level 30+ requirement.
