### PR TITLE
Cavernous Maw fixes

### DIFF
--- a/scripts/zones/Abyssea-Altepa/npcs/Cavernous_Maw.lua
+++ b/scripts/zones/Abyssea-Altepa/npcs/Cavernous_Maw.lua
@@ -1,0 +1,44 @@
+-----------------------------------
+-- Area: Abyssea Altepa
+--  NPC: Cavernous Maw
+-- @pos 444.000 -0.500 320.000 218
+-- Notes Teleports Players to South Gustaberg
+-----------------------------------
+package.loaded["scripts/zones/Abyssea-Altepa/TextIDs"] = nil;
+-----------------------------------
+
+-----------------------------------
+-- onTrade Action
+-----------------------------------
+
+function onTrade(player,npc,trade)
+end;
+
+-----------------------------------
+-- onTrigger Action
+-----------------------------------
+
+function onTrigger(player,npc)
+    player:startEvent(0x00C8);
+end;
+
+-----------------------------------
+-- onEventUpdate
+-----------------------------------
+
+function onEventUpdate(player,csid,option)
+    -- printf("CSID: %u",csid);
+    -- printf("RESULT: %u",option);
+end;
+
+-----------------------------------
+-- onEventFinish
+-----------------------------------
+
+function onEventFinish(player,csid,option)
+    -- printf("CSID: %u",csid);
+    -- printf("RESULT: %u",option);
+    if(csid == 0x00C8 and option == 1) then
+        player:setPos(343,0,-679,199,107)
+    end
+end;

--- a/scripts/zones/Abyssea-Attohwa/npcs/Cavernous_Maw.lua
+++ b/scripts/zones/Abyssea-Attohwa/npcs/Cavernous_Maw.lua
@@ -1,0 +1,47 @@
+-----------------------------------
+-- Area: Abyssea - Attohwa
+--  NPC: Cavernous Maw
+-- @pos -133.197 20.242 -181.658 215
+-- Notes: Teleports Players to Buburimu Peninsula
+-----------------------------------
+package.loaded["scripts/zones/Abyssea-Attohwa/TextIDs"] = nil;
+-----------------------------------
+
+require("scripts/globals/settings");
+require("scripts/zones/Abyssea-Attohwa/TextIDs");
+
+-----------------------------------
+-- onTrade Action
+-----------------------------------
+
+function onTrade(player,npc,trade)
+end;
+
+-----------------------------------
+-- onTrigger Action
+-----------------------------------
+
+function onTrigger(player,npc)
+    player:startEvent(0x00c8);
+end;
+
+-----------------------------------
+-- onEventUpdate
+-----------------------------------
+
+function onEventUpdate(player,csid,option)
+    -- printf("CSID: %u",csid);
+    -- printf("RESULT: %u",option);
+end;
+
+-----------------------------------
+-- onEventFinish
+-----------------------------------
+
+function onEventFinish(player,csid,option)
+    -- printf("CSID: %u",csid);
+    -- printf("RESULT: %u",option);
+    if(csid == 0x00c8 and option == 1) then
+        player:setPos(-338,-23,47,167,118);
+    end
+end;

--- a/scripts/zones/Abyssea-Grauberg/npcs/Cavernous_Maw.lua
+++ b/scripts/zones/Abyssea-Grauberg/npcs/Cavernous_Maw.lua
@@ -1,13 +1,13 @@
 -----------------------------------
 -- Area: Abyssea - Grauberg
--- Name: Cavernous Maw
--- Teleports Players to North Gustaberg
+--  NPC: Cavernous Maw
 -- @pos -564.000, 30.300, -760.000 254
+-- Teleports Players to North Gustaberg
 -----------------------------------
 package.loaded["scripts/zones/Abyssea-Grauberg/TextIDs"] = nil;
 -----------------------------------
 
-require("scripts/globals/teleports");
+require("scripts/globals/settings");
 require("scripts/zones/Abyssea-Grauberg/TextIDs");
 
 -----------------------------------
@@ -41,7 +41,7 @@ end;
 function onEventFinish(player,csid,option)
     -- printf("CSID: %u",csid);
     -- printf("RESULT: %u",option);
-    if(csid == 0x00C8 and option == 1) then
+    if (csid == 0x00C8 and option == 1) then
         player:setPos(-71,0.001,601,126,106);
     end
 end;

--- a/scripts/zones/Abyssea-Konschtat/npcs/Cavernous_Maw.lua
+++ b/scripts/zones/Abyssea-Konschtat/npcs/Cavernous_Maw.lua
@@ -1,12 +1,13 @@
 -----------------------------------
--- Area: Abyssea Konschatat
--- Name: Cavernous Maw
--- Teleports Players to Konschatat Highlands
+-- Area: Abyssea - Konschatat
+--  NPC: Cavernous Maw
 -- @pos 159.943 -72.109 -839.986 15
+-- Teleports Players to Konschatat Highlands
 -----------------------------------
 package.loaded["scripts/zones/Abyssea-Konschtat/TextIDs"] = nil;
 -----------------------------------
 
+require("scripts/globals/settings");
 require("scripts/zones/Abyssea-Konschtat/TextIDs");
 
 -----------------------------------
@@ -40,7 +41,7 @@ end;
 function onEventFinish(player,csid,option)
     -- printf("CSID: %u",csid);
     -- printf("RESULT: %u",option);
-    if(csid == 0x00C8 and option == 1) then
+    if (csid == 0x00C8 and option == 1) then
         player:setPos(91,-68,-582,237,108);
     end
 end;

--- a/scripts/zones/Abyssea-La_Theine/npcs/Cavernous_Maw.lua
+++ b/scripts/zones/Abyssea-La_Theine/npcs/Cavernous_Maw.lua
@@ -1,0 +1,47 @@
+-----------------------------------
+-- Area: Abyssea - La Theine
+--  NPC: Cavernous Maw
+-- @pos -480.009, 0.000, 799.927 132
+-- Teleports Players to La Theine Plateau
+-----------------------------------
+package.loaded["scripts/zones/Abyssea-La_Theine/TextIDs"] = nil;
+-----------------------------------
+
+require("scripts/globals/settings");
+require("scripts/zones/Abyssea-La_Theine/TextIDs");
+
+-----------------------------------
+-- onTrade Action
+-----------------------------------
+
+function onTrade(player,npc,trade)
+end;
+
+-----------------------------------
+-- onTrigger Action
+-----------------------------------
+
+function onTrigger(player,npc)
+    player:startEvent(0x00c8);
+end;
+
+-----------------------------------
+-- onEventUpdate
+-----------------------------------
+
+function onEventUpdate(player,csid,option)
+    -- printf("CSID: %u",csid);
+    -- printf("RESULT: %u",option);
+end;
+
+-----------------------------------
+-- onEventFinish
+-----------------------------------
+
+function onEventFinish(player,csid,option)
+    -- printf("CSID: %u",csid);
+    -- printf("RESULT: %u",option);
+    if(csid == 0x00c8 and option == 1) then
+        player:setPos(-562,0.001,640,26,102);
+    end
+end;

--- a/scripts/zones/Abyssea-Misareaux/npcs/Cavernous_Maw.lua
+++ b/scripts/zones/Abyssea-Misareaux/npcs/Cavernous_Maw.lua
@@ -1,0 +1,47 @@
+-----------------------------------
+-- Area: Abyssea - Misareaux
+--  NPC: Cavernous Maw
+-- @pos 676.070, -16.063, 318.999 216
+-- Teleports Players to Valkrum Dunes
+-----------------------------------
+package.loaded["scripts/zones/Abyssea-Misareaux/TextIDs"] = nil;
+-----------------------------------
+
+require("scripts/globals/settings");
+require("scripts/zones/Abyssea-Misareaux/TextIDs");
+
+-----------------------------------
+-- onTrade Action
+-----------------------------------
+
+function onTrade(player,npc,trade)
+end;
+
+-----------------------------------
+-- onTrigger Action
+-----------------------------------
+
+function onTrigger(player,npc)
+    player:startEvent(0x00C8);
+end;
+
+-----------------------------------
+-- onEventUpdate
+-----------------------------------
+
+function onEventUpdate(player,csid,option)
+    -- printf("CSID: %u",csid);
+    -- printf("RESULT: %u",option);
+end;
+
+-----------------------------------
+-- onEventFinish
+-----------------------------------
+
+function onEventFinish(player,csid,option)
+    -- printf("CSID: %u",csid);
+    -- printf("RESULT: %u",option);
+    if(csid == 0x00C8 and option ==1) then
+        player:setPos(362,0.001,-119,4,103);
+    end
+end;

--- a/scripts/zones/Abyssea-Tahrongi/npcs/Cavernous_Maw.lua
+++ b/scripts/zones/Abyssea-Tahrongi/npcs/Cavernous_Maw.lua
@@ -1,0 +1,47 @@
+-----------------------------------
+-- Area: Abyssea - Tahrongi
+--  NPC: Cavernous Maw
+-- @pos -31.000, 47.000, -681.000 45
+-- Teleports Players to Tahrongi Canyon
+-----------------------------------
+package.loaded["scripts/zones/Abyssea-Tahrongi/TextIDs"] = nil;
+-----------------------------------
+
+require("scripts/globals/settings");
+require("scripts/zones/Abyssea-Tahrongi/TextIDs");
+
+-----------------------------------
+-- onTrade Action
+-----------------------------------
+
+function onTrade(player,npc,trade)
+end;
+
+-----------------------------------
+-- onTrigger Action
+-----------------------------------
+
+function onTrigger(player,npc)
+    player:startEvent(0x00C8);
+end;
+
+-----------------------------------
+-- onEventUpdate
+-----------------------------------
+
+function onEventUpdate(player,csid,option)
+    -- printf("CSID: %u",csid);
+    -- printf("RESULT: %u",option);
+end;
+
+-----------------------------------
+-- onEventFinish
+-----------------------------------
+
+function onEventFinish(player,csid,option)
+    -- printf("CSID: %u",csid);
+    -- printf("RESULT: %u",option);
+    if(csid == 0x00C8 and option ==1) then
+        player:setPos(-28,46,-680,76,117);
+    end
+end;

