### PR TITLE
Core: Conquest influence fix

### DIFF
--- a/src/map/conquest_system.cpp
+++ b/src/map/conquest_system.cpp
@@ -79,54 +79,25 @@ namespace conquest
 
         if (ret != SQL_ERROR && Sql_NextRow(SqlHandle) == SQL_SUCCESS)
         {
-            int san_inf = Sql_GetIntData(SqlHandle, 0);
-            int bas_inf = Sql_GetIntData(SqlHandle, 1);
-            int win_inf = Sql_GetIntData(SqlHandle, 2);
-            int bst_inf = Sql_GetIntData(SqlHandle, 3);
+            int influences[4] =
+            {
+                Sql_GetIntData(SqlHandle, 0),
+                Sql_GetIntData(SqlHandle, 1),
+                Sql_GetIntData(SqlHandle, 2),
+                Sql_GetIntData(SqlHandle, 3),
+            };
 
-            switch (PChar->profile.nation)
+            auto value = std::max<int>(5000 - influences[PChar->profile.nation], 0) / 3 + 1;
+            auto gain = 3 * value;
+            auto loss = -value;
+
+            for (auto i = 0; i < 4; ++i)
             {
-            case 0:
-            {
-                int total = dsp_max(5000 - san_inf, 0);
-                double bas_rat = (float)bas_inf / total;
-                double win_rat = (float)win_inf / total;
-                double bst_rat = (float)bst_inf / total;
-                san_inf += points;
-                bas_inf = dsp_max(total - points, 0) * bas_rat;
-                win_inf = dsp_max(total - points, 0) * win_rat;
-                bst_inf = dsp_max(total - points, 0) * bst_rat;
-                break;
+                influences[i] += i == PChar->profile.nation ? gain : loss;
             }
-            case 1:
-            {
-                int total = dsp_max(5000 - bas_inf, 0);
-                double san_rat = (float)san_inf / total;
-                double win_rat = (float)win_inf / total;
-                double bst_rat = (float)bst_inf / total;
-                bas_inf += points;
-                san_inf = dsp_max(total - points, 0) * san_rat;
-                win_inf = dsp_max(total - points, 0) * win_rat;
-                bst_inf = dsp_max(total - points, 0) * bst_rat;
-                break;
-            }
-            case 2:
-            {
-                int total = dsp_max(5000 - win_inf,0);
-                double san_rat = (float)san_inf / total;
-                double bas_rat = (float)bas_inf / total;
-                double bst_rat = (float)bst_inf / total;
-                win_inf += points;
-                san_inf = dsp_max(total - points, 0) * san_rat;
-                bas_inf = dsp_max(total - points, 0) * bas_rat;
-                bst_inf = dsp_max(total - points, 0) * bst_rat;
-                break;
-            }
-            default:
-                break;
-            }
+
             Sql_Query(SqlHandle, "UPDATE conquest_system SET sandoria_influence = %d, bastok_influence = %d, "
-                "windurst_influence = %d, beastmen_influence = %d WHERE region_id = %d;", san_inf, bas_inf, win_inf, bst_inf, region);
+                "windurst_influence = %d, beastmen_influence = %d WHERE region_id = %d;", influences[0], influences[1], influences[2], influences[3], region);
         }
     }
 

--- a/src/map/conquest_system.cpp
+++ b/src/map/conquest_system.cpp
@@ -61,7 +61,50 @@ namespace conquest
 		});
 	}
 
