### PR TITLE
Use proper port 54230 for several noname zones

### DIFF
--- a/sql/zone_settings.sql
+++ b/sql/zone_settings.sql
@@ -94,7 +94,7 @@ INSERT INTO `zone_settings` VALUES (45,2,'127.0.0.1',54230,'Abyssea-Tahrongi',51
 INSERT INTO `zone_settings` VALUES (46,2,'127.0.0.1',54230,'Open_sea_route_to_Al_Zahbi',147,101,138,0,0.00,152,0);
 INSERT INTO `zone_settings` VALUES (47,2,'127.0.0.1',54230,'Open_sea_route_to_Mhaura',147,101,138,0,0.00,152,0);
 INSERT INTO `zone_settings` VALUES (48,1,'127.0.0.1',54230,'Al_Zahbi',178,178,178,0,0.00,24,0);
-INSERT INTO `zone_settings` VALUES (49,0,'127.0.0.1',0,'noname',0,0,0,0,0.00,0,0);
+INSERT INTO `zone_settings` VALUES (49,0,'127.0.0.1',54230,'noname',0,0,0,0,0.00,0,0);
 INSERT INTO `zone_settings` VALUES (50,1,'127.0.0.1',54230,'Aht_Urhgan_Whitegate',178,178,178,0,0.00,1032,0);
 INSERT INTO `zone_settings` VALUES (51,2,'127.0.0.1',54230,'Wajaom_Woodlands',149,101,138,0,0.00,156,0);
 INSERT INTO `zone_settings` VALUES (52,2,'127.0.0.1',54230,'Bhaflau_Thickets',149,101,138,0,0.00,156,0);
@@ -178,7 +178,7 @@ INSERT INTO `zone_settings` VALUES (129,6,'127.0.0.1',54230,'Ghoyus_Reverie',0,2
 INSERT INTO `zone_settings` VALUES (130,1,'127.0.0.1',54230,'RuAun_Gardens',210,101,191,0,0.00,152,0);
 INSERT INTO `zone_settings` VALUES (131,3,'127.0.0.1',54230,'Mordion_Gaol',0,0,0,0,0.00,0,0);
 INSERT INTO `zone_settings` VALUES (132,2,'127.0.0.1',54230,'Abyssea-La_Theine',51,52,52,0,0.00,0,0);
-INSERT INTO `zone_settings` VALUES (133,0,'127.0.0.1',0,'noname',0,0,0,0,0.00,0,0);
+INSERT INTO `zone_settings` VALUES (133,0,'127.0.0.1',54230,'noname',0,0,0,0,0.00,0,0);
 INSERT INTO `zone_settings` VALUES (134,5,'127.0.0.1',54230,'Dynamis-Beaucedine',121,121,121,0,0.00,400,0);
 INSERT INTO `zone_settings` VALUES (135,5,'127.0.0.1',54230,'Dynamis-Xarcabard',119,119,119,0,0.00,400,0);
 INSERT INTO `zone_settings` VALUES (136,2,'127.0.0.1',54230,'Beaucedine_Glacier_[S]',0,101,215,0,0.00,152,0);
@@ -234,7 +234,7 @@ INSERT INTO `zone_settings` VALUES (185,5,'127.0.0.1',54230,'Dynamis-San_dOria',
 INSERT INTO `zone_settings` VALUES (186,5,'127.0.0.1',54230,'Dynamis-Bastok',121,121,121,0,0.00,400,0);
 INSERT INTO `zone_settings` VALUES (187,5,'127.0.0.1',54230,'Dynamis-Windurst',121,121,121,0,0.00,400,0);
 INSERT INTO `zone_settings` VALUES (188,5,'127.0.0.1',54230,'Dynamis-Jeuno',121,121,121,0,0.00,400,0);
-INSERT INTO `zone_settings` VALUES (189,0,'127.0.0.1',0,'noname',0,0,0,0,0.00,0,0);
+INSERT INTO `zone_settings` VALUES (189,0,'127.0.0.1',54230,'noname',0,0,0,0,0.00,0,0);
 INSERT INTO `zone_settings` VALUES (190,3,'127.0.0.1',54230,'King_Ranperres_Tomb',0,115,102,0,0.00,145,0);
 INSERT INTO `zone_settings` VALUES (191,3,'127.0.0.1',54230,'Dangruf_Wadi',0,115,102,0,0.00,145,0);
 INSERT INTO `zone_settings` VALUES (192,3,'127.0.0.1',54230,'Inner_Horutoto_Ruins',0,115,102,0,0.00,145,0);
@@ -244,7 +244,7 @@ INSERT INTO `zone_settings` VALUES (195,3,'127.0.0.1',54230,'The_Eldieme_Necropo
 INSERT INTO `zone_settings` VALUES (196,3,'127.0.0.1',54230,'Gusgen_Mines',0,115,102,0,0.00,145,0);
 INSERT INTO `zone_settings` VALUES (197,3,'127.0.0.1',54230,'Crawlers_Nest',0,115,102,0,0.00,145,0);
 INSERT INTO `zone_settings` VALUES (198,3,'127.0.0.1',54230,'Maze_of_Shakhrami',0,115,102,0,0.00,145,0);
-INSERT INTO `zone_settings` VALUES (199,0,'127.0.0.1',0,'noname',0,0,0,0,0.00,0,0);
+INSERT INTO `zone_settings` VALUES (199,0,'127.0.0.1',54230,'noname',0,0,0,0,0.00,0,0);
 INSERT INTO `zone_settings` VALUES (200,3,'127.0.0.1',54230,'Garlaige_Citadel',0,115,102,0,0.00,145,0);
 INSERT INTO `zone_settings` VALUES (201,4,'127.0.0.1',54230,'Cloister_of_Gales',0,0,0,0,0.00,145,0);
 INSERT INTO `zone_settings` VALUES (202,4,'127.0.0.1',54230,'Cloister_of_Storms',0,0,0,0,0.00,145,0);
@@ -255,7 +255,7 @@ INSERT INTO `zone_settings` VALUES (206,4,'127.0.0.1',54230,'QuBia_Arena',0,125,
 INSERT INTO `zone_settings` VALUES (207,4,'127.0.0.1',54230,'Cloister_of_Flames',0,0,0,0,0.00,145,0);
 INSERT INTO `zone_settings` VALUES (208,3,'127.0.0.1',54230,'Quicksand_Caves',0,115,192,0,0.00,145,0);
 INSERT INTO `zone_settings` VALUES (209,4,'127.0.0.1',54230,'Cloister_of_Tremors',0,0,0,0,0.00,145,0);
-INSERT INTO `zone_settings` VALUES (210,0,'127.0.0.1',0,'noname',0,0,0,0,0.00,0,0);
+INSERT INTO `zone_settings` VALUES (210,0,'127.0.0.1',54230,'noname',0,0,0,0,0.00,0,0);
 INSERT INTO `zone_settings` VALUES (211,4,'127.0.0.1',54230,'Cloister_of_Tides',0,0,0,0,0.00,145,0);
 INSERT INTO `zone_settings` VALUES (212,3,'127.0.0.1',54230,'Gustav_Tunnel',0,115,192,0,0.00,145,0);
 INSERT INTO `zone_settings` VALUES (213,3,'127.0.0.1',54230,'Labyrinth_of_Onzozo',0,115,192,0,0.00,145,0);
@@ -264,7 +264,7 @@ INSERT INTO `zone_settings` VALUES (215,2,'127.0.0.1',54230,'Abyssea-Attohwa',51
 INSERT INTO `zone_settings` VALUES (216,2,'127.0.0.1',54230,'Abyssea-Misareaux',51,52,52,0,0.00,0,0);
 INSERT INTO `zone_settings` VALUES (217,2,'127.0.0.1',54230,'Abyssea-Vunkerl',51,52,52,0,0.00,0,0);
 INSERT INTO `zone_settings` VALUES (218,2,'127.0.0.1',54230,'Abyssea-Altepa',51,52,52,0,0.00,0,0);
-INSERT INTO `zone_settings` VALUES (219,0,'127.0.0.1',0,'noname',0,0,0,0,0.00,0,0);
+INSERT INTO `zone_settings` VALUES (219,0,'127.0.0.1',54230,'noname',0,0,0,0,0.00,0,0);
 INSERT INTO `zone_settings` VALUES (220,0,'127.0.0.1',54230,'Ship_bound_for_Selbina',106,101,103,0,0.00,152,0);
 INSERT INTO `zone_settings` VALUES (221,0,'127.0.0.1',54230,'Ship_bound_for_Mhaura',106,101,103,0,0.00,152,0);
 INSERT INTO `zone_settings` VALUES (222,4,'127.0.0.1',54230,'Provenance',56,56,56,0,0.00,0,0);
@@ -274,7 +274,7 @@ INSERT INTO `zone_settings` VALUES (225,2,'127.0.0.1',54230,'Windurst-Jeuno_Airs
 INSERT INTO `zone_settings` VALUES (226,2,'127.0.0.1',54230,'Kazham-Jeuno_Airship',128,128,128,0,0.00,8,0);
 INSERT INTO `zone_settings` VALUES (227,2,'127.0.0.1',54230,'Ship_bound_for_Selbina',106,101,103,0,0.00,152,0);
 INSERT INTO `zone_settings` VALUES (228,2,'127.0.0.1',54230,'Ship_bound_for_Mhaura',106,101,103,0,0.00,152,0);
-INSERT INTO `zone_settings` VALUES (229,0,'127.0.0.1',0,'noname',0,0,0,0,0.00,0,0);
+INSERT INTO `zone_settings` VALUES (229,0,'127.0.0.1',54230,'noname',0,0,0,0,0.00,0,0);
 INSERT INTO `zone_settings` VALUES (230,1,'127.0.0.1',54230,'Southern_San_dOria',107,107,107,0,0.00,72,0);
 INSERT INTO `zone_settings` VALUES (231,1,'127.0.0.1',54230,'Northern_San_dOria',107,107,107,0,0.00,72,0);
 INSERT INTO `zone_settings` VALUES (232,1,'127.0.0.1',54230,'Port_San_dOria',107,107,107,0,0.00,72,0);


### PR DESCRIPTION
This is simple, was causing error 3001 if a character logged out in one of these zones. Note: only affected noname zones, and character would get error 3001 and hang on downloading screen . Don't forget to re-update ZoneIP after pull!