### PR TITLE
Add missing Phuabo TP moves.

### DIFF
--- a/scripts/globals/mobskills/Aerial_Collision.lua
+++ b/scripts/globals/mobskills/Aerial_Collision.lua
@@ -1,0 +1,34 @@
+---------------------------------------------
+--  Aerial Collusion
+--  Description: Cone Attack damage and Defense Down, strips Utsusemi (MOBPARAM_WIPE_SHADOWS)
+---------------------------------------------
+
+require("/scripts/globals/settings");
+require("/scripts/globals/status");
+require("/scripts/globals/monstertpmoves");
+---------------------------------------------
+
+---------------------------------------------
+-- onMobSkillCheck no animation check required
+---------------------------------------------
+function onMobSkillCheck(target,mob,skill)
+	return 0;
+end;
+
+---------------------------------------------
+-- onMobSkillCheck no animation check required
+---------------------------------------------
+function onMobWeaponSkill(target, mob, skill)
+	local typeEffect = EFFECT_DEFENSE_DOWN;
+
+	local numhits = 1;
+	local accmod = 1;
+	local dmgmod = 1;
+	local info = MobPhysicalMove(mob,target,skill,numhits,accmod,dmgmod,TP_NO_EFFECT);
+	local dmg = MobFinalAdjustments(info.dmg,mob,skill,target,MOBSKILL_PHYSICAL,MOBPARAM_NONE,MOBPARAM_WIPE_SHADOWS);
+
+	MobPhysicalStatusEffectMove(mob, target, skill, typeEffect, 10, 0, 30);
+
+	target:delHP(dmg);
+	return dmg;
+end;

--- a/scripts/globals/mobskills/Spine_Lash.lua
+++ b/scripts/globals/mobskills/Spine_Lash.lua
@@ -1,0 +1,31 @@
+---------------------------------------------
+--  Spine Lash
+--  Phaubo
+--  Blinkable 1 hit, plague on hit. 
+---------------------------------------------
+
+require("/scripts/globals/settings");
+require("/scripts/globals/status");
+require("/scripts/globals/monstertpmoves");
+
+---------------------------------------------
+
+function onMobSkillCheck(target,mob,skill)
+	return 0;
+end;
+
+function onMobWeaponSkill(target, mob, skill)
+	
+	local typeEffect = EFFECT_PLAGUE;
+
+	local numhits = 1;
+	local accmod = 1;
+	local dmgmod = 1;
+	local info = MobPhysicalMove(mob,target,skill,numhits,accmod,dmgmod,0,1,2,3);
+	local dmg = MobFinalAdjustments(info.dmg,mob,skill,target,MOBSKILL_PHYSICAL,0,info.hitslanded);
+
+    MobPhysicalStatusEffectMove(mob, target, skill, typeEffect, 1, 0, 60);
+
+	target:delHP(dmg);
+	return dmg;
+end;

--- a/scripts/globals/mobskills/Voiceless_Storm.lua
+++ b/scripts/globals/mobskills/Voiceless_Storm.lua
@@ -1,0 +1,34 @@
+---------------------------------------------
+--  Voiceless Storm
+--  Description: AOE Damage, Silence, strips Utsusemi (MOBPARAM_WIPE_SHADOWS)
+---------------------------------------------
+
+require("/scripts/globals/settings");
+require("/scripts/globals/status");
+require("/scripts/globals/monstertpmoves");
+---------------------------------------------
+
+---------------------------------------------
+-- onMobSkillCheck no animation check required
+---------------------------------------------
+function onMobSkillCheck(target,mob,skill)
+	return 0;
+end;
+
+---------------------------------------------
+-- onMobSkillCheck no animation check required
+---------------------------------------------
+function onMobWeaponSkill(target, mob, skill)
+	local typeEffect = EFFECT_SILENCE;
+
+	local numhits = 1;
+	local accmod = 1;
+	local dmgmod = 1;
+	local info = MobPhysicalMove(mob,target,skill,numhits,accmod,dmgmod,TP_NO_EFFECT);
+	local dmg = MobFinalAdjustments(info.dmg,mob,skill,target,MOBSKILL_PHYSICAL,MOBPARAM_NONE,MOBPARAM_WIPE_SHADOWS);
+
+	MobPhysicalStatusEffectMove(mob, target, skill, typeEffect, 1, 0, 60);
+
+	target:delHP(dmg);
+	return dmg;
+end;

--- a/sql/mob_skill.sql
+++ b/sql/mob_skill.sql
@@ -1764,12 +1764,12 @@ INSERT INTO `mob_skill` VALUES (1126,439,1014,'Crystaline_Cocoon',0,7.0,2000,100
 
 
 -- Phuabo
-INSERT INTO `mob_skill` VALUES (1097,194,1004,'Aerial_collision',4,10.0,2000,1000,4,0,0,0);
+INSERT INTO `mob_skill` VALUES (1097,194,1004,'Aerial_Collision',4,10.0,2000,1000,4,0,0,0);
 INSERT INTO `mob_skill` VALUES (1101,194,1008,'Tidal_Dive',1,15.0,2000,1000,4,0,0,0);
 INSERT INTO `mob_skill` VALUES (1098,194,1005,'Vapor_Spray',4,12.0,2000,1000,4,0,0,0);
-INSERT INTO `mob_skill` VALUES (1099,194,1006,'Spine_lash',4,12.0,2000,1000,4,0,0,0);
-INSERT INTO `mob_skill` VALUES (1100,194,1007,'Voiceless_storm',1,15.0,2000,1000,4,0,0,0);
-INSERT INTO `mob_skill` VALUES (1102,194,1009,'Plasma_charge',0,7.0,2000,1000,1,0,0,0);
+INSERT INTO `mob_skill` VALUES (1099,194,1006,'Spine_Lash',4,12.0,2000,1000,4,0,0,0);
+INSERT INTO `mob_skill` VALUES (1100,194,1007,'Voiceless_Storm',1,15.0,2000,1000,4,0,0,0);
+INSERT INTO `mob_skill` VALUES (1102,194,1009,'Plasma_Charge',0,7.0,2000,1000,1,0,0,0);
 
 -- Xzomit
 INSERT INTO `mob_skill` VALUES (1091,269,998,'Dual_strike',0,7.0,2000,1000,4,0,0,0);


### PR DESCRIPTION
Added:

	1.	Aerial Collision
		a.	Cone Damage, Defense Down, Strips Shadows
	2.	Voiceless Storm
		a.	AoE Damage, Silence, Strips Shadows
	3.	Spine Lash
		a.	Narrow Cone/Single Target damage, Plague, Absorbed by Shadows
Modified:

	1.	Fixed issue with Capitalization in mob_skills.sql for Phuabo Family. Following DSP Naming Convention now for Mob Skills. 

Server Log for some duration of fighting with some zoning in between: 
http://pastebin.com/RVXv0xNZ

Server Startup: 
http://pastebin.com/index/RVXv0xNZ

Refrences:
http://wiki.ffxiclopedia.org/wiki/Category:Phuabo