### PR TITLE
Added the KeyItem method of completing "In Defiant Challenge".

### DIFF
--- a/scripts/globals/settings.lua
+++ b/scripts/globals/settings.lua
@@ -117,6 +117,7 @@ AF2_FAME = 40; -- base fame for completing an AF2 quest
 AF3_FAME = 60; -- base fame for completing an AF3 quest
 DEBUG_MODE = 0; -- Set to 1 to activate auto-warping to the next location (only supported by certain missions / quests).
 QM_RESET_TIME = 300; -- Default time (in seconds) you have from killing ???-pop mission NMs to click again and get key item, until ??? resets.
+OldSchoolG1 = false; -- Set to true to require farming Exoray Mold, Bombd Coal, and Ancient Papyrus drops instead of allowing key item method.
 OldSchoolG2 = false; -- Set true to require the NMs for "Atop the Highest Mountains" be dead to get KI like before SE changed it.
 FrigiciteDuration = 30; -- When OldSChoolG2 is enabled, this is the time (in seconds) you have from killing Boreal NMs to click the "???" target.
 

--- a/scripts/zones/Crawlers_Nest/npcs/qm10.lua
+++ b/scripts/zones/Crawlers_Nest/npcs/qm10.lua
@@ -1,0 +1,67 @@
+-----------------------------------
+-- Area: Crawlers' Nest
+--  NPC: qm10 (??? - Exoray Mold Crumbs)
+-- Involved in Quest: In Defiant Challenge
+-- @pos -83.391 -8.222 79.065 197
+-----------------------------------
+package.loaded["scripts/zones/Crawlers_Nest/TextIDs"] = nil;
+-----------------------------------
+
+require("scripts/globals/quests");
+require("scripts/globals/keyitems");
+require("scripts/globals/settings");
+require("scripts/zones/Crawlers_Nest/TextIDs");
+
+-----------------------------------
+-- onTrade Action
+-----------------------------------
+
+function onTrade(player,npc,trade)
+end;
+
+-----------------------------------
+-- onTrigger Action
+-----------------------------------
+
+function onTrigger(player,npc)
+    if (OldSchoolG1 == false) then
+        if (player:hasItem(1089) == false and player:hasKeyItem(EXORAY_MOLD_CRUMB1) == false
+        and player:getQuestStatus(JEUNO,IN_DEFIANT_CHALLENGE) == QUEST_ACCEPTED) then
+            player:addKeyItem(EXORAY_MOLD_CRUMB1);
+            player:messageSpecial(KEYITEM_OBTAINED,EXORAY_MOLD_CRUMB1);
+        end
+
+        if (player:hasKeyItem(EXORAY_MOLD_CRUMB1) and player:hasKeyItem(EXORAY_MOLD_CRUMB2) and player:hasKeyItem(EXORAY_MOLD_CRUMB3)) then
+            if (player:getFreeSlotsCount() >= 1) then
+                player:addItem(1089, 1);
+                player:messageSpecial(ITEM_OBTAINED, 1089);
+            else
+                player:messageSpecial(ITEM_CANNOT_BE_OBTAINED, 1089);
+            end
+        end
+        
+        if (player:hasItem(1089)) then
+            player:delKeyItem(EXORAY_MOLD_CRUMB1);
+            player:delKeyItem(EXORAY_MOLD_CRUMB2);
+            player:delKeyItem(EXORAY_MOLD_CRUMB3);
+        end
+    end
+end;
+
+-----------------------------------
+-- onEventUpdate
+-----------------------------------
+
+function onEventUpdate(player,csid,option)
+    -- printf("CSID2: %u",csid);
+    -- printf("RESULT2: %u",option);
+end;
+
+-----------------------------------
+-- onEventFinish
+-----------------------------------
+
+function onEventFinish(player,csid,option)
+    -- printf("CSID: %u",csid);
+    -- printf("RESULT: %u",option);
+end;

