### PR TITLE
Implement Zdei - One Commit this time! 

### DIFF
--- a/scripts/globals/mobskills/Decayed_Filament.lua
+++ b/scripts/globals/mobskills/Decayed_Filament.lua
@@ -1,0 +1,35 @@
+---------------------------------------------
+--  Decayed Filament
+--  Zedi, while in Animation form 2 (Bars)
+--  Blinkable 1-2 hit, addtional effect poison on hit. 
+---------------------------------------------
+
+require("/scripts/globals/settings");
+require("/scripts/globals/status");
+require("/scripts/globals/monstertpmoves");
+
+---------------------------------------------
+
+function onMobSkillCheck(target,mob,skill)
+	if(mob:AnimationSub() ~= 2) then
+		return 1;
+	end
+
+	return 0;
+end;
+
+function onMobWeaponSkill(target, mob, skill)
+
+	local numhits = 2;
+	local accmod = 1;
+	local dmgmod = 1;
+	local info = MobPhysicalMove(mob,target,skill,numhits,accmod,dmgmod,0,1,2,3);
+	local dmg = MobFinalAdjustments(info.dmg,mob,skill,target,MOBSKILL_PHYSICAL,0,info.hitslanded);
+	local typeEffect = EFFECT_POISON;
+
+    MobPhysicalStatusEffectMove(mob, target, skill, typeEffect, 18, 3, 60);
+
+	target:delHP(dmg);
+	return dmg;
+
+end;

--- a/scripts/globals/mobskills/Optic_Induration.lua
+++ b/scripts/globals/mobskills/Optic_Induration.lua
@@ -13,6 +13,9 @@ require("/scripts/globals/monstertpmoves");
 
 ---------------------------------------------
 function onMobSkillCheck(target,mob,skill)
+	if(mob:AnimationSub() == 2 or mob:AnimationSub() == 3) then
+		return 1;
+	end
 	return 0;
 end;
 
@@ -25,7 +28,10 @@ function onMobWeaponSkill(target, mob, skill)
 	local accmod = 1;
 	local info = MobMagicalMove(mob,target,skill,mob:getWeaponDmg()*3,ELE_DARK,dmgmod,TP_NO_EFFECT);
 	local dmg = MobFinalAdjustments(info.dmg,mob,skill,target,MOBSKILL_MAGICAL,MOBPARAM_DARK,MOBPARAM_IGNORE_SHADOWS);
-    target:delHP(dmg);
+
+	target:delHP(dmg);
 	mob:resetEnmity(target);
+
 	return dmg;
+
 end;

--- a/scripts/globals/mobskills/Reactor_Cool.lua
+++ b/scripts/globals/mobskills/Reactor_Cool.lua
@@ -1,0 +1,29 @@
+---------------------------------------------
+-- Reactor Cool
+-- Gives Undispellable Ice Spikes and Defense Boost
+---------------------------------------------
+
+require("/scripts/globals/settings");
+require("/scripts/globals/status");
+require("/scripts/globals/monstertpmoves");
+
+---------------------------------------------------
+
+function onMobSkillCheck(target,mob,skill)
+	return 0;
+end;
+
+function onMobWeaponSkill(target, mob, skill)
+	local typeEffect = EFFECT_ICE_SPIKES;
+	local typeEffect2 = EFFECT_DEFENSE_BOOST;
+    local randy = math.random(15,30);
+
+    skill:setMsg(MobBuffMove(mob, typeEffect, randy, 0, 60));
+		local effect1 = mob:getStatusEffect(EFFECT_ICE_SPIKES);
+		effect1:unsetFlag(EFFECTFLAG_DISPELABLE);
+	skill:setMsg(MobBuffMove(mob, typeEffect2, 26, 0, 60));
+		local effect2 = mob:getStatusEffect(EFFECT_DEFENSE_BOOST);
+		effect2:unsetFlag(EFFECTFLAG_DISPELABLE);
+
+	return typeEffect;
+end;

--- a/scripts/globals/mobskills/Reactor_Overheat.lua
+++ b/scripts/globals/mobskills/Reactor_Overheat.lua
@@ -1,0 +1,35 @@
+---------------------------------------------
+--  Reactor Overheat
+--  Zedi, while in Animation form 3 (Rings)
+--  Blinkable 1-3 hit, addtional effect Plague on hit. 
+---------------------------------------------
+
+require("/scripts/globals/settings");
+require("/scripts/globals/status");
+require("/scripts/globals/monstertpmoves");
+
+---------------------------------------------
+
+function onMobSkillCheck(target,mob,skill)
+	if(mob:AnimationSub() ~= 3) then
+		return 1;
+	end
+
+	return 0;
+end;
+
+function onMobWeaponSkill(target, mob, skill)
+
+	local numhits = 2;
+	local accmod = 1;
+	local dmgmod = 1;
+	local info = MobPhysicalMove(mob,target,skill,numhits,accmod,dmgmod,0,1,2,3);
+	local dmg = MobFinalAdjustments(info.dmg,mob,skill,target,MOBSKILL_PHYSICAL,0,info.hitslanded);
+	local typeEffect = EFFECT_PLAGUE;
+
+    MobPhysicalStatusEffectMove(mob, target, skill, typeEffect, 1, 0, 60);
+
+	target:delHP(dmg);
+	return dmg;
+
+end;

