### PR TITLE
Implement Aern TP Moves

### DIFF
--- a/scripts/globals/mobskills/Auroral_Wind.lua
+++ b/scripts/globals/mobskills/Auroral_Wind.lua
@@ -1,0 +1,35 @@
+---------------------------------------------
+--  Auroral Wind
+--
+--  Family: Aern
+--  Type: Magical
+--  Can be dispelled: N/A
+--  Utsusemi/Blink absorb: Ignores shadows
+--  Range: Unknown cone
+--  Notes:
+---------------------------------------------
+
+require("/scripts/globals/settings");
+require("/scripts/globals/status");
+require("/scripts/globals/monstertpmoves");
+
+---------------------------------------------
+function onMobSkillCheck(target,mob,skill)
+    return 0;
+end;
+
+function onMobWeaponSkill(target, mob, skill)
+	local typeEffect = EFFECT_SILENCE;
+
+	MobStatusEffectMove(mob, target, typeEffect, 1, 0, 60);
+
+	local dmgmod = 1;
+	local accmod = 1;
+	local info = MobMagicalMove(mob,target,skill,mob:getWeaponDmg()*3,ELE_DARK,dmgmod,TP_NO_EFFECT);
+	local dmg = MobFinalAdjustments(info.dmg,mob,skill,target,MOBSKILL_MAGICAL,MOBPARAM_DARK,MOBPARAM_IGNORE_SHADOWS);
+
+	target:delHP(dmg);
+
+	return dmg;
+
+end;

--- a/scripts/globals/mobskills/Auroral_Wind.lua
+++ b/scripts/globals/mobskills/Auroral_Wind.lua
@@ -25,7 +25,7 @@ function onMobWeaponSkill(target, mob, skill)
 
 	local dmgmod = 1;
 	local accmod = 1;
-	local info = MobMagicalMove(mob,target,skill,mob:getWeaponDmg()*3,ELE_DARK,dmgmod,TP_NO_EFFECT);
+	local info = MobMagicalMove(mob,target,skill,mob:getWeaponDmg()*3,ELE_WIND,dmgmod,TP_NO_EFFECT);
 	local dmg = MobFinalAdjustments(info.dmg,mob,skill,target,MOBSKILL_MAGICAL,MOBPARAM_DARK,MOBPARAM_IGNORE_SHADOWS);
 
 	target:delHP(dmg);

--- a/scripts/globals/mobskills/Biotic_Boomerang.lua
+++ b/scripts/globals/mobskills/Biotic_Boomerang.lua
@@ -1,0 +1,31 @@
+---------------------------------------------
+--  Biotic Boomerang
+--  Aern (BST & WAR)
+--  Blinkable 2-3 hit, addtional effect plague on hit. 
+---------------------------------------------
+
+require("/scripts/globals/settings");
+require("/scripts/globals/status");
+require("/scripts/globals/monstertpmoves");
+
+---------------------------------------------
+
+function onMobSkillCheck(target,mob,skill)
+	return 0;
+end;
+
+function onMobWeaponSkill(target, mob, skill)
+
+	local numhits = math.random(2,3);
+	local accmod = 1;
+	local dmgmod = 1;
+	local info = MobPhysicalMove(mob,target,skill,numhits,accmod,dmgmod,0,1,2,3);
+	local dmg = MobFinalAdjustments(info.dmg,mob,skill,target,MOBSKILL_PHYSICAL,0,info.hitslanded);
+	local typeEffect = EFFECT_PLAGUE;
+
+	MobPhysicalStatusEffectMove(mob, target, skill, typeEffect, 18, 3, 60);
+
+	target:delHP(dmg);
+	return dmg;
+
+end;

--- a/scripts/globals/mobskills/Crystaline_Cocoon.lua
+++ b/scripts/globals/mobskills/Crystaline_Cocoon.lua
@@ -1,0 +1,31 @@
+---------------------------------------------------
+-- Crystaline Cocoon
+-- Family: Aern
+-- Type: Enhancing
+-- Can be dispelled: Yes
+-- Utsusemi/Blink absorb: N/A
+-- Range: Self
+-- Notes:
+---------------------------------------------------
+
+require("/scripts/globals/settings");
+require("/scripts/globals/status");
+require("/scripts/globals/monstertpmoves");
+
+---------------------------------------------------
+
+function onMobSkillCheck(target,mob,skill)
+    return 0;
+end;
+
+function onMobWeaponSkill(target, mob, skill)
+
+    local typeEffect1 = EFFECT_PROTECT;
+	local typeEffect2 = EFFECT_SHELL;
+
+	skill:setMsg(MobBuffMove(mob, typeEffect, 50, 0, 60));
+	MobBuffMove(mob, typeEffect1, 50, 0, 60);
+	MobBuffMove(mob, typeEffect2, 50, 0, 60);
+
+    return typeEffect1;
+end;

