### PR TITLE
SQL/Scripts - Soulflayer & Yovra moves

### DIFF
--- a/scripts/globals/mobskills/Immortal_Anathema.lua
+++ b/scripts/globals/mobskills/Immortal_Anathema.lua
@@ -1,0 +1,27 @@
+---------------------------------------------
+--  Immortal Anathema
+--
+--  Description: Inflicts a curse on all targets in an area of effect.
+--  Type: Enfeebling
+--  Utsusemi/Blink absorb: Ignores shadows
+--  Range: AoE
+--  Notes: 
+---------------------------------------------
+require("scripts/globals/settings");
+require("scripts/globals/status");
+require("scripts/globals/monstertpmoves");
+
+---------------------------------------------
+function onMobSkillCheck(target,mob,skill)
+    return 0;
+end;
+
+function onMobWeaponSkill(target, mob, skill)
+    local typeEffect = EFFECT_CURSE_I;
+
+    local msg = MobStatusEffectMove(mob, target, typeEffect, 25, 0, 300);
+
+    skill:setMsg(msg);
+
+    return typeEffect;
+end;

--- a/scripts/globals/mobskills/Luminous_Drape.lua
+++ b/scripts/globals/mobskills/Luminous_Drape.lua
@@ -1,0 +1,29 @@
+---------------------------------------------------
+--  Luminous Drape
+--
+--  Description: A glowing curtain charms all nearby targets.
+--  Type: Enfeebling
+--  Utsusemi/Blink absorb: Ignores shadows
+--  Range: AoE 10'
+--  Notes: 
+---------------------------------------------------
+
+require("scripts/globals/settings");
+require("scripts/globals/status");
+require("scripts/globals/monstertpmoves");
+
+---------------------------------------------------
+
+function onMobSkillCheck(target,mob,skill)
+    return 0;
+end;
+
+function onMobWeaponSkill(target, mob, skill)
+    local typeEffect = EFFECT_CHARM_I;
+    local msg = MobStatusEffectMove(mob, target, typeEffect, 1, 0, 60);
+	
+    skill:setMsg(msg);
+    mob:resetEnmity(target);
+
+    return typeEffect;
+end

--- a/scripts/globals/mobskills/Mind_Blast.lua
+++ b/scripts/globals/mobskills/Mind_Blast.lua
@@ -1,0 +1,29 @@
+---------------------------------------------
+--  Mind Blast
+--
+--  Description: Deals lightning damage to an enemy. Additional effect: "Paralysis"
+--  Type: Magical (lightning)
+--  Utsusemi/Blink absorb: Wipes shadows
+--  Range: Cone
+--  Notes: 
+---------------------------------------------
+require("scripts/globals/settings");
+require("scripts/globals/status");
+require("scripts/globals/monstertpmoves");
+---------------------------------------------
+function onMobSkillCheck(target,mob,skill)
+    return 0;
+end;
+
+function onMobWeaponSkill(target, mob, skill)
+    local typeEffect = EFFECT_PARALYSIS;
+
+    MobStatusEffectMove(mob, target, typeEffect, 20, 0, 180);
+
+    local dmgmod = 1;
+    local accmod = 1;
+    local info = MobMagicalMove(mob,target,skill,mob:getWeaponDmg()*6,ELE_THUNDER,dmgmod,TP_NO_EFFECT);
+    local dmg = MobFinalAdjustments(info.dmg,mob,skill,target,MOBSKILL_MAGICAL,MOBPARAM_THUNDER,MOBPARAM_WIPE_SHADOWS);
+    target:delHP(dmg);
+    return dmg;
+end;

