### PR TITLE
Misc LockStyle Changes

### DIFF
--- a/src/map/lua/lua_baseentity.cpp
+++ b/src/map/lua/lua_baseentity.cpp
@@ -5666,6 +5666,7 @@ inline int32 CLuaBaseEntity::equipItem(lua_State *L)
         PItem = (CItemArmor*)PChar->getStorage(containerID)->GetItem(SLOT);
         charutils::EquipItem(PChar, SLOT, PItem->getSlotType(), containerID);
         charutils::SaveCharEquip(PChar);
+        charutils::SaveCharLook(PChar);
     }
     return 0;
 }

--- a/src/map/packet_system.cpp
+++ b/src/map/packet_system.cpp
@@ -2362,6 +2362,7 @@ void SmallPacket0x050(map_session_data_t* session, CCharEntity* PChar, CBasicPac
 
     charutils::EquipItem(PChar, slotID, equipSlotID, containerID); //current
     charutils::SaveCharEquip(PChar);
+    charutils::SaveCharLook(PChar);
     luautils::CheckForGearSet(PChar); // check for gear set on gear change
     PChar->UpdateHealth();
     return;
@@ -2389,6 +2390,7 @@ void SmallPacket0x051(map_session_data_t* session, CCharEntity* PChar, CBasicPac
 
     }
     charutils::SaveCharEquip(PChar);
+    charutils::SaveCharLook(PChar);
     luautils::CheckForGearSet(PChar); // check for gear set on gear change
     PChar->UpdateHealth();
     return;
@@ -2426,7 +2428,7 @@ void SmallPacket0x053(map_session_data_t* session, CCharEntity* PChar, CBasicPac
     if (type == 0 && PChar->getStyleLocked()) 
     {
         charutils::SetStyleLock(PChar, false);
-        charutils::SaveCharEquip(PChar);
+        charutils::SaveCharLook(PChar);
     }
     else if (type == 1) 
     {
@@ -2472,12 +2474,12 @@ void SmallPacket0x053(map_session_data_t* session, CCharEntity* PChar, CBasicPac
                 break;
             }
         }
-        charutils::SaveCharEquip(PChar);
+        charutils::SaveCharLook(PChar);
     }
     else if (type == 4) 
     {
         charutils::SetStyleLock(PChar, true);
-        charutils::SaveCharEquip(PChar);
+        charutils::SaveCharLook(PChar);
     }
 
     if (type != 1 && type != 2) 
@@ -4970,7 +4972,7 @@ void SmallPacket0x100(map_session_data_t* session, CCharEntity* PChar, CBasicPac
             }
 
         }
-        charutils::SetStyleLock(PChar, false);
+        
         luautils::CheckForGearSet(PChar); // check for gear set on gear change
 
         charutils::BuildingCharSkillsTable(PChar);

--- a/src/map/packet_system.cpp
+++ b/src/map/packet_system.cpp
@@ -4973,6 +4973,7 @@ void SmallPacket0x100(map_session_data_t* session, CCharEntity* PChar, CBasicPac
 
         }
         
+        charutils::SetStyleLock(PChar, false);
         luautils::CheckForGearSet(PChar); // check for gear set on gear change
 
         charutils::BuildingCharSkillsTable(PChar);

--- a/src/map/utils/charutils.cpp
+++ b/src/map/utils/charutils.cpp
@@ -1838,9 +1838,10 @@ namespace charutils
         else
             for (uint8 i = 0; i < SLOT_LINK1; i++)
                 PChar->styleItems[i] = 0;
+        
+        if (PChar->getStyleLocked() != isStyleLocked)
+            PChar->pushPacket(new CMessageStandardPacket(isStyleLocked ? 0x10B : 0x10C));
         PChar->setStyleLocked(isStyleLocked);
-
-        PChar->pushPacket(new CMessageStandardPacket(PChar->getStyleLocked() ? 0x10B : 0x10C));
     }
 
     void UpdateWeaponStyle(CCharEntity* PChar, uint8 equipSlotID, CItemWeapon* PItem) 
@@ -2061,6 +2062,7 @@ namespace charutils
 
         BuildingCharWeaponSkills(PChar);
         SaveCharEquip(PChar);
+        SaveCharLook(PChar);
     }
 
     void RemoveAllEquipment(CCharEntity* PChar)
@@ -2081,6 +2083,7 @@ namespace charutils
 
         BuildingCharWeaponSkills(PChar);
         SaveCharEquip(PChar);
+        SaveCharLook(PChar);
     }
 
     /************************************************************************
@@ -4011,7 +4014,10 @@ namespace charutils
                 Sql_Query(SqlHandle, fmtQuery, PChar->id, i, PChar->equip[i], PChar->equipLoc[i], PChar->equip[i], PChar->equipLoc[i]);
             }
         }
+    }
 
+    void SaveCharLook(CCharEntity* PChar)
+    {
         const int8* Query = "UPDATE char_look "
             "SET head = %u, body = %u, hands = %u, legs = %u, feet = %u, main = %u, sub = %u, ranged = %u "
             "WHERE charid = %u;";

--- a/src/map/utils/charutils.h
+++ b/src/map/utils/charutils.h
@@ -126,6 +126,7 @@ namespace charutils
     void	SaveCharJob(CCharEntity* PChar, JOBTYPE job);		        // сохраняем уровень для выбранной профессий персонажа
     void	SaveCharExp(CCharEntity* PChar, JOBTYPE job);		        // сохраняем опыт для выбранной профессии персонажа
     void	SaveCharEquip(CCharEntity* PChar);					        // сохраняем экипировку и внешний вид персонажа
+    void    SaveCharLook(CCharEntity* PChar);                           // Saves a character's appearance based on style locking.
     void	SaveCharPosition(CCharEntity* PChar);				        // сохраняем позицию персонажа
     void	SaveMissionsList(CCharEntity* PChar);                       // Save the missions list
     void	SaveQuestsList(CCharEntity* PChar);					        // сохраняем список ксевтов


### PR DESCRIPTION
CORE: Correct lockstyle to only send message if lock status is changing.
CORE: Correct lockstyle to only send one message when changing jobs.

When changing jobs, the client was sending a lockstyle packet and receiving a lockstyle status update. The server was pushing a lockstyle status update at the same time. The status message should now only be sent when it has changed from the current status.


CORE: Split SaveCharEquip and SaveCharLook into two methods.

There have been reports that equipment is not being equipped / being unequipped after zoning. I've worked with a few people to get reproducible steps, but have been unable to find a way to reproduce it locally. Looking at the code, the only way I see for lockstyle to interfere with what gear is actually equipped would be to save an empty gearset before DSP has equipped the player's gear. I have split the SaveCharEquip method into two methods: SaveCharEquip and SaveCharLook. SaveCharLook now deals with saving a character's appearance / style and is called whenever SaveCharEquip is called, unless there are no appearance changes. 