### PR TITLE
Update Chocobo Renter system to mimic retail

### DIFF
--- a/scripts/globals/chocobo.lua
+++ b/scripts/globals/chocobo.lua
@@ -52,7 +52,7 @@ end;
 ---------------------------------------
 
 function getChocoboPrice(player)
-    local zone = player:getZone();
+    local zone = player:getZoneID();
     local price = 0;
 
     for u = 1, table.getn(chocobo), 2 do

--- a/scripts/globals/chocobo.lua
+++ b/scripts/globals/chocobo.lua
@@ -1,0 +1,87 @@
+-------------------------------------------------
+--  Author: santssoft
+--  Chocobo functions
+--  Info from:
+--      http://wiki.ffxiclopedia.org/wiki/Chocobo_Renter
+--      http://ffxi.allakhazam.com/wiki/Traveling_in_Vana'diel
+-------------------------------------------------
+
+require("scripts/globals/settings");
+
+--[[-----------------------------------------------
+Description:
+    chocobo = Zone, { [1] Lowest price, [2] Amount added to base price, [3] Amount discounted per time interval, [4] Amount of seconds before price decay, [5] Quest "A Chocobo Riding Game" chance }
+--]]-----------------------------------------------
+
+chocobo = {230,{100,20,5,60,0.10},  -- Southern San d'Oria
+           234,{100,20,5,60,0.10},  -- Bastok Mines
+           241,{100,20,5,60,0.10},  -- Windurst Woods
+           244,{200,25,5,90,0.00},  -- Upper Jeuno
+           245,{200,25,5,90,0.00},  -- Lower Jeuno
+           246,{200,25,5,90,0.00},  -- Port Jeuno
+           250,{ 90,10,5,60,0.10},  -- Kazham
+           252,{ 90,10,5,60,0.00},  -- Norg
+           247,{ 90,10,5,60,0.00},  -- Rabao
+           102,{200,25,5,90,0.00},  -- La Theine Plateau
+           108,{200,25,5,90,0.00},  -- Konschtat Highlands
+           117,{200,25,5,90,0.00},  -- Tahrongi Canyon
+           114,{200,25,5,90,0.00},  -- Eastern Altepa Desert
+           124,{200,25,5,90,0.00},  -- Yhoator Jungle
+            48,{250,25,5,90,0.00},  -- Al Zahbi
+            51,{200,20,5,90,0.00},  -- Wajaom Woodlands
+            80,{150,20,5,90,0.00},  -- Southern San d'Oria [S]
+            87,{150,20,5,90,0.00},  -- Bastok Markets [S]
+            94,{150,20,5,90,0.00},  -- Windurst Waters [S]
+            82,{200,25,5,90,0.00},  -- Jugner Forest [S]
+            90,{200,25,5,90,0.00},  -- Pashhow Marshlands [S]
+            97,{200,25,5,90,0.00}}; -- Meriphataud Mountains [S]
+
+---------------------------------------
+-- Set chocobo Prices on server start
+---------------------------------------
+
+function setChocoboPrices()
+    for u = 1, table.getn(chocobo), 2 do
+        SetServerVariable("[CHOCOBO]["..chocobo[u].."]Price", chocobo[u + 1][1]);
+        SetServerVariable("[CHOCOBO]["..chocobo[u].."]Time", os.time(t));
+    end
+end;
+
+---------------------------------------
+-- return chocobo Price
+---------------------------------------
+
+function getChocoboPrice(player)
+    local zone = player:getZone();
+    local price = 0;
+
+    for u = 1, table.getn(chocobo), 2 do
+        if(chocobo[u] == zone) then
+            local last_price = GetServerVariable("[CHOCOBO]["..zone.."]Price");
+            local last_time = GetServerVariable("[CHOCOBO]["..zone.."]Time");
+
+            price = last_price - (math.floor((os.time(t) - last_time) / chocobo[u + 1][4]) * chocobo[u + 1][3]);
+
+            if (price < chocobo[u + 1][1]) then
+                price = chocobo[u + 1][1];
+            end
+        end
+    end
+
+    return price;
+end
+
+---------------------------------------
+-- update chocobo Price
+---------------------------------------
+
+function updateChocoboPrice(player, price)
+    local zone = player:getZoneID();
+
+    for u = 1, table.getn(chocobo), 2 do
+        if(chocobo[u] == zone) then
+            SetServerVariable("[CHOCOBO]["..chocobo[u].."]Price", price + chocobo[u + 1][2]);
+            SetServerVariable("[CHOCOBO]["..chocobo[u].."]Time", os.time(t));
+        end
+    end
+end;

--- a/scripts/globals/chocobo.lua
+++ b/scripts/globals/chocobo.lua
@@ -10,31 +10,31 @@ require("scripts/globals/settings");
 
 --[[-----------------------------------------------
 Description:
-    chocobo = Zone, { [1] Lowest price, [2] Amount added to base price, [3] Amount discounted per time interval, [4] Amount of seconds before price decay, [5] Quest "A Chocobo Riding Game" chance }
+    chocobo = Zone, { [1] Base price, [2] Amount added to base price, [3] Amount discounted per time interval, [4] Amount of seconds before price decay, [5] Quest "A Chocobo Riding Game" chance }
 --]]-----------------------------------------------
 
-chocobo = {230,{100,20,5,60,0.10},  -- Southern San d'Oria
-           234,{100,20,5,60,0.10},  -- Bastok Mines
-           241,{100,20,5,60,0.10},  -- Windurst Woods
-           244,{200,25,5,90,0.00},  -- Upper Jeuno
-           245,{200,25,5,90,0.00},  -- Lower Jeuno
-           246,{200,25,5,90,0.00},  -- Port Jeuno
-           250,{ 90,10,5,60,0.10},  -- Kazham
-           252,{ 90,10,5,60,0.00},  -- Norg
-           247,{ 90,10,5,60,0.00},  -- Rabao
-           102,{200,25,5,90,0.00},  -- La Theine Plateau
-           108,{200,25,5,90,0.00},  -- Konschtat Highlands
-           117,{200,25,5,90,0.00},  -- Tahrongi Canyon
-           114,{200,25,5,90,0.00},  -- Eastern Altepa Desert
-           124,{200,25,5,90,0.00},  -- Yhoator Jungle
-            48,{250,25,5,90,0.00},  -- Al Zahbi
-            51,{200,20,5,90,0.00},  -- Wajaom Woodlands
-            80,{150,20,5,90,0.00},  -- Southern San d'Oria [S]
-            87,{150,20,5,90,0.00},  -- Bastok Markets [S]
-            94,{150,20,5,90,0.00},  -- Windurst Waters [S]
-            82,{200,25,5,90,0.00},  -- Jugner Forest [S]
-            90,{200,25,5,90,0.00},  -- Pashhow Marshlands [S]
-            97,{200,25,5,90,0.00}}; -- Meriphataud Mountains [S]
+local chocobo = {230,{baseprice = 100,addedprice = 20,decayprice = 5,decaytime = 60,questchance = 0.10},  -- Southern San d'Oria
+                 234,{baseprice = 100,addedprice = 20,decayprice = 5,decaytime = 60,questchance = 0.10},  -- Bastok Mines
+                 241,{baseprice = 100,addedprice = 20,decayprice = 5,decaytime = 60,questchance = 0.10},  -- Windurst Woods
+                 244,{baseprice = 200,addedprice = 25,decayprice = 5,decaytime = 90,questchance = 0.00},  -- Upper Jeuno
+                 245,{baseprice = 200,addedprice = 25,decayprice = 5,decaytime = 90,questchance = 0.00},  -- Lower Jeuno
+                 246,{baseprice = 200,addedprice = 25,decayprice = 5,decaytime = 90,questchance = 0.00},  -- Port Jeuno
+                 250,{baseprice =  90,addedprice = 10,decayprice = 5,decaytime = 60,questchance = 0.10},  -- Kazham
+                 252,{baseprice =  90,addedprice = 10,decayprice = 5,decaytime = 60,questchance = 0.00},  -- Norg
+                 247,{baseprice =  90,addedprice = 10,decayprice = 5,decaytime = 60,questchance = 0.00},  -- Rabao
+                 102,{baseprice = 200,addedprice = 25,decayprice = 5,decaytime = 90,questchance = 0.00},  -- La Theine Plateau
+                 108,{baseprice = 200,addedprice = 25,decayprice = 5,decaytime = 90,questchance = 0.00},  -- Konschtat Highlands
+                 117,{baseprice = 200,addedprice = 25,decayprice = 5,decaytime = 90,questchance = 0.00},  -- Tahrongi Canyon
+                 114,{baseprice = 200,addedprice = 25,decayprice = 5,decaytime = 90,questchance = 0.00},  -- Eastern Altepa Desert
+                 124,{baseprice = 200,addedprice = 25,decayprice = 5,decaytime = 90,questchance = 0.00},  -- Yhoator Jungle
+                  48,{baseprice = 250,addedprice = 25,decayprice = 5,decaytime = 90,questchance = 0.00},  -- Al Zahbi
+                  51,{baseprice = 200,addedprice = 20,decayprice = 5,decaytime = 90,questchance = 0.00},  -- Wajaom Woodlands
+                  80,{baseprice = 150,addedprice = 20,decayprice = 5,decaytime = 90,questchance = 0.00},  -- Southern San d'Oria [S]
+                  87,{baseprice = 150,addedprice = 20,decayprice = 5,decaytime = 90,questchance = 0.00},  -- Bastok Markets [S]
+                  94,{baseprice = 150,addedprice = 20,decayprice = 5,decaytime = 90,questchance = 0.00},  -- Windurst Waters [S]
+                  82,{baseprice = 200,addedprice = 25,decayprice = 5,decaytime = 90,questchance = 0.00},  -- Jugner Forest [S]
+                  90,{baseprice = 200,addedprice = 25,decayprice = 5,decaytime = 90,questchance = 0.00},  -- Pashhow Marshlands [S]
+                  97,{baseprice = 200,addedprice = 25,decayprice = 5,decaytime = 90,questchance = 0.00}}; -- Meriphataud Mountains [S]
 
 ---------------------------------------
 -- Set chocobo Prices on server start