--- a/scripts/globals/mobskills/Reactor_Overload.lua
+++ b/scripts/globals/mobskills/Reactor_Overload.lua
@@ -1,0 +1,35 @@
+---------------------------------------------
+--  Reactor Overload
+--  Zedi, while in Animation form 3 (Rings)
+--  Blinkable 1-3 hit, addtional effect Silence on hit. 
+---------------------------------------------
+
+require("/scripts/globals/settings");
+require("/scripts/globals/status");
+require("/scripts/globals/monstertpmoves");
+
+---------------------------------------------
+
+function onMobSkillCheck(target,mob,skill)
+	if(mob:AnimationSub() ~= 3) then
+		return 1;
+	end
+
+	return 0;
+end;
+
+function onMobWeaponSkill(target, mob, skill)
+
+	local numhits = 2;
+	local accmod = 1;
+	local dmgmod = 1;
+	local info = MobPhysicalMove(mob,target,skill,numhits,accmod,dmgmod,0,1,2,3);
+	local dmg = MobFinalAdjustments(info.dmg,mob,skill,target,MOBSKILL_PHYSICAL,0,info.hitslanded);
+	local typeEffect = EFFECT_SILENCE;
+
+    MobPhysicalStatusEffectMove(mob, target, skill, typeEffect, 1, 0, 60);
+
+	target:delHP(dmg);
+	return dmg;
+
+end;

--- a/scripts/globals/mobskills/Static_Filament.lua
+++ b/scripts/globals/mobskills/Static_Filament.lua
@@ -1,0 +1,35 @@
+---------------------------------------------
+--  Static Filament
+--  Zedi, while in Animation form 2 (Bars)
+--  Blinkable 1-2 hit, addtional effect stun on hit. 
+---------------------------------------------
+
+require("/scripts/globals/settings");
+require("/scripts/globals/status");
+require("/scripts/globals/monstertpmoves");
+
+---------------------------------------------
+
+function onMobSkillCheck(target,mob,skill)
+	if(mob:AnimationSub() ~= 2) then
+		return 1;
+	end
+
+	return 0;
+end;
+
+function onMobWeaponSkill(target, mob, skill)
+
+	local numhits = 2;
+	local accmod = 1;
+	local dmgmod = 1;
+	local info = MobPhysicalMove(mob,target,skill,numhits,accmod,dmgmod,0,1,2,3);
+	local dmg = MobFinalAdjustments(info.dmg,mob,skill,target,MOBSKILL_PHYSICAL,0,info.hitslanded);
+	local typeEffect = EFFECT_STUN;
+
+    MobPhysicalStatusEffectMove(mob, target, skill, typeEffect, 1, 0, 4);
+
+	target:delHP(dmg);
+	return dmg;
+
+end;

--- a/scripts/zones/Grand_Palace_of_HuXzoi/mobs/Eo_zdei.lua
+++ b/scripts/zones/Grand_Palace_of_HuXzoi/mobs/Eo_zdei.lua
@@ -1,0 +1,51 @@
+-----------------------------------
+-- Area: Grand Palace of Hu'Xzoi
+-- MOB:  Eo'Zdei
+-- Animation Sub 0 Pot Form
+-- Animation Sub 1 Pot Form (reverse eye position)
+-- Animation Sub 2 Bar Form
+-- Animation Sub 3 Ring Form
+-----------------------------------
+
+require("scripts/globals/status");
+
+-----------------------------------
+-- OnMobSpawn Action
+-- Set AnimationSub to 0, put it in pot form
+-----------------------------------
+
+function onMobSpawn(mob)
+	mob:AnimationSub(0);
+end;
+
+-----------------------------------
+-- onMobFight Action
+-- Randomly change forms
+-----------------------------------
+
+function onMobFight(mob)
+
+	local randomTime = math.random(15,45);
+	local changeTime = mob:getLocalVar("changeTime");
+
+	if(mob:AnimationSub() == 0 and mob:getBattleTime() - changeTime > randomTime) then
+		mob:AnimationSub(math.random(2,3));
+		mob:setLocalVar("changeTime", mob:getBattleTime());
+	elseif(mob:AnimationSub() == 1 and mob:getBattleTime() - changeTime > randomTime) then
+		mob:AnimationSub(math.random(2,3));
+		mob:setLocalVar("changeTime", mob:getBattleTime());
+	elseif(mob:AnimationSub() == 2 and mob:getBattleTime() - changeTime > randomTime) then
+		local aniChance = math.random(0,1);
+		if(aniChance == 0) then
+			mob:AnimationSub(0);
+			mob:setLocalVar("changeTime", mob:getBattleTime());
+		else
+			mob:AnimationSub(3)
+			mob:setLocalVar("changeTime", mob:getBattleTime());
+		end
+	elseif(mob:AnimationSub() == 3 and mob:getBattleTime() - changeTime > randomTime) then
+		mob:AnimationSub(math.random(0,2));
+		mob:setLocalVar("changeTime", mob:getBattleTime());
+	end
+
+end;