--- a/scripts/globals/mobskills/Depuration.lua
+++ b/scripts/globals/mobskills/Depuration.lua
@@ -1,0 +1,33 @@
+---------------------------------------------
+--  Depuration
+--  Family: Aern
+--  Type: Healing
+--  Can be dispelled: N/A
+--  Utsusemi/Blink absorb: N/A
+--  Range: Self
+--  Notes: Erases all negative effects on the mob. Aerns will generally not attempt to use this ability if no erasable effects exist on them.
+---------------------------------------------
+
+require("/scripts/globals/settings");
+require("/scripts/globals/status");
+require("/scripts/globals/monstertpmoves");
+
+---------------------------------------------
+
+function onMobSkillCheck(target,mob,skill)
+    
+	local dispel = target:eraseStatusEffect();
+	
+	if(dispel ~= EFFECT_NONE) then
+        return 0;
+    end
+
+    return 1;
+
+end;
+
+function onMobWeaponSkill(target, mob, skill)
+
+    mob:eraseAllStatusEffect();
+
+end;

--- a/scripts/globals/mobskills/Impact_Stream.lua
+++ b/scripts/globals/mobskills/Impact_Stream.lua
@@ -1,0 +1,32 @@
+---------------------------------------------
+--  Impact Stream
+--
+--  Description: 50% Defense Down, Stun
+--  Type: Magical
+--  Wipe Shadows
+--  Range: 10.0' AoE
+--  Notes: 
+---------------------------------------------
+
+require("/scripts/globals/settings");
+require("/scripts/globals/status");
+require("/scripts/globals/monstertpmoves");
+
+---------------------------------------------
+function onMobSkillCheck(target,mob,skill)
+    return 0;
+end;
+
+function onMobWeaponSkill(target, mob, skill)
+	local typeEffect1 = EFFECT_STUN;
+	local typeEffect2 = EFFECT_DEFENSE_DOWN;
+
+	MobStatusEffectMove(mob, target, typeEffect1, 1, 0, 4);
+	MobStatusEffectMove(mob, target, typeEffect2, 50, 0, 60);
+
+	local dmgmod = 1;
+	local info = MobMagicalMove(mob,target,skill,mob:getWeaponDmg()*2.5,ELE_LIGHT,dmgmod,0,1);
+	local dmg = MobFinalAdjustments(info.dmg,mob,skill,target,MOBSKILL_MAGICAL,MOBPARAM_EARTH,MOBPARAM_WIPE_SHADOWS);
+	target:delHP(dmg);
+	return dmg;
+end;

--- a/scripts/globals/mobskills/Medusa_Javelin.lua
+++ b/scripts/globals/mobskills/Medusa_Javelin.lua
@@ -1,0 +1,31 @@
+---------------------------------------------
+--  Medusa Javelin
+--  Aern (DRG & SAM)
+--  Blinkable 1 hit, Knockback, Hate Reset
+---------------------------------------------
+
+require("/scripts/globals/settings");
+require("/scripts/globals/status");
+require("/scripts/globals/monstertpmoves");
+
+---------------------------------------------
+
+function onMobSkillCheck(target,mob,skill)
+	return 0;
+end;
+
+function onMobWeaponSkill(target, mob, skill)
+
+	local numhits = 1;
+	local accmod = 1;
+	local dmgmod = 1.5;
+	local info = MobPhysicalMove(mob,target,skill,numhits,accmod,dmgmod,TP_NO_EFFECT);
+	local dmg = MobFinalAdjustments(info.dmg,mob,skill,target,MOBSKILL_PHYSICAL,MOBPARAM_NONE,info.hitslanded);
+	target:delHP(dmg);
+
+	local typeEffect = EFFECT_PETRIFICATION;
+
+	MobPhysicalStatusEffectMove(mob, target, skill, typeEffect, 1, 0, 60);
+
+	return dmg;
+end;

--- a/scripts/globals/mobskills/Sideswipe.lua
+++ b/scripts/globals/mobskills/Sideswipe.lua
@@ -1,11 +1,7 @@
 ---------------------------------------------
---  Glacier Splitter
---
---  Description: Cleaves into targets in a fan-shaped area. Additional effect: Paralyze
---  Type: Physical
---  Utsusemi/Blink absorb: 1-3 shadows
---  Range: Unknown cone
---  Notes: Only used the Aern wielding a sword (RDM, DRK, and PLD).
+--  Sideswipe
+--  Aern (NIN & MNK)
+--  Blinkable 1 hit, Knockback, Hate Reset
 ---------------------------------------------
 
 require("/scripts/globals/settings");
@@ -13,22 +9,21 @@ require("/scripts/globals/status");
 require("/scripts/globals/monstertpmoves");
 
 ---------------------------------------------
+
 function onMobSkillCheck(target,mob,skill)
-    return 0;
+	return 0;
 end;
 
 function onMobWeaponSkill(target, mob, skill)
 
-	local numhits = math.random(1,3);
+	local numhits = 1;
 	local accmod = 1;
 	local dmgmod = 1;
 	local info = MobPhysicalMove(mob,target,skill,numhits,accmod,dmgmod,TP_NO_EFFECT);
 	local dmg = MobFinalAdjustments(info.dmg,mob,skill,target,MOBSKILL_PHYSICAL,MOBPARAM_SLASH,info.hitslanded);
