### PR TITLE
SCRIPTS: fixing barspell typos

### DIFF
--- a/scripts/globals/magic.lua
+++ b/scripts/globals/magic.lua
@@ -1566,7 +1566,7 @@ function calculateBarspellPower(caster,enhanceSkill)
 		enhanceSkill = 0;
 	end
 
-	local power = 40 + 0.2 * enchanceSkill + meritBonus;
+	local power = 40 + 0.2 * enhanceSkill + meritBonus;
 	
 	local equippedLegs = caster:getEquipID(SLOT_LEGS);
 	if(equippedLegs == 15119) then

--- a/scripts/globals/spells/baraera.lua
+++ b/scripts/globals/spells/baraera.lua
@@ -13,14 +13,14 @@ function onMagicCastingCheck(caster,target,spell)
 end;
 
 function onSpellCast(caster,target,spell)
-	enchanceSkill = caster:getSkillLevel(ENHANCING_MAGIC_SKILL);
+	local enhanceSkill = caster:getSkillLevel(ENHANCING_MAGIC_SKILL);
 
 	local power = calculateBarspellPower(caster,enhanceSkill);
 
 	local duration = 150;
 
-	if(enchanceSkill >180)then
-		duration = 150 + 0.8 * (enchanceSkill - 180);
+	if(enhanceSkill >180)then
+		duration = 150 + 0.8 * (enhanceSkill - 180);
 	end
 
 	if (caster:hasStatusEffect(EFFECT_COMPOSURE) == true and caster:getID() == target:getID()) then

--- a/scripts/globals/spells/baraero.lua
+++ b/scripts/globals/spells/baraero.lua
@@ -13,14 +13,14 @@ function onMagicCastingCheck(caster,target,spell)
 end;
 
 function onSpellCast(caster,target,spell)
-	enchanceSkill = caster:getSkillLevel(ENHANCING_MAGIC_SKILL);
+	local enhanceSkill = caster:getSkillLevel(ENHANCING_MAGIC_SKILL);
 
 	local power = calculateBarspellPower(caster,enhanceSkill);
 
 	local duration = 150;
 
-	if(enchanceSkill >180)then
-		duration = 150 + 0.8 * (enchanceSkill - 180);
+	if(enhanceSkill >180)then
+		duration = 150 + 0.8 * (enhanceSkill - 180);
 	end
 
 	if (caster:hasStatusEffect(EFFECT_COMPOSURE) == true and caster:getID() == target:getID()) then

--- a/scripts/globals/spells/baramnesia.lua
+++ b/scripts/globals/spells/baramnesia.lua
@@ -16,14 +16,14 @@ function onSpellCast(caster,target,spell)
     local meritBonus = caster:getMerit(MERIT_BAR_SPELL_EFFECT);	
     --printf("Barspell: Merit Bonus +%d", meritBonus);
     
-    local enchanceSkill = caster:getSkillLevel(34);
+    local enhanceSkill = caster:getSkillLevel(34);
 
-    local power = 1 + 0.02 * enchanceSkill + meritBonus;
+    local power = 1 + 0.02 * enhanceSkill + meritBonus;
 
     local duration = 150;
 
-    if(enchanceSkill >180)then
-        duration = 150 + 0.8 * (enchanceSkill - 180);
+    if(enhanceSkill >180)then
+        duration = 150 + 0.8 * (enhanceSkill - 180);
     end
 
     if (caster:hasStatusEffect(EFFECT_COMPOSURE) == true and caster:getID() == target:getID()) then

--- a/scripts/globals/spells/baramnesra.lua
+++ b/scripts/globals/spells/baramnesra.lua
@@ -16,14 +16,14 @@ function onSpellCast(caster,target,spell)
     local meritBonus = caster:getMerit(MERIT_BAR_SPELL_EFFECT);	
     --printf("Barspell: Merit Bonus +%d", meritBonus);
     
-	local enchanceSkill = caster:getSkillLevel(34);
+	local enhanceSkill = caster:getSkillLevel(34);
 
-    local power = 1 + 0.02 * enchanceSkill + meritBonus;
+    local power = 1 + 0.02 * enhanceSkill + meritBonus;
 
 	local duration = 150;
 