--- a/scripts/zones/Crawlers_Nest/npcs/qm11.lua
+++ b/scripts/zones/Crawlers_Nest/npcs/qm11.lua
@@ -1,0 +1,67 @@
+-----------------------------------
+-- Area: Crawlers' Nest
+--  NPC: qm11 (??? - Exoray Mold Crumbs)
+-- Involved in Quest: In Defiant Challenge
+-- @pos 98.081 -38.75 -181.198 197
+-----------------------------------
+package.loaded["scripts/zones/Crawlers_Nest/TextIDs"] = nil;
+-----------------------------------
+
+require("scripts/globals/quests");
+require("scripts/globals/keyitems");
+require("scripts/globals/settings");
+require("scripts/zones/Crawlers_Nest/TextIDs");
+
+-----------------------------------
+-- onTrade Action
+-----------------------------------
+
+function onTrade(player,npc,trade)
+end;
+
+-----------------------------------
+-- onTrigger Action
+-----------------------------------
+
+function onTrigger(player,npc)
+    if (OldSchoolG1 == false) then
+        if (player:hasItem(1089) == false and player:hasKeyItem(EXORAY_MOLD_CRUMB2) == false
+        and player:getQuestStatus(JEUNO,IN_DEFIANT_CHALLENGE) == QUEST_ACCEPTED) then
+            player:addKeyItem(EXORAY_MOLD_CRUMB2);
+            player:messageSpecial(KEYITEM_OBTAINED,EXORAY_MOLD_CRUMB2);
+        end
+
+        if (player:hasKeyItem(EXORAY_MOLD_CRUMB1) and player:hasKeyItem(EXORAY_MOLD_CRUMB2) and player:hasKeyItem(EXORAY_MOLD_CRUMB3)) then
+            if (player:getFreeSlotsCount() >= 1) then
+                player:addItem(1089, 1);
+                player:messageSpecial(ITEM_OBTAINED, 1089);
+            else
+                player:messageSpecial(ITEM_CANNOT_BE_OBTAINED, 1089);
+            end
+        end
+
+        if (player:hasItem(1089)) then
+            player:delKeyItem(EXORAY_MOLD_CRUMB1);
+            player:delKeyItem(EXORAY_MOLD_CRUMB2);
+            player:delKeyItem(EXORAY_MOLD_CRUMB3);
+        end
+    end
+end;
+
+-----------------------------------
+-- onEventUpdate
+-----------------------------------
+
+function onEventUpdate(player,csid,option)
+    -- printf("CSID2: %u",csid);
+    -- printf("RESULT2: %u",option);
+end;
+
+-----------------------------------
+-- onEventFinish
+-----------------------------------
+
+function onEventFinish(player,csid,option)
+    -- printf("CSID: %u",csid);
+    -- printf("RESULT: %u",option);
+end;