--- a/scripts/zones/The_Garden_of_RuHmet/mobs/Aw_zdei.lua
+++ b/scripts/zones/The_Garden_of_RuHmet/mobs/Aw_zdei.lua
@@ -1,0 +1,51 @@
+-----------------------------------
+-- Area: The Garden of Ru'Hmet
+-- MOB:  Aw'Zdei
+-- Animation Sub 0 Pot Form
+-- Animation Sub 1 Pot Form (reverse eye position)
+-- Animation Sub 2 Bar Form
+-- Animation Sub 3 Ring Form
+-----------------------------------
+
+require("scripts/globals/status");
+
+-----------------------------------
+-- OnMobSpawn Action
+-- Set AnimationSub to 0, put it in pot form
+-----------------------------------
+
+function onMobSpawn(mob)
+	mob:AnimationSub(0);
+end;
+
+-----------------------------------
+-- onMobFight Action
+-- Randomly change forms
+-----------------------------------
+
+function onMobFight(mob)
+
+	local randomTime = math.random(15,45);
+	local changeTime = mob:getLocalVar("changeTime");
+
+	if(mob:AnimationSub() == 0 and mob:getBattleTime() - changeTime > randomTime) then
+		mob:AnimationSub(math.random(2,3));
+		mob:setLocalVar("changeTime", mob:getBattleTime());
+	elseif(mob:AnimationSub() == 1 and mob:getBattleTime() - changeTime > randomTime) then
+		mob:AnimationSub(math.random(2,3));
+		mob:setLocalVar("changeTime", mob:getBattleTime());
+	elseif(mob:AnimationSub() == 2 and mob:getBattleTime() - changeTime > randomTime) then
+		local aniChance = math.random(0,1);
+		if(aniChance == 0) then
+			mob:AnimationSub(0);
+			mob:setLocalVar("changeTime", mob:getBattleTime());
+		else
+			mob:AnimationSub(3)
+			mob:setLocalVar("changeTime", mob:getBattleTime());
+		end
+	elseif(mob:AnimationSub() == 3 and mob:getBattleTime() - changeTime > randomTime) then
+		mob:AnimationSub(math.random(0,2));
+		mob:setLocalVar("changeTime", mob:getBattleTime());
+	end
+
+end;

--- a/sql/mob_skill.sql
+++ b/sql/mob_skill.sql
@@ -1693,7 +1693,7 @@ INSERT INTO `mob_skill` VALUES (1195,109,1073,'Morning_Glory',1,15.0,2000,1000,4
 INSERT INTO `mob_skill` VALUES (1197,109,1069,'Nutrient_Aborption',0,7.0,2000,1000,4,0,0,0);
 
 -- Zdei - T-Sight aggro @ 15  yalms. 
--- INSERT INTO `mob_skill` VALUES (1207,272,1074,'Reactor_Cool',0,7.0,2000,1500,1,0,0,0);
+INSERT INTO `mob_skill` VALUES (1207,272,1074,'Reactor_Cool',0,7.0,2000,1500,1,0,0,0);
 INSERT INTO `mob_skill` VALUES (1209,272,1076,'Optic_Induration',4,15.0,2000,1000,4,0,0,0);
 INSERT INTO `mob_skill` VALUES (1210,272,1077,'Static_Filament',4,10.0,2000,1000,4,0,0,0); -- bar form only
 INSERT INTO `mob_skill` VALUES (1211,272,1078,'Decayed_Filament',4,8.0,2000,1000,4,0,0,0); -- bar form only


### PR DESCRIPTION
```
Reactor Cool

    o Undispellable Ice spikes and Defense Boost

    o Used in Any Form

Static Filament

    o Usable only in Bar Form (AnimationSub() == 2)

    o Blinkable 1-2 Hit Cone Stun

Decayed Filament

    o Usable only in Bar Form (AnimationSub() == 2)

    o Blinkable 1-2 hit AoE Poison

Reactor Overload

    o Usable only in Ring Form (AnimationSub() == 3)

    o Blinkable 1-3 hit AoE Silence.

Reactor Overheat

    o Usable only in Ring Form (AnimationSub() == 3)

    o Blinkable 1-3 hit AoE Plague.

Zdei Logic

    o Added Eo’Zdei

     Animation change every 15-45 seconds

     Does not change form to previous form

     Has 4 forms

        • 0, Pot Form, Big Eye Facing Target

        • 1, Pot Form, Small Eye Facing Target

        • 2, Bar Form

        • 3, Ring Form

Added Aw’Zdei

     Animation change every 15-45 seconds

     Does not change form to previous form

     Has 4 forms

        • 0, Pot Form, Big Eye Facing Target

        • 1, Pot Form, Small Eye Facing Target

        • 2, Bar Form

        • 3, Ring Form
```

Modified

```
Optic Induration

    o   Set to only use in Pot Form, per BGWiki

Updated mob_skills.sql to enable Reactor Cool
```

References

http://www.bg-wiki.com/bg/Category:Zdei

http://wiki.ffxiclopedia.org/wiki/Category%3AZdei
