### PR TITLE
CORE: Reprisal fix

### DIFF
--- a/scripts/globals/effects/reprisal.lua
+++ b/scripts/globals/effects/reprisal.lua
@@ -12,7 +12,9 @@ require("scripts/globals/status");
 
 function onEffectGain(target,effect)
     target:addMod(MOD_SPIKES,6);
-    target:addMod(MOD_SPIKES_DMG, effect:getPower());
+     -- Spike damage is calculated on hit in battleutils::TakePhysicalDamage
+    target:setMod(MOD_SPIKES_DMG, 0);
+    target:addMod(MOD_SHIELDBLOCKRATE, 50);
 end;
 
 -----------------------------------
@@ -28,5 +30,6 @@ end;
 
 function onEffectLose(target,effect)
     target:delMod(MOD_SPIKES,6);
-    target:delMod(MOD_SPIKES_DMG, effect:getPower());
+    target:setMod(MOD_SPIKES_DMG, 0);
+    target:delMod(MOD_SHIELDBLOCKRATE, 50);
 end;

--- a/scripts/globals/spells/reprisal.lua
+++ b/scripts/globals/spells/reprisal.lua
@@ -14,18 +14,14 @@ end;
 
 function onSpellCast(caster,target,spell)
     local duration = 60;
+    local maxReflectedDamage = target:getMaxHP() * 2;
+    local reflectedPercent = 33;
   local typeEffect = EFFECT_REPRISAL;
     if (caster:hasStatusEffect(EFFECT_COMPOSURE) == true and caster:getID() == target:getID()) then
         duration = duration * 3;
     end
 
-    local int = caster:getStat(MOD_MND);
-    local magicAtk = caster:getMod(MOD_MATT);
-
-    -- totally guessing
-    local power = ((int + 10) / 20 + 2) * (1 + (magicAtk / 100));
-
-   if(target:addStatusEffect(typeEffect,power,0,duration)) then
+   if(target:addStatusEffect(typeEffect,reflectedPercent, 0,duration, 0, maxReflectedDamage, 1)) then
      spell:setMsg(230);
    else
      spell:setMsg(75);

--- a/scripts/globals/status.lua
+++ b/scripts/globals/status.lua
@@ -1236,11 +1236,13 @@ MOD_ABSORB_DMG_TO_MP          = 0x204 -- Unlike PLD gear mod, works on all damag
 
 MOD_EGGHELM                   = 0x205 -- Egg Helm (Chocobo Digging)
 
+MOD_SHIELDBLOCKRATE           = 0x206 -- Affects shield block rate, percent based (modID = 518))
+
 -- MOD_SPARE = 0x138 -- (modId = 312)
 -- MOD_SPARE = 0x139 -- (modId = 313)
 -- MOD_SPARE = 0x13A -- (modId = 314)
 -- MOD_SPARE = 0x13B -- (modId = 315)
--- MOD_SPARE = 0x206 -- (modId = 518)
+-- MOD_SPARE = 0x207 -- (modId = 519)
 
 ------------------------------------
 -- Merit Definitions

--- a/src/map/modifier.h
+++ b/src/map/modifier.h
@@ -561,11 +561,13 @@ enum MODIFIER
 
     MOD_EGGHELM                   = 0x205,
 
+    MOD_SHIELDBLOCKRATE           = 0x206, // Affects shield block rate, percent based (modID = 518)
+
     // MOD_SPARE = 0x138, // (modId = 312)
     // MOD_SPARE = 0x139, // (modId = 313)
     // MOD_SPARE = 0x13A, // (modId = 314)
     // MOD_SPARE = 0x13B, // (modId = 315)
-    // MOD_SPARE = 0x206, // (modId = 518)
+    // MOD_SPARE = 0x207, // (modId = 519)
 
 };
 


### PR DESCRIPTION
Reprisal now gives the 50% bonus to block rates, the spike damage is
based off of damage blocked not damage taken, and it expires when it
reflects 2x the caster's max HP