### PR TITLE
CORE / SCRIPTS: Fixing Pet Skill TP / Bloodpacts

### DIFF
--- a/scripts/globals/abilities/pets/aero_ii.lua
+++ b/scripts/globals/abilities/pets/aero_ii.lua
@@ -24,7 +24,7 @@ function onPetAbility(target, pet, skill)
 	--add on bonuses (staff/day/weather/jas/mab/etc all go in this function)
 	dmg = mobAddBonuses(pet,spell,target,dmg, 4);
 	--add on TP bonuses
-	local tp = pet:getTP();
+	local tp = skill:getTP();
 	if tp < 100 then
 		tp = 100;
 	end

--- a/scripts/globals/abilities/pets/aero_iv.lua
+++ b/scripts/globals/abilities/pets/aero_iv.lua
@@ -24,7 +24,7 @@ function onPetAbility(target, pet, skill)
 	--add on bonuses (staff/day/weather/jas/mab/etc all go in this function)
 	dmg = mobAddBonuses(pet,spell,target,dmg, 4);
 	--add on TP bonuses
-	local tp = pet:getTP();
+	local tp = skill:getTP();
 	if tp < 100 then
 		tp = 100;
 	end

--- a/scripts/globals/abilities/pets/blizzard_ii.lua
+++ b/scripts/globals/abilities/pets/blizzard_ii.lua
@@ -24,7 +24,7 @@ function onPetAbility(target, pet, skill)
 	--add on bonuses (staff/day/weather/jas/mab/etc all go in this function)
 	dmg = mobAddBonuses(pet,spell,target,dmg, 5);
 	--add on TP bonuses
-	local tp = pet:getTP();
+	local tp = skill:getTP();
 	if tp < 100 then
 		tp = 100;
 	end

--- a/scripts/globals/abilities/pets/blizzard_iv.lua
+++ b/scripts/globals/abilities/pets/blizzard_iv.lua
@@ -24,7 +24,7 @@ function onPetAbility(target, pet, skill)
 	--add on bonuses (staff/day/weather/jas/mab/etc all go in this function)
 	dmg = mobAddBonuses(pet,spell,target,dmg, 5);
 	--add on TP bonuses
-	local tp = pet:getTP();
+	local tp = skill:getTP();
 	if tp < 100 then
 		tp = 100;
 	end

--- a/scripts/globals/abilities/pets/fire_ii.lua
+++ b/scripts/globals/abilities/pets/fire_ii.lua
@@ -14,7 +14,8 @@ function onAbilityCheck(player, target, ability)
 end;
 
 function onPetAbility(target, pet, skill)
-	local spell = getSpell(145);
+	
+    local spell = getSpell(145);
 	--calculate raw damage
 	local dmg = calculateMagicDamage(133,1,pet,spell,target,ELEMENTAL_MAGIC_SKILL,MOD_INT,false);
 	--get resist multiplier (1x if no resist)
@@ -24,11 +25,12 @@ function onPetAbility(target, pet, skill)
 	--add on bonuses (staff/day/weather/jas/mab/etc all go in this function)
 	dmg = mobAddBonuses(pet,spell,target,dmg, 1);
 	--add on TP bonuses
-	local tp = pet:getTP();
-	if tp < 100 then
-		tp = 100;
-	end
-	dmg = dmg * tp / 100;
+	local tp = skill:getTP();
+	--if tp < 100 then
+	--	tp = 100;
+	--end
+    print(tostring(tp));
+	dmg = dmg + tp * 10;
 	--add in final adjustments
 	dmg = finalMagicAdjustments(pet,target,spell,dmg);
 	return dmg;

--- a/scripts/globals/abilities/pets/fire_ii.lua
+++ b/scripts/globals/abilities/pets/fire_ii.lua
@@ -14,7 +14,6 @@ function onAbilityCheck(player, target, ability)
 end;
 
 function onPetAbility(target, pet, skill)
-	
     local spell = getSpell(145);
 	--calculate raw damage
 	local dmg = calculateMagicDamage(133,1,pet,spell,target,ELEMENTAL_MAGIC_SKILL,MOD_INT,false);

--- a/scripts/globals/abilities/pets/fire_ii.lua
+++ b/scripts/globals/abilities/pets/fire_ii.lua
@@ -26,11 +26,10 @@ function onPetAbility(target, pet, skill)
 	dmg = mobAddBonuses(pet,spell,target,dmg, 1);
 	--add on TP bonuses
 	local tp = skill:getTP();
-	--if tp < 100 then
-	--	tp = 100;
-	--end
-    print(tostring(tp));
-	dmg = dmg + tp * 10;
+	if tp < 100 then
+		tp = 100;
+	end
+	dmg = dmg * tp / 100;
 	--add in final adjustments
 	dmg = finalMagicAdjustments(pet,target,spell,dmg);
 	return dmg;

