### PR TITLE
Scripts: fix some (not all) of the retail accuracy issues in the add effect weapon scripts.

### DIFF
--- a/scripts/globals/items/adder_jambiya.lua
+++ b/scripts/globals/items/adder_jambiya.lua
@@ -17,10 +17,8 @@ function onAdditionalEffect(player,target,damage)
     if (math.random(0,99) >= chance or applyResistanceAddEffect(player,target,ELE_ICE,0) <= 0.5) then
         return 0,0,0;
     else
-        target:delStatusEffect(EFFECT_EVASION_DOWN)
-        if (not target:hasStatusEffect(EFFECT_EVASION_DOWN)) then
-            target:addStatusEffect(EFFECT_EVASION_DOWN, 10, 0, 60);
-        end
-        return SUBEFFECT_DEFENSE_DOWN, 160, EFFECT_EVASION_DOWN; -- I believe this is the correct subeffect animation.
+        target:delStatusEffect(EFFECT_EVASION_BOOST);
+        target:addStatusEffect(EFFECT_EVASION_DOWN, 10, 0, 60);
+        return SUBEFFECT_EVASION_DOWN, 160, EFFECT_EVASION_DOWN;
     end
 end;

--- a/scripts/globals/items/adder_jambiya_+1.lua
+++ b/scripts/globals/items/adder_jambiya_+1.lua
@@ -13,13 +13,12 @@ require("scripts/globals/magic");
 
 function onAdditionalEffect(player,target,damage)
     local chance = 15;
+
     if (math.random(0,99) >= chance or applyResistanceAddEffect(player,target,ELE_ICE,0) <= 0.5) then
         return 0,0,0;
     else
-        target:delStatusEffect(EFFECT_EVASION_DOWN)
-        if (not target:hasStatusEffect(EFFECT_EVASION_DOWN)) then
-            target:addStatusEffect(EFFECT_EVASION_DOWN, 13, 0, 60);
-        end
-        return SUBEFFECT_DEFENSE_DOWN, 160, EFFECT_EVASION_DOWN; -- I believe this is the correct subeffect animation.
+        target:delStatusEffect(EFFECT_DEFENSE_BOOST);
+        target:addStatusEffect(EFFECT_DEFENSE_DOWN, 12, 0, 60);
+        return SUBEFFECT_DEFENSE_DOWN, 160, EFFECT_DEFENSE_DOWN;
     end
 end;

--- a/scripts/globals/items/amanomurakumo.lua
+++ b/scripts/globals/items/amanomurakumo.lua
@@ -3,6 +3,7 @@
 -- Item: Amanomurakumo
 -- Additional Effect: 10% Attack Down
 -----------------------------------------
+
 require("scripts/globals/status");
 require("scripts/globals/magic");
 
@@ -18,10 +19,8 @@ function onAdditionalEffect(player,target,damage)
     if (math.random(0,99) >= chance or applyResistanceAddEffect(player,target,ELE_WATER,0) <= 0.5) then
         return 0,0,0;
     else
-        target:delStatusEffect(EFFECT_ATTACK_DOWN)
-        if (not target:hasStatusEffect(EFFECT_ATTACK_DOWN)) then
-            target:addStatusEffect(EFFECT_ATTACK_DOWN, 10, 0, 60);
-        end
-        return SUBEFFECT_DEFENSE_DOWN, 160, EFFECT_ATTACK_DOWN;
+        target:delStatusEffect(EFFECT_ATTACK_BOOST);
+        target:addStatusEffect(EFFECT_ATTACK_DOWN, 10, 0, 60); -- Power needs verification/correction
+        return SUBEFFECT_ATTACK_DOWN, 160, EFFECT_ATTACK_DOWN;
     end
 end;

--- a/scripts/globals/items/apocalypse.lua
+++ b/scripts/globals/items/apocalypse.lua
@@ -11,19 +11,16 @@ require("scripts/globals/magic");
 -----------------------------------
 function onAdditionalEffect(player,target,damage)
     local chance = 10;
-    if (target:getMainLvl() > player:getMainLvl()) then
-        chance = chance - 5 * (target:getMainLvl() - player:getMainLvl())
-        chance = utils.clamp(chance, 5, 95);
-    end
-    if(target:hasImmunity(64)) then
-        spell:setMsg(75);
-    elseif (math.random(0,99) >= chance or applyResistanceAddEffect(player,target,ELE_DARK,0) <= 0.5) then
+
+    -- if (target:hasImmunity(64)) then
+        -- spell:setMsg(75);
+    -- This does nothing, as this is not a spell, and it doesn't get used in the return. 
+    -- That should be handled in the resist check in the global anyways.
+
+    if (math.random(0,99) >= chance or applyResistanceAddEffect(player,target,ELE_DARK,0) <= 0.5) then
         return 0,0,0;
     else
-        target:delStatusEffect(EFFECT_BLINDNESS)
-        if (not target:hasStatusEffect(EFFECT_BLINDNESS)) then
-            target:addStatusEffect(EFFECT_BLINDNESS, 15, 0, 30);
-        end
+        target:addStatusEffect(EFFECT_BLINDNESS, 15, 0, 30);
         return SUBEFFECT_BLIND, 160, EFFECT_BLINDNESS;
     end
 end;

--- a/scripts/globals/items/bayards_sword.lua
+++ b/scripts/globals/items/bayards_sword.lua
@@ -17,10 +17,8 @@ function onAdditionalEffect(player,target,damage)
     if (math.random(0,99) >= chance or applyResistanceAddEffect(player,target,ELE_ICE,0) <= 0.5) then
         return 0,0,0;
     else
