### PR TITLE
Updated Chivalry math to adjust for merit values

### DIFF
--- a/scripts/globals/abilities/chivalry.lua
+++ b/scripts/globals/abilities/chivalry.lua
@@ -16,7 +16,7 @@ end;
 function onUseAbility(player, target, ability)
     local merits = player:getMerit(MERIT_CHIVALRY);
 --(TP * .5) + ((0.015 * TP) * MND) = MP Gained
-	local amount = ((target:getTP()*(0.5)) + ((0.015*target:getTP()) * target:getStat(MOD_MND))) * ((merits - 5) / 100)
-    target:setTP(0);
+	local amount = ((target:getTP()*(0.5)) + ((0.015*target:getTP()) * target:getStat(MOD_MND))) * (1 +(((merits/5) - 5) / 100));	
+	target:setTP(0);
 	return target:addMP(amount);
 end;

--- a/scripts/zones/The_Boyahda_Tree/npcs/qm2.lua
+++ b/scripts/zones/The_Boyahda_Tree/npcs/qm2.lua
@@ -33,7 +33,7 @@ function onTrigger(player,npc)
 	local zoneMinute = VanadielMinute();
 	local correctTime = zoneHour >= 19 or zoneHour < 4 or (zoneHour == 4 and zoneMinute == 0);
 	
-	if(GetMobAction(17404339) == 0) then
+	if(GetMobAction(17404337) == 0) then
 		if (player:hasKeyItem(MOONDROP)) then
 			player:messageSpecial(CAN_SEE_SKY);
 			


### PR DESCRIPTION
Updated chivalry math to correctly return 438 mp at 300% TP and 64 MND.  printing value to console of one merit turned out to be 25 and multiplying first value by 1+ 0.05 per extra merit = 5% increase in mp per merit.