### PR TITLE
CORE: adding checks and handling for no weapon equipped/unarmed weapon item

### DIFF
--- a/src/map/utils/charutils.cpp
+++ b/src/map/utils/charutils.cpp
@@ -834,11 +834,18 @@ void LoadInventory(CCharEntity* PChar)
 		Sql_NumRows(SqlHandle) != 0)
 	{
 		CItemLinkshell* PLinkshell = NULL;
+		bool hasMainWeapon = false;
 
 		while (Sql_NextRow(SqlHandle) == SQL_SUCCESS)
 		{
 			if (Sql_GetUIntData(SqlHandle, 1) < 16)
+			{
+				if (Sql_GetUIntData(SqlHandle, 0) == 7)
+				{
+					hasMainWeapon = true;
+				}
 				EquipItem(PChar, Sql_GetUIntData(SqlHandle, 0), Sql_GetUIntData(SqlHandle, 1), Sql_GetUIntData(SqlHandle, 2));
+			}
 			else
 			{
 				uint8 SlotID = Sql_GetUIntData(SqlHandle, 0);
@@ -853,6 +860,13 @@ void LoadInventory(CCharEntity* PChar)
 				}
 			}
 		}
+
+		// If no weapon is equipped, equip the appropriate unarmed weapon item
+		if (!hasMainWeapon)
+		{
+			CheckUnarmedWeapon(PChar);
+		}
+
 		if (PLinkshell)
 		{
 			linkshell::AddOnlineMember(PChar, PLinkshell);


### PR DESCRIPTION
I noticed while playing around on a private server that I had set up with the HEAD revision of the code that classes with the Hand-to-Hand skill do not get two rounds of attack when the character first logs in with no weapon equipped.  This actually hindered my ability to play Monk from level 1 on another private server, because I could not kill anything before I was killed.

This fix should prevent that bug from occurring by checking the character's main weapon slot when their equipment is retrieved from the database.  If no main weapon is equipped, then the CheckUnarmedWeapon function will be called to equip the appropriate unarmed weapon item.

I did some preliminary testing by changing jobs, ensuring that I had no weapon equipped, logging out, logging back in, and attacking an enemy.  It appeared to work for both MNK and WAR (As far as getting two attack rounds), and BLM (One attack round).  It also appeared to trigger immediately after calling the @changejobs command which is shipped with the default darkstar project package.