-        target:delStatusEffect(EFFECT_EVASION_DOWN)
-        if (not target:hasStatusEffect(EFFECT_EVASION_DOWN)) then
-            target:addStatusEffect(EFFECT_EVASION_DOWN, 10, 0, 60);
-        end
-        return SUBEFFECT_DEFENSE_DOWN, 160, EFFECT_EVASION_DOWN; -- I believe this is the correct subeffect animation.
+        target:delStatusEffect(EFFECT_EVASION_BOOST);
+        target:addStatusEffect(EFFECT_EVASION_DOWN, 10, 0, 60);
+        return SUBEFFECT_EVASION_DOWN, 160, EFFECT_EVASION_DOWN;
     end
 end;

--- a/scripts/globals/items/blind_dagger.lua
+++ b/scripts/globals/items/blind_dagger.lua
@@ -17,10 +17,7 @@ function onAdditionalEffect(player,target,damage)
     if (math.random(0,99) >= chance or applyResistanceAddEffect(player,target,ELE_DARK,0) <= 0.5) then
         return 0,0,0;
     else
-        target:delStatusEffect(EFFECT_BLINDNESS);
-        if (not target:hasStatusEffect(EFFECT_BLINDNESS)) then
-            target:addStatusEffect(EFFECT_BLINDNESS, 10, 0, 30);
-        end
+        target:addStatusEffect(EFFECT_BLINDNESS, 10, 0, 30);
         return SUBEFFECT_BLIND, 160, EFFECT_BLINDNESS;
     end
 end;

--- a/scripts/globals/items/blind_dagger_+1.lua
+++ b/scripts/globals/items/blind_dagger_+1.lua
@@ -17,10 +17,7 @@ function onAdditionalEffect(player,target,damage)
     if (math.random(0,99) >= chance or applyResistanceAddEffect(player,target,ELE_DARK,0) <= 0.5) then
         return 0,0,0;
     else
-        target:delStatusEffect(EFFECT_BLINDNESS);
-        if (not target:hasStatusEffect(EFFECT_BLINDNESS)) then
-            target:addStatusEffect(EFFECT_BLINDNESS, 10, 0, 30);
-        end
+        target:addStatusEffect(EFFECT_BLINDNESS, 10, 0, 30);
         return SUBEFFECT_BLIND, 160, EFFECT_BLINDNESS;
     end
 end;

--- a/scripts/globals/items/blind_knife.lua
+++ b/scripts/globals/items/blind_knife.lua
@@ -17,10 +17,7 @@ function onAdditionalEffect(player,target,damage)
     if (math.random(0,99) >= chance or applyResistanceAddEffect(player,target,ELE_DARK,0) <= 0.5) then
         return 0,0,0;
     else
-        target:delStatusEffect(EFFECT_BLINDNESS);
-        if (not target:hasStatusEffect(EFFECT_BLINDNESS)) then
-            target:addStatusEffect(EFFECT_BLINDNESS, 10, 0, 30);
-        end
+        target:addStatusEffect(EFFECT_BLINDNESS, 10, 0, 30);
         return SUBEFFECT_BLIND, 160, EFFECT_BLINDNESS;
     end
 end;

--- a/scripts/globals/items/blind_knife_+1.lua
+++ b/scripts/globals/items/blind_knife_+1.lua
@@ -17,10 +17,7 @@ function onAdditionalEffect(player,target,damage)
     if (math.random(0,99) >= chance or applyResistanceAddEffect(player,target,ELE_DARK,0) <= 0.5) then
         return 0,0,0;
     else
-        target:delStatusEffect(EFFECT_BLINDNESS);
-        if (not target:hasStatusEffect(EFFECT_BLINDNESS)) then
-            target:addStatusEffect(EFFECT_BLINDNESS, 10, 0, 30);
-        end
+        target:addStatusEffect(EFFECT_BLINDNESS, 10, 0, 30);
         return SUBEFFECT_BLIND, 160, EFFECT_BLINDNESS;
     end
 end;

--- a/scripts/globals/items/bravura.lua
+++ b/scripts/globals/items/bravura.lua
@@ -17,10 +17,8 @@ function onAdditionalEffect(player,target,damage)
     if (math.random(0,99) >= chance or applyResistanceAddEffect(player,target,ELE_ICE,0) <= 0.5) then
         return 0,0,0;
     else
-        target:delStatusEffect(EFFECT_EVASION_DOWN)
-        if (not target:hasStatusEffect(EFFECT_EVASION_DOWN)) then
-            target:addStatusEffect(EFFECT_EVASION_DOWN, 15, 0, 60);
-        end
-        return SUBEFFECT_DEFENSE_DOWN, 160, EFFECT_EVASION_DOWN; -- I believe this is the correct subeffect animation.
+        target:delStatusEffect(EFFECT_EVASION_BOOST)
+        target:addStatusEffect(EFFECT_EVASION_DOWN, 15, 0, 60);
+        return SUBEFFECT_EVASION_DOWN, 160, EFFECT_EVASION_DOWN;
     end
 end;

--- a/scripts/globals/items/busuto.lua
+++ b/scripts/globals/items/busuto.lua
@@ -17,10 +17,7 @@ function onAdditionalEffect(player,target,damage)
     if (math.random(0,99) >= chance or applyResistanceAddEffect(player,target,ELE_WATER,0) <= 0.5) then
         return 0,0,0;
     else
