### PR TITLE
Fix onMobDeath returns (issue caused when I fixed #923)...Tested with multi boxed party in 3 zones.

### DIFF
--- a/src/map/lua/luautils.cpp
+++ b/src/map/lua/luautils.cpp
@@ -2391,13 +2391,13 @@ int32 OnMobDeath(CBaseEntity* PMob, CBaseEntity* PKiller)
 
         PChar->ForAlliance([PChar, PMob, PKiller, &File](CBattleEntity* PMember)
         {
-            if (prepFile(File, "onMobDeathEx"))
-            {
-                return;
-            }
-
             if (PMember->getZone() == PChar->getZone())
             {
+                if (prepFile(File, "onMobDeathEx"))
+                {
+                    return;
+                }
+
                 CLuaBaseEntity LuaMobEntity(PMob);
                 CLuaBaseEntity LuaKillerEntity(PMember);
 


### PR DESCRIPTION
I tested before too, didn't see the return problem when I was testing in an alliance.