### PR TITLE
Fixed Metatron Torment Aftermath

### DIFF
--- a/scripts/globals/weaponskills/metatron_torment.lua
+++ b/scripts/globals/weaponskills/metatron_torment.lua
@@ -44,11 +44,11 @@ function onUseWeaponSkill(player, target, wsID)
 	if((player:getEquipID(SLOT_MAIN) == 18294) and (player:getMainJob() == JOB_WAR)) then
 		if(damage > 0) then
 			if(player:getTP() >= 100 and player:getTP() < 200) then
-				player:addStatusEffect(EFFECT_AFTERMATH, 21, 0, 20, 0, 5);
+				player:addStatusEffect(EFFECT_AFTERMATH, -21, 0, 20, 0, 5);
 			elseif(player:getTP() >= 200 and player:getTP() < 300) then
-				player:addStatusEffect(EFFECT_AFTERMATH, 21, 0, 40, 0, 5);
+				player:addStatusEffect(EFFECT_AFTERMATH, -21, 0, 40, 0, 5);
 			elseif(player:getTP() == 300) then
-				player:addStatusEffect(EFFECT_AFTERMATH, 21, 0, 60, 0, 5);
+				player:addStatusEffect(EFFECT_AFTERMATH, -21, 0, 60, 0, 5);
 			end
 		end
 	end


### PR DESCRIPTION
Metatron Torment aftermath was increasing damage taken rather than decreasing it.