### PR TITLE
New conf setting to allow adjusting delay before engaging next mob.

### DIFF
--- a/conf/map_darkstar.conf
+++ b/conf/map_darkstar.conf
@@ -76,6 +76,10 @@ level_sync_enable: 0
 #Enable/disable jobs other than BST and RNG having widescan
 all_jobs_widescan: 1
 
+#Acts as multiplier for the delay between engaging targets. 0.80 would be a 20% reduction from retail. Does not change attack round delay.
+#WARNING: even seemingly small changes can potentially be exploitable (especially with high delay weapons).
+engage_delay_mod: 1.00
+
 #Modifier to apply to player speed. 0 means default speed of 40, where 20 would mean speed 60 or -10 would mean speed 30.
 speed_mod: 0
 

--- a/src/map/ai/ai_char_normal.cpp
+++ b/src/map/ai/ai_char_normal.cpp
@@ -301,7 +301,7 @@ void CAICharNormal::ActionEngage()
 		{
 			if (distance(m_PChar->loc.p, m_PBattleTarget->loc.p) <= 30)
 			{
-				if (m_Tick > m_LastMeleeTime + m_PChar->m_Weapons[SLOT_MAIN]->getDelay())
+				if (m_Tick > ((m_LastMeleeTime + m_PChar->m_Weapons[SLOT_MAIN]->getDelay())*map_config.engage_delay_mod))
 				{
                     if (m_PChar->animation == ANIMATION_CHOCOBO)
                     {

--- a/src/map/map.cpp
+++ b/src/map/map.cpp
@@ -895,6 +895,7 @@ int32 map_config_default()
     map_config.exp_loss_level = 4;
     map_config.level_sync_enable = 0;
     map_config.all_jobs_widescan = 1;
+    map_config.engage_delay_mod = 1.0f;
     map_config.speed_mod = 0;
     map_config.mob_speed_mod = 0;
     map_config.skillup_chance_multiplier = 2.5f;
@@ -1100,6 +1101,10 @@ int32 map_config_read(const int8* cfgName)
         else if (strcmp(w1,"all_jobs_widescan") == 0)
         {
             map_config.all_jobs_widescan = atoi(w2);
+        }
+        else if (strcmp(w1,"engage_delay_mod") == 0)
+        {
+            map_config.engage_delay_mod = atoi(w2);
         }
         else if (strcmp(w1,"speed_mod") == 0)
         {

--- a/src/map/map.h
+++ b/src/map/map.h
@@ -84,6 +84,7 @@ struct map_config_t
 	int8   exp_loss_level;			// Minimum main job level at which a character may lose experience points.
     bool   level_sync_enable;       // Enable/disable Level Sync
     bool   all_jobs_widescan;       // Enable/disable jobs other than BST and RNG having widescan.
+    float  engage_delay_mod;        // Acts as a multiplier for delay for engaging a mob.
     int8   speed_mod;               // Modifier to add to player speed
     int8   mob_speed_mod;           // Modifier to add to monster speed
 	float  skillup_chance_multiplier;		// Constant used in the skillup formula that has a strong effect on skill-up rates


### PR DESCRIPTION
Someone had shared a setting to eliminate the engage delay before but it had a prob with being exploitable. I had some of my offline friends test this for me over the last 4 months with settings of 0.50,  0.75 and my own server has been using 0.85, everyone reports it functioning as I intended to reduce but not eliminate the delay without effecting delay between melee attacks after engaging.

Reason I think this has a shot at being in DarkStar: 
SE actually has changed this in the past. 

Reason it might not:
Engage delay used to be shorter in retail but was exploitable by a specially formed macro while using a high delay weapon. My implementation attempts to allow you to avoid reopening that exploit without enforcing the huge pause SE used, but this can be misused so I understand if you choose to close/reject this without merge.