### PR TITLE
Fixes tombstone cutscene for san mission 6-2.

### DIFF
--- a/scripts/zones/King_Ranperres_Tomb/npcs/Tombstone.lua
+++ b/scripts/zones/King_Ranperres_Tomb/npcs/Tombstone.lua
@@ -42,10 +42,8 @@ function onTrigger(player,npc)
 		else
 			player:startEvent(0x0002);
 		end
-	elseif(npc:getID() == 17555928) then 
-	    if(currentMission == RANPERRE_S_FINAL_REST and MissionStatus == 2) then
-	        player:startEvent(0x0008);
-	    end
+	elseif(currentMission == RANPERRE_S_FINAL_REST and MissionStatus == 2) then
+		player:startEvent(0x0008);
 	end
 	
 end; 


### PR DESCRIPTION
removed obsolete npc:getID check since both tombstones are compared by coordinates.