--- a/scripts/zones/Abyssea-Uleguerand/npcs/Cavernous_Maw.lua
+++ b/scripts/zones/Abyssea-Uleguerand/npcs/Cavernous_Maw.lua
@@ -1,0 +1,47 @@
+-----------------------------------
+-- Area: Abyssea - Uleguerand
+--  NPC: Cavernous Maw
+-- @pos -246.000, -40.600, -520.000 253
+-- Notes: Teleports Players to Xarcabard
+-----------------------------------
+package.loaded["scripts/zones/Abyssea-Uleguerand/TextIDs"] = nil;
+-----------------------------------
+
+require("scripts/globals/settings");
+require("scripts/zones/Abyssea-Uleguerand/TextIDs");
+
+-----------------------------------
+-- onTrade Action
+-----------------------------------
+
+function onTrade(player,npc,trade)
+end;
+
+-----------------------------------
+-- onTrigger Action
+-----------------------------------
+
+function onTrigger(player,npc)
+    player:startEvent(0x00c8);
+end;
+
+-----------------------------------
+-- onEventUpdate
+-----------------------------------
+
+function onEventUpdate(player,csid,option)
+    -- printf("CSID: %u",csid);
+    -- printf("RESULT: %u",option);
+end;
+
+-----------------------------------
+-- onEventFinish
+-----------------------------------
+
+function onEventFinish(player,csid,option)
+    -- printf("CSID: %u",csid);
+    -- printf("RESULT: %u",option);
+    if(csid == 0x00c8 and option == 1) then
+        player:setPos(269,-7,-75,192,112);
+    end
+end;

--- a/scripts/zones/Abyssea-Vunkerl/npcs/Cavernous_Maw.lua
+++ b/scripts/zones/Abyssea-Vunkerl/npcs/Cavernous_Maw.lua
@@ -1,0 +1,47 @@
+-----------------------------------
+-- Area: Abyssea - Vunkerl
+--  NPC: Cavernous Maw
+-- @pos -360.000 -46.750 700.000 217
+-- Notes: Teleports Players to Jugner Forest
+-----------------------------------
+package.loaded["scripts/zones/Abyssea-Vunkerl/TextIDs"] = nil;
+-----------------------------------
+
+require("scripts/globals/settings");
+require("scripts/zones/Abyssea-Vunkerl/TextIDs");
+
+-----------------------------------
+-- onTrade Action
+-----------------------------------
+
+function onTrade(player,npc,trade)
+end;
+
+-----------------------------------
+-- onTrigger Action
+-----------------------------------
+
+function onTrigger(player,npc)
+    player:startEvent(0x00c8);
+end;
+
+-----------------------------------
+-- onEventUpdate
+-----------------------------------
+
+function onEventUpdate(player,csid,option)
+    -- printf("CSID: %u",csid);
+    -- printf("RESULT: %u",option);
+end;
+
+-----------------------------------
+-- onEventFinish
+-----------------------------------
+
+function onEventFinish(player,csid,option)
+    -- printf("CSID: %u",csid);
+    -- printf("RESULT: %u",option);
+    if(csid == 0x00c8 and option == 1) then
+        player:setPos(241,0.001,11,42,104);
+    end
+end;

--- a/scripts/zones/Batallia_Downs/npcs/Cavernous_Maw.lua
+++ b/scripts/zones/Batallia_Downs/npcs/Cavernous_Maw.lua
@@ -1,7 +1,8 @@
 -----------------------------------
--- Cavernous Maw
--- Teleports Players to Batallia_Downs_S
+-- Area: Batallia Downs
+--  NPC: Cavernous Maw
 -- @pos -48 0.1 435 105
+-- Teleports Players to Batallia Downs [S]
 -----------------------------------
 package.loaded["scripts/zones/Batallia_Downs/TextIDs"] = nil;
 -----------------------------------
@@ -18,22 +19,20 @@ require("scripts/zones/Batallia_Downs/TextIDs");
 -----------------------------------
 
 function onTrade(player,npc,trade)
-end; 
+end;
 
 -----------------------------------
 -- onTrigger Action
 -----------------------------------
 
 function onTrigger(player,npc)
-	
-	if(ENABLE_WOTG == 1 and player:hasKeyItem(PURE_WHITE_FEATHER) == false) then
-		player:startEvent(0x01f4,0);
-	elseif(ENABLE_WOTG == 1 and hasMawActivated(player,0)) then
-		player:startEvent(0x038e);
-	else
-		player:messageSpecial(NOTHING_HAPPENS);
-	end
-	
+    if (ENABLE_WOTG == 1 and player:hasKeyItem(PURE_WHITE_FEATHER) == false) then
+        player:startEvent(0x01f4,0);
+    elseif (ENABLE_WOTG == 1 and hasMawActivated(player,0)) then
+        player:startEvent(0x038e);
+    else
+        player:messageSpecial(NOTHING_HAPPENS);
+    end
 end;
 
 -----------------------------------
@@ -41,8 +40,8 @@ end;
 -----------------------------------
 
 function onEventUpdate(player,csid,option)
---printf("CSID: %u",csid);
---printf("RESULT: %u",option);
+    -- printf("CSID: %u",csid);
+    -- printf("RESULT: %u",option);
 end;
 
 -----------------------------------
@@ -50,27 +49,25 @@ end;
 -----------------------------------
 
 function onEventFinish(player,csid,option)
---printf("CSID: %u",csid);
---printf("RESULT: %u",option);
-
-	if(csid == 0x01f4) then
-		local r = math.random(1,3);
-		player:addKeyItem(PURE_WHITE_FEATHER);
-		player:messageSpecial(KEYITEM_OBTAINED,PURE_WHITE_FEATHER);
-		player:completeMission(WOTG,CAVERNOUS_MAWS);
-		player:addMission(WOTG,BACK_TO_THE_BEGINNING);
-		if(r == 1) then
-			player:addNationTeleport(MAW,1);
-			toMaw(player,1); -- go to Batallia_Downs[S]
-		elseif(r == 2) then
-			player:addNationTeleport(MAW,2);
-			toMaw(player,3); -- go to Rolanberry_Fields_[S]
-		elseif(r == 3) then
-			player:addNationTeleport(MAW,4);
-			toMaw(player,5); -- go to Sauromugue_Champaign_[S]
-		end;
-	elseif(csid == 0x038e and option == 1) then
-		toMaw(player,1); -- go to Batallia_Downs[S]
-	end;
-	
+    -- printf("CSID: %u",csid);
+    -- printf("RESULT: %u",option);
+    if (csid == 0x01f4) then
+        local r = math.random(1,3);
+        player:addKeyItem(PURE_WHITE_FEATHER);
+        player:messageSpecial(KEYITEM_OBTAINED,PURE_WHITE_FEATHER);
+        player:completeMission(WOTG,CAVERNOUS_MAWS);
+        player:addMission(WOTG,BACK_TO_THE_BEGINNING);
+        if (r == 1) then
+            player:addNationTeleport(MAW,1);
+            toMaw(player,1); -- go to Batallia_Downs[S]
+        elseif (r == 2) then
+            player:addNationTeleport(MAW,2);
+            toMaw(player,3); -- go to Rolanberry_Fields_[S]
+        elseif (r == 3) then
+            player:addNationTeleport(MAW,4);
+            toMaw(player,5); -- go to Sauromugue_Champaign_[S]
+        end;
+    elseif (csid == 0x038e and option == 1) then
+        toMaw(player,1); -- go to Batallia_Downs[S]
+    end;
 end;

--- a/scripts/zones/Batallia_Downs_[S]/npcs/Cavernous_Maw.lua
+++ b/scripts/zones/Batallia_Downs_[S]/npcs/Cavernous_Maw.lua
@@ -1,7 +1,8 @@
 -----------------------------------
--- Cavernous Maw
--- Teleports Players to Batallia Downs
+-- Area: Batallia Downs [S]
+--  NPC: Cavernous Maw
 -- @pos -48 0 435 84
+-- Teleports Players to Batallia Downs
 -----------------------------------
 package.loaded["scripts/zones/Batallia_Downs_[S]/TextIDs"] = nil;
 -----------------------------------
@@ -15,20 +16,18 @@ require("scripts/zones/Batallia_Downs_[S]/TextIDs");
 -----------------------------------
 
 function onTrade(player,npc,trade)
-end; 
+end;
 
 -----------------------------------
 -- onTrigger Action
 -----------------------------------
 
 function onTrigger(player,npc)
-	
-	if(hasMawActivated(player,0) == false) then
-		player:startEvent(0x0064);
-	else
-		player:startEvent(0x0065);
-	end
-	
+    if (hasMawActivated(player,0) == false) then
+        player:startEvent(0x0064);
+    else
+        player:startEvent(0x0065);
+    end
 end;
 
 -----------------------------------
@@ -36,8 +35,8 @@ end;
 -----------------------------------
 
 function onEventUpdate(player,csid,option)
---printf("CSID: %u",csid);
---printf("RESULT: %u",option);
+    -- printf("CSID: %u",csid);
+    -- printf("RESULT: %u",option);
 end;
 
 -----------------------------------
@@ -45,15 +44,12 @@ end;
 -----------------------------------
 
 function onEventFinish(player,csid,option)
---printf("CSID: %u",csid);
---printf("RESULT: %u",option);
-
-	if(option == 1) then
-		if(csid == 0x0064) then
-			player:addNationTeleport(MAW,1);
-		end
-		
-		toMaw(player,2);
-	end
-	
+    -- printf("CSID: %u",csid);
+    -- printf("RESULT: %u",option);
+    if (option == 1) then
+        if (csid == 0x0064) then
+            player:addNationTeleport(MAW,1);
+        end
+        toMaw(player,2);
+    end
 end;

