### PR TITLE
Added Functionality to NPC Gonija, and Two Chocobos

### DIFF
--- a/scripts/zones/Bastok_Mines/npcs/Gonija.lua
+++ b/scripts/zones/Bastok_Mines/npcs/Gonija.lua
@@ -1,0 +1,43 @@
+-----------------------------------
+--  Area: Bastok Mines
+--   NPC: Gonija
+--  Type: Chocobo Breeder
+--  @pos 28 0 -105 234
+-----------------------------------
+
+package.loaded["scripts/zones/Bastok_Mines/TextIDs"] = nil;
+
+require("scripts/zones/Bastok_Mines/TextIDs");
+
+-----------------------------------
+-- onTrade Action
+-----------------------------------
+
+function onTrade(player,npc,trade)
+end;
+
+-----------------------------------
+-- onTrigger Action
+-----------------------------------
+
+function onTrigger(player,npc)
+        player:startEvent(0x0216);
+end;
+
+-----------------------------------
+-- onEventUpdate
+-----------------------------------
+
+function onEventUpdate(player,csid,option)
+        -- printf("CSID: %u",csid);
+        -- printf("RESULT: %u",option);
+end;
+
+-----------------------------------
+-- onEventFinish
+-----------------------------------
+
+function onEventFinish(player,csid,option)
+        -- printf("CSID: %u",csid);
+        -- printf("RESULT: %u",option);
+end;

--- a/scripts/zones/Upper_Jeuno/npcs/ChocoboA.lua
+++ b/scripts/zones/Upper_Jeuno/npcs/ChocoboA.lua
@@ -1,0 +1,43 @@
+-----------------------------------
+-- Area: Upper Jeuno
+-- NPC: Chocobo
+-- Pos: -50 8 89 244
+-----------------------------------
+
+package.loaded["scripts/zones/Upper_Jeuno/TextIDs"] = nil;
+
+require("scripts/zones/Upper_Jeuno/TextIDs");
+
+-----------------------------------
+-- onTrade Action
+-----------------------------------
+
+function onTrade(player,npc,trade)
+
+end;
+
+-----------------------------------
+-- onTrigger Action
+-----------------------------------
+
+function onTrigger(player,npc)
+        player:startEvent(0x2770);
+end;
+
+-----------------------------------
+-- onEventUpdate
+-----------------------------------
+
+function onEventUpdate(player,csid,option)
+        -- printf("CSID: %u",csid);
+        -- printf("RESULT: %u",option);
+end;
+
+-----------------------------------
+-- onEventFinish
+-----------------------------------
+
+function onEventFinish(player,csid,option)
+        -- printf("CSID: %u",csid);
+        -- printf("RESULT: %u",option);
+end;

--- a/scripts/zones/Upper_Jeuno/npcs/ChocoboB.lua
+++ b/scripts/zones/Upper_Jeuno/npcs/ChocoboB.lua
@@ -1,0 +1,43 @@
+-----------------------------------
+-- Area: Upper Jeuno
+-- NPC: Chocobo
+-- Pos: -57 8 83 244
+-----------------------------------
+
+package.loaded["scripts/zones/Upper_Jeuno/TextIDs"] = nil;
+
+require("scripts/zones/Upper_Jeuno/TextIDs");
+
+-----------------------------------
+-- onTrade Action
+-----------------------------------
+
+function onTrade(player,npc,trade)
+
+end;
+
+-----------------------------------
+-- onTrigger Action
+-----------------------------------
+
+function onTrigger(player,npc)
+        player:startEvent(0x2772);
+end;
+
+-----------------------------------
+-- onEventUpdate
+-----------------------------------
+
+function onEventUpdate(player,csid,option)
+        -- printf("CSID: %u",csid);
+        -- printf("RESULT: %u",option);
+end;
+
+-----------------------------------
+-- onEventFinish
+-----------------------------------
+
+function onEventFinish(player,csid,option)
+        -- printf("CSID: %u",csid);
+        -- printf("RESULT: %u",option);
+end;


### PR DESCRIPTION
Added functionality to Gonija (Bastok Mines) and to the two chocobos in
Upper Jeuno in the pen with the chocobo used in the quest "Chocobo's
Wounds."  Currently all of the chocobos share the same script,
interacting with either of the two chocobos causes the third chocobo to
move and Kweh, etc.. while the first two do nothing.