### PR TITLE
SCRIPT: Blue Magic enfeeb fixes

### DIFF
--- a/scripts/globals/magic.lua
+++ b/scripts/globals/magic.lua
@@ -579,7 +579,7 @@ function applyResistanceEffect(player,spell,target,diff,skill,bonus,effect)
 			effectres = MOD_POISONRES;
 		elseif(effect == EFFECT_PARALYZE) then
 			effectres = MOD_PARALYZERES;
-		elseif(effect == EFFECT_BLIND) then
+		elseif(effect == EFFECT_BLINDNESS) then
 			effectres = MOD_BLINDRES
 		elseif(effect == EFFECT_SILENCE) then
 			effectres = MOD_SILENCERES;

--- a/scripts/globals/spells/bluemagic/filamented_hold.lua
+++ b/scripts/globals/spells/bluemagic/filamented_hold.lua
@@ -32,7 +32,7 @@ end;
 function onSpellCast(caster,target,spell)
 
     local dINT = caster:getStat(MOD_MND) - target:getStat(MOD_MND);
-    local resist = applyResistance(caster,spell,target,dINT,37);
+    local resist = applyResistanceEffect(caster,spell,target,dINT,BLUE_SKILL, 0, EFFECT_SLOW);
     
     if(resist > (0.0652)) then
         -- resisted!

--- a/scripts/globals/spells/bluemagic/frightful_roar.lua
+++ b/scripts/globals/spells/bluemagic/frightful_roar.lua
@@ -33,7 +33,7 @@ function onSpellCast(caster,target,spell)
 
     local duration = 60;
     local dINT = caster:getStat(MOD_MND) - target:getStat(MOD_MND);
-    local resist = applyResistance(caster,spell,target,dINT,37);
+    local resist = applyResistance(caster,spell,target,dINT,BLUE_SKILL);
     
     if(resist > (0.0652)) then
         -- resisted!

--- a/scripts/globals/spells/bluemagic/infrasonics.lua
+++ b/scripts/globals/spells/bluemagic/infrasonics.lua
@@ -33,7 +33,7 @@ function onSpellCast(caster,target,spell)
 
     local duration = 60;
     local dINT = caster:getStat(MOD_MND) - target:getStat(MOD_MND);
-    local resist = applyResistance(caster,spell,target,dINT,37);
+    local resist = applyResistance(caster,spell,target,dINT,BLUE_SKILL);
     
     if(resist > 0.0625) then
         -- resisted!

--- a/scripts/globals/spells/bluemagic/lowing.lua
+++ b/scripts/globals/spells/bluemagic/lowing.lua
@@ -33,7 +33,7 @@ function onSpellCast(caster,target,spell)
 
     local duration = 60;    
     local dINT = caster:getStat(MOD_MND) - target:getStat(MOD_MND);
-    local resist = applyResistance(caster,spell,target,dINT,37);
+    local resist = applyResistance(caster,spell,target,dINT,BLUE_SKILL);
     
     if(resist > 0.0625) then
     -- resisted!

--- a/scripts/globals/spells/bluemagic/sandspray.lua
+++ b/scripts/globals/spells/bluemagic/sandspray.lua
@@ -33,7 +33,7 @@ function onSpellCast(caster,target,spell)
 
     local duration = 60;
     local dINT = caster:getStat(MOD_MND) - target:getStat(MOD_MND);
-    local resist = applyResistance(caster,spell,target,dINT,37);
+    local resist = applyResistanceEffect(caster,spell,target,dINT,BLUE_SKILL,0,EFFECT_BLINDNESS);
     
     if(resist > 0.0625) then
         -- resisted!

--- a/scripts/globals/spells/bluemagic/sound_blast.lua
+++ b/scripts/globals/spells/bluemagic/sound_blast.lua
@@ -33,7 +33,7 @@ function onSpellCast(caster,target,spell)
 
     local duration = 30;
     local dINT = caster:getStat(MOD_MND) - target:getStat(MOD_MND);
-    local resist = applyResistance(caster,spell,target,dINT,37);
+    local resist = applyResistance(caster,spell,target,dINT,BLUE_SKILL);
     
     if(resist > (0.0652)) then
         -- resisted!

--- a/scripts/globals/spells/bluemagic/stinking_gas.lua
+++ b/scripts/globals/spells/bluemagic/stinking_gas.lua
@@ -33,7 +33,7 @@ function onSpellCast(caster,target,spell)
 
     local duration = 60;
     local dINT = caster:getStat(MOD_MND) - target:getStat(MOD_MND);
-    local resist = applyResistance(caster,spell,target,dINT,37);
+    local resist = applyResistance(caster,spell,target,dINT,BLUE_SKILL);
     
     if(resist > 0.0625) then
         -- resisted!

--- a/scripts/globals/spells/bluemagic/temporal_shift.lua
+++ b/scripts/globals/spells/bluemagic/temporal_shift.lua
@@ -33,7 +33,7 @@ function onSpellCast(caster,target,spell)
 
     local duration = 5;
     local dINT = caster:getStat(MOD_INT) - target:getStat(MOD_INT);
-    local resist = applyResistance(caster,spell,target,dINT,37);
+    local resist = applyResistanceEffect(caster,spell,target,dINT,BLUE_SKILL,0,EFFECT_STUN);
     
     if(resist <= (1/16)) then
         -- resisted!


### PR DESCRIPTION
A few blue magic enfeebling spells were using Dark Magic skill instead of Blue skill.