### PR TITLE
CORE: postpone calls to UpdateHealth() until equipment swaps are complete

### DIFF
--- a/src/map/utils/charutils.cpp
+++ b/src/map/utils/charutils.cpp
@@ -1326,7 +1326,7 @@ namespace charutils
     *																		*
     ************************************************************************/
 
-    void UnequipItem(CCharEntity* PChar, uint8 equipSlotID)
+    void UnequipItem(CCharEntity* PChar, uint8 equipSlotID, bool update)
     {
         CItem* PItem = PChar->getEquip((SLOTTYPE)equipSlotID);
 
@@ -1444,11 +1444,13 @@ namespace charutils
             break;
             }
 
-            charutils::BuildingCharSkillsTable(PChar);
-
-            PChar->UpdateHealth();
-            PChar->m_EquipSwap = true;
-            PChar->updatemask |= UPDATE_LOOK;
+            if (update)
+            {
+                charutils::BuildingCharSkillsTable(PChar);
+                PChar->UpdateHealth();
+                PChar->m_EquipSwap = true;
+                PChar->updatemask |= UPDATE_LOOK;
+            }
         }
     }
 
@@ -1498,7 +1500,7 @@ namespace charutils
             }
         }
 
-        UnequipItem(PChar, equipSlotID);
+        UnequipItem(PChar, equipSlotID, false);
 
         if (PItem->getEquipSlotId() & (1 << equipSlotID))
         {
@@ -1506,7 +1508,7 @@ namespace charutils
 
             if (removeSlotID > 0)
             {
-                UnequipItem(PChar, removeSlotID);
+                UnequipItem(PChar, removeSlotID, false);
             }
 
             switch (equipSlotID)
@@ -1533,12 +1535,12 @@ namespace charutils
                                 CItemWeapon* PWeapon = (CItemWeapon*)armor;
                                 if (PWeapon->getSkillType() != SKILL_NON || ((CItemWeapon*)PItem)->getSkillType() == SKILL_H2H)
                                 {
-                                    UnequipItem(PChar, SLOT_SUB);
+                                    UnequipItem(PChar, SLOT_SUB, false);
                                 }
                             }
                             else
                             {
-                                UnequipItem(PChar, SLOT_SUB);
+                                UnequipItem(PChar, SLOT_SUB, false);
                             }
                         }
                         if (((CItemWeapon*)PItem)->getSkillType() == SKILL_H2H)
@@ -1582,7 +1584,7 @@ namespace charutils
                     {
                         if (!PItem->isType(ITEM_WEAPON))
                         {
-                            UnequipItem(PChar, SLOT_MAIN);
+                            UnequipItem(PChar, SLOT_MAIN, false);
                         }
                     }
                     case SKILL_DAG:
@@ -1602,7 +1604,7 @@ namespace charutils
                     {
                         if (!PItem->isType(ITEM_WEAPON))
                         {
-                            UnequipItem(PChar, SLOT_MAIN);
+                            UnequipItem(PChar, SLOT_MAIN, false);
                         }
                         else if (!((CItemWeapon*)PItem)->getSkillType() == SKILL_NON)
                         {
@@ -1625,7 +1627,7 @@ namespace charutils
                         if (((CItemWeapon*)PItem)->getSkillType() != weapon->getSkillType() ||
                             ((CItemWeapon*)PItem)->getSubSkillType() != weapon->getSubSkillType())
                         {
-                            UnequipItem(PChar, SLOT_AMMO);
+                            UnequipItem(PChar, SLOT_AMMO, false);
                         }
                     }
                     PChar->m_Weapons[SLOT_RANGED] = (CItemWeapon*)PItem;
@@ -1643,7 +1645,7 @@ namespace charutils
                         if (((CItemWeapon*)PItem)->getSkillType() != weapon->getSkillType() ||
                             ((CItemWeapon*)PItem)->getSubSkillType() != weapon->getSubSkillType())
                         {
-                            UnequipItem(PChar, SLOT_RANGED);
+                            UnequipItem(PChar, SLOT_RANGED, false);
                         }
                     }
                     if (PChar->equip[SLOT_RANGED] == 0)
@@ -1661,7 +1663,7 @@ namespace charutils
                 {
                     uint8 removeSlotID = armor->getRemoveSlotId();
                     if (removeSlotID == SLOT_HEAD) {
-                        UnequipItem(PChar, SLOT_BODY);
+                        UnequipItem(PChar, SLOT_BODY, false);
                     }
                 }
                 PChar->look.head = PItem->getModelId();
@@ -1684,7 +1686,7 @@ namespace charutils
                     uint8 removeSlotID = armor->getRemoveSlotId();
                     if (removeSlotID == SLOT_HANDS)
                     {
-                        UnequipItem(PChar, SLOT_BODY);
+                        UnequipItem(PChar, SLOT_BODY, false);
                     }
                 }
                 PChar->look.hands = PItem->getModelId();
@@ -1707,7 +1709,7 @@ namespace charutils
                     uint8 removeSlotID = armor->getRemoveSlotId();
                     if (removeSlotID == SLOT_FEET)
                     {
-                        UnequipItem(PChar, SLOT_LEGS);
+                        UnequipItem(PChar, SLOT_LEGS, false);
                     }
                 }
                 PChar->look.feet = PItem->getModelId();

--- a/src/map/utils/charutils.h
+++ b/src/map/utils/charutils.h
@@ -77,7 +77,7 @@ namespace charutils
     void	CheckValidEquipment(CCharEntity* PChar);
     void	CheckEquipLogic(CCharEntity* PChar, SCRIPTTYPE ScriptType, uint32 param);
     void	EquipItem(CCharEntity* PChar, uint8 slotID, uint8 equipSlotID, uint8 containerID);
-    void	UnequipItem(CCharEntity* PChar, uint8 equipSlotID);
+    void	UnequipItem(CCharEntity* PChar, uint8 equipSlotID, bool update = true); //call with update == false to prevent calls to UpdateHealth() - used for correct handling of stats on armor swaps
     void    RemoveSub(CCharEntity* PChar);
     bool    EquipArmor(CCharEntity* PChar, uint8 slotID, uint8 equipSlotID);
     void	CheckUnarmedWeapon(CCharEntity* PChar);


### PR DESCRIPTION
this allows for correct calculation of HP/MP when swapping from 2 equipment items in the same slot that both have +HP/MP

i.e.  you have full mp and swap from MP+24 item to MP+14 item, now you only lose 10 mp, before your max mp was adjusted correctly but you end up 14 shy of max