### PR TITLE
Scripts: Repaired text IDs in Cloister of Frost.

### DIFF
--- a/scripts/zones/Cloister_of_Frost/TextIDs.lua
+++ b/scripts/zones/Cloister_of_Frost/TextIDs.lua
@@ -8,7 +8,14 @@ ITEM_CANNOT_BE_OBTAINED = 6379; -- You cannot obtain the item <item> come back a
 
 -- Quest dialog
 YOU_CANNOT_ENTER_THE_BATTLEFIELD = 7197; -- You cannot enter the battlefield at present.
-          IFRIT_UNLOCKED = 7555; -- You are now able to summon
+                  SHIVA_UNLOCKED = 7555; -- You are now able to summon
+
+-- ZM4 Dialog
+    CANNOT_REMOVE_FRAG = 7645; -- It is an oddly shaped stone monument
+ ALREADY_OBTAINED_FRAG = 7646; -- You have already obtained this monument
+ALREADY_HAVE_ALL_FRAGS = 7647; -- You have obtained all of the fragments
+       FOUND_ALL_FRAGS = 7648; -- You have obtained ! You now have all 8 fragments of light!
+       ZILART_MONUMENT = 7649; -- It is an ancient Zilart monument
 
 -- Other
 PROTOCRYSTAL = 7221; -- It is a giant crystal.


### PR DESCRIPTION
Looks like file accidentally got replaced with wrong copy at some point in the past.
I seem to recall somebody on IRC saying they were fixing this but they never made a pull request...