### PR TITLE
Fixed 3 busted GM commands

### DIFF
--- a/scripts/commands/mobhere.lua
+++ b/scripts/commands/mobhere.lua
@@ -24,8 +24,8 @@ function onTrigger(player, mobId, noDepop)
     end
 
     SpawnMob( mobId );
-    if (player:getZone() == mob:getZone()) then
-        mob:setPos( player:getXPos(), player:getYPos(), player:getZPos(), 0, player:getZone() );
+    if (player:getZoneID() == mob:getZoneID()) then
+        mob:setPos( player:getXPos(), player:getYPos(), player:getZPos(), player:getRotPos() player:getZoneID() );
     else
         if (noDepop == nil or noDepop == 0) then
             DespawnMob( mobId );

--- a/scripts/commands/npchere.lua
+++ b/scripts/commands/npchere.lua
@@ -19,16 +19,17 @@ function onTrigger(player, npcId)
 
     local npc = GetNPCByID(npcId);
     if (npc == nil) then
-        player:PrintToPlayer( string.format( "Mob with ID '%i' not found!", npcId ) );
+        player:PrintToPlayer( string.format( "NPC with ID '%i' not found!", npcId ) );
         return;
     end
 
-    SpawnMob( npcId ); -- Yes, that does work on NPC's as well.
-    if (player:getZone() == mob:getZone()) then
-        npc:setPos( player:getXPos(), player:getYPos(), player:getZPos(), 0, player:getZone() );
+    npc:setStatus(STATUS_NORMAL);
+    if (player:getZoneID() == npc:getZoneID()) then
+        npc:setPos( player:getXPos(), player:getYPos(), player:getZPos(), player:getRotPos(), player:getZoneID() );
+        npc:setStatus(STATUS_UPDATE);
     else
         if (noDepop == nil or noDepop == 0) then
-            DespawnMob( npcId );
+            npc:setStatus(STATUS_DISAPPEAR);
             player:PrintToPlayer("Despawned the NPC because of an error.");
         end
         player:PrintToPlayer("NPC could not be moved to current pos - you are probably in the wrong zone.");

--- a/scripts/commands/posfix.lua
+++ b/scripts/commands/posfix.lua
@@ -1,6 +1,6 @@
 ---------------------------------------------------------------------------------------------------
 -- func: @posfix
--- auth: Link (as "resetplayer"), Modified by TeoTwawki.
+-- auth: Link (as "resetplayer"), renamed by TeoTwawki.
 -- desc: Resets a targets account session and warps them to Jeuno.
 ---------------------------------------------------------------------------------------------------
 
@@ -11,16 +11,6 @@ cmdprops =
 };
 
 function onTrigger(player, target)
-    if (target == nil) then -- This only prints if no target was specified at all.
-        player:PrintToPlayer("You must enter a valid Character name.");
-        return;
-    end
-
-    local targ = GetPlayerByName(target);
-    if (targ == nil) then -- This only prints if a target was specified but that target didn't exist.
-        player:PrintToPlayer( string.format( "Player named '%s' not found!", target ) );
-        return;
-    end
-
     player:resetPlayer( targ );
+    player:PrintToPlayer("Done.");
 end;


### PR DESCRIPTION
1. getzone changed, changed again, then we got getzoneID so using that now.
2. spawnmob no longer works for NPC objects, it used to.

Added rot in there while I was at it, semi useful if moving NPCs around. Tested these, however sometimes you have to zone to see the NPC change even though I used status update. Might be just me though, I had a lot open during testing so my PC has that laggy feel.