### PR TITLE
Fixed magic_hammer.lua

### DIFF
--- a/scripts/globals/spells/bluemagic/magic_hammer.lua
+++ b/scripts/globals/spells/bluemagic/magic_hammer.lua
@@ -56,6 +56,9 @@ function onSpellCast(caster,target,spell)
         dmg = BlueMagicalSpell(caster, target, spell, params, MND_BASED);
         dmg = BlueFinalAdjustments(caster, target, spell, dmg, params);
         if (target:getMP() > 0) then
+            if (target:getMP < dmg) then
+                dmg = target:getMP();
+            end
             caster:addMP(dmg);
         else
             return 0;

--- a/scripts/globals/spells/bluemagic/magic_hammer.lua
+++ b/scripts/globals/spells/bluemagic/magic_hammer.lua
@@ -30,33 +30,37 @@ end;
 -----------------------------------------
 
 function onSpellCast(caster,target,spell)
-
+    local damage = 0;
     local multi = 1.5;
-    local params = {};
-    -- This data should match information on http://wiki.ffxiclopedia.org/wiki/Calculating_Blue_Magic_Damage
-        params.multiplier = multi;
-        params.tMultiplier = 1.0;
-        params.duppercap = 35;
-        params.str_wsc = 0.0;
-        params.dex_wsc = 0.0;
-        params.vit_wsc = 0.0;
-        params.agi_wsc = 0.0;
-        params.int_wsc = 0.0;
-        params.mnd_wsc = 0.39;
-        params.chr_wsc = 0.0;
-    damage = BlueMagicalSpell(caster, target, spell, params, MND_BASED);
-    damage = BlueFinalAdjustments(caster, target, spell, damage, params);
-    
-    if(caster:hasStatusEffect(EFFECT_AZURE_LORE)) then
+
+    if (caster:hasStatusEffect(EFFECT_AZURE_LORE)) then
         multi = multi + 0.50;
     end
-    
-        caster:addMP(dmg);
-    
-    if(target:isUndead()) then
-        spell:setMsg(75); -- No effect        
-        return damage;
+
+    local params = {};
+    -- This data should match information on http://wiki.ffxiclopedia.org/wiki/Calculating_Blue_Magic_Damage
+    params.multiplier = multi;
+    params.tMultiplier = 1.0;
+    params.duppercap = 35;
+    params.str_wsc = 0.0;
+    params.dex_wsc = 0.0;
+    params.vit_wsc = 0.0;
+    params.agi_wsc = 0.0;
+    params.int_wsc = 0.0;
+    params.mnd_wsc = 0.39;
+    params.chr_wsc = 0.0;
+
+    if (target:isUndead()) then
+        spell:setMsg(75); -- No effect
+    else
+        dmg = BlueMagicalSpell(caster, target, spell, params, MND_BASED);
+        dmg = BlueFinalAdjustments(caster, target, spell, dmg, params);
+        if (target:getMP() > 0) then
+            caster:addMP(dmg);
+        else
+            return 0;
+        end
     end
-    
+
     return dmg;
 end;


### PR DESCRIPTION
1. was adding MP even when no mp should have been given to the player.
2. Was returning a nil variable resulting in players showing me screenshots of their 131k drain messages.
3. Azure Lore check adjust variable after it was already used in dmg calc instead of before, so was having no effect.

This script is tested and drains MP only when the target is both not undead and has MP to drain. drain amount is equal to damage dealt. All Blue Mages I have consulted tell me I have the behavior correct (I never touched the job on retail).