-	/************************************************************************
+    void UpdateInfluencePoints(int points, unsigned int nation, REGIONTYPE region)
+    {
+        if (region == REGIONTYPE::REGION_UNKNOWN)
+        {
+            return;
+        }
+
+        std::string Query = "SELECT sandoria_influence, bastok_influence, windurst_influence, beastmen_influence FROM conquest_system WHERE region_id = %d;";
+
+        int ret = Sql_Query(SqlHandle, Query.c_str(), region);
+
+        if (ret == SQL_ERROR || Sql_NextRow(SqlHandle) != SQL_SUCCESS)
+        {
+            return;
+        }
+
+        int influences[4] =
+        {
+            Sql_GetIntData(SqlHandle, 0),
+            Sql_GetIntData(SqlHandle, 1),
+            Sql_GetIntData(SqlHandle, 2),
+            Sql_GetIntData(SqlHandle, 3),
+        };
+
+        auto lost = 0;
+        for (auto i = 0; i < 4; ++i)
+        {
+            if (i == nation)
+            {
+                continue;
+            }
+
+            auto loss = std::min<int>(points * influences[i] / static_cast<float>(5000 - influences[nation]), influences[i]);
+            influences[i] -= loss;
+            lost += loss;
+        }
+
+        influences[nation] += lost;
+
+        Sql_Query(SqlHandle, "UPDATE conquest_system SET sandoria_influence = %d, bastok_influence = %d, "
+            "windurst_influence = %d, beastmen_influence = %d WHERE region_id = %d;", influences[0], influences[1], influences[2], influences[3], region);
+    }
+
+    /************************************************************************
     *    GainInfluencePoints                                                *
     *    +1 point for nation							                    *
     *						                                                *
@@ -69,114 +112,65 @@ namespace conquest
 
     void GainInfluencePoints(CCharEntity* PChar, uint32 points)
     {
-        REGIONTYPE region = PChar->loc.zone->GetRegionID();
-        if (region == REGIONTYPE::REGION_UNKNOWN)
-            return;
-
-        std::string Query = "SELECT sandoria_influence, bastok_influence, windurst_influence, beastmen_influence FROM conquest_system WHERE region_id = %d;";
-
-        int ret = Sql_Query(SqlHandle, Query.c_str(), region);
-
-        if (ret != SQL_ERROR && Sql_NextRow(SqlHandle) == SQL_SUCCESS)
-        {
-            int influences[4] =
-            {
-                Sql_GetIntData(SqlHandle, 0),
-                Sql_GetIntData(SqlHandle, 1),
-                Sql_GetIntData(SqlHandle, 2),
-                Sql_GetIntData(SqlHandle, 3),
-            };
-
-            auto value = std::max<int>(5000 - influences[PChar->profile.nation], 0) / 3 + 1;
-            auto gain = 3 * value;
-            auto loss = -value;
-
-            for (auto i = 0; i < 4; ++i)
-            {
-                influences[i] += i == PChar->profile.nation ? gain : loss;
-            }
-
-            Sql_Query(SqlHandle, "UPDATE conquest_system SET sandoria_influence = %d, bastok_influence = %d, "
-                "windurst_influence = %d, beastmen_influence = %d WHERE region_id = %d;", influences[0], influences[1], influences[2], influences[3], region);
-        }
+        conquest::UpdateInfluencePoints(points, PChar->profile.nation, PChar->loc.zone->GetRegionID());
     }
 
-	/************************************************************************
+    /************************************************************************
     *    LoseInfluencePoints                                                *
     *    -x point for nation							                    *
     *    +x point for beastmen                                              *
     ************************************************************************/
 
