### PR TITLE
SCRIPTS/CORE: Add Scavenge Functionality

### DIFF
--- a/scripts/globals/abilities/scavenge.lua
+++ b/scripts/globals/abilities/scavenge.lua
@@ -13,7 +13,7 @@ require("scripts/globals/status");
 -- onAbilityCheck
 -----------------------------------
 
-function onAbilityCheck(player,target,ability)
+function onAbilityCheck(player,target,ability,action)
     return 0,0;
 end;
 

--- a/scripts/globals/abilities/scavenge.lua
+++ b/scripts/globals/abilities/scavenge.lua
@@ -14,35 +14,59 @@ require("scripts/globals/status");
 -----------------------------------
 
 function onAbilityCheck(player,target,ability)
-	return 0,0;
+    return 0,0;
 end;
 
 -----------------------------------
 -- onUseAbility
 -----------------------------------
 
-function onUseAbility(user,target,ability)
+function onUseAbility(player, target, ability, action)
 
     -- RNG AF2 quest check
-    local FireAndBrimstoneCS = user:getVar("fireAndBrimstone");
+    local FireAndBrimstoneCS = player:getVar("fireAndBrimstone");
 
-    if (user:getZoneID() == 151 and FireAndBrimstoneCS == 5 and -- zone + quest match
-        user:getYPos() > -43 and user:getYPos() < -38 and -- Y match
-        user:getXPos() > -85 and user:getXPos() < -73 and -- X match
-        user:getZPos() > -85 and user:getZPos() < -75 and -- Z match
+    if (player:getZoneID() == 151 and FireAndBrimstoneCS == 5 and -- zone + quest match
+        player:getYPos() > -43 and player:getYPos() < -38 and -- Y match
+        player:getXPos() > -85 and player:getXPos() < -73 and -- X match
+        player:getZPos() > -85 and player:getZPos() < -75 and -- Z match
         math.random(100) < 50) then
 
-        if (user:getFreeSlotsCount() == 0) then
-            user:messageSpecial(ITEM_CANNOT_BE_OBTAINED,1113);
+        if (player:getFreeSlotsCount() == 0) then
+            player:messageSpecial(ITEM_CANNOT_BE_OBTAINED,1113);
         else
-            user:addItem(1113);
-            user:messageSpecial(ITEM_OBTAINED,1113);
+            player:addItem(1113);
+            player:messageSpecial(ITEM_OBTAINED,1113);
         end
 
     else
 
-    -- TODO: whom ever fancies making scavenger.  The RNG stuff can then be refactored
-
+    local bonuses = (player:getMod(MOD_SCAVENGE_EFFECT)  + player:getMerit(MERIT_SCAVENGE_EFFECT) ) / 100;
+    local arrowsToReturn = math.floor(math.floor(player:getLocalVar("ArrowsUsed")  % 10000) * (player:getMainLvl() / 200 + bonuses));
+    
+        if(arrowsToReturn == 0) then
+            action:setMessageID(139);
+        else
+            if (arrowsToReturn > 99) then
+                arrowsToReturn = 99;
+            end
+            
+            local arrowID = math.floor(player:getLocalVar("ArrowsUsed")  / 10000);
+            
+            player:addItem(arrowID, arrowsToReturn);        
+    
+            if (arrowsToReturn == 1) then
+                action:setParam(arrowID);
+                action:setMessageID(140);
+            else 
+                action:setParam(arrowID);
+                action:setMessageID(674);
+                action:setAdditionalEffect(1);
+                action:setAddEffectParam(arrowsToReturn);
+            end
+        end
+        
+        -- Reset use count
+        player:setLocalVar("ArrowsUsed", 0);
     end
-
 end;

--- a/src/map/ai/ai_char_normal.cpp
+++ b/src/map/ai/ai_char_normal.cpp
@@ -2037,6 +2037,17 @@ void CAICharNormal::ActionJobAbilityFinish()
             }
             m_PChar->m_ActionList.push_back(Action);
         }
