### PR TITLE
CORE: Correcting an equipment slot comparison

### DIFF
--- a/src/map/utils/charutils.cpp
+++ b/src/map/utils/charutils.cpp
@@ -840,10 +840,11 @@ void LoadInventory(CCharEntity* PChar)
 		{
 			if (Sql_GetUIntData(SqlHandle, 1) < 16)
 			{
-				if (Sql_GetUIntData(SqlHandle, 0) == 7)
+				if (Sql_GetUIntData(SqlHandle, 1) == SLOT_MAIN)
 				{
 					hasMainWeapon = true;
 				}
+
 				EquipItem(PChar, Sql_GetUIntData(SqlHandle, 0), Sql_GetUIntData(SqlHandle, 1), Sql_GetUIntData(SqlHandle, 2));
 			}
 			else
@@ -872,8 +873,8 @@ void LoadInventory(CCharEntity* PChar)
 			linkshell::AddOnlineMember(PChar, PLinkshell);
 		}
 	}
-    else
-    {
+	else
+	{
 		ShowError(CL_RED"Loading error from char_equip\n" CL_RESET);
 	}
 


### PR DESCRIPTION
In response to issue #791 - correcting the SQL column which is used for comparison and making use of the SLOT_MAIN enum value.  An edge case bug still exists such that the appropriate unarmed weapon item will not be equipped when the user logs in with no equipment at all.  I will investigate this bug further.

Performed a few tests by logging in with a Monk unarmed with a body piece equipped and then attacking something, logging in as a Monk with nothing equipped and then attacking something, logging in as a Monk with a weapon equipped and attacking something, and logging in as a Dark Knight with a weapon equipped and attacking something.