### PR TITLE
new GM command

### DIFF
--- a/scripts/commands/getid.lua
+++ b/scripts/commands/getid.lua
@@ -1,0 +1,20 @@
+---------------------------------------------------------------------------------------------------
+-- func: @getid
+-- auth: TeoTwawki
+-- desc: Prints the ID of the currently selected target under the cursor
+---------------------------------------------------------------------------------------------------
+
+cmdprops =
+{
+    permission = 1,
+    parameters = ""
+};
+
+function onTrigger(player)
+    local targ = player:fetchTargetsID();
+    if (targ ~= nil) then
+        player:PrintToPlayer(string.format("Selected Target's ID is: %u ", targ));
+    else
+        player:PrintToPlayer("Must select a target using in game cursor first.");
+    end
+end;

--- a/src/map/lua/lua_baseentity.cpp
+++ b/src/map/lua/lua_baseentity.cpp
@@ -6269,6 +6269,29 @@ inline int32 CLuaBaseEntity::getShortID(lua_State *L)
     return 1;
 }
 
+// For use in GM command @getid to get the ID of MOBs, NPCs, and even Players.
+inline int32 CLuaBaseEntity::fetchTargetsID(lua_State* L)
+{
+    DSP_DEBUG_BREAK_IF(m_PBaseEntity == nullptr);
+    DSP_DEBUG_BREAK_IF(m_PBaseEntity->objtype != TYPE_PC);
+
+    CCharEntity* PChar = (CCharEntity*)m_PBaseEntity;
+    CBattleEntity* PTarget = (CBattleEntity*)PChar->loc.zone->GetEntity(PChar->m_TargID);
+
+    if (PTarget == NULL)
+    {
+        ShowDebug(CL_CYAN"lua::Tried to fetch target's ID with no target selected. \n" CL_RESET);
+        lua_pushnil(L);
+    }
+    else
+    {
+        ShowDebug("Currently selected target's ID is: %i \n", PTarget->id);
+        lua_pushinteger( L, PTarget->id );
+    }
+
+    return 1;
+}
+
 /************************************************************************
 *                                                                       *
 *  Get Entity's name                                                    *
@@ -9577,6 +9600,7 @@ Lunar<CLuaBaseEntity>::Register_t CLuaBaseEntity::methods[] =
     LUNAR_DECLARE_METHOD(CLuaBaseEntity,leavegame),
     LUNAR_DECLARE_METHOD(CLuaBaseEntity,getID),
     LUNAR_DECLARE_METHOD(CLuaBaseEntity,getShortID),
+    LUNAR_DECLARE_METHOD(CLuaBaseEntity,fetchTargetsID),
     LUNAR_DECLARE_METHOD(CLuaBaseEntity,getName),
     LUNAR_DECLARE_METHOD(CLuaBaseEntity,getHP),
     LUNAR_DECLARE_METHOD(CLuaBaseEntity,getHPP),

--- a/src/map/lua/lua_baseentity.h
+++ b/src/map/lua/lua_baseentity.h
@@ -84,6 +84,7 @@ public:
 
     int32 getID(lua_State *L);              // Gets Entity Id
     int32 getShortID(lua_State *L);
+    int32 fetchTargetsID(lua_State *L);     // Returns the ID any object under players in game cursor.
     int32 getName(lua_State *L);            // Gets Entity Name
 
     int32 getHPP(lua_State*);               // Returns Entity Health %


### PR DESCRIPTION
Prints the ID of the currently selected target under the cursor (mobs npcs and even players, anything). 

This has made ID related bug fixing and working with multiple objects that have the same name go much faster for me. Also saves me having to look up a players charid when I need to find their stuff in a database table.