--- a/scripts/globals/abilities/pets/fire_iv.lua
+++ b/scripts/globals/abilities/pets/fire_iv.lua
@@ -24,7 +24,7 @@ function onPetAbility(target, pet, skill)
 	--add on bonuses (staff/day/weather/jas/mab/etc all go in this function)
 	dmg = mobAddBonuses(pet,spell,target,dmg, 1);
 	--add on TP bonuses
-	local tp = pet:getTP();
+	local tp = skill:getTP();
 	if tp < 100 then
 		tp = 100;
 	end

--- a/scripts/globals/abilities/pets/geocrush.lua
+++ b/scripts/globals/abilities/pets/geocrush.lua
@@ -16,7 +16,7 @@ end;
 function onPetAbility(target, pet, skill)
 
 	local dINT = math.floor(pet:getStat(MOD_INT) - target:getStat(MOD_INT));
-	local tp = pet:getTP();
+	local tp = skill:getTP();
 	local master = pet:getMaster();
 	local merits = 0;
 	if (master ~= nil and master:isPC()) then

--- a/scripts/globals/abilities/pets/grand_fall.lua
+++ b/scripts/globals/abilities/pets/grand_fall.lua
@@ -16,7 +16,7 @@ end;
 function onPetAbility(target, pet, skill)
 
 	local dINT = math.floor(pet:getStat(MOD_INT) - target:getStat(MOD_INT));
-	local tp = pet:getTP();
+	local tp = skill:getTP();
 	local master = pet:getMaster();
 	local merits = 0;
 	if (master ~= nil and master:isPC()) then

--- a/scripts/globals/abilities/pets/heavenly_strike.lua
+++ b/scripts/globals/abilities/pets/heavenly_strike.lua
@@ -16,7 +16,7 @@ end;
 function onPetAbility(target, pet, skill)
 
 	local dINT = math.floor(pet:getStat(MOD_INT) - target:getStat(MOD_INT));
-	local tp = pet:getTP();
+	local tp = skill:getTP();
 	local master = pet:getMaster();
 	local merits = 0;
 	if (master ~= nil and master:isPC()) then

--- a/scripts/globals/abilities/pets/meteor_strike.lua
+++ b/scripts/globals/abilities/pets/meteor_strike.lua
@@ -16,7 +16,7 @@ end;
 function onPetAbility(target, pet, skill)
 
 	local dINT = math.floor(pet:getStat(MOD_INT) - target:getStat(MOD_INT));
-	local tp = pet:getTP();
+	local tp = skill:getTP();
 	local master = pet:getMaster();
 	local merits = 0;
 	if (master ~= nil and master:isPC()) then

--- a/scripts/globals/abilities/pets/spring_water.lua
+++ b/scripts/globals/abilities/pets/spring_water.lua
@@ -14,7 +14,7 @@ end;
 
 function onPetAbility(target, pet, skill)
 	local base = 47 + pet:getMainLvl()*3;
-	local tp = pet:getTP();
+	local tp = skill:getTP();
 	if tp < 100 then
 		tp = 100;
 	end

--- a/scripts/globals/abilities/pets/stone_ii.lua
+++ b/scripts/globals/abilities/pets/stone_ii.lua
@@ -24,7 +24,7 @@ function onPetAbility(target, pet, skill)
 	--add on bonuses (staff/day/weather/jas/mab/etc all go in this function)
 	dmg = mobAddBonuses(pet,spell,target,dmg, 2);
 	--add on TP bonuses
-	local tp = pet:getTP();
+	local tp = skill:getTP();
 	if tp < 100 then
 		tp = 100;
 	end

--- a/scripts/globals/abilities/pets/stone_iv.lua
+++ b/scripts/globals/abilities/pets/stone_iv.lua
@@ -24,7 +24,7 @@ function onPetAbility(target, pet, skill)
 	--add on bonuses (staff/day/weather/jas/mab/etc all go in this function)
 	dmg = mobAddBonuses(pet,spell,target,dmg, 2);
 	--add on TP bonuses
-	local tp = pet:getTP();
+	local tp = skill:getTP();
 	if tp < 100 then
 		tp = 100;
 	end

--- a/scripts/globals/abilities/pets/thunder_ii.lua
+++ b/scripts/globals/abilities/pets/thunder_ii.lua
@@ -24,7 +24,7 @@ function onPetAbility(target, pet, skill)
 	--add on bonuses (staff/day/weather/jas/mab/etc all go in this function)
 	dmg = mobAddBonuses(pet,spell,target,dmg, 6);
 	--add on TP bonuses
