### PR TITLE
NPCs: Introduce Expansion Restriction Support

### DIFF
--- a/scripts/globals/conquest.lua
+++ b/scripts/globals/conquest.lua
@@ -1160,21 +1160,24 @@ function SetRegionalConquestOverseers(region)
     local nation  = GetRegionOwner(region);
 
     for i = 1, table.getn(npclist), 2 do
-        if(npclist[i+1] == nation) then
-            GetNPCByID(npclist[i]):setStatus(0);
-        else
-            GetNPCByID(npclist[i]):setStatus(2);
-        end
-
-        if(npclist[i+1] == OTHER) then
-            if(nation ~= BEASTMEN) then
-                GetNPCByID(npclist[i]):setStatus(0);
+    	local npc = GetNPCByID(npclist[i]);
+    	
+    	if(npc ~= nil) then
+            if(npclist[i+1] == nation) then
+                npc:setStatus(0);
             else
-                GetNPCByID(npclist[i]):setStatus(2);
+                npc:setStatus(2);
             end
-        end
+        
+            if(npclist[i+1] == OTHER) then
+                if(nation ~= BEASTMEN) then
+                    npc:setStatus(0);
+                else
+                    npc:setStatus(2);
+                end
+            end
 	end
-
+    end
 end;
 
 -----------------------------------
@@ -1311,25 +1314,3 @@ function conquestUpdate(zone, player, updateType, messageBase)
         end
     end
 end;
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-

--- a/scripts/globals/settings.lua
+++ b/scripts/globals/settings.lua
@@ -27,6 +27,12 @@ ENABLE_ASA     = 0;
 ENABLE_ABYSSEA = 0;
 ENABLE_SOA     = 0;
 
+-- Setting to lock content more accurately to the expansions you have defined above
+-- This generally results in a more accurate presentation of your selected expansions
+-- as well as a less confusing player experience for things that are disabled (things that are disabled are not loaded)
+-- This feature correlates to the required_expansion column in the SQL files
+RESTRICT_BY_EXPANSION = 1;
+
 -- CHARACTER CONFIG
 INITIAL_LEVEL_CAP = 50; --The initial level cap for new players.  There seems to be a hardcap of 255.
 MAX_LEVEL = 75; -- Level max of the server, works by disabling Maat quests.

--- a/scripts/globals/zone.lua
+++ b/scripts/globals/zone.lua
@@ -23,9 +23,7 @@ function SetFieldManual(manuals)
     if (FIELD_MANUALS == 1) then
         for i,id in ipairs(manuals) do
             local npc = GetNPCByID(id);
-            if(npc == nil) then
-                printf("'SetFieldManual' Error trying to load undefined npc (%d)", id);
-            else
+            if(npc ~= nil) then
                 npc:setStatus(0);
             end
         end
@@ -41,9 +39,7 @@ function SetGroundsTome(tome)
     if (GROUNDS_TOMES == 1) then
         for i,id in ipairs(tome) do
             local npc = GetNPCByID(id);
-            if(npc == nil) then
-                printf("'SetGroundsTome' Error trying to load undefined npc (%d)", id);
-            else
+            if(npc ~= nil) then
                 npc:setStatus(0);
             end
         end

--- a/scripts/zones/Attohwa_Chasm/Zone.lua
+++ b/scripts/zones/Attohwa_Chasm/Zone.lua
@@ -118,7 +118,10 @@ end;
 -----------------------------------	
 
 function onGameHour()
-    GetNPCByID(16806283):openDoor(); -- Attohwa Chasm miasma
+    local npc = GetNPCByID(16806283);
+    if(npc ~= nil) then
+    	npc:openDoor(); -- Attohwa Chasm miasma
+    end
 end;
 
 -----------------------------------	

--- a/src/map/lua/luautils.h
+++ b/src/map/lua/luautils.h
@@ -101,7 +101,7 @@ namespace luautils
 	int32 clearVarFromAll(lua_State *);											// Deletes a specific player variable from all players
 
     int32 GetTextIDVariable(uint16 ZoneID, const char* variable);               // загружаем значение переменной TextID указанной зоны
-	uint8 GetSettingsVariable(const char* variable);                            // Gets a Variable Value from Settings.lua
+	uint8 GetSettingsVariable(std::string variable);                            // Gets a Variable Value from Settings.lua
 	bool IsExpansionEnabled(const char* expansionCode);                         // Check if an Expansion is Enabled In Settings.lua
 
 	int32 OnGameDay(CZone* PZone);								                // Automatic action of NPC every game day