--- a/scripts/zones/Crawlers_Nest/npcs/qm12.lua
+++ b/scripts/zones/Crawlers_Nest/npcs/qm12.lua
@@ -1,0 +1,67 @@
+-----------------------------------
+-- Area: Crawlers' Nest
+--  NPC: qm12 (??? - Exoray Mold Crumbs)
+-- Involved in Quest: In Defiant Challenge
+-- @pos 99.326 -0.126 -188.869 197
+-----------------------------------
+package.loaded["scripts/zones/Crawlers_Nest/TextIDs"] = nil;
+-----------------------------------
+
+require("scripts/globals/quests");
+require("scripts/globals/keyitems");
+require("scripts/globals/settings");
+require("scripts/zones/Crawlers_Nest/TextIDs");
+
+-----------------------------------
+-- onTrade Action
+-----------------------------------
+
+function onTrade(player,npc,trade)
+end;
+
+-----------------------------------
+-- onTrigger Action
+-----------------------------------
+
+function onTrigger(player,npc)
+    if (OldSchoolG1 == false) then
+        if (player:hasItem(1089) == false and player:hasKeyItem(EXORAY_MOLD_CRUMB3) == false
+        and player:getQuestStatus(JEUNO,IN_DEFIANT_CHALLENGE) == QUEST_ACCEPTED) then
+            player:addKeyItem(EXORAY_MOLD_CRUMB3);
+            player:messageSpecial(KEYITEM_OBTAINED,EXORAY_MOLD_CRUMB3);
+        end
+
+        if (player:hasKeyItem(EXORAY_MOLD_CRUMB1) and player:hasKeyItem(EXORAY_MOLD_CRUMB2) and player:hasKeyItem(EXORAY_MOLD_CRUMB3)) then
+            if (player:getFreeSlotsCount() >= 1) then
+                player:addItem(1089, 1);
+                player:messageSpecial(ITEM_OBTAINED, 1089);
+            else
+                player:messageSpecial(ITEM_CANNOT_BE_OBTAINED, 1089);
+            end
+        end
+
+        if (player:hasItem(1089)) then
+            player:delKeyItem(EXORAY_MOLD_CRUMB1);
+            player:delKeyItem(EXORAY_MOLD_CRUMB2);
+            player:delKeyItem(EXORAY_MOLD_CRUMB3);
+        end
+    end
+end;
+
+-----------------------------------
+-- onEventUpdate
+-----------------------------------
+
+function onEventUpdate(player,csid,option)
+    -- printf("CSID2: %u",csid);
+    -- printf("RESULT2: %u",option);
+end;
+
+-----------------------------------
+-- onEventFinish
+-----------------------------------
+
+function onEventFinish(player,csid,option)
+    -- printf("CSID: %u",csid);
+    -- printf("RESULT: %u",option);
+end;

--- a/scripts/zones/Garlaige_Citadel/npcs/qm18.lua
+++ b/scripts/zones/Garlaige_Citadel/npcs/qm18.lua
@@ -1,0 +1,67 @@
+-----------------------------------
+-- Area: Garlaige Citadel
+--  NPC: qm18 (??? - Bomb Coal Fragments)
+-- Involved in Quest: In Defiant Challenge
+-- @pos -13.425,-1.176,191.669 200
+-----------------------------------
+package.loaded["scripts/zones/Garlaige_Citadel/TextIDs"] = nil;
+-----------------------------------
+
+require("scripts/globals/quests");
+require("scripts/globals/keyitems");
+require("scripts/globals/settings");
+require("scripts/zones/Garlaige_Citadel/TextIDs");
+
+-----------------------------------
+-- onTrade Action
+-----------------------------------
+
+function onTrade(player,npc,trade)
+end;
+
+-----------------------------------
+-- onTrigger Action
+-----------------------------------
+
+function onTrigger(player,npc)
+    if (OldSchoolG1 == false) then
+        if (player:hasItem(1090) == false and player:hasKeyItem(BOMB_COAL_FRAGMENT1) == false
+        and player:getQuestStatus(JEUNO,IN_DEFIANT_CHALLENGE) == QUEST_ACCEPTED) then
+            player:addKeyItem(BOMB_COAL_FRAGMENT1);
+            player:messageSpecial(KEYITEM_OBTAINED,BOMB_COAL_FRAGMENT1);
+        end
+
+        if (player:hasKeyItem(BOMB_COAL_FRAGMENT1) and player:hasKeyItem(BOMB_COAL_FRAGMENT2) and player:hasKeyItem(BOMB_COAL_FRAGMENT3)) then
+            if (player:getFreeSlotsCount() >= 1) then
+                player:addItem(1090, 1);
+                player:messageSpecial(ITEM_OBTAINED, 1090);
+            else
+                player:messageSpecial(ITEM_CANNOT_BE_OBTAINED, 1090);
+            end
+        end
+
+        if (player:hasItem(1090)) then
+            player:delKeyItem(BOMB_COAL_FRAGMENT1);
+            player:delKeyItem(BOMB_COAL_FRAGMENT2);
+            player:delKeyItem(BOMB_COAL_FRAGMENT3);
+        end
+    end
+end;
+
+-----------------------------------
+-- onEventUpdate
+-----------------------------------
+
+function onEventUpdate(player,csid,option)
+    -- printf("CSID2: %u",csid);
+    -- printf("RESULT2: %u",option);
+end;
+
+-----------------------------------
+-- onEventFinish
+-----------------------------------
+
+function onEventFinish(player,csid,option)
+    -- printf("CSID: %u",csid);
+    -- printf("RESULT: %u",option);
+end;