-        target:delStatusEffect(EFFECT_POISON);
-        if (not target:hasStatusEffect(EFFECT_POISON)) then
-            target:addStatusEffect(EFFECT_POISON, 4, 3, 30);
-        end
+        target:addStatusEffect(EFFECT_POISON, 4, 3, 30);
         return SUBEFFECT_POISON, 160, EFFECT_POISON;
     end
 end;

--- a/scripts/globals/items/busuto_+1.lua
+++ b/scripts/globals/items/busuto_+1.lua
@@ -17,10 +17,7 @@ function onAdditionalEffect(player,target,damage)
     if (math.random(0,99) >= chance or applyResistanceAddEffect(player,target,ELE_WATER,0) <= 0.5) then
         return 0,0,0;
     else
-        target:delStatusEffect(EFFECT_POISON);
-        if (not target:hasStatusEffect(EFFECT_POISON)) then
-            target:addStatusEffect(EFFECT_POISON, 4, 3, 30);
-        end
+        target:addStatusEffect(EFFECT_POISON, 4, 3, 30);
         return SUBEFFECT_POISON, 160, EFFECT_POISON;
     end
 end;

--- a/scripts/globals/items/cruel_scythe.lua
+++ b/scripts/globals/items/cruel_scythe.lua
@@ -18,9 +18,7 @@ function onAdditionalEffect(player,target,damage)
         return 0,0,0;
     else
         target:delStatusEffect(EFFECT_EVASION_DOWN)
-        if (not target:hasStatusEffect(EFFECT_EVASION_DOWN)) then
-            target:addStatusEffect(EFFECT_EVASION_DOWN, 12, 0, 60);
-        end
-        return SUBEFFECT_DEFENSE_DOWN, 160, EFFECT_EVASION_DOWN; -- I believe this is the correct subeffect animation.
+        target:addStatusEffect(EFFECT_EVASION_DOWN, 12, 0, 60); -- Retail is actually 12.5% but DSP doesn't have the decimal place
+        return SUBEFFECT_EVASION_DOWN, 160, EFFECT_EVASION_DOWN;
     end
 end;

--- a/scripts/globals/items/cruel_spear.lua
+++ b/scripts/globals/items/cruel_spear.lua
@@ -17,10 +17,8 @@ function onAdditionalEffect(player,target,damage)
     if (math.random(0,99) >= chance or applyResistanceAddEffect(player,target,ELE_ICE,0) <= 0.5) then
         return 0,0,0;
     else
-        target:delStatusEffect(EFFECT_EVASION_DOWN)
-        if (not target:hasStatusEffect(EFFECT_EVASION_DOWN)) then
-            target:addStatusEffect(EFFECT_EVASION_DOWN, 12, 0, 60);
-        end
-        return SUBEFFECT_DEFENSE_DOWN, 160, EFFECT_EVASION_DOWN; -- I believe this is the correct subeffect animation.
+        target:delStatusEffect(EFFECT_EVASION_BOOST);
+        target:addStatusEffect(EFFECT_EVASION_DOWN, 12, 0, 60);
+        return SUBEFFECT_EVASION_DOWN, 160, EFFECT_EVASION_DOWN;
     end
 end;

--- a/scripts/globals/items/custodes.lua
+++ b/scripts/globals/items/custodes.lua
@@ -27,10 +27,7 @@ function onAdditionalEffect(player,target,damage)
     if (math.random(0,99) >= chance or applyResistanceAddEffect(player,target,ELE_ICE,0) <= 0.5) then
         return 0,0,0;
     else
-        target:delStatusEffect(EFFECT_PARALYSIS)
-        if (not target:hasStatusEffect(EFFECT_PARALYSIS)) then
-            target:addStatusEffect(EFFECT_PARALYSIS, 1, 0, 60);
-        end
+        target:addStatusEffect(EFFECT_PARALYSIS, 5, 0, 30);
         return SUBEFFECT_PARALYSIS, 160, EFFECT_PARALYSIS;
     end
 end;

--- a/scripts/globals/items/dark_mezraq.lua
+++ b/scripts/globals/items/dark_mezraq.lua
@@ -17,10 +17,8 @@ function onAdditionalEffect(player,target,damage)
     if (math.random(0,99) >= chance or applyResistanceAddEffect(player,target,ELE_ICE,0) <= 0.5) then
         return 0,0,0;
     else
-        target:delStatusEffect(EFFECT_EVASION_DOWN)
-        if (not target:hasStatusEffect(EFFECT_EVASION_DOWN)) then
-            target:addStatusEffect(EFFECT_EVASION_DOWN, 10, 0, 60);
-        end
-        return SUBEFFECT_DEFENSE_DOWN, 160, EFFECT_EVASION_DOWN; -- I believe this is the correct subeffect animation.
+        target:delStatusEffect(EFFECT_EVASION_BOOST);
+        target:addStatusEffect(EFFECT_EVASION_DOWN, 25, 0, 30);
+        return SUBEFFECT_EVASION_DOWN, 160, EFFECT_EVASION_DOWN;
     end
 end;

--- a/scripts/globals/items/dark_mezraq_+1.lua
+++ b/scripts/globals/items/dark_mezraq_+1.lua
@@ -17,10 +17,8 @@ function onAdditionalEffect(player,target,damage)
     if (math.random(0,99) >= chance or applyResistanceAddEffect(player,target,ELE_ICE,0) <= 0.5) then
         return 0,0,0;
     else
