### PR TITLE
updateClaim function added

### DIFF
--- a/src/map/lua/lua_baseentity.cpp
+++ b/src/map/lua/lua_baseentity.cpp
@@ -5918,6 +5918,30 @@ inline int32 CLuaBaseEntity::updateEnmity(lua_State *L)
 }
 
 /************************************************************************
+*                                                                       *
+*  updates enmity and claims monster									*
+*                                                                       *
+************************************************************************/
+
+inline int32 CLuaBaseEntity::updateClaim(lua_State *L)
+{
+	DSP_DEBUG_BREAK_IF(m_PBaseEntity == NULL);
+	DSP_DEBUG_BREAK_IF(m_PBaseEntity->objtype != TYPE_MOB);
+
+	//DSP_DEBUG_BREAK_IF(lua_gettop(L) > 1);
+	DSP_DEBUG_BREAK_IF(lua_isnil(L, 1) || !lua_isuserdata(L, 1));
+
+	CLuaBaseEntity* PEntity = Lunar<CLuaBaseEntity>::check(L, 1);
+
+	if (PEntity != NULL &&
+		PEntity->GetBaseEntity()->objtype != TYPE_NPC)
+	{
+		battleutils::ClaimMob((CMobEntity*)m_PBaseEntity, (CBattleEntity*)PEntity->GetBaseEntity());
+	}
+	return 0;
+}
+
+/************************************************************************
     Resets all enmity of player on mob.
     Example:
     mob:resetEnmity(target)
@@ -9111,9 +9135,9 @@ inline int32 CLuaBaseEntity::getPartyLeader(lua_State* L) // Todo: also add abil
             if (PLeaderName != nullptr)
             {
                 lua_pushstring(L, PLeaderName);
-                return 1;
-            }
+            return 1;
         }
+    }
     }
 
     lua_pushnil(L);
@@ -10012,6 +10036,7 @@ Lunar<CLuaBaseEntity>::Register_t CLuaBaseEntity::methods[] =
     LUNAR_DECLARE_METHOD(CLuaBaseEntity,injectPacket),
     LUNAR_DECLARE_METHOD(CLuaBaseEntity,showPosition),
     LUNAR_DECLARE_METHOD(CLuaBaseEntity,updateEnmity),
+	LUNAR_DECLARE_METHOD(CLuaBaseEntity,updateClaim),
     LUNAR_DECLARE_METHOD(CLuaBaseEntity,resetEnmity),
     LUNAR_DECLARE_METHOD(CLuaBaseEntity,lowerEnmity),
     LUNAR_DECLARE_METHOD(CLuaBaseEntity,updateEnmityFromDamage),

--- a/src/map/lua/lua_baseentity.cpp
+++ b/src/map/lua/lua_baseentity.cpp
@@ -2430,7 +2430,7 @@ inline int32 CLuaBaseEntity::levelRestriction(lua_State* L)
                 CPetEntity* PPet = (CPetEntity*)PChar->PPet;
                 if (PPet->getPetType() == PETTYPE_WYVERN)
                 {
-					petutils::LoadWyvernStatistics(PChar, PPet, true);
+                    petutils::LoadWyvernStatistics(PChar, PPet, true);
                 }
                 else
                 {
@@ -4163,27 +4163,27 @@ inline int32 CLuaBaseEntity::costume(lua_State *L)
 
 inline int32 CLuaBaseEntity::costume2(lua_State *L)
 {
-	DSP_DEBUG_BREAK_IF(m_PBaseEntity == nullptr);
-	DSP_DEBUG_BREAK_IF(m_PBaseEntity->objtype != TYPE_PC);
+    DSP_DEBUG_BREAK_IF(m_PBaseEntity == nullptr);
+    DSP_DEBUG_BREAK_IF(m_PBaseEntity->objtype != TYPE_PC);
 
-	CCharEntity* PChar = (CCharEntity*)m_PBaseEntity;
+    CCharEntity* PChar = (CCharEntity*)m_PBaseEntity;
 
-	if (!lua_isnil(L, 1) && lua_isnumber(L, 1))
-	{
-		uint16 model = (uint16)lua_tointeger(L, 1);
+    if (!lua_isnil(L, 1) && lua_isnumber(L, 1))
+    {
+        uint16 model = (uint16)lua_tointeger(L, 1);
 
-		if (PChar->m_Monstrosity != model &&
-			PChar->status != STATUS_SHUTDOWN &&
-			PChar->status != STATUS_DISAPPEAR)
-		{
-			PChar->m_Monstrosity = model;
+        if (PChar->m_Monstrosity != model &&
+            PChar->status != STATUS_SHUTDOWN &&
+            PChar->status != STATUS_DISAPPEAR)
+        {
+            PChar->m_Monstrosity = model;
             PChar->updatemask |= UPDATE_LOOK;
-			PChar->pushPacket(new CCharAppearancePacket(PChar));
-		}
-		return 0;
-	}
-	lua_pushinteger(L, PChar->m_Monstrosity);
-	return 1;
+            PChar->pushPacket(new CCharAppearancePacket(PChar));
+        }
+        return 0;
+    }
+    lua_pushinteger(L, PChar->m_Monstrosity);
+    return 1;
 }
 
 /************************************************************************
@@ -4257,10 +4257,10 @@ inline int32 CLuaBaseEntity::setStatus(lua_State *L)
 
 inline int32 CLuaBaseEntity::getStatus(lua_State *L)
 {
-	DSP_DEBUG_BREAK_IF(m_PBaseEntity == nullptr);
+    DSP_DEBUG_BREAK_IF(m_PBaseEntity == nullptr);
 
-	lua_pushinteger(L,m_PBaseEntity->status);
-	return 1;
+    lua_pushinteger(L,m_PBaseEntity->status);
+    return 1;
 }
 
 //==========================================================//
@@ -5627,17 +5627,17 @@ inline int32 CLuaBaseEntity::equipItem(lua_State *L)
     CCharEntity* PChar = (CCharEntity*)m_PBaseEntity;
 
     uint16 itemID = (uint16)lua_tointeger(L,1);
-	uint8 containerID;
-	if (lua_isnil(L, 2) || !lua_isnumber(L, 2))
-		containerID = LOC_INVENTORY;
-	else
-		containerID = (uint8)lua_tointeger(L, 2);
-	uint8 SLOT = PChar->getStorage(containerID)->SearchItem(itemID);
+    uint8 containerID;
+    if (lua_isnil(L, 2) || !lua_isnumber(L, 2))
+        containerID = LOC_INVENTORY;
+    else
+        containerID = (uint8)lua_tointeger(L, 2);
+    uint8 SLOT = PChar->getStorage(containerID)->SearchItem(itemID);
     CItemArmor* PItem;
 
     if(SLOT != ERROR_SLOTID){
-		PItem = (CItemArmor*)PChar->getStorage(containerID)->GetItem(SLOT);
-		charutils::EquipItem(PChar, SLOT, PItem->getSlotType(), containerID);
+        PItem = (CItemArmor*)PChar->getStorage(containerID)->GetItem(SLOT);
+        charutils::EquipItem(PChar, SLOT, PItem->getSlotType(), containerID);
         charutils::SaveCharEquip(PChar);
     }
     return 0;
@@ -5662,11 +5662,11 @@ inline int32 CLuaBaseEntity::lockEquipSlot(lua_State *L)
 
     CCharEntity* PChar = (CCharEntity*)m_PBaseEntity;
 
-	charutils::EquipItem(PChar, 0, SLOT, LOC_INVENTORY);
+    charutils::EquipItem(PChar, 0, SLOT, LOC_INVENTORY);
 
     PChar->m_EquipBlock |= 1 << SLOT;
     PChar->pushPacket(new CCharAppearancePacket(PChar));
-	PChar->pushPacket(new CEquipPacket(0, SLOT, LOC_INVENTORY));
+    PChar->pushPacket(new CEquipPacket(0, SLOT, LOC_INVENTORY));
     PChar->pushPacket(new CCharJobsPacket(PChar));
     PChar->updatemask |= UPDATE_LOOK;
 
@@ -5925,20 +5925,20 @@ inline int32 CLuaBaseEntity::updateEnmity(lua_State *L)
 
 inline int32 CLuaBaseEntity::updateClaim(lua_State *L)
 {
-	DSP_DEBUG_BREAK_IF(m_PBaseEntity == NULL);
-	DSP_DEBUG_BREAK_IF(m_PBaseEntity->objtype != TYPE_MOB);
+    DSP_DEBUG_BREAK_IF(m_PBaseEntity == NULL);
+    DSP_DEBUG_BREAK_IF(m_PBaseEntity->objtype != TYPE_MOB);
 
-	//DSP_DEBUG_BREAK_IF(lua_gettop(L) > 1);
-	DSP_DEBUG_BREAK_IF(lua_isnil(L, 1) || !lua_isuserdata(L, 1));
+    //DSP_DEBUG_BREAK_IF(lua_gettop(L) > 1);
+    DSP_DEBUG_BREAK_IF(lua_isnil(L, 1) || !lua_isuserdata(L, 1));
 
-	CLuaBaseEntity* PEntity = Lunar<CLuaBaseEntity>::check(L, 1);
+    CLuaBaseEntity* PEntity = Lunar<CLuaBaseEntity>::check(L, 1);
 
-	if (PEntity != NULL &&
-		PEntity->GetBaseEntity()->objtype != TYPE_NPC)
-	{
-		battleutils::ClaimMob((CMobEntity*)m_PBaseEntity, (CBattleEntity*)PEntity->GetBaseEntity());
-	}
-	return 0;
+    if (PEntity != NULL &&
+        PEntity->GetBaseEntity()->objtype != TYPE_NPC)
+    {
+        battleutils::ClaimMob((CMobEntity*)m_PBaseEntity, (CBattleEntity*)PEntity->GetBaseEntity());
+    }
+    return 0;
 }
 
 /************************************************************************
@@ -8846,7 +8846,7 @@ inline int32 CLuaBaseEntity::pathTo(lua_State* L)
 
     if (m_PBaseEntity->PBattleAI && m_PBaseEntity->PBattleAI->m_PPathFind)
     {
-		m_PBaseEntity->PBattleAI->m_PPathFind->PathTo(point, PATHFLAG_RUN | PATHFLAG_WALLHACK | PATHFLAG_SCRIPT);
+        m_PBaseEntity->PBattleAI->m_PPathFind->PathTo(point, PATHFLAG_RUN | PATHFLAG_WALLHACK | PATHFLAG_SCRIPT);
     }
 
     return 0;
@@ -9135,9 +9135,9 @@ inline int32 CLuaBaseEntity::getPartyLeader(lua_State* L) // Todo: also add abil
             if (PLeaderName != nullptr)
             {
                 lua_pushstring(L, PLeaderName);
-            return 1;
+                return 1;
+            }
         }
-    }
     }
 
     lua_pushnil(L);
@@ -9232,16 +9232,16 @@ inline int32 CLuaBaseEntity::messageText(lua_State* L)
 
     uint16 messageID = (uint16)lua_tointeger(L, 2);
 
-	bool showName = true;
+    bool showName = true;
     uint8 mode = 0;
 
-	if (!lua_isnil(L, 3))
-	{
+    if (!lua_isnil(L, 3))
+    {
         if (lua_isboolean(L, 3))
             showName = lua_toboolean(L, 3);
         else if (lua_isnumber(L, 3))
             mode = lua_tointeger(L, 3);
-	}
+    }
 
     if (!lua_isnil(L, 4) && lua_isnumber(L, 4))
     {
@@ -9252,8 +9252,8 @@ inline int32 CLuaBaseEntity::messageText(lua_State* L)
         ((CCharEntity*)m_PBaseEntity)->pushPacket(new CMessageTextPacket(PTarget, messageID, showName, mode));
     }
     else{//broadcast in range
-		m_PBaseEntity->loc.zone->PushPacket(m_PBaseEntity, CHAR_INRANGE, new CMessageTextPacket(PTarget, messageID, showName, mode));
-	}
+        m_PBaseEntity->loc.zone->PushPacket(m_PBaseEntity, CHAR_INRANGE, new CMessageTextPacket(PTarget, messageID, showName, mode));
+    }
     return 0;
 }
 
@@ -9458,13 +9458,13 @@ inline int32 CLuaBaseEntity::getAllegiance(lua_State* L)
 
 inline int32 CLuaBaseEntity::stun(lua_State* L)
 {
-	DSP_DEBUG_BREAK_IF(m_PBaseEntity == nullptr);
-	DSP_DEBUG_BREAK_IF(m_PBaseEntity->objtype != TYPE_MOB);
-	DSP_DEBUG_BREAK_IF(lua_isnil(L, 1) || !lua_isnumber(L, 1));
+    DSP_DEBUG_BREAK_IF(m_PBaseEntity == nullptr);
+    DSP_DEBUG_BREAK_IF(m_PBaseEntity->objtype != TYPE_MOB);
+    DSP_DEBUG_BREAK_IF(lua_isnil(L, 1) || !lua_isnumber(L, 1));
 
-	((CAIMobDummy*)m_PBaseEntity->PBattleAI)->Stun(lua_tointeger(L, 1));
+    ((CAIMobDummy*)m_PBaseEntity->PBattleAI)->Stun(lua_tointeger(L, 1));
 
-	return 0;
+    return 0;
 }
 
 inline int32 CLuaBaseEntity::weaknessTrigger(lua_State* L)
@@ -9994,12 +9994,12 @@ Lunar<CLuaBaseEntity>::Register_t CLuaBaseEntity::methods[] =
     LUNAR_DECLARE_METHOD(CLuaBaseEntity,speed),
     LUNAR_DECLARE_METHOD(CLuaBaseEntity,resetPlayer),
     LUNAR_DECLARE_METHOD(CLuaBaseEntity,costume),
-	LUNAR_DECLARE_METHOD(CLuaBaseEntity,costume2),
+    LUNAR_DECLARE_METHOD(CLuaBaseEntity,costume2),
     LUNAR_DECLARE_METHOD(CLuaBaseEntity,canUseCostume),
     LUNAR_DECLARE_METHOD(CLuaBaseEntity,canUseChocobo),
     LUNAR_DECLARE_METHOD(CLuaBaseEntity,canUsePet),
     LUNAR_DECLARE_METHOD(CLuaBaseEntity,setStatus),
-	LUNAR_DECLARE_METHOD(CLuaBaseEntity,getStatus),
+    LUNAR_DECLARE_METHOD(CLuaBaseEntity,getStatus),
     LUNAR_DECLARE_METHOD(CLuaBaseEntity,sendRaise),
     LUNAR_DECLARE_METHOD(CLuaBaseEntity,sendReraise),
     LUNAR_DECLARE_METHOD(CLuaBaseEntity,sendTractor),
@@ -10036,7 +10036,7 @@ Lunar<CLuaBaseEntity>::Register_t CLuaBaseEntity::methods[] =
     LUNAR_DECLARE_METHOD(CLuaBaseEntity,injectPacket),
     LUNAR_DECLARE_METHOD(CLuaBaseEntity,showPosition),
     LUNAR_DECLARE_METHOD(CLuaBaseEntity,updateEnmity),
-	LUNAR_DECLARE_METHOD(CLuaBaseEntity,updateClaim),
+    LUNAR_DECLARE_METHOD(CLuaBaseEntity,updateClaim),
     LUNAR_DECLARE_METHOD(CLuaBaseEntity,resetEnmity),
     LUNAR_DECLARE_METHOD(CLuaBaseEntity,lowerEnmity),
     LUNAR_DECLARE_METHOD(CLuaBaseEntity,updateEnmityFromDamage),
@@ -10248,7 +10248,7 @@ Lunar<CLuaBaseEntity>::Register_t CLuaBaseEntity::methods[] =
     LUNAR_DECLARE_METHOD(CLuaBaseEntity,spawn),
     LUNAR_DECLARE_METHOD(CLuaBaseEntity,getCurrentAction),
     LUNAR_DECLARE_METHOD(CLuaBaseEntity,getAllegiance),
-	LUNAR_DECLARE_METHOD(CLuaBaseEntity,stun),
+    LUNAR_DECLARE_METHOD(CLuaBaseEntity,stun),
     LUNAR_DECLARE_METHOD(CLuaBaseEntity,weaknessTrigger),
     LUNAR_DECLARE_METHOD(CLuaBaseEntity,getBehaviour),
     LUNAR_DECLARE_METHOD(CLuaBaseEntity,setBehaviour),

--- a/src/map/lua/lua_baseentity.h
+++ b/src/map/lua/lua_baseentity.h
@@ -143,7 +143,7 @@ public:
     int32 setAnimation(lua_State*);         // Set Entity Animation
     int32 AnimationSub(lua_State*);         // get or set animationsub
     int32 costume(lua_State*);              // get or set user costume
-	int32 costume2(lua_State*);				// set monstrosity costume
+    int32 costume2(lua_State*);				// set monstrosity costume
     int32 canUseCostume(lua_State*);        // check to see if character can use costume, 0 if so
     int32 canUseChocobo(lua_State *L);      // check to see if character can use chocobo, 0 if so
     int32 canUsePet(lua_State *L);          // check to see if character can call pet, 0 if so
@@ -313,7 +313,7 @@ public:
     int32 getFameLevel(lua_State*);         // Gets Fame Level for specified nation
 
     int32 setStatus(lua_State*);            // Sets Character's Status
-	int32 getStatus(lua_State*);
+    int32 getStatus(lua_State*);
 
     int32 sendRaise(lua_State*);            // send raise request to char
     int32 sendReraise(lua_State*);          // send raise request to char
@@ -321,7 +321,7 @@ public:
     int32 SendRevision(lua_State*);         // send Git revision to char
 
     int32 updateEnmity(lua_State*);           // Adds Enmity to player for specified mob
-	int32 updateClaim(lua_State*);           // Adds Enmity to player for specified mob and claims
+    int32 updateClaim(lua_State*);           // Adds Enmity to player for specified mob and claims
     int32 updateEnmityFromDamage(lua_State*); // Adds Enmity to player for specified mob for the damage specified
     int32 updateEnmityFromCure(lua_State*);
     int32 addEnmity(lua_State*);            // Add specified amount of enmity (target, CE, VE)
@@ -566,7 +566,7 @@ public:
     int32 spawn(lua_State* L);
     int32 getCurrentAction(lua_State* L);
     int32 getAllegiance(lua_State* L);
-	int32 stun(lua_State* L);
+    int32 stun(lua_State* L);
     int32 weaknessTrigger(lua_State* L);
     int32 setBehaviour(lua_State* L);
     int32 getBehaviour(lua_State* L);
@@ -575,8 +575,6 @@ public:
     int32 setModelId(lua_State* L);
     int32 setAggroFlag(lua_State* L);
     int32 unsetAggroFlag(lua_State* L);
-	int32 addFishingZone(lua_State* L);
-	//int32 addFishingZonePoint()
     int32 instantiateMob(lua_State* L);
 
     int32 getActiveManeuvers(lua_State*);

--- a/src/map/lua/lua_baseentity.h
+++ b/src/map/lua/lua_baseentity.h
@@ -321,6 +321,7 @@ public:
     int32 SendRevision(lua_State*);         // send Git revision to char
 
     int32 updateEnmity(lua_State*);           // Adds Enmity to player for specified mob
+	int32 updateClaim(lua_State*);           // Adds Enmity to player for specified mob and claims
     int32 updateEnmityFromDamage(lua_State*); // Adds Enmity to player for specified mob for the damage specified
     int32 updateEnmityFromCure(lua_State*);
     int32 addEnmity(lua_State*);            // Add specified amount of enmity (target, CE, VE)
@@ -574,6 +575,8 @@ public:
     int32 setModelId(lua_State* L);
     int32 setAggroFlag(lua_State* L);
     int32 unsetAggroFlag(lua_State* L);
+	int32 addFishingZone(lua_State* L);
+	//int32 addFishingZonePoint()
     int32 instantiateMob(lua_State* L);
 
     int32 getActiveManeuvers(lua_State*);


### PR DESCRIPTION
updateClaim LUA function added to make a monster claimed through script.
similar to updateEnmity but actually marks the monster as claimed.  good for scripted spawning of quest monsters or fished up NM

example in LUA:

SpawnMob(monsterid):updateClaim(player);