-    if(enchanceSkill >180)then
-        duration = 150 + 0.8 * (enchanceSkill - 180);
+    if(enhanceSkill >180)then
+        duration = 150 + 0.8 * (enhanceSkill - 180);
     end
 
 	if (caster:hasStatusEffect(EFFECT_COMPOSURE) == true and caster:getID() == target:getID()) then

--- a/scripts/globals/spells/barblind.lua
+++ b/scripts/globals/spells/barblind.lua
@@ -16,14 +16,14 @@ function onSpellCast(caster,target,spell)
     local meritBonus = caster:getMerit(MERIT_BAR_SPELL_EFFECT);	
     --printf("Barspell: Merit Bonus +%d", meritBonus);
     
-    local enchanceSkill = caster:getSkillLevel(34);
+    local enhanceSkill = caster:getSkillLevel(34);
 
     local duration = 150;
 
-    local power = 1 + 0.02 * enchanceSkill + meritBonus;
+    local power = 1 + 0.02 * enhanceSkill + meritBonus;
 
-    if(enchanceSkill >180)then
-        duration = 150 + 0.8 * (enchanceSkill - 180);
+    if(enhanceSkill >180)then
+        duration = 150 + 0.8 * (enhanceSkill - 180);
     end
 
     if (caster:hasStatusEffect(EFFECT_COMPOSURE) == true and caster:getID() == target:getID()) then

--- a/scripts/globals/spells/barblindra.lua
+++ b/scripts/globals/spells/barblindra.lua
@@ -16,14 +16,14 @@ function onSpellCast(caster,target,spell)
     local meritBonus = caster:getMerit(MERIT_BAR_SPELL_EFFECT);	
     --printf("Barspell: Merit Bonus +%d", meritBonus);
     
-	local enchanceSkill = caster:getSkillLevel(34);
+	local enhanceSkill = caster:getSkillLevel(34);
     
-    local power = 1 + 0.02 * enchanceSkill + meritBonus;
+    local power = 1 + 0.02 * enhanceSkill + meritBonus;
 
 	local duration = 150;
 
-	if(enchanceSkill >180)then
-		duration = 150 + 0.8 * (enchanceSkill - 180);
+	if(enhanceSkill >180)then
+		duration = 150 + 0.8 * (enhanceSkill - 180);
 	end
 
 	if (caster:hasStatusEffect(EFFECT_COMPOSURE) == true and caster:getID() == target:getID()) then

--- a/scripts/globals/spells/barblizzara.lua
+++ b/scripts/globals/spells/barblizzara.lua
@@ -13,14 +13,14 @@ function onMagicCastingCheck(caster,target,spell)
 end;
 
 function onSpellCast(caster,target,spell)
-	enchanceSkill = caster:getSkillLevel(ENHANCING_MAGIC_SKILL);
+	local enhanceSkill = caster:getSkillLevel(ENHANCING_MAGIC_SKILL);
 
 	local power = calculateBarspellPower(caster,enhanceSkill);
 
 	local duration = 150;
 
-	if(enchanceSkill >180)then
-		duration = 150 + 0.8 * (enchanceSkill - 180);
+	if(enhanceSkill >180)then
+		duration = 150 + 0.8 * (enhanceSkill - 180);
 	end
 
 	if (caster:hasStatusEffect(EFFECT_COMPOSURE) == true and caster:getID() == target:getID()) then

--- a/scripts/globals/spells/barblizzard.lua
+++ b/scripts/globals/spells/barblizzard.lua
@@ -13,14 +13,14 @@ function onMagicCastingCheck(caster,target,spell)
 end;
 
 function onSpellCast(caster,target,spell)
-	enchanceSkill = caster:getSkillLevel(ENHANCING_MAGIC_SKILL);
+	local enhanceSkill = caster:getSkillLevel(ENHANCING_MAGIC_SKILL);
 
 	local power = calculateBarspellPower(caster,enhanceSkill);
 
 	local duration = 150;
 