-	local tp = pet:getTP();
+	local tp = skill:getTP();
 	if tp < 100 then
 		tp = 100;
 	end

--- a/scripts/globals/abilities/pets/thunder_iv.lua
+++ b/scripts/globals/abilities/pets/thunder_iv.lua
@@ -24,7 +24,7 @@ function onPetAbility(target, pet, skill)
 	--add on bonuses (staff/day/weather/jas/mab/etc all go in this function)
 	dmg = mobAddBonuses(pet,spell,target,dmg, 6);
 	--add on TP bonuses
-	local tp = pet:getTP();
+	local tp = skill:getTP();
 	if tp < 100 then
 		tp = 100;
 	end

--- a/scripts/globals/abilities/pets/thunderspark.lua
+++ b/scripts/globals/abilities/pets/thunderspark.lua
@@ -28,7 +28,7 @@ function onPetAbility(target, pet, skill)
 	damage.dmg = damage.dmg*resist;
 	--add on bonuses (staff/day/weather/jas/mab/etc all go in this function)
 	damage.dmg = mobAddBonuses(pet,spell,target,damage.dmg,1);
-	local tp = pet:getTP();
+	local tp = skill:getTP();
 	if tp < 100 then
 		tp = 100;
 	end

--- a/scripts/globals/abilities/pets/thunderstorm.lua
+++ b/scripts/globals/abilities/pets/thunderstorm.lua
@@ -16,7 +16,7 @@ end;
 function onPetAbility(target, pet, skill)
 
 	local dINT = math.floor(pet:getStat(MOD_INT) - target:getStat(MOD_INT));
-	local tp = pet:getTP();
+	local tp = skill:getTP();
 	local master = pet:getMaster();
 	local merits = 0;
 	if (master ~= nil and master:isPC()) then

--- a/scripts/globals/abilities/pets/water_ii.lua
+++ b/scripts/globals/abilities/pets/water_ii.lua
@@ -24,7 +24,7 @@ function onPetAbility(target, pet, skill)
 	--add on bonuses (staff/day/weather/jas/mab/etc all go in this function)
 	dmg = mobAddBonuses(pet,spell,target,dmg, 3);
 	--add on TP bonuses
-	local tp = pet:getTP();
+	local tp = skill:getTP();
 	if tp < 100 then
 		tp = 100;
 	end

--- a/scripts/globals/abilities/pets/water_iv.lua
+++ b/scripts/globals/abilities/pets/water_iv.lua
@@ -24,7 +24,7 @@ function onPetAbility(target, pet, skill)
 	--add on bonuses (staff/day/weather/jas/mab/etc all go in this function)
 	dmg = mobAddBonuses(pet,spell,target,dmg, 3);
 	--add on TP bonuses
-	local tp = pet:getTP();
+	local tp = skill:getTP();
 	if tp < 100 then
 		tp = 100;
 	end

--- a/scripts/globals/abilities/pets/wind_blade.lua
+++ b/scripts/globals/abilities/pets/wind_blade.lua
@@ -16,7 +16,7 @@ end;
 function onPetAbility(target, pet, skill)
 
 	local dINT = math.floor(pet:getStat(MOD_INT) - target:getStat(MOD_INT));
-	local tp = pet:getTP();
+	local tp = skill:getTP();
 	local master = pet:getMaster();
 	local merits = 0;
 	if (master ~= nil and master:isPC()) then

--- a/src/map/ai/ai_pet_dummy.cpp
+++ b/src/map/ai/ai_pet_dummy.cpp
@@ -322,9 +322,9 @@ void CAIPetDummy::preparePetAbility(CBattleEntity* PTarg){
         Action.param = m_PMobSkill->getMsgForAction();
         Action.messageID = 43; //readies message
         Action.knockback = 0;
-
-        m_PPet->health.tp = 0;
+ 
         m_skillTP = m_PPet->health.tp;
+        m_PPet->health.tp = 0;
 
         m_PPet->m_ActionList.push_back(Action);
         m_PPet->loc.zone->PushPacket(m_PPet, CHAR_INRANGE, new CActionPacket(m_PPet));


### PR DESCRIPTION
Prior to this change, the mobskill's TP value was assigned to the pet's TP value after this value had already been reduced to 0 (from preparing the skill). I first noticed this problem when tinkering around with avatar bloodpacts that use TP (like meteorite) and seeing that there was no effect with variance in TP.

In addition, many of the avatar bloodpacts had referenced pet:getTP(), but the pet's TP is reduced to 0 after preparing the skill, so I changed this to instead refer to skill:getTP(), which should now contain the correct TP value for the skills in question.
