### PR TITLE
Tombstone CS fix sandy 1-2

### DIFF
--- a/scripts/zones/King_Ranperres_Tomb/npcs/Tombstone.lua
+++ b/scripts/zones/King_Ranperres_Tomb/npcs/Tombstone.lua
@@ -37,7 +37,7 @@ function onTrigger(player,npc)
 	local Z = npc:getZPos();
 	
 	if(X >= -1 and X <= 1 and Z >= -106 and Z <= -102) then
-		if(player:getCurrentMission(SANDORIA) == BAT_HUNT and MissionStatus <= 1 and BatHuntCompleted == false) then -- Bug caused players to have MissionStatus 1 at start, so self-healing is necessary.
+		if(currentMission == BAT_HUNT and MissionStatus == 0) then 
 			player:startEvent(0x0004);
 		else
 			player:startEvent(0x0002);


### PR DESCRIPTION
This quest is repeatable, if the check contains a Boolean for the
"BathuntComplete" then next time this quest is repeated the player will
be stuck. The MissionStatus check is set to 0.