--- a/scripts/globals/mobskills/Mind_Purge.lua
+++ b/scripts/globals/mobskills/Mind_Purge.lua
@@ -1,0 +1,35 @@
+---------------------------------------------------
+--  Mind Purge
+--
+--  Description: Dispels all buffs from a single target, including food.
+--  Type: Enfeebling
+--  Utsusemi/Blink absorb: Dispels shadows
+--  Range: Single target
+--  Notes: 
+---------------------------------------------------
+
+require("scripts/globals/settings");
+require("scripts/globals/status");
+require("scripts/globals/monstertpmoves");
+
+---------------------------------------------------
+
+function onMobSkillCheck(target,mob,skill)
+    return 0;
+end;
+
+function onMobWeaponSkill(target, mob, skill)
+
+    local dispel =  target:dispelAllStatusEffect(bit.bor(EFFECTFLAG_DISPELABLE, EFFECTFLAG_FOOD));
+    local msg; -- to be set later
+
+    if(dispel == 0) then
+        msg = MSG_NO_EFFECT; -- no effect
+    else
+        msg = MSG_DISAPPEAR_NUM;
+    end
+	
+    skill:setMsg(msg);
+
+    return dispel;
+end

--- a/scripts/globals/mobskills/Murk.lua
+++ b/scripts/globals/mobskills/Murk.lua
@@ -15,20 +15,20 @@ function onMobSkillCheck(target,mob,skill)
 end;
 
 function onMobWeaponSkill(target, mob, skill)
-    local silenced = false;
-    local blinded = false;
 
-    silenced = MobStatusEffectMove(mob, target, EFFECT_SLOW, 128, 0, 60);
+    local slowed = false;
+    local weight = false;
 
-    blinded = MobStatusEffectMove(mob, target, EFFECT_WEIGHT, 40, 0, 60);
+    slowed = MobStatusEffectMove(mob, target, EFFECT_SLOW, 128, 0, 60);
+    weight = MobStatusEffectMove(mob, target, EFFECT_WEIGHT, 40, 0, 60);
 
     skill:setMsg(MSG_ENFEEB_IS);
 
-    -- display silenced first, else blind
-    if(silenced == MSG_ENFEEB_IS) then
-        typeEffect = EFFECT_SILENCE;
-    elseif(blinded == MSG_ENFEEB_IS) then
-        typeEffect = EFFECT_BLINDNESS;
+    -- display slow first, else weight
+    if(slowed == MSG_ENFEEB_IS) then
+        typeEffect = EFFECT_SLOW;
+    elseif(weight == MSG_ENFEEB_IS) then
+        typeEffect = EFFECT_WEIGHT;
     else
         skill:setMsg(MSG_MISS);
     end

--- a/scripts/globals/mobskills/Tribulation.lua
+++ b/scripts/globals/mobskills/Tribulation.lua
@@ -1,0 +1,41 @@
+---------------------------------------------
+--  Tribulation
+--
+--  Description: Inflicts Bio and blinds all targets in an area of effect.
+--  Type: Enfeebling
+--  Utsusemi/Blink absorb: Ignores shadows
+--  Range: AoE
+--  Notes: Bio effect can take away up to 39/tick.
+---------------------------------------------
+
+require("scripts/globals/settings");
+require("scripts/globals/status");
+require("scripts/globals/monstertpmoves");
+
+---------------------------------------------
+
+function onMobSkillCheck(target,mob,skill)
+    return 0;
+end;
+
+function onMobWeaponSkill(target, mob, skill)
+
+    local blinded = false;
+    local bio = false;
+
+    blinded = MobStatusEffectMove(mob, target, EFFECT_BLINDNESS, 20, 0, 120);
+    bio = MobStatusEffectMove(mob, target, EFFECT_BIO, 39, 0, 120);
+
+    skill:setMsg(MSG_ENFEEB_IS);
+
+    -- display blind first, else bio
+    if(blinded == MSG_ENFEEB_IS) then
+        typeEffect = EFFECT_BLINDNESS;
+    elseif(bio == MSG_ENFEEB_IS) then
+        typeEffect = EFFECT_BIO;
+    else
+        skill:setMsg(MSG_MISS);
+    end
+
+    return typeEffect;
+end;

