### PR TITLE
Fix missing require.

### DIFF
--- a/scripts/commands/npchere.lua
+++ b/scripts/commands/npchere.lua
@@ -12,6 +12,8 @@ cmdprops =
 };
 
 function onTrigger(player, npcId)
+    require("scripts/globals/status");
+
     if (npcId == nil) then
         player:PrintToPlayer("You must enter a valid npcId.");
         return;


### PR DESCRIPTION
Worked when before without the require during testing because:
1) If something else just loaded status.lua then those variables would be defined even without a require.
2) Status normal had an ID of zero anyway.