### PR TITLE
Fix charmed pet crash #799 

### DIFF
--- a/src/map/lua/luautils.cpp
+++ b/src/map/lua/luautils.cpp
@@ -2331,7 +2331,10 @@ int32 OnMobDeath(CBaseEntity* PMob, CBaseEntity* PKiller)
 
     CLuaBaseEntity LuaMobEntity(PMob);
 
-    luautils::OnMobDeathEx(PMob, PKiller, true);
+    if (PKiller)
+    {
+        luautils::OnMobDeathEx(PMob, PKiller, true);
+    }
 
     int8 File[255];
     memset(File, 0, sizeof(File));


### PR DESCRIPTION
So, apparently Pkiller was not already certain to be a player entity. I thought it was. Later I'll probably need to do some work to make pet kills exec onMobDeathEx on their master for those danged magian trials. :/