--- a/scripts/zones/Garlaige_Citadel/npcs/qm19.lua
+++ b/scripts/zones/Garlaige_Citadel/npcs/qm19.lua
@@ -1,0 +1,67 @@
+-----------------------------------
+-- Area: Garlaige Citadel
+--  NPC: qm19 (??? - Bomb Coal Fragments)
+-- Involved in Quest: In Defiant Challenge
+-- @pos -50.175 6.264 251.669 200
+-----------------------------------
+package.loaded["scripts/zones/Garlaige_Citadel/TextIDs"] = nil;
+-----------------------------------
+
+require("scripts/globals/quests");
+require("scripts/globals/keyitems");
+require("scripts/globals/settings");
+require("scripts/zones/Garlaige_Citadel/TextIDs");
+
+-----------------------------------
+-- onTrade Action
+-----------------------------------
+
+function onTrade(player,npc,trade)
+end;
+
+-----------------------------------
+-- onTrigger Action
+-----------------------------------
+
+function onTrigger(player,npc)
+    if (OldSchoolG1 == false) then
+        if (player:hasItem(1090) == false and player:hasKeyItem(BOMB_COAL_FRAGMENT2) == false
+        and player:getQuestStatus(JEUNO,IN_DEFIANT_CHALLENGE) == QUEST_ACCEPTED) then
+            player:addKeyItem(BOMB_COAL_FRAGMENT2);
+            player:messageSpecial(KEYITEM_OBTAINED,BOMB_COAL_FRAGMENT2);
+        end
+
+        if (player:hasKeyItem(BOMB_COAL_FRAGMENT1) and player:hasKeyItem(BOMB_COAL_FRAGMENT2) and player:hasKeyItem(BOMB_COAL_FRAGMENT3)) then
+            if (player:getFreeSlotsCount() >= 1) then
+                player:addItem(1090, 1);
+                player:messageSpecial(ITEM_OBTAINED, 1090);
+            else
+                player:messageSpecial(ITEM_CANNOT_BE_OBTAINED, 1090);
+            end
+        end
+
+        if (player:hasItem(1090)) then
+            player:delKeyItem(BOMB_COAL_FRAGMENT1);
+            player:delKeyItem(BOMB_COAL_FRAGMENT2);
+            player:delKeyItem(BOMB_COAL_FRAGMENT3);
+        end
+    end
+end;
+
+-----------------------------------
+-- onEventUpdate
+-----------------------------------
+
+function onEventUpdate(player,csid,option)
+    -- printf("CSID2: %u",csid);
+    -- printf("RESULT2: %u",option);
+end;
+
+-----------------------------------
+-- onEventFinish
+-----------------------------------
+
+function onEventFinish(player,csid,option)
+    -- printf("CSID: %u",csid);
+    -- printf("RESULT: %u",option);
+end;