-	if(enchanceSkill >180)then
-		duration = 150 + 0.8 * (enchanceSkill - 180);
+	if(enhanceSkill >180)then
+		duration = 150 + 0.8 * (enhanceSkill - 180);
 	end
 
 	if (caster:hasStatusEffect(EFFECT_COMPOSURE) == true and caster:getID() == target:getID()) then

--- a/scripts/globals/spells/barfira.lua
+++ b/scripts/globals/spells/barfira.lua
@@ -13,14 +13,14 @@ function onMagicCastingCheck(caster,target,spell)
 end;
 
 function onSpellCast(caster,target,spell)
-	enchanceSkill = caster:getSkillLevel(ENHANCING_MAGIC_SKILL);
+	local enhanceSkill = caster:getSkillLevel(ENHANCING_MAGIC_SKILL);
 
 	local power = calculateBarspellPower(caster,enhanceSkill);
 
 	local duration = 150;
 
-	if(enchanceSkill >180)then
-		duration = 150 + 0.8 * (enchanceSkill - 180);
+	if(enhanceSkill >180)then
+		duration = 150 + 0.8 * (enhanceSkill - 180);
 	end
 
 	if (caster:hasStatusEffect(EFFECT_COMPOSURE) == true and caster:getID() == target:getID()) then

--- a/scripts/globals/spells/barfire.lua
+++ b/scripts/globals/spells/barfire.lua
@@ -13,14 +13,14 @@ function onMagicCastingCheck(caster,target,spell)
 end;
 
 function onSpellCast(caster,target,spell)
-	enchanceSkill = caster:getSkillLevel(ENHANCING_MAGIC_SKILL);
+	local enhanceSkill = caster:getSkillLevel(ENHANCING_MAGIC_SKILL);
 
 	local power = calculateBarspellPower(caster,enhanceSkill);
 
 	local duration = 150;
 
-	if(enchanceSkill >180)then
-		duration = 150 + 0.8 * (enchanceSkill - 180);
+	if(enhanceSkill >180)then
+		duration = 150 + 0.8 * (enhanceSkill - 180);
 	end
 
 	if (caster:hasStatusEffect(EFFECT_COMPOSURE) == true and caster:getID() == target:getID()) then

--- a/scripts/globals/spells/barparalyze.lua
+++ b/scripts/globals/spells/barparalyze.lua
@@ -16,14 +16,14 @@ function onSpellCast(caster,target,spell)
     local meritBonus = caster:getMerit(MERIT_BAR_SPELL_EFFECT);	
     --printf("Barspell: Merit Bonus +%d", meritBonus);
     
-    local enchanceSkill = caster:getSkillLevel(34);
+    local enhanceSkill = caster:getSkillLevel(34);
 
-    local power = 1 + 0.02 * enchanceSkill + meritBonus;
+    local power = 1 + 0.02 * enhanceSkill + meritBonus;
 
     local duration = 150;
 
-    if(enchanceSkill >180)then
-        duration = 150 + 0.8 * (enchanceSkill - 180);
+    if(enhanceSkill >180)then
+        duration = 150 + 0.8 * (enhanceSkill - 180);
     end
 
     if (caster:hasStatusEffect(EFFECT_COMPOSURE) == true and caster:getID() == target:getID()) then

--- a/scripts/globals/spells/barparalyzra.lua
+++ b/scripts/globals/spells/barparalyzra.lua
@@ -16,14 +16,14 @@ function onSpellCast(caster,target,spell)
     local meritBonus = caster:getMerit(MERIT_BAR_SPELL_EFFECT);	
     --printf("Barspell: Merit Bonus +%d", meritBonus);
     
-	local enchanceSkill = caster:getSkillLevel(34);
+	local enhanceSkill = caster:getSkillLevel(34);
 
-    local power = 1 + 0.02 * enchanceSkill + meritBonus;
+    local power = 1 + 0.02 * enhanceSkill + meritBonus;
 
 	local duration = 150;
 
-    if(enchanceSkill >180)then
-        duration = 150 + 0.8 * (enchanceSkill - 180);
+    if(enhanceSkill >180)then
+        duration = 150 + 0.8 * (enhanceSkill - 180);
     end
 
 	if (caster:hasStatusEffect(EFFECT_COMPOSURE) == true and caster:getID() == target:getID()) then