+        else if (m_PJobAbility->getID() == ABILITY_SCAVENGE)
+        {
+            Action.ActionTarget = m_PBattleSubTarget;
+            Action.reaction = REACTION_NONE;
+            Action.speceffect = SPECEFFECT_RECOIL;
+            Action.animation = m_PJobAbility->getAnimationID();
+
+            int32 value = luautils::OnUseAbility(m_PChar, m_PBattleSubTarget, GetCurrentJobAbility(), &Action);
+
+            m_PChar->m_ActionList.push_back(Action);
+        }
         else
         {
             Action.ActionTarget = m_PBattleSubTarget;

--- a/src/map/ai/ai_char_normal.cpp
+++ b/src/map/ai/ai_char_normal.cpp
@@ -63,6 +63,41 @@ This file is part of DarkStar-server source code.
 #include "ai_char_normal.h"
 #include "ai_pet_dummy.h"
 
+void trackArrowUsageForScavenge(CItemWeapon* PAmmo, CCharEntity* m_PChar)
+{
+    // Check if local has been set yet
+    if (m_PChar->GetLocalVar("ArrowsUsed") == 0)
+    {
+        // Local not set yet so set
+        m_PChar->SetLocalVar("ArrowsUsed", PAmmo->getID() * 10000 + 1);
+        //printf("\n arrows used: %i", m_PChar->GetLocalVar("ArrowsUsed"));
+    }
+    else
+    {
+        // Local exists now check if arrow used is same as last time
+        if ((floor(m_PChar->GetLocalVar("ArrowsUsed") / 10000)) == PAmmo->getID())
+        {
+            // Same arrow used as last time now check that arrows used do not go above 1980
+            if (floor(m_PChar->GetLocalVar("ArrowsUsed") % 10000) >= 1980)
+            {
+                // Do not increment arrows used past 1980
+                //printf("\n arrows used: %i", m_PChar->GetLocalVar("ArrowsUsed"));
+            }
+            else
+            {
+                // Safe to increment arrows used
+                m_PChar->SetLocalVar("ArrowsUsed", m_PChar->GetLocalVar("ArrowsUsed") + 1);
+                //printf("\n arrows used %i", m_PChar->GetLocalVar("ArrowsUsed"));
+            }
+        }
+        else
+        {
+            // Different arrow is being used so remake local
+            m_PChar->SetLocalVar("ArrowsUsed", PAmmo->getID() * 10000 + 1);
+            //printf("\n arrows used: %i", m_PChar->GetLocalVar("ArrowsUsed"));
+        }
+    }
+}
 
 /************************************************************************
 *																		*
@@ -1108,6 +1143,7 @@ void CAICharNormal::ActionRangedFinish()
             {
                 if ((PAmmo->getQuantity() - 1) < 1) // ammo will run out after this shot, make sure we remove it from equip
                 {
+                    trackArrowUsageForScavenge(PAmmo, m_PChar);
                     uint8 slot = m_PChar->equip[SLOT_AMMO];
 		    uint8 loc = m_PChar->equipLoc[SLOT_AMMO];
                     charutils::UnequipItem(m_PChar, SLOT_AMMO);
@@ -1118,6 +1154,7 @@ void CAICharNormal::ActionRangedFinish()
                 }
                 else
                 {
+                    trackArrowUsageForScavenge(PAmmo, m_PChar);
                     charutils::UpdateItem(m_PChar, m_PChar->equipLoc[SLOT_AMMO], m_PChar->equip[SLOT_AMMO], -1);
                 }
                 m_PChar->pushPacket(new CInventoryFinishPacket());
@@ -1972,6 +2009,7 @@ void CAICharNormal::ActionJobAbilityFinish()
 
                 if ((PAmmo->getQuantity() - 1) < 1) // ammo will run out after this shot, make sure we remove it from equip
                 {
+                    trackArrowUsageForScavenge(PAmmo, m_PChar);
                     uint8 slot = m_PChar->equip[SLOT_AMMO];
 		    uint8 loc = m_PChar->equipLoc[SLOT_AMMO];
                     charutils::UnequipItem(m_PChar, SLOT_AMMO);
@@ -1980,6 +2018,7 @@ void CAICharNormal::ActionJobAbilityFinish()
                 }
                 else
                 {
+                    trackArrowUsageForScavenge(PAmmo, m_PChar);
                     charutils::UpdateItem(m_PChar, m_PChar->equipLoc[SLOT_AMMO], m_PChar->equip[SLOT_AMMO], -1);
                 }
 

--- a/src/map/lua/lua_action.cpp
+++ b/src/map/lua/lua_action.cpp
@@ -1,0 +1,83 @@
+/*
+===========================================================================
+
+  Copyright (c) 2010-2015 Darkstar Dev Teams
+
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program.  If not, see http://www.gnu.org/licenses/
+
+  This file is part of DarkStar-server source code.
+
+===========================================================================
+*/
+
+#include "lua_action.h"
+
+CLuaAction::CLuaAction(lua_State *L)
+{
+    if( !lua_isnil(L,-1) )
+    {
+        m_PLuaAction = (apAction_t*)(lua_touserdata(L, -1));
+        lua_pop(L,1);
+    }else{
+        m_PLuaAction = nullptr;
+    }
+}
+
+CLuaAction::CLuaAction(apAction_t* Action)
+{
+    m_PLuaAction = Action;
+}
+
+inline int32 CLuaAction::setParam(lua_State* L)
+{
+    DSP_DEBUG_BREAK_IF(m_PLuaAction == nullptr);
+    m_PLuaAction->param = lua_tointeger(L, -1);
+    return 0;
+}
+
+inline int32 CLuaAction::setMessageID(lua_State* L)
+{
+    DSP_DEBUG_BREAK_IF(m_PLuaAction == nullptr);
+
+    m_PLuaAction->messageID = lua_tointeger(L, -1);
+    return 0;
+}
+
+inline int32 CLuaAction::setAdditionalEffect(lua_State* L)
+{
+    DSP_DEBUG_BREAK_IF(m_PLuaAction == nullptr);
+
+    m_PLuaAction->additionalEffect = static_cast<SUBEFFECT>(lua_tointeger(L, -1));
+    return 0;
+}
+
+inline int32 CLuaAction::setAddEffectParam(lua_State* L)
+{
+    DSP_DEBUG_BREAK_IF(m_PLuaAction == nullptr);
+    m_PLuaAction->addEffectParam = lua_tointeger(L, -1);
+    return 0;
+}
+
+
+// Initialize Lua Methods
+const int8 CLuaAction::className[] = "CAction";
+
+Lunar<CLuaAction>::Register_t CLuaAction::methods[] = 
+{
+    LUNAR_DECLARE_METHOD(CLuaAction, setParam),
+    LUNAR_DECLARE_METHOD(CLuaAction, setMessageID),
+    LUNAR_DECLARE_METHOD(CLuaAction, setAddEffectParam),
+    LUNAR_DECLARE_METHOD(CLuaAction, setAdditionalEffect),
+    {nullptr,nullptr}
+};

--- a/src/map/lua/lua_action.h
+++ b/src/map/lua/lua_action.h
@@ -1,0 +1,55 @@
+/*
+===========================================================================
+
+  Copyright (c) 2010-2015 Darkstar Dev Teams
+
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program.  If not, see http://www.gnu.org/licenses/
+
+  This file is part of DarkStar-server source code.
+
+===========================================================================
+*/
+
+#ifndef _LUAACTION_H
+#define _LUAACTION_H
+
+#include "../../common/cbasetypes.h"
+#include "../../common/lua/lunar.h"
+
+#include "../entities/battleentity.h"
+
+class CLuaAction
+{
+    apAction_t* m_PLuaAction;
+
+public:
+
+    static const int8 className[];
+    static Lunar<CLuaAction>::Register_t methods[];
+
+    CLuaAction(lua_State*);
+    CLuaAction(apAction_t*);
+
+    apAction_t* GetAction() const
+    {
+        return m_PLuaAction;
+    }
+
+    int32 setParam(lua_State*);
+    int32 setMessageID(lua_State*);
+    int32 setAddEffectParam(lua_State*);
+    int32 setAdditionalEffect(lua_State*);
+};
+
+#endif

--- a/src/map/lua/luautils.cpp
+++ b/src/map/lua/luautils.cpp
@@ -32,6 +32,7 @@
 
 #include "luautils.h"
 #include "lua_ability.h"
+#include "lua_action.h"
 #include "lua_baseentity.h"
 #include "lua_battlefield.h"
 #include "lua_region.h"
@@ -45,6 +46,7 @@
 
 #include "../alliance.h"
 #include "../ability.h"
+#include "../action.h"
 #include "../entities/baseentity.h"
 #include "../utils/battleutils.h"
 #include "../entities/charentity.h"
@@ -135,6 +137,7 @@ int32 init()
     lua_register(LuaHandle,"getSpell",luautils::getSpell);
 
     Lunar<CLuaAbility>::Register(LuaHandle);
+    Lunar<CLuaAction>::Register(LuaHandle);
 	Lunar<CLuaBaseEntity>::Register(LuaHandle);
     Lunar<CLuaBattlefield>::Register(LuaHandle);
 	Lunar<CLuaInstance>::Register(LuaHandle);
@@ -3294,9 +3297,12 @@ int32 OnUseAbility(CCharEntity* PChar, CBattleEntity* PTarget, CAbility* PAbilit
 
     CLuaAbility LuaAbility(PAbility);
 	Lunar<CLuaAbility>::push(LuaHandle,&LuaAbility);
+	
+    CLuaAction LuaAction(action);
+    Lunar<CLuaAction>::push(LuaHandle, &LuaAction);
 
-	if( lua_pcall(LuaHandle,3,LUA_MULTRET,0) )
-	{
+    if( lua_pcall(LuaHandle,4,LUA_MULTRET,0) )
+    {
 		ShowError("luautils::onUseAbility: %s\n",lua_tostring(LuaHandle,-1));
         lua_pop(LuaHandle, 1);
 		return 0;

--- a/src/map/lua/luautils.cpp
+++ b/src/map/lua/luautils.cpp
@@ -46,7 +46,6 @@
 
 #include "../alliance.h"
 #include "../ability.h"
-#include "../action.h"
 #include "../entities/baseentity.h"
 #include "../utils/battleutils.h"
 #include "../entities/charentity.h"

--- a/win32/DSGame-server/DSGame-server.vcxproj
+++ b/win32/DSGame-server/DSGame-server.vcxproj
@@ -268,6 +268,7 @@
     <ClInclude Include="..\..\src\map\linkshell.h" />
     <ClInclude Include="..\..\src\map\lua\luautils.h" />
     <ClInclude Include="..\..\src\map\lua\lua_ability.h" />
+    <ClInclude Include="..\..\src\map\lua\lua_action.h" />
     <ClInclude Include="..\..\src\map\lua\lua_baseentity.h" />
     <ClInclude Include="..\..\src\map\lua\lua_battlefield.h" />
     <ClInclude Include="..\..\src\map\lua\lua_instance.h" />
@@ -504,6 +505,7 @@
     <ClCompile Include="..\..\src\map\linkshell.cpp" />
     <ClCompile Include="..\..\src\map\lua\luautils.cpp" />
     <ClCompile Include="..\..\src\map\lua\lua_ability.cpp" />
+    <ClCompile Include="..\..\src\map\lua\lua_action.cpp" />
     <ClCompile Include="..\..\src\map\lua\lua_baseentity.cpp" />
     <ClCompile Include="..\..\src\map\lua\lua_battlefield.cpp" />
     <ClCompile Include="..\..\src\map\lua\lua_instance.cpp" />

--- a/win32/DSGame-server/DSGame-server.vcxproj.filters
+++ b/win32/DSGame-server/DSGame-server.vcxproj.filters
@@ -569,6 +569,9 @@
     <ClInclude Include="..\..\src\map\lua\lua_ability.h">
       <Filter>Header Files\lua</Filter>
     </ClInclude>
+    <ClInclude Include="..\..\src\map\lua\lua_action.h">
+      <Filter>Header Files\lua</Filter>
+    </ClInclude>
     <ClInclude Include="..\..\src\map\recast_container.h">
       <Filter>Header Files</Filter>
     </ClInclude>
@@ -1280,6 +1283,9 @@
       <Filter>Source Files\ai</Filter>
     </ClCompile>
     <ClCompile Include="..\..\src\map\lua\lua_ability.cpp">
+      <Filter>Source Files\lua</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\map\lua\lua_action.cpp">
       <Filter>Source Files\lua</Filter>
     </ClCompile>
     <ClCompile Include="..\..\src\map\recast_container.cpp">


### PR DESCRIPTION
The following is my testing from retail and I did similar testing with the code I made for dsp.
The formula I am testing:
-floor(used * (jobLv / 200 + Scavenge Effect bonus))

Test formula:
-floor(3 arrow test * (66 / 200)) = .99 did not get an arrow
-floor(99 arrows used * (66 / 200)) = 32.67 got 32 arrows
-floor(304 arrows used * (66 / 200)) = 100.32 got 99 arrows
-floor(50 arrows used * (66 / 200 + Hunter's Socks(.05))) = 19 got 19 arrows

Use count variable tests:
-unlimited shot and recycle do not use count
-zoning resets use count
-using scavenge resets use count
-Using a different arrow resets use count
-switching to same arrow and using keeps count
-max use count is 99
-Do not have to have bonus gear on while using arrows
	Can put bonus gear on before using the skill to get bonus

Bonus from Gear/Merits:
-Found Hunter's Socks to be .05

~I did notestthese myself but am going with what wikia and bg have
http://ffxiclopedia.wikia.com/wiki/Scavenge_Effect
https://www.bg-wiki.com/bg/Scavenge

-Hunter's Socks +1 .05
-Orion Socks .07
- .05 per merit point up to .25

Least amount of arrows used to get stack back:
floor(122 arrows used * (99 / 200 + .07 + .25)) = 99.43

Heightist amount of arrows a lv 10 with no bonus would have to use to get 99 arrows 

-floor(1980 arrow test * (10 / 200)) = 99

