### PR TITLE
Converted item ID checks for occasionally does increased damage into a modifier check

### DIFF
--- a/scripts/globals/status.lua
+++ b/scripts/globals/status.lua
@@ -1177,8 +1177,9 @@ MOD_FERAL_HOWL_DURATION       =0x1F7 -- +20% duration per merit when wearing aug
 MOD_MANEUVER_BONUS            =0x1F8 -- Maneuver Stat Bonus
 MOD_OVERLOAD_THRESH           =0x1F9 -- Overload Threshold Bonus
 
--- MOD_SPARE =0x1FA -- (modId = 506)
--- MOD_SPARE =0x1FB -- (modId = 507)
+MOD_EXTRA_DMG_CHANCE          =0x1FA -- Proc rate of MOD_OCC_DO_EXTRA_DMG. 111 would be 11.1% (modId = 506)
+MOD_OCC_DO_EXTRA_DMG          =0x1FB -- Multiplier for "Occasionally do x times normal damage". 250 would be 2.5 times damage. (modId = 507)
+
 -- MOD_SPARE =0x1FC -- (modId = 508)
 -- MOD_SPARE =0x1FD -- (modId = 509)
 -- MOD_SPARE =0x1FE -- (modId = 510)

--- a/sql/item_mods.sql
+++ b/sql/item_mods.sql
@@ -16436,54 +16436,152 @@ INSERT INTO `item_mods` VALUES(18257, 10, 4);
 INSERT INTO `item_mods` VALUES(18257, 59, 3);
 INSERT INTO `item_mods` VALUES(18257, 228, 2);
 INSERT INTO `item_mods` VALUES(18263, 356, 10);
+
+-- -------------------------------------------------------
+-- Spharai (75)
+-- -------------------------------------------------------
 INSERT INTO `item_mods` VALUES(18264, 23, 20);
 INSERT INTO `item_mods` VALUES(18264, 291, 5);
 INSERT INTO `item_mods` VALUES(18264, 355, 10);
+INSERT INTO `item_mods` VALUES(18264, 506, 160); -- 16% chance of extra dmg.
+INSERT INTO `item_mods` VALUES(18264, 507, 250); -- Occ. 2.5x dmg
+
 INSERT INTO `item_mods` VALUES(18269, 356, 26);
+
+-- -------------------------------------------------------
+-- Mandau (75)
+-- -------------------------------------------------------
 INSERT INTO `item_mods` VALUES(18270, 23, 20);
 INSERT INTO `item_mods` VALUES(18270, 355, 26);
+INSERT INTO `item_mods` VALUES(18270, 506, 160); -- 16% chance of extra dmg.
+INSERT INTO `item_mods` VALUES(18270, 507, 300); -- Occ. 3x dmg
+
 INSERT INTO `item_mods` VALUES(18275, 356, 43);
+
+-- -------------------------------------------------------
+-- Excalibur (75)
+-- -------------------------------------------------------
 INSERT INTO `item_mods` VALUES(18276, 23, 20);
 INSERT INTO `item_mods` VALUES(18276, 355, 43);
+INSERT INTO `item_mods` VALUES(18276, 506, 160); -- 16% chance of extra dmg.
+INSERT INTO `item_mods` VALUES(18276, 507, 250); -- Occ. 2.5x dmg
+
 INSERT INTO `item_mods` VALUES(18281, 356, 57);
+
+-- -------------------------------------------------------
+-- Ragnarok (75)
+-- -------------------------------------------------------
 INSERT INTO `item_mods` VALUES(18282, 25, 20);
 INSERT INTO `item_mods` VALUES(18282, 165, 5);
 INSERT INTO `item_mods` VALUES(18282, 355, 57);
+INSERT INTO `item_mods` VALUES(18282, 506, 160); -- 16% chance of extra dmg.
+INSERT INTO `item_mods` VALUES(18282, 507, 250); -- Occ. 2.5x dmg
+
 INSERT INTO `item_mods` VALUES(18287, 356, 73);
+
+-- -------------------------------------------------------
+-- Guttler (75)
+-- -------------------------------------------------------
 INSERT INTO `item_mods` VALUES(18288, 23, 20);
 INSERT INTO `item_mods` VALUES(18288, 355, 73);
+INSERT INTO `item_mods` VALUES(18288, 506, 160); -- 16% chance of extra dmg.
+INSERT INTO `item_mods` VALUES(18288, 507, 250); -- Occ. 2.5x dmg
+
 INSERT INTO `item_mods` VALUES(18293, 356, 89);
+
+-- -------------------------------------------------------
+-- Bravura (75)
+-- -------------------------------------------------------
 INSERT INTO `item_mods` VALUES(18294, 25, 20);
 INSERT INTO `item_mods` VALUES(18294, 355, 89);
