### PR TITLE
CORE: Remove superlink from Waking Dreams BCNM

### DIFF
--- a/src/map/utils/mobutils.cpp
+++ b/src/map/utils/mobutils.cpp
@@ -585,9 +585,9 @@ void CalculateStats(CMobEntity * PMob)
         PMob->m_maxRoamDistance = 0.5f;
     }
 
-    if((zoneType == ZONETYPE_BATTLEFIELD) && (PMob->m_bcnmID != 864) && (PMob->m_bcnmID != 704))
+    if((zoneType == ZONETYPE_BATTLEFIELD) && (PMob->m_bcnmID != 864) && (PMob->m_bcnmID != 704) && (PMob->m_bcnmID != 706))
     {
-        // bcnmID 864 (desires of emptiness) and 704 (darkness named) don't superlink
+        // bcnmID 864 (desires of emptiness), 704 (darkness named), and 706 (waking dreams) don't superlink
         // force all mobs in same instance to superlink
         // plus one in case id is zero
         PMob->setMobMod(MOBMOD_SUPERLINK, PMob->m_battlefieldID);


### PR DESCRIPTION
Because the Diremites are only supposed to attack if you fall down below.

BCNM ID from: https://github.com/DarkstarProject/darkstar/blob/master/sql/bcnm_info.sql#L216