-        target:delStatusEffect(EFFECT_EVASION_DOWN)
-        if (not target:hasStatusEffect(EFFECT_EVASION_DOWN)) then
-            target:addStatusEffect(EFFECT_EVASION_DOWN, 12, 0, 60);
-        end
-        return SUBEFFECT_DEFENSE_DOWN, 160, EFFECT_EVASION_DOWN; -- I believe this is the correct subeffect animation.
+        target:delStatusEffect(EFFECT_EVASION_BOOST);
+        target:addStatusEffect(EFFECT_EVASION_DOWN, 25, 0, 30);
+        return SUBEFFECT_EVASION_DOWN, 160, EFFECT_EVASION_DOWN;
     end
 end;

--- a/scripts/globals/items/dotanuki.lua
+++ b/scripts/globals/items/dotanuki.lua
@@ -17,10 +17,8 @@ function onAdditionalEffect(player,target,damage)
     if (math.random(0,99) >= chance or applyResistanceAddEffect(player,target,ELE_ICE,0) <= 0.5) then
         return 0,0,0;
     else
-        target:delStatusEffect(EFFECT_EVASION_DOWN)
-        if (not target:hasStatusEffect(EFFECT_EVASION_DOWN)) then
-            target:addStatusEffect(EFFECT_EVASION_DOWN, 10, 0, 60);
-        end
-        return SUBEFFECT_DEFENSE_DOWN, 160, EFFECT_EVASION_DOWN; -- I believe this is the correct subeffect animation.
+        target:delStatusEffect(EFFECT_EVASION_BOOST);
+        target:addStatusEffect(EFFECT_EVASION_DOWN, 10, 0, 30);
+        return SUBEFFECT_EVASION_DOWN, 160, EFFECT_EVASION_DOWN;
     end
 end;

--- a/scripts/globals/items/federation_signet_staff.lua
+++ b/scripts/globals/items/federation_signet_staff.lua
@@ -20,5 +20,5 @@ end;
 
 function onItemUse(target)
     target:delStatusEffect(EFFECT_SIGNET);
-    target:addStatusEffect(EFFECT_SIGNET,0,0,3600);
+    target:addStatusEffect(EFFECT_SIGNET,0,0,18000);
 end;

--- a/scripts/globals/items/garudas_dagger.lua
+++ b/scripts/globals/items/garudas_dagger.lua
@@ -28,10 +28,7 @@ function onAdditionalEffect(player,target,damage)
     if (math.random(0,99) >= chance or applyResistanceAddEffect(player,target,ELE_WIND,0) <= 0.5) then
         return 0,0,0;
     else
-        target:delStatusEffect(EFFECT_SILENCE);
-        if (not target:hasStatusEffect(EFFECT_SILENCE)) then
-            target:addStatusEffect(EFFECT_SILENCE, 1, 0, 60);
-        end
+        target:addStatusEffect(EFFECT_SILENCE, 10, 0, 30);
         return SUBEFFECT_SILENCE, 160, EFFECT_SILENCE;
     end
 end;

--- a/scripts/globals/items/gungnir.lua
+++ b/scripts/globals/items/gungnir.lua
@@ -11,17 +11,12 @@ require("scripts/globals/magic");
 -----------------------------------
 function onAdditionalEffect(player,target,damage)
     local chance = 10;
-    if (target:getMainLvl() > player:getMainLvl()) then
-        chance = chance - 5 * (target:getMainLvl() - player:getMainLvl())
-        chance = utils.clamp(chance, 5, 95);
-    end
+
     if (math.random(0,99) >= chance or applyResistanceAddEffect(player,target,ELE_WIND,0) <= 0.5) then
         return 0,0,0;
     else
         target:delStatusEffect(EFFECT_DEFENSE_BOOST)
-        if (not target:hasStatusEffect(EFFECT_DEFENSE_DOWN)) then
-            target:addStatusEffect(EFFECT_DEFENSE_DOWN, 17, 0, 60);
-        end
+        target:addStatusEffect(EFFECT_DEFENSE_DOWN, 17, 0, 60); -- Power and duration needs verification
         return SUBEFFECT_DEFENSE_DOWN, 160, EFFECT_DEFENSE_DOWN;
     end
 end;

--- a/scripts/globals/items/guttler.lua
+++ b/scripts/globals/items/guttler.lua
@@ -11,17 +11,11 @@ require("scripts/globals/magic");
 -----------------------------------
 function onAdditionalEffect(player,target,damage)
     local chance = 10;
-    if (target:getMainLvl() > player:getMainLvl()) then
-        chance = chance - 5 * (target:getMainLvl() - player:getMainLvl())
-        chance = utils.clamp(chance, 5, 95);
-    end
+
     if (math.random(0,99) >= chance or applyResistanceAddEffect(player,target,ELE_ICE,0) <= 0.5) then
         return 0,0,0;
     else
-        target:delStatusEffect(EFFECT_CHOKE)
-        if (not target:hasStatusEffect(EFFECT_CHOKE)) then
-            target:addStatusEffect(EFFECT_CHOKE, 17, 0, 60);
-        end
+        target:addStatusEffect(EFFECT_CHOKE, 17, 0, 60);
         return SUBEFFECT_CHOKE, 160, EFFECT_CHOKE;
     end
 end;

--- a/scripts/globals/items/hermes_quencher.lua
+++ b/scripts/globals/items/hermes_quencher.lua
@@ -13,11 +13,11 @@ require("scripts/globals/settings");
 function onItemCheck(target)
     local result = 0;
 
-if (target:hasStatusEffect(EFFECT_MEDICINE) == true) then
-    result = 111;
-end
+    if (target:hasStatusEffect(EFFECT_MEDICINE) == true) then
+        result = 111;
+    end
 
-return result;
+    return result;
 end;
 
 