+INSERT INTO `item_mods` VALUES(18294, 506, 160); -- 16% chance of extra dmg.
+INSERT INTO `item_mods` VALUES(18294, 507, 200); -- Occ. 2x dmg
+
 INSERT INTO `item_mods` VALUES(18299, 356, 121);
+
+-- -------------------------------------------------------
+-- Gungnir (75)
+-- -------------------------------------------------------
 INSERT INTO `item_mods` VALUES(18300, 25, 20);
 INSERT INTO `item_mods` VALUES(18300, 355, 121);
+INSERT INTO `item_mods` VALUES(18300, 506, 160); -- 16% chance of extra dmg.
+INSERT INTO `item_mods` VALUES(18300, 507, 250); -- Occ. 2.5x dmg
+
 INSERT INTO `item_mods` VALUES(18305, 356, 105);
+
+-- -------------------------------------------------------
+--Apocalypse (75)
+-- -------------------------------------------------------
 INSERT INTO `item_mods` VALUES(18306, 25, 20);
 INSERT INTO `item_mods` VALUES(18306, 355, 105);
+INSERT INTO `item_mods` VALUES(18306, 506, 160); -- 16% chance of extra dmg.
+INSERT INTO `item_mods` VALUES(18306, 507, 200); -- Occ. 2x dmg
+
 INSERT INTO `item_mods` VALUES(18311, 356, 137);
+
+-- -------------------------------------------------------
+-- Kikoku (75)
+-- -------------------------------------------------------
 INSERT INTO `item_mods` VALUES(18312, 23, 20);
 INSERT INTO `item_mods` VALUES(18312, 355, 137);
+INSERT INTO `item_mods` VALUES(18312, 507, 160); -- 16% chance of extra dmg.
+INSERT INTO `item_mods` VALUES(18312, 506, 300); -- Occ. 3x dmg
+
 INSERT INTO `item_mods` VALUES(18317, 356, 153);
+
+-- -------------------------------------------------------
+-- Amanomurakumo (75)
+-- -------------------------------------------------------
 INSERT INTO `item_mods` VALUES(18318, 25, 20);
 INSERT INTO `item_mods` VALUES(18318, 355, 153);
+INSERT INTO `item_mods` VALUES(18318, 506, 160); -- 16% chance of extra dmg.
+INSERT INTO `item_mods` VALUES(18318, 507, 250); -- Occ. 2.5x dmg
+
 INSERT INTO `item_mods` VALUES(18323, 356, 170);
+
+-- -------------------------------------------------------
+-- Mjollnir (75)
+-- -------------------------------------------------------
 INSERT INTO `item_mods` VALUES(18324, 23, 20);
 INSERT INTO `item_mods` VALUES(18324, 355, 170);
+INSERT INTO `item_mods` VALUES(18324, 506, 160); -- 16% chance of extra dmg.
+INSERT INTO `item_mods` VALUES(18324, 507, 300); -- Occ. 3x dmg
+
 INSERT INTO `item_mods` VALUES(18329, 356, 185);
+
+-- -------------------------------------------------------
+-- Claustrum (75)
+-- -------------------------------------------------------
 INSERT INTO `item_mods` VALUES(18330, 25, 20);
 INSERT INTO `item_mods` VALUES(18330, 355, 185);
+INSERT INTO `item_mods` VALUES(18330, 506, 160); -- 16% chance of extra dmg.
+INSERT INTO `item_mods` VALUES(18330, 507, 250); -- Occ. 2.5x dmg
+
 INSERT INTO `item_mods` VALUES(18335, 356, 216);
+
+-- -------------------------------------------------------
+-- Annihilator (75)
+-- -------------------------------------------------------
 INSERT INTO `item_mods` VALUES(18336, 24, 10);
 INSERT INTO `item_mods` VALUES(18336, 26, 20);
 INSERT INTO `item_mods` VALUES(18336, 355, 216);
+INSERT INTO `item_mods` VALUES(18336, 506, 160); -- 16% chance of extra dmg.
+INSERT INTO `item_mods` VALUES(18336, 507, 300); -- Occ. 3x dmg
+
 INSERT INTO `item_mods` VALUES(18342, 14, 4);
 INSERT INTO `item_mods` VALUES(18342, 119, 10);
 INSERT INTO `item_mods` VALUES(18342, 121, 10);
 INSERT INTO `item_mods` VALUES(18347, 356, 200);
+
+-- -------------------------------------------------------
+-- Yoichinoyumi (75)
+-- -------------------------------------------------------
 INSERT INTO `item_mods` VALUES(18348, 24, 10);
 INSERT INTO `item_mods` VALUES(18348, 26, 20);
 INSERT INTO `item_mods` VALUES(18348, 355, 200);
