### PR TITLE
Create Adelbrecht.lua and Bastok Markets [S] Exit NPC, since you cannot exit normally.

### DIFF
--- a/scripts/zones/Bastok_Markets_[S]/npcs/Adelbrecht.lua
+++ b/scripts/zones/Bastok_Markets_[S]/npcs/Adelbrecht.lua
@@ -1,0 +1,56 @@
+-----------------------------------
+-- Area: Bastok Markets (S)
+-- NPC: Adelbrecht
+-- Starts Quests: The Fighting Fourth
+-- Involved in Missions: Back to the Beginning
+-----------------------------------
+package.loaded["scripts/zones/Bastok_Markets_[S]/TextIDs"] = nil;
+package.loaded["scripts/globals/missions"] = nil;
+-----------------------------------
+
+require("scripts/globals/titles");
+require("scripts/globals/missions");
+require("scripts/globals/quests");
+require("scripts/zones/Bastok_Markets_[S]/TextIDs");
+require("scripts/globals/keyitems");
+
+-----------------------------------
+-- onTrade Action
+-----------------------------------
+
+function onTrade(player,npc,trade)
+end;
+
+-----------------------------------
+-- onTrigger Action
+-----------------------------------
+
+function onTrigger(player,npc)
+
+	if (player:getCurrentMission(WOTG) == BACK_TO_THE_BEGINNING and player:getVar("WotgStatus")==12 and player:hasKeyItem(922) ==true) then
+		player:startEvent(0x008b,0,922);--WOTG event
+	elseif(player:getCurrentMission(WOTG) == BACK_TO_THE_BEGINNING and player:getVar("WotgStatus")==13 and player:hasKeyItem(922) ==true and player:hasKeyItem(917)) then
+		player:startEvent(0x008c,0,917)
+	end
+end;
+
+
+-----------------------------------
+-- onEventFinish
+-----------------------------------
+
+function onEventFinish(player,csid,option)
+--printf("CSID: %u",csid);
+--printf("RESULT: %u",option);
+
+		if(csid == 0x008b and option == 1) then
+			player:addKeyItem(BATTLE_RATIONS);
+			player:messageSpecial(KEYITEM_OBTAINED,BATTLE_RATIONS);
+			player:addQuest(CRYSTAL_WAR, THE_FIGHTING_FOURTH);
+			player:setVar("WotgStatus",13);
+		elseif (csid == 0x008c and option == 1) then
+			player:delKeyItem(BATTLE_RATIONS);
+			player:delQuest(CRYSTAL_WAR, THE_FIGHTING_FOURTH);
+			player:setVar("WotgStatus",12);
+		end
+end;

--- a/scripts/zones/Bastok_Markets_[S]/npcs/RedCanyon.lua
+++ b/scripts/zones/Bastok_Markets_[S]/npcs/RedCanyon.lua
@@ -1,0 +1,28 @@
+-----------------------------------
+-- Area: Bastok Markets (S)
+-- NPC: Red Canyon
+-----------------------------------
+package.loaded["scripts/zones/Bastok_Markets_[S]/TextIDs"] = nil;
+-----------------------------------
+require("scripts/zones/Bastok_Markets_[S]/TextIDs");
+
+
+-----------------------------------
+-- onTrigger Action
+-----------------------------------
+
+function onTrigger(player,npc)
+	player:startEvent(0x00c8)
+end;
+
+-----------------------------------
+-- onEventFinish
+-----------------------------------
+
+function onEventFinish(player,csid,option)
+printf("CSID: %u",csid);
+printf("RESULT: %u",option);
+	if(csid == 0x00c8 and option == 1) then
+		player:setPos(380,0,147,192,88);
+	end
+end;


### PR DESCRIPTION
Added in the NPC needed for WoTG mission advancement and the first step of the quest required before mission can be advanced.
Also added in the abandon quest stuff based on the cs review.

Added the npc that will let you out of Bastok Markets [S]. Only other way to exit is to use wallhack.