--- a/scripts/globals/items/hi-reraiser.lua
+++ b/scripts/globals/items/hi-reraiser.lua
@@ -11,7 +11,7 @@ require("scripts/globals/status");
 -----------------------------------------
 
 function onItemCheck(target)
-	return 0;
+    return 0;
 end;
 
 -----------------------------------------
@@ -19,7 +19,7 @@ end;
 -----------------------------------------
 
 function onItemUse(target)
-	local duration = 5400;
-		target:delStatusEffect(EFFECT_RERAISE);
-		target:addStatusEffect(EFFECT_RERAISE,2,0,duration);
+    local duration = 5400;
+    target:delStatusEffect(EFFECT_RERAISE);
+    target:addStatusEffect(EFFECT_RERAISE,2,0,duration);
 end;

--- a/scripts/globals/items/hushed_baghnakhs.lua
+++ b/scripts/globals/items/hushed_baghnakhs.lua
@@ -18,10 +18,7 @@ function onAdditionalEffect(player,target,damage)
     if (math.random(0,99) >= chance or applyResistanceAddEffect(player,target,ELE_WIND,0) <= 0.5) then
         return 0,0,0;
     else
-        target:delStatusEffect(EFFECT_SILENCE);
-        if (not target:hasStatusEffect(EFFECT_SILENCE)) then
-            target:addStatusEffect(EFFECT_SILENCE, 1, 0, 60);
-        end
+        target:addStatusEffect(EFFECT_SILENCE, 5, 0, 30);
         return SUBEFFECT_SILENCE, 160, EFFECT_SILENCE;
     end
 end;

--- a/scripts/globals/items/hushed_dagger.lua
+++ b/scripts/globals/items/hushed_dagger.lua
@@ -18,10 +18,7 @@ function onAdditionalEffect(player,target,damage)
     if (math.random(0,99) >= chance or applyResistanceAddEffect(player,target,ELE_WIND,0) <= 0.5) then
         return 0,0,0;
     else
-        target:delStatusEffect(EFFECT_SILENCE);
-        if (not target:hasStatusEffect(EFFECT_SILENCE)) then
-            target:addStatusEffect(EFFECT_SILENCE, 1, 0, 60);
-        end
+        target:addStatusEffect(EFFECT_SILENCE, 5, 0, 30);
         return SUBEFFECT_SILENCE, 160, EFFECT_SILENCE;
     end
 end;

--- a/scripts/globals/items/kikoku.lua
+++ b/scripts/globals/items/kikoku.lua
@@ -3,6 +3,7 @@
 -- Item: Kikoku
 -- Additional Effect: Paralysis
 -----------------------------------------
+
 require("scripts/globals/status");
 require("scripts/globals/magic");
 
@@ -11,17 +12,11 @@ require("scripts/globals/magic");
 -----------------------------------
 function onAdditionalEffect(player,target,damage)
     local chance = 10;
-    if (target:getMainLvl() > player:getMainLvl()) then
-        chance = chance - 5 * (target:getMainLvl() - player:getMainLvl())
-        chance = utils.clamp(chance, 5, 95);
-    end
+
     if (math.random(0,99) >= chance or applyResistanceAddEffect(player,target,ELE_ICE,0) <= 0.5) then
         return 0,0,0;
     else
-        target:delStatusEffect(EFFECT_PARALYSIS)
-        if (not target:hasStatusEffect(EFFECT_PARALYSIS)) then
-            target:addStatusEffect(EFFECT_PARALYSIS, 15, 0, 30);
-        end
+        target:addStatusEffect(EFFECT_PARALYSIS, 17, 0, 30); -- Power needs verification/adjustment.
         return SUBEFFECT_PARALYSIS, 160, EFFECT_PARALYSIS;
     end
 end;

--- a/scripts/globals/items/kingdom_signet_staff.lua
+++ b/scripts/globals/items/kingdom_signet_staff.lua
@@ -20,5 +20,5 @@ end;
 
 function onItemUse(target)
     target:delStatusEffect(EFFECT_SIGNET);
-    target:addStatusEffect(EFFECT_SIGNET,0,0,3600);
+    target:addStatusEffect(EFFECT_SIGNET,0,0,18000);
 end;

--- a/scripts/globals/items/mandau.lua
+++ b/scripts/globals/items/mandau.lua
@@ -13,13 +13,11 @@ require("scripts/globals/magic");
 
 function onAdditionalEffect(player,target,damage)
     local chance = 10;
+
     if (math.random(0,99) >= chance or applyResistanceAddEffect(player,target,ELE_WATER,0) <= 0.5) then
         return 0,0,0;
     else
-        target:delStatusEffect(EFFECT_POISON);
-        if (not target:hasStatusEffect(EFFECT_POISON)) then
-            target:addStatusEffect(EFFECT_POISON, 10, 3, 30);
-        end
+        target:addStatusEffect(EFFECT_POISON, 10, 3, 30); -- Power and Duration needs verified.
         return SUBEFFECT_POISON, 160, EFFECT_POISON;
     end
 end;

--- a/scripts/globals/items/mezraq.lua
+++ b/scripts/globals/items/mezraq.lua
@@ -18,9 +18,7 @@ function onAdditionalEffect(player,target,damage)
         return 0,0,0;
     else
         target:delStatusEffect(EFFECT_EVASION_DOWN)
-        if (not target:hasStatusEffect(EFFECT_EVASION_DOWN)) then
-            target:addStatusEffect(EFFECT_EVASION_DOWN, 10, 0, 60);
-        end
-        return SUBEFFECT_DEFENSE_DOWN, 160, EFFECT_EVASION_DOWN; -- I believe this is the correct subeffect animation.
+        target:addStatusEffect(EFFECT_EVASION_DOWN, 25, 0, 30);
+        return SUBEFFECT_EVASION_DOWN, 160, EFFECT_EVASION_DOWN;
     end
 end;

