### PR TITLE
Update Derrick.lua

### DIFF
--- a/scripts/zones/Lower_Jeuno/npcs/Derrick.lua
+++ b/scripts/zones/Lower_Jeuno/npcs/Derrick.lua
@@ -61,9 +61,12 @@ function onEventUpdate(player,csid,option)
 --printf("RESULT: %u",option);
 
 	if (csid == 0x00e6 and option == 10) then
-		if (player:delGil(500000)) then
+		if (player:getGil() > 499999) then
+			player:delGil(500000);
 			player:addKeyItem(AIRSHIP_PASS);
-			player:updateEvent(1,0);
+			player:updateEvent(0, 1);
+		else
+			player:updateEvent(0, 0);
 		end
 	end
 


### PR DESCRIPTION
Fixes a minor bug where when buying an airship pass directly from Derrick in Lower Jeuno the message 'Um, you don't have enough money.' is displayed irregardless of whether you do or not.