### PR TITLE
Adjusted login name and password to allow any printable ASCII characters, minor refactoring

### DIFF
--- a/src/common/socket.cpp
+++ b/src/common/socket.cpp
@@ -856,12 +856,12 @@ int32 realloc_fifo(int32 fd, uint32 rfifo_size, uint32 wfifo_size)
 		return 0;
 
 	if( session[fd]->max_rdata != rfifo_size && session[fd]->rdata_size < rfifo_size) {
-		RECREATE(session[fd]->rdata, unsigned char, rfifo_size);
+		RECREATE(session[fd]->rdata, char, rfifo_size);
 		session[fd]->max_rdata  = rfifo_size;
 	}
 
 	if( session[fd]->max_wdata != wfifo_size && session[fd]->wdata_size < wfifo_size) {
-		RECREATE(session[fd]->wdata, unsigned char, wfifo_size);
+		RECREATE(session[fd]->wdata, char, wfifo_size);
 		session[fd]->max_wdata  = wfifo_size;
 	}
 	return 0;
@@ -887,7 +887,7 @@ int32 realloc_writefifo(int32 fd, size_t addition)
 	else // no change
 		return 0;
 
-	RECREATE(session[fd]->wdata, unsigned char, newsize);
+	RECREATE(session[fd]->wdata, char, newsize);
 	session[fd]->max_wdata  = newsize;
 
 	return 0;
@@ -1103,8 +1103,8 @@ void set_eof(int32 fd)
 int create_session(int fd, RecvFunc func_recv, SendFunc func_send, ParseFunc func_parse)
 {
 	CREATE(session[fd], struct socket_data, 1);
-	CREATE(session[fd]->rdata, unsigned char, RFIFO_SIZE);
-	CREATE(session[fd]->wdata, unsigned char, WFIFO_SIZE);
+	CREATE(session[fd]->rdata, char, RFIFO_SIZE);
+	CREATE(session[fd]->wdata, char, WFIFO_SIZE);
 
 	session[fd]->max_rdata  = RFIFO_SIZE;
 	session[fd]->max_wdata  = WFIFO_SIZE;

--- a/src/common/socket.h
+++ b/src/common/socket.h
@@ -243,7 +243,7 @@ extern int32 naddr_;   // # of ip addresses
 
 		uint32 client_addr; // remote client address
 
-		unsigned char *rdata, *wdata;
+		char *rdata, *wdata;
 		size_t max_rdata, max_wdata;
 		size_t rdata_size, wdata_size;
 		size_t rdata_pos;

--- a/src/login/lobby.cpp
+++ b/src/login/lobby.cpp
@@ -75,7 +75,7 @@ int32 lobbydata_parse(int32 fd)
 		if( RFIFOREST(fd) >= 5 &&
 			RBUFB(session[fd]->rdata,0) == 0xA1 )
 		{
-			unsigned char *buff = session[fd]->rdata;
+			char* buff = session[fd]->rdata;
 
 			int32 accid = RBUFL(buff,1);
 
@@ -107,7 +107,7 @@ int32 lobbydata_parse(int32 fd)
 
 	if( RFIFOREST(fd) >= 1 )
 	{
-		unsigned char *buff = session[fd]->rdata;
+		char* buff = session[fd]->rdata;
 		if (RBUFB(buff,0) == 0x0d) ShowDebug(CL_RED"Posible Crash Attempt from IP: " CL_WHITE"<%s>\n" CL_RESET,ip2str(session[fd]->client_addr,nullptr),nullptr);
 		ShowDebug("lobbydata_parse:Incoming Packet:" CL_WHITE"<%x>" CL_RESET" from ip:<%s>\n",RBUFB(buff,0),ip2str(sd->client_addr,nullptr));
 
@@ -419,7 +419,7 @@ int32 lobbyview_parse(int32 fd)
 
 	if( RFIFOREST(fd) >= 9)
 	{
-		unsigned char *buff = session[fd]->rdata;
+		char* buff = session[fd]->rdata;
 		ShowDebug("lobbyview_parse:Incoming Packet:" CL_WHITE"<%x>" CL_RESET" from ip:<%s>\n",RBUFB(buff,8),ip2str(sd->client_addr,nullptr));
 		uint8 code = RBUFB(buff,8);
 		switch(code)

--- a/src/login/login_auth.cpp
+++ b/src/login/login_auth.cpp
@@ -40,7 +40,7 @@
 int32 login_fd;					//main fd(socket) of server
 
 /*
-*	
+*
 *		LOGIN SECTION
 *
 */
@@ -78,7 +78,7 @@ int32 login_parse(int32 fd)
 		return 0;
 	}
 
-	//all auth packets have one structure: 
+	//all auth packets have one structure:
 	// [login][passwords][code] => summary assign 33 bytes
 	if( session[fd]->rdata_size == 33 )
 	{
@@ -108,7 +108,7 @@ int32 login_parse(int32 fd)
 			const int8* fmtQuery = "SELECT accounts.id,accounts.status \
 									FROM accounts \
 									WHERE accounts.login = '%s' AND accounts.password = PASSWORD('%s')";
-			int32 ret = Sql_Query(SqlHandle, fmtQuery, name.c_str(), password.c_str());	
+			int32 ret = Sql_Query(SqlHandle, fmtQuery, name.c_str(), password.c_str());
 			if( ret != SQL_ERROR  && Sql_NumRows(SqlHandle) != 0)
 			{
 				ret = Sql_NextRow(SqlHandle);
@@ -190,7 +190,7 @@ int32 login_parse(int32 fd)
 								break;
 							}
 						}
-					} 
+					}
 				}
 				//////
 
