### PR TITLE
Perma-(De)Buff on zone Fix

### DIFF
--- a/scripts/globals/player.lua
+++ b/scripts/globals/player.lua
@@ -25,7 +25,7 @@ function onGameIn(player, firstlogin, zoning)
     end
 
     if (zoning) then -- Things checked ONLY during zone in go here.
-        -- Nothing here yet :P
+        player:delStatusEffectsByDuration(5); --wipes statuses about to wear off, prevents permanent buffs/debuffs
     end
 
     -- Things checked BOTH during logon AND zone in below this line.

--- a/src/map/lua/lua_baseentity.cpp
+++ b/src/map/lua/lua_baseentity.cpp
@@ -4732,6 +4732,16 @@ inline int32 CLuaBaseEntity::delStatusEffectSilent(lua_State* L)
     return 1;
 }
 
+inline int32 CLuaBaseEntity::delStatusEffectsByDuration(lua_State* L)
+{
+	DSP_DEBUG_BREAK_IF(m_PBaseEntity == nullptr);
+	DSP_DEBUG_BREAK_IF(m_PBaseEntity->objtype == TYPE_NPC);
+
+	((CBattleEntity*)m_PBaseEntity)->StatusEffectContainer->DelStatusEffectsByDuration((uint32)lua_tointeger(L,1));
+
+	return 1;
+}
+
 //==========================================================//
 
 inline int32 CLuaBaseEntity::removePartyEffect(lua_State *L)
@@ -10042,6 +10052,7 @@ Lunar<CLuaBaseEntity>::Register_t CLuaBaseEntity::methods[] =
     LUNAR_DECLARE_METHOD(CLuaBaseEntity,getStatusEffectElement),
     LUNAR_DECLARE_METHOD(CLuaBaseEntity,delStatusEffect),
     LUNAR_DECLARE_METHOD(CLuaBaseEntity,delStatusEffectsByFlag),
+    LUNAR_DECLARE_METHOD(CLuaBaseEntity,delStatusEffectsByDuration),
     LUNAR_DECLARE_METHOD(CLuaBaseEntity,delStatusEffectSilent),
     LUNAR_DECLARE_METHOD(CLuaBaseEntity,eraseStatusEffect),
     LUNAR_DECLARE_METHOD(CLuaBaseEntity,healingWaltz),

--- a/src/map/lua/lua_baseentity.h
+++ b/src/map/lua/lua_baseentity.h
@@ -347,6 +347,7 @@ public:
     int32 delStatusEffect(lua_State*);        // Removes Status Effect
     int32 delStatusEffectsByFlag(lua_State*); // Removes Status Effects by Flag
     int32 delStatusEffectSilent(lua_State*);  // Removes Status Effect, suppresses message
+    int32 delStatusEffectsByDuration(lua_State*); //Removes Status Effects by Duration
     int32 eraseStatusEffect(lua_State*);      // Used with "Erase" spell
     int32 healingWaltz(lua_State*);           // Used with "Healing Waltz" ability
     int32 dispelStatusEffect(lua_State*);     // Used with "Dispel" spell

--- a/src/map/status_effect_container.cpp
+++ b/src/map/status_effect_container.cpp
@@ -564,10 +564,8 @@ void CStatusEffectContainer::DelStatusEffectsByType(uint16 Type)
 }
 
 /************************************************************************
-*																		*
-*  Removes Status Effects by Duration   						*
-*																		*
-************************************************************************/
+		Removes Status Effects By Duration
+*************************************************************************/
 
 void CStatusEffectContainer::DelStatusEffectsByDuration(uint32 Duration)
 {

--- a/src/map/status_effect_container.cpp
+++ b/src/map/status_effect_container.cpp
@@ -564,6 +564,23 @@ void CStatusEffectContainer::DelStatusEffectsByType(uint16 Type)
 }
 
 /************************************************************************
+*																		*
+*  Removes Status Effects by Duration   						*
+*																		*
+************************************************************************/
+
+void CStatusEffectContainer::DelStatusEffectsByDuration(uint32 Duration)
+{
+	for (uint16 i = 0; i < m_StatusEffectList.size(); ++i)
+	{
+       if  (m_StatusEffectList.at(i)->GetDuration() <= Duration)
+		{
+			RemoveStatusEffect(i--, true);
+		}
+	}
+}
+
+/************************************************************************
 *                                                                       *
 *  Удаляем все эффекты с указанными флагами                             *
 *                                                                       *

--- a/src/map/status_effect_container.h
+++ b/src/map/status_effect_container.h
@@ -53,6 +53,7 @@ public:
     void DelStatusEffectsByFlag(uint32 flag, bool silent = false);                   // удаляем все эффекты с указанным типом
     void DelStatusEffectsByIcon(uint16 IconID);                 // удаляем все эффекты с указанной иконкой
     void DelStatusEffectsByType(uint16 Type);
+    void DelStatusEffectsByDuration(uint32 Duration);
     bool DelStatusEffectByTier(EFFECT StatusID, uint16 power);
     void KillAllStatusEffect();
 


### PR DESCRIPTION
Added a function to status_effect_container, "delStatusEffectsByDuration"

Removes status effects which have a duration less than the time specified

Called the function in Scripts\Globals\Player.lua on zone, with a default time of 5 seconds.

Seems to have fixed issue #1461 