--- a/scripts/zones/Garlaige_Citadel/npcs/qm20.lua
+++ b/scripts/zones/Garlaige_Citadel/npcs/qm20.lua
@@ -1,0 +1,67 @@
+-----------------------------------
+-- Area: Garlaige Citadel
+--  NPC: qm20 (??? - Bomb Coal Fragments)
+-- Involved in Quest: In Defiant Challenge
+-- @pos -137.047 0 347.502 200
+-----------------------------------
+package.loaded["scripts/zones/Garlaige_Citadel/TextIDs"] = nil;
+-----------------------------------
+
+require("scripts/globals/quests");
+require("scripts/globals/keyitems");
+require("scripts/globals/settings");
+require("scripts/zones/Garlaige_Citadel/TextIDs");
+
+-----------------------------------
+-- onTrade Action
+-----------------------------------
+
+function onTrade(player,npc,trade)
+end;
+
+-----------------------------------
+-- onTrigger Action
+-----------------------------------
+
+function onTrigger(player,npc)
+    if (OldSchoolG1 == false) then
+        if (player:hasItem(1090) == false and player:hasKeyItem(BOMB_COAL_FRAGMENT3) == false
+        and player:getQuestStatus(JEUNO,IN_DEFIANT_CHALLENGE) == QUEST_ACCEPTED) then
+            player:addKeyItem(BOMB_COAL_FRAGMENT3);
+            player:messageSpecial(KEYITEM_OBTAINED,BOMB_COAL_FRAGMENT3);
+        end
+
+        if (player:hasKeyItem(BOMB_COAL_FRAGMENT1) and player:hasKeyItem(BOMB_COAL_FRAGMENT2) and player:hasKeyItem(BOMB_COAL_FRAGMENT3)) then
+            if (player:getFreeSlotsCount() >= 1) then
+                player:addItem(1090, 1);
+                player:messageSpecial(ITEM_OBTAINED, 1090);
+            else
+                player:messageSpecial(ITEM_CANNOT_BE_OBTAINED, 1090);
+            end
+        end
+
+        if (player:hasItem(1090)) then
+            player:delKeyItem(BOMB_COAL_FRAGMENT1);
+            player:delKeyItem(BOMB_COAL_FRAGMENT2);
+            player:delKeyItem(BOMB_COAL_FRAGMENT3);
+        end
+    end
+end;
+
+-----------------------------------
+-- onEventUpdate
+-----------------------------------
+
+function onEventUpdate(player,csid,option)
+    -- printf("CSID2: %u",csid);
+    -- printf("RESULT2: %u",option);
+end;
+
+-----------------------------------
+-- onEventFinish
+-----------------------------------
+
+function onEventFinish(player,csid,option)
+    -- printf("CSID: %u",csid);
+    -- printf("RESULT: %u",option);
+end;