--- a/scripts/globals/items/mezraq_+1.lua
+++ b/scripts/globals/items/mezraq_+1.lua
@@ -17,10 +17,8 @@ function onAdditionalEffect(player,target,damage)
     if (math.random(0,99) >= chance or applyResistanceAddEffect(player,target,ELE_ICE,0) <= 0.5) then
         return 0,0,0;
     else
-        target:delStatusEffect(EFFECT_EVASION_DOWN)
-        if (not target:hasStatusEffect(EFFECT_EVASION_DOWN)) then
-            target:addStatusEffect(EFFECT_EVASION_DOWN, 13, 0, 60);
-        end
-        return SUBEFFECT_DEFENSE_DOWN, 160, EFFECT_EVASION_DOWN; -- I believe this is the correct subeffect animation.
+        target:delStatusEffect(EFFECT_EVASION_BOOST);
+        target:addStatusEffect(EFFECT_EVASION_DOWN, 25, 0, 30);
+        return SUBEFFECT_EVASION_DOWN, 160, EFFECT_EVASION_DOWN;
     end
 end;

--- a/scripts/globals/items/misery_staff.lua
+++ b/scripts/globals/items/misery_staff.lua
@@ -17,10 +17,7 @@ function onAdditionalEffect(player,target,damage)
     if (math.random(0,99) >= chance or applyResistanceAddEffect(player,target,ELE_DARK,0) <= 0.5) then
         return 0,0,0;
     else
-        target:delStatusEffect(EFFECT_CURSE_I);
-        if (not target:hasStatusEffect(EFFECT_CURSE_I)) then
-            target:addStatusEffect(EFFECT_CURSE_I, 1, 0, 60);
-        end
+        target:addStatusEffect(EFFECT_CURSE_I, 5, 0, 30);
         return SUBEFFECT_CURSE, 160, EFFECT_CURSE_I;
     end
 end;

--- a/scripts/globals/items/mokuto.lua
+++ b/scripts/globals/items/mokuto.lua
@@ -17,10 +17,7 @@ function onAdditionalEffect(player,target,damage)
     if (math.random(0,99) >= chance or applyResistanceAddEffect(player,target,ELE_WIND,0) <= 0.5) then
         return 0,0,0;
     else
-        target:delStatusEffect(EFFECT_SILENCE);
-        if (not target:hasStatusEffect(EFFECT_SILENCE)) then
-            target:addStatusEffect(EFFECT_SILENCE, 1, 0, 60);
-        end
+        target:addStatusEffect(EFFECT_SILENCE, 5, 0, 30);
         return SUBEFFECT_SILENCE, 160, EFFECT_SILENCE;
     end
 end;

--- a/scripts/globals/items/mokuto_+1.lua
+++ b/scripts/globals/items/mokuto_+1.lua
@@ -16,10 +16,7 @@ function onAdditionalEffect(player,target,damage)
     if (math.random(0,99) >= chance or applyResistanceAddEffect(player,target,ELE_WIND,0) <= 0.5) then
         return 0,0,0;
     else
-        target:delStatusEffect(EFFECT_SILENCE);
-        if (not target:hasStatusEffect(EFFECT_SILENCE)) then
-            target:addStatusEffect(EFFECT_SILENCE, 1, 0, 60);
-        end
+        target:addStatusEffect(EFFECT_SILENCE, 10, 0, 30);
         return SUBEFFECT_SILENCE, 160, EFFECT_SILENCE;
     end
 end;

--- a/scripts/globals/items/nadrs.lua
+++ b/scripts/globals/items/nadrs.lua
@@ -17,10 +17,7 @@ function onAdditionalEffect(player,target,damage)
     if (math.random(0,99) >= chance or applyResistanceAddEffect(player,target,ELE_WATER,0) <= 0.5) then
         return 0,0,0;
     else
-        target:delStatusEffect(EFFECT_POISON);
-        if (not target:hasStatusEffect(EFFECT_POISON)) then
-            target:addStatusEffect(EFFECT_POISON, 4, 3, 30);
-        end
+        target:addStatusEffect(EFFECT_POISON, 4, 3, 30);
         return SUBEFFECT_POISON, 160, EFFECT_POISON;
     end
 end;

--- a/scripts/globals/items/pinch_of_rainbow_powder.lua
+++ b/scripts/globals/items/pinch_of_rainbow_powder.lua
@@ -1,7 +1,7 @@
 -----------------------------------------
---	ID: 5362
---	Rainbow Powder
---	When applied, it makes things invisible.
+-- ID: 5362
+-- Rainbow Powder
+-- When applied, it makes things invisible.
 -----------------------------------------
 
 require("scripts/globals/status");
@@ -11,11 +11,13 @@ require("scripts/globals/status");
 -----------------------------------------
 
 function onItemCheck(target)
-local result = 0;
-	if (target:hasStatusEffect(EFFECT_MEDICINE) == true) then
-		result = 111;
-	end
-return result;
+    local result = 0;
+
+    if (target:hasStatusEffect(EFFECT_MEDICINE) == true) then
+        result = 111;
+    end
+
+    return result;
 end;
 
 -----------------------------------------
@@ -24,6 +26,6 @@ end;
 
 function onItemUse(target)
     target:delStatusEffect(EFFECT_INVISIBLE);