--- a/src/map/utils/zoneutils.cpp
+++ b/src/map/utils/zoneutils.cpp
@@ -67,24 +67,30 @@ void UpdateTreasureSpawnPoint(uint32 npcid, uint32 respawnTime)
 {
 	CBaseEntity* PNpc = zoneutils::GetEntity(npcid, TYPE_NPC);
 
-	if (PNpc != NULL) {
+	int32 ret = Sql_Query(SqlHandle, "SELECT treasure_spawn_points.pos, treasure_spawn_points.pos_rot, treasure_spawn_points.pos_x, treasure_spawn_points.pos_y, treasure_spawn_points.pos_z, npc_list.required_expansion FROM `treasure_spawn_points` INNER JOIN `npc_list` ON treasure_spawn_points.npcid = npc_list.npcid WHERE treasure_spawn_points.npcid=%u ORDER BY RAND() LIMIT 1", npcid);
 
-		int32 ret = Sql_Query(SqlHandle, "SELECT pos, pos_rot, pos_x, pos_y, pos_z FROM `treasure_spawn_points` WHERE npcid=%u ORDER BY RAND() LIMIT 1", npcid);
+	if ( ret != SQL_ERROR && Sql_NumRows(SqlHandle) != 0 && Sql_NextRow(SqlHandle) == SQL_SUCCESS) {
+		int8* expansionCode;
+		Sql_GetData(SqlHandle, 5, &expansionCode, NULL);
 
-		if ( ret != SQL_ERROR && Sql_NumRows(SqlHandle) != 0 && Sql_NextRow(SqlHandle) == SQL_SUCCESS) {
-			PNpc->loc.p.rotation = Sql_GetIntData(SqlHandle,1);
-			PNpc->loc.p.x = Sql_GetFloatData(SqlHandle,2);
-			PNpc->loc.p.y = Sql_GetFloatData(SqlHandle,3);
-			PNpc->loc.p.z = Sql_GetFloatData(SqlHandle,4);
-			// ShowDebug(CL_YELLOW"zoneutils::UpdateTreasureSpawnPoint: After %i - %d (%f, %f, %f), %d\n" CL_RESET, Sql_GetIntData(SqlHandle,0), PNpc->id, PNpc->loc.p.x,PNpc->loc.p.y,PNpc->loc.p.z, PNpc->loc.zone->GetID());
-		} else {
-			ShowDebug(CL_RED"zonetuils::UpdateTreasureSpawnPoint: SQL error or treasure <%u> not found in treasurespawnpoints table.\n" CL_RESET, npcid);
+		if (luautils::IsExpansionEnabled(expansionCode) == false){
+			return;
 		}
 
-		CTaskMgr::getInstance()->AddTask(new CTaskMgr::CTask("reappear_npc", gettick()+respawnTime, PNpc, CTaskMgr::TASK_ONCE, reappear_npc));
+		if (PNpc != NULL) {
+			PNpc->loc.p.rotation = Sql_GetIntData(SqlHandle, 1);
+			PNpc->loc.p.x = Sql_GetFloatData(SqlHandle, 2);
+			PNpc->loc.p.y = Sql_GetFloatData(SqlHandle, 3);
+			PNpc->loc.p.z = Sql_GetFloatData(SqlHandle, 4);
+			// ShowDebug(CL_YELLOW"zoneutils::UpdateTreasureSpawnPoint: After %i - %d (%f, %f, %f), %d\n" CL_RESET, Sql_GetIntData(SqlHandle,0), PNpc->id, PNpc->loc.p.x,PNpc->loc.p.y,PNpc->loc.p.z, PNpc->loc.zone->GetID());
+			CTaskMgr::getInstance()->AddTask(new CTaskMgr::CTask("reappear_npc", gettick() + respawnTime, PNpc, CTaskMgr::TASK_ONCE, reappear_npc));
+		}
+		else {
+			ShowDebug(CL_RED"zonetuils::UpdateTreasureSpawnPoint: treasure <%u> not found\n" CL_RESET, npcid);
+		}
 	} else {
-		ShowDebug(CL_RED"zonetuils::UpdateTreasureSpawnPoint: treasure <%u> not found\n" CL_RESET, npcid);
-	}
+		ShowDebug(CL_RED"zonetuils::UpdateTreasureSpawnPoint: SQL error or treasure <%u> not found in treasurespawnpoints table.\n" CL_RESET, npcid);
+	}		
 }
 
 /************************************************************************
@@ -257,7 +263,8 @@ void LoadNPCList()
           status,\
           unknown,\
           look,\
-          name_prefix \
+          name_prefix, \
+		  required_expansion \
         FROM npc_list INNER JOIN zone_settings \
         ON (npcid & 0xFFF000) >> 12 = zone_settings.zoneid \
         WHERE IF(%d <> 0, '%s' = zoneip AND %d = zoneport, TRUE);";
@@ -268,6 +275,13 @@ void LoadNPCList()
 	{
 		while(Sql_NextRow(SqlHandle) == SQL_SUCCESS)
 		{
+			int8* expansionCode;
+			Sql_GetData(SqlHandle, 16, &expansionCode, NULL);
+
+			if (luautils::IsExpansionEnabled(expansionCode) == false){
+				continue;
+			}
+
 			uint32 NpcID = Sql_GetUIntData(SqlHandle, 0);
 			uint16 ZoneID = (NpcID - 0x1000000) >> 12;
 


### PR DESCRIPTION
This commit introduces support for restricting npcs by expansion, using the same approach that was used for spells/abilities/traits

This gets rid of npcs that are not relevant to the era that the server wants to play in - ex: Cavernous Maws without WOTG, Geo stuff from SOA, etc

The approach for tagging npcs is the same as for the other files - the expansion tagged is the latest expansion out at the time the npc was introduced

I only hit obvious ones and tagged expansion zones with their expansion - I am sure they are more. If there are specific npcs that should be mass tagged with a specific expansion, I have a script that can do this by polutils name (will commit it in my next batch update, coming soon)

This makes things more accurate to the era a server wants to play in, as well as reduces memory and resource waste for those servers by not loading unwanted npcs.

I have tested disabling all expansions and re-enabling and the functionality appears to work. I don't get any startup warnings with all expansions disabled. If you find any issues though feel free to tag me and I will look into it.