@@ -213,10 +213,10 @@ int32 login_parse(int32 fd)
 				do_close_login(sd,fd);
 				return -1;
 			}
-						
+
 			if( Sql_NumRows(SqlHandle) == 0 )
 			{
-				//creating new account_id 
+				//creating new account_id
 				char *fmtQuery = "SELECT max(accounts.id) FROM accounts;";
 
 				uint32 accid = 0;
@@ -224,7 +224,7 @@ int32 login_parse(int32 fd)
 				if( Sql_Query(SqlHandle,fmtQuery) != SQL_ERROR  && Sql_NumRows(SqlHandle) != 0)
 				{
 					Sql_NextRow(SqlHandle);
-					
+
 					accid = Sql_GetUIntData(SqlHandle,0)+1;
 				}else{
 					WBUFB(session[fd]->wdata,0) = LOGIN_ERROR_CREATE;
@@ -234,7 +234,7 @@ int32 login_parse(int32 fd)
 				}
 
 				accid = (accid < 1000 ? 1000 : accid);
-			
+
 				//creating new account
 				time_t timecreate;
 				tm*	   timecreateinfo;
@@ -292,5 +292,5 @@ int32 do_close_login(login_session_data_t* loginsd,int32 fd)
 
 bool check_string(std::string const& str, std::size_t max_length)
 {
-    return str.size() <= max_length && std::all_of(str.cbegin(), str.cend(), [](char const& c) { return c >= 0x20; });
+    return str.size() > 0 && str.size() <= max_length && std::all_of(str.cbegin(), str.cend(), [](char const& c) { return c >= 0x20; });
 }

--- a/src/login/login_auth.cpp
+++ b/src/login/login_auth.cpp
@@ -35,7 +35,7 @@
 #include <string.h>
 #include <ctype.h>
 
-#include <numeric>
+#include <algorithm>
 
 int32 login_fd;					//main fd(socket) of server
 
@@ -292,5 +292,5 @@ int32 do_close_login(login_session_data_t* loginsd,int32 fd)
 
 bool check_string(std::string const& str, std::size_t max_length)
 {
-    return str.size() > 0 && str.size() <= max_length && std::all_of(str.cbegin(), str.cend(), [](char const& c) { return c >= 0x20; });
+    return !str.empty() && str.size() <= max_length && std::all_of(str.cbegin(), str.cend(), [](char const& c) { return c >= 0x20; });
 }

--- a/src/login/login_auth.cpp
+++ b/src/login/login_auth.cpp
@@ -34,6 +34,9 @@
 #include <stdlib.h>
 #include <string.h>
 #include <ctype.h>
+
+#include <numeric>
+
 int32 login_fd;					//main fd(socket) of server
 
 /*
@@ -79,23 +82,17 @@ int32 login_parse(int32 fd)
 	// [login][passwords][code] => summary assign 33 bytes
 	if( session[fd]->rdata_size == 33 )
 	{
-		unsigned char* buff = session[fd]->rdata;
+		char* buff = session[fd]->rdata;
 		int8 code = RBUFB(buff,32);
 
-		char login[17];
-		char password[17];
+        std::string name(buff, buff + 16);
+        std::string password(buff + 16, buff + 32);
 
-		memset(login,0,sizeof(login));
-		memset(sd->login,0,sizeof(sd->login));
-		memset(password,0,sizeof(password));
-
-		memcpy(login,buff,16);
-		memcpy(sd->login,login,16);
-		memcpy(password,buff+16,16);
+        std::fill_n(sd->login, sizeof sd->login, '\0');
+        std::copy(name.cbegin(), name.cend(), sd->login);
 
 		//data check
-		if( login_datacheck(login,3,sizeof(login)) == -1 ||
-			login_datacheck(password,6,sizeof(password)) == -1 )
+        if (check_string(name, 16) && check_string(password, 16))
 		{
 			ShowWarning(CL_WHITE"login_parse" CL_RESET":" CL_WHITE"%s" CL_RESET" send unreadable data\n",ip2str(sd->client_addr,nullptr));
 			WBUFB(session[fd]->wdata,0) = LOGIN_ERROR;
@@ -111,7 +108,7 @@ int32 login_parse(int32 fd)
 			const int8* fmtQuery = "SELECT accounts.id,accounts.status \
 									FROM accounts \
 									WHERE accounts.login = '%s' AND accounts.password = PASSWORD('%s')";
-			int32 ret = Sql_Query(SqlHandle,fmtQuery,login,password);	
+			int32 ret = Sql_Query(SqlHandle, fmtQuery, name.c_str(), password.c_str());	
 			if( ret != SQL_ERROR  && Sql_NumRows(SqlHandle) != 0)
 			{
 				ret = Sql_NextRow(SqlHandle);
@@ -184,7 +181,7 @@ int32 login_parse(int32 fd)
 				}
 
 				if(numCons>1){
-					ShowInfo("login_parse:" CL_WHITE"<%s>" CL_RESET" has logged in %i times! Removing older logins.\n",login,numCons);
+					ShowInfo("login_parse:" CL_WHITE"<%s>" CL_RESET" has logged in %i times! Removing older logins.\n", name.c_str(), numCons);
 					for(int j=0; j<(numCons-1); j++){
 						for(login_sd_list_t::iterator i = login_sd_list.begin(); i != login_sd_list.end(); ++i ){
 							if( (*i)->accid == sd->accid ){
@@ -197,19 +194,19 @@ int32 login_parse(int32 fd)
 				}
 				//////
 
-				ShowInfo("login_parse:" CL_WHITE"<%s>" CL_RESET" was connected\n",login,status);
+				ShowInfo("login_parse:" CL_WHITE"<%s>" CL_RESET" was connected\n", name.c_str(), status);
 				return 0;
 			}else{
 				WBUFB(session[fd]->wdata,0) = LOGIN_ERROR;
 				WFIFOSET(fd,1);
-				ShowWarning("login_parse: unexisting user" CL_WHITE"<%s>" CL_RESET" tried to connect\n",login);
+				ShowWarning("login_parse: unexisting user" CL_WHITE"<%s>" CL_RESET" tried to connect\n", name.c_str());
 				do_close_login(sd,fd);
 			}
 			}
 			break;
 		case LOGIN_CREATE:
 			//looking for same login
-			if( Sql_Query(SqlHandle,"SELECT accounts.id FROM accounts WHERE accounts.login = '%s'",login) == SQL_ERROR )
+			if( Sql_Query(SqlHandle,"SELECT accounts.id FROM accounts WHERE accounts.login = '%s'", name.c_str()) == SQL_ERROR )
 			{
 				WBUFB(session[fd]->wdata,0) = LOGIN_ERROR_CREATE;
 				WFIFOSET(fd,1);
@@ -250,7 +247,7 @@ int32 login_parse(int32 fd)
 				fmtQuery = "INSERT INTO accounts(id,login,password,timecreate,timelastmodify,status,priv)\
 									   VALUES(%d,'%s',PASSWORD('%s'),'%s',NULL,%d,%d);";
 
-				if( Sql_Query(SqlHandle,fmtQuery,accid,login,password,
+				if (Sql_Query(SqlHandle, fmtQuery, accid, name.c_str(), password,
 							  strtimecreate,ACCST_NORMAL,ACCPRIV_USER) == SQL_ERROR )
 				{
 					WBUFB(session[fd]->wdata,0) = LOGIN_ERROR_CREATE;
@@ -259,12 +256,12 @@ int32 login_parse(int32 fd)
 					return -1;
 				}
 
-				ShowStatus(CL_WHITE"login_parse" CL_RESET": account<" CL_WHITE"%s" CL_RESET"> was created\n",login);
+				ShowStatus(CL_WHITE"login_parse" CL_RESET": account<" CL_WHITE"%s" CL_RESET"> was created\n", name.c_str());
 				WBUFB(session[fd]->wdata,0) = LOGIN_SUCCESS_CREATE;
 				WFIFOSET(fd,1);
 				do_close_login(sd,fd);
 			}else{
-				ShowWarning(CL_WHITE"login_parse" CL_RESET": account<" CL_WHITE"%s" CL_RESET"> already exists\n",login);
+				ShowWarning(CL_WHITE"login_parse" CL_RESET": account<" CL_WHITE"%s" CL_RESET"> already exists\n", name.c_str());
 				WBUFB(session[fd]->wdata,0) = LOGIN_ERROR_CREATE;
 				WFIFOSET(fd,1);
 				do_close_login(sd,fd);
@@ -293,18 +290,7 @@ int32 do_close_login(login_session_data_t* loginsd,int32 fd)
 	return 0;
 }
 
-int8 login_datacheck(const char *buf, size_t MinSize, size_t MaxSize)
+bool check_string(std::string const& str, std::size_t max_length)
 {
-    size_t str_size = strnlen(buf, MaxSize);
-    if (str_size < MinSize)
-    {
-        return -1;
-    }
-
-    for (size_t i = 0; i < str_size; ++i)
-    {
-        if ((buf[i] >= -1 && buf[i] <= 255) && !isalpha(buf[i]) && !isdigit(buf[i]))
-            return -1;
-    }
-    return 0;
+    return str.size() <= max_length && std::all_of(str.cbegin(), str.cend(), [](char const& c) { return c >= 0x20; });
 }

--- a/src/login/login_auth.h
+++ b/src/login/login_auth.h
@@ -51,7 +51,8 @@ int32 connect_client_login(int32 listenfd);
 
 int32 login_parse(int32 fd);
 
-int8  login_datacheck(const char *,size_t,size_t);
+bool check_string(std::string const& str, std::size_t max_length);
+
 /*=============================================
 * login data close socket
 *-------------------------------------------*/


### PR DESCRIPTION
The entire *DSConnect* solution needs a bit of an upgrade to become a bit less last millennium, but that would require more of an overhaul than I'm personally willing to commit to.

The changes in here are very simple, I adjusted the log in check for name and password. The original issue before now was that only alphanumeric passwords were allowed. This meant that people who mistakenly felt that alphanumeric passwords were not secure enough would not be able to choose a password of their liking.

This adjustment allows people to choose any password they want so long as it consists of printable ASCII characters. This could be adjusted to allow all UTF-8 characters, but would be more work than I was willing to invest.

I also adjusted the name check similarly, and the reasoning behind it is that the name is never visible to anyone else (unless the server admins feel like manually browsing the database). It's not their character name, as such it doesn't need to conform to any character naming rules and conventions, it will only be used for their own log in process.

## On passwords

I decided to allow any length for the password (except for empty passwords, i.e. zero-length). Since this is a somewhat controversial decision I would like to explain the reasoning behind it. Some people here already know a lot about the issue, but many people don't, and even worse, some people are misinformed on the subject. So I figured I'd leave this for people here to read and think about and evaluate for themselves if my decisions make sense.

### Technical strength

Technically passwords are harder to crack if they are longer and contain a wider range of and more random characters. This is due to password breakers trying certain techniques to get to the real password quickly. The most popular is to limit brute force to alphanumeric characters, because many people are too lazy to use special characters. This gives them a much smaller range of characters to iterate through, as such it speeds up the speed of the hack significantly. Another popular technique is called a dictionary attack, which tries combinations of common words and phrases, because it is somewhat likely for certain people to use known words as their passwords, so they can remember it easily.

There are many other techniques and combination of techniques employed that make brute forcing easier, but all of them rely on trying to guess the structure of the password and limit their search to passwords within that domain.

Here is an example of the typical argument made for inclusion of numbers and special characters into the password:
If a password consists of 8 alphabetical characters, and a password hacker could guess 1 billion passwords per second, it would, at most, only take them 3.5 minutes to guess the right one, due to a limited number of combinations.

The argument is very valid, but the suggested fix is awful. Forcing users to massacre their wanted password is the worst of all possible solutions to that problem and shifts the burden of security completely on the user instead of the developer.

The proper way to guard against this is to time password entries and implement a threshold for number of attempts per second. If you limit your system to allow only two password check attempts per second, even a purely alphabetical lower case password of length 8 will take thousands of years to guess right, and the user won't experience any inconvenience. The only drawback of this method is if the password guessing rate is very high, but that is not the case for us. This mostly only affects devices with commonly known initial passwords (like wi-fi routers, which often used initial passwords like "0000" in the past, although they are also switching away from that model).

The key to this is to have a well designed system that only allows password entry through a single entry point that is well guarded. But it stops *any* kind of brute force attack dead in its tracks, and password guessing is the only argument in favor of forcing all kinds of weird password selection rules.

There are still various other types of security vulnerabilities, but none relating to password strength itself. You don't need to know the actual password for rainbow table attacks, and other methods are there to prevent against that (like using a salt on password hashes). You also don't need to guess the password for man-in-the-middle attacks, this requires secure communication with the server to prevent. The password guessing was the only attack that this is supposed to prevent, and such a system is much simpler than having complicated password validation checks.

Note that I did *not* actually implement such a timed check, although it can be done, if requested.

### Philosophical argument

This one is very debatable, but personally I think that the *responsibility* for password security lies *entirely* on the user, and not at all on the developer. I don't think any person these days is dumb enough to not know the risks in choosing "abcd" as their password. If they still want to do it, I don't want to insult their intelligence by assuming that they were too dumb to realize the weakness of the password, but instead would rather assume that they simply don't care much for the password to be strong. And if they don't care, why should we?

I know everyone has a different opinion on this, and for different kinds of businesses the answer to this problem may be different. I can absolutely understand if banks employ a forced structure on passwords to make them more secure by default (although most don't and prefer other types of password security, for example the timed method mentioned above, as well as a limited number of guesses, which I don't think would make a great addition in our case, because it would require a backup system if they screw up). But for this, I don't think that we need to be bothered even *if* this lack of enforced security results in someone getting their account compromised.

I think everyone should be responsible for choosing their own password, and when they do so, I hope (only for them) that they [are reasonable about it](https://xkcd.com/936/). In this vein, it might make sense to increase the maximum length for passwords, but that would also require a somewhat deeper recode than what I did here.