--- a/scripts/globals/spells/barpetra.lua
+++ b/scripts/globals/spells/barpetra.lua
@@ -16,14 +16,14 @@ function onSpellCast(caster,target,spell)
     local meritBonus = caster:getMerit(MERIT_BAR_SPELL_EFFECT);	
     --printf("Barspell: Merit Bonus +%d", meritBonus);
     
-	local enchanceSkill = caster:getSkillLevel(34);
+	local enhanceSkill = caster:getSkillLevel(34);
 
-    local power = 1 + 0.02 * enchanceSkill + meritBonus;
+    local power = 1 + 0.02 * enhanceSkill + meritBonus;
 
 	local duration = 150;
 
-    if(enchanceSkill >180)then
-        duration = 150 + 0.8 * (enchanceSkill - 180);
+    if(enhanceSkill >180)then
+        duration = 150 + 0.8 * (enhanceSkill - 180);
     end
 
 	if (caster:hasStatusEffect(EFFECT_COMPOSURE) == true and caster:getID() == target:getID()) then

--- a/scripts/globals/spells/barpetrify.lua
+++ b/scripts/globals/spells/barpetrify.lua
@@ -16,14 +16,14 @@ function onSpellCast(caster,target,spell)
     local meritBonus = caster:getMerit(MERIT_BAR_SPELL_EFFECT);	
     --printf("Barspell: Merit Bonus +%d", meritBonus);
     
-    local enchanceSkill = caster:getSkillLevel(34);
+    local enhanceSkill = caster:getSkillLevel(34);
 
-    local power = 1 + 0.02 * enchanceSkill + meritBonus;
+    local power = 1 + 0.02 * enhanceSkill + meritBonus;
 
     local duration = 150;
 
-    if(enchanceSkill >180)then
-        duration = 150 + 0.8 * (enchanceSkill - 180);
+    if(enhanceSkill >180)then
+        duration = 150 + 0.8 * (enhanceSkill - 180);
     end
 
     if (caster:hasStatusEffect(EFFECT_COMPOSURE) == true and caster:getID() == target:getID()) then

--- a/scripts/globals/spells/barpoison.lua
+++ b/scripts/globals/spells/barpoison.lua
@@ -16,14 +16,14 @@ function onSpellCast(caster,target,spell)
     local meritBonus = caster:getMerit(MERIT_BAR_SPELL_EFFECT);	
     --printf("Barspell: Merit Bonus +%d", meritBonus);
     
-    local enchanceSkill = caster:getSkillLevel(34);
+    local enhanceSkill = caster:getSkillLevel(34);
 
-    local power = 1 + 0.02 * enchanceSkill + meritBonus;
+    local power = 1 + 0.02 * enhanceSkill + meritBonus;
 
     local duration = 150;
 
-    if(enchanceSkill >180)then
-        duration = 150 + 0.8 * (enchanceSkill - 180);
+    if(enhanceSkill >180)then
+        duration = 150 + 0.8 * (enhanceSkill - 180);
     end
 
     if (caster:hasStatusEffect(EFFECT_COMPOSURE) == true and caster:getID() == target:getID()) then

--- a/scripts/globals/spells/barpoisonra.lua
+++ b/scripts/globals/spells/barpoisonra.lua
@@ -16,14 +16,14 @@ function onSpellCast(caster,target,spell)
     local meritBonus = caster:getMerit(MERIT_BAR_SPELL_EFFECT);	
     --printf("Barspell: Merit Bonus +%d", meritBonus);
     
-	local enchanceSkill = caster:getSkillLevel(34);
+	local enhanceSkill = caster:getSkillLevel(34);
 
-    local power = 1 + 0.02 * enchanceSkill + meritBonus;
+    local power = 1 + 0.02 * enhanceSkill + meritBonus;
 
 	local duration = 150;
 
-    if(enchanceSkill >180)then
-        duration = 150 + 0.8 * (enchanceSkill - 180);
+    if(enhanceSkill >180)then
+        duration = 150 + 0.8 * (enhanceSkill - 180);
     end
 
 	if (caster:hasStatusEffect(EFFECT_COMPOSURE) == true and caster:getID() == target:getID()) then