-
-	local typeEffect = EFFECT_PARALYSIS;
-
-	MobPhysicalStatusEffectMove(mob, target, skill, typeEffect, 15, 0, 120);
-
 	target:delHP(dmg);
+
+	mob:resetEnmity(target);
 	return dmg;
+
 end;

--- a/scripts/globals/mobskills/Wing_Thrust.lua
+++ b/scripts/globals/mobskills/Wing_Thrust.lua
@@ -1,11 +1,10 @@
 ---------------------------------------------
---  Glacier Splitter
---
---  Description: Cleaves into targets in a fan-shaped area. Additional effect: Paralyze
+--  Wing Thrust
+--  Family: Aern
 --  Type: Physical
---  Utsusemi/Blink absorb: 1-3 shadows
---  Range: Unknown cone
---  Notes: Only used the Aern wielding a sword (RDM, DRK, and PLD).
+--  Can be dispelled: N/A
+--  Utsusemi/Blink absorb: 4 Shadows
+--  Range: Single Target 7.0'
 ---------------------------------------------
 
 require("/scripts/globals/settings");
@@ -14,20 +13,19 @@ require("/scripts/globals/monstertpmoves");
 
 ---------------------------------------------
 function onMobSkillCheck(target,mob,skill)
-    return 0;
+	return 0;
 end;
 
 function onMobWeaponSkill(target, mob, skill)
+	local typeEffect = EFFECT_SLOW;
 
-	local numhits = math.random(1,3);
+	local numhits = 4;
 	local accmod = 1;
 	local dmgmod = 1;
 	local info = MobPhysicalMove(mob,target,skill,numhits,accmod,dmgmod,TP_NO_EFFECT);
-	local dmg = MobFinalAdjustments(info.dmg,mob,skill,target,MOBSKILL_PHYSICAL,MOBPARAM_SLASH,info.hitslanded);
+	local dmg = MobFinalAdjustments(info.dmg,mob,skill,target,MOBSKILL_PHYSICAL,MOBPARAM_NONE,info.hitslanded);
 
-	local typeEffect = EFFECT_PARALYSIS;
-
-	MobPhysicalStatusEffectMove(mob, target, skill, typeEffect, 15, 0, 120);
+    MobPhysicalStatusEffectMove(mob, target, skill, typeEffect, 128, 0, 60);
 
 	target:delHP(dmg);
 	return dmg;

--- a/sql/mob_skill.sql
+++ b/sql/mob_skill.sql
@@ -1750,7 +1750,7 @@ INSERT INTO `mob_skill` VALUES (1123,440,1011,'Auroral_Wind',4,10.0,2000,1000,4,
 INSERT INTO `mob_skill` VALUES (1124,440,1012,'Impact_Stream',1,10.0,2000,1500,4,0,0,0);
 INSERT INTO `mob_skill` VALUES (1125,440,1013,'Depuration',0,7.0,2000,1000,1,0,0,0);
 INSERT INTO `mob_skill` VALUES (1126,440,1014,'Crystaline_Cocoon',0,7.0,2000,1000,1,0,0,0);
-INSERT INTO `mob_skill` VALUES (1130,440,1021,'Medusa_Javelin',0,7.0,2000,1000,1,0,0,0);
+INSERT INTO `mob_skill` VALUES (1130,440,1021,'Medusa_Javelin',0,7.0,2000,1000,4,0,0,0);
 
 
 -- Aern staff type smn whm


### PR DESCRIPTION
Implement Aern TP Moves. 

Added
Impact Stream - 10' AOE damage, Stun and Defense Down, wipes Shadow Images.

Wing Thrust - Single target damage, adds Slow, absorbed by 4 Shadow Images. The Slow does not overwrite Haste, but is extremely potent.	

Crystaline Cocoon - Shell and Protect	

Auroral Wind - Cone Attack wind damage and silence	

Depuration - Full Erase	

Sideswipe - Single target damage, knockback, and hate reset, used only by unarmed Aerns (Ninja, Monk)	

Biotic Boomerang - AoE Plague, absorbed by 2 Shadow Images, used only by Axe-wielding Aerns (Ranger, Warrior, Beastmaster)	

Medusa Javelin - Single target damage and Petrification, absorbed by 1 Shadow Image, used only by Polearm-wielding Aerns (Samurai, Dragoon)	

Modified: White Space Cleanup
Glacier Splitter - Cone Attack damage and Paralyze, absorbed by 1-3 Shadow Images, used only by Sword-wielding Aerns (Red Mage, Dark Knight, Paladin) 

Modified Mob_Skill.sql: Change from self target to Enemy. 
INSERT INTO `mob_skill` VALUES (1130,440,1021,'Medusa_Javelin',0,7.0,2000,1000,1,0,0,0); -- Self
INSERT INTO `mob_skill` VALUES (1130,440,1021,'Medusa_Javelin',0,7.0,2000,1000,4,0,0,0); -- Enemy Target

Reference: 
http://wiki.ffxiclopedia.org/wiki/Category:Aern