--- a/scripts/zones/The_Eldieme_Necropolis/npcs/qm7.lua
+++ b/scripts/zones/The_Eldieme_Necropolis/npcs/qm7.lua
@@ -1,0 +1,67 @@
+-----------------------------------
+-- Area: The Eldieme Necropolis
+--  NPC: qm7 (??? - Ancient Papyrus Shreds)
+-- Involved in Quest: In Defiant Challenge
+-- @pos 105.275 -32 92.551 195
+-----------------------------------
+package.loaded["scripts/zones/The_Eldieme_Necropolis/TextIDs"] = nil;
+-----------------------------------
+
+require("scripts/globals/quests");
+require("scripts/globals/keyitems");
+require("scripts/globals/settings");
+require("scripts/zones/The_Eldieme_Necropolis/TextIDs");
+
+-----------------------------------
+-- onTrade Action
+-----------------------------------
+
+function onTrade(player,npc,trade)
+end;
+
+-----------------------------------
+-- onTrigger Action
+-----------------------------------
+
+function onTrigger(player,npc)
+    if (OldSchoolG1 == false) then
+        if (player:hasItem(1088) == false and player:hasKeyItem(ANCIENT_PAPYRUS_SHRED1) == false
+        and player:getQuestStatus(JEUNO,IN_DEFIANT_CHALLENGE) == QUEST_ACCEPTED) then
+            player:addKeyItem(ANCIENT_PAPYRUS_SHRED1);
+            player:messageSpecial(KEYITEM_OBTAINED,ANCIENT_PAPYRUS_SHRED1);
+        end
+
+        if (player:hasKeyItem(ANCIENT_PAPYRUS_SHRED1) and player:hasKeyItem(ANCIENT_PAPYRUS_SHRED2) and player:hasKeyItem(ANCIENT_PAPYRUS_SHRED3)) then
+            if (player:getFreeSlotsCount() >= 1) then
+                player:addItem(1088, 1);
+                player:messageSpecial(ITEM_OBTAINED, 1088);
+            else
+                player:messageSpecial(ITEM_CANNOT_BE_OBTAINED, 1088);
+            end
+        end
+
+        if (player:hasItem(1088)) then
+            player:delKeyItem(ANCIENT_PAPYRUS_SHRED1);
+            player:delKeyItem(ANCIENT_PAPYRUS_SHRED2);
+            player:delKeyItem(ANCIENT_PAPYRUS_SHRED3);
+        end
+    end
+end;
+
+-----------------------------------
+-- onEventUpdate
+-----------------------------------
+
+function onEventUpdate(player,csid,option)
+    -- printf("CSID2: %u",csid);
+    -- printf("RESULT2: %u",option);
+end;
+
+-----------------------------------
+-- onEventFinish
+-----------------------------------
+
+function onEventFinish(player,csid,option)
+    -- printf("CSID: %u",csid);
+    -- printf("RESULT: %u",option);
+end;

--- a/scripts/zones/The_Eldieme_Necropolis/npcs/qm8.lua
+++ b/scripts/zones/The_Eldieme_Necropolis/npcs/qm8.lua
@@ -1,0 +1,67 @@
+-----------------------------------
+-- Area: The Eldieme Necropolis
+--  NPC: qm8 (??? - Ancient Papyrus Shreds)
+-- Involved in Quest: In Defiant Challenge
+-- @pos 105.275 -32 92.551 195
+-----------------------------------
+package.loaded["scripts/zones/The_Eldieme_Necropolis/TextIDs"] = nil;
+-----------------------------------
+
+require("scripts/globals/quests");
+require("scripts/globals/keyitems");
+require("scripts/globals/settings");
+require("scripts/zones/The_Eldieme_Necropolis/TextIDs");
+
+-----------------------------------
+-- onTrade Action
+-----------------------------------
+
+function onTrade(player,npc,trade)
+end;
+
+-----------------------------------
+-- onTrigger Action
+-----------------------------------
+
+function onTrigger(player,npc)
+    if (OldSchoolG1 == false) then
+        if (player:hasItem(1088) == false and player:hasKeyItem(ANCIENT_PAPYRUS_SHRED2) == false
+        and player:getQuestStatus(JEUNO,IN_DEFIANT_CHALLENGE) == QUEST_ACCEPTED) then
+            player:addKeyItem(ANCIENT_PAPYRUS_SHRED2);
+            player:messageSpecial(KEYITEM_OBTAINED,ANCIENT_PAPYRUS_SHRED2);
+        end
+
+        if (player:hasKeyItem(ANCIENT_PAPYRUS_SHRED1) and player:hasKeyItem(ANCIENT_PAPYRUS_SHRED2) and player:hasKeyItem(ANCIENT_PAPYRUS_SHRED3)) then
+            if (player:getFreeSlotsCount() >= 1) then
+                player:addItem(1088, 1);
+                player:messageSpecial(ITEM_OBTAINED, 1088);
+            else
+                player:messageSpecial(ITEM_CANNOT_BE_OBTAINED, 1088);
+            end
+        end
+
+        if (player:hasItem(1088)) then
+            player:delKeyItem(ANCIENT_PAPYRUS_SHRED1);
+            player:delKeyItem(ANCIENT_PAPYRUS_SHRED2);
+            player:delKeyItem(ANCIENT_PAPYRUS_SHRED3);
+        end
+    end
+end;
+
+-----------------------------------
+-- onEventUpdate
+-----------------------------------
+
+function onEventUpdate(player,csid,option)
+    -- printf("CSID2: %u",csid);
+    -- printf("RESULT2: %u",option);
+end;
+
+-----------------------------------
+-- onEventFinish
+-----------------------------------
+
+function onEventFinish(player,csid,option)
+    -- printf("CSID: %u",csid);
+    -- printf("RESULT: %u",option);
+end;