-	target:addStatusEffect(EFFECT_INVISIBLE,0,10,180);
-	target:addStatusEffect(EFFECT_MEDICINE,0,0,180);
+    target:addStatusEffect(EFFECT_INVISIBLE,0,10,180);
+    target:addStatusEffect(EFFECT_MEDICINE,0,0,180);
 end;

--- a/scripts/globals/items/poison_baghnakhs.lua
+++ b/scripts/globals/items/poison_baghnakhs.lua
@@ -17,10 +17,7 @@ function onAdditionalEffect(player,target,damage)
     if (math.random(0,99) >= chance or applyResistanceAddEffect(player,target,ELE_WATER,0) <= 0.5) then
         return 0,0,0;
     else
-        target:delStatusEffect(EFFECT_POISON);
-        if (not target:hasStatusEffect(EFFECT_POISON)) then
-            target:addStatusEffect(EFFECT_POISON, 4, 3, 30);
-        end
+        target:addStatusEffect(EFFECT_POISON, 4, 3, 30);
         return SUBEFFECT_POISON, 160, EFFECT_POISON;
     end
 end;

--- a/scripts/globals/items/poison_baghnakhs_+1.lua
+++ b/scripts/globals/items/poison_baghnakhs_+1.lua
@@ -17,10 +17,7 @@ function onAdditionalEffect(player,target,damage)
     if (math.random(0,99) >= chance or applyResistanceAddEffect(player,target,ELE_WATER,0) <= 0.5) then
         return 0,0,0;
     else
-        target:delStatusEffect(EFFECT_POISON);
-        if (not target:hasStatusEffect(EFFECT_POISON)) then
-            target:addStatusEffect(EFFECT_POISON, 4, 3, 30);
-        end
+        target:addStatusEffect(EFFECT_POISON, 4, 3, 30);
         return SUBEFFECT_POISON, 160, EFFECT_POISON;
     end
 end;

--- a/scripts/globals/items/poison_baselard.lua
+++ b/scripts/globals/items/poison_baselard.lua
@@ -17,10 +17,7 @@ function onAdditionalEffect(player,target,damage)
     if (math.random(0,99) >= chance or applyResistanceAddEffect(player,target,ELE_WATER,0) <= 0.5) then
         return 0,0,0;
     else
-        target:delStatusEffect(EFFECT_POISON);
-        if (not target:hasStatusEffect(EFFECT_POISON)) then
-            target:addStatusEffect(EFFECT_POISON, 4, 3, 30);
-        end
+        target:addStatusEffect(EFFECT_POISON, 4, 3, 30);
         return SUBEFFECT_POISON, 160, EFFECT_POISON;
     end
 end;

--- a/scripts/globals/items/poison_cesti.lua
+++ b/scripts/globals/items/poison_cesti.lua
@@ -17,10 +17,7 @@ function onAdditionalEffect(player,target,damage)
     if (math.random(0,99) >= chance or applyResistanceAddEffect(player,target,ELE_WATER,0) <= 0.5) then
         return 0,0,0;
     else
-        target:delStatusEffect(EFFECT_POISON);
-        if (not target:hasStatusEffect(EFFECT_POISON)) then
-            target:addStatusEffect(EFFECT_POISON, 4, 3, 30);
-        end
+        target:addStatusEffect(EFFECT_POISON, 4, 3, 30);
         return SUBEFFECT_POISON, 160, EFFECT_POISON;
     end
 end;

--- a/scripts/globals/items/poison_cesti_+1.lua
+++ b/scripts/globals/items/poison_cesti_+1.lua
@@ -17,10 +17,7 @@ function onAdditionalEffect(player,target,damage)
     if (math.random(0,99) >= chance or applyResistanceAddEffect(player,target,ELE_WATER,0) <= 0.5) then
         return 0,0,0;
     else
-        target:delStatusEffect(EFFECT_POISON);
-        if (not target:hasStatusEffect(EFFECT_POISON)) then
-            target:addStatusEffect(EFFECT_POISON, 4, 3, 30);
-        end
+        target:addStatusEffect(EFFECT_POISON, 4, 3, 30);
         return SUBEFFECT_POISON, 160, EFFECT_POISON;
     end
 end;

--- a/scripts/globals/items/poison_claws.lua
+++ b/scripts/globals/items/poison_claws.lua
@@ -17,10 +17,7 @@ function onAdditionalEffect(player,target,damage)
     if (math.random(0,99) >= chance or applyResistanceAddEffect(player,target,ELE_WATER,0) <= 0.5) then
         return 0,0,0;
     else
-        target:delStatusEffect(EFFECT_POISON);
-        if (not target:hasStatusEffect(EFFECT_POISON)) then
-            target:addStatusEffect(EFFECT_POISON, 4, 3, 30);
-        end
+        target:addStatusEffect(EFFECT_POISON, 4, 3, 30);
         return SUBEFFECT_POISON, 160, EFFECT_POISON;
     end
 end;

--- a/scripts/globals/items/poison_claws_+1.lua
+++ b/scripts/globals/items/poison_claws_+1.lua
@@ -17,10 +17,7 @@ function onAdditionalEffect(player,target,damage)
     if (math.random(0,99) >= chance or applyResistanceAddEffect(player,target,ELE_WATER,0) <= 0.5) then
         return 0,0,0;
     else
-        target:delStatusEffect(EFFECT_POISON);
-        if (not target:hasStatusEffect(EFFECT_POISON)) then
-            target:addStatusEffect(EFFECT_POISON, 4, 3, 30);
-        end
+        target:addStatusEffect(EFFECT_POISON, 4, 3, 30);
         return SUBEFFECT_POISON, 160, EFFECT_POISON;
     end
 end;