--- a/scripts/globals/spells/barsilence.lua
+++ b/scripts/globals/spells/barsilence.lua
@@ -16,14 +16,14 @@ function onSpellCast(caster,target,spell)
     local meritBonus = caster:getMerit(MERIT_BAR_SPELL_EFFECT);	
     --printf("Barspell: Merit Bonus +%d", meritBonus);
     
-    local enchanceSkill = caster:getSkillLevel(34);
+    local enhanceSkill = caster:getSkillLevel(34);
 
     local duration = 150;
 
-    local power = 1 + 0.02 * enchanceSkill + meritBonus;
+    local power = 1 + 0.02 * enhanceSkill + meritBonus;
 
-    if(enchanceSkill >180)then
-        duration = 150 + 0.8 * (enchanceSkill - 180);
+    if(enhanceSkill >180)then
+        duration = 150 + 0.8 * (enhanceSkill - 180);
     end
 
     if (caster:hasStatusEffect(EFFECT_COMPOSURE) == true and caster:getID() == target:getID()) then

--- a/scripts/globals/spells/barsilencera.lua
+++ b/scripts/globals/spells/barsilencera.lua
@@ -16,14 +16,14 @@ function onSpellCast(caster,target,spell)
     local meritBonus = caster:getMerit(MERIT_BAR_SPELL_EFFECT);	
     --printf("Barspell: Merit Bonus +%d", meritBonus);
     
-	local enchanceSkill = caster:getSkillLevel(34);
+	local enhanceSkill = caster:getSkillLevel(34);
 
-    local power = 1 + 0.02 * enchanceSkill + meritBonus;
+    local power = 1 + 0.02 * enhanceSkill + meritBonus;
 
 	local duration = 150;
 
-    if(enchanceSkill >180)then
-        duration = 150 + 0.8 * (enchanceSkill - 180);
+    if(enhanceSkill >180)then
+        duration = 150 + 0.8 * (enhanceSkill - 180);
     end
 
 	if (caster:hasStatusEffect(EFFECT_COMPOSURE) == true and caster:getID() == target:getID()) then

--- a/scripts/globals/spells/barsleep.lua
+++ b/scripts/globals/spells/barsleep.lua
@@ -16,14 +16,14 @@ function onSpellCast(caster,target,spell)
     local meritBonus = caster:getMerit(MERIT_BAR_SPELL_EFFECT);	
     --printf("Barspell: Merit Bonus +%d", meritBonus);
     
-    local enchanceSkill = caster:getSkillLevel(34);
+    local enhanceSkill = caster:getSkillLevel(34);
 
-    local power = 1 + 0.02 * enchanceSkill + meritBonus;
+    local power = 1 + 0.02 * enhanceSkill + meritBonus;
 
     local duration = 150;
 
-    if(enchanceSkill >180)then
-        duration = 150 + 0.8 * (enchanceSkill - 180);
+    if(enhanceSkill >180)then
+        duration = 150 + 0.8 * (enhanceSkill - 180);
     end
 
     if (caster:hasStatusEffect(EFFECT_COMPOSURE) == true and caster:getID() == target:getID()) then

--- a/scripts/globals/spells/barsleepra.lua
+++ b/scripts/globals/spells/barsleepra.lua
@@ -16,14 +16,14 @@ function onSpellCast(caster,target,spell)
     local meritBonus = caster:getMerit(MERIT_BAR_SPELL_EFFECT);	
     --printf("Barspell: Merit Bonus +%d", meritBonus);
     
-	local enchanceSkill = caster:getSkillLevel(34);
+	local enhanceSkill = caster:getSkillLevel(34);
 
-    local power = 1 + 0.02 * enchanceSkill + meritBonus;
+    local power = 1 + 0.02 * enhanceSkill + meritBonus;
 
 	local duration = 150;
 
-    if(enchanceSkill >180)then
-        duration = 150 + 0.8 * (enchanceSkill - 180);
+    if(enhanceSkill >180)then
+        duration = 150 + 0.8 * (enhanceSkill - 180);
     end
 
 	if (caster:hasStatusEffect(EFFECT_COMPOSURE) == true and caster:getID() == target:getID()) then