--- a/scripts/globals/mobskills/Vitriolic_Barrage.lua
+++ b/scripts/globals/mobskills/Vitriolic_Barrage.lua
@@ -1,0 +1,29 @@
+---------------------------------------------
+--  Vitrolic Barrage
+--
+--  Description: Bombards nearby targets with acid, dealing fixed Water damage. Additional effect: Poison 
+--  Type: ??? (Water)
+--  Utsusemi/Blink absorb: Wipes shadows
+--  Range: AoE 10'
+--  Notes: Poison is 20/tic
+---------------------------------------------
+require("scripts/globals/settings");
+require("scripts/globals/status");
+require("scripts/globals/monstertpmoves");
+---------------------------------------------
+function onMobSkillCheck(target,mob,skill)
+    return 0;
+end;
+
+function onMobWeaponSkill(target, mob, skill)
+    local needles = 1000 / skill:getTotalTargets();
+    local typeEffect = EFFECT_POISON;
+
+    MobStatusEffectMove(mob, target, typeEffect, 20, 3, 60);
+
+    local dmg = MobFinalAdjustments(needles,mob,skill,target,MOBSKILL_PHYSICAL,MOBPARAM_WATER,MOBPARAM_WIPE_SHADOWS);
+
+    target:delHP(dmg);
+
+    return dmg;
+end;

--- a/scripts/globals/spells/bluemagic/mind_blast.lua
+++ b/scripts/globals/spells/bluemagic/mind_blast.lua
@@ -54,7 +54,6 @@ function onSpellCast(caster,target,spell)
 
     if(damage > 0 and resist > 0.3) then
         local typeEffect = EFFECT_PARALYSIS;
-        target:delStatusEffect(typeEffect); -- Wiki says it can overwrite itself or other binds
         target:addStatusEffect(typeEffect,52,0,getBlueEffectDuration(caster,resist,typeEffect)); -- No info for power on the internet, static to 12 for now.
     end
 