--- a/scripts/zones/Buburimu_Peninsula/npcs/Cavernous_Maw.lua
+++ b/scripts/zones/Buburimu_Peninsula/npcs/Cavernous_Maw.lua
@@ -1,0 +1,63 @@
+-----------------------------------
+-- Area: Buburimu Peninsula
+--  NPC: Cavernous Maw
+-- @pos -334 -24 52
+-- Teleports Players to Abyssea - Attohwa
+-----------------------------------
+package.loaded["scripts/zones/Buburimu_Peninsula/TextIDs"] = nil;
+-----------------------------------
+
+require("scripts/globals/settings");
+require("scripts/globals/keyitems");
+require("scripts/globals/quests");
+require("scripts/globals/abyssea");
+require("scripts/zones/Buburimu_Peninsula/TextIDs");
+
+-----------------------------------
+-- onTrade Action
+-----------------------------------
+
+function onTrade(player,npc,trade)
+end;
+
+-----------------------------------
+-- onTrigger Action
+-----------------------------------
+
+function onTrigger(player,npc)
+    if (ENABLE_ABYSSEA == 1 and player:getMainLvl() >= 30) then
+        local HasStone = getTravStonesTotal(player);
+        if (HasStone >= 1 and player:getQuestStatus(ABYSSEA, DAWN_OF_DEATH) == QUEST_ACCEPTED
+        and player:getQuestStatus(ABYSSEA, A_FLUTTERY_FIEND) == QUEST_AVAILABLE) then
+            player:startEvent(62);
+        else
+            player:startEvent(61,0,1); -- No param = no entry.
+        end
+    else
+        player:messageSpecial(NOTHING_HAPPENS);
+    end
+end;
+
+-----------------------------------
+-- onEventUpdate
+-----------------------------------
+
+function onEventUpdate(player,csid,option)
+    -- printf("CSID: %u",csid);
+    -- printf("RESULT: %u",option);
+end;
+
+-----------------------------------
+-- onEventFinish Action
+-----------------------------------
+function onEventFinish(player,csid,option)
+    -- printf("CSID: %u",csid);
+    -- printf("RESULT: %u",option);
+    if (csid == 62) then
+        player:addQuest(ABYSSEA, A_FLUTTERY_FIEND);
+    elseif (csid == 63) then
+        -- Killed Itzpapalotl
+    elseif (csid == 61 and option == 1) then
+        player:setPos(-140, 20, -181, 131, 215);
+    end
+end;

--- a/scripts/zones/East_Ronfaure/npcs/Cavernous_Maw.lua
+++ b/scripts/zones/East_Ronfaure/npcs/Cavernous_Maw.lua
@@ -1,7 +1,8 @@
 -----------------------------------
--- Cavernous Maw
--- Teleports Players to East Ronfaure [S]
+-- Area: East Ronfaure
+--  NPC: Cavernous Maw
 -- @pos 322 -59 503 101
+-- Teleports Players to East Ronfaure [S]
 -----------------------------------
 package.loaded["scripts/zones/East_Ronfaure/TextIDs"] = nil;
 -----------------------------------
@@ -17,20 +18,18 @@ require("scripts/zones/East_Ronfaure/TextIDs");
 -----------------------------------
 
 function onTrade(player,npc,trade)
-end; 
+end;
 
 -----------------------------------
 -- onTrigger Action
 -----------------------------------
 
 function onTrigger(player,npc)
-	
-	if(ENABLE_WOTG == 1 and player:hasKeyItem(PURE_WHITE_FEATHER) and hasMawActivated(player,6)) then
-		player:startEvent(0x0388);
-	else
-		player:messageSpecial(NOTHING_HAPPENS);
-	end
-	
+    if (ENABLE_WOTG == 1 and player:hasKeyItem(PURE_WHITE_FEATHER) and hasMawActivated(player,6)) then
+        player:startEvent(0x0388);
+    else
+        player:messageSpecial(NOTHING_HAPPENS);
+    end
 end;
 
 -----------------------------------
@@ -38,20 +37,18 @@ end;
 -----------------------------------
 
 function onEventUpdate(player,csid,option)
---printf("CSID: %u",csid);
---printf("RESULT: %u",option);
+    -- printf("CSID: %u",csid);
+    -- printf("RESULT: %u",option);
 end;
-   
+
 -----------------------------------
 -- onEventFinish Action
 -----------------------------------
 
 function onEventFinish(player,csid,option)
---print("CSID:",csid);
---print("RESULT:",option);
-	
-	if(csid == 0x0388 and option == 1) then
-		toMaw(player,9);
-	end
-	
+    -- printf("CSID:",csid);
+    -- printf("RESULT:",option);
+    if (csid == 0x0388 and option == 1) then
+        toMaw(player,9);
+    end
 end;

--- a/scripts/zones/East_Ronfaure_[S]/npcs/Cavernous_Maw.lua
+++ b/scripts/zones/East_Ronfaure_[S]/npcs/Cavernous_Maw.lua
@@ -1,5 +1,6 @@
 -----------------------------------
--- Cavernous Maw
+-- Area: East Ronfaure [S]
+--  NPC: Cavernous Maw
 -- Teleports Players to East Ronfaure
 -- @pos 322 -59 503 81
 -----------------------------------
@@ -16,20 +17,18 @@ require("scripts/zones/East_Ronfaure_[S]/TextIDs");
 -----------------------------------
 
 function onTrade(player,npc,trade)
-end; 
+end;
 
 -----------------------------------
 -- onTrigger Action
 -----------------------------------
 
 function onTrigger(player,npc)
-	
-	if(hasMawActivated(player,6) == false) then
-		player:startEvent(0x0064);
-	else
-		player:startEvent(0x0065);
-	end
-	
+    if (hasMawActivated(player,6) == false) then
+        player:startEvent(0x0064);
+    else
+        player:startEvent(0x0065);
+    end
 end;
 
 -----------------------------------
@@ -37,24 +36,21 @@ end;
 -----------------------------------
 
 function onEventUpdate(player,csid,option)
---printf("CSID: %u",csid);
---printf("RESULT: %u",option);
+    -- printf("CSID: %u",csid);
+    -- printf("RESULT: %u",option);
 end;
-   
+
 -----------------------------------
 -- onEventFinish Action
 -----------------------------------
 
 function onEventFinish(player,csid,option)
---print("CSID:",csid);
---print("RESULT:",option);
-	
-	if(option == 1) then
-		if(csid == 0x0064) then
-			player:addNationTeleport(MAW,64);
-		end
-		
-		toMaw(player,10);
-	end
-	
+    -- printf("CSID:",csid);
+    -- printf("RESULT:",option);
+    if (option == 1) then
+        if (csid == 0x0064) then
+            player:addNationTeleport(MAW,64);
+        end
+        toMaw(player,10);
+    end
 end;

--- a/scripts/zones/Jugner_Forest/npcs/Cavernous_Maw.lua
+++ b/scripts/zones/Jugner_Forest/npcs/Cavernous_Maw.lua
@@ -1,8 +1,8 @@
 -----------------------------------
 -- Area: Jugner Forest
--- NPC: Cavernous Maw
--- Teleports Players to Jugner Forest [S]
+--  NPC: Cavernous Maw
 -- @pos -118 -8 -518 104
+-- Teleports Players to Jugner Forest [S]
 -----------------------------------
 package.loaded["scripts/zones/Jugner_Forest/TextIDs"] = nil;
 -----------------------------------
@@ -18,20 +18,18 @@ require("scripts/zones/Jugner_Forest/TextIDs");
 -----------------------------------
 
 function onTrade(player,npc,trade)
-end; 
+end;
 
 -----------------------------------
 -- onTrigger Action
 -----------------------------------
 
 function onTrigger(player,npc)
-	
-	if(ENABLE_WOTG == 1 and player:hasKeyItem(PURE_WHITE_FEATHER) and hasMawActivated(player,3)) then
-		player:startEvent(0x0389);
-	else
-		player:messageSpecial(NOTHING_HAPPENS);
-	end
-	
+    if (ENABLE_WOTG == 1 and player:hasKeyItem(PURE_WHITE_FEATHER) and hasMawActivated(player,3)) then
+        player:startEvent(0x0389);
+    else
+        player:messageSpecial(NOTHING_HAPPENS);
+    end
 end;
 
 -----------------------------------
@@ -39,19 +37,17 @@ end;
 -----------------------------------
 
 function onEventUpdate(player,csid,option)
---printf("CSID: %u",csid);
---printf("RESULT: %u",option);
+    -- printf("CSID: %u",csid);
+    -- printf("RESULT: %u",option);
 end;
-   
+
 -----------------------------------
 -- onEventFinish Action
 -----------------------------------
 function onEventFinish(player,csid,option)
---printf("CSID: %u",csid);
---printf("RESULT: %u",option);
-	
-	if(csid == 0x0389 and option == 1) then
-		toMaw(player,13);
-	end
-	
+    -- printf("CSID: %u",csid);
+    -- printf("RESULT: %u",option);
+    if (csid == 0x0389 and option == 1) then
+        toMaw(player,13);
+    end
 end;

--- a/scripts/zones/Jugner_Forest/npcs/Cavernous_Maw_2.lua
+++ b/scripts/zones/Jugner_Forest/npcs/Cavernous_Maw_2.lua
@@ -1,0 +1,64 @@
+-----------------------------------
+-- Area: Jugner Forest
+--  NPC: Cavernous Maw
+-- @pos 246.318, -0.709, 5.706 104
+-- Teleports Players to Abyssea - Vunkerl
+-----------------------------------
+package.loaded["scripts/zones/Jugner_Forest/TextIDs"] = nil;
+-----------------------------------
+
+require("scripts/globals/settings");
+require("scripts/globals/keyitems");
+require("scripts/globals/quests");
+require("scripts/globals/abyssea");
+require("scripts/zones/Jugner_Forest/TextIDs");
+
+-----------------------------------
+-- onTrade Action
+-----------------------------------
+
+function onTrade(player,npc,trade)
+end;
+
+-----------------------------------
+-- onTrigger Action
+-----------------------------------
+
+function onTrigger(player,npc)
+    if (ENABLE_ABYSSEA == 1 and player:getMainLvl() >= 30) then
+        local HasStone = getTravStonesTotal(player);
+        if (HasStone >= 1 and player:getQuestStatus(ABYSSEA, DAWN_OF_DEATH) == QUEST_ACCEPTED
+        and player:getQuestStatus(ABYSSEA, THE_BEAST_OF_BASTORE) == QUEST_AVAILABLE) then
+            player:startEvent(48);
+        else
+            player:startEvent(47,0,1); -- No param = no entry.
+        end
+    else
+        player:messageSpecial(NOTHING_HAPPENS);
+    end
+end;
+
+-----------------------------------
+-- onEventUpdate
+-----------------------------------
+
+function onEventUpdate(player,csid,option)
+    -- printf("CSID: %u",csid);
+    -- printf("RESULT: %u",option);
+end;
+
+-----------------------------------
+-- onEventFinish Action
+-----------------------------------
+
+function onEventFinish(player,csid,option)
+    -- printf("CSID: %u",csid);
+    -- printf("RESULT: %u",option);
+    if (csid == 48) then
+        player:addQuest(ABYSSEA, THE_BEAST_OF_BASTORE);
+    elseif (csid == 49) then
+        -- Killed Sedna
+    elseif (csid == 47 and option == 1) then
+        player:setPos(-351,-46.750,699.5,10,217);
+    end
+end;