--- a/scripts/globals/spells/barstone.lua
+++ b/scripts/globals/spells/barstone.lua
@@ -13,14 +13,14 @@ function onMagicCastingCheck(caster,target,spell)
 end;
 
 function onSpellCast(caster,target,spell)
-	enchanceSkill = caster:getSkillLevel(ENHANCING_MAGIC_SKILL);
+	local enhanceSkill = caster:getSkillLevel(ENHANCING_MAGIC_SKILL);
 
 	local power = calculateBarspellPower(caster,enhanceSkill);
 
 	local duration = 150;
 
-	if(enchanceSkill >180)then
-		duration = 150 + 0.8 * (enchanceSkill - 180);
+	if(enhanceSkill >180)then
+		duration = 150 + 0.8 * (enhanceSkill - 180);
 	end
 
 	if (caster:hasStatusEffect(EFFECT_COMPOSURE) == true and caster:getID() == target:getID()) then

--- a/scripts/globals/spells/barstonra.lua
+++ b/scripts/globals/spells/barstonra.lua
@@ -13,14 +13,14 @@ function onMagicCastingCheck(caster,target,spell)
 end;
 
 function onSpellCast(caster,target,spell)
-	enchanceSkill = caster:getSkillLevel(ENHANCING_MAGIC_SKILL);
+	local enhanceSkill = caster:getSkillLevel(ENHANCING_MAGIC_SKILL);
 
 	local power = calculateBarspellPower(caster,enhanceSkill);
 
 	local duration = 150;
 
-	if(enchanceSkill >180)then
-		duration = 150 + 0.8 * (enchanceSkill - 180);
+	if(enhanceSkill >180)then
+		duration = 150 + 0.8 * (enhanceSkill - 180);
 	end
 
 	if (caster:hasStatusEffect(EFFECT_COMPOSURE) == true and caster:getID() == target:getID()) then

--- a/scripts/globals/spells/barthunder.lua
+++ b/scripts/globals/spells/barthunder.lua
@@ -13,14 +13,14 @@ function onMagicCastingCheck(caster,target,spell)
 end;
 
 function onSpellCast(caster,target,spell)
-	enchanceSkill = caster:getSkillLevel(ENHANCING_MAGIC_SKILL);
+	local enhanceSkill = caster:getSkillLevel(ENHANCING_MAGIC_SKILL);
 
 	local power = calculateBarspellPower(caster,enhanceSkill);
 
 	local duration = 150;
 
-	if(enchanceSkill >180)then
-		duration = 150 + 0.8 * (enchanceSkill - 180);
+	if(enhanceSkill >180)then
+		duration = 150 + 0.8 * (enhanceSkill - 180);
 	end
 
 	if (caster:hasStatusEffect(EFFECT_COMPOSURE) == true and caster:getID() == target:getID()) then

--- a/scripts/globals/spells/barthundra.lua
+++ b/scripts/globals/spells/barthundra.lua
@@ -13,14 +13,14 @@ function onMagicCastingCheck(caster,target,spell)
 end;
 
 function onSpellCast(caster,target,spell)
-	enchanceSkill = caster:getSkillLevel(ENHANCING_MAGIC_SKILL);
+	local enhanceSkill = caster:getSkillLevel(ENHANCING_MAGIC_SKILL);
 
 	local power = calculateBarspellPower(caster,enhanceSkill);
 
 	local duration = 150;
 
-	if(enchanceSkill >180)then
-		duration = 150 + 0.8 * (enchanceSkill - 180);
+	if(enhanceSkill >180)then
+		duration = 150 + 0.8 * (enhanceSkill - 180);
 	end
 
 	if (caster:hasStatusEffect(EFFECT_COMPOSURE) == true and caster:getID() == target:getID()) then

--- a/scripts/globals/spells/barvira.lua
+++ b/scripts/globals/spells/barvira.lua
@@ -16,14 +16,14 @@ function onSpellCast(caster,target,spell)
     local meritBonus = caster:getMerit(MERIT_BAR_SPELL_EFFECT);	
     --printf("Barspell: Merit Bonus +%d", meritBonus);
     
