### PR TITLE
 SCRIPTS: added [dmg can be avoided by players]

### DIFF
--- a/scripts/globals/mobskills/Dragon_Breath.lua
+++ b/scripts/globals/mobskills/Dragon_Breath.lua
@@ -31,7 +31,7 @@ function onMobWeaponSkill(target, mob, skill)
         
     angle = mob:getRotPos() - angle;
             
-    dmgmod = dmgmod * ((128-math.abs(angle))/128);
+    dmgmod = dmgmod * ((128-math.abs(angle)*3)/128);
         
     utils.clamp(dmgmod, 50, 1600);
     


### PR DESCRIPTION
the dmg outpout can be avoided by standing on/near the wyrm's two front feet.