-	void LoseInfluencePoints(CCharEntity* PChar)
-	{
-		REGIONTYPE region = PChar->loc.zone->GetRegionID();
-		uint16 point = 0;
+    void LoseInfluencePoints(CCharEntity* PChar)
+    {
+        REGIONTYPE region = PChar->loc.zone->GetRegionID();
+        int points = 0;
 
-		switch (region)
-		{
-			case REGION_RONFAURE:
-			case REGION_GUSTABERG:
-			case REGION_SARUTABARUTA:
-			{
-				point = 10;
-                break;
-			}
-			case REGION_ZULKHEIM:
-			case REGION_KOLSHUSHU:
-			case REGION_NORVALLEN:
-			case REGION_DERFLAND:
-			case REGION_ARAGONEU:
-			{
-				point = 50;
-                break;
-			}
-			case REGION_QUFIMISLAND:
-			case REGION_LITELOR:
-			case REGION_KUZOTZ:
-			case REGION_ELSHIMOLOWLANDS:
-			{
-				point = 75;
-                break;
-			}
-			case REGION_VOLLBOW:
-			case REGION_VALDEAUNIA:
-			case REGION_FAUREGANDI:
-			case REGION_ELSHIMOUPLANDS:
-			{
-				point = 300;
-                break;
-			}
-			case REGION_TULIA:
-			case REGION_MOVALPOLOS:
-			case REGION_TAVNAZIA:
-			{
-				point = 600;
-                break;
-			}
-		}
-        std::string Query = "SELECT sandoria_influence, bastok_influence, windurst_influence, beastmen_influence FROM conquest_system WHERE region_id = %d;";
-
-        int ret = Sql_Query(SqlHandle, Query.c_str(), region);
-
-        if (ret != SQL_ERROR && Sql_NextRow(SqlHandle) == SQL_SUCCESS)
+        switch (region)
         {
-            int san_inf = Sql_GetIntData(SqlHandle, 0);
-            int bas_inf = Sql_GetIntData(SqlHandle, 1);
-            int win_inf = Sql_GetIntData(SqlHandle, 2);
-            int bst_inf = Sql_GetIntData(SqlHandle, 3);
-            int total = dsp_max(5000 - bst_inf, 0);
-            double san_rat = (float)san_inf / total;
-            double bas_rat = (float)bas_inf / total;
-            double win_rat = (float)win_inf / total;
-            bst_inf += point;
-            san_inf = dsp_max(total - point, 0) * san_rat;
-            bas_inf = dsp_max(total - point, 0) * bas_rat;
-            win_inf = dsp_max(total - point, 0) * win_rat;
-
-            Sql_Query(SqlHandle, "UPDATE conquest_system SET sandoria_influence = %d, bastok_influence = %d, "
-                "windurst_influence = %d, beastmen_influence = %d WHERE region_id = %d;", san_inf, bas_inf, win_inf, bst_inf, region);
+            case REGION_RONFAURE:
+            case REGION_GUSTABERG:
+            case REGION_SARUTABARUTA:
+            {
+                points = 10;
+                break;
+            }
+            case REGION_ZULKHEIM:
+            case REGION_KOLSHUSHU:
+            case REGION_NORVALLEN:
+            case REGION_DERFLAND:
+            case REGION_ARAGONEU:
+            {
+                points = 50;
+                break;
+            }
+            case REGION_QUFIMISLAND:
+            case REGION_LITELOR:
+            case REGION_KUZOTZ:
+            case REGION_ELSHIMOLOWLANDS:
+            {
+                points = 75;
+                break;
+            }
+            case REGION_VOLLBOW:
+            case REGION_VALDEAUNIA:
+            case REGION_FAUREGANDI:
+            case REGION_ELSHIMOUPLANDS:
+            {
+                points = 300;
+                break;
+            }
+            case REGION_TULIA:
+            case REGION_MOVALPOLOS:
+            case REGION_TAVNAZIA:
+            {
+                points = 600;
+                break;
+            }
         }
-	}
+
+        conquest::UpdateInfluencePoints(points, BEASTMEN, region);
+    }
 
 	/************************************************************************
     *                                                                       *

--- a/src/map/conquest_system.h
+++ b/src/map/conquest_system.h
@@ -53,6 +53,7 @@ namespace conquest
 {
 	void	UpdateConquestSystem();										// Update conquest information in the DB
 
+    void    UpdateInfluencePoints(int points, unsigned int nation, unsigned int region);
 	void	GainInfluencePoints(CCharEntity* PChar, uint32 points);		// Gain influence for player's nation (+1)
 	void	LoseInfluencePoints(CCharEntity* PChar);					// Lose influence for player's nation and gain for beastmen influence
 	


### PR DESCRIPTION
The current code for calculating influence has a few issues, mostly relating to integer underflow. It is also a bit redundant between nations and can be shortened. This pull request aims to address both these concerns.

The influence calculation itself presents a bit of a challenge, since it involves integer calculations with a limited pool of available resource, e.g. influence points.

#### Problems

##### Underflow and negative numbers

The current method uses unsigned integers, which underflowed as soon as the values went negative, resulting in absurdly high numbers in the database. The problem here is the values going negative in the first place.

This problem can be avoided by bounding the result of the calculation to a certain maximum. However, it is more elegantly solved by a proportional distribution, since that would guarantee no underflow by default. If a nation only had 12 points, and you based your calculations of the point loss on its ratio of the total available pool, it would never concede more than its maximum by design.

##### Proportional distribution

A nation with a large amount of influence should lose a larger chunk than a nation with a low amount of influence, when a third nation gains something.

Such a system is currently already in-place, but it calculates the ratio wrong, which results in more subtractions than the nation's pool of influence may allow. The points gained by one nation should be multiplied by the every other nation's ratio before they are subtracted.

##### Equality invariant

The number of total points should always add up to 5000. This is also not trivial to achieve, since just rounding or truncating numbers can lose information required to keep the invariant intact.

To guarantee this, two things need to be taken into account. First, the algorithm needs to guarantee that the amount gained by one nation never exceeds the sum of the amount lost by all other nations. Secondly, no points may be lost due to integer conversions.

#### Solution

The following algorithm addresses all three issues:
```c++
        int influences[4] =
        {
            Sql_GetIntData(SqlHandle, 0),
            Sql_GetIntData(SqlHandle, 1),
            Sql_GetIntData(SqlHandle, 2),
            Sql_GetIntData(SqlHandle, 3),
        };

        auto lost = 0;
        for (auto i = 0; i < 4; ++i)
        {
            if (i == nation)
            {
                continue;
            }

            auto loss = std::min<int>(points * influences[i] / static_cast<float>(5000 - influences[nation]), influences[i]);
            influences[i] -= loss;
            lost += loss;
        }

        influences[nation] += lost;
```

As mentioned above, it can never go negative for a nation, because of the proportional distribution. There is still a check in place, which is needed in case one nation gains more than 5000 points, which also can't be allowed.

The proportional distribution is guaranteed by the division by the available points between the three remaining nations. That way it always gets scaled to the maximum number of available points for each nation.

The reason it can guarantee the equality invariant is because the number added is not the number originally provided, but the number that was actually subtracted from the previous nations. In certain cases this may differ from the original number, such as when points are lost due to integral conversions. But this will, at most, differ by 3 points from the provided value.

A slightly more reliable number might be generated if the number was not truncated, but rounded. However, I did not consider this a big issue, so I did not implement it here. It can easily be added, if that is wanted.