### PR TITLE
String marshalling wrapper

### DIFF
--- a/src/map/marshal/string.hpp
+++ b/src/map/marshal/string.hpp
@@ -1,0 +1,168 @@
+/*
+===========================================================================
+
+Copyright © 2015 Darkstar Dev Teams
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see http://www.gnu.org/licenses/
+
+This file is part of DarkStar-server source code.
+
+===========================================================================
+*/
+
+#if defined(_MSC_VER)
+#pragma warning(push)
+#pragma warning(disable: 4351 4996)
+#endif
+
+#include <string>
+#include <algorithm>
+#include <sstream>
+
+namespace marshal
+{
+    template<std::size_t capacity, bool precise = false>
+    class string
+    {
+    private:
+        char buffer[capacity] = {};
+
+        template<bool condition = precise>
+        typename std::enable_if<condition>::type cleanup(std::size_t index)
+        {
+            std::fill_n(buffer + index, capacity - index, '\0');
+        }
+        template<bool condition = precise>
+        typename std::enable_if<!condition>::type cleanup(std::size_t index)
+        {
+            buffer[std::min(index, capacity - 1)] = '\0';
+        }
+
+        void assign(std::string const& text)
+        {
+            auto index = std::min(text.length(), capacity);
+            std::copy_n(text.begin(), index, buffer);
+
+            cleanup(index);
+
+            std::transform(cbegin(), cend(), begin(), [](char const& c)
+            {
+                return c ? c : '.';
+            });
+        }
+
+    public:
+        // Constructors
+        string()
+        {}
+
+        // Copy
+        template<std::size_t R, bool C>
+        string(string<R, C> const& other)
+            : string(std::string(other))
+        {}
+        string(char const* text)
+            : string(std::string(text))
+        {}
+
+        string(std::string const& text)
+        {
+            assign(text);
+        }
+
+        // Conversions
+        operator std::string() const
+        {
+            return std::string(buffer, buffer + capacity);
+        }
+
+        // Indexing
+        char& operator [](std::size_t index)
+        {
+            return buffer[index];
+        }
+
+        // Dereference
+        char& operator *()
+        {
+            return *buffer;
+        }
+
+        // Bool conversion, true if non-empty
+        explicit operator bool() const
+        {
+            return buffer[0] != '\0';
+        }
+
+        // Container functions
+        char* begin()
+        {
+            return buffer;
+        }
+
+        char* end()
+        {
+            return buffer + capacity;
+        }
+
+        char const* cbegin()
+        {
+            return buffer;
+        }
+
+        char const* cend()
+        {
+            return buffer + capacity;
+        }
+
+        char const* data()
+        {
+            return buffer;
+        }
+
+        std::size_t size()
+        {
+            return capacity;
+        }
+        std::size_t max_size()
+        {
+            return capacity;
+        }
+
+        // Stream operators
+        template<std::size_t N, bool C>
+        friend std::ostream operator <<(std::ostream& stream, string const& str);
+        template<std::size_t N, bool C>
+        friend std::istream operator >>(std::istream& stream, string& str);
+    };
+
+    template<std::size_t N, bool C>
+    std::ostream& operator <<(std::ostream& stream, string<N, C> const& str)
+    {
+        return stream << std::string(str);
+    }
+
+    template<std::size_t N, bool C>
+    std::istream& operator >>(std::istream& stream, string<N, C>& str)
+    {
+        std::string value;
+        stream >> value;
+        str.assign(value);
+        return stream;
+    }
+}
+
+#if defined(_MSC_VER)
+#pragma warning(pop)
+#endif

--- a/src/map/marshal/string.hpp
+++ b/src/map/marshal/string.hpp
@@ -55,11 +55,6 @@ namespace marshal
             std::copy_n(text.begin(), index, buffer);
 
             cleanup(index);
-
-            std::transform(cbegin(), cend(), begin(), [](char const& c)
-            {
-                return c ? c : '.';
-            });
         }
 
     public:

--- a/win32/DSGame-server/DSGame-server.vcxproj
+++ b/win32/DSGame-server/DSGame-server.vcxproj
@@ -234,6 +234,7 @@
     <ClInclude Include="..\..\src\map\blue_spell.h" />
     <ClInclude Include="..\..\src\map\blue_trait.h" />
     <ClInclude Include="..\..\src\map\guild.h" />
+    <ClInclude Include="..\..\src\map\marshal\string.hpp" />
     <ClInclude Include="..\..\src\map\message.h" />
     <ClInclude Include="..\..\src\map\commandhandler.h" />
     <ClInclude Include="..\..\src\map\conquest_system.h" />