--- a/scripts/zones/The_Eldieme_Necropolis/npcs/qm9.lua
+++ b/scripts/zones/The_Eldieme_Necropolis/npcs/qm9.lua
@@ -1,0 +1,67 @@
+-----------------------------------
+-- Area: The Eldieme Necropolis
+--  NPC: qm9 (??? - Ancient Papyrus Shreds)
+-- Involved in Quest: In Defiant Challenge
+-- @pos 92.272 -32 -64.676 195
+-----------------------------------
+package.loaded["scripts/zones/The_Eldieme_Necropolis/TextIDs"] = nil;
+-----------------------------------
+
+require("scripts/globals/quests");
+require("scripts/globals/keyitems");
+require("scripts/globals/settings");
+require("scripts/zones/The_Eldieme_Necropolis/TextIDs");
+
+-----------------------------------
+-- onTrade Action
+-----------------------------------
+
+function onTrade(player,npc,trade)
+end;
+
+-----------------------------------
+-- onTrigger Action
+-----------------------------------
+
+function onTrigger(player,npc)
+    if (OldSchoolG1 == false) then
+        if (player:hasItem(1088) == false and player:hasKeyItem(ANCIENT_PAPYRUS_SHRED3) == false
+        and player:getQuestStatus(JEUNO,IN_DEFIANT_CHALLENGE) == QUEST_ACCEPTED) then
+            player:addKeyItem(ANCIENT_PAPYRUS_SHRED3);
+            player:messageSpecial(KEYITEM_OBTAINED,ANCIENT_PAPYRUS_SHRED3);
+        end
+
+        if (player:hasKeyItem(ANCIENT_PAPYRUS_SHRED1) and player:hasKeyItem(ANCIENT_PAPYRUS_SHRED2) and player:hasKeyItem(ANCIENT_PAPYRUS_SHRED3)) then
+            if (player:getFreeSlotsCount() >= 1) then
+                player:addItem(1088, 1);
+                player:messageSpecial(ITEM_OBTAINED, 1088);
+            else
+                player:messageSpecial(ITEM_CANNOT_BE_OBTAINED, 1088);
+            end
+        end
+
+        if (player:hasItem(1088)) then
+            player:delKeyItem(ANCIENT_PAPYRUS_SHRED1);
+            player:delKeyItem(ANCIENT_PAPYRUS_SHRED2);
+            player:delKeyItem(ANCIENT_PAPYRUS_SHRED3);
+        end
+    end
+end;
+
+-----------------------------------
+-- onEventUpdate
+-----------------------------------
+
+function onEventUpdate(player,csid,option)
+    -- printf("CSID2: %u",csid);
+    -- printf("RESULT2: %u",option);
+end;
+
+-----------------------------------
+-- onEventFinish
+-----------------------------------
+
+function onEventFinish(player,csid,option)
+    -- printf("CSID: %u",csid);
+    -- printf("RESULT: %u",option);
+end;


### PR DESCRIPTION
A setting has been added for OldSchool servers that wish to enforce the old requirement of mob farming.

The comment on ffxiclopedia is extremely misleading. You cannot collect key items before speaking with Maat, but you can farm the drops at any time. Maat doesn't care HOW you got the items. The description on https://www.bg-wiki.com/bg/In_Defiant_Challenge says nothing about any conflict in item acquisition.