### PR TITLE
Retaliation: Adjusting base proc rate math based on parses

### DIFF
--- a/src/map/utils/battleutils.cpp
+++ b/src/map/utils/battleutils.cpp
@@ -541,11 +541,11 @@ bool HandleSpikesDamage(CBattleEntity* PAttacker, CBattleEntity* PDefender, apAc
 
     // Handle Retaliation
     if (PDefender->StatusEffectContainer->HasStatusEffect(EFFECT_RETALIATION)
-        && battleutils::GetHitRate(PDefender, PAttacker) > WELL512::irand()%100
+        && battleutils::GetHitRate(PDefender, PAttacker)/2 > WELL512::irand()%100
         && isFaceing(PDefender->loc.p, PAttacker->loc.p, 40))
     {
         // Retaliation rate is based on player acc vs mob evasion. Missed retaliations do not even display in log.
-        // Other theories exist were not proven or reliably tested (I have to assume to many things to even consider JP translations about weapon delay), this at least has data to back it up.
+        // Other theories exist but were not proven or reliably tested (I have to assume too many things to even consider JP translations about weapon delay), this at least has data to back it up.
         // https://web.archive.org/web/20141228105335/http://www.bluegartr.com/threads/120193-Retaliation-Testing?s=7a6221e10ffdfaa6a7f5e8f0387f787d&p=4620727&viewfull=1#post4620727
         Action->reaction = REACTION_HIT;
         Action->spikesEffect = SUBEFFECT_COUNTER;


### PR DESCRIPTION
@maxtherabbit now when you are done with whatever you do with dsp's hitrate, it'll be perfect (since you already volunteered to look into that, and TY btw). For now it'll still be high because hitrate is high.

Friend's Parsed hitrate: 87.2%
Friend's Retaliated percent of hits: 42.3%

Info at bottom of BG thread on BG:
Normal: Acc-98.48%, Retaliation-43.6%
Blind Pot: Acc-22.67%, Retaliation-11.6%
http://www.bluegartr.com/threads/120193-Retaliation-Testing?p=4620727&viewfull=1#post4620727

Looks like half(ish) of hitrate to me, rather than hitrate = proc. I should have caught that before, same BG thread.