### PR TITLE
KI order change for Kuftal Coffer

### DIFF
--- a/scripts/zones/Kuftal_Tunnel/npcs/Treasure_Coffer.lua
+++ b/scripts/zones/Kuftal_Tunnel/npcs/Treasure_Coffer.lua
@@ -38,11 +38,11 @@ function onTrade(player,npc,trade)
 		
 		if(AFHandsActivated == 12 and player:hasKeyItem(OLD_GAUNTLETS) == false) then 
 			questItemNeeded = 1;
-		elseif(player:hasKeyItem(MAP_OF_THE_KUFTAL_TUNNEL) == false) then
-			questItemNeeded = 2;
 		elseif(player:getQuestStatus(OUTLANDS,TRUE_WILL) == QUEST_ACCEPTED and player:getVar("trueWillCS") == 2 and player:hasKeyItem(LARGE_TRICK_BOX) == false) then
-			questItemNeeded = 3;
+			questItemNeeded = 2;
 		elseif(player:getQuestStatus(SANDORIA,KNIGHT_STALKER) == QUEST_ACCEPTED and player:getVar("KnightStalker_Progress") == 1) then
+			questItemNeeded = 3;
+		elseif(player:hasKeyItem(MAP_OF_THE_KUFTAL_TUNNEL) == false) then
 			questItemNeeded = 4;
 		end
 		--------------------------------------
@@ -67,14 +67,14 @@ function onTrade(player,npc,trade)
 					player:addKeyItem(OLD_GAUNTLETS);
 					player:messageSpecial(KEYITEM_OBTAINED,OLD_GAUNTLETS); -- Old Gauntlets (KI)
 				elseif(questItemNeeded == 2) then
+					player:addKeyItem(LARGE_TRICK_BOX);
+					player:messageSpecial(KEYITEM_OBTAINED,LARGE_TRICK_BOX); -- Large Trick Box (KI, NIN AF3)
+				elseif(questItemNeeded == 3) then
+					player:addKeyItem(CHALLENGE_TO_THE_ROYAL_KNIGHTS); -- DRG AF3 (KI)
+					player:messageSpecial(KEYITEM_OBTAINED,CHALLENGE_TO_THE_ROYAL_KNIGHTS);
+				elseif(questItemNeeded == 4) then
 					player:addKeyItem(MAP_OF_THE_KUFTAL_TUNNEL);
 					player:messageSpecial(KEYITEM_OBTAINED,MAP_OF_THE_KUFTAL_TUNNEL); -- Map of the Kuftal Tunnel (KI)
-				elseif(questItemNeeded == 3) then
-					player:addKeyItem(LARGE_TRICK_BOX);
-					player:messageSpecial(KEYITEM_OBTAINED,LARGE_TRICK_BOX);
-				elseif(questItemNeeded == 4) then
-					player:addKeyItem(CHALLENGE_TO_THE_ROYAL_KNIGHTS); -- DRG AF3
-					player:messageSpecial(KEYITEM_OBTAINED,CHALLENGE_TO_THE_ROYAL_KNIGHTS);
 				else
 					player:setVar("["..zone.."]".."Treasure_"..TreasureType,os.time() + math.random(CHEST_MIN_ILLUSION_TIME,CHEST_MAX_ILLUSION_TIME)); 
 					


### PR DESCRIPTION
Bumped the map down to be after the NIN and DRG AF quest KIs so people don't have to get two coffer keys for their AF if they don't already have the map.