### PR TITLE
Fix issue with Rescue Drill, Update Zone Location Comment for Endracion

### DIFF
--- a/scripts/zones/La_Theine_Plateau/npcs/Galaihaurat.lua
+++ b/scripts/zones/La_Theine_Plateau/npcs/Galaihaurat.lua
@@ -26,7 +26,7 @@ function onTrigger(player,npc)
 	if(player:getCurrentMission(SANDORIA) == THE_RESCUE_DRILL) then
 		local MissionStatus = player:getVar("MissionStatus");
 		
-		if(MissionStatus == 0) then
+		if(MissionStatus == 1) then
 			player:startEvent(0x006e);
 		elseif(MissionStatus == 2) then
 			player:showText(npc, RESCUE_DRILL + 16);

--- a/scripts/zones/Southern_San_dOria/npcs/Endracion.lua
+++ b/scripts/zones/Southern_San_dOria/npcs/Endracion.lua
@@ -1,5 +1,5 @@
 -----------------------------------
--- Area: Northern San d'Oria
+-- Area: Southern San d'Oria
 -- NPC:  Endracion
 -- @pos -110 1 -34 230
 -----------------------------------


### PR DESCRIPTION
Rescue Drill, Mission status was set to 1, Galaihaurat.lua asks for mission status 0 in line 29. Updated to check for mission status 1 in Galaihaurat.lua