+INSERT INTO `item_mods` VALUES(18348, 506, 160); -- 16% chance of extra dmg.
+INSERT INTO `item_mods` VALUES(18348, 507, 300); -- Occ. 3x dmg
+
 INSERT INTO `item_mods` VALUES(18350, 10, 3);
 INSERT INTO `item_mods` VALUES(18351, 8, 3);
 INSERT INTO `item_mods` VALUES(18351, 10, 4);

--- a/src/map/modifier.h
+++ b/src/map/modifier.h
@@ -551,7 +551,9 @@ enum MODIFIER
 
     MOD_GOV_CLEARS                = 0x1F0, // 4% bonus per Grounds of Valor Page clear (modId = 496)
 
-    //MOD_SPARE =0x1FB, // (modId = 507)
+    MOD_EXTRA_DMG_CHANCE          = 0x1FA, // Proc rate of MOD_OCC_DO_EXTRA_DMG. 111 would be 11.1% (modId = 506)
+    MOD_OCC_DO_EXTRA_DMG          = 0x1FB, // Multiplier for "Occasionally do x times normal damage". 250 would be 2.5 times damage. (modId = 507)
+
     //MOD_SPARE =0x1FC, // (modId = 508)
     //MOD_SPARE =0x1FD, // (modId = 509)
     //MOD_SPARE =0x1FE, // (modId = 510)
@@ -560,7 +562,7 @@ enum MODIFIER
 
 };
 
-#define MAX_MODIFIER 506
+#define MAX_MODIFIER 508
 
 
 

--- a/src/map/utils/attackutils.cpp
+++ b/src/map/utils/attackutils.cpp
@@ -152,47 +152,13 @@ uint32 CheckForDamageMultiplier(CCharEntity* PChar, CItemWeapon* PWeapon, uint32
 	}
 	uint32 originalDamage = damage;
 
-	switch (PWeapon->getID())
+	if (PWeapon->getModifier(MOD_OCC_DO_EXTRA_DMG) > 0 && PWeapon->getModifier(MOD_EXTRA_DMG_CHANCE) > 0)
 	{
-		//relic weapons have 16% (ffxiclopedia) chance to do x times damage, cannot proc with weapon skills
-
-		// Relic: 2.5 times damage
-		case 18264:		// Spharai, h2h
-		case 18276:		// Excalibur, sword
-		case 18282:		// Ragnarok, great sword
-		case 18288:		// Guttler, axe
-		case 18300:		// Gungnir, polearm
-		case 18318:		// Amanomurakumo, great katana
-		case 18330:		// Claustrum, staff
-			if (WELL512::irand()%100 <= 16) return (damage = (damage * (float)2.5));
-			break;
-
-		// Relic: 3 times damage
-		case 18270:		// Mandau, dagger
-		case 18312:		// Kikoku, katana
-		case 18324:		// Mjollnir, club
-		case 18336:		// Annihilator, marksmanship
-		case 18348:		// Yoichinoyumi, archery
-			if (WELL512::irand()%100 <= 16) return (damage = (damage * 3));
-			break;
-
-		// Relic: 2 times damage
-		case 18294:		// Bravura, great axe
-		case 18306:		// Apocalypse, scythe
-			if (WELL512::irand()%100 <= 16) return (damage = (damage * 2));
-			break;
-
-
-		//mythic weapons, same distribution as multi attacking weapons
-
-		// Mythic: 2 time damage
-		case 19001:		// Gastraphetes(lvl75), marksmanship
-		case 19007:		// Death Penalty(lvl75), marksmanship
-			if (WELL512::irand()%100 > 55) return (damage = (damage * 2));
-			break;
-
-		default:			
-			break;
+		// Relic weapons have 16% (ffxiclopedia) chance to do x times damage, cannot proc with weapon skills
+		if (WELL512::irand()%100 <= (PWeapon->getModifier(MOD_EXTRA_DMG_CHANCE)/100))
+		{
+			return (damage = (damage * (PWeapon->getModifier(MOD_OCC_DO_EXTRA_DMG)/100)));
+		}
 	}
 
 	switch (attackType)


### PR DESCRIPTION
Added item_mods.sql entries for relic/mythic already in table that have this property. 

Acceptable change? The other way to do this would have been 2x, 2.5x, and 3x as 3 separate mods.

Might have done it that way in the first place had I seen the lv 95+ Mythics before I had 99% finished this, although I think this is more flexible. Let me know if I should change it. Did not yet add missing post lv75 relics. Will get to those soon unless someone beats me to it, just wanted to make sure this logic was ok first.

I probably didn't need the extra decimal place for the % proc rate but this way if it turns out something out there that is something point something percent, bases are covered already.