### PR TITLE
Scripts: Healing breath to use pet max HP

### DIFF
--- a/scripts/globals/abilities/pets/healing_breath_i.lua
+++ b/scripts/globals/abilities/pets/healing_breath_i.lua
@@ -28,7 +28,7 @@ function onPetAbility(target, pet, skill, master)
 
    local gear = master:getMod(MOD_WYVERN_BREATH)/256; -- Master gear that enhances breath
 
-	local base = math.floor((45/256)*(1+(pet:getTP()/1024))*(pet:getHP())+42);
+	local base = math.floor((45/256)*(1+(pet:getTP()/1024))*(pet:getMaxHP())+42);
 	if(target:getHP()+base > target:getMaxHP()) then
 		base = target:getMaxHP() - target:getHP(); --cap it
 	end

--- a/scripts/globals/abilities/pets/healing_breath_ii.lua
+++ b/scripts/globals/abilities/pets/healing_breath_ii.lua
@@ -28,7 +28,7 @@ function onPetAbility(target, pet, skill, master)
 
    local gear = master:getMod(MOD_WYVERN_BREATH)/256; -- Master gear that enhances breath
 
-	local base = math.floor((45/256)*(1+(pet:getTP()/1024))*(pet:getHP())+42);
+	local base = math.floor((45/256)*(1+(pet:getTP()/1024))*(pet:getMaxHP())+42);
 	if(target:getHP()+base > target:getMaxHP()) then
 		base = target:getMaxHP() - target:getHP(); --cap it
 	end

--- a/scripts/globals/abilities/pets/healing_breath_iii.lua
+++ b/scripts/globals/abilities/pets/healing_breath_iii.lua
@@ -33,6 +33,7 @@ function onPetAbility(target, pet, skill, master)
       -- Supposedly unused Wyvern HP+ gear added potency, that is 991 current + unused +50 HP > 991 + no HP+ gear.  I have not seen proof of this though.
    -- Source 1, HB IV multiplier: http://www.bluegartr.com/threads/108543-Wyvern-Breath-Testing?p=5017811&viewfull=1#post5017811
    -- Source 2, Lots of info: http://www.bluegartr.com/threads/108543-Wyvern-Breath-Testing?p=5357018&viewfull=1#post5357018
+   -- Source for max HP instead of current: http://www.bluegartr.com/threads/108543-Wyvern-Breath-Testing?p=4995110&viewfull=1#post4995110
 
    ---------- Deep Breathing ----------
    -- 0 for none
@@ -47,7 +48,7 @@ function onPetAbility(target, pet, skill, master)
 
    local gear = master:getMod(MOD_WYVERN_BREATH)/256; -- Master gear that enhances breath
 
-   local base = math.floor((45/256)*(gear+(pet:getTP()/1024)+deep+1)*(pet:getHP())+42);
+   local base = math.floor((45/256)*(gear+(pet:getTP()/1024)+deep+1)*(pet:getMaxHP())+42);
    if(target:getHP()+base > target:getMaxHP()) then
       base = target:getMaxHP() - target:getHP(); --cap it
    end


### PR DESCRIPTION
Source: http://www.bluegartr.com/threads/108543-Wyvern-Breath-Testing?p=4995110&viewfull=1#post4995110

While a later post in that thread (from the same user) says Healing Breath uses wyvern HP, it doesn't say *current* HP - seems to be an accidental omission/known assumption for DRG players, which got carried over directly to bgwiki. ffxiclopedia has Healing Breath use wyvern max HP as well.