@@ -424,7 +425,6 @@
     <ClInclude Include="..\..\src\map\zone_entities.h" />
     <ClInclude Include="..\..\src\map\zone_instance.h" />
     <ClInclude Include="resource.h" />
-    <ClInclude Include="string.hpp" />
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="..\..\src\common\blowfish.cpp" />

--- a/win32/DSGame-server/DSGame-server.vcxproj
+++ b/win32/DSGame-server/DSGame-server.vcxproj
@@ -424,6 +424,7 @@
     <ClInclude Include="..\..\src\map\zone_entities.h" />
     <ClInclude Include="..\..\src\map\zone_instance.h" />
     <ClInclude Include="resource.h" />
+    <ClInclude Include="string.hpp" />
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="..\..\src\common\blowfish.cpp" />

--- a/win32/DSGame-server/DSGame-server.vcxproj.filters
+++ b/win32/DSGame-server/DSGame-server.vcxproj.filters
@@ -78,6 +78,9 @@
     <Filter Include="Header Files\utils">
       <UniqueIdentifier>{4809b9f1-e6f6-4976-a83b-e246e6dc5671}</UniqueIdentifier>
     </Filter>
+    <Filter Include="Header Files\marshal">
+      <UniqueIdentifier>{f4feca65-7602-491a-9a5a-ef9bf50cda29}</UniqueIdentifier>
+    </Filter>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\src\map\ability.h">
@@ -823,6 +826,9 @@
     </ClInclude>
     <ClInclude Include="..\..\src\map\guild.h">
       <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="string.hpp">
+      <Filter>Header Files\marshal</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>

--- a/win32/DSGame-server/DSGame-server.vcxproj.filters
+++ b/win32/DSGame-server/DSGame-server.vcxproj.filters
@@ -827,7 +827,7 @@
     <ClInclude Include="..\..\src\map\guild.h">
       <Filter>Header Files</Filter>
     </ClInclude>
-    <ClInclude Include="string.hpp">
+    <ClInclude Include="..\..\src\map\marshal\string.hpp">
       <Filter>Header Files\marshal</Filter>
     </ClInclude>
   </ItemGroup>


### PR DESCRIPTION
This class wraps around a native `char` array and is meant to facilitate string sending between the server and the client. It has a number of advantages over the current setup.

### Easy string handling while preserving constant underlying size

String handling is notoriously difficult in C++. Using the basic C strings (`char[]`) does not provide any members that facilitate string handling. Copies, assignment and transformations are not natively possible and need to be done through separate handler functions. The `std::string` class attempts to fix that by providing various helper member functions, and does so quite well. The drawback is that the class itself is rather complex and cannot be easily serialized. To do that people resort to using the `std::string::c_str` member method to get the underlying `char` pointer - which gets them into the same mess as using regular C strings.

This class provides an abstraction over `char` arrays, yet keeps the native size and memory layout, so it can easily be used in data transfer, because it is serialized by design.

#### Usage

The type is `marshal::string<size, precise>`. The first template parameter indicates the size in bytes the string takes. The second parameter (a boolean value, default is `false`) indicates whether assignment should always be precise. If this is false, it will append a null terminator to any assignment, and leave the remaining buffer unchanged, which can result in garbage memory after the null terminator. This is not an issue for most strings, which is why it's the default (as it saves a bit of performance). But for arbitrary data (which can contain any number of null bytes) it could result in corrupt packets. Hence, the second parameter should be set to `true` when handling arbitrary data blocks, but can be set to `false` (or omitted) when handling strings.

This example creates a string of size 13 that will *not* be adjusted past the null byte:
```c++
marshal::string<13> str("abcdefgh");
std::cout << str;
// Output:
// abcdefgh
// Internal representation of str (dashes indicate null bytes):
// abcdefgh-----

str = "1234";
std::cout << str;
// Output:
// 1234
// Internal representation of str, (dashes indicate null bytes):
// 1234-fgh-----

str = "zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz";
std::cout << str;
// Output:
// zzzzzzzzzzzz
// Internal representation of str, (dashes indicate null bytes):
// zzzzzzzzzzzz-
```

The example shows that when the string output was set to "1234", the remaining bytes from the previous value `abcdefgh` were untouched. It also shows that, when setting it to a value larger than the array allows it gets cut off at the last byte.

The next example shows how the same assignments would behave if the `precise` argument was set to `true`:

```c++
marshal::string<13, true> str("abcdefgh");
std::cout << str;
// Output:
// abcdefgh
// Internal representation of str, (dashes indicate null bytes):
// abcdefgh-----

str = "1234";
std::cout << str;
// Output:
// 1234
// Internal representation of str, (dashes indicate null bytes):
// 1234---------

str = "zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz";
std::cout << str;
// Output:
// zzzzzzzzzzzzz......
// Internal representation of str, (dashes indicate null bytes):
// zzzzzzzzzzzzz
```

The three key differences are:
1. In the second assignment the remaining bytes from the previous value `abcdefgh` were erased.
2. In the third assignment, the internal representation does not contain a final zero byte, but all 13 places are used for the provided value.
3. The output for the third assignment can be problematic if the following memory is not zeroed. This shows that the `precise` argument should usually be set to `false` for strings to guarantee that it can be read out properly.

#### Features

This class supports most standard container related members, such as `begin`, `end`, `cbegin` and `cend`, and as such can be used in almost all places that work on standard containers. Furthermore it supports indexing the string to obtain single characters, as expected of a string class. It supports conversions to and from both `char const*` and `std::string`. It overrides the boolean conversion operator to return `true` if it's non-empty, `false` otherwise. It is also compatible with streams in both directions.

### Avoid manual string copying

Assume we have a member `bool active`. If we want to send it to the client, all we have to do is this:
```c++
ref<bool>(index) = active;
```

Now assume we have the a member `char name[24]` that needs to be sent to the client. Currently you have to do this one of the following:

```c++
// 1.
std::copy_n(name, sizeof name, ref<char*>(index));
// 2.
std::copy(name, name + sizeof name, ref<char*>(index));
// 3.
strcpy(ref<char*>(index), name); // Shortest, but does not work on arbitrary data, only valid C strings
// 4.
memcpy(ref<char*>(index), name, sizeof name);
```

All of these (and many more variations on them) are used throughout DSP. All involve manually specifying memory boundaries and adjusting for those when structs change. In addition, it results in code which differs by type. Strings cannot currently be handled the same as numbers and boolean values.

With this new class, the assignment operator was overloaded to do the copying and automatically handles the free memory as specified. So if you change the `name` member to be of type `marshal::string<24>`, you can handle it uniformly like all numeric and boolean data:

```c++
ref<marshal::string<24>>(index) = name
```

This will copy name to the specified position inside the packet and add a null terminator, if necessary. If the remaining memory (of the 24 bytes) also needs to be zeroed, setting the second template parameter to `true` will take care of that:

```c++
ref<marshal::string<24, true>>(index) = name
```

### Reduced bug surface area

Since you avoid up to three manual copies, the chances to introduce bugs are reduced and the amount of work that needs to be done to adapt to changes during version updates is reduced.

### Integrates well with new packet handler

This class was made from the desire to integrate easier with the new packet handler. As such, this was the primary focus of the development of this class. Assume the following struct:

```c++
struct foo
{
    bool first;
    float third;
    int fifth;
}
```

The recent packet handler changes allow bulk-assignment to and from the entire struct:
```c++
ref<foo>(index) = some_foo;
some_foo = ref<foo>(index);
```

However, this did not work if the struct contained strings:

```c++
struct foo
{
    bool first;
    char second[31];
    float third;
    char fourth[5];
    int fifth;
};
```

In this case you still have to assign all members manually. You have to do three manual assignments and two manual copies to assign the entire struct:

```c++
ref<bool>(index) = some_foo.first;
std::copy_n(some_foo.second, sizeof some_foo.second, ref<char*>(index + 1));
ref<float>(index + 1 + 31) = some_foo.third;
std::copy_n(some_foo.fourth, sizeof some_foo.fourth, ref<char*>(index + 1 + 31 + 4));
ref<int>(index + 1 + 31 + 4 + 5) = some_foo.fifth;
```

This is only for one side of the conversion, the same five assignments must be done to reverse the direction. With this class, however, the following works.

```c++
struct foo
{
    bool first;
    marshal::string<31, true> second;
    float third;
    marshal::string<5> fourth;
    int fifth;
};

ref<foo>(index) = some_foo;
some_foo = ref<foo>(index);
```

As such it works exactly the same as all other such assignments. This allows for the data of each packet to be kept in a struct, no manual copying ever needs to take place anymore for many packets. This makes future maintenance of packets much easier, because data is not kept in multiple places anymore -- only in one.