@@ -42,7 +42,7 @@ chocobo = {230,{100,20,5,60,0.10},  -- Southern San d'Oria
 
 function setChocoboPrices()
     for u = 1, table.getn(chocobo), 2 do
-        SetServerVariable("[CHOCOBO]["..chocobo[u].."]Price", chocobo[u + 1][1]);
+        SetServerVariable("[CHOCOBO]["..chocobo[u].."]Price", chocobo[u + 1]["baseprice"]);
         SetServerVariable("[CHOCOBO]["..chocobo[u].."]Time", os.time(t));
     end
 end;
@@ -60,7 +60,7 @@ function getChocoboPrice(player)
             local last_price = GetServerVariable("[CHOCOBO]["..zone.."]Price");
             local last_time = GetServerVariable("[CHOCOBO]["..zone.."]Time");
 
-            price = last_price - (math.floor((os.time(t) - last_time) / chocobo[u + 1][4]) * chocobo[u + 1][3]);
+            price = last_price - (math.floor((os.time(t) - last_time) / chocobo[u + 1]["decaytime"]) * chocobo[u + 1]["decayprice"]);
 
             if (price < chocobo[u + 1][1]) then
                 price = chocobo[u + 1][1];
@@ -80,7 +80,7 @@ function updateChocoboPrice(player, price)
 
     for u = 1, table.getn(chocobo), 2 do
         if(chocobo[u] == zone) then
-            SetServerVariable("[CHOCOBO]["..chocobo[u].."]Price", price + chocobo[u + 1][2]);
+            SetServerVariable("[CHOCOBO]["..chocobo[u].."]Price", price + chocobo[u + 1]["addedprice"]);
             SetServerVariable("[CHOCOBO]["..chocobo[u].."]Time", os.time(t));
         end
     end

--- a/scripts/globals/chocobo.lua
+++ b/scripts/globals/chocobo.lua
@@ -42,7 +42,7 @@ local chocobo = {230,{baseprice = 100,addedprice = 20,decayprice = 5,decaytime =
 
 function setChocoboPrices()
     for u = 1, table.getn(chocobo), 2 do
-        SetServerVariable("[CHOCOBO]["..chocobo[u].."]Price", chocobo[u + 1]["baseprice"]);
+        SetServerVariable("[CHOCOBO]["..chocobo[u].."]Price", chocobo[u + 1].baseprice);
         SetServerVariable("[CHOCOBO]["..chocobo[u].."]Time", os.time(t));
     end
 end;
@@ -60,7 +60,7 @@ function getChocoboPrice(player)
             local last_price = GetServerVariable("[CHOCOBO]["..zone.."]Price");
             local last_time = GetServerVariable("[CHOCOBO]["..zone.."]Time");
 
-            price = last_price - (math.floor((os.time(t) - last_time) / chocobo[u + 1]["decaytime"]) * chocobo[u + 1]["decayprice"]);
+            price = last_price - (math.floor((os.time(t) - last_time) / chocobo[u + 1].decaytime) * chocobo[u + 1].decayprice);
 
             if (price < chocobo[u + 1][1]) then
                 price = chocobo[u + 1][1];
@@ -80,7 +80,7 @@ function updateChocoboPrice(player, price)
 
     for u = 1, table.getn(chocobo), 2 do
         if(chocobo[u] == zone) then
-            SetServerVariable("[CHOCOBO]["..chocobo[u].."]Price", price + chocobo[u + 1]["addedprice"]);
+            SetServerVariable("[CHOCOBO]["..chocobo[u].."]Price", price + chocobo[u + 1].addedprice);
             SetServerVariable("[CHOCOBO]["..chocobo[u].."]Time", os.time(t));
         end
     end

--- a/scripts/globals/status.lua
+++ b/scripts/globals/status.lua
@@ -1221,7 +1221,8 @@ MOD_AUGMENTS_THIRD_EYE        = 0x1FC -- Adds counter to 3rd eye anticipates & i
 MOD_CLAMMING_IMPROVED_RESULTS = 0x1FD -- (modId = 509)
 MOD_CLAMMING_REDUCED_INCIDENTS= 0x1FE -- (modId = 510)
 
--- MOD_SPARE = 0x1FF -- (modId = 511)
+MOD_CHOCOBO_RIDING_TIME       = 0x1FF -- Increases chocobo riding time (modId = 511)
+
 -- MOD_SPARE = 0x200 -- (modId = 512)
 -- MOD_SPARE = 0x201 -- (modId = 513)
 -- MOD_SPARE = 0x202 -- (modId = 514)

--- a/scripts/zones/Al_Zahbi/npcs/Dahaaba.lua
+++ b/scripts/zones/Al_Zahbi/npcs/Dahaaba.lua
@@ -1,14 +1,14 @@
 -----------------------------------
---  Area: Al Zahbi
---   NPC: Dahaaba
---  Type: Chocobo Renter
--- @zone: 48
---  @pos -65.309 -1 -39.585
--- 
--- Auto-Script: Requires Verification (Verified by Brawndo)
+-- Area: Al Zahbi
+--  NPC: Dahaaba
+-- Type: Chocobo Renter
+-- @pos -65.309 -1 -39.585
 -----------------------------------
-package.loaded["scripts/zones/Al_Zahbi/TextIDs"] = nil;
------------------------------------
+
+require("scripts/globals/chocobo");
+require("scripts/globals/keyitems");
+require("scripts/globals/settings");
+require("scripts/globals/status");
 
 -----------------------------------
 -- onTrade Action
@@ -22,16 +22,18 @@ end;
 -----------------------------------
 
 function onTrigger(player,npc)
-	
-	price = 100;
-	gil = player:getGil();
+    local level = player:getMainLvl();
+    local gil = player:getGil();
 
-	if(player:hasKeyItem(CHOCOBO_LICENSE) and player:getMainLvl() >= 20) then
-		player:startEvent(0x010e,price,gil);
-	else
-		player:startEvent(0x010ef,price,gil);
-	end
-	
+    if (player:hasKeyItem(CHOCOBO_LICENSE) and level >= 20) then
+        local price = getChocoboPrice(player);
+        player:setLocalVar("chocoboPriceOffer",price);
+
+        player:startEvent(0x010E,price,gil);
+    else
+        player:startEvent(0x010F);
+    end
+
 end;
 
 -----------------------------------
@@ -39,8 +41,8 @@ end;
 -----------------------------------
 
 function onEventUpdate(player,csid,option)
--- printf("CSID: %u",csid);
--- printf("RESULT: %u",option);
+    -- printf("CSID: %u",csid);
+    -- printf("RESULT: %u",option);
 end;
 
 -----------------------------------
@@ -48,20 +50,20 @@ end;
 -----------------------------------
 
 function onEventFinish(player,csid,option)
--- printf("CSID: %u",csid);
--- printf("RESULT: %u",option);
-	
-	price = 100;
-	level = player:getMainLvl();
+    -- printf("CSID: %u",csid);
+    -- printf("RESULT: %u",option);
 
-	if(csid == 0x010e and option == 0) then
-		if(level >= 20) then
-			player:addStatusEffectEx(EFFECT_CHOCOBO,EFFECT_CHOCOBO,1,0,1800,true);
-		else
-			player:addStatusEffectEx(EFFECT_CHOCOBO,EFFECT_CHOCOBO,1,0,900,true);
-		end
-		player:delGil(price);
-		player:setPos(610,-24,356,0x80,0x33);
-	end
-	
+    local price = player:getLocalVar("chocoboPriceOffer");
+
+    if (csid == 0x010E and option == 0) then
+        if (player:delGil(price)) then
+            updateChocoboPrice(player, price);
+
+            local duration = 1800 + (player:getMod(MOD_CHOCOBO_RIDING_TIME) * 60)
+
+            player:addStatusEffectEx(EFFECT_CHOCOBO,EFFECT_CHOCOBO,1,0,duration,true);
+
+            player:setPos(610,-24,356,0x80,0x33);
+        end
+    end
 end;

--- a/scripts/zones/Bastok_Markets/Zone.lua
+++ b/scripts/zones/Bastok_Markets/Zone.lua
@@ -3,11 +3,13 @@
 -- Zone: Bastok_Markets (235)
 --
 -----------------------------------
-
 package.loaded["scripts/zones/Bastok_Markets/TextIDs"] = nil;
+-----------------------------------
+
+require("scripts/globals/chocobo");
 require("scripts/globals/events/harvest_festivals");
-require("scripts/globals/zone");
 require("scripts/globals/settings");
+require("scripts/globals/zone");
 require("scripts/zones/Bastok_Markets/TextIDs");
 
 -----------------------------------
@@ -15,89 +17,89 @@ require("scripts/zones/Bastok_Markets/TextIDs");
 -----------------------------------
 
 function onInitialize(zone)
-
     applyHalloweenNpcCostumes(zone:getID())
 
-end;			
+    setChocoboPrices();
+end;
 
------------------------------------			
--- onZoneIn			
------------------------------------			
+-----------------------------------
+-- onZoneIn
+-----------------------------------
 
-function onZoneIn(player,prevZone)			
-	cs = -1;		
-	-- FIRST LOGIN (START CS)		
-	if (player:getPlaytime(false) == 0) then		
-		if (OPENING_CUTSCENE_ENABLE == 1) then	
-			--cs = 0x00;
-		end	
-		player:setPos(-280,-12,-91,15);	
-		player:setHomePoint();	
-	end		
-	-- MOG HOUSE EXIT		
-	if ((player:getXPos() == 0) and (player:getYPos() == 0) and (player:getZPos() == 0)) then		
-		position = math.random(1,5) - 33;	
-		player:setPos(-177,-8,position,127);	
-		if (player:getMainJob() ~= player:getVar("PlayerMainJob")) then	
-			cs = 0x7534;
-		end	
-		player:setVar("PlayerMainJob",0);	
-	end		
-	return cs;		
-end;			
+function onZoneIn(player,prevZone)
+    local cs = -1;
+    -- FIRST LOGIN (START CS)
+    if (player:getPlaytime(false) == 0) then
+        if (OPENING_CUTSCENE_ENABLE == 1) then
+            --cs = 0x00;
+        end
+        player:setPos(-280,-12,-91,15);
+        player:setHomePoint();
+    end
+    -- MOG HOUSE EXIT
+    if ((player:getXPos() == 0) and (player:getYPos() == 0) and (player:getZPos() == 0)) then
+        position = math.random(1,5) - 33;
+        player:setPos(-177,-8,position,127);
+        if (player:getMainJob() ~= player:getVar("PlayerMainJob")) then
+            cs = 0x7534;
+        end
+        player:setVar("PlayerMainJob",0);
+    end
+    return cs;
+end;
 
------------------------------------		
--- onConquestUpdate		
------------------------------------		
+-----------------------------------
+-- onConquestUpdate
+-----------------------------------
 
 function onConquestUpdate(zone, updatetype)
     local players = zone:getPlayers();
-    
+
     for name, player in pairs(players) do
         conquestUpdate(zone, player, updatetype, CONQUEST_BASE);
     end
 end;
 
------------------------------------			
--- onRegionEnter			
------------------------------------			
+-----------------------------------
+-- onRegionEnter
+-----------------------------------
 
-function onRegionEnter(player,region)	
-end;	
-
------------------------------------			
--- onGameDay	
------------------------------------			
-
-function onGameDay()
-
-	-- Removes daily the bit mask that tracks the treats traded for Harvest Festival.
-	if (isHalloweenEnabled() ~= 0) then
-		clearVarFromAll("harvestFestTreats");
-		clearVarFromAll("harvestFestTreats2");
-	end
+function onRegionEnter(player,region)
 end;
 
------------------------------------	
--- onEventUpdate	
------------------------------------	
+-----------------------------------
+-- onGameDay
+-----------------------------------
 
-function onEventUpdate(player,csid,option)	
-	--printf("CSID: %u",csid);
-	--printf("RESULT: %u",option);
-end;	
+function onGameDay()
+    -- Removes daily the bit mask that tracks the treats traded for Harvest Festival.
+    if (isHalloweenEnabled() ~= 0) then
+        clearVarFromAll("harvestFestTreats");
+        clearVarFromAll("harvestFestTreats2");
+    end
+end;
 
------------------------------------	
--- onEventFinish	
------------------------------------	
+-----------------------------------
+-- onEventUpdate
+-----------------------------------
 
-function onEventFinish(player,csid,option)		
-	--printf("CSID: %u",csid);	
-	--printf("RESULT: %u",option);	
-	if(csid == 0x00) then	
-		player:messageSpecial(ITEM_OBTAINED,0x218);
-	elseif (csid == 0x7534 and option == 0) then	
-		player:setHomePoint();
-		player:messageSpecial(HOMEPOINT_SET);
-	end	
-end;		
+function onEventUpdate(player,csid,option)
+    -- printf("CSID: %u",csid);
+    -- printf("RESULT: %u",option);
+end;
+
+-----------------------------------
+-- onEventFinish
+-----------------------------------
+
+function onEventFinish(player,csid,option)
+    -- printf("CSID: %u",csid);
+    -- printf("RESULT: %u",option);
+
+    if (csid == 0x00) then
+        player:messageSpecial(ITEM_OBTAINED,0x218);
+    elseif (csid == 0x7534 and option == 0) then
+        player:setHomePoint();
+        player:messageSpecial(HOMEPOINT_SET);
+    end
+end;

--- a/scripts/zones/Bastok_Mines/npcs/Eulaphe.lua
+++ b/scripts/zones/Bastok_Mines/npcs/Eulaphe.lua
@@ -1,12 +1,13 @@
 -----------------------------------
 -- Area: Bastok Mines
--- NPC: Eulaphe
--- Chocobo Vendor
+--  NPC: Eulaphe
+-- Type: Chocobo Renter
 -----------------------------------
 
-require("scripts/globals/settings");
+require("scripts/globals/chocobo");
 require("scripts/globals/keyitems");
-
+require("scripts/globals/settings");
+require("scripts/globals/status");
 
 -----------------------------------
 -- onTrade Action
@@ -15,45 +16,60 @@ require("scripts/globals/keyitems");
 function onTrade(player,npc,trade)
 end;
 
-
 -----------------------------------
 -- onTrigger Action
 -----------------------------------
 
 function onTrigger(player,npc)
+    local level = player:getMainLvl();
+    local gil = player:getGil();
 
-price = 100;
-gil = player:getGil();
-hasLicense = player:hasKeyItem(CHOCOBO_LICENSE);
-level = player:getMainLvl();
+    if (player:hasKeyItem(CHOCOBO_LICENSE) and level >= 15) then
+        local price = getChocoboPrice(player);
+        player:setLocalVar("chocoboPriceOffer",price);
 
-	if (hasLicense and level >= 15) then
-		player:startEvent(0x003e,price,gil);
-	else
-		player:startEvent(0x0041,price,gil);
-	end
+        if (level >= 20) then
+            level = 0;
+        end
 
+        player:startEvent(0x003E,price,gil,level);
+    else
+        player:startEvent(0x0041);
+    end
 end;
 
-  
+-----------------------------------
+-- onEventUpdate
+-----------------------------------
+
+function onEventUpdate(player,csid,option)
+    -- printf("CSID: %u",csid);
+    -- printf("RESULT: %u",option);
+end;
+
 -----------------------------------
 -- onEventFinish Action
 -----------------------------------
+
 function onEventFinish(player,csid,option)
---print("CSID:",csid);
---print("OPTION:",option);
+    -- printf("CSID: %u",csid);
+    -- printf("RESULT: %u",option);
 
-    local price = 100;
+    local price = player:getLocalVar("chocoboPriceOffer");
 
-	if (csid == 0x003e and option == 0) then
+    if (csid == 0x003E and option == 0) then
         if (player:delGil(price)) then
+            updateChocoboPrice(player, price);
+
             if (player:getMainLvl() >= 20) then
-                player:addStatusEffectEx(EFFECT_CHOCOBO,EFFECT_CHOCOBO,1,0,1800,true);
+                local duration = 1800 + (player:getMod(MOD_CHOCOBO_RIDING_TIME) * 60)
+
+                player:addStatusEffectEx(EFFECT_CHOCOBO,EFFECT_CHOCOBO,1,0,duration,true);
             else
                 player:addStatusEffectEx(EFFECT_CHOCOBO,EFFECT_CHOCOBO,1,0,900,true);
             end
-            player:setPos(580,0,-305,0x40,0x6b);
-        end
-	end
 
+            player:setPos(580,0,-305,0x40,0x6B);
+        end
+    end
 end;

--- a/scripts/zones/Bastok_Mines/npcs/Quelle.lua
+++ b/scripts/zones/Bastok_Mines/npcs/Quelle.lua
@@ -1,12 +1,13 @@
 -----------------------------------
 -- Area: Bastok Mines
--- NPC: Quelle
--- Chocobo Vendor
+--  NPC: Quelle
+-- Type: Chocobo Renter
 -----------------------------------
 
-require("scripts/globals/settings");
+require("scripts/globals/chocobo");
 require("scripts/globals/keyitems");
-require("scripts/globals/quests");
+require("scripts/globals/settings");
+require("scripts/globals/status");
 
 -----------------------------------
 -- onTrade Action
@@ -15,46 +16,60 @@ require("scripts/globals/quests");
 function onTrade(player,npc,trade)
 end;
 
-
 -----------------------------------
 -- onTrigger Action
 -----------------------------------
 
 function onTrigger(player,npc)
+    local level = player:getMainLvl();
+    local gil = player:getGil();
 
-price = 100;
-gil = player:getGil();
-hasLicense = player:hasKeyItem(CHOCOBO_LICENSE);
-ChocobosWounds = player:getQuestStatus(JEUNO,CHOCOBO_S_WOUNDS);
-level = player:getMainLvl();
+    if (player:hasKeyItem(CHOCOBO_LICENSE) and level >= 15) then
+        local price = getChocoboPrice(player);
+        player:setLocalVar("chocoboPriceOffer",price);
 
-	if ((hasLicense and level >= 15) or (level >=15 and ChocobosWounds == QUEST_COMPLETED)) then
-		player:startEvent(0x003f,price,gil);
-	else
-		player:startEvent(0x0042,price,gil);
-	end
+        if (level >= 20) then
+            level = 0;
+        end
 
+        player:startEvent(0x003F,price,gil,level);
+    else
+        player:startEvent(0x0042);
+    end
 end;
 
-  
+-----------------------------------
+-- onEventUpdate
+-----------------------------------
+
+function onEventUpdate(player,csid,option)
+    -- printf("CSID: %u",csid);
+    -- printf("RESULT: %u",option);
+end;
+
 -----------------------------------
 -- onEventFinish Action
 -----------------------------------
+
 function onEventFinish(player,csid,option)
---print("CSID:",csid);
---print("OPTION:",option);
+    -- printf("CSID: %u",csid);
+    -- printf("RESULT: %u",option);
 
-    local price = 100;
+    local price = player:getLocalVar("chocoboPriceOffer");
 
-	if (csid == 0x003f and option == 0) then
+    if (csid == 0x003F and option == 0) then
         if (player:delGil(price)) then
+            updateChocoboPrice(player, price);
+
             if (player:getMainLvl() >= 20) then
-                player:addStatusEffectEx(EFFECT_CHOCOBO,EFFECT_CHOCOBO,1,0,1800,true);
+                local duration = 1800 + (player:getMod(MOD_CHOCOBO_RIDING_TIME) * 60)
+
+                player:addStatusEffectEx(EFFECT_CHOCOBO,EFFECT_CHOCOBO,1,0,duration,true);
             else
                 player:addStatusEffectEx(EFFECT_CHOCOBO,EFFECT_CHOCOBO,1,0,900,true);
             end
-            player:setPos(580,0,-305,0x40,0x6b);
-        end
-	end
 
+            player:setPos(580,0,-305,0x40,0x6B);
+        end
+    end
 end;

--- a/scripts/zones/Eastern_Altepa_Desert/npcs/Eulaclaire.lua
+++ b/scripts/zones/Eastern_Altepa_Desert/npcs/Eulaclaire.lua
@@ -1,12 +1,13 @@
 -----------------------------------
 -- Area: Eastern Altepa Desert
--- NPC: Eulaclaire
--- Chocobo Vendor
+--  NPC: Eulaclaire
+-- Type: Chocobo Renter
 -----------------------------------
 
-require("scripts/globals/settings");
+require("scripts/globals/chocobo");
 require("scripts/globals/keyitems");
-require("scripts/globals/quests");
+require("scripts/globals/settings");
+require("scripts/globals/status");
 
 -----------------------------------
 -- onTrade Action
@@ -15,45 +16,50 @@ require("scripts/globals/quests");
 function onTrade(player,npc,trade)
 end;
 
-
 -----------------------------------
 -- onTrigger Action
 -----------------------------------
 
 function onTrigger(player,npc)
+    local level = player:getMainLvl();
+    local gil = player:getGil();
 
-price = 100;
-gil = player:getGil();
-hasLicense = player:hasKeyItem(CHOCOBO_LICENSE);
-ChocobosWounds = player:getQuestStatus(JEUNO,CHOCOBO_S_WOUNDS);
-level = player:getMainLvl();
+    if (player:hasKeyItem(CHOCOBO_LICENSE) and level >= 20) then
+        local price = getChocoboPrice(player);
+        player:setLocalVar("chocoboPriceOffer",price);
 
-	if ((hasLicense and level >= 15) or (level >=15 and ChocobosWounds == QUEST_COMPLETED)) then
-		player:startEvent(0x0006,price,gil);
-	else
-		player:startEvent(0x0007,price,gil);
-	end
-
+        player:startEvent(0x0006,price,gil);
+    else
+        player:startEvent(0x0007);
+    end
 end;
 
+-----------------------------------
+-- onEventUpdate
+-----------------------------------
+
+function onEventUpdate(player,csid,option)
+    -- printf("CSID: %u",csid);
+    -- printf("RESULT: %u",option);
+end;
   
 -----------------------------------
 -- onEventFinish Action
 -----------------------------------
+
 function onEventFinish(player,csid,option)
---print("CSID:",csid);
---print("OPTION:",option);
+    -- printf("CSID: %u",csid);
+    -- printf("RESULT: %u",option);
 
-    local price = 100;
+    local price = player:getLocalVar("chocoboPriceOffer");
 
-	if (csid == 0x0006 and option == 0) then
+    if (csid == 0x0006 and option == 0) then
         if (player:delGil(price)) then
-            if (player:getMainLvl() >= 20) then
-                player:addStatusEffectEx(EFFECT_CHOCOBO,EFFECT_CHOCOBO,1,0,1800,true);
-            else
-                player:addStatusEffectEx(EFFECT_CHOCOBO,EFFECT_CHOCOBO,1,0,900,true);
-            end
-        end
-	end
+            updateChocoboPrice(player, price);
 
+            local duration = 1800 + (player:getMod(MOD_CHOCOBO_RIDING_TIME) * 60)
+
+            player:addStatusEffectEx(EFFECT_CHOCOBO,EFFECT_CHOCOBO,1,0,duration,true);
+        end
+    end
 end;

--- a/scripts/zones/Kazham/npcs/Tielleque.lua
+++ b/scripts/zones/Kazham/npcs/Tielleque.lua
@@ -1,12 +1,13 @@
 -----------------------------------
 -- Area: Kazham
--- NPC: Tielleque
--- Chocobo Vendor
+--  NPC: Tielleque
+-- Type: Chocobo Renter
 -----------------------------------
 
-require("scripts/globals/settings");
+require("scripts/globals/chocobo");
 require("scripts/globals/keyitems");
-require("scripts/globals/quests");
+require("scripts/globals/settings");
+require("scripts/globals/status");
 
 -----------------------------------
 -- onTrade Action
@@ -15,46 +16,52 @@ require("scripts/globals/quests");
 function onTrade(player,npc,trade)
 end;
 
-
 -----------------------------------
 -- onTrigger Action
 -----------------------------------
 
 function onTrigger(player,npc)
+    local level = player:getMainLvl();
+    local gil = player:getGil();
 
-price = 100;
-gil = player:getGil();
-hasLicense = player:hasKeyItem(CHOCOBO_LICENSE);
-ChocobosWounds = player:getQuestStatus(JEUNO,CHOCOBO_S_WOUNDS);
-level = player:getMainLvl();
+    if (player:hasKeyItem(CHOCOBO_LICENSE) and level >= 20) then
+        local price = getChocoboPrice(player);
+        player:setLocalVar("chocoboPriceOffer",price);
 
-	if ((hasLicense and level >= 15) or (level >=15 and ChocobosWounds == QUEST_COMPLETED)) then
-		player:startEvent(0x2720,price,gil);
-	else
-		player:startEvent(0x2721,price,gil);
-	end
-
+        player:startEvent(0x2720,price,gil);
+    else
+        player:startEvent(0x2721);
+    end
 end;
 
+-----------------------------------
+-- onEventUpdate
+-----------------------------------
+
+function onEventUpdate(player,csid,option)
+    -- printf("CSID: %u",csid);
+    -- printf("RESULT: %u",option);
+end;
   
 -----------------------------------
 -- onEventFinish Action
 -----------------------------------
+
 function onEventFinish(player,csid,option)
---print("CSID:",csid);
---print("OPTION:",option);
+    -- printf("CSID: %u",csid);
+    -- printf("RESULT: %u",option);
 
-    local price = 100;
+    local price = player:getLocalVar("chocoboPriceOffer");
 
-	if (csid == 0x2720 and option == 0) then
+    if (csid == 0x2720 and option == 0) then
         if (player:delGil(price)) then
-            if (player:getMainLvl() >= 20) then
-                player:addStatusEffectEx(EFFECT_CHOCOBO,EFFECT_CHOCOBO,1,0,1800,true);
-            else
-                player:addStatusEffectEx(EFFECT_CHOCOBO,EFFECT_CHOCOBO,1,0,900,true);
-            end
-            player:setPos(-240,0,528,0x40,0x7b);
-        end
-	end
+            updateChocoboPrice(player, price);
 
+            local duration = 1800 + (player:getMod(MOD_CHOCOBO_RIDING_TIME) * 60)
+
+            player:addStatusEffectEx(EFFECT_CHOCOBO,EFFECT_CHOCOBO,1,0,duration,true);
+
+            player:setPos(-240,0,528,0x40,0x7B);
+        end
+    end
 end;

--- a/scripts/zones/Konschtat_Highlands/npcs/Plaiaude.lua
+++ b/scripts/zones/Konschtat_Highlands/npcs/Plaiaude.lua
@@ -1,13 +1,14 @@
 -----------------------------------
 -- Area: Konschtat Highlands
--- NPC:  Plaiaude
--- Type: Chocobo Vendor
+--  NPC: Plaiaude
+-- Type: Chocobo Renter
 -- @pos 244.705 24.034 296.973 108
 -----------------------------------
 
-require("scripts/globals/settings");
+require("scripts/globals/chocobo");
 require("scripts/globals/keyitems");
-require("scripts/globals/quests");
+require("scripts/globals/settings");
+require("scripts/globals/status");
 
 -----------------------------------
 -- onTrade Action
@@ -21,40 +22,45 @@ end;
 -----------------------------------
 
 function onTrigger(player,npc)
+    local level = player:getMainLvl();
+    local gil = player:getGil();
 
-local price = 100;
-local gil = player:getGil();
-local hasLicense = player:hasKeyItem(CHOCOBO_LICENSE);
-local ChocobosWounds = player:getQuestStatus(JEUNO,CHOCOBO_S_WOUNDS);
-local level = player:getMainLvl();
+    if (player:hasKeyItem(CHOCOBO_LICENSE) and level >= 20) then
+        local price = getChocoboPrice(player);
+        player:setLocalVar("chocoboPriceOffer",price);
 
-	if ((hasLicense and level >= 15) or (level >=15 and ChocobosWounds == QUEST_COMPLETED)) then
-		player:startEvent(0x038e,price,gil);
-	else
-		player:startEvent(0x038f,price,gil);
-	end
-
+        player:startEvent(0x038E,price,gil);
+    else
+        player:startEvent(0x038F);
+    end
 end;
 
+-----------------------------------
+-- onEventUpdate
+-----------------------------------
+
+function onEventUpdate(player,csid,option)
+    -- printf("CSID: %u",csid);
+    -- printf("RESULT: %u",option);
+end;
   
 -----------------------------------
 -- onEventFinish Action
 -----------------------------------
+
 function onEventFinish(player,csid,option)
---print("CSID:",csid);
---print("OPTION:",option);
+    -- printf("CSID: %u",csid);
+    -- printf("RESULT: %u",option);
 
-	local price = 100;
-	local level = player:getMainLvl();
+    local price = player:getLocalVar("chocoboPriceOffer");
 
-	if (csid == 0x038e and option == 0) then
+    if (csid == 0x038E and option == 0) then
         if (player:delGil(price)) then
-            if (level >= 20) then
-                player:addStatusEffectEx(EFFECT_CHOCOBO,EFFECT_CHOCOBO,1,0,1800,true);
-            else
-                player:addStatusEffectEx(EFFECT_CHOCOBO,EFFECT_CHOCOBO,1,0,900,true);
-            end
-        end
-	end
+            updateChocoboPrice(player, price);
 
+            local duration = 1800 + (player:getMod(MOD_CHOCOBO_RIDING_TIME) * 60)
+
+            player:addStatusEffectEx(EFFECT_CHOCOBO,EFFECT_CHOCOBO,1,0,duration,true);
+        end
+    end
 end;

--- a/scripts/zones/La_Theine_Plateau/npcs/Coumaine.lua
+++ b/scripts/zones/La_Theine_Plateau/npcs/Coumaine.lua
@@ -1,12 +1,13 @@
 -----------------------------------
 -- Area: La Theine Plateau
--- NPC:  Coumaine
+--  NPC: Coumaine
 -- Type: Chocobo Vendor
 -----------------------------------
 
-require("scripts/globals/settings");
+require("scripts/globals/chocobo");
 require("scripts/globals/keyitems");
-require("scripts/globals/quests");
+require("scripts/globals/settings");
+require("scripts/globals/status");
 
 -----------------------------------
 -- onTrade Action
@@ -15,46 +16,50 @@ require("scripts/globals/quests");
 function onTrade(player,npc,trade)
 end;
 
-
 -----------------------------------
 -- onTrigger Action
 -----------------------------------
 
 function onTrigger(player,npc)
+    local level = player:getMainLvl();
+    local gil = player:getGil();
 
-local price = 100;
-local gil = player:getGil();
-local hasLicense = player:hasKeyItem(CHOCOBO_LICENSE);
-local ChocobosWounds = player:getQuestStatus(JEUNO,CHOCOBO_S_WOUNDS);
-local level = player:getMainLvl();
+    if (player:hasKeyItem(CHOCOBO_LICENSE) and level >= 20) then
+        local price = getChocoboPrice(player);
+        player:setLocalVar("chocoboPriceOffer",price);
 
-	if ((hasLicense and level >= 15) or (level >=15 and ChocobosWounds == QUEST_COMPLETED)) then
-		player:startEvent(0x0078,price,gil);
-	else
-		player:startEvent(0x0079,price,gil);
-	end
-
+        player:startEvent(0x0078,price,gil);
+    else
+        player:startEvent(0x0079);
+    end
 end;
 
+-----------------------------------
+-- onEventUpdate
+-----------------------------------
+
+function onEventUpdate(player,csid,option)
+    -- printf("CSID: %u",csid);
+    -- printf("RESULT: %u",option);
+end;
   
 -----------------------------------
 -- onEventFinish Action
 -----------------------------------
+
 function onEventFinish(player,csid,option)
---print("CSID:",csid);
---print("OPTION:",option);
+    -- printf("CSID: %u",csid);
+    -- printf("RESULT: %u",option);
 
-local price = 100;
-local level = player:getMainLvl();
+    local price = player:getLocalVar("chocoboPriceOffer");
 
-	if (csid == 0x0078 and option == 0) then
+    if (csid == 0x0078 and option == 0) then
         if (player:delGil(price)) then
-            if (level >= 20) then
-                player:addStatusEffectEx(EFFECT_CHOCOBO,EFFECT_CHOCOBO,1,0,1800,true);
-            else
-                player:addStatusEffectEx(EFFECT_CHOCOBO,EFFECT_CHOCOBO,1,0,900,true);
-            end
-        end
-	end
+            updateChocoboPrice(player, price);
 
+            local duration = 1800 + (player:getMod(MOD_CHOCOBO_RIDING_TIME) * 60)
+
+            player:addStatusEffectEx(EFFECT_CHOCOBO,EFFECT_CHOCOBO,1,0,duration,true);
+        end
+    end
 end;

--- a/scripts/zones/Lower_Jeuno/npcs/Audee.lua
+++ b/scripts/zones/Lower_Jeuno/npcs/Audee.lua
@@ -1,12 +1,13 @@
 -----------------------------------
 -- Area: Lower Jeuno
--- NPC: Audee
--- Chocobo Vendor
+--  NPC: Audee
+-- Type: Chocobo Renter
 -----------------------------------
 
-require("scripts/globals/settings");
+require("scripts/globals/chocobo");
 require("scripts/globals/keyitems");
-require("scripts/globals/quests");
+require("scripts/globals/settings");
+require("scripts/globals/status");
 
 -----------------------------------
 -- onTrade Action
@@ -15,47 +16,52 @@ require("scripts/globals/quests");
 function onTrade(player,npc,trade)
 end;
 
-
 -----------------------------------
 -- onTrigger Action
 -----------------------------------
 
 function onTrigger(player,npc)
+    local level = player:getMainLvl();
+    local gil = player:getGil();
 
-price = 100;
-gil = player:getGil();
-hasLicense = player:hasKeyItem(CHOCOBO_LICENSE);
-ChocobosWounds = player:getQuestStatus(JEUNO,CHOCOBO_S_WOUNDS);
-level = player:getMainLvl();
+    if (player:hasKeyItem(CHOCOBO_LICENSE) and level >= 20) then
+        local price = getChocoboPrice(player);
+        player:setLocalVar("chocoboPriceOffer",price);
 
-	if ((hasLicense and level >= 15) or (level >=15 and ChocobosWounds == QUEST_COMPLETED)) then
-		player:startEvent(0x2712,price,gil);
-	else
-		player:startEvent(0x2715,price,gil);
-	end
-
+        player:startEvent(0x2712,price,gil);
+    else
+        player:startEvent(0x2715);
+    end
 end;
 
+-----------------------------------
+-- onEventUpdate
+-----------------------------------
+
+function onEventUpdate(player,csid,option)
+    -- printf("CSID: %u",csid);
+    -- printf("RESULT: %u",option);
+end;
   
 -----------------------------------
 -- onEventFinish Action
 -----------------------------------
+
 function onEventFinish(player,csid,option)
---print("CSID:",csid);
---print("OPTION:",option);
+    -- printf("CSID: %u",csid);
+    -- printf("RESULT: %u",option);
 
-price = 100;
-level = player:getMainLvl();
+    local price = player:getLocalVar("chocoboPriceOffer");
 
-	if (csid == 0x2712 and option == 0) then
+    if (csid == 0x2712 and option == 0) then
         if (player:delGil(price)) then
-            if (level >= 20) then
-                player:addStatusEffectEx(EFFECT_CHOCOBO,EFFECT_CHOCOBO,1,0,1800,true);
-            else
-                player:addStatusEffectEx(EFFECT_CHOCOBO,EFFECT_CHOCOBO,1,0,900,true);
-            end
-            player:setPos(340,24,608,0x70,0x6e);
-        end
-	end
+            updateChocoboPrice(player, price);
 
+            local duration = 1800 + (player:getMod(MOD_CHOCOBO_RIDING_TIME) * 60)
+
+            player:addStatusEffectEx(EFFECT_CHOCOBO,EFFECT_CHOCOBO,1,0,duration,true);
+
+            player:setPos(340,24,608,0x70,0x6E);
+        end
+    end
 end;

--- a/scripts/zones/Lower_Jeuno/npcs/Fephita.lua
+++ b/scripts/zones/Lower_Jeuno/npcs/Fephita.lua
@@ -1,12 +1,13 @@
 -----------------------------------
 -- Area: Lower Jeuno
--- NPC: Fephita
--- Chocobo Vendor
+--  NPC: Fephita
+-- Type: Chocobo Renter
 -----------------------------------
 
-require("scripts/globals/settings");
+require("scripts/globals/chocobo");
 require("scripts/globals/keyitems");
-require("scripts/globals/quests");
+require("scripts/globals/settings");
+require("scripts/globals/status");
 
 -----------------------------------
 -- onTrade Action
@@ -15,46 +16,52 @@ require("scripts/globals/quests");
 function onTrade(player,npc,trade)
 end;
 
-
 -----------------------------------
 -- onTrigger Action
 -----------------------------------
 
 function onTrigger(player,npc)
+    local level = player:getMainLvl();
+    local gil = player:getGil();
 
-price = 100;
-gil = player:getGil();
-hasLicense = player:hasKeyItem(CHOCOBO_LICENSE);
-ChocobosWounds = player:getQuestStatus(JEUNO,CHOCOBO_S_WOUNDS);
-level = player:getMainLvl();
+    if (player:hasKeyItem(CHOCOBO_LICENSE) and level >= 20) then
+        local price = getChocoboPrice(player);
+        player:setLocalVar("chocoboPriceOffer",price);
 
-	if ((hasLicense and level >= 15) or (level >=15 and ChocobosWounds == QUEST_COMPLETED)) then
-		player:startEvent(0x2713,price,gil);
-	else
-		player:startEvent(0x2716,price,gil);
-	end
-
+        player:startEvent(0x2713,price,gil);
+    else
+        player:startEvent(0x2716);
+    end
 end;
 
+-----------------------------------
+-- onEventUpdate
+-----------------------------------
+
+function onEventUpdate(player,csid,option)
+    -- printf("CSID: %u",csid);
+    -- printf("RESULT: %u",option);
+end;
   
 -----------------------------------
 -- onEventFinish Action
 -----------------------------------
+
 function onEventFinish(player,csid,option)
---print("CSID:",csid);
---print("OPTION:",option);
+    -- printf("CSID: %u",csid);
+    -- printf("RESULT: %u",option);
 
-    local price = 100;
+    local price = player:getLocalVar("chocoboPriceOffer");
 
-	if (csid == 0x2713 and option == 0) then
+    if (csid == 0x2713 and option == 0) then
         if (player:delGil(price)) then
-            if (player:getMainLvl() >= 20) then
-                player:addStatusEffectEx(EFFECT_CHOCOBO,EFFECT_CHOCOBO,1,0,1800,true);
-            else
-                player:addStatusEffectEx(EFFECT_CHOCOBO,EFFECT_CHOCOBO,1,0,900,true);
-            end
-            player:setPos(340,24,608,0x70,0x6e);
-        end
-	end
+            updateChocoboPrice(player, price);
 
+            local duration = 1800 + (player:getMod(MOD_CHOCOBO_RIDING_TIME) * 60)
+
+            player:addStatusEffectEx(EFFECT_CHOCOBO,EFFECT_CHOCOBO,1,0,duration,true);
+
+            player:setPos(340,24,608,0x70,0x6E);
+        end
+    end
 end;

--- a/scripts/zones/Port_Jeuno/npcs/Caffie.lua
+++ b/scripts/zones/Port_Jeuno/npcs/Caffie.lua
@@ -1,12 +1,13 @@
 -----------------------------------
 -- Area: Port Jeuno
--- NPC: Caffie
--- Chocobo Vendor
+--  NPC: Caffie
+-- Type: Chocobo Renter
 -----------------------------------
 
-require("scripts/globals/settings");
+require("scripts/globals/chocobo");
 require("scripts/globals/keyitems");
-require("scripts/globals/quests");
+require("scripts/globals/settings");
+require("scripts/globals/status");
 
 -----------------------------------
 -- onTrade Action
@@ -15,46 +16,52 @@ require("scripts/globals/quests");
 function onTrade(player,npc,trade)
 end;
 
-
 -----------------------------------
 -- onTrigger Action
 -----------------------------------
 
 function onTrigger(player,npc)
+    local level = player:getMainLvl();
+    local gil = player:getGil();
 
-price = 100;
-gil = player:getGil();
-hasLicense = player:hasKeyItem(CHOCOBO_LICENSE);
-ChocobosWounds = player:getQuestStatus(JEUNO,CHOCOBO_S_WOUNDS);
-level = player:getMainLvl();
+    if (player:hasKeyItem(CHOCOBO_LICENSE) and level >= 20) then
+        local price = getChocoboPrice(player);
+        player:setLocalVar("chocoboPriceOffer",price);
 
-	if ((hasLicense and level >= 15) or (level >=15 and ChocobosWounds == QUEST_COMPLETED)) then
-		player:startEvent(0x2712,price,gil);
-	else
-		player:startEvent(0x2715,price,gil);
-	end
-
+        player:startEvent(0x2712,price,gil);
+    else
+        player:startEvent(0x2715);
+    end
 end;
 
+-----------------------------------
+-- onEventUpdate
+-----------------------------------
+
+function onEventUpdate(player,csid,option)
+    -- printf("CSID: %u",csid);
+    -- printf("RESULT: %u",option);
+end;
   
 -----------------------------------
 -- onEventFinish Action
 -----------------------------------
+
 function onEventFinish(player,csid,option)
---print("CSID:",csid);
---print("OPTION:",option);
+    -- printf("CSID: %u",csid);
+    -- printf("RESULT: %u",option);
 
-    local price = 100;
+    local price = player:getLocalVar("chocoboPriceOffer");
 
-	if (csid == 0x2712 and option == 0) then
+    if (csid == 0x2712 and option == 0) then
         if (player:delGil(price)) then
-            if (player:getMainLvl() >= 20) then
-                player:addStatusEffectEx(EFFECT_CHOCOBO,EFFECT_CHOCOBO,1,0,1800,true);
-            else
-                player:addStatusEffectEx(EFFECT_CHOCOBO,EFFECT_CHOCOBO,1,0,900,true);
-            end
+            updateChocoboPrice(player, price);
+
+            local duration = 1800 + (player:getMod(MOD_CHOCOBO_RIDING_TIME) * 60)
+
+            player:addStatusEffectEx(EFFECT_CHOCOBO,EFFECT_CHOCOBO,1,0,duration,true);
+
             player:setPos(-574,2,400,0,0x78);
         end
-	end
-
+    end
 end;

--- a/scripts/zones/Port_Jeuno/npcs/Narsha.lua
+++ b/scripts/zones/Port_Jeuno/npcs/Narsha.lua
@@ -1,12 +1,13 @@
 -----------------------------------
 -- Area: Port Jeuno
--- NPC: Narsha
--- Chocobo Vendor
+--  NPC: Narsha
+-- Type: Chocobo Renter
 -----------------------------------
 
-require("scripts/globals/settings");
+require("scripts/globals/chocobo");
 require("scripts/globals/keyitems");
-require("scripts/globals/quests");
+require("scripts/globals/settings");
+require("scripts/globals/status");
 
 -----------------------------------
 -- onTrade Action
@@ -15,46 +16,52 @@ require("scripts/globals/quests");
 function onTrade(player,npc,trade)
 end;
 
-
 -----------------------------------
 -- onTrigger Action
 -----------------------------------
 
 function onTrigger(player,npc)
+    local level = player:getMainLvl();
+    local gil = player:getGil();
 
-price = 100;
-gil = player:getGil();
-hasLicense = player:hasKeyItem(CHOCOBO_LICENSE);
-ChocobosWounds = player:getQuestStatus(JEUNO,CHOCOBO_S_WOUNDS);
-level = player:getMainLvl();
+    if (player:hasKeyItem(CHOCOBO_LICENSE) and level >= 20) then
+        local price = getChocoboPrice(player);
+        player:setLocalVar("chocoboPriceOffer",price);
 
-	if ((hasLicense and level >= 15) or (level >=15 and ChocobosWounds == QUEST_COMPLETED)) then
-		player:startEvent(0x2713,price,gil);
-	else
-		player:startEvent(0x2716,price,gil);
-	end
-
+        player:startEvent(0x2713,price,gil);
+    else
+        player:startEvent(0x2716);
+    end
 end;
 
+-----------------------------------
+-- onEventUpdate
+-----------------------------------
+
+function onEventUpdate(player,csid,option)
+    -- printf("CSID: %u",csid);
+    -- printf("RESULT: %u",option);
+end;
   
 -----------------------------------
 -- onEventFinish Action
 -----------------------------------
+
 function onEventFinish(player,csid,option)
---print("CSID:",csid);
---print("OPTION:",option);
+    -- printf("CSID: %u",csid);
+    -- printf("RESULT: %u",option);
 
-    local price = 100;
+    local price = player:getLocalVar("chocoboPriceOffer");
 
-	if (csid == 0x2713 and option == 0) then
+    if (csid == 0x2713 and option == 0) then
         if (player:delGil(price)) then
-            if (player:getMainLvl() >= 20) then
-                player:addStatusEffectEx(EFFECT_CHOCOBO,EFFECT_CHOCOBO,1,0,1800,true);
-            else
-                player:addStatusEffectEx(EFFECT_CHOCOBO,EFFECT_CHOCOBO,1,0,900,true);
-            end
+            updateChocoboPrice(player, price);
+
+            local duration = 1800 + (player:getMod(MOD_CHOCOBO_RIDING_TIME) * 60)
+
+            player:addStatusEffectEx(EFFECT_CHOCOBO,EFFECT_CHOCOBO,1,0,duration,true);
+
             player:setPos(-574,2,400,0,0x78);
         end
-	end
-
+    end
 end;

--- a/scripts/zones/Rabao/npcs/Guinavie.lua
+++ b/scripts/zones/Rabao/npcs/Guinavie.lua
@@ -4,9 +4,10 @@
 -- Chocobo Vendor
 -----------------------------------
 
-require("scripts/globals/settings");
+require("scripts/globals/chocobo");
 require("scripts/globals/keyitems");
-require("scripts/globals/quests");
+require("scripts/globals/settings");
+require("scripts/globals/status");
 
 -----------------------------------
 -- onTrade Action
@@ -15,46 +16,52 @@ require("scripts/globals/quests");
 function onTrade(player,npc,trade)
 end;
 
-
 -----------------------------------
 -- onTrigger Action
 -----------------------------------
 
 function onTrigger(player,npc)
+    local level = player:getMainLvl();
+    local gil = player:getGil();
 
-price = 100;
-gil = player:getGil();
-hasLicense = player:hasKeyItem(CHOCOBO_LICENSE);
-ChocobosWounds = player:getQuestStatus(JEUNO,CHOCOBO_S_WOUNDS);
-level = player:getMainLvl();
+    if (player:hasKeyItem(CHOCOBO_LICENSE) and level >= 20) then
+        local price = getChocoboPrice(player);
+        player:setLocalVar("chocoboPriceOffer",price);
 
-	if ((hasLicense and level >= 15) or (level >=15 and ChocobosWounds == QUEST_COMPLETED)) then
-		player:startEvent(0x004f,price,gil);
-	else
-		player:startEvent(0x0050,price,gil);
-	end
-
+        player:startEvent(0x004F,price,gil);
+    else
+        player:startEvent(0x0050);
+    end
 end;
 
+-----------------------------------
+-- onEventUpdate
+-----------------------------------
+
+function onEventUpdate(player,csid,option)
+    -- printf("CSID: %u",csid);
+    -- printf("RESULT: %u",option);
+end;
   
 -----------------------------------
 -- onEventFinish Action
 -----------------------------------
+
 function onEventFinish(player,csid,option)
---print("CSID:",csid);
---print("OPTION:",option);
+    -- printf("CSID: %u",csid);
+    -- printf("RESULT: %u",option);
 
-    local price = 100;
+    local price = player:getLocalVar("chocoboPriceOffer");
 
-	if (csid == 0x004f and option == 0) then
+    if (csid == 0x004F and option == 0) then
         if (player:delGil(price)) then
-            if (player:getMainLvl() >= 20) then
-                player:addStatusEffectEx(EFFECT_CHOCOBO,EFFECT_CHOCOBO,1,0,1800,true);
-            else
-                player:addStatusEffectEx(EFFECT_CHOCOBO,EFFECT_CHOCOBO,1,0,900,true);
-            end
-            player:setPos(420,8,360,0x40,0x7d);
-        end
-	end
+            updateChocoboPrice(player, price);
 
+            local duration = 1800 + (player:getMod(MOD_CHOCOBO_RIDING_TIME) * 60)
+
+            player:addStatusEffectEx(EFFECT_CHOCOBO,EFFECT_CHOCOBO,1,0,duration,true);
+
+            player:setPos(420,8,360,0x40,0x7D);
+        end
+    end
 end;

--- a/scripts/zones/Southern_San_dOria/npcs/Camereine.lua
+++ b/scripts/zones/Southern_San_dOria/npcs/Camereine.lua
@@ -1,69 +1,86 @@
 -----------------------------------
 -- Area: Southern San d'Oria
--- NPC: Camereine
--- Chocobo Vendor
--- @zone 230 
+--  NPC: Camereine
+-- Type: Chocobo Renter
 -- @pos -8 1 -100
 -----------------------------------
+package.loaded["scripts/zones/Southern_San_dOria/TextIDs"] = nil;
+-----------------------------------
 
-require("scripts/globals/settings");
+require("scripts/globals/chocobo");
 require("scripts/globals/keyitems");
-require("scripts/globals/quests");
+require("scripts/globals/settings");
+require("scripts/globals/status");
+require("scripts/zones/Southern_San_dOria/TextIDs");
 
 -----------------------------------
 -- onTrade Action
 -----------------------------------
 
 function onTrade(player,npc,trade)
-	if (FlyerForRegine == 1) then
-		count = trade:getItemCount();
-		MagicFlyer = trade:hasItemQty(532,1);
-		if (MagicFlyer == true and count == 1) then
-			player:messageSpecial(FLYER_REFUSED);
-		end
-	end
+    if (FlyerForRegine == 1) then
+        count = trade:getItemCount();
+        MagicFlyer = trade:hasItemQty(532,1);
+        if (MagicFlyer == true and count == 1) then
+            player:messageSpecial(FLYER_REFUSED);
+        end
+    end
 end;
-
 
 -----------------------------------
 -- onTrigger Action
 -----------------------------------
 
 function onTrigger(player,npc)
+    local level = player:getMainLvl();
+    local gil = player:getGil();
 
-price = 100;
-gil = player:getGil();
-hasLicense = player:hasKeyItem(CHOCOBO_LICENSE);
-ChocobosWounds = player:getQuestStatus(JEUNO,CHOCOBO_S_WOUNDS);
-level = player:getMainLvl();
+    if (player:hasKeyItem(CHOCOBO_LICENSE) and level >= 15) then
+        local price = getChocoboPrice(player);
+        player:setLocalVar("chocoboPriceOffer",price);
 
-	if ((hasLicense and level >= 15) or (level >=15 and ChocobosWounds == QUEST_COMPLETED)) then
-		player:startEvent(0x0257,price,gil);
-	else
-		player:startEvent(0x025a,price,gil);
-	end
+        if (level >= 20) then
+            level = 0;
+        end
 
+        player:startEvent(0x0257,price,gil,level);
+    else
+        player:startEvent(0x025A);
+    end
 end;
 
-  
+-----------------------------------
+-- onEventUpdate
+-----------------------------------
+
+function onEventUpdate(player,csid,option)
+    -- printf("CSID: %u",csid);
+    -- printf("RESULT: %u",option);
+end;
+
 -----------------------------------
 -- onEventFinish Action
 -----------------------------------
+
 function onEventFinish(player,csid,option)
---print("CSID:",csid);
---print("OPTION:",option);
+    -- printf("CSID: %u",csid);
+    -- printf("RESULT: %u",option);
 
-    local price = 100;
+    local price = player:getLocalVar("chocoboPriceOffer");
 
-	if (csid == 0x0257 and option == 0) then
+    if (csid == 0x0257 and option == 0) then
         if (player:delGil(price)) then
+            updateChocoboPrice(player, price);
+
             if (player:getMainLvl() >= 20) then
-                player:addStatusEffectEx(EFFECT_CHOCOBO,EFFECT_CHOCOBO,1,0,1800,true);
+                local duration = 1800 + (player:getMod(MOD_CHOCOBO_RIDING_TIME) * 60)
+
+                player:addStatusEffectEx(EFFECT_CHOCOBO,EFFECT_CHOCOBO,1,0,duration,true);
             else
                 player:addStatusEffectEx(EFFECT_CHOCOBO,EFFECT_CHOCOBO,1,0,900,true);
             end
+
             player:setPos(-126,-62,274,0x65,0x64);
         end
-	end
-
+    end
 end;

--- a/scripts/zones/Southern_San_dOria/npcs/Emoussine.lua
+++ b/scripts/zones/Southern_San_dOria/npcs/Emoussine.lua
@@ -1,70 +1,86 @@
 -----------------------------------
 -- Area: Southern San d'Oria
--- NPC: Emoussine
--- Chocobo Vendor
--- zone 230
+--  NPC: Emoussine
+-- Type: Chocobo Renter
 -- @pos -11 1 -100
 -----------------------------------
+package.loaded["scripts/zones/Southern_San_dOria/TextIDs"] = nil;
+-----------------------------------
 
-require("scripts/globals/settings");
+require("scripts/globals/chocobo");
 require("scripts/globals/keyitems");
-require("scripts/globals/quests");
+require("scripts/globals/settings");
+require("scripts/globals/status");
+require("scripts/zones/Southern_San_dOria/TextIDs");
 
 -----------------------------------
 -- onTrade Action
 -----------------------------------
 
 function onTrade(player,npc,trade)
-	if (FlyerForRegine == 1) then
-		count = trade:getItemCount();
-		MagicFlyer = trade:hasItemQty(532,1);
-		if (MagicFlyer == true and count == 1) then
-			player:messageSpecial(FLYER_REFUSED);
-		end
-	end
-	
+    if (FlyerForRegine == 1) then
+        count = trade:getItemCount();
+        MagicFlyer = trade:hasItemQty(532,1);
+        if (MagicFlyer == true and count == 1) then
+            player:messageSpecial(FLYER_REFUSED);
+        end
+    end
 end;
-
 
 -----------------------------------
 -- onTrigger Action
 -----------------------------------
 
 function onTrigger(player,npc)
+    local level = player:getMainLvl();
+    local gil = player:getGil();
 
-price = 100;
-gil = player:getGil();
-hasLicense = player:hasKeyItem(CHOCOBO_LICENSE);
-ChocobosWounds = player:getQuestStatus(JEUNO,CHOCOBO_S_WOUNDS);
-level = player:getMainLvl();
+    if (player:hasKeyItem(CHOCOBO_LICENSE) and level >= 15) then
+        local price = getChocoboPrice(player);
+        player:setLocalVar("chocoboPriceOffer",price);
 
-	if ((hasLicense and level >= 15) or (level >=15 and ChocobosWounds == QUEST_COMPLETED)) then
-		player:startEvent(0x0258,price,gil);
-	else
-		player:startEvent(0x025b,price,gil);
-	end
+        if (level >= 20) then
+            level = 0;
+        end
 
+        player:startEvent(0x0258,price,gil,level);
+    else
+        player:startEvent(0x025B);
+    end
 end;
 
-  
+-----------------------------------
+-- onEventUpdate
+-----------------------------------
+
+function onEventUpdate(player,csid,option)
+    -- printf("CSID: %u",csid);
+    -- printf("RESULT: %u",option);
+end;
+
 -----------------------------------
 -- onEventFinish Action
 -----------------------------------
+
 function onEventFinish(player,csid,option)
---print("CSID:",csid);
---print("OPTION:",option);
+    -- printf("CSID: %u",csid);
+    -- printf("RESULT: %u",option);
 
-    local price = 100;
+    local price = player:getLocalVar("chocoboPriceOffer");
 
-	if (csid == 0x0258 and option == 0) then
+    if (csid == 0x0258 and option == 0) then
         if (player:delGil(price)) then
+            updateChocoboPrice(player, price);
+
             if (player:getMainLvl() >= 20) then
-                player:addStatusEffectEx(EFFECT_CHOCOBO,EFFECT_CHOCOBO,1,0,1800,true);
+                local duration = 1800 + (player:getMod(MOD_CHOCOBO_RIDING_TIME) * 60)
+
+                player:addStatusEffectEx(EFFECT_CHOCOBO,EFFECT_CHOCOBO,1,0,duration,true);
             else
                 player:addStatusEffectEx(EFFECT_CHOCOBO,EFFECT_CHOCOBO,1,0,900,true);
             end
+
             player:setPos(-126,-62,274,0x65,0x64);
         end
-	end
-
+    end
 end;

--- a/scripts/zones/Tahrongi_Canyon/npcs/Pucotte.lua
+++ b/scripts/zones/Tahrongi_Canyon/npcs/Pucotte.lua
@@ -1,13 +1,14 @@
 -----------------------------------
 -- Area: Tahrongi Canyon
--- NPC:  Pucotte
--- Type: Chocobo Vendor
+--  NPC: Pucotte
+-- Type: Chocobo Renter
 -- @pos 101.591 39.999 360.898 117
 -----------------------------------
 
-require("scripts/globals/settings");
+require("scripts/globals/chocobo");
 require("scripts/globals/keyitems");
-require("scripts/globals/quests");
+require("scripts/globals/settings");
+require("scripts/globals/status");
 
 -----------------------------------
 -- onTrade Action
@@ -21,38 +22,45 @@ end;
 -----------------------------------
 
 function onTrigger(player,npc)
+    local level = player:getMainLvl();
+    local gil = player:getGil();
 
-price = 100;
-gil = player:getGil();
-hasLicense = player:hasKeyItem(CHOCOBO_LICENSE);
-ChocobosWounds = player:getQuestStatus(JEUNO,CHOCOBO_S_WOUNDS);
-level = player:getMainLvl();
+    if (player:hasKeyItem(CHOCOBO_LICENSE) and level >= 20) then
+        local price = getChocoboPrice(player);
+        player:setLocalVar("chocoboPriceOffer",price);
 
-	if ((hasLicense and level >= 15) or (level >=15 and ChocobosWounds == QUEST_COMPLETED)) then
-		player:startEvent(0x038e,price,gil);
-	else
-		player:startEvent(0x038f,price,gil);
-	end
-
+        player:startEvent(0x038E,price,gil);
+    else
+        player:startEvent(0x038F);
+    end
 end;
 
 -----------------------------------
+-- onEventUpdate
+-----------------------------------
+
+function onEventUpdate(player,csid,option)
+    -- printf("CSID: %u",csid);
+    -- printf("RESULT: %u",option);
+end;
+  
+-----------------------------------
 -- onEventFinish Action
 -----------------------------------
+
 function onEventFinish(player,csid,option)
---print("CSID:",csid);
---print("OPTION:",option);
+    -- printf("CSID: %u",csid);
+    -- printf("RESULT: %u",option);
 
-    local price = 100;
+    local price = player:getLocalVar("chocoboPriceOffer");
 
-	if (csid == 0x038e and option == 0) then
+    if (csid == 0x038E and option == 0) then
         if (player:delGil(price)) then
-            if (player:getMainLvl() >= 20) then
-                player:addStatusEffectEx(EFFECT_CHOCOBO,EFFECT_CHOCOBO,1,0,1800,true);
-            else
-                player:addStatusEffectEx(EFFECT_CHOCOBO,EFFECT_CHOCOBO,1,0,900,true);
-            end
-        end
-	end
+            updateChocoboPrice(player, price);
 
+            local duration = 1800 + (player:getMod(MOD_CHOCOBO_RIDING_TIME) * 60)
+
+            player:addStatusEffectEx(EFFECT_CHOCOBO,EFFECT_CHOCOBO,1,0,duration,true);
+        end
+    end
 end;

--- a/scripts/zones/Upper_Jeuno/npcs/Couvoullie.lua
+++ b/scripts/zones/Upper_Jeuno/npcs/Couvoullie.lua
@@ -1,12 +1,13 @@
 -----------------------------------
 -- Area: Upper Jeuno
--- NPC: Couvoullie
--- Chocobo Vendor
+--  NPC: Couvoullie
+-- Type: Chocobo Renter
 -----------------------------------
 
-require("scripts/globals/settings");
+require("scripts/globals/chocobo");
 require("scripts/globals/keyitems");
-require("scripts/globals/quests");
+require("scripts/globals/settings");
+require("scripts/globals/status");
 
 -----------------------------------
 -- onTrade Action
@@ -15,46 +16,52 @@ require("scripts/globals/quests");
 function onTrade(player,npc,trade)
 end;
 
-
 -----------------------------------
 -- onTrigger Action
 -----------------------------------
 
 function onTrigger(player,npc)
+    local level = player:getMainLvl();
+    local gil = player:getGil();
 
-price = 100;
-gil = player:getGil();
-hasLicense = player:hasKeyItem(CHOCOBO_LICENSE);
-ChocobosWounds = player:getQuestStatus(JEUNO,CHOCOBO_S_WOUNDS);
-level = player:getMainLvl();
+    if (player:hasKeyItem(CHOCOBO_LICENSE) and level >= 20) then
+        local price = getChocoboPrice(player);
+        player:setLocalVar("chocoboPriceOffer",price);
 
-	if ((hasLicense and level >= 15) or (level >=15 and ChocobosWounds == QUEST_COMPLETED)) then
-		player:startEvent(0x2713,price,gil);
-	else
-		player:startEvent(0x2716,price,gil);
-	end
-
+        player:startEvent(0x2713,price,gil);
+    else
+        player:startEvent(0x2716);
+    end
 end;
 
+-----------------------------------
+-- onEventUpdate
+-----------------------------------
+
+function onEventUpdate(player,csid,option)
+    -- printf("CSID: %u",csid);
+    -- printf("RESULT: %u",option);
+end;
   
 -----------------------------------
 -- onEventFinish Action
 -----------------------------------
+
 function onEventFinish(player,csid,option)
---print("CSID:",csid);
---print("OPTION:",option);
+    -- printf("CSID: %u",csid);
+    -- printf("RESULT: %u",option);
 
-    local price = 100;
+    local price = player:getLocalVar("chocoboPriceOffer");
 
-	if (csid == 0x2713 and option == 0) then
+    if (csid == 0x2713 and option == 0) then
         if (player:delGil(price)) then
-            if (player:getMainLvl() >= 20) then
-                player:addStatusEffectEx(EFFECT_CHOCOBO,EFFECT_CHOCOBO,1,0,1800,true);
-            else
-                player:addStatusEffectEx(EFFECT_CHOCOBO,EFFECT_CHOCOBO,1,0,900,true);
-            end
+            updateChocoboPrice(player, price);
+
+            local duration = 1800 + (player:getMod(MOD_CHOCOBO_RIDING_TIME) * 60)
+
+            player:addStatusEffectEx(EFFECT_CHOCOBO,EFFECT_CHOCOBO,1,0,duration,true);
+
             player:setPos(486,8,-160,0x80,0x69);
         end
-	end
-
+    end
 end;

--- a/scripts/zones/Upper_Jeuno/npcs/Mairee.lua
+++ b/scripts/zones/Upper_Jeuno/npcs/Mairee.lua
@@ -1,12 +1,13 @@
 -----------------------------------
 -- Area: Upper Jeuno
--- NPC: Mairee
--- Chocobo Vendor
+--  NPC: Mairee
+-- Type: Chocobo Renter
 -----------------------------------
 
-require("scripts/globals/settings");
+require("scripts/globals/chocobo");
 require("scripts/globals/keyitems");
-require("scripts/globals/quests");
+require("scripts/globals/settings");
+require("scripts/globals/status");
 
 -----------------------------------
 -- onTrade Action
@@ -15,46 +16,52 @@ require("scripts/globals/quests");
 function onTrade(player,npc,trade)
 end;
 
-
 -----------------------------------
 -- onTrigger Action
 -----------------------------------
 
 function onTrigger(player,npc)
+    local level = player:getMainLvl();
+    local gil = player:getGil();
 
-price = 100;
-gil = player:getGil();
-hasLicense = player:hasKeyItem(CHOCOBO_LICENSE);
-ChocobosWounds = player:getQuestStatus(JEUNO,CHOCOBO_S_WOUNDS);
-level = player:getMainLvl();
+    if (player:hasKeyItem(CHOCOBO_LICENSE) and level >= 20) then
+        local price = getChocoboPrice(player);
+        player:setLocalVar("chocoboPriceOffer",price);
 
-	if ((hasLicense and level >= 15) or (level >=15 and ChocobosWounds == QUEST_COMPLETED)) then
-		player:startEvent(0x2712,price,gil);
-	else
-		player:startEvent(0x2715,price,gil);
-	end
-
+        player:startEvent(0x2712,price,gil);
+    else
+        player:startEvent(0x2715);
+    end
 end;
 
+-----------------------------------
+-- onEventUpdate
+-----------------------------------
+
+function onEventUpdate(player,csid,option)
+    -- printf("CSID: %u",csid);
+    -- printf("RESULT: %u",option);
+end;
   
 -----------------------------------
 -- onEventFinish Action
 -----------------------------------
+
 function onEventFinish(player,csid,option)
---print("CSID:",csid);
---print("OPTION:",option);
+    -- printf("CSID: %u",csid);
+    -- printf("RESULT: %u",option);
 
-    local price = 100;
+    local price = player:getLocalVar("chocoboPriceOffer");
 
-	if (csid == 0x2712 and option == 0) then
+    if (csid == 0x2712 and option == 0) then
         if (player:delGil(price)) then
-            if (player:getMainLvl() >= 20) then
-                player:addStatusEffectEx(EFFECT_CHOCOBO,EFFECT_CHOCOBO,1,0,1800,true);
-            else
-                player:addStatusEffectEx(EFFECT_CHOCOBO,EFFECT_CHOCOBO,1,0,900,true);
-            end
+            updateChocoboPrice(player, price);
+
+            local duration = 1800 + (player:getMod(MOD_CHOCOBO_RIDING_TIME) * 60)
+
+            player:addStatusEffectEx(EFFECT_CHOCOBO,EFFECT_CHOCOBO,1,0,duration,true);
+
             player:setPos(486,8,-160,0x80,0x69);
         end
-	end
-
+    end
 end;

--- a/scripts/zones/Wajaom_Woodlands/npcs/Watisa.lua
+++ b/scripts/zones/Wajaom_Woodlands/npcs/Watisa.lua
@@ -1,6 +1,6 @@
 -----------------------------------
 --  Area: Wajaom Woodlands
---  NPC:  Watisa
+--   NPC: Watisa
 --  Type: Chocobo Renter
 --  @pos -201 -11 93 51
 -----------------------------------
@@ -20,16 +20,17 @@ end;
 -----------------------------------
 
 function onTrigger(player,npc)
-	
-	price = 100;
-	gil = player:getGil();
+    local level = player:getMainLvl();
+    local gil = player:getGil();
 
-	if(player:hasKeyItem(CHOCOBO_LICENSE) and player:getMainLvl() >= 20) then
-		player:startEvent(0x0009,price,gil);
-	else
-		player:startEvent(0x000a,price,gil);
-	end
-	
+    if (player:hasKeyItem(CHOCOBO_LICENSE) and level >= 20) then
+        local price = getChocoboPrice(player);
+        player:setLocalVar("chocoboPriceOffer",price);
+
+        player:startEvent(0x0009,price,gil);
+    else
+        player:startEvent(0x000a);
+    end
 end;
 
 -----------------------------------
@@ -37,28 +38,27 @@ end;
 -----------------------------------
 
 function onEventUpdate(player,csid,option)
--- printf("CSID: %u",csid);
--- printf("RESULT: %u",option);
+    -- printf("CSID: %u",csid);
+    -- printf("RESULT: %u",option);
 end;
-
+  
 -----------------------------------
--- onEventFinish
+-- onEventFinish Action
 -----------------------------------
 
 function onEventFinish(player,csid,option)
--- printf("CSID: %u",csid);
--- printf("RESULT: %u",option);
+    -- printf("CSID: %u",csid);
+    -- printf("RESULT: %u",option);
 
-    local price = 100;
+    local price = player:getLocalVar("chocoboPriceOffer");
 
-	if(csid == 0x0009 and option == 0) then
+    if(csid == 0x0009 and option == 0) then
         if (player:delGil(price)) then
-            if (player:getMainLvl() >= 20) then
-                player:addStatusEffectEx(EFFECT_CHOCOBO,EFFECT_CHOCOBO,1,0,1800,true);
-            else
-                player:addStatusEffectEx(EFFECT_CHOCOBO,EFFECT_CHOCOBO,1,0,900,true);
-            end
+            updateChocoboPrice(player, price);
+
+            local duration = 1800 + (player:getMod(MOD_CHOCOBO_RIDING_TIME) * 60)
+
+            player:addStatusEffectEx(EFFECT_CHOCOBO,EFFECT_CHOCOBO,1,0,duration,true);
         end
-	end
-	
+    end
 end;

--- a/scripts/zones/Windurst_Woods/npcs/Amimi.lua
+++ b/scripts/zones/Windurst_Woods/npcs/Amimi.lua
@@ -1,13 +1,13 @@
 -----------------------------------
 -- Area: Windurst Woods
--- NPC: Amimi
--- Chocobo Vendor
+--  NPC: Amimi
+-- Type: Chocobo Renter
 -----------------------------------
 
-require("scripts/globals/settings");
+require("scripts/globals/chocobo");
 require("scripts/globals/keyitems");
+require("scripts/globals/settings");
 require("scripts/globals/status");
-require("scripts/globals/quests");
 
 -----------------------------------
 -- onTrade Action
@@ -16,46 +16,60 @@ require("scripts/globals/quests");
 function onTrade(player,npc,trade)
 end;
 
-
 -----------------------------------
 -- onTrigger Action
 -----------------------------------
 
 function onTrigger(player,npc)
+    local level = player:getMainLvl();
+    local gil = player:getGil();
 
-price = 100;
-gil = player:getGil();
-hasLicense = player:hasKeyItem(CHOCOBO_LICENSE);
-ChocobosWounds = player:getQuestStatus(JEUNO,CHOCOBO_S_WOUNDS);
-level = player:getMainLvl();
+    if (player:hasKeyItem(CHOCOBO_LICENSE) and level >= 15) then
+        local price = getChocoboPrice(player);
+        player:setLocalVar("chocoboPriceOffer",price);
 
-	if ((hasLicense and level >= 15) or (level >=15 and ChocobosWounds == QUEST_COMPLETED)) then
-		player:startEvent(0x2714,price,gil);
-	else
-		player:startEvent(0x2717,price,gil);
-	end
+        if (level >= 20) then
+            level = 0;
+        end
 
+        player:startEvent(0x2714,price,gil,level);
+    else
+        player:startEvent(0x2717);
+    end
 end;
 
-  
+-----------------------------------
+-- onEventUpdate
+-----------------------------------
+
+function onEventUpdate(player,csid,option)
+    -- printf("CSID: %u",csid);
+    -- printf("RESULT: %u",option);
+end;
+
 -----------------------------------
 -- onEventFinish Action
 -----------------------------------
-function onEventFinish(player,csid,option)
---print("CSID:",csid);
---print("OPTION:",option);
 
-    local price = 100;
+function onEventFinish(player,csid,option)
+    -- printf("CSID: %u",csid);
+    -- printf("RESULT: %u",option);
+
+    local price = player:getLocalVar("chocoboPriceOffer");
 
 	if (csid == 0x2714 and option == 0) then
         if (player:delGil(price)) then
+            updateChocoboPrice(player, price);
+
             if (player:getMainLvl() >= 20) then
-                player:addStatusEffectEx(EFFECT_CHOCOBO,EFFECT_CHOCOBO,1,0,1800,true);
+                local duration = 1800 + (player:getMod(MOD_CHOCOBO_RIDING_TIME) * 60)
+
+                player:addStatusEffectEx(EFFECT_CHOCOBO,EFFECT_CHOCOBO,1,0,duration,true);
             else
                 player:addStatusEffectEx(EFFECT_CHOCOBO,EFFECT_CHOCOBO,1,0,900,true);
             end
+
             player:setPos(-122,-4,-520,0,0x74);
         end
-	end
-
+    end
 end;

--- a/scripts/zones/Windurst_Woods/npcs/Orlaine.lua
+++ b/scripts/zones/Windurst_Woods/npcs/Orlaine.lua
@@ -4,9 +4,10 @@
 -- Chocobo Vendor
 -----------------------------------
 
-require("scripts/globals/settings");
+require("scripts/globals/chocobo");
 require("scripts/globals/keyitems");
-require("scripts/globals/quests");
+require("scripts/globals/settings");
+require("scripts/globals/status");
 
 -----------------------------------
 -- onTrade Action
@@ -15,46 +16,60 @@ require("scripts/globals/quests");
 function onTrade(player,npc,trade)
 end;
 
-
 -----------------------------------
 -- onTrigger Action
 -----------------------------------
 
 function onTrigger(player,npc)
+    local level = player:getMainLvl();
+    local gil = player:getGil();
 
-price = 100;
-gil = player:getGil();
-hasLicense = player:hasKeyItem(CHOCOBO_LICENSE);
-ChocobosWounds = player:getQuestStatus(JEUNO,CHOCOBO_S_WOUNDS);
-level = player:getMainLvl();
+    if (player:hasKeyItem(CHOCOBO_LICENSE) and level >= 15) then
+        local price = getChocoboPrice(player);
+        player:setLocalVar("chocoboPriceOffer",price);
 
-	if ((hasLicense and level >= 15) or (level >=15 and ChocobosWounds == QUEST_COMPLETED)) then
-		player:startEvent(0x2712,price,gil);
-	else
-		player:startEvent(0x2715,price,gil);
-	end
+        if (level >= 20) then
+            level = 0;
+        end
 
+        player:startEvent(0x2712,price,gil,level);
+    else
+        player:startEvent(0x2715);
+    end
 end;
 
-  
+-----------------------------------
+-- onEventUpdate
+-----------------------------------
+
+function onEventUpdate(player,csid,option)
+    -- printf("CSID: %u",csid);
+    -- printf("RESULT: %u",option);
+end;
+
 -----------------------------------
 -- onEventFinish Action
 -----------------------------------
+
 function onEventFinish(player,csid,option)
---print("CSID:",csid);
---print("OPTION:",option);
+    -- printf("CSID: %u",csid);
+    -- printf("RESULT: %u",option);
 
-    local price = 100;
+    local price = player:getLocalVar("chocoboPriceOffer");
 
-	if (csid == 0x2712 and option == 0) then
+    if (csid == 0x2712 and option == 0) then
         if (player:delGil(price)) then
+            updateChocoboPrice(player, price);
+
             if (player:getMainLvl() >= 20) then
-                player:addStatusEffectEx(EFFECT_CHOCOBO,EFFECT_CHOCOBO,1,0,1800,true);
+                local duration = 1800 + (player:getMod(MOD_CHOCOBO_RIDING_TIME) * 60)
+
+                player:addStatusEffectEx(EFFECT_CHOCOBO,EFFECT_CHOCOBO,1,0,duration,true);
             else
                 player:addStatusEffectEx(EFFECT_CHOCOBO,EFFECT_CHOCOBO,1,0,900,true);
             end
+
             player:setPos(-122,-4,-520,0,0x74);
         end
-	end
-
+    end
 end;

--- a/scripts/zones/Windurst_Woods/npcs/Sariale.lua
+++ b/scripts/zones/Windurst_Woods/npcs/Sariale.lua
@@ -1,12 +1,13 @@
 -----------------------------------
 -- Area: Windurst Woods
--- NPC: Sariale
--- Chocobo Vendor
+--  NPC: Sariale
+-- Type: Chocobo Renter
 -----------------------------------
 
-require("scripts/globals/settings");
+require("scripts/globals/chocobo");
 require("scripts/globals/keyitems");
-require("scripts/globals/quests");
+require("scripts/globals/settings");
+require("scripts/globals/status");
 
 -----------------------------------
 -- onTrade Action
@@ -15,46 +16,60 @@ require("scripts/globals/quests");
 function onTrade(player,npc,trade)
 end;
 
-
 -----------------------------------
 -- onTrigger Action
 -----------------------------------
 
 function onTrigger(player,npc)
+    local level = player:getMainLvl();
+    local gil = player:getGil();
 
-price = 100;
-gil = player:getGil();
-hasLicense = player:hasKeyItem(CHOCOBO_LICENSE);
-ChocobosWounds = player:getQuestStatus(JEUNO,CHOCOBO_S_WOUNDS);
-level = player:getMainLvl();
+    if (player:hasKeyItem(CHOCOBO_LICENSE) and level >= 15) then
+        local price = getChocoboPrice(player);
+        player:setLocalVar("chocoboPriceOffer",price);
 
-	if ((hasLicense and level >= 15) or (level >=15 and ChocobosWounds == QUEST_COMPLETED)) then
-		player:startEvent(0x2713,price,gil);
-	else
-		player:startEvent(0x2716,price,gil);
-	end
+        if (level >= 20) then
+            level = 0;
+        end
 
+        player:startEvent(0x2713,price,gil);
+    else
+        player:startEvent(0x2716);
+    end
 end;
 
-  
+-----------------------------------
+-- onEventUpdate
+-----------------------------------
+
+function onEventUpdate(player,csid,option)
+    -- printf("CSID: %u",csid);
+    -- printf("RESULT: %u",option);
+end;
+
 -----------------------------------
 -- onEventFinish Action
 -----------------------------------
+
 function onEventFinish(player,csid,option)
---print("CSID:",csid);
---print("OPTION:",option);
+    -- printf("CSID: %u",csid);
+    -- printf("RESULT: %u",option);
 
-    local price = 100;
+    local price = player:getLocalVar("chocoboPriceOffer");
 
-	if (csid == 0x2713 and option == 0) then
+    if (csid == 0x2713 and option == 0) then
         if (player:delGil(price)) then
+            updateChocoboPrice(player, price);
+
             if (player:getMainLvl() >= 20) then
-                player:addStatusEffectEx(EFFECT_CHOCOBO,EFFECT_CHOCOBO,1,0,1800,true);
+                local duration = 1800 + (player:getMod(MOD_CHOCOBO_RIDING_TIME) * 60)
+
+                player:addStatusEffectEx(EFFECT_CHOCOBO,EFFECT_CHOCOBO,1,0,duration,true);
             else
                 player:addStatusEffectEx(EFFECT_CHOCOBO,EFFECT_CHOCOBO,1,0,900,true);
             end
+
             player:setPos(-122,-4,-520,0,0x74);
         end
-	end
-
+    end
 end;

--- a/scripts/zones/Yhoator_Jungle/npcs/Paurelde.lua
+++ b/scripts/zones/Yhoator_Jungle/npcs/Paurelde.lua
@@ -1,12 +1,13 @@
 -----------------------------------
 -- Area: Yhoator Jungle
--- NPC: Paurelde
--- Chocobo Vendor
+--  NPC: Paurelde
+-- Type: Chocobo Renter
 -----------------------------------
 
-require("scripts/globals/settings");
+require("scripts/globals/chocobo");
 require("scripts/globals/keyitems");
-require("scripts/globals/quests");
+require("scripts/globals/settings");
+require("scripts/globals/status");
 
 -----------------------------------
 -- onTrade Action
@@ -15,45 +16,50 @@ require("scripts/globals/quests");
 function onTrade(player,npc,trade)
 end;
 
-
 -----------------------------------
 -- onTrigger Action
 -----------------------------------
 
 function onTrigger(player,npc)
+    local level = player:getMainLvl();
+    local gil = player:getGil();
 
-local price = 100;
-local gil = player:getGil();
-local hasLicense = player:hasKeyItem(CHOCOBO_LICENSE);
-local ChocobosWounds = player:getQuestStatus(JEUNO,CHOCOBO_S_WOUNDS);
-local level = player:getMainLvl();
+    if (player:hasKeyItem(CHOCOBO_LICENSE) and level >= 20) then
+        local price = getChocoboPrice(player);
+        player:setLocalVar("chocoboPriceOffer",price);
 
-	if ((hasLicense and level >= 15) or (level >=15 and ChocobosWounds == QUEST_COMPLETED)) then
-		player:startEvent(0x000c,price,gil);
-	else
-		player:startEvent(0x000d,price,gil);
-	end
-
+        player:startEvent(0x000C,price,gil);
+    else
+        player:startEvent(0x000D);
+    end
 end;
 
+-----------------------------------
+-- onEventUpdate
+-----------------------------------
+
+function onEventUpdate(player,csid,option)
+    -- printf("CSID: %u",csid);
+    -- printf("RESULT: %u",option);
+end;
   
 -----------------------------------
 -- onEventFinish Action
 -----------------------------------
+
 function onEventFinish(player,csid,option)
---print("CSID:",csid);
---print("OPTION:",option);
+    -- printf("CSID: %u",csid);
+    -- printf("RESULT: %u",option);
 
-    local price = 100;
+    local price = player:getLocalVar("chocoboPriceOffer");
 
-	if (csid == 0x000c and option == 0) then
+    if (csid == 0x000C and option == 0) then
         if (player:delGil(price)) then
-            if (player:getMainLvl() >= 20) then
-                player:addStatusEffectEx(EFFECT_CHOCOBO,EFFECT_CHOCOBO,1,0,1800,true);
-            else
-                player:addStatusEffectEx(EFFECT_CHOCOBO,EFFECT_CHOCOBO,1,0,900,true);
-            end
-        end
-	end
+            updateChocoboPrice(player, price);
 
+            local duration = 1800 + (player:getMod(MOD_CHOCOBO_RIDING_TIME) * 60)
+
+            player:addStatusEffectEx(EFFECT_CHOCOBO,EFFECT_CHOCOBO,1,0,duration,true);
+        end
+    end
 end;

--- a/sql/item_mods.sql
+++ b/sql/item_mods.sql
@@ -1439,6 +1439,11 @@ INSERT INTO `item_mods` VALUES (10921, 1, 8); -- DEF:8
 -- -------------------------------------------------------
 INSERT INTO `item_mods` VALUES (10922, 1, 9); -- DEF:9
 
+-- -------------------------------------------------------
+-- Chocobo Torque
+-- -------------------------------------------------------
+INSERT INTO `item_mods` VALUES (10924, 509, 4); -- Chocobo riding time +4 min
+
 INSERT INTO `item_mods` VALUES (10929, 1, 10);
 INSERT INTO `item_mods` VALUES (10929, 10, 9);
 INSERT INTO `item_mods` VALUES (10929, 246, 2); -- TODO: Confirm Amount
@@ -2198,7 +2203,13 @@ INSERT INTO `item_mods` VALUES (11316, 1, 1);
 INSERT INTO `item_mods` VALUES (11317, 1, 1);
 INSERT INTO `item_mods` VALUES (11318, 1, 2);
 INSERT INTO `item_mods` VALUES (11319, 1, 2);
-INSERT INTO `item_mods` VALUES (11321, 1, 2);
+
+-- -------------------------------------------------------
+-- Orange Racing Silks
+-- -------------------------------------------------------
+INSERT INTO `item_mods` VALUES (11321, 1, 2); -- DEF+2
+INSERT INTO `item_mods` VALUES (11321, 509, 10); -- Chocobo riding time +10 min
+
 INSERT INTO `item_mods` VALUES (11322, 1, 2);
 INSERT INTO `item_mods` VALUES (11323, 1, 2);
 INSERT INTO `item_mods` VALUES (11324, 1, 2);
@@ -8750,8 +8761,19 @@ INSERT INTO `item_mods` VALUES (13808, 1, 2);
 INSERT INTO `item_mods` VALUES (13808, 127, 1);
 INSERT INTO `item_mods` VALUES (13809, 1, 12);
 INSERT INTO `item_mods` VALUES (13809, 127, 1);
-INSERT INTO `item_mods` VALUES (13810, 1, 2);
-INSERT INTO `item_mods` VALUES (13811, 1, 12);
+
+-- -------------------------------------------------------
+-- Chocobo Jack Coat
+-- -------------------------------------------------------
+INSERT INTO `item_mods` VALUES (13810, 1, 2); -- DEF+2
+INSERT INTO `item_mods` VALUES (13810, 509, 5); -- Chocobo riding time +5 min
+
+-- -------------------------------------------------------
+-- Rider's Jack Coat 
+-- -------------------------------------------------------
+INSERT INTO `item_mods` VALUES (13811, 1, 12); -- DEF+12
+INSERT INTO `item_mods` VALUES (13811, 509, 5); -- Chocobo riding time +5 min
+
 INSERT INTO `item_mods` VALUES (13812, 1, 45);
 INSERT INTO `item_mods` VALUES (13813, 1, 50);
 INSERT INTO `item_mods` VALUES (13814, 1, 29);
@@ -9618,8 +9640,19 @@ INSERT INTO `item_mods` VALUES (14070, 1, 1);
 INSERT INTO `item_mods` VALUES (14070, 127, 1);
 INSERT INTO `item_mods` VALUES (14071, 1, 3);
 INSERT INTO `item_mods` VALUES (14071, 127, 1);
-INSERT INTO `item_mods` VALUES (14072, 1, 1);
-INSERT INTO `item_mods` VALUES (14073, 1, 3);
+
+-- -------------------------------------------------------
+-- Chocobo Boots
+-- -------------------------------------------------------
+INSERT INTO `item_mods` VALUES (14072, 1, 1); -- DEF+1
+INSERT INTO `item_mods` VALUES (14072, 509, 3); -- Chocobo riding time +3 min
+
+-- -------------------------------------------------------
+-- Rider's Boots
+-- -------------------------------------------------------
+INSERT INTO `item_mods` VALUES (14073, 1, 3); -- DEF+3
+INSERT INTO `item_mods` VALUES (14073, 509, 3); -- Chocobo riding time +3 min
+
 INSERT INTO `item_mods` VALUES (14074, 1, 8);
 INSERT INTO `item_mods` VALUES (14074, 14, -6);
 INSERT INTO `item_mods` VALUES (14074, 23, 12);
@@ -9954,8 +9987,19 @@ INSERT INTO `item_mods` VALUES (14171, 1, 1);
 INSERT INTO `item_mods` VALUES (14171, 127, 1);
 INSERT INTO `item_mods` VALUES (14172, 1, 3);
 INSERT INTO `item_mods` VALUES (14172, 127, 1);
-INSERT INTO `item_mods` VALUES (14173, 1, 1);
-INSERT INTO `item_mods` VALUES (14174, 1, 3);
+
+-- -------------------------------------------------------
+-- Chocobo Jack Coat
+-- -------------------------------------------------------
+INSERT INTO `item_mods` VALUES (14173, 1, 1); -- DEF+1
+INSERT INTO `item_mods` VALUES (14173, 509, 5); -- Chocobo riding time +5 min
+
+-- -------------------------------------------------------
+-- Rider's Jack Coat 
+-- -------------------------------------------------------
+INSERT INTO `item_mods` VALUES (14174, 1, 3); -- DEF+3
+INSERT INTO `item_mods` VALUES (14174, 509, 5); -- Chocobo riding time +5 min
+
 INSERT INTO `item_mods` VALUES (14175, 1, 19);
 INSERT INTO `item_mods` VALUES (14175, 13, -11);
 INSERT INTO `item_mods` VALUES (14175, 23, 6);
@@ -10425,8 +10469,19 @@ INSERT INTO `item_mods` VALUES (14292, 1, 1);
 INSERT INTO `item_mods` VALUES (14292, 127, 1);
 INSERT INTO `item_mods` VALUES (14293, 1, 8);
 INSERT INTO `item_mods` VALUES (14293, 127, 1);
-INSERT INTO `item_mods` VALUES (14294, 1, 1);
-INSERT INTO `item_mods` VALUES (14295, 1, 8);
+
+-- -------------------------------------------------------
+-- Chocobo Hose
+-- -------------------------------------------------------
+INSERT INTO `item_mods` VALUES (14294, 1, 1); -- DEF+1
+INSERT INTO `item_mods` VALUES (14294, 509, 4); -- Chocobo riding time +4 min
+
+-- -------------------------------------------------------
+-- Rider's Hose
+-- -------------------------------------------------------
+INSERT INTO `item_mods` VALUES (14295, 1, 8); -- DEF+8
+INSERT INTO `item_mods` VALUES (14295, 509, 4); -- Chocobo riding time +4 min
+
 INSERT INTO `item_mods` VALUES (14296, 1, 38);
 INSERT INTO `item_mods` VALUES (14296, 5, -21);
 INSERT INTO `item_mods` VALUES (14296, 10, -11);
@@ -17820,6 +17875,12 @@ INSERT INTO `item_mods` VALUES (17072, 5, 10);
 INSERT INTO `item_mods` VALUES (17072, 12, 5);
 INSERT INTO `item_mods` VALUES (17073, 12, 10);
 INSERT INTO `item_mods` VALUES (17073, 13, 10);
+
+-- -------------------------------------------------------
+-- Chocobo Wand
+-- -------------------------------------------------------
+INSERT INTO `item_mods` VALUES (17074, 509, 30); -- Chocobo riding time +30 min
+
 INSERT INTO `item_mods` VALUES (17075, 2, 27);
 
 -- -------------------------------------------------------

--- a/sql/item_mods.sql
+++ b/sql/item_mods.sql
@@ -1442,7 +1442,7 @@ INSERT INTO `item_mods` VALUES (10922, 1, 9); -- DEF:9
 -- -------------------------------------------------------
 -- Chocobo Torque
 -- -------------------------------------------------------
-INSERT INTO `item_mods` VALUES (10924, 509, 4); -- Chocobo riding time +4 min
+INSERT INTO `item_mods` VALUES (10924, 511, 4); -- Chocobo riding time +4 min
 
 INSERT INTO `item_mods` VALUES (10929, 1, 10);
 INSERT INTO `item_mods` VALUES (10929, 10, 9);
@@ -2208,7 +2208,7 @@ INSERT INTO `item_mods` VALUES (11319, 1, 2);
 -- Orange Racing Silks
 -- -------------------------------------------------------
 INSERT INTO `item_mods` VALUES (11321, 1, 2); -- DEF+2
-INSERT INTO `item_mods` VALUES (11321, 509, 10); -- Chocobo riding time +10 min
+INSERT INTO `item_mods` VALUES (11321, 511, 10); -- Chocobo riding time +10 min
 
 INSERT INTO `item_mods` VALUES (11322, 1, 2);
 INSERT INTO `item_mods` VALUES (11323, 1, 2);
@@ -8766,13 +8766,13 @@ INSERT INTO `item_mods` VALUES (13809, 127, 1);
 -- Chocobo Jack Coat
 -- -------------------------------------------------------
 INSERT INTO `item_mods` VALUES (13810, 1, 2); -- DEF+2
-INSERT INTO `item_mods` VALUES (13810, 509, 5); -- Chocobo riding time +5 min
+INSERT INTO `item_mods` VALUES (13810, 511, 5); -- Chocobo riding time +5 min
 
 -- -------------------------------------------------------
 -- Rider's Jack Coat 
 -- -------------------------------------------------------
 INSERT INTO `item_mods` VALUES (13811, 1, 12); -- DEF+12
-INSERT INTO `item_mods` VALUES (13811, 509, 5); -- Chocobo riding time +5 min
+INSERT INTO `item_mods` VALUES (13811, 511, 5); -- Chocobo riding time +5 min
 
 INSERT INTO `item_mods` VALUES (13812, 1, 45);
 INSERT INTO `item_mods` VALUES (13813, 1, 50);
@@ -9645,13 +9645,13 @@ INSERT INTO `item_mods` VALUES (14071, 127, 1);
 -- Chocobo Boots
 -- -------------------------------------------------------
 INSERT INTO `item_mods` VALUES (14072, 1, 1); -- DEF+1
-INSERT INTO `item_mods` VALUES (14072, 509, 3); -- Chocobo riding time +3 min
+INSERT INTO `item_mods` VALUES (14072, 511, 3); -- Chocobo riding time +3 min
 
 -- -------------------------------------------------------
 -- Rider's Boots
 -- -------------------------------------------------------
 INSERT INTO `item_mods` VALUES (14073, 1, 3); -- DEF+3
-INSERT INTO `item_mods` VALUES (14073, 509, 3); -- Chocobo riding time +3 min
+INSERT INTO `item_mods` VALUES (14073, 511, 3); -- Chocobo riding time +3 min
 
 INSERT INTO `item_mods` VALUES (14074, 1, 8);
 INSERT INTO `item_mods` VALUES (14074, 14, -6);
@@ -9992,13 +9992,13 @@ INSERT INTO `item_mods` VALUES (14172, 127, 1);
 -- Chocobo Jack Coat
 -- -------------------------------------------------------
 INSERT INTO `item_mods` VALUES (14173, 1, 1); -- DEF+1
-INSERT INTO `item_mods` VALUES (14173, 509, 5); -- Chocobo riding time +5 min
+INSERT INTO `item_mods` VALUES (14173, 511, 5); -- Chocobo riding time +5 min
 
 -- -------------------------------------------------------
 -- Rider's Jack Coat 
 -- -------------------------------------------------------
 INSERT INTO `item_mods` VALUES (14174, 1, 3); -- DEF+3
-INSERT INTO `item_mods` VALUES (14174, 509, 5); -- Chocobo riding time +5 min
+INSERT INTO `item_mods` VALUES (14174, 511, 5); -- Chocobo riding time +5 min
 
 INSERT INTO `item_mods` VALUES (14175, 1, 19);
 INSERT INTO `item_mods` VALUES (14175, 13, -11);
@@ -10474,13 +10474,13 @@ INSERT INTO `item_mods` VALUES (14293, 127, 1);
 -- Chocobo Hose
 -- -------------------------------------------------------
 INSERT INTO `item_mods` VALUES (14294, 1, 1); -- DEF+1
-INSERT INTO `item_mods` VALUES (14294, 509, 4); -- Chocobo riding time +4 min
+INSERT INTO `item_mods` VALUES (14294, 511, 4); -- Chocobo riding time +4 min
 
 -- -------------------------------------------------------
 -- Rider's Hose
 -- -------------------------------------------------------
 INSERT INTO `item_mods` VALUES (14295, 1, 8); -- DEF+8
-INSERT INTO `item_mods` VALUES (14295, 509, 4); -- Chocobo riding time +4 min
+INSERT INTO `item_mods` VALUES (14295, 511, 4); -- Chocobo riding time +4 min
 
 INSERT INTO `item_mods` VALUES (14296, 1, 38);
 INSERT INTO `item_mods` VALUES (14296, 5, -21);
@@ -17879,7 +17879,7 @@ INSERT INTO `item_mods` VALUES (17073, 13, 10);
 -- -------------------------------------------------------
 -- Chocobo Wand
 -- -------------------------------------------------------
-INSERT INTO `item_mods` VALUES (17074, 509, 30); -- Chocobo riding time +30 min
+INSERT INTO `item_mods` VALUES (17074, 511, 30); -- Chocobo riding time +30 min
 
 INSERT INTO `item_mods` VALUES (17075, 2, 27);
 

--- a/src/map/modifier.h
+++ b/src/map/modifier.h
@@ -22,7 +22,7 @@
 */
 
 /*
-MOD_NAME						=0xHEX#, // MOD DESCRIPTION (modId = DEC#)
+    MOD_NAME                      =0xHEX#, // MOD DESCRIPTION (modId = DEC#)
 */
 
 #ifndef _CMODIFIER_H
@@ -32,395 +32,395 @@ MOD_NAME						=0xHEX#, // MOD DESCRIPTION (modId = DEC#)
 
 enum MODIFIER
 {
-	MOD_NONE                      = 0x00,
+    MOD_NONE                      = 0x00,
 
-	MOD_DEF                       = 0x01, // Target's Defense (modId = 1)
-	MOD_HP                        = 0x02, // Target's HP (modId = 2)
-	MOD_HPP                       = 0x03, // HP Percentage (modId = 3)
-	MOD_CONVMPTOHP                = 0x04, // MP -> HP (Cassie Earring) (modId = 4)
-	MOD_MP                        = 0x05, // MP +/- (modId = 5)
-	MOD_MPP                       = 0x06, // MP Percentage (modId = 6)
-	MOD_CONVHPTOMP                = 0x07, // HP -> MP (modId = 7)
+    MOD_DEF                       = 0x01,  // Target's Defense (modId = 1)
+    MOD_HP                        = 0x02,  // Target's HP (modId = 2)
+    MOD_HPP                       = 0x03,  // HP Percentage (modId = 3)
+    MOD_CONVMPTOHP                = 0x04,  // MP -> HP (Cassie Earring) (modId = 4)
+    MOD_MP                        = 0x05,  // MP +/- (modId = 5)
+    MOD_MPP                       = 0x06,  // MP Percentage (modId = 6)
+    MOD_CONVHPTOMP                = 0x07,  // HP -> MP (modId = 7)
 
-	MOD_STR                       = 0x08, // Strength (modId = 8)
-	MOD_DEX                       = 0x09, // Dexterity (modId = 9)
-	MOD_VIT                       = 0x0A, // Vitality (modId = 10)
-	MOD_AGI                       = 0x0B, // Agility (modId = 11)
-	MOD_INT                       = 0x0C, // Intelligence (modId = 12)
-	MOD_MND                       = 0x0D, // Mind (modId = 13)
-	MOD_CHR                       = 0x0E, // Charisma (modId = 14)
+    MOD_STR                       = 0x08,  // Strength (modId = 8)
+    MOD_DEX                       = 0x09,  // Dexterity (modId = 9)
+    MOD_VIT                       = 0x0A,  // Vitality (modId = 10)
+    MOD_AGI                       = 0x0B,  // Agility (modId = 11)
+    MOD_INT                       = 0x0C,  // Intelligence (modId = 12)
+    MOD_MND                       = 0x0D,  // Mind (modId = 13)
+    MOD_CHR                       = 0x0E,  // Charisma (modId = 14)
 
-	// Elemental Defenses
+    // Elemental Defenses
 
-	MOD_FIREDEF                   = 0x0F, // Fire Defense (modId = 15)
-	MOD_ICEDEF                    = 0x10, // Ice Defense (modId = 16)
-	MOD_WINDDEF                   = 0x11, // Wind Defense (modId = 17)
-	MOD_EARTHDEF                  = 0x12, // Earth Defense (modId = 18)
-	MOD_THUNDERDEF                = 0x13, // Thunder Defense (modId = 19)
-	MOD_WATERDEF                  = 0x14, // Water Defense (modId = 20)
-	MOD_LIGHTDEF                  = 0x15, // Light Defense (modId = 21)
-	MOD_DARKDEF                   = 0x16, // Dark Defense (modId = 22)
+    MOD_FIREDEF                   = 0x0F,  // Fire Defense (modId = 15)
+    MOD_ICEDEF                    = 0x10,  // Ice Defense (modId = 16)
+    MOD_WINDDEF                   = 0x11,  // Wind Defense (modId = 17)
+    MOD_EARTHDEF                  = 0x12,  // Earth Defense (modId = 18)
+    MOD_THUNDERDEF                = 0x13,  // Thunder Defense (modId = 19)
+    MOD_WATERDEF                  = 0x14,  // Water Defense (modId = 20)
+    MOD_LIGHTDEF                  = 0x15,  // Light Defense (modId = 21)
+    MOD_DARKDEF                   = 0x16,  // Dark Defense (modId = 22)
 
-	MOD_ATT                       = 0x17, // Attack (modId = 23)
-	MOD_RATT                      = 0x18, // Ranged Attack (modId = 24)
+    MOD_ATT                       = 0x17,  // Attack (modId = 23)
+    MOD_RATT                      = 0x18,  // Ranged Attack (modId = 24)
 
-	MOD_ACC                       = 0x19, // Accuracy (modId = 25)
-	MOD_RACC                      = 0x1A, // Ranged Accuracy (modId = 26)
+    MOD_ACC                       = 0x19,  // Accuracy (modId = 25)
+    MOD_RACC                      = 0x1A,  // Ranged Accuracy (modId = 26)
 
-	MOD_ENMITY                    = 0x1B, // Enmity (modId = 27)
-    MOD_ENMITY_LOSS_REDUCTION     = 0x1F6,// Reduces Enmity lost when taking damage
+    MOD_ENMITY                    = 0x1B,  // Enmity (modId = 27)
+    MOD_ENMITY_LOSS_REDUCTION     = 0x1F6, // Reduces Enmity lost when taking damage
 
-	MOD_MATT                      = 0x1C, // Magic Attack (modId = 28)
-	MOD_MDEF                      = 0x1D, // Magic Defense (modId = 29)
-	MOD_MACC                      = 0x1E, // Magic Accuracy (modId = 30)
-	MOD_MEVA                      = 0x1F, // Magic Evasion (modId = 31)
+    MOD_MATT                      = 0x1C,  // Magic Attack (modId = 28)
+    MOD_MDEF                      = 0x1D,  // Magic Defense (modId = 29)
+    MOD_MACC                      = 0x1E,  // Magic Accuracy (modId = 30)
+    MOD_MEVA                      = 0x1F,  // Magic Evasion (modId = 31)
 
-	// Magic Accuracy and Elemental Attacks
+    // Magic Accuracy and Elemental Attacks
 
-	MOD_FIREATT                   = 0x20, // Fire Damage (modId = 32)
-	MOD_ICEATT                    = 0x21, // Ice Damage (modId = 33)
-	MOD_WINDATT                   = 0x22, // Wind Damage (modId = 34)
-	MOD_EARTHATT                  = 0x23, // Earth Damage (modId = 35)
-	MOD_THUNDERATT                = 0x24, // Thunder Damage (modId = 36)
-	MOD_WATERATT                  = 0x25, // Water Damage (modId = 37)
-	MOD_LIGHTATT                  = 0x26, // Light Damage (modId = 38)
-	MOD_DARKATT                   = 0x27, // Dark Damage (modId = 39)
-	MOD_FIREACC                   = 0x28, // Fire Accuracy (modId = 40)
-	MOD_ICEACC                    = 0x29, // Ice Accuracy (modId = 41)
-	MOD_WINDACC                   = 0x2A, // Wind Accuracy (modId = 42)
-	MOD_EARTHACC                  = 0x2B, // Earth Accuracy (modId = 43)
-	MOD_THUNDERACC                = 0x2C, // Thunder Accuracy (modId = 44)
-	MOD_WATERACC                  = 0x2D, // Water Accuracy (modId = 45)
-	MOD_LIGHTACC                  = 0x2E, // Light Accuracy (modId = 46)
-	MOD_DARKACC                   = 0x2F, // Dark Accuracy (modId = 47)
+    MOD_FIREATT                   = 0x20,  // Fire Damage (modId = 32)
+    MOD_ICEATT                    = 0x21,  // Ice Damage (modId = 33)
+    MOD_WINDATT                   = 0x22,  // Wind Damage (modId = 34)
+    MOD_EARTHATT                  = 0x23,  // Earth Damage (modId = 35)
+    MOD_THUNDERATT                = 0x24,  // Thunder Damage (modId = 36)
+    MOD_WATERATT                  = 0x25,  // Water Damage (modId = 37)
+    MOD_LIGHTATT                  = 0x26,  // Light Damage (modId = 38)
+    MOD_DARKATT                   = 0x27,  // Dark Damage (modId = 39)
+    MOD_FIREACC                   = 0x28,  // Fire Accuracy (modId = 40)
+    MOD_ICEACC                    = 0x29,  // Ice Accuracy (modId = 41)
+    MOD_WINDACC                   = 0x2A,  // Wind Accuracy (modId = 42)
+    MOD_EARTHACC                  = 0x2B,  // Earth Accuracy (modId = 43)
+    MOD_THUNDERACC                = 0x2C,  // Thunder Accuracy (modId = 44)
+    MOD_WATERACC                  = 0x2D,  // Water Accuracy (modId = 45)
+    MOD_LIGHTACC                  = 0x2E,  // Light Accuracy (modId = 46)
+    MOD_DARKACC                   = 0x2F,  // Dark Accuracy (modId = 47)
 
-	MOD_WSACC                     = 0x30, // Weaponskill Accuracy (modId = 48)
+    MOD_WSACC                     = 0x30,  // Weaponskill Accuracy (modId = 48)
 
-	// Resistance to damage type
-	// Value is stored as a percentage of damage reduction (to within 1000)
-	// Example: 1000              = 100%, 875= 87.5%
+    // Resistance to damage type
+    // Value is stored as a percentage of damage reduction (to within 1000)
+    // Example: 1000              = 100%, 875= 87.5%
 
-	MOD_SLASHRES                  = 0x31, // Slash Resistance (modId = 49)
-	MOD_PIERCERES                 = 0x32, // Piercing Resistance (modId = 50)
-	MOD_IMPACTRES                 = 0x33, // Impact Resistance (modId = 51)
-	MOD_HTHRES                    = 0x34, // Hand-To-Hand Resistance (modId = 52)
+    MOD_SLASHRES                  = 0x31,  // Slash Resistance (modId = 49)
+    MOD_PIERCERES                 = 0x32,  // Piercing Resistance (modId = 50)
+    MOD_IMPACTRES                 = 0x33,  // Impact Resistance (modId = 51)
+    MOD_HTHRES                    = 0x34,  // Hand-To-Hand Resistance (modId = 52)
 
 
-	// Damage Reduction to Elements
-	// Value is stored as a percentage of damage reduction (to within 1000)
-	// Example: 1000              = 100%, 875= 87.5%
+    // Damage Reduction to Elements
+    // Value is stored as a percentage of damage reduction (to within 1000)
+    // Example: 1000              = 100%, 875= 87.5%
 
-	MOD_FIRERES                   = 0x36, // % Fire Resistance (modId = 54)
-	MOD_ICERES                    = 0x37, // % Ice Resistance (modId = 55)
-	MOD_WINDRES                   = 0x38, // % Wind Resistance (modId = 56)
-	MOD_EARTHRES                  = 0x39, // % Earth Resistance (modId = 57)
-	MOD_THUNDERRES                = 0x3A, // % Thunder Resistance (modId = 58)
-	MOD_WATERRES                  = 0x3B, // % Water Resistance (modId = 59)
-	MOD_LIGHTRES                  = 0x3C, // % Light Resistance (modId = 60)
-	MOD_DARKRES                   = 0x3D, // % Dark Resistance (modId = 61)
+    MOD_FIRERES                   = 0x36,  // % Fire Resistance (modId = 54)
+    MOD_ICERES                    = 0x37,  // % Ice Resistance (modId = 55)
+    MOD_WINDRES                   = 0x38,  // % Wind Resistance (modId = 56)
+    MOD_EARTHRES                  = 0x39,  // % Earth Resistance (modId = 57)
+    MOD_THUNDERRES                = 0x3A,  // % Thunder Resistance (modId = 58)
+    MOD_WATERRES                  = 0x3B,  // % Water Resistance (modId = 59)
+    MOD_LIGHTRES                  = 0x3C,  // % Light Resistance (modId = 60)
+    MOD_DARKRES                   = 0x3D,  // % Dark Resistance (modId = 61)
 
-	MOD_ATTP                      = 0x3E, // % Attack (modId = 62)
-	MOD_DEFP                      = 0x3F, // % Defense (modId = 63)
-	MOD_ACCP                      = 0x40, // % Accuracy (modId = 64)
-	MOD_EVAP                      = 0x41, // % Evasion (modId = 65)
-	MOD_RATTP                     = 0x42, // % Ranged Attack (modId = 66)
-	MOD_RACCP                     = 0x43, // % Ranged Attack Accuracy (modId = 67)
+    MOD_ATTP                      = 0x3E,  // % Attack (modId = 62)
+    MOD_DEFP                      = 0x3F,  // % Defense (modId = 63)
+    MOD_ACCP                      = 0x40,  // % Accuracy (modId = 64)
+    MOD_EVAP                      = 0x41,  // % Evasion (modId = 65)
+    MOD_RATTP                     = 0x42,  // % Ranged Attack (modId = 66)
+    MOD_RACCP                     = 0x43,  // % Ranged Attack Accuracy (modId = 67)
 
-	MOD_EVA                       = 0x44, // Evasion (modId = 68)
-	MOD_RDEF                      = 0x45, // Ranged Defense (modId = 69)
-	MOD_REVA                      = 0x46, // Ranged Evasion (modId = 70)
-	MOD_MPHEAL                    = 0x47, // MP Recovered while healing (modId = 71)
-	MOD_HPHEAL                    = 0x48, // HP Recovered while healing (modId = 72)
-	MOD_STORETP                   = 0x49, // Increases the rate at which TP is gained (modId = 73)
-	MOD_TACTICAL_PARRY            = 0x1E6, // Tactical Parry Tp Bonus (modId = 486)
-	MOD_MAG_BURST_BONUS           = 0x1E7, // Magic Burst Bonus Modifier (percent) (modId = 487)	
-	MOD_INHIBIT_TP                = 0x1E8, // Inhibits TP Gain (percent) (modId = 488)
+    MOD_EVA                       = 0x44,  // Evasion (modId = 68)
+    MOD_RDEF                      = 0x45,  // Ranged Defense (modId = 69)
+    MOD_REVA                      = 0x46,  // Ranged Evasion (modId = 70)
+    MOD_MPHEAL                    = 0x47,  // MP Recovered while healing (modId = 71)
+    MOD_HPHEAL                    = 0x48,  // HP Recovered while healing (modId = 72)
+    MOD_STORETP                   = 0x49,  // Increases the rate at which TP is gained (modId = 73)
+    MOD_TACTICAL_PARRY            = 0x1E6, // Tactical Parry Tp Bonus (modId = 486)
+    MOD_MAG_BURST_BONUS           = 0x1E7, // Magic Burst Bonus Modifier (percent) (modId = 487)
+    MOD_INHIBIT_TP                = 0x1E8, // Inhibits TP Gain (percent) (modId = 488)
 
-	// Working Skills (weapon combat skills)
+    // Working Skills (weapon combat skills)
 
-	MOD_HTH                       = 0x50, // Hand To Hand Skill (modId = 80)
-	MOD_DAGGER                    = 0x51, // Dagger Skill (modId = 81)
-	MOD_SWORD                     = 0x52, // Sword Skill (modId = 82)
-	MOD_GSWORD                    = 0x53, // Great Sword Skill (modId = 83)
-	MOD_AXE                       = 0x54, // Axe Skill (modId = 84)
-	MOD_GAXE                      = 0x55, // Great Axe Skill (modId = 85)
-	MOD_SCYTHE                    = 0x56, // Scythe Skill (modId = 86)
-	MOD_POLEARM                   = 0x57, // Polearm Skill (modId = 87)
-	MOD_KATANA                    = 0x58, // Katana Skill (modId = 88)
-	MOD_GKATANA                   = 0x59, // Great Katana Skill (modId = 89)
-	MOD_CLUB                      = 0x5A, // Club Skill (modId = 90)
-	MOD_STAFF                     = 0x5B, // Staff Skill (modId = 91)
-    MOD_AUTO_MELEE_SKILL          = 0x65, // Automaton Melee Skill (modId = 101)
-    MOD_AUTO_RANGED_SKILL         = 0x66, // Automaton Range Skill (modId = 102)
-    MOD_AUTO_MAGIC_SKILL          = 0x67, // Automaton Magic Skill (modId = 103)
-	MOD_ARCHERY                   = 0x68, // Archery Skill (modId = 104)
-	MOD_MARKSMAN                  = 0x69, // Marksman Skill (modId = 105)
-	MOD_THROW                     = 0x6A, // Throw Skill (modId = 106)
-	MOD_GUARD                     = 0x6B, // Guard Skill (modId = 107)
-	MOD_EVASION                   = 0x6C, // Evasion Skill (modId = 108)
-	MOD_SHIELD                    = 0x6D, // Shield Skill (modId = 109)
-	MOD_PARRY                     = 0x6E, // Parry Skill (modId = 110)
+    MOD_HTH                       = 0x50,  // Hand To Hand Skill (modId = 80)
+    MOD_DAGGER                    = 0x51,  // Dagger Skill (modId = 81)
+    MOD_SWORD                     = 0x52,  // Sword Skill (modId = 82)
+    MOD_GSWORD                    = 0x53,  // Great Sword Skill (modId = 83)
+    MOD_AXE                       = 0x54,  // Axe Skill (modId = 84)
+    MOD_GAXE                      = 0x55,  // Great Axe Skill (modId = 85)
+    MOD_SCYTHE                    = 0x56,  // Scythe Skill (modId = 86)
+    MOD_POLEARM                   = 0x57,  // Polearm Skill (modId = 87)
+    MOD_KATANA                    = 0x58,  // Katana Skill (modId = 88)
+    MOD_GKATANA                   = 0x59,  // Great Katana Skill (modId = 89)
+    MOD_CLUB                      = 0x5A,  // Club Skill (modId = 90)
+    MOD_STAFF                     = 0x5B,  // Staff Skill (modId = 91)
+    MOD_AUTO_MELEE_SKILL          = 0x65,  // Automaton Melee Skill (modId = 101)
+    MOD_AUTO_RANGED_SKILL         = 0x66,  // Automaton Range Skill (modId = 102)
+    MOD_AUTO_MAGIC_SKILL          = 0x67,  // Automaton Magic Skill (modId = 103)
+    MOD_ARCHERY                   = 0x68,  // Archery Skill (modId = 104)
+    MOD_MARKSMAN                  = 0x69,  // Marksman Skill (modId = 105)
+    MOD_THROW                     = 0x6A,  // Throw Skill (modId = 106)
+    MOD_GUARD                     = 0x6B,  // Guard Skill (modId = 107)
+    MOD_EVASION                   = 0x6C,  // Evasion Skill (modId = 108)
+    MOD_SHIELD                    = 0x6D,  // Shield Skill (modId = 109)
+    MOD_PARRY                     = 0x6E,  // Parry Skill (modId = 110)
 
-	// Magic Skills
+    // Magic Skills
 
-	MOD_DIVINE                    = 0x6F, // Divine Magic Skill (modId = 111)
-	MOD_HEALING                   = 0x70, // Healing Magic Skill (modId = 112)
-	MOD_ENHANCE                   = 0x71, // Enhancing Magic Skill (modId = 113)
-	MOD_ENFEEBLE                  = 0x72, // Enfeebling Magic Skill (modId = 114)
-	MOD_ELEM                      = 0x73, // Elemental Magic Skill (modId = 115)
-	MOD_DARK                      = 0x74, // Dark Magic Skill (modId = 116)
-	MOD_SUMMONING                 = 0x75, // Summoning Magic Skill (modId = 117)
-	MOD_NINJUTSU                  = 0x76, // Ninjutsu Magic Skill (modId = 118)
-	MOD_SINGING                   = 0x77, // Singing Magic Skill (modId = 119)
-	MOD_STRING                    = 0x78, // String Magic Skill (modId = 120)
-	MOD_WIND                      = 0x79, // Wind Magic Skill (modId = 121)
-	MOD_BLUE                      = 0x7A, // Blue Magic Skill (modId = 122)
+    MOD_DIVINE                    = 0x6F,  // Divine Magic Skill (modId = 111)
+    MOD_HEALING                   = 0x70,  // Healing Magic Skill (modId = 112)
+    MOD_ENHANCE                   = 0x71,  // Enhancing Magic Skill (modId = 113)
+    MOD_ENFEEBLE                  = 0x72,  // Enfeebling Magic Skill (modId = 114)
+    MOD_ELEM                      = 0x73,  // Elemental Magic Skill (modId = 115)
+    MOD_DARK                      = 0x74,  // Dark Magic Skill (modId = 116)
+    MOD_SUMMONING                 = 0x75,  // Summoning Magic Skill (modId = 117)
+    MOD_NINJUTSU                  = 0x76,  // Ninjutsu Magic Skill (modId = 118)
+    MOD_SINGING                   = 0x77,  // Singing Magic Skill (modId = 119)
+    MOD_STRING                    = 0x78,  // String Magic Skill (modId = 120)
+    MOD_WIND                      = 0x79,  // Wind Magic Skill (modId = 121)
+    MOD_BLUE                      = 0x7A,  // Blue Magic Skill (modId = 122)
 
-	// Synthesis Skills
+    // Synthesis Skills
 
-	MOD_FISH                      = 0x7F, // Fishing Skill (modId = 127)
-	MOD_WOOD                      = 0x80, // Woodworking Skill (modId = 128)
-	MOD_SMITH                     = 0x81, // Smithing Skill (modId = 129)
-	MOD_GOLDSMITH                 = 0x82, // Goldsmithing Skill (modId = 130)
-	MOD_CLOTH                     = 0x83, // Clothcraft Skill (modId = 131)
-	MOD_LEATHER                   = 0x84, // Leathercraft Skill (modId = 132)
-	MOD_BONE                      = 0x85, // Bonecraft Skill (modId = 133)
-	MOD_ALCHEMY                   = 0x86, // Alchemy Skill (modId = 134)
-	MOD_COOK                      = 0x87, // Cooking Skill (modId = 135)
-	MOD_SYNERGY                   = 0x88, // Synergy Skill (modId = 136)
-	MOD_RIDING                    = 0x89, // Riding Skill (modId = 137)
+    MOD_FISH                      = 0x7F,  // Fishing Skill (modId = 127)
+    MOD_WOOD                      = 0x80,  // Woodworking Skill (modId = 128)
+    MOD_SMITH                     = 0x81,  // Smithing Skill (modId = 129)
+    MOD_GOLDSMITH                 = 0x82,  // Goldsmithing Skill (modId = 130)
+    MOD_CLOTH                     = 0x83,  // Clothcraft Skill (modId = 131)
+    MOD_LEATHER                   = 0x84,  // Leathercraft Skill (modId = 132)
+    MOD_BONE                      = 0x85,  // Bonecraft Skill (modId = 133)
+    MOD_ALCHEMY                   = 0x86,  // Alchemy Skill (modId = 134)
+    MOD_COOK                      = 0x87,  // Cooking Skill (modId = 135)
+    MOD_SYNERGY                   = 0x88,  // Synergy Skill (modId = 136)
+    MOD_RIDING                    = 0x89,  // Riding Skill (modId = 137)
 
-	// Chance you will not make an hq synth (Impossibility of HQ synth)
+    // Chance you will not make an hq synth (Impossibility of HQ synth)
 
-	MOD_ANTIHQ_WOOD               = 0x90, // Woodworking Success Rate % (modId = 144)
-	MOD_ANTIHQ_SMITH              = 0x91, // Smithing Success Rate % (modId = 145)
-	MOD_ANTIHQ_GOLDSMITH          = 0x92, // Goldsmithing Success Rate % (modId = 146)
-	MOD_ANTIHQ_CLOTH              = 0x93, // Clothcraft Success Rate % (modId = 147)
-	MOD_ANTIHQ_LEATHER            = 0x94, // Leathercraft Success Rate % (modId = 148)
-	MOD_ANTIHQ_BONE               = 0x95, // Bonecraft Success Rate % (modId = 149)
-	MOD_ANTIHQ_ALCHEMY            = 0x96, // Alchemy Success Rate % (modId = 150)
-	MOD_ANTIHQ_COOK               = 0x97, // Cooking Success Rate % (modId = 151)
+    MOD_ANTIHQ_WOOD               = 0x90,  // Woodworking Success Rate % (modId = 144)
+    MOD_ANTIHQ_SMITH              = 0x91,  // Smithing Success Rate % (modId = 145)
+    MOD_ANTIHQ_GOLDSMITH          = 0x92,  // Goldsmithing Success Rate % (modId = 146)
+    MOD_ANTIHQ_CLOTH              = 0x93,  // Clothcraft Success Rate % (modId = 147)
+    MOD_ANTIHQ_LEATHER            = 0x94,  // Leathercraft Success Rate % (modId = 148)
+    MOD_ANTIHQ_BONE               = 0x95,  // Bonecraft Success Rate % (modId = 149)
+    MOD_ANTIHQ_ALCHEMY            = 0x96,  // Alchemy Success Rate % (modId = 150)
+    MOD_ANTIHQ_COOK               = 0x97,  // Cooking Success Rate % (modId = 151)
 
-	// Damage / Crit Damage / Delay
+    // Damage / Crit Damage / Delay
 
-	MOD_DMG                       = 0xA0, // Damage Taken % (modId = 160)
-	MOD_DMGPHYS                   = 0xA1, // Physical Damage Taken % (modId = 161)
-	MOD_DMGBREATH                 = 0xA2, // Breath Damage Taken % (modId = 162)
-	MOD_DMGMAGIC                  = 0xA3, // Magic Damage Taken % - 256 base! (value of -24 means -24/256 magic damage taken) (modId = 163)
-	MOD_DMGRANGE                  = 0xA4, // Range Damage Taken % (modId = 164)
+    MOD_DMG                       = 0xA0,  // Damage Taken % (modId = 160)
+    MOD_DMGPHYS                   = 0xA1,  // Physical Damage Taken % (modId = 161)
+    MOD_DMGBREATH                 = 0xA2,  // Breath Damage Taken % (modId = 162)
+    MOD_DMGMAGIC                  = 0xA3,  // Magic Damage Taken % - 256 base! (value of -24 means -24/256 magic damage taken) (modId = 163)
+    MOD_DMGRANGE                  = 0xA4,  // Range Damage Taken % (modId = 164)
 
-	MOD_UDMGPHYS                  = 0x183, // Uncapped Damage Multipliers (modId = 387)
-	MOD_UDMGBREATH                = 0x184, // Used in sentinal, invincible, physical shield etc (modId = 388)
-	MOD_UDMGMAGIC                 = 0x185, // (modId = 389)
-	MOD_UDMGRANGE                 = 0x186, // (modId = 390)
+    MOD_UDMGPHYS                  = 0x183, // Uncapped Damage Multipliers (modId = 387)
+    MOD_UDMGBREATH                = 0x184, // Used in sentinal, invincible, physical shield etc (modId = 388)
+    MOD_UDMGMAGIC                 = 0x185, // (modId = 389)
+    MOD_UDMGRANGE                 = 0x186, // (modId = 390)
 
-	MOD_CRITHITRATE               = 0xA5, // Raises chance to crit (modId = 165)
-	MOD_CRIT_DMG_INCREASE		  = 0x1A5, // Raises the damage of critcal hit by percent % (modId = 421)
-	MOD_ENEMYCRITRATE             = 0xA6, // Raises chance enemy will crit (modId = 166)
+    MOD_CRITHITRATE               = 0xA5,  // Raises chance to crit (modId = 165)
+    MOD_CRIT_DMG_INCREASE         = 0x1A5, // Raises the damage of critcal hit by percent % (modId = 421)
+    MOD_ENEMYCRITRATE             = 0xA6,  // Raises chance enemy will crit (modId = 166)
 
-	MOD_HASTE_MAGIC               = 0xA7, // Haste (and Slow) from magic - 1024 base! (448 cap) (modId = 167)
-	MOD_HASTE_ABILITY             = 0x17F, // Haste (and Slow) from abilities - 1024 base! (256 cap?) (modId = 383)
-	MOD_HASTE_GEAR                = 0x180, // Haste (and Slow) from equipment - 1024 base! (256 cap) (modId = 384)
-	MOD_SPELLINTERRUPT            = 0xA8, // % Spell Interruption Rate (modId = 168)
-	MOD_MOVE                      = 0xA9, // % Movement Speed (modId = 169)
-	MOD_FASTCAST                  = 0xAA, // Increases Spell Cast Time (TRAIT) (modId = 170)
-	MOD_UFASTCAST                 = 0x197, // uncapped fast cast (modId = 407)
-	MOD_DELAY                     = 0xAB, // Increase/Decrease Delay (modId = 171)
-	MOD_RANGED_DELAY              = 0xAC, // Increase/Decrease Ranged Delay (modId = 172)
-	MOD_MARTIAL_ARTS              = 0xAD, // The integer amount of delay to reduce from H2H weapons' base delay. (TRAIT) (modId = 173)
-	MOD_SKILLCHAINBONUS           = 0xAE, // Damage bonus applied to skill chain damage.  Modifier from effects/traits (modId = 174)
-	MOD_SKILLCHAINDMG             = 0xAF, // Damage bonus applied to skill chain damage.  Modifier from gear (multiplicative after effect/traits) (modId = 175)
+    MOD_HASTE_MAGIC               = 0xA7,  // Haste (and Slow) from magic - 1024 base! (448 cap) (modId = 167)
+    MOD_HASTE_ABILITY             = 0x17F, // Haste (and Slow) from abilities - 1024 base! (256 cap?) (modId = 383)
+    MOD_HASTE_GEAR                = 0x180, // Haste (and Slow) from equipment - 1024 base! (256 cap) (modId = 384)
+    MOD_SPELLINTERRUPT            = 0xA8,  // % Spell Interruption Rate (modId = 168)
+    MOD_MOVE                      = 0xA9,  // % Movement Speed (modId = 169)
+    MOD_FASTCAST                  = 0xAA,  // Increases Spell Cast Time (TRAIT) (modId = 170)
+    MOD_UFASTCAST                 = 0x197, // uncapped fast cast (modId = 407)
+    MOD_DELAY                     = 0xAB,  // Increase/Decrease Delay (modId = 171)
+    MOD_RANGED_DELAY              = 0xAC,  // Increase/Decrease Ranged Delay (modId = 172)
+    MOD_MARTIAL_ARTS              = 0xAD,  // The integer amount of delay to reduce from H2H weapons' base delay. (TRAIT) (modId = 173)
+    MOD_SKILLCHAINBONUS           = 0xAE,  // Damage bonus applied to skill chain damage.  Modifier from effects/traits (modId = 174)
+    MOD_SKILLCHAINDMG             = 0xAF,  // Damage bonus applied to skill chain damage.  Modifier from gear (multiplicative after effect/traits) (modId = 175)
 
-	// FOOD!
+    // FOOD!
 
-	MOD_FOOD_HPP                  = 0xB0, // (modId = 176)
-	MOD_FOOD_HP_CAP               = 0xB1, // (modId = 177)
-	MOD_FOOD_MPP                  = 0xB2, // (modId = 178)
-	MOD_FOOD_MP_CAP               = 0xB3, // (modId = 179)
-	MOD_FOOD_ATTP                 = 0xB4, // (modId = 180)
-	MOD_FOOD_ATT_CAP              = 0xB5, // (modId = 181)
-	MOD_FOOD_DEFP                 = 0xB6, // (modId = 182)
-	MOD_FOOD_DEF_CAP              = 0xB7, // (modId = 183)
-	MOD_FOOD_ACCP                 = 0xB8, // (modId = 184)
-	MOD_FOOD_ACC_CAP              = 0xB9, // (modId = 185)
-	MOD_FOOD_RATTP                = 0xBA, // (modId = 186)
-	MOD_FOOD_RATT_CAP             = 0xBB, // (modId = 187)
-	MOD_FOOD_RACCP                = 0xBC, // (modId = 188)
-	MOD_FOOD_RACC_CAP             = 0xBD, // (modId = 190)
+    MOD_FOOD_HPP                  = 0xB0,  // (modId = 176)
+    MOD_FOOD_HP_CAP               = 0xB1,  // (modId = 177)
+    MOD_FOOD_MPP                  = 0xB2,  // (modId = 178)
+    MOD_FOOD_MP_CAP               = 0xB3,  // (modId = 179)
+    MOD_FOOD_ATTP                 = 0xB4,  // (modId = 180)
+    MOD_FOOD_ATT_CAP              = 0xB5,  // (modId = 181)
+    MOD_FOOD_DEFP                 = 0xB6,  // (modId = 182)
+    MOD_FOOD_DEF_CAP              = 0xB7,  // (modId = 183)
+    MOD_FOOD_ACCP                 = 0xB8,  // (modId = 184)
+    MOD_FOOD_ACC_CAP              = 0xB9,  // (modId = 185)
+    MOD_FOOD_RATTP                = 0xBA,  // (modId = 186)
+    MOD_FOOD_RATT_CAP             = 0xBB,  // (modId = 187)
+    MOD_FOOD_RACCP                = 0xBC,  // (modId = 188)
+    MOD_FOOD_RACC_CAP             = 0xBD,  // (modId = 190)
 
-	// Killer-Effects - (Most by Traits/JobAbility)
+    // Killer-Effects - (Most by Traits/JobAbility)
 
-	MOD_VERMIN_KILLER             = 0xE0, // Enhances "Vermin Killer" effect (modId = 224)
-	MOD_BIRD_KILLER               = 0xE1, // Enhances "Bird Killer" effect (modId = 225)
-	MOD_AMORPH_KILLER             = 0xE2, // Enhances "Amorph Killer" effect (modId = 226)
-	MOD_LIZARD_KILLER             = 0xE3, // Enhances "Lizard Killer" effect (modId = 227)
-	MOD_AQUAN_KILLER              = 0xE4, // Enhances "Aquan Killer" effect (modId = 228)
-	MOD_PLANTOID_KILLER           = 0xE5, // Enhances "Plantiod Killer" effect (modId = 229)
-	MOD_BEAST_KILLER              = 0xE6, // Enhances "Beast Killer" effect (modId = 230)
-	MOD_UNDEAD_KILLER             = 0xE7, // Enhances "Undead Killer" effect (modId = 231)
-	MOD_ARCANA_KILLER             = 0xE8, // Enhances "Arcana Killer" effect (modId = 232)
-	MOD_DRAGON_KILLER             = 0xE9, // Enhances "Dragon Killer" effect (modId = 233)
-	MOD_DEMON_KILLER              = 0xEA, // Enhances "Demon Killer" effect (modId = 234)
-	MOD_EMPTY_KILLER              = 0xEB, // Enhances "Empty Killer" effect (modId = 235)
-	MOD_HUMANOID_KILLER           = 0xEC, // Enhances "Humanoid Killer" effect (modId = 236)
-	MOD_LUMORIAN_KILLER           = 0xED, // Enhances "Lumorian Killer" effect (modId = 237)
-	MOD_LUMINION_KILLER           = 0xEE, // Enhances "Luminion Killer" effect (modId = 238)
+    MOD_VERMIN_KILLER             = 0xE0,  // Enhances "Vermin Killer" effect (modId = 224)
+    MOD_BIRD_KILLER               = 0xE1,  // Enhances "Bird Killer" effect (modId = 225)
+    MOD_AMORPH_KILLER             = 0xE2,  // Enhances "Amorph Killer" effect (modId = 226)
+    MOD_LIZARD_KILLER             = 0xE3,  // Enhances "Lizard Killer" effect (modId = 227)
+    MOD_AQUAN_KILLER              = 0xE4,  // Enhances "Aquan Killer" effect (modId = 228)
+    MOD_PLANTOID_KILLER           = 0xE5,  // Enhances "Plantiod Killer" effect (modId = 229)
+    MOD_BEAST_KILLER              = 0xE6,  // Enhances "Beast Killer" effect (modId = 230)
+    MOD_UNDEAD_KILLER             = 0xE7,  // Enhances "Undead Killer" effect (modId = 231)
+    MOD_ARCANA_KILLER             = 0xE8,  // Enhances "Arcana Killer" effect (modId = 232)
+    MOD_DRAGON_KILLER             = 0xE9,  // Enhances "Dragon Killer" effect (modId = 233)
+    MOD_DEMON_KILLER              = 0xEA,  // Enhances "Demon Killer" effect (modId = 234)
+    MOD_EMPTY_KILLER              = 0xEB,  // Enhances "Empty Killer" effect (modId = 235)
+    MOD_HUMANOID_KILLER           = 0xEC,  // Enhances "Humanoid Killer" effect (modId = 236)
+    MOD_LUMORIAN_KILLER           = 0xED,  // Enhances "Lumorian Killer" effect (modId = 237)
+    MOD_LUMINION_KILLER           = 0xEE,  // Enhances "Luminion Killer" effect (modId = 238)
 
-	// Resistances to enfeebles - Traits/Job Ability
+    // Resistances to enfeebles - Traits/Job Ability
 
-	MOD_SLEEPRES                  = 0xF0, // Enhances "Resist Sleep" effect (modId = 240)
-	MOD_POISONRES                 = 0xF1, // Enhances "Resist Poison" effect (modId = 241)
-	MOD_PARALYZERES               = 0xF2, // Enhances "Resist Paralyze" effect (modId = 242)
-	MOD_BLINDRES                  = 0xF3, // Enhances "Resist Blind" effect (modId = 243)
-	MOD_SILENCERES                = 0xF4, // Enhances "Resist Silence" effect (modId = 244)
-	MOD_VIRUSRES                  = 0xF5, // Enhances "Resist Virus" effect (modId = 245)
-	MOD_PETRIFYRES                = 0xF6, // Enhances "Resist Petrify" effect (modId = 246)
-	MOD_BINDRES                   = 0xF7, // Enhances "Resist Bind" effect (modId = 247)
-	MOD_CURSERES                  = 0xF8, // Enhances "Resist Curse" effect (modId = 248)
-	MOD_GRAVITYRES                = 0xF9, // Enhances "Resist Gravity" effect (modId = 249)
-	MOD_SLOWRES                   = 0xFA, // Enhances "Resist Slow" effect (modId = 250)
-	MOD_STUNRES                   = 0xFB, // Enhances "Resist Stun" effect (modId = 251)
-	MOD_CHARMRES                  = 0xFC, // Enhances "Resist Charm" effect (modId = 252)
-	MOD_DEATHRES                  = 0xFF, // Used by gear and ATMA that give resistance to instance KO (modId = 255)
- 
-	MOD_PARALYZE                  = 0x101, // Paralyze -- percent chance to proc (modId = 257)
-	MOD_MIJIN_GAKURE              = 0x102, // Tracks whether or not you used this ability to die. (modId = 258)
-	MOD_DUAL_WIELD                = 0x103, // Percent reduction in dual wield delay. (modId = 259)
+    MOD_SLEEPRES                  = 0xF0,  // Enhances "Resist Sleep" effect (modId = 240)
+    MOD_POISONRES                 = 0xF1,  // Enhances "Resist Poison" effect (modId = 241)
+    MOD_PARALYZERES               = 0xF2,  // Enhances "Resist Paralyze" effect (modId = 242)
+    MOD_BLINDRES                  = 0xF3,  // Enhances "Resist Blind" effect (modId = 243)
+    MOD_SILENCERES                = 0xF4,  // Enhances "Resist Silence" effect (modId = 244)
+    MOD_VIRUSRES                  = 0xF5,  // Enhances "Resist Virus" effect (modId = 245)
+    MOD_PETRIFYRES                = 0xF6,  // Enhances "Resist Petrify" effect (modId = 246)
+    MOD_BINDRES                   = 0xF7,  // Enhances "Resist Bind" effect (modId = 247)
+    MOD_CURSERES                  = 0xF8,  // Enhances "Resist Curse" effect (modId = 248)
+    MOD_GRAVITYRES                = 0xF9,  // Enhances "Resist Gravity" effect (modId = 249)
+    MOD_SLOWRES                   = 0xFA,  // Enhances "Resist Slow" effect (modId = 250)
+    MOD_STUNRES                   = 0xFB,  // Enhances "Resist Stun" effect (modId = 251)
+    MOD_CHARMRES                  = 0xFC,  // Enhances "Resist Charm" effect (modId = 252)
+    MOD_DEATHRES                  = 0xFF,  // Used by gear and ATMA that give resistance to instance KO (modId = 255)
 
-	// Warrior
-	MOD_DOUBLE_ATTACK             = 0x120, // Percent chance to proc (modId = 288)
+    MOD_PARALYZE                  = 0x101, // Paralyze -- percent chance to proc (modId = 257)
+    MOD_MIJIN_GAKURE              = 0x102, // Tracks whether or not you used this ability to die. (modId = 258)
+    MOD_DUAL_WIELD                = 0x103, // Percent reduction in dual wield delay. (modId = 259)
+
+    // Warrior
+    MOD_DOUBLE_ATTACK             = 0x120, // Percent chance to proc (modId = 288)
     MOD_WARCRY_DURATION           = 0x1E3, // Warcy duration bonus from gear
 
-	// Monk
-	MOD_SUBTLE_BLOW               = 0x121, // How much TP to reduce. (modId = 289)
-	MOD_COUNTER                   = 0x123, // Percent chance to counter (modId = 291)
-	MOD_KICK_ATTACK				  = 0x124, // Percent chance to kick (modId = 292)
-	MOD_PERFECT_COUNTER_ATT		  = 0x1AC, // TODO: Raises weapon damage by 20 when countering while under the Perfect Counter effect. This also affects Weapon Rank (though not if fighting barehanded). (modId = 428)
-	MOD_FOOTWORK_ATT_BONUS		  = 0x1AD, // TODO: Raises the attack bonus of Footwork. (Tantra Gaiters +2 raise 100/1024 to 152/1024) (modId = 429)
+    // Monk
+    MOD_SUBTLE_BLOW               = 0x121, // How much TP to reduce. (modId = 289)
+    MOD_COUNTER                   = 0x123, // Percent chance to counter (modId = 291)
+    MOD_KICK_ATTACK               = 0x124, // Percent chance to kick (modId = 292)
+    MOD_PERFECT_COUNTER_ATT       = 0x1AC, // TODO: Raises weapon damage by 20 when countering while under the Perfect Counter effect. This also affects Weapon Rank (though not if fighting barehanded). (modId = 428)
+    MOD_FOOTWORK_ATT_BONUS        = 0x1AD, // TODO: Raises the attack bonus of Footwork. (Tantra Gaiters +2 raise 100/1024 to 152/1024) (modId = 429)
 
-	// White Mage
-	MOD_AFFLATUS_SOLACE           = 0x125, // Pool of HP accumulated during Afflatus Solace (modId = 293)
-	MOD_AFFLATUS_MISERY           = 0x126, // Pool of HP accumulated during Afflatus Misery (modId = 294)
-	MOD_AUSPICE_EFFECT	          = 0x1E4, // Bonus to Auspice Subtle Blow Effect.
+    // White Mage
+    MOD_AFFLATUS_SOLACE           = 0x125, // Pool of HP accumulated during Afflatus Solace (modId = 293)
+    MOD_AFFLATUS_MISERY           = 0x126, // Pool of HP accumulated during Afflatus Misery (modId = 294)
+    MOD_AUSPICE_EFFECT            = 0x1E4, // Bonus to Auspice Subtle Blow Effect.
 
-	// Black Mage
-	MOD_CLEAR_MIND                = 0x127, // Used in conjunction with MOD_HEALMP to increase amount between tics (modId = 295)
-	MOD_CONSERVE_MP               = 0x128, // Percent chance (modId = 296)
+    // Black Mage
+    MOD_CLEAR_MIND                = 0x127, // Used in conjunction with MOD_HEALMP to increase amount between tics (modId = 295)
+    MOD_CONSERVE_MP               = 0x128, // Percent chance (modId = 296)
 
-	// Red Mage
-	MOD_BLINK                     = 0x12B, // Tracks blink shadows (modId = 299)
-	MOD_STONESKIN                 = 0x12C, // Tracks stoneskin HP pool (modId = 300)
-	MOD_PHALANX                   = 0x12D, // Tracks direct damage reduction (modId = 301)
+    // Red Mage
+    MOD_BLINK                     = 0x12B, // Tracks blink shadows (modId = 299)
+    MOD_STONESKIN                 = 0x12C, // Tracks stoneskin HP pool (modId = 300)
+    MOD_PHALANX                   = 0x12D, // Tracks direct damage reduction (modId = 301)
 
-	// Thief
-	MOD_STEAL                     = 0x12A, // Increase/Decrease THF Steal chance (modId = 298)
-	MOD_TRIPLE_ATTACK             = 0x12E, // Percent chance (modId = 302)
-	MOD_TREASURE_HUNTER           = 0x12F, // Percent chance (modId = 303)
+    // Thief
+    MOD_STEAL                     = 0x12A, // Increase/Decrease THF Steal chance (modId = 298)
+    MOD_TRIPLE_ATTACK             = 0x12E, // Percent chance (modId = 302)
+    MOD_TREASURE_HUNTER           = 0x12F, // Percent chance (modId = 303)
 
-	// Paladin
-	MOD_ABSORB_DMG_TO_MP		  = 0x1AA, //	Absorbs a percentage of damage taken to MP. (modId = 426)
-	MOD_ENMITY_REDUCTION_PHYSICAL =0x1AB, // TODO: Reduces Enmity decrease when taking physical damage (modId = 427)
+    // Paladin
+    MOD_ABSORB_DMG_TO_MP          = 0x1AA, // Absorbs a percentage of damage taken to MP. (modId = 426)
+    MOD_ENMITY_REDUCTION_PHYSICAL = 0x1AB, // TODO: Reduces Enmity decrease when taking physical damage (modId = 427)
     MOD_SHIELD_MASTERY_TP         = 0x1E5, // Shield mastery TP bonus when blocking with a shield (modId = 485)
 
-	// Dark Knight
+    // Dark Knight
 
-	// Beastmaster
-	MOD_TAME                      = 0x130, // Additional percent chance to charm (modId = 304)
-	MOD_CHARM_TIME                = 0x168, // extends the charm time only, no effect of charm chance (modId = 360)
-	MOD_REWARD_HP_BONUS           = 0x16C, // Percent to add to reward HP healed. (364) (modId = 364)
-	MOD_CHARM_CHANCE              = 0x187, // extra chance to charm (light+apollo staff ect) (modId = 391)
+    // Beastmaster
+    MOD_TAME                      = 0x130, // Additional percent chance to charm (modId = 304)
+    MOD_CHARM_TIME                = 0x168, // extends the charm time only, no effect of charm chance (modId = 360)
+    MOD_REWARD_HP_BONUS           = 0x16C, // Percent to add to reward HP healed. (364) (modId = 364)
+    MOD_CHARM_CHANCE              = 0x187, // extra chance to charm (light+apollo staff ect) (modId = 391)
     MOD_FERAL_HOWL_DURATION       = 0x1F7, // +20% duration per merit when wearing augmented Monster Jackcoat +2 (modId = 503)
 
-	// Bard
+    // Bard
     MOD_MINNE_EFFECT              = 0x1B1, // (modId = 433)
-    MOD_MINUET_EFFECT	          = 0x1B2, // (modId = 434)
-    MOD_PAEON_EFFECT	          = 0x1B3, // (modId = 435)
-    MOD_REQUIEM_EFFECT	          = 0x1B4, // (modId = 436)
-    MOD_THRENODY_EFFECT	          = 0x1B5, // (modId = 437)
-    MOD_MADRIGAL_EFFECT	          = 0x1B6, // (modId = 438)
-    MOD_MAMBO_EFFECT	          = 0x1B7, // (modId = 439)
-    MOD_LULLABY_EFFECT	          = 0x1B8, // (modId = 440)
-    MOD_ETUDE_EFFECT	          = 0x1B9, // (modId = 441)
-    MOD_BALLAD_EFFECT	          = 0x1BA, // (modId = 442)
-    MOD_MARCH_EFFECT	          = 0x1BB, // (modId = 443)
-    MOD_FINALE_EFFECT	          = 0x1BC, // (modId = 444)
-    MOD_CAROL_EFFECT	          = 0x1BD, // (modId = 445)
-    MOD_MAZURKA_EFFECT	          = 0x1BE, // (modId = 446)
-    MOD_ELEGY_EFFECT	          = 0x1BF, // (modId = 447)
-    MOD_PRELUDE_EFFECT	          = 0x1C0, // (modId = 448)
-    MOD_HYMNUS_EFFECT	          = 0x1C1, // (modId = 449)
-    MOD_VIRELAI_EFFECT	          = 0x1C2, // (modId = 450)
+    MOD_MINUET_EFFECT             = 0x1B2, // (modId = 434)
+    MOD_PAEON_EFFECT              = 0x1B3, // (modId = 435)
+    MOD_REQUIEM_EFFECT            = 0x1B4, // (modId = 436)
+    MOD_THRENODY_EFFECT           = 0x1B5, // (modId = 437)
+    MOD_MADRIGAL_EFFECT           = 0x1B6, // (modId = 438)
+    MOD_MAMBO_EFFECT              = 0x1B7, // (modId = 439)
+    MOD_LULLABY_EFFECT            = 0x1B8, // (modId = 440)
+    MOD_ETUDE_EFFECT              = 0x1B9, // (modId = 441)
+    MOD_BALLAD_EFFECT             = 0x1BA, // (modId = 442)
+    MOD_MARCH_EFFECT              = 0x1BB, // (modId = 443)
+    MOD_FINALE_EFFECT             = 0x1BC, // (modId = 444)
+    MOD_CAROL_EFFECT              = 0x1BD, // (modId = 445)
+    MOD_MAZURKA_EFFECT            = 0x1BE, // (modId = 446)
+    MOD_ELEGY_EFFECT              = 0x1BF, // (modId = 447)
+    MOD_PRELUDE_EFFECT            = 0x1C0, // (modId = 448)
+    MOD_HYMNUS_EFFECT             = 0x1C1, // (modId = 449)
+    MOD_VIRELAI_EFFECT            = 0x1C2, // (modId = 450)
     MOD_SCHERZO_EFFECT            = 0x1C3, // (modId = 451)
     MOD_ALL_SONGS_EFFECT          = 0x1C4, // (modId = 452)
     MOD_MAXIMUM_SONGS_BONUS       = 0x1C5, // (modId = 453)
     MOD_SONG_DURATION_BONUS       = 0x1C6, // (modId = 454)
     MOD_SONG_SPELLCASTING_TIME    = 0x1C7, // (modId = 455)
 
-	// Ranger
-	MOD_RECYCLE                   = 0x131, // Percent chance to recycle (modId = 305)
-	MOD_SNAP_SHOT                 = 0x16D, // Percent reduction to range attack delay (modId = 365)
-	MOD_RAPID_SHOT                = 0x167, // Percent chance to proc rapid shot (modId = 359)
-	MOD_WIDESCAN                  = 0x154, // (modId = 340)
-	MOD_BARRAGE_ACC               = 0x1A4, // Barrage accuracy (modId = 420)
-	MOD_DOUBLE_SHOT_RATE          = 0x1A6, // The rate that double shot can proc. Without this, the default is 40%. (modId = 422)
-	MOD_VELOCITY_SNAPSHOT_BONUS   = 0x1A7, // Increases Snapshot whilst Velocity Shot is up. (modId = 423)
-	MOD_VELOCITY_RATT_BONUS       = 0x1A8, // Increases Ranged Attack whilst Velocity Shot is up. (modId = 424)
-	MOD_SHADOW_BIND_EXT           = 0x1A9, // Extends the time of shadowbind (modId = 425)
+    // Ranger
+    MOD_RECYCLE                   = 0x131, // Percent chance to recycle (modId = 305)
+    MOD_SNAP_SHOT                 = 0x16D, // Percent reduction to range attack delay (modId = 365)
+    MOD_RAPID_SHOT                = 0x167, // Percent chance to proc rapid shot (modId = 359)
+    MOD_WIDESCAN                  = 0x154, // (modId = 340)
+    MOD_BARRAGE_ACC               = 0x1A4, // Barrage accuracy (modId = 420)
+    MOD_DOUBLE_SHOT_RATE          = 0x1A6, // The rate that double shot can proc. Without this, the default is 40%. (modId = 422)
+    MOD_VELOCITY_SNAPSHOT_BONUS   = 0x1A7, // Increases Snapshot whilst Velocity Shot is up. (modId = 423)
+    MOD_VELOCITY_RATT_BONUS       = 0x1A8, // Increases Ranged Attack whilst Velocity Shot is up. (modId = 424)
+    MOD_SHADOW_BIND_EXT           = 0x1A9, // Extends the time of shadowbind (modId = 425)
 
-	// Samurai
-	MOD_ZANSHIN					  = 0x132, // Zanshin percent chance (modId = 306)
+    // Samurai
+    MOD_ZANSHIN                   = 0x132, // Zanshin percent chance (modId = 306)
 
-	// Ninja
-	MOD_UTSUSEMI                  = 0x133, // Everyone's favorite --tracks shadows. (modId = 307)
-	MOD_NINJA_TOOL                = 0x134, // Percent chance to not use a tool. (modId = 308)
+    // Ninja
+    MOD_UTSUSEMI                  = 0x133, // Everyone's favorite --tracks shadows. (modId = 307)
+    MOD_NINJA_TOOL                = 0x134, // Percent chance to not use a tool. (modId = 308)
 
-	// Dragoon
-	MOD_JUMP_TP_BONUS             = 0x169, // bonus tp player receives when using jump (must be divided by 10) (modId = 361)
-	MOD_JUMP_ATT_BONUS            = 0x16A, // ATT% bonus for jump + high jump (modId = 362)
-	MOD_HIGH_JUMP_ENMITY_REDUCTION = 0x16B, // for gear that reduces more enmity from high jump (modId = 363)
+    // Dragoon
+    MOD_JUMP_TP_BONUS             = 0x169, // bonus tp player receives when using jump (must be divided by 10) (modId = 361)
+    MOD_JUMP_ATT_BONUS            = 0x16A, // ATT% bonus for jump + high jump (modId = 362)
+    MOD_HIGH_JUMP_ENMITY_REDUCTION = 0x16B, // for gear that reduces more enmity from high jump (modId = 363)
 
-	// Summoner
-	MOD_AVATAR_PERPETUATION       = 0x173, //stores base cost of current avatar (modId = 371)
-	MOD_WEATHER_REDUCTION         = 0x174, //stores perpetuation reduction depending on weather (modId = 372)
-	MOD_DAY_REDUCTION             = 0x175, //stores perpetuation reduction depending on day (modId = 373)
-	MOD_PERPETUATION_REDUCTION    = 0x15A, //stores the MP/tick reduction from gear (modId = 346)
-	MOD_BP_DELAY                  = 0x165, //stores blood pact delay reduction (modId = 357)
+    // Summoner
+    MOD_AVATAR_PERPETUATION       = 0x173, // stores base cost of current avatar (modId = 371)
+    MOD_WEATHER_REDUCTION         = 0x174, // stores perpetuation reduction depending on weather (modId = 372)
+    MOD_DAY_REDUCTION             = 0x175, // stores perpetuation reduction depending on day (modId = 373)
+    MOD_PERPETUATION_REDUCTION    = 0x15A, // stores the MP/tick reduction from gear (modId = 346)
+    MOD_BP_DELAY                  = 0x165, // stores blood pact delay reduction (modId = 357)
 
-	// Blue Mage
-	MOD_BLUE_POINTS               = 0x135, // Tracks extra blue points (modId = 309)
+    // Blue Mage
+    MOD_BLUE_POINTS               = 0x135, // Tracks extra blue points (modId = 309)
 
-	// Corsair
-	MOD_EXP_BONUS                 = 0x17E, // (modId = 382)
+    // Corsair
+    MOD_EXP_BONUS                 = 0x17E, // (modId = 382)
 
-	MOD_PET_MABB                  = 0x138, // Tracks totals (modId = 312)
-	MOD_PET_MACC                  = 0x139, // Tracks totals (modId = 313)
-	MOD_PET_ATTP                  = 0x13A, // Tracks totals (modId = 314)
-	MOD_PET_ACC                   = 0x13B, // Tracks totals (modId = 315)
-	MOD_DMG_REFLECT               = 0x13C, // Tracks totals (modId = 316)
-	MOD_ROLL_ROGUES               = 0x13D, // Tracks totals (modId = 317)
-	MOD_ROLL_GALLANTS             = 0x13E, // Tracks totals (modId = 318)
-	MOD_ROLL_CHAOS                = 0x13F, // Tracks totals (modId = 319)
-	MOD_ROLL_BEAST                = 0x140, // Tracks totals (modId = 320)
-	MOD_ROLL_CHORAL               = 0x141, // Tracks totals (modId = 321)
-	MOD_ROLL_HUNTERS              = 0x142, // Tracks totals (modId = 322)
-	MOD_ROLL_SAMURAI              = 0x143, // Tracks totals (modId = 323)
-	MOD_ROLL_NINJA                = 0x144, // Tracks totals (modId = 324)
-	MOD_ROLL_DRACHEN              = 0x145, // Tracks totals (modId = 325)
-	MOD_ROLL_EVOKERS              = 0x146, // Tracks totals (modId = 326)
-	MOD_ROLL_MAGUS                = 0x147, // Tracks totals (modId = 327)
-	MOD_ROLL_CORSAIRS             = 0x148, // Tracks totals (modId = 328)
-	MOD_ROLL_PUPPET               = 0x149, // Tracks totals (modId = 329)
-	MOD_ROLL_DANCERS              = 0x14A, // Tracks totals (modId = 330)
-	MOD_ROLL_SCHOLARS             = 0x14B, // Tracks totals (modId = 331)
-	MOD_BUST                      = 0x14C, // # of busts (modId = 332)
+    MOD_PET_MABB                  = 0x138, // Tracks totals (modId = 312)
+    MOD_PET_MACC                  = 0x139, // Tracks totals (modId = 313)
+    MOD_PET_ATTP                  = 0x13A, // Tracks totals (modId = 314)
+    MOD_PET_ACC                   = 0x13B, // Tracks totals (modId = 315)
+    MOD_DMG_REFLECT               = 0x13C, // Tracks totals (modId = 316)
+    MOD_ROLL_ROGUES               = 0x13D, // Tracks totals (modId = 317)
+    MOD_ROLL_GALLANTS             = 0x13E, // Tracks totals (modId = 318)
+    MOD_ROLL_CHAOS                = 0x13F, // Tracks totals (modId = 319)
+    MOD_ROLL_BEAST                = 0x140, // Tracks totals (modId = 320)
+    MOD_ROLL_CHORAL               = 0x141, // Tracks totals (modId = 321)
+    MOD_ROLL_HUNTERS              = 0x142, // Tracks totals (modId = 322)
+    MOD_ROLL_SAMURAI              = 0x143, // Tracks totals (modId = 323)
+    MOD_ROLL_NINJA                = 0x144, // Tracks totals (modId = 324)
+    MOD_ROLL_DRACHEN              = 0x145, // Tracks totals (modId = 325)
+    MOD_ROLL_EVOKERS              = 0x146, // Tracks totals (modId = 326)
+    MOD_ROLL_MAGUS                = 0x147, // Tracks totals (modId = 327)
+    MOD_ROLL_CORSAIRS             = 0x148, // Tracks totals (modId = 328)
+    MOD_ROLL_PUPPET               = 0x149, // Tracks totals (modId = 329)
+    MOD_ROLL_DANCERS              = 0x14A, // Tracks totals (modId = 330)
+    MOD_ROLL_SCHOLARS             = 0x14B, // Tracks totals (modId = 331)
+    MOD_BUST                      = 0x14C, // # of busts (modId = 332)
     MOD_QUICK_DRAW_DMG            = 0x19B, // (modId = 411)
 
-	// Puppetmaster
+    // Puppetmaster
     MOD_MANEUVER_BONUS            = 0x1F8, // (modId = 504) Maneuver Stat Bonus
     MOD_OVERLOAD_THRESH           = 0x1F9, // (modId = 505) Overload Threshold Bonus
 
-	// Dancer
-	MOD_FINISHING_MOVES           = 0x14D, // Tracks # of finishing moves (modId = 333)    
+    // Dancer
+    MOD_FINISHING_MOVES           = 0x14D, // Tracks # of finishing moves (modId = 333)
     MOD_SAMBA_DURATION            = 0x1EA, // Samba duration bonus(modId = 490)
     MOD_WALTZ_POTENTCY            = 0x1EB, // Waltz Potentcy Bonus(modId = 491)
     MOD_CHOCO_JIG_DURATION        = 0x1EC, // Jig duration bonus (modId = 492)
@@ -433,92 +433,92 @@ enum MODIFIER
 
     //Scholar
     MOD_BLACK_MAGIC_COST          = 0x189, // MP cost for black magic (light/dark arts) (modId = 393)
-	MOD_WHITE_MAGIC_COST          = 0x18A, // MP cost for white magic (light/dark arts) (modId = 394)
-	MOD_BLACK_MAGIC_CAST          = 0x18B, // Cast time for black magic (light/dark arts) (modId = 395)
-	MOD_WHITE_MAGIC_CAST          = 0x18C, // Cast time for black magic (light/dark arts) (modId = 396)
-	MOD_BLACK_MAGIC_RECAST        = 0x18D, // Recast time for black magic (light/dark arts) (modId = 397)
-	MOD_WHITE_MAGIC_RECAST        = 0x18E, // Recast time for white magic (light/dark arts) (modId = 398)
-	MOD_ALACRITY_CELERITY_EFFECT  = 0x18F, // Bonus for celerity/alacrity effect (modId = 399)
-	MOD_LIGHT_ARTS_EFFECT         = 0x14E, // (modId = 334)
-	MOD_DARK_ARTS_EFFECT          = 0x14F, // (modId = 335)
-	MOD_LIGHT_ARTS_SKILL          = 0x150, // (modId = 336)
-	MOD_DARK_ARTS_SKILL           = 0x151, // (modId = 337)
-	MOD_REGEN_EFFECT              = 0x152, // (modId = 338)
-	MOD_REGEN_DURATION            = 0x153, // (modId = 339)
-	MOD_HELIX_EFFECT              = 0x1DE, // (modId = 478)
-	MOD_HELIX_DURATION            = 0x1DD, // (modId = 477)
-	MOD_STORMSURGE_EFFECT         = 0x190, // (modId = 400)
-	MOD_SUBLIMATION_BONUS         = 0x191, // (modId = 401)
+    MOD_WHITE_MAGIC_COST          = 0x18A, // MP cost for white magic (light/dark arts) (modId = 394)
+    MOD_BLACK_MAGIC_CAST          = 0x18B, // Cast time for black magic (light/dark arts) (modId = 395)
+    MOD_WHITE_MAGIC_CAST          = 0x18C, // Cast time for black magic (light/dark arts) (modId = 396)
+    MOD_BLACK_MAGIC_RECAST        = 0x18D, // Recast time for black magic (light/dark arts) (modId = 397)
+    MOD_WHITE_MAGIC_RECAST        = 0x18E, // Recast time for white magic (light/dark arts) (modId = 398)
+    MOD_ALACRITY_CELERITY_EFFECT  = 0x18F, // Bonus for celerity/alacrity effect (modId = 399)
+    MOD_LIGHT_ARTS_EFFECT         = 0x14E, // (modId = 334)
+    MOD_DARK_ARTS_EFFECT          = 0x14F, // (modId = 335)
+    MOD_LIGHT_ARTS_SKILL          = 0x150, // (modId = 336)
+    MOD_DARK_ARTS_SKILL           = 0x151, // (modId = 337)
+    MOD_REGEN_EFFECT              = 0x152, // (modId = 338)
+    MOD_REGEN_DURATION            = 0x153, // (modId = 339)
+    MOD_HELIX_EFFECT              = 0x1DE, // (modId = 478)
+    MOD_HELIX_DURATION            = 0x1DD, // (modId = 477)
+    MOD_STORMSURGE_EFFECT         = 0x190, // (modId = 400)
+    MOD_SUBLIMATION_BONUS         = 0x191, // (modId = 401)
     MOD_GRIMOIRE_SPELLCASTING     = 0x1E9, // (modID = 489) "Grimoire: Reduces spellcasting time" bonus
 
-	MOD_ENSPELL                   = 0x155, //stores the type of enspell active (0 if nothing) (modId = 341)
-	MOD_ENSPELL_DMG               = 0x157, //stores the base damage of the enspell before reductions (modId = 343)
+    MOD_ENSPELL                   = 0x155, // stores the type of enspell active (0 if nothing) (modId = 341)
+    MOD_ENSPELL_DMG               = 0x157, // stores the base damage of the enspell before reductions (modId = 343)
     MOD_ENSPELL_DMG_BONUS         = 0x1B0, // (modId = 432)
-	MOD_SPIKES                    = 0x156, //store the type of spike spell active (0 if nothing) (modId = 342)
-	MOD_SPIKES_DMG                = 0x158, //stores the base damage of the spikes before reductions (modId = 344)
+    MOD_SPIKES                    = 0x156, // store the type of spike spell active (0 if nothing) (modId = 342)
+    MOD_SPIKES_DMG                = 0x158, // stores the base damage of the spikes before reductions (modId = 344)
 
-	MOD_TP_BONUS                  = 0x159, // (modId = 345)
+    MOD_TP_BONUS                  = 0x159, // (modId = 345)
 
-	//stores the amount of elemental affinity (elemental staves mostly)
-	MOD_FIRE_AFFINITY             = 0x15B, // Fire Affinity (modId = 347)
-	MOD_EARTH_AFFINITY            = 0x15C, // Earth Affinity (modId = 348)
-	MOD_WATER_AFFINITY            = 0x15D, // Water Affinity (modId = 349)
-	MOD_ICE_AFFINITY              = 0x15E, // Ice Affinity (modId = 350)
-	MOD_THUNDER_AFFINITY          = 0x15F, // Lightning Affinity (modId = 351)
-	MOD_WIND_AFFINITY             = 0x160, // Wind Affinity (modId = 352)
-	MOD_LIGHT_AFFINITY            = 0x161, // Light Affinity (modId = 353)
-	MOD_DARK_AFFINITY             = 0x162, // Dark Affinity (modId = 354)
+    //stores the amount of elemental affinity (elemental staves mostly)
+    MOD_FIRE_AFFINITY             = 0x15B, // Fire Affinity (modId = 347)
+    MOD_EARTH_AFFINITY            = 0x15C, // Earth Affinity (modId = 348)
+    MOD_WATER_AFFINITY            = 0x15D, // Water Affinity (modId = 349)
+    MOD_ICE_AFFINITY              = 0x15E, // Ice Affinity (modId = 350)
+    MOD_THUNDER_AFFINITY          = 0x15F, // Lightning Affinity (modId = 351)
+    MOD_WIND_AFFINITY             = 0x160, // Wind Affinity (modId = 352)
+    MOD_LIGHT_AFFINITY            = 0x161, // Light Affinity (modId = 353)
+    MOD_DARK_AFFINITY             = 0x162, // Dark Affinity (modId = 354)
 
-	// Special Modifier+
+    // Special Modifier+
 
-	MOD_ADDS_WEAPONSKILL          = 0x163, // (modId = 355)
-	MOD_ADDS_WEAPONSKILL_DYN      = 0x164, // In Dynamis (modId = 356)
+    MOD_ADDS_WEAPONSKILL          = 0x163, // (modId = 355)
+    MOD_ADDS_WEAPONSKILL_DYN      = 0x164, // In Dynamis (modId = 356)
 
-	MOD_STEALTH                   = 0x166, // (modId = 358)
+    MOD_STEALTH                   = 0x166, // (modId = 358)
 
-	MOD_MAIN_DMG_RATING           = 0x16E, //adds damage rating to main hand weapon (maneater/blau dolch etc hidden effects) (modId = 366)
-	MOD_SUB_DMG_RATING            = 0x16F, //adds damage rating to off hand weapon (modId = 367)
-	MOD_REGAIN                    = 0x170, //auto regain TP (from items) | this is multiplied by 10 e.g. 20 is 2% TP (modId = 368)
-	MOD_REGAIN_DOWN               = 0x196, // plague, reduce tp (modId = 406)
-	MOD_REFRESH                   = 0x171, //auto refresh from equipment (modId = 369)
-	MOD_REFRESH_DOWN              = 0x195, // plague, reduce mp (modId = 405)
-	MOD_REGEN                     = 0x172, //auto regen from equipment (modId = 370)
-	MOD_REGEN_DOWN                = 0x194, // poison (modId = 404)
-	MOD_CURE_POTENCY              = 0x176, //% cure potency | bonus from gear is capped at 50 (modId = 374)
-	MOD_CURE_POTENCY_RCVD         = 0x177, //% potency of received cure | healer's roll, some items have this (modId = 375)
-	MOD_RANGED_DMG_RATING         = 0x178, //adds damage rating to ranged weapon (modId = 376)
-	MOD_MAIN_DMG_RANK             = 0x179, //adds weapon rank to main weapon (modId = 377) (http://wiki.bluegartr.com/bg/Weapon_Rank)
-	MOD_SUB_DMG_RANK              = 0x17A, //adds weapon rank to sub weapon (modId = 378)
-	MOD_RANGED_DMG_RANK           = 0x17B, //adds weapon rank to ranged weapon (modId = 379)
-	MOD_DELAYP                    = 0x17C, //delay addition percent (does not affect tp gain) (modId = 380)
-	MOD_RANGED_DELAYP             = 0x17D, //ranged delay addition percent (does not affect tp gain) (modId = 381)
+    MOD_MAIN_DMG_RATING           = 0x16E, // adds damage rating to main hand weapon (maneater/blau dolch etc hidden effects) (modId = 366)
+    MOD_SUB_DMG_RATING            = 0x16F, // adds damage rating to off hand weapon (modId = 367)
+    MOD_REGAIN                    = 0x170, // auto regain TP (from items) | this is multiplied by 10 e.g. 20 is 2% TP (modId = 368)
+    MOD_REGAIN_DOWN               = 0x196, // plague, reduce tp (modId = 406)
+    MOD_REFRESH                   = 0x171, // auto refresh from equipment (modId = 369)
+    MOD_REFRESH_DOWN              = 0x195, // plague, reduce mp (modId = 405)
+    MOD_REGEN                     = 0x172, // auto regen from equipment (modId = 370)
+    MOD_REGEN_DOWN                = 0x194, // poison (modId = 404)
+    MOD_CURE_POTENCY              = 0x176, // % cure potency | bonus from gear is capped at 50 (modId = 374)
+    MOD_CURE_POTENCY_RCVD         = 0x177, // % potency of received cure | healer's roll, some items have this (modId = 375)
+    MOD_RANGED_DMG_RATING         = 0x178, // adds damage rating to ranged weapon (modId = 376)
+    MOD_MAIN_DMG_RANK             = 0x179, // adds weapon rank to main weapon (modId = 377) (http://wiki.bluegartr.com/bg/Weapon_Rank)
+    MOD_SUB_DMG_RANK              = 0x17A, // adds weapon rank to sub weapon (modId = 378)
+    MOD_RANGED_DMG_RANK           = 0x17B, // adds weapon rank to ranged weapon (modId = 379)
+    MOD_DELAYP                    = 0x17C, // delay addition percent (does not affect tp gain) (modId = 380)
+    MOD_RANGED_DELAYP             = 0x17D, // ranged delay addition percent (does not affect tp gain) (modId = 381)
 
-	MOD_SHIELD_BASH               = 0x181, // (modId = 385)
-	MOD_KICK_DMG                  = 0x182, // increases kick attack damage (modId = 386)
-	MOD_WEAPON_BASH               = 0x188, // (modId = 392)
+    MOD_SHIELD_BASH               = 0x181, // (modId = 385)
+    MOD_KICK_DMG                  = 0x182, // increases kick attack damage (modId = 386)
+    MOD_WEAPON_BASH               = 0x188, // (modId = 392)
 
-	MOD_WYVERN_BREATH             = 0x192, // (modId = 402)
+    MOD_WYVERN_BREATH             = 0x192, // (modId = 402)
 
 
-	/// Gear set modifiers
-	MOD_DA_DOUBLE_DAMAGE		  = 0x198, // Double attack's double damage chance %. (modId = 408)
-	MOD_TA_TRIPLE_DAMAGE		  = 0x199, // Triple attack's triple damage chance %. (modId = 409)
-	MOD_ZANSHIN_DOUBLE_DAMAGE	  = 0x19A, // Zanshin's double damage chance %. (modId = 410)
-	MOD_RAPID_SHOT_DOUBLE_DAMAGE  = 0x1DF, // Rapid shot's double damage chance %. (modId = 479)
-	MOD_ABSORB_DMG_CHANCE		  = 0x1E0, // Chance to absorb damage % (modId = 480)
-	MOD_EXTRA_DUAL_WIELD_ATTACK   = 0x1E1, // Chance to land an extra attack when dual wielding (modId = 481)
-	MOD_EXTRA_KICK_ATTACK		  = 0x1E2, // Occasionally allows a second Kick Attack during an attack round without the use of Footwork.  (modId = 482)
-	MOD_SAMBA_DOUBLE_DAMAGE		  = 0x19F, // Double damage chance when samba is up. (modId = 415)
-	MOD_NULL_PHYSICAL_DAMAGE	  = 0x1A0, // Chance to null physical damage. (modId = 416)
-	MOD_QUICK_DRAW_TRIPLE_DAMAGE  = 0x1A1, // Chance to do triple damage with quick draw. (modId = 417)
-	MOD_BAR_ELEMENT_NULL_CHANCE	  = 0x1A2, // Bar Elemental spells will occasionally nullify damage of the same element. (modId = 418)
-	MOD_GRIMOIRE_INSTANT_CAST	  = 0x1A3, // Spells that match your current Arts will occasionally cast instantly, without recast. (modId = 419) 
-	MOD_QUAD_ATTACK				  = 0x1AE, // Quadruple attack chance. (modId = 430)
+    /// Gear set modifiers
+    MOD_DA_DOUBLE_DAMAGE          = 0x198, // Double attack's double damage chance %. (modId = 408)
+    MOD_TA_TRIPLE_DAMAGE          = 0x199, // Triple attack's triple damage chance %. (modId = 409)
+    MOD_ZANSHIN_DOUBLE_DAMAGE     = 0x19A, // Zanshin's double damage chance %. (modId = 410)
+    MOD_RAPID_SHOT_DOUBLE_DAMAGE  = 0x1DF, // Rapid shot's double damage chance %. (modId = 479)
+    MOD_ABSORB_DMG_CHANCE         = 0x1E0, // Chance to absorb damage % (modId = 480)
+    MOD_EXTRA_DUAL_WIELD_ATTACK   = 0x1E1, // Chance to land an extra attack when dual wielding (modId = 481)
+    MOD_EXTRA_KICK_ATTACK         = 0x1E2, // Occasionally allows a second Kick Attack during an attack round without the use of Footwork.  (modId = 482)
+    MOD_SAMBA_DOUBLE_DAMAGE       = 0x19F, // Double damage chance when samba is up. (modId = 415)
+    MOD_NULL_PHYSICAL_DAMAGE      = 0x1A0, // Chance to null physical damage. (modId = 416)
+    MOD_QUICK_DRAW_TRIPLE_DAMAGE  = 0x1A1, // Chance to do triple damage with quick draw. (modId = 417)
+    MOD_BAR_ELEMENT_NULL_CHANCE   = 0x1A2, // Bar Elemental spells will occasionally nullify damage of the same element. (modId = 418)
+    MOD_GRIMOIRE_INSTANT_CAST     = 0x1A3, // Spells that match your current Arts will occasionally cast instantly, without recast. (modId = 419)
+    MOD_QUAD_ATTACK               = 0x1AE, // Quadruple attack chance. (modId = 430)
 
-	// Reraise (Auto Reraise, used by gear)
-	MOD_RERAISE_I				  = 0x1C8, // Reraise. (modId = 456)
-	MOD_RERAISE_II				  = 0x1C9, // Reraise II. (modId = 457)
-	MOD_RERAISE_III				  = 0x1CA, // Reraise III. (modId = 458)
+    // Reraise (Auto Reraise, used by gear)
+    MOD_RERAISE_I                 = 0x1C8, // Reraise. (modId = 456)
+    MOD_RERAISE_II                = 0x1C9, // Reraise II. (modId = 457)
+    MOD_RERAISE_III               = 0x1CA, // Reraise III. (modId = 458)
 
     //Elemental Absorb Chance
     MOD_FIRE_ABSORB               = 0x1CB, // (modId = 459)
@@ -561,8 +561,9 @@ enum MODIFIER
 
     MOD_CLAMMING_IMPROVED_RESULTS = 0x1FD, // (modId = 509)
     MOD_CLAMMING_REDUCED_INCIDENTS= 0x1FE, // (modId = 510)
-	
-	// MOD_SPARE = 0x1FF, // (modId = 511)
+
+    MOD_CHOCOBO_RIDING_TIME       = 0x1FF, // Increases chocobo riding time (modId = 511)
+
     // MOD_SPARE = 0x200, // (modId = 512)
     // MOD_SPARE = 0x201, // (modId = 513)
     // MOD_SPARE = 0x202, // (modId = 514)
@@ -571,30 +572,30 @@ enum MODIFIER
 
 };
 
-#define MAX_MODIFIER 511
+#define MAX_MODIFIER 512
 
 
 
 /************************************************************************
-*  Modifier Class														*
+*  Modifier Class                                                       *
 ************************************************************************/
 
 class CModifier
 {
 public:
 
-	uint16	getModID();
-	int16	getModAmount();
+    uint16  getModID();
+    int16   getModAmount();
 
-	void	setModAmount(int16 amount);
+    void    setModAmount(int16 amount);
 
-	 CModifier(uint16 type, int16 amount = 0);
-	~CModifier();
+     CModifier(uint16 type, int16 amount = 0);
+    ~CModifier();
 
 private:
 
-	uint16	m_id;
-	int16	m_amount;
+    uint16  m_id;
+    int16   m_amount;
 };
 
 #endif


### PR DESCRIPTION
CORE: Add modifier chocobo riding time (modId = 509). Cleanup modifier.h

SQL: Add modifier chocobo riding time to: Chocobo Boots, Rider's Boots, Chocobo Gloves, Rider's Gloves, Chocobo Hose, Rider's Hose, Chocobo Jack Coat, Rider's Jack Coat, Chocobo Wand, Chocobo Torque, Orange Racing Silks

SCRIPTS: Add chocobo.lua with general functions. Cleanup modified lua files. Modified NPC's to mimic retail:
    - Players must be level 20 and have a Chocobo License. In San d'Oria, Bastok and Windurst you can rent a chocobo at level 15 or above.
    - Normal riding time of a chocobo is 30 minutes. If your level are 15-20, riding time is 15 minutes.
    - Chocobo gear only affects to level 20 or above players.

TODO:
    - NPC's accepts Chocobo Ticket and Chocopass (Chocopass only in San d'Oria, Bastok and Windurst).
    - A Chocobo Riding Game Quest.
    - NPC's on WOTG areas.