--- a/sql/mob_skill.sql
+++ b/sql/mob_skill.sql
@@ -1737,13 +1737,13 @@ INSERT INTO `mob_skill` VALUES (1212,272,1079,'Reactor_Overheat',4,10.0,2000,100
 INSERT INTO `mob_skill` VALUES (1213,272,1080,'Reactor_Overload',1,8.0,2000,1000,4,0,0,0); -- ring form only
 
 -- Yovra
--- INSERT INTO `mob_skill` VALUES (1114,271,1022,'Vitriolic_Barrage',1,10.0,2000,1500,4,0,0,0);
+INSERT INTO `mob_skill` VALUES (1114,271,1022,'Vitriolic_Barrage',1,10.0,2000,1500,4,0,0,0);
 INSERT INTO `mob_skill` VALUES (1115,271,1023,'Primal_Drill',1,10.0,2000,1500,4,0,0,0);
 INSERT INTO `mob_skill` VALUES (1116,271,1024,'Concussive_Oscillation',1,15.0,2000,1500,4,0,0,7);
 INSERT INTO `mob_skill` VALUES (1117,271,1025,'Ion_Shower',1,15.0,2000,1500,4,0,0,0);
 -- INSERT INTO `mob_skill` VALUES (1118,271,1026,'Torrential_Torment',1,15.0,2000,1500,4,0,0,0);
 INSERT INTO `mob_skill` VALUES (1119,271,1027,'Asthenic_Fog',1,15.0,2000,1500,4,0,0,0);
--- INSERT INTO `mob_skill` VALUES (1120,271,1028,'Luminous_Drape',1,10.0,2000,1500,4,0,0,0);
+INSERT INTO `mob_skill` VALUES (1120,271,1028,'Luminous_Drape',1,10.0,2000,1500,4,0,0,0);
 -- INSERT INTO `mob_skill` VALUES (1121,271,1029,'Fluorescence',0,7.0,2000,1500,1,0,0,0);
 
 -- Aern H2H fam 3 nin mnk
@@ -2745,8 +2745,8 @@ INSERT INTO `mob_skill` VALUES (1887,389,152,'Perfect_defense',1,18.0,2000,1000,
 
 -- Soulflayers
 INSERT INTO `mob_skill` VALUES (1707,233,1327,'Mind_Blast',4,10.0,2000,1000,4,0,0,0);
-INSERT INTO `mob_skill` VALUES (1708,233,1328,'Immortal_Mind',0,7.0,2000,1000,1,0,0,0);
-INSERT INTO `mob_skill` VALUES (1709,233,1329,'Immortal_Shield',0,7.0,2000,1000,1,0,0,0);
+-- INSERT INTO `mob_skill` VALUES (1708,233,1328,'Immortal_Mind',0,7.0,2000,1000,1,0,0,0);
+-- INSERT INTO `mob_skill` VALUES (1709,233,1329,'Immortal_Shield',0,7.0,2000,1000,1,0,0,0);
 INSERT INTO `mob_skill` VALUES (1710,233,1330,'Mind_Purge',0,7.0,2000,1000,4,0,0,0);
 INSERT INTO `mob_skill` VALUES (1711,233,1331,'Tribulation',1,15.0,2000,1000,4,0,0,0);
 INSERT INTO `mob_skill` VALUES (1712,233,1332,'Immortal_Anathema',1,15.0,2000,1000,4,0,0,0);
@@ -2921,12 +2921,12 @@ INSERT INTO `mob_skill` VALUES (1497,310,1185,'Hysteric_Barrage',0,7.0,2000,1500
 INSERT INTO `mob_skill` VALUES (1502,310,1190,'Tail_Slap',4,10.0,2000,1500,4,0,0,3);
 
 -- Mahjlaef the Paintorn (311)
--- INSERT INTO `mob_skill` VALUES (1707,311,1327,'Mind_Blast',4,10.0,2000,1000,4,0,0,0);
+INSERT INTO `mob_skill` VALUES (1707,311,1327,'Mind_Blast',4,10.0,2000,1000,4,0,0,0);
 -- INSERT INTO `mob_skill` VALUES (1708,311,1328,'Immortal_Mind',0,7.0,2000,1000,1,0,0,0);
 -- INSERT INTO `mob_skill` VALUES (1709,311,1329,'Immortal_Shield',0,7.0,2000,1000,1,0,0,0);
--- INSERT INTO `mob_skill` VALUES (1710,311,1330,'Mind_Purge',0,7.0,2000,1000,4,0,0,0);
--- INSERT INTO `mob_skill` VALUES (1711,311,1331,'Tribulation',1,15.0,2000,1000,4,0,0,0);
--- INSERT INTO `mob_skill` VALUES (1712,311,1332,'Immortal_Anathema',1,15.0,2000,1000,4,0,0,0);
+INSERT INTO `mob_skill` VALUES (1710,311,1330,'Mind_Purge',0,7.0,2000,1000,4,0,0,0);
+INSERT INTO `mob_skill` VALUES (1711,311,1331,'Tribulation',1,15.0,2000,1000,4,0,0,0);
+INSERT INTO `mob_skill` VALUES (1712,311,1332,'Immortal_Anathema',1,15.0,2000,1000,4,0,0,0);
 -- INSERT INTO `mob_skill` VALUES (0,311,0,'Reprobation',1,18.0,2000,1500,4,0,0,0); -- Only by NM
 
 -- Nuhn (312)


### PR DESCRIPTION
Implemented Immortal Anathema, Mind Blast, Mind Purge, and Tribulation for Soulflayers, and Luminous Drape and Vitriolic Barrage for Yovra. For the Mind Blast BLU spell, all sources I checked did not say that bind er... paralysis overwrites itself/other sources so I removed it.

I did not implement Immortal Shield or Immortal Mind because I could not find a source for their power, nor do I know how to do the animation that exists while Immortal Shield buff is active.