-    local enchanceSkill = caster:getSkillLevel(34);
+    local enhanceSkill = caster:getSkillLevel(34);
 
-    local power = 1 + 0.02 * enchanceSkill + meritBonus;
+    local power = 1 + 0.02 * enhanceSkill + meritBonus;
 
     local duration = 150;
 
-    if(enchanceSkill >180)then
-        duration = 150 + 0.8 * (enchanceSkill - 180);
+    if(enhanceSkill >180)then
+        duration = 150 + 0.8 * (enhanceSkill - 180);
     end
 
     if (caster:hasStatusEffect(EFFECT_COMPOSURE) == true and caster:getID() == target:getID()) then

--- a/scripts/globals/spells/barvirus.lua
+++ b/scripts/globals/spells/barvirus.lua
@@ -16,14 +16,14 @@ function onSpellCast(caster,target,spell)
     local meritBonus = caster:getMerit(MERIT_BAR_SPELL_EFFECT);	
     --printf("Barspell: Merit Bonus +%d", meritBonus);
     
-    local enchanceSkill = caster:getSkillLevel(34);
+    local enhanceSkill = caster:getSkillLevel(34);
 
-    local power = 1 + 0.02 * enchanceSkill + meritBonus;
+    local power = 1 + 0.02 * enhanceSkill + meritBonus;
 
     local duration = 150;
 
-    if(enchanceSkill >180)then
-        duration = 150 + 0.8 * (enchanceSkill - 180);
+    if(enhanceSkill >180)then
+        duration = 150 + 0.8 * (enhanceSkill - 180);
     end
 
     if (caster:hasStatusEffect(EFFECT_COMPOSURE) == true and caster:getID() == target:getID()) then

--- a/scripts/globals/spells/barwater.lua
+++ b/scripts/globals/spells/barwater.lua
@@ -13,14 +13,14 @@ function onMagicCastingCheck(caster,target,spell)
 end;
 
 function onSpellCast(caster,target,spell)
-	enchanceSkill = caster:getSkillLevel(ENHANCING_MAGIC_SKILL);
+	local enhanceSkill = caster:getSkillLevel(ENHANCING_MAGIC_SKILL);
 
 	local power = calculateBarspellPower(caster,enhanceSkill);
 
 	local duration = 150;
 
-	if(enchanceSkill >180)then
-		duration = 150 + 0.8 * (enchanceSkill - 180);
+	if(enhanceSkill >180)then
+		duration = 150 + 0.8 * (enhanceSkill - 180);
 	end
 
 	if (caster:hasStatusEffect(EFFECT_COMPOSURE) == true and caster:getID() == target:getID()) then

--- a/scripts/globals/spells/barwatera.lua
+++ b/scripts/globals/spells/barwatera.lua
@@ -13,14 +13,14 @@ function onMagicCastingCheck(caster,target,spell)
 end;
 
 function onSpellCast(caster,target,spell)
-	enchanceSkill = caster:getSkillLevel(ENHANCING_MAGIC_SKILL);
+	local enhanceSkilll = caster:getSkillLevel(ENHANCING_MAGIC_SKILL);
 
 	local power = calculateBarspellPower(caster,enhanceSkill);
 
 	local duration = 150;
 
-	if(enchanceSkill >180)then
-		duration = 150 + 0.8 * (enchanceSkill - 180);
+	if(enhanceSkill >180)then
+		duration = 150 + 0.8 * (enhanceSkill - 180);
 	end
 
 	if (caster:hasStatusEffect(EFFECT_COMPOSURE) == true and caster:getID() == target:getID()) then


### PR DESCRIPTION
The enhancing skill was assigned to the variable enchanceSkill instead of enhanceSkill. This caused problems in two specific instances:

In magic.lua, the calculateBarspellPower function uses the formal parameter enhanceSkill, but later adds the undefined variable enchanceSkill to the power local variable.

In the elemental barspell scripts, the enhancing skill is assigned to enchanceSkill, but the undefined variable enhanceSkill is being passed to calculateBarspellPower.

For consistency,  I just renamed all instances of enchanceSkill to enhanceSkill in the barspells.