### PR TITLE
Revert incorrect fix

### DIFF
--- a/scripts/zones/La_Theine_Plateau/npcs/Galaihaurat.lua
+++ b/scripts/zones/La_Theine_Plateau/npcs/Galaihaurat.lua
@@ -26,7 +26,7 @@ function onTrigger(player,npc)
 	if(player:getCurrentMission(SANDORIA) == THE_RESCUE_DRILL) then
 		local MissionStatus = player:getVar("MissionStatus");
 		
-		if(MissionStatus == 1) then
+		if(MissionStatus == 0) then
 			player:startEvent(0x006e);
 		elseif(MissionStatus == 2) then
 			player:showText(npc, RESCUE_DRILL + 16);

--- a/scripts/zones/Southern_San_dOria/npcs/Endracion.lua
+++ b/scripts/zones/Southern_San_dOria/npcs/Endracion.lua
@@ -1,5 +1,5 @@
 -----------------------------------
--- Area: Southern San d'Oria
+-- Area: Northern San d'Oria
 -- NPC:  Endracion
 -- @pos -110 1 -34 230
 -----------------------------------


### PR DESCRIPTION
Spoke with @korietsu already. Change here were incorrect, mission status is never set to 1 before talking to this NPC. Its likely either a GM on his server used @completemission without clearing the previous mission variable or perhaps a previous mission is bugged during repeats, we don't know right. Just know this mission doe snot work after this change so it needs undone.