### PR TITLE
Modified LockStyle Implementation

### DIFF
--- a/sql/char_style.sql
+++ b/sql/char_style.sql
@@ -1,0 +1,26 @@
+/*
+MySQL Data Transfer
+Source Host: localhost
+Source Database: dspdb
+Target Host: localhost
+Target Database: dspdb
+Date: 03/05/2015 09:21:00 PM
+*/
+
+SET SQL_MODE="NO_AUTO_VALUE_ON_ZERO";
+-- ----------------------------
+-- Table structure for char_style
+-- ----------------------------
+DROP TABLE IF EXISTS `char_style`;
+CREATE TABLE IF NOT EXISTS `char_style` (
+  `charid` int(10) unsigned NOT NULL,
+  `head` smallint(5) unsigned NOT NULL DEFAULT '0',
+  `body` smallint(5) unsigned NOT NULL DEFAULT '0',
+  `hands` smallint(5) unsigned NOT NULL DEFAULT '0',
+  `legs` smallint(5) unsigned NOT NULL DEFAULT '0',
+  `feet` smallint(5) unsigned NOT NULL DEFAULT '0',
+  `main` smallint(5) unsigned NOT NULL DEFAULT '0',
+  `sub` smallint(5) unsigned NOT NULL DEFAULT '0',
+  `ranged` smallint(5) unsigned NOT NULL DEFAULT '0',
+  PRIMARY KEY (`charid`)
+) ENGINE=MyISAM DEFAULT CHARSET=utf8 AVG_ROW_LENGTH=20;

--- a/sql/chars.sql
+++ b/sql/chars.sql
@@ -46,6 +46,7 @@ CREATE TABLE `chars` (
   `isnewplayer` smallint(3) NOT NULL DEFAULT '1',
   `mentor` smallint(3) NOT NULL DEFAULT '0',
   `campaign_allegiance` tinyint(1) unsigned NOT NULL DEFAULT '0',
+  `isstylelocked` tinyint(1) NOT NULL DEFAULT '0',
   PRIMARY KEY (`charid`),
   FULLTEXT KEY `charname` (`charname`)
 ) ENGINE=MyISAM DEFAULT CHARSET=utf8;

--- a/src/map/entities/charentity.cpp
+++ b/src/map/entities/charentity.cpp
@@ -348,10 +348,6 @@ bool CCharEntity::getStyleLocked()
 
 void CCharEntity::setStyleLocked(bool isStyleLocked)
 {
-  if (isStyleLocked) {
-	memcpy(&mainlook, &look, sizeof(look));
-  }
-
   m_isStyleLocked = isStyleLocked;
 }
 

--- a/src/map/entities/charentity.h
+++ b/src/map/entities/charentity.h
@@ -192,6 +192,7 @@ public:
     bool					m_EquipSwap;					// true if equipment was recently changed
     uint8					equip[18];						//      SlotID where equipment is
     uint8					equipLoc[18];					// ContainerID where equipment is
+    uint16                  styleItems[16];                 // Item IDs for items that are style locked.
 
     uint8					m_ZonesList[36];				// список посещенных персонажем зон
     uint8					m_SpellList[128];				// список изученных заклинаний

--- a/src/map/lua/lua_baseentity.cpp
+++ b/src/map/lua/lua_baseentity.cpp
@@ -5223,6 +5223,7 @@ inline int32 CLuaBaseEntity::changeJob(lua_State *L)
         blueutils::UnequipAllBlueSpells(PChar);
     }
     puppetutils::LoadAutomaton(PChar);
+    charutils::SetStyleLock(PChar, false);
     luautils::CheckForGearSet(PChar); // check for gear set on gear change
     charutils::BuildingCharSkillsTable(PChar);
     charutils::CalculateStats(PChar);
@@ -5308,6 +5309,7 @@ inline int32 CLuaBaseEntity::setsLevel(lua_State *L)
     PChar->SetSLevel(PChar->jobs.job[PChar->GetSJob()]);
     PChar->jobs.exp[PChar->GetSJob()] = charutils::GetExpNEXTLevel(PChar->jobs.job[PChar->GetSJob()]) - 1;
 
+    charutils::SetStyleLock(PChar, false);
     charutils::BuildingCharSkillsTable(PChar);
     charutils::CalculateStats(PChar);
     charutils::CheckValidEquipment(PChar);
@@ -5355,6 +5357,7 @@ inline int32 CLuaBaseEntity::setLevel(lua_State *L)
     PChar->SetSLevel(PChar->jobs.job[PChar->GetSJob()]);
     PChar->jobs.exp[PChar->GetMJob()] = charutils::GetExpNEXTLevel(PChar->jobs.job[PChar->GetMJob()]) - 1;
 
+    charutils::SetStyleLock(PChar, false);
     blueutils::ValidateBlueSpells(PChar);
     charutils::CalculateStats(PChar);
     charutils::CheckValidEquipment(PChar);

--- a/src/map/utils/charutils.cpp
+++ b/src/map/utils/charutils.cpp
@@ -1831,7 +1831,7 @@ namespace charutils
                 auto PItem = PChar->getEquip((SLOTTYPE)i);
                 PChar->styleItems[i] = (PItem == nullptr) ? 0 : PItem->getID();
             }
-            memcpy(&PChar->mainlook, &PChar->look, sizeof(PChar->look));
+            PChar->mainlook = PChar->look;
         }
         else {
             for (uint8 i = 0; i < SLOT_LINK1; i++) {

--- a/src/map/utils/charutils.h
+++ b/src/map/utils/charutils.h
@@ -81,6 +81,9 @@ namespace charutils
     void    RemoveSub(CCharEntity* PChar);
     bool    EquipArmor(CCharEntity* PChar, uint8 slotID, uint8 equipSlotID);
     void	CheckUnarmedWeapon(CCharEntity* PChar);
+    void    SetStyleLock(CCharEntity* PChar, bool isStyleLocked);
+    void    UpdateWeaponStyle(CCharEntity* PChar, uint8 equipSlotID, CItemWeapon* PItem);
+    void    UpdateArmorStyle(CCharEntity* PChar, uint8 equipSlotID);
 
     void    UpdateHealth(CCharEntity* PChar);
 


### PR DESCRIPTION
I'm not completely happy with this implementation, so I'm hoping for some feedback on potential improvements in addition to the normal. What is coded matches the retail behavior as best as I was able to ascertain. The following statements are true, from what I've gathered:

1. You can only set an item as a style if you currently own it (exists in any inventory).
2. You can only set an item as a style if you can equip that item normally (1+ job can equip).
3. A set weapon style only works if the skill type of the equipped weapon matches the styled weapon.
4. If you drop an item that is set as a style, it will be maintained until the next appearance update. When that occurs, the slot it was styled to will become empty.
5. If you drop an item that is set as a style but have another copy of the item, the style will remain.
6. If an item you have previously owned is used in a style you are attempting to lock, the currently equipped gear's appearance will be used instead.
7. If an equipment slot style is set to Remove, the styled appearance will be empty. 
8. If the style is locked without using an equipment set, the currently equipped gear is used as the style set.
9. Style remains locked through zoning and logging out/in.