--- a/scripts/globals/items/poison_dagger.lua
+++ b/scripts/globals/items/poison_dagger.lua
@@ -17,10 +17,7 @@ function onAdditionalEffect(player,target,damage)
     if (math.random(0,99) >= chance or applyResistanceAddEffect(player,target,ELE_WATER,0) <= 0.5) then
         return 0,0,0;
     else
-        target:delStatusEffect(EFFECT_POISON);
-        if (not target:hasStatusEffect(EFFECT_POISON)) then
-            target:addStatusEffect(EFFECT_POISON, 4, 3, 30);
-        end
+        target:addStatusEffect(EFFECT_POISON, 4, 3, 30);
         return SUBEFFECT_POISON, 160, EFFECT_POISON;
     end
 end;

--- a/scripts/globals/items/poison_dagger_+1.lua
+++ b/scripts/globals/items/poison_dagger_+1.lua
@@ -17,10 +17,7 @@ function onAdditionalEffect(player,target,damage)
     if (math.random(0,99) >= chance or applyResistanceAddEffect(player,target,ELE_WATER,0) <= 0.5) then
         return 0,0,0;
     else
-        target:delStatusEffect(EFFECT_POISON);
-        if (not target:hasStatusEffect(EFFECT_POISON)) then
-            target:addStatusEffect(EFFECT_POISON, 4, 3, 30);
-        end
+        target:addStatusEffect(EFFECT_POISON, 4, 3, 30);
         return SUBEFFECT_POISON, 160, EFFECT_POISON;
     end
 end;

--- a/scripts/globals/items/republic_signet_staff.lua
+++ b/scripts/globals/items/republic_signet_staff.lua
@@ -20,5 +20,5 @@ end;
 
 function onItemUse(target)
     target:delStatusEffect(EFFECT_SIGNET);
-    target:addStatusEffect(EFFECT_SIGNET,0,0,3600);
+    target:addStatusEffect(EFFECT_SIGNET,0,0,18000);
 end;

--- a/scripts/globals/items/thalassocrat.lua
+++ b/scripts/globals/items/thalassocrat.lua
@@ -12,15 +12,13 @@ require("scripts/globals/magic");
 -----------------------------------
 
 function onAdditionalEffect(player,target,damage)
-    local chance = 10;
+    local chance = 5;
 
     if (math.random(0,99) >= chance or applyResistanceAddEffect(player,target,ELE_ICE,0) <= 0.5) then
         return 0,0,0;
     else
-        target:delStatusEffect(EFFECT_EVASION_DOWN)
-        if (not target:hasStatusEffect(EFFECT_EVASION_DOWN)) then
-            target:addStatusEffect(EFFECT_EVASION_DOWN, 10, 0, 60);
-        end
-        return SUBEFFECT_DEFENSE_DOWN, 160, EFFECT_EVASION_DOWN; -- I believe this is the correct subeffect animation.
+        target:delStatusEffect(EFFECT_EVASION_BOOST);
+        target:addStatusEffect(EFFECT_EVASION_DOWN, 25, 0, 30);
+        return SUBEFFECT_EVASION_DOWN, 160, EFFECT_EVASION_DOWN;
     end
 end;

--- a/scripts/globals/items/thalassocrat_+1.lua
+++ b/scripts/globals/items/thalassocrat_+1.lua
@@ -17,10 +17,8 @@ function onAdditionalEffect(player,target,damage)
     if (math.random(0,99) >= chance or applyResistanceAddEffect(player,target,ELE_ICE,0) <= 0.5) then
         return 0,0,0;
     else
-        target:delStatusEffect(EFFECT_EVASION_DOWN)
-        if (not target:hasStatusEffect(EFFECT_EVASION_DOWN)) then
-            target:addStatusEffect(EFFECT_EVASION_DOWN, 10, 0, 60);
-        end
-        return SUBEFFECT_DEFENSE_DOWN, 160, EFFECT_EVASION_DOWN; -- I believe this is the correct subeffect animation.
+        target:delStatusEffect(EFFECT_EVASION_BOOST);
+        target:addStatusEffect(EFFECT_EVASION_DOWN, 25, 0, 30);
+        return SUBEFFECT_EVASION_DOWN, 160, EFFECT_EVASION_DOWN;
     end
 end;

--- a/scripts/globals/status.lua
+++ b/scripts/globals/status.lua
@@ -73,11 +73,13 @@ STATUS_SHUTDOWN			= 20;
     SUBEFFECT_STUN              = 16;
     SUBEFFECT_CURSE             = 17;
     SUBEFFECT_DEFENSE_DOWN      = 18;  -- 1-01001      37
+    SUBEFFECT_EVASION_DOWN      = 18;  -- ID needs verification
+    SUBEFFECT_ATTACK_DOWN       = 18;  -- ID needs verification
     SUBEFFECT_DEATH             = 19;
     SUBEFFECT_SHIELD            = 20;
     SUBEFFECT_HP_DRAIN          = 21;  -- 1-10101      43
     SUBEFFECT_MP_DRAIN          = 22;  -- This is correct animation
-    SUBEFFECT_TP_DRAIN          = 22;  -- Not sure this is correct
+    SUBEFFECT_TP_DRAIN          = 22;  -- Not sure this is correct, might be 21
 	SUBEFFECT_HASTE             = 23;
 
 -- SPIKES


### PR DESCRIPTION
Also corrected just the duration of signet staves (see issue #1491).

I started to comment on things that needs to be checked in retail before realizing that is nearly all of them...We have very little in the way of verified retail power levels and durations here and 90% of these are copy paste work.