### PR TITLE
Update gitignore to ignore autotools-generated files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -116,3 +116,30 @@ UpgradeLog*.XML
 *.exe
 *.out
 *.app
+
+# Generated executables
+/dsconnect
+/dsgame
+/dssearch
+
+# Generated files, mostly autotools-related
+.deps
+/Makefile
+/Makefile.in
+/aclocal.m4
+/autom4te.cache
+/compile
+/configure
+/config.*
+/depcomp
+/missing
+/install-sh
+
+src/common/config.h
+src/common/config.h.in
+src/common/stamp-h1
+
+/sources.am
+
+# Misc, such as vim swap files
+*.sw?


### PR DESCRIPTION
I've been working with the code on Linux, and a lot of build-related files were cluttering-up git's file-tracking.

I hope these additions are useful.