--- a/scripts/zones/Jugner_Forest_[S]/npcs/Cavernous_Maw.lua
+++ b/scripts/zones/Jugner_Forest_[S]/npcs/Cavernous_Maw.lua
@@ -1,7 +1,8 @@
 -----------------------------------
--- Cavernous Maw
--- Teleports Players to Jugner Forest
+-- Area: Jugner Forest [S]
+--  NPC: Cavernous Maw
 -- @pos -118 -8 -520 82
+-- Teleports Players to Jugner Forest
 -----------------------------------
 package.loaded["scripts/zones/Jugner_Forest_[S]/TextIDs"] = nil;
 -----------------------------------
@@ -16,20 +17,18 @@ require("scripts/zones/Jugner_Forest_[S]/TextIDs");
 -----------------------------------
 
 function onTrade(player,npc,trade)
-end; 
+end;
 
 -----------------------------------
 -- onTrigger Action
 -----------------------------------
 
 function onTrigger(player,npc)
-	
-	if(hasMawActivated(player,3) == false) then
-		player:startEvent(0x0065);
-	else
-		player:startEvent(0x0066);
-	end
-	
+    if (hasMawActivated(player,3) == false) then
+        player:startEvent(0x0065);
+    else
+        player:startEvent(0x0066);
+    end
 end;
 
 -----------------------------------
@@ -37,24 +36,21 @@ end;
 -----------------------------------
 
 function onEventUpdate(player,csid,option)
---printf("CSID: %u",csid);
---printf("RESULT: %u",option);
+    -- printf("CSID: %u",csid);
+    -- printf("RESULT: %u",option);
 end;
-   
+
 -----------------------------------
 -- onEventFinish Action
 -----------------------------------
 
 function onEventFinish(player,csid,option)
---printf("CSID: %u",csid);
---printf("RESULT: %u",option);
-	
-	if(option == 1) then
-		if(csid == 0x0065) then
-			player:addNationTeleport(MAW,8);
-		end
-		
-		toMaw(player,14);
-	end
-	
+    -- printf("CSID: %u",csid);
+    -- printf("RESULT: %u",option);
+    if (option == 1) then
+        if (csid == 0x0065) then
+            player:addNationTeleport(MAW,8);
+        end
+        toMaw(player,14);
+    end
 end;

--- a/scripts/zones/Konschtat_Highlands/npcs/Cavernous_Maw.lua
+++ b/scripts/zones/Konschtat_Highlands/npcs/Cavernous_Maw.lua
@@ -1,8 +1,8 @@
 -----------------------------------
 -- Area: Konschtat Highlands
 --  NPC: Cavernous Maw
--- Teleports Players to Abyssea - Konschtat
 -- @pos 96.344, -69.080, -580.008 108
+-- Teleports Players to Abyssea - Konschtat
 -----------------------------------
 package.loaded["scripts/zones/Konschtat_Highlands/TextIDs"] = nil;
 -----------------------------------
@@ -31,7 +31,7 @@ function onTrigger(player,npc)
         and player:getQuestStatus(ABYSSEA, TO_PASTE_A_PEISTE) == QUEST_AVAILABLE) then
             player:startEvent(0);
         else
-            player:startEvent(0x006B,0,1); -- No param = no entry.
+            player:startEvent(107,0,1); -- No param = no entry.
         end
     else
         player:messageSpecial(NOTHING_HAPPENS);
@@ -56,9 +56,9 @@ function onEventFinish(player,csid,option)
     -- printf("RESULT: %u",option);
     if (csid == 0) then
         player:addQuest(ABYSSEA, TO_PASTE_A_PEISTE);
-    elseif (csid ==1) then
+    elseif (csid == 1) then
         -- Killed Kukulkan
-    elseif(csid == 0x006B and option == 1) then
+    elseif (csid == 107 and option == 1) then
         player:setPos(153,-72,-840,140,15);
     end
 end;

--- a/scripts/zones/La_Theine_Plateau/npcs/Cavernous_Maw.lua
+++ b/scripts/zones/La_Theine_Plateau/npcs/Cavernous_Maw.lua
@@ -1,0 +1,66 @@
+-----------------------------------
+-- Area: La Theine Plateau
+--  NPC: Cavernous Maw
+-- @pos 95.344, -69.080, -580.008 108
+-- Teleports Players to Abyssea - La Theine
+-----------------------------------
+package.loaded["scripts/zones/La_Theine_Plateau/TextIDs"] = nil;
+-----------------------------------
+
+require("scripts/globals/settings");
+require("scripts/globals/keyitems");
+require("scripts/globals/quests");
+require("scripts/globals/abyssea");
+require("scripts/zones/La_Theine_Plateau/TextIDs");
+
+-----------------------------------
+
+-----------------------------------
+-- onTrade Action
+-----------------------------------
+
+function onTrade(player,npc,trade)
+end;
+
+-----------------------------------
+-- onTrigger Action
+-----------------------------------
+
+function onTrigger(player,npc)
+    if (ENABLE_ABYSSEA == 1 and player:getMainLvl() >= 30) then
+        local HasStone = getTravStonesTotal(player);
+        if (HasStone >= 1 and player:getQuestStatus(ABYSSEA, DAWN_OF_DEATH) == QUEST_ACCEPTED
+        and player:getQuestStatus(ABYSSEA, A_GOLDSTRUCK_GIGAS) == QUEST_AVAILABLE) then
+            player:startEvent(9);
+        else
+            player:startEvent(218,0,1); -- No param = no entry.
+        end
+    else
+        player:messageSpecial(NOTHING_HAPPENS);
+    end
+end;
+
+-----------------------------------
+-- onEventUpdate
+-----------------------------------
+
+function onEventUpdate(player,csid,option)
+    -- printf("CSID: %u",csid);
+    -- printf("RESULT: %u",option);
+end;
+
+-----------------------------------
+-- onEventFinish
+-----------------------------------
+
+function onEventFinish(player,csid,option)
+    -- printf("CSID: %u",csid);
+    -- printf("RESULT: %u",option);
+    if (csid == 9) then
+        player:addQuest(ABYSSEA, A_GOLDSTRUCK_GIGAS);
+    elseif (csid == 10) then
+        -- Killed Briareus
+    elseif (csid == 218 and option == 1) then
+        player:setPos(-480,0,794,62,132);
+    end
+end;

--- a/scripts/zones/Meriphataud_Mountains/npcs/Cavernous_Maw.lua
+++ b/scripts/zones/Meriphataud_Mountains/npcs/Cavernous_Maw.lua
@@ -1,8 +1,8 @@
 -----------------------------------
 -- Area: Meriphataud Mountains
--- NPC:  Cavernous Maw
--- Teleports Players to Meriphataud Mountains [S]
+--  NPC: Cavernous Maw
 -- @pos 597 -32 279 119
+-- Teleports Players to Meriphataud Mountains [S]
 -----------------------------------
 package.loaded["scripts/zones/Meriphataud_Mountains/TextIDs"] = nil;
 -----------------------------------
@@ -18,20 +18,18 @@ require("scripts/zones/Meriphataud_Mountains/TextIDs");
 -----------------------------------
 
 function onTrade(player,npc,trade)
-end; 
+end;
 
 -----------------------------------
 -- onTrigger Action
 -----------------------------------
 
 function onTrigger(player,npc)
-	
-	if(ENABLE_WOTG == 1 and player:hasKeyItem(PURE_WHITE_FEATHER) and hasMawActivated(player,5)) then
-		player:startEvent(0x0389);
-	else
-		player:messageSpecial(NOTHING_HAPPENS);
-	end
-	
+    if (ENABLE_WOTG == 1 and player:hasKeyItem(PURE_WHITE_FEATHER) and hasMawActivated(player,5)) then
+        player:startEvent(0x0389);
+    else
+        player:messageSpecial(NOTHING_HAPPENS);
+    end
 end;
 
 -----------------------------------
@@ -39,19 +37,17 @@ end;
 -----------------------------------
 
 function onEventUpdate(player,csid,option)
---printf("CSID: %u",csid);
---printf("RESULT: %u",option);
+    -- printf("CSID: %u",csid);
+    -- printf("RESULT: %u",option);
 end;
-   
+
 -----------------------------------
 -- onEventFinish Action
 -----------------------------------
 function onEventFinish(player,csid,option)
---printf("CSID: %u",csid);
---printf("RESULT: %u",option);
-	
-	if(csid == 0x0389 and option == 1) then
-		toMaw(player,17);
-	end
-	
+    -- printf("CSID: %u",csid);
+    -- printf("RESULT: %u",option);
+    if (csid == 0x0389 and option == 1) then
+        toMaw(player,17);
+    end
 end;

--- a/scripts/zones/Meriphataud_Mountains_[S]/npcs/Cavernous_Maw.lua
+++ b/scripts/zones/Meriphataud_Mountains_[S]/npcs/Cavernous_Maw.lua
@@ -1,7 +1,8 @@
 -----------------------------------
--- Cavernous Maw
--- Teleports Players to Meriphataud Mountains
+-- Area: Meriphataud Mountains [S]
+--  NPC: Cavernous Maw
 -- @pos 597 -32 279 97
+-- Teleports Players to Meriphataud Mountains
 -----------------------------------
 package.loaded["scripts/zones/Meriphataud_Mountains_[S]/TextIDs"] = nil;
 -----------------------------------
@@ -16,20 +17,18 @@ require("scripts/zones/Meriphataud_Mountains_[S]/TextIDs");
 -----------------------------------
 
 function onTrade(player,npc,trade)
-end; 
+end;
 
 -----------------------------------
 -- onTrigger Action
 -----------------------------------
 
 function onTrigger(player,npc)
-	
-	if(hasMawActivated(player,5) == false) then
-		player:startEvent(0x0066);
-	else
-		player:startEvent(0x0067);
-	end
-	
+    if (hasMawActivated(player,5) == false) then
+        player:startEvent(0x0066);
+    else
+        player:startEvent(0x0067);
+    end
 end;
 
 -----------------------------------
@@ -37,24 +36,21 @@ end;
 -----------------------------------
 
 function onEventUpdate(player,csid,option)
---printf("CSID: %u",csid);
---printf("RESULT: %u",option);
+    -- printf("CSID: %u",csid);
+    -- printf("RESULT: %u",option);
 end;
-   
+
 -----------------------------------
 -- onEventFinish Action
 -----------------------------------
 
 function onEventFinish(player,csid,option)
---printf("CSID: %u",csid);
---printf("RESULT: %u",option);
-	
-	if(option == 1) then
-		if(csid == 0x0066) then
-			player:addNationTeleport(MAW,32);
-		end
-		
-		toMaw(player,18);
-	end
-	
+    -- printf("CSID: %u",csid);
+    -- printf("RESULT: %u",option);
+    if (option == 1) then
+        if (csid == 0x0066) then
+            player:addNationTeleport(MAW,32);
+        end
+        toMaw(player,18);
+    end
 end;

--- a/scripts/zones/North_Gustaberg/npcs/Cavernous_Maw.lua
+++ b/scripts/zones/North_Gustaberg/npcs/Cavernous_Maw.lua
@@ -1,8 +1,8 @@
 -----------------------------------
 -- Area: North Gustaberg
--- NPC:  Cavernous Maw
--- Teleports Players to North Gustaberg [S]
+--  NPC: Cavernous Maw
 -- @pos 466 0 479 106
+-- Teleports Players to North Gustaberg [S]
 -----------------------------------
 package.loaded["scripts/zones/North_Gustaberg/TextIDs"] = nil;
 -----------------------------------
@@ -18,20 +18,18 @@ require("scripts/zones/North_Gustaberg/TextIDs");
 -----------------------------------
 
 function onTrade(player,npc,trade)
-end; 
+end;
 
 -----------------------------------
 -- onTrigger Action
 -----------------------------------
 
 function onTrigger(player,npc)
-	
-	if(ENABLE_WOTG == 1 and player:hasKeyItem(PURE_WHITE_FEATHER) and hasMawActivated(player,7)) then
-		player:startEvent(0x0387);
-	else
-		player:messageSpecial(NOTHING_HAPPENS);
-	end
-	
+    if (ENABLE_WOTG == 1 and player:hasKeyItem(PURE_WHITE_FEATHER) and hasMawActivated(player,7)) then
+        player:startEvent(0x0387);
+    else
+        player:messageSpecial(NOTHING_HAPPENS);
+    end
 end;
 
 -----------------------------------
@@ -39,19 +37,17 @@ end;
 -----------------------------------
 
 function onEventUpdate(player,csid,option)
---printf("CSID: %u",csid);
---printf("RESULT: %u",option);
+    -- printf("CSID: %u",csid);
+    -- printf("RESULT: %u",option);
 end;
-   
+
 -----------------------------------
 -- onEventFinish Action
 -----------------------------------
 function onEventFinish(player,csid,option)
---print("CSID:",csid);
---print("RESULT:",option);
-	
-	if(csid == 0x0387 and option == 1) then
-		toMaw(player,11);
-	end
-	
+    -- printf("CSID:",csid);
+    -- printf("RESULT:",option);
+    if (csid == 0x0387 and option == 1) then
+        toMaw(player,11);
+    end
 end;

--- a/scripts/zones/North_Gustaberg/npcs/Cavernous_Maw_2.lua
+++ b/scripts/zones/North_Gustaberg/npcs/Cavernous_Maw_2.lua
@@ -1,0 +1,63 @@
+-----------------------------------
+-- Area: North Gustaberg
+--  NPC: Cavernous Maw
+-- @pos -78 -0.5 600 106
+-- Teleports Players to Abyssea - Grauberg
+-----------------------------------
+package.loaded["scripts/zones/North_Gustaberg/TextIDs"] = nil;
+-----------------------------------
+
+require("scripts/globals/settings");
+require("scripts/globals/keyitems");
+require("scripts/globals/teleports");
+require("scripts/globals/abyssea");
+require("scripts/zones/North_Gustaberg/TextIDs");
+
+-----------------------------------
+-- onTrade Action
+-----------------------------------
+
+function onTrade(player,npc,trade)
+end; 
+
+-----------------------------------
+-- onTrigger Action
+-----------------------------------
+
+function onTrigger(player,npc)
+    if (ENABLE_ABYSSEA == 1 and player:getMainLvl() >= 30) then
+        local HasStone = getTravStonesTotal(player);
+        if (HasStone >= 1 and player:getQuestStatus(ABYSSEA, DAWN_OF_DEATH) == QUEST_ACCEPTED
+        and player:getQuestStatus(ABYSSEA, AN_ULCEROUS_URAGNITE) == QUEST_AVAILABLE) then
+            player:startEvent(0);
+        else
+            player:startEvent(908,0,1); -- No param = no entry.
+        end
+    else
+        player:messageSpecial(NOTHING_HAPPENS);
+    end
+end;
+
+-----------------------------------
+-- onEventUpdate
+-----------------------------------
+
+function onEventUpdate(player,csid,option)
+    -- printf("CSID: %u",csid);
+    -- printf("RESULT: %u",option);
+end;
+   
+-----------------------------------
+-- onEventFinish Action
+-----------------------------------
+function onEventFinish(player,csid,option)
+    -- print("CSID:",csid);
+    -- print("RESULT:",option);
+    if (csid == 0) then
+        player:addQuest(ABYSSEA, AN_ULCEROUS_URAGNITE);
+    elseif (csid == 1) then
+        -- Killed Amphitrite
+    elseif (csid == 908 and option == 1) then
+        player:setPos(-555,31,-760,0,254); 
+    end
+end;

--- a/scripts/zones/North_Gustaberg_[S]/npcs/Cavernous_Maw.lua
+++ b/scripts/zones/North_Gustaberg_[S]/npcs/Cavernous_Maw.lua
@@ -1,7 +1,8 @@
 -----------------------------------
--- Cavernous Maw
--- Teleports Players to North Gustaberg
+-- Area: North Gustaberg [S]
+--  NPC: Cavernous Maw
 -- @pos 466 0 479 88
+-- Teleports Players to North Gustaberg
 -----------------------------------
 package.loaded["scripts/zones/North_Gustaberg_[S]/TextIDs"] = nil;
 -----------------------------------
@@ -16,20 +17,18 @@ require("scripts/zones/North_Gustaberg_[S]/TextIDs");
 -----------------------------------
 
 function onTrade(player,npc,trade)
-end; 
+end;
 
 -----------------------------------
 -- onTrigger Action
 -----------------------------------
 
 function onTrigger(player,npc)
-	
-	if(hasMawActivated(player,7) == false) then
-		player:startEvent(0x0064);
-	else
-		player:startEvent(0x0065);
-	end
-	
+    if (hasMawActivated(player,7) == false) then
+        player:startEvent(0x0064);
+    else
+        player:startEvent(0x0065);
+    end
 end;
 
 -----------------------------------
@@ -37,23 +36,20 @@ end;
 -----------------------------------
 
 function onEventUpdate(player,csid,option)
---printf("CSID: %u",csid);
---printf("RESULT: %u",option);
+    -- printf("CSID: %u",csid);
+    -- printf("RESULT: %u",option);
 end;
-   
+
 -----------------------------------
 -- onEventFinish Action
 -----------------------------------
 function onEventFinish(player,csid,option)
---print("CSID:",csid);
---print("RESULT:",option);
-	
-	if(option == 1) then
-		if(csid == 0x0064) then
-			player:addNationTeleport(MAW,128);
-		end
-		
-		toMaw(player,12);
-	end
-	
+    -- printf("CSID:",csid);
+    -- printf("RESULT:",option);
+    if (option == 1) then
+        if (csid == 0x0064) then
+            player:addNationTeleport(MAW,128);
+        end
+        toMaw(player,12);
+    end
 end;

--- a/scripts/zones/Pashhow_Marshlands/npcs/Cavernous_Maw.lua
+++ b/scripts/zones/Pashhow_Marshlands/npcs/Cavernous_Maw.lua
@@ -1,8 +1,8 @@
 -----------------------------------
--- Area: Pashhow Marshlands	
--- NPC: Cavernous Maw
--- Teleports Players to Pashhow Marshlands [S]
+-- Area: Pashhow Marshlands
+--  NPC: Cavernous Maw
 -- @pos 418 25 27 109
+-- Teleports Players to Pashhow Marshlands [S]
 -----------------------------------
 package.loaded["scripts/zones/Pashhow_Marshlands/TextIDs"] = nil;
 -----------------------------------
@@ -18,20 +18,18 @@ require("scripts/zones/Pashhow_Marshlands/TextIDs");
 -----------------------------------
 
 function onTrade(player,npc,trade)
-end; 
+end;
 
 -----------------------------------
 -- onTrigger Action
 -----------------------------------
 
 function onTrigger(player,npc)
-	
-	if(ENABLE_WOTG == 1 and player:hasKeyItem(PURE_WHITE_FEATHER) and hasMawActivated(player,4)) then
-		player:startEvent(0x0389);
-	else
-		player:messageSpecial(NOTHING_HAPPENS);
-	end
-	
+    if (ENABLE_WOTG == 1 and player:hasKeyItem(PURE_WHITE_FEATHER) and hasMawActivated(player,4)) then
+        player:startEvent(0x0389);
+    else
+        player:messageSpecial(NOTHING_HAPPENS);
+    end
 end;
 
 -----------------------------------
@@ -39,19 +37,17 @@ end;
 -----------------------------------
 
 function onEventUpdate(player,csid,option)
---printf("CSID: %u",csid);
---printf("RESULT: %u",option);
+    -- printf("CSID: %u",csid);
+    -- printf("RESULT: %u",option);
 end;
-   
+
 -----------------------------------
 -- onEventFinish Action
 -----------------------------------
 function onEventFinish(player,csid,option)
---printf("CSID: %u",csid);
---printf("RESULT: %u",option);
-	
-	if(csid == 0x0389 and option == 1) then
-		toMaw(player,15);
-	end
-	
+    -- printf("CSID: %u",csid);
+    -- printf("RESULT: %u",option);
+    if (csid == 0x0389 and option == 1) then
+        toMaw(player,15);
+    end
 end;

--- a/scripts/zones/Pashhow_Marshlands_[S]/npcs/Cavernous_Maw.lua
+++ b/scripts/zones/Pashhow_Marshlands_[S]/npcs/Cavernous_Maw.lua
@@ -1,7 +1,8 @@
 -----------------------------------
--- Cavernous Maw
--- Teleports Players to Pashhow_Marshlands
+-- Area: Sauromugue Champaign
+--  NPC: Cavernous Maw
 -- @pos 418 25 27 90
+-- Teleports Players to Pashhow_Marshlands
 -----------------------------------
 package.loaded["scripts/zones/Pashhow_Marshlands_[S]/TextIDs"] = nil;
 -----------------------------------
@@ -16,20 +17,18 @@ require("scripts/zones/Pashhow_Marshlands_[S]/TextIDs");
 -----------------------------------
 
 function onTrade(player,npc,trade)
-end; 
+end;
 
 -----------------------------------
 -- onTrigger Action
 -----------------------------------
 
 function onTrigger(player,npc)
-	
-	if(hasMawActivated(player,4) == false) then
-		player:startEvent(0x0064);
-	else
-		player:startEvent(0x0065);
-	end
-	
+    if (hasMawActivated(player,4) == false) then
+        player:startEvent(0x0064);
+    else
+        player:startEvent(0x0065);
+    end
 end;
 
 -----------------------------------
@@ -37,24 +36,21 @@ end;
 -----------------------------------
 
 function onEventUpdate(player,csid,option)
---printf("CSID: %u",csid);
---printf("RESULT: %u",option);
+    -- printf("CSID: %u",csid);
+    -- printf("RESULT: %u",option);
 end;
-   
+
 -----------------------------------
 -- onEventFinish Action
 -----------------------------------
 
 function onEventFinish(player,csid,option)
---printf("CSID: %u",csid);
---printf("RESULT: %u",option);
-	
-	if(option == 1) then
-		if(csid == 0x0064) then
-			player:addNationTeleport(MAW,16);
-		end
-		
-		toMaw(player,16);
-	end
-	
+    -- printf("CSID: %u",csid);
+    -- printf("RESULT: %u",option);
+    if (option == 1) then
+        if (csid == 0x0064) then
+            player:addNationTeleport(MAW,16);
+        end
+        toMaw(player,16);
+    end
 end;

--- a/scripts/zones/Rolanberry_Fields/npcs/Cavernous_Maw.lua
+++ b/scripts/zones/Rolanberry_Fields/npcs/Cavernous_Maw.lua
@@ -1,8 +1,8 @@
 -----------------------------------
--- Area: Rolanberry Fields	
--- NPC:  Cavernous Maw
--- Teleports Players to Rolanberry_Fields_S
+-- Area: Rolanberry Fields
+--  NPC: Cavernous Maw
 -- @pos -198 8 361 110
+-- Teleports Players to Rolanberry Fields [S]
 -----------------------------------
 package.loaded["scripts/zones/Rolanberry_Fields/TextIDs"] = nil;
 -----------------------------------
@@ -19,22 +19,20 @@ require("scripts/zones/Rolanberry_Fields/TextIDs");
 -----------------------------------
 
 function onTrade(player,npc,trade)
-end; 
+end;
 
 -----------------------------------
 -- onTrigger Action
 -----------------------------------
 
 function onTrigger(player,npc)
-	
-	if(ENABLE_WOTG == 1 and player:hasKeyItem(PURE_WHITE_FEATHER) == false) then
-		player:startEvent(0x01f4,1);
-	elseif(ENABLE_WOTG == 1 and hasMawActivated(player,1)) then
-		player:startEvent(0x0388);
-	else
-		player:messageSpecial(NOTHING_HAPPENS);
-	end
-	
+    if (ENABLE_WOTG == 1 and player:hasKeyItem(PURE_WHITE_FEATHER) == false) then
+        player:startEvent(0x01f4,1);
+    elseif (ENABLE_WOTG == 1 and hasMawActivated(player,1)) then
+        player:startEvent(0x0388);
+    else
+        player:messageSpecial(NOTHING_HAPPENS);
+    end
 end;
 
 -----------------------------------
@@ -42,8 +40,8 @@ end;
 -----------------------------------
 
 function onEventUpdate(player,csid,option)
---printf("CSID: %u",csid);
---printf("RESULT: %u",option);
+    -- printf("CSID: %u",csid);
+    -- printf("RESULT: %u",option);
 end;
 
 -----------------------------------
@@ -51,28 +49,25 @@ end;
 -----------------------------------
 
 function onEventFinish(player,csid,option)
---print("CSID:",csid);
---print("RESULT:",option);
-	
-	if(csid == 0x01f4) then
-		local r = math.random(1,3);
-		player:addKeyItem(PURE_WHITE_FEATHER);
-		player:messageSpecial(KEYITEM_OBTAINED,PURE_WHITE_FEATHER);
-		player:completeMission(WOTG,CAVERNOUS_MAWS);
-		player:addMission(WOTG,BACK_TO_THE_BEGINNING);
-		if(r == 1) then
-			player:addNationTeleport(MAW,1);
-			toMaw(player,1); -- go to Batallia_Downs[S]
-		elseif(r == 2) then
-			player:addNationTeleport(MAW,2);
-			toMaw(player,3); -- go to Rolanberry_Fields_[S]
-		elseif(r == 3) then
-			player:addNationTeleport(MAW,4);
-			toMaw(player,5); -- go to Sauromugue_Champaign_[S]
-		end;
-	elseif(csid == 0x0388 and option == 1) then
-		toMaw(player,3); -- go to Rolanberry_Fields_[S]
-	end;
-	
+    -- printf("CSID:",csid);
+    -- printf("RESULT:",option);
+    if (csid == 0x01f4) then
+        local r = math.random(1,3);
+        player:addKeyItem(PURE_WHITE_FEATHER);
+        player:messageSpecial(KEYITEM_OBTAINED,PURE_WHITE_FEATHER);
+        player:completeMission(WOTG,CAVERNOUS_MAWS);
+        player:addMission(WOTG,BACK_TO_THE_BEGINNING);
+        if (r == 1) then
+            player:addNationTeleport(MAW,1);
+            toMaw(player,1); -- go to Batallia_Downs[S]
+        elseif (r == 2) then
+            player:addNationTeleport(MAW,2);
+            toMaw(player,3); -- go to Rolanberry_Fields_[S]
+        elseif (r == 3) then
+            player:addNationTeleport(MAW,4);
+            toMaw(player,5); -- go to Sauromugue_Champaign_[S]
+        end;
+    elseif (csid == 0x0388 and option == 1) then
+        toMaw(player,3); -- go to Rolanberry_Fields_[S]
+    end;
 end;
-

--- a/scripts/zones/Rolanberry_Fields_[S]/npcs/Cavernous_Maw.lua
+++ b/scripts/zones/Rolanberry_Fields_[S]/npcs/Cavernous_Maw.lua
@@ -1,7 +1,8 @@
 -----------------------------------
--- Cavernous Maw
--- Teleports Players to Rolanberry Fields
+-- Area: Sauromugue Champaign
+--  NPC: Cavernous Maw
 -- @pos -198 8 360 91
+-- Teleports Players to Rolanberry Fields
 -----------------------------------
 package.loaded["scripts/zones/Rolanberry_Fields_[S]/TextIDs"] = nil;
 -----------------------------------
@@ -15,20 +16,18 @@ require("scripts/zones/Rolanberry_Fields_[S]/TextIDs");
 -----------------------------------
 
 function onTrade(player,npc,trade)
-end; 
+end;
 
 -----------------------------------
 -- onTrigger Action
 -----------------------------------
 
 function onTrigger(player,npc)
-	
-	if(hasMawActivated(player,1) == false) then
-		player:startEvent(0x0065);
-	else
-		player:startEvent(0x0066);
-	end
-	
+    if (hasMawActivated(player,1) == false) then
+        player:startEvent(0x0065);
+    else
+        player:startEvent(0x0066);
+    end
 end;
 
 -----------------------------------
@@ -36,8 +35,8 @@ end;
 -----------------------------------
 
 function onEventUpdate(player,csid,option)
---printf("CSID: %u",csid);
---printf("RESULT: %u",option);
+    -- printf("CSID: %u",csid);
+    -- printf("RESULT: %u",option);
 end;
 
 -----------------------------------
@@ -45,15 +44,12 @@ end;
 -----------------------------------
 
 function onEventFinish(player,csid,option)
---print("CSID:",csid);
---print("RESULT:",option);
-	
-	if(option == 1) then
-		if(csid == 0x0065) then
-			player:addNationTeleport(MAW,2);
-		end
-		
-		toMaw(player,4);
-	end
-	
+    -- printf("CSID:",csid);
+    -- printf("RESULT:",option);
+    if (option == 1) then
+        if (csid == 0x0065) then
+            player:addNationTeleport(MAW,2);
+        end
+        toMaw(player,4);
+    end
 end;

--- a/scripts/zones/Sauromugue_Champaign/npcs/Cavernous_Maw.lua
+++ b/scripts/zones/Sauromugue_Champaign/npcs/Cavernous_Maw.lua
@@ -1,6 +1,6 @@
 -----------------------------------
 -- Area: Sauromugue Champaign
--- NPC:  Cavernous Maw
+--  NPC: Cavernous Maw
 -- Teleports Players to Sauromugue_Champaign_S
 -- @pos 369 8 -227 120
 -----------------------------------
@@ -19,22 +19,20 @@ require("scripts/zones/Sauromugue_Champaign/TextIDs");
 -----------------------------------
 
 function onTrade(player,npc,trade)
-end; 
+end;
 
 -----------------------------------
 -- onTrigger Action
 -----------------------------------
 
 function onTrigger(player,npc)
-	
-	if(ENABLE_WOTG == 1 and player:hasKeyItem(PURE_WHITE_FEATHER) == false) then
-		player:startEvent(0x01f4,2);
-	elseif(ENABLE_WOTG == 1 and hasMawActivated(player,2)) then
-		player:startEvent(0x0388);
-	else
-		player:messageSpecial(NOTHING_HAPPENS);
-	end
-	
+    if (ENABLE_WOTG == 1 and player:hasKeyItem(PURE_WHITE_FEATHER) == false) then
+        player:startEvent(0x01f4,2);
+    elseif (ENABLE_WOTG == 1 and hasMawActivated(player,2)) then
+        player:startEvent(0x0388);
+    else
+        player:messageSpecial(NOTHING_HAPPENS);
+    end
 end;
 
 -----------------------------------
@@ -42,36 +40,34 @@ end;
 -----------------------------------
 
 function onEventUpdate(player,csid,option)
---printf("CSID: %u",csid);
---printf("RESULT: %u",option);
+    -- printf("CSID: %u",csid);
+    -- printf("RESULT: %u",option);
 end;
-   
+
 -----------------------------------
 -- onEventFinish Action
 -----------------------------------
 
 function onEventFinish(player,csid,option)
---print("CSID:",csid);
---print("RESULT:",option);
-	
-	if(csid == 0x01f4) then
-		local r = math.random(1,3);
-		player:addKeyItem(PURE_WHITE_FEATHER);
-		player:messageSpecial(KEYITEM_OBTAINED,PURE_WHITE_FEATHER);
-		player:completeMission(WOTG,CAVERNOUS_MAWS);
-		player:addMission(WOTG,BACK_TO_THE_BEGINNING);
-		if(r == 1) then
-			player:addNationTeleport(MAW,1);
-			toMaw(player,1); -- go to Batallia_Downs[S]
-		elseif(r == 2) then
-			player:addNationTeleport(MAW,2);
-			toMaw(player,3); -- go to Rolanberry_Fields_[S]
-		elseif(r == 3) then
-			player:addNationTeleport(MAW,4);
-			toMaw(player,5); -- go to Sauromugue_Champaign_[S]
-		end;
-	elseif(csid == 0x0388 and option == 1) then
-		toMaw(player,5); -- go to Sauromugue_Champaign_[S]
-	end;
-	
+    -- printf("CSID:",csid);
+    -- printf("RESULT:",option);
+    if (csid == 0x01f4) then
+        local r = math.random(1,3);
+        player:addKeyItem(PURE_WHITE_FEATHER);
+        player:messageSpecial(KEYITEM_OBTAINED,PURE_WHITE_FEATHER);
+        player:completeMission(WOTG,CAVERNOUS_MAWS);
+        player:addMission(WOTG,BACK_TO_THE_BEGINNING);
+        if (r == 1) then
+            player:addNationTeleport(MAW,1);
+            toMaw(player,1); -- go to Batallia_Downs[S]
+        elseif (r == 2) then
+            player:addNationTeleport(MAW,2);
+            toMaw(player,3); -- go to Rolanberry_Fields_[S]
+        elseif (r == 3) then
+            player:addNationTeleport(MAW,4);
+            toMaw(player,5); -- go to Sauromugue_Champaign_[S]
+        end;
+    elseif (csid == 0x0388 and option == 1) then
+        toMaw(player,5); -- go to Sauromugue_Champaign_[S]
+    end;
 end;

--- a/scripts/zones/Sauromugue_Champaign_[S]/npcs/Cavernous_Maw.lua
+++ b/scripts/zones/Sauromugue_Champaign_[S]/npcs/Cavernous_Maw.lua
@@ -1,7 +1,8 @@
 -----------------------------------
--- Cavernous Maw
--- Teleports Players to Sauromugue_Champaign
+-- Area: Sauromugue Champaign [S]
+--  NPC: Cavernous Maw
 -- @pos 369 8 -227 98
+-- Teleports Players to Sauromugue_Champaign
 -----------------------------------
 package.loaded["scripts/zones/Sauromugue_Champaign_[S]/TextIDs"] = nil;
 -----------------------------------
@@ -15,20 +16,18 @@ require("scripts/zones/Sauromugue_Champaign_[S]/TextIDs");
 -----------------------------------
 
 function onTrade(player,npc,trade)
-end; 
+end;
 
 -----------------------------------
 -- onTrigger Action
 -----------------------------------
 
 function onTrigger(player,npc)
-	
-	if(hasMawActivated(player,2) == false) then
-		player:startEvent(0x0065);
-	else
-		player:startEvent(0x0066);
-	end
-	
+    if (hasMawActivated(player,2) == false) then
+        player:startEvent(0x0065);
+    else
+        player:startEvent(0x0066);
+    end
 end;
 
 -----------------------------------
@@ -36,24 +35,22 @@ end;
 -----------------------------------
 
 function onEventUpdate(player,csid,option)
---printf("CSID: %u",csid);
---printf("RESULT: %u",option);
+    -- printf("CSID: %u",csid);
+    -- printf("RESULT: %u",option);
 end;
-   
+
 -----------------------------------
 -- onEventFinish Action
 -----------------------------------
 
 function onEventFinish(player,csid,option)
---print("CSID:",csid);
---print("RESULT:",option);
-	
-	if(option == 1) then
-		if(csid == 0x0065) then
-			player:addNationTeleport(MAW,4);
-		end
-		
-		toMaw(player,6);
-	end
-	
+    -- printf("CSID:",csid);
+    -- printf("RESULT:",option);
+    if (option == 1) then
+        if (csid == 0x0065) then
+            player:addNationTeleport(MAW,4);
+        end
+
+        toMaw(player,6);
+    end
 end;

--- a/scripts/zones/South_Gustaberg/npcs/Cavernous_Maw.lua
+++ b/scripts/zones/South_Gustaberg/npcs/Cavernous_Maw.lua
@@ -1,0 +1,66 @@
+-----------------------------------
+-- Area: South Gustaberg
+--  NPC: Cavernous Maw
+-- @pos 340 -0.5 -680
+-- Teleports Players to Abyssea - Altepa
+-----------------------------------
+package.loaded["scripts/zones/South_Gustaberg/TextIDs"] = nil;
+-----------------------------------
+
+require("scripts/globals/settings");
+require("scripts/globals/keyitems");
+require("scripts/globals/quests");
+require("scripts/globals/abyssea");
+require("scripts/zones/South_Gustaberg/TextIDs");
+
+-----------------------------------
+
+-----------------------------------
+-- onTrade Action
+-----------------------------------
+
+function onTrade(player,npc,trade)
+end;
+
+-----------------------------------
+-- onTrigger Action
+-----------------------------------
+
+function onTrigger(player,npc)
+    if (ENABLE_ABYSSEA == 1 and player:getMainLvl() >= 30) then
+        local HasStone = getTravStonesTotal(player);
+        if (HasStone >= 1 and player:getQuestStatus(ABYSSEA, DAWN_OF_DEATH) == QUEST_ACCEPTED
+        and player:getQuestStatus(ABYSSEA, A_BEAKED_BLUSTERER) == QUEST_AVAILABLE) then
+            player:startEvent(0);
+        else
+            player:startEvent(914,0,1); -- No param = no entry.
+        end
+    else
+        player:messageSpecial(NOTHING_HAPPENS);
+    end
+end;
+
+-----------------------------------
+-- onEventUpdate
+-----------------------------------
+
+function onEventUpdate(player,csid,option)
+    -- printf("CSID: %u",csid);
+    -- printf("RESULT: %u",option);
+end;
+
+-----------------------------------
+-- onEventFinish
+-----------------------------------
+
+function onEventFinish(player,csid,option)
+    -- printf("CSID: %u",csid);
+    -- printf("RESULT: %u",option);
+    if (csid == 0) then
+        player:addQuest(ABYSSEA, A_BEAKED_BLUSTERER);
+    elseif (csid == 1) then
+        -- Killed Bennu
+    elseif (csid == 914 and option == 1) then
+        player:setPos(432, 0, 321, 125, 218);
+    end
+end;

--- a/scripts/zones/Tahrongi_Canyon/npcs/Cavernous_Maw.lua
+++ b/scripts/zones/Tahrongi_Canyon/npcs/Cavernous_Maw.lua
@@ -1,0 +1,64 @@
+-----------------------------------
+-- Area: Tahrongi Canyon
+--  NPC: Cavernous Maw
+-- @pos -28.597, 46.056, -685.754 117
+-- Teleports Players to Abyssea - Tahrongi
+-----------------------------------
+package.loaded["scripts/zones/Tahrongi_Canyon/TextIDs"] = nil;
+-----------------------------------
+
+require("scripts/globals/settings");
+require("scripts/globals/keyitems");
+require("scripts/globals/quests");
+require("scripts/globals/abyssea");
+require("scripts/zones/Tahrongi_Canyon/TextIDs");
+
+-----------------------------------
+-- onTrade Action
+-----------------------------------
+
+function onTrade(player,npc,trade)
+end;
+
+-----------------------------------
+-- onTrigger Action
+-----------------------------------
+
+function onTrigger(player,npc)
+    if (ENABLE_ABYSSEA == 1 and player:getMainLvl() >= 30) then
+        local HasStone = getTravStonesTotal(player);
+        if (HasStone >= 1 and player:getQuestStatus(ABYSSEA, DAWN_OF_DEATH) == QUEST_ACCEPTED
+        and player:getQuestStatus(ABYSSEA, MEGADRILE_MENACE) == QUEST_AVAILABLE) then
+            player:startEvent(38);
+        else
+            player:startEvent(100,0,1); -- No param = no entry.
+        end
+    else
+        player:messageSpecial(NOTHING_HAPPENS);
+    end
+end;
+
+-----------------------------------
+-- onEventUpdate
+-----------------------------------
+
+function onEventUpdate(player,csid,option)
+    -- printf("CSID: %u",csid);
+    -- printf("RESULT: %u",option);
+end;
+
+-----------------------------------
+-- onEventFinish
+-----------------------------------
+
+function onEventFinish(player,csid,option)
+    -- printf("CSID: %u",csid);
+    -- printf("RESULT: %u",option);
+    if (csid == 38) then
+        player:addQuest(ABYSSEA, MEGADRILE_MENACE);
+    elseif (csid == 39) then
+        -- Killed Glavoid
+    elseif (csid == 100 and option == 1) then
+        player:setPos(-24,44,-678,240,45);
+    end
+end;

--- a/scripts/zones/Valkurm_Dunes/npcs/Cavernous_Maw.lua
+++ b/scripts/zones/Valkurm_Dunes/npcs/Cavernous_Maw.lua
@@ -1,0 +1,64 @@
+-----------------------------------
+-- Area: Valkurm Dunes
+--  NPC: Cavernous Maw
+-- @pos 368.980, -0.443, -119.874 103
+-- Teleports Players to Abyssea Misareaux
+-----------------------------------
+package.loaded["scripts/zones/Valkurm_Dunes/TextIDs"] = nil;
+-----------------------------------
+
+require("scripts/globals/settings");
+require("scripts/globals/keyitems");
+require("scripts/globals/quests");
+require("scripts/globals/abyssea");
+require("scripts/zones/Valkurm_Dunes/TextIDs");
+
+-----------------------------------
+-- onTrade Action
+-----------------------------------
+
+function onTrade(player,npc,trade)
+end;
+
+-----------------------------------
+-- onTrigger Action
+-----------------------------------
+
+function onTrigger(player,npc)
+    if (ENABLE_ABYSSEA == 1 and player:getMainLvl() >= 30) then
+        local HasStone = getTravStonesTotal(player);
+        if (HasStone >= 1 and player:getQuestStatus(ABYSSEA, DAWN_OF_DEATH) == QUEST_ACCEPTED
+        and player:getQuestStatus(ABYSSEA, A_DELECTABLE_DEMON) == QUEST_AVAILABLE) then
+            player:startEvent(56);
+        else
+            player:startEvent(55,0,1); -- No param = no entry.
+        end
+    else
+        player:messageSpecial(NOTHING_HAPPENS);
+    end
+end;
+
+-----------------------------------
+-- onEventUpdate
+-----------------------------------
+
+function onEventUpdate(player,csid,option)
+    -- printf("CSID: %u",csid);
+    -- printf("RESULT: %u",option);
+end;
+
+-----------------------------------
+-- onEventFinish
+-----------------------------------
+
+function onEventFinish(player,csid,option)
+    -- printf("CSID: %u",csid);
+    -- printf("RESULT: %u",option);
+    if (csid == 56) then
+        player:addQuest(ABYSSEA, A_DELECTABLE_DEMON);
+    elseif (csid == 57) then
+        -- Killed Cirein-croin
+    elseif (csid == 55 and option == 1) then
+        player:setPos(670,-15,318,119,216);
+    end
+end;

--- a/scripts/zones/West_Sarutabaruta/npcs/Cavernous_Maw.lua
+++ b/scripts/zones/West_Sarutabaruta/npcs/Cavernous_Maw.lua
@@ -1,6 +1,6 @@
 -----------------------------------
 -- Area: West Sarutabaruta
--- NPC: Cavernous Maw
+--  NPC: Cavernous Maw
 -- Teleports Players to West Sarutabaruta [S]
 -- @pos -2.229 0.001 -162.715 115
 -----------------------------------
@@ -18,20 +18,18 @@ require("scripts/zones/West_Sarutabaruta/TextIDs");
 -----------------------------------
 
 function onTrade(player,npc,trade)
-end; 
+end;
 
 -----------------------------------
 -- onTrigger Action
 -----------------------------------
 
 function onTrigger(player,npc)
-	
-	if(ENABLE_WOTG == 1 and player:hasKeyItem(PURE_WHITE_FEATHER) and hasMawActivated(player,8)) then
-		player:startEvent(0x0388);
-	else
-		player:messageSpecial(NOTHING_HAPPENS);
-	end
-	
+    if (ENABLE_WOTG == 1 and player:hasKeyItem(PURE_WHITE_FEATHER) and hasMawActivated(player,8)) then
+        player:startEvent(0x0388);
+    else
+        player:messageSpecial(NOTHING_HAPPENS);
+    end
 end;
 
 -----------------------------------
@@ -39,19 +37,17 @@ end;
 -----------------------------------
 
 function onEventUpdate(player,csid,option)
---printf("CSID: %u",csid);
---printf("RESULT: %u",option);
+    -- printf("CSID: %u",csid);
+    -- printf("RESULT: %u",option);
 end;
-   
+
 -----------------------------------
 -- onEventFinish Action
 -----------------------------------
 function onEventFinish(player,csid,option)
---printf("CSID: %u",csid);
---printf("RESULT: %u",option);
-	
-	if(csid == 0x0388 and option == 1) then
-		toMaw(player,7);
-	end
-	
+    -- printf("CSID: %u",csid);
+    -- printf("RESULT: %u",option);
+    if (csid == 0x0388 and option == 1) then
+        toMaw(player,7);
+    end
 end;

--- a/scripts/zones/West_Sarutabaruta_[S]/npcs/Cavernous_Maw.lua
+++ b/scripts/zones/West_Sarutabaruta_[S]/npcs/Cavernous_Maw.lua
@@ -1,7 +1,8 @@
 -----------------------------------
--- Cavernous Maw
--- Teleports Players to West Sarutabaruta
+-- Area: West Sarutabaruta [S]
+--  NPC: Cavernous Maw
 -- @pos 0 0 -165 95
+-- Teleports Players to West Sarutabaruta
 -----------------------------------
 package.loaded["scripts/zones/West_Sarutabaruta_[S]/TextIDs"] = nil;
 -----------------------------------
@@ -16,20 +17,18 @@ require("scripts/zones/West_Sarutabaruta_[S]/TextIDs");
 -----------------------------------
 
 function onTrade(player,npc,trade)
-end; 
+end;
 
 -----------------------------------
 -- onTrigger Action
 -----------------------------------
 
 function onTrigger(player,npc)
-	
-	if(hasMawActivated(player,8) == false) then
-		player:startEvent(0x0064);
-	else
-		player:startEvent(0x0065);
-	end
-	
+    if (hasMawActivated(player,8) == false) then
+        player:startEvent(0x0064);
+    else
+        player:startEvent(0x0065);
+    end
 end;
 
 -----------------------------------
@@ -37,24 +36,21 @@ end;
 -----------------------------------
 
 function onEventUpdate(player,csid,option)
---printf("CSID: %u",csid);
---printf("RESULT: %u",option);
+    -- printf("CSID: %u",csid);
+    -- printf("RESULT: %u",option);
 end;
-   
+
 -----------------------------------
 -- onEventFinish Action
 -----------------------------------
 
 function onEventFinish(player,csid,option)
---printf("CSID: %u",csid);
---printf("RESULT: %u",option);
-	
-	if(option == 1) then
-		if(csid == 0x0064) then
-			player:addNationTeleport(MAW,256);
-		end
-		
-		toMaw(player,8);
-	end
-	
+    -- printf("CSID: %u",csid);
+    -- printf("RESULT: %u",option);
+    if (option == 1) then
+        if (csid == 0x0064) then
+            player:addNationTeleport(MAW,256);
+        end
+        toMaw(player,8);
+    end
 end;

--- a/scripts/zones/Xarcabard/npcs/Cavernous_Maw.lua
+++ b/scripts/zones/Xarcabard/npcs/Cavernous_Maw.lua
@@ -1,0 +1,66 @@
+-----------------------------------
+-- Area: Xarcabard
+--  NPC: Cavernous Maw
+-- @pos 270 -9 -70
+-- Teleports Players to Abyssea - Uleguerand
+-----------------------------------
+package.loaded["scripts/zones/Xarcabard/TextIDs"] = nil;
+-----------------------------------
+
+require("scripts/globals/settings");
+require("scripts/globals/keyitems");
+require("scripts/globals/quests");
+require("scripts/globals/abyssea");
+require("scripts/zones/Xarcabard/TextIDs");
+
+-----------------------------------
+
+-----------------------------------
+-- onTrade Action
+-----------------------------------
+
+function onTrade(player,npc,trade)
+end;
+
+-----------------------------------
+-- onTrigger Action
+-----------------------------------
+
+function onTrigger(player,npc)
+    if (ENABLE_ABYSSEA == 1 and player:getMainLvl() >= 30) then
+        local HasStone = getTravStonesTotal(player);
+        if (HasStone >= 1 and player:getQuestStatus(ABYSSEA, DAWN_OF_DEATH) == QUEST_ACCEPTED
+        and player:getQuestStatus(ABYSSEA, A_MAN_EATING_MITE) == QUEST_AVAILABLE) then
+            player:startEvent(58);
+        else
+            player:startEvent(204,0,1); -- No param = no entry.
+        end
+    else
+        player:messageSpecial(NOTHING_HAPPENS);
+    end
+end;
+
+-----------------------------------
+-- onEventUpdate
+-----------------------------------
+
+function onEventUpdate(player,csid,option)
+    -- printf("CSID: %u",csid);
+    -- printf("RESULT: %u",option);
+end;
+
+-----------------------------------
+-- onEventFinish
+-----------------------------------
+
+function onEventFinish(player,csid,option)
+    -- printf("CSID: %u",csid);
+    -- printf("RESULT: %u",option);
+    if (csid == 58) then
+        player:addQuest(ABYSSEA, A_MAN_EATING_MITE);
+    elseif (csid == 59) then
+        -- Killed Resheph
+    elseif (csid == 204 and option == 1) then
+        player:setPos(-240, -40, -520, 251, 253);
+    end
+end;


### PR DESCRIPTION
Fixed all Abyssea maws and scripted them up through "Dawn of Death". In zones where more than one Cavernous Maw exists in npc_list.sql the Abyssea entry maw will be "Cavernous_Maw_2" to separate it from WotG's "Cavernous_Maw". Fixed the expansion tagging that had some marked for wrong expansion.

Todo: move quest complete cs check into the zone.lua for each zone, because I'm pretty sure the maw isn't used to trigger that. I'll do it later after the NMs actually work and the quest can actually be done.

There are also some minor changes just for consistencies sake.

@gedads, noticed during cs that some of the maws pos are slightly off, could you check the retail positioning later after this is merged? Thanks. (Example: in Buburimu when the player char is supposed to be looking at the maw before being approached by an NPC, he's staring at the wall and the maw is off to the side).