### PR TITLE
Scripts: Healing Breath and Spirit Link updates

### DIFF
--- a/scripts/globals/abilities/pets/healing_breath_i.lua
+++ b/scripts/globals/abilities/pets/healing_breath_i.lua
@@ -13,26 +13,30 @@ function onAbilityCheck(player, target, ability)
 end;
 
 function onPetAbility(target, pet, skill, master)
-	-- TODO: Correct base value (45/256).  See Healing Breath III for details.
+
+   -- TODO:
+   -- Healing Breath I and II should have lower multipliers.  They'll need to be corrected if the multipliers are ever found.  Don't want to over-correct right now.
 
    ---------- Deep Breathing ----------
    -- 0 for none
-   -- 1 for first merit
-   -- 0.25 for each merit after the first
-   -- TODO: 0.1 per merit for augmented AF2 (10663 *w/ augment*)
+   -- 50 for first merit
+   -- 5 for each merit after the first
+   -- TODO: 5 per merit for augmented AF2 (10663 *w/ augment*)
    local deep = 0;
    if (pet:hasStatusEffect(EFFECT_MAGIC_ATK_BOOST) == true) then
-      deep = 1+((master:getMerit(MERIT_DEEP_BREATHING)-1)*0.25);
+      deep = 50 + (master:getMerit(MERIT_DEEP_BREATHING)-1)*5;
       pet:delStatusEffect(EFFECT_MAGIC_ATK_BOOST);
    end
 
-   local gear = master:getMod(MOD_WYVERN_BREATH)/256; -- Master gear that enhances breath
+   local gear = master:getMod(MOD_WYVERN_BREATH); -- Master gear that enhances breath
 
-	local base = math.floor((45/256)*(1+(pet:getTP()/1024))*(pet:getMaxHP())+42);
-	if(target:getHP()+base > target:getMaxHP()) then
-		base = target:getMaxHP() - target:getHP(); --cap it
-	end
-	skill:setMsg(MSG_SELF_HEAL);
-	target:addHP(base);
-	return base;
+   local tp = math.floor(skill:getTP()/20)/1.165; -- HP only increases for every 20% TP
+
+   local base = math.floor(((45+tp+gear+deep)/256)*(pet:getMaxHP())+42);
+   if(target:getHP()+base > target:getMaxHP()) then
+      base = target:getMaxHP() - target:getHP(); --cap it
+   end
+   skill:setMsg(MSG_SELF_HEAL);
+   target:addHP(base);
+   return base;
 end

--- a/scripts/globals/abilities/pets/healing_breath_ii.lua
+++ b/scripts/globals/abilities/pets/healing_breath_ii.lua
@@ -13,26 +13,30 @@ function onAbilityCheck(player, target, ability)
 end;
 
 function onPetAbility(target, pet, skill, master)
-	-- TODO: Correct base value (45/256).  See Healing Breath III for details.
+
+   -- TODO:
+   -- Healing Breath I and II should have lower multipliers.  They'll need to be corrected if the multipliers are ever found.  Don't want to over-correct right now.
 
    ---------- Deep Breathing ----------
    -- 0 for none
-   -- 1 for first merit
-   -- 0.25 for each merit after the first
-   -- TODO: 0.1 per merit for augmented AF2 (10663 *w/ augment*)
+   -- 50 for first merit
+   -- 5 for each merit after the first
+   -- TODO: 5 per merit for augmented AF2 (10663 *w/ augment*)
    local deep = 0;
    if (pet:hasStatusEffect(EFFECT_MAGIC_ATK_BOOST) == true) then
-      deep = 1+((master:getMerit(MERIT_DEEP_BREATHING)-1)*0.25);
+      deep = 50 + (master:getMerit(MERIT_DEEP_BREATHING)-1)*5;
       pet:delStatusEffect(EFFECT_MAGIC_ATK_BOOST);
    end
 
-   local gear = master:getMod(MOD_WYVERN_BREATH)/256; -- Master gear that enhances breath
+   local gear = master:getMod(MOD_WYVERN_BREATH); -- Master gear that enhances breath
 
-	local base = math.floor((45/256)*(1+(pet:getTP()/1024))*(pet:getMaxHP())+42);
-	if(target:getHP()+base > target:getMaxHP()) then
-		base = target:getMaxHP() - target:getHP(); --cap it
-	end
-	skill:setMsg(MSG_SELF_HEAL);
-	target:addHP(base);
-	return base;
+   local tp = math.floor(skill:getTP()/20)/1.165; -- HP only increases for every 20% TP
+
+   local base = math.floor(((45+tp+gear+deep)/256)*(pet:getMaxHP())+42);
+   if(target:getHP()+base > target:getMaxHP()) then
+      base = target:getMaxHP() - target:getHP(); --cap it
+   end
+   skill:setMsg(MSG_SELF_HEAL);
+   target:addHP(base);
+   return base;
 end

--- a/scripts/globals/abilities/pets/healing_breath_iii.lua
+++ b/scripts/globals/abilities/pets/healing_breath_iii.lua
@@ -13,42 +13,32 @@ function onAbilityCheck(player, target, ability)
 end;
 
 function onPetAbility(target, pet, skill, master)
-   -- Healing Breath III formula:
-   -- floor(0.1757*(Drachen Brais Bonus + "Wyvern Exp Bonus" + 1) * (Helm Bonus + Wyvern TP Bonus + Deep Breathing Bonus + 1)*(Wyvern HP + Wyvern HP+ Gear) + 42)
 
-   -- http://images2.wikia.nocookie.net/__cb20080714061150/ffxi/images/3/32/Healingbreathgraph.jpg
+   -- Info:
+   -- Breath Formula: http://www.bluegartr.com/threads/108543-Wyvern-Breath-Testing?p=5357018&viewfull=1#post5357018
+   -- Healing Breath Results: http://images2.wikia.nocookie.net/__cb20080714061150/ffxi/images/3/32/Healingbreathgraph.jpg (Assume Wyvern has 991 HP)
 
    -- TODO:
-   -- Wyvern stats are wrong.  Should be main job DRG, complete with traits.  Current method uses subjob to track wyvern type.  Healing wyvern ends up with 901 HP @ 75 instead of 991.
-      -- 991 HP is pre-2010 DRG buff
-      -- Wyvern gets row/grade "5" for race in CalculateStats()
-   -- Healing Breath I and II should have lower multipliers.  They'll need to be corrected if the multipliers are ever found.  Don't want to over-correct right now.
-   -- Drachen Brais provide a 10% increase to HP.  0.1 on that slot provides the correct increase, or 0.15 for HQs.
-      -- Per Source 2 below, +HP% gear is applied to Base + non% HP gear.  (991+50)*1.10  If you do that, the formula seems to output the same either way.
    -- Wyvern Exp Bonus is +6% HP per 200 exp gained until 1,000 exp cap, granting a max 30% (0.3 works in the formula)
-      -- This might be handled the same way Drachen Brais are above.  Did not check.
       -- Exp bonus wears off at zone, dismiss, etc, and shouldn't be handled here, as it also adds to other stats.
-   -- Wyvern TP bonus appears to be CurrentTP/1024
-   -- Wyvern HP is the wyvern's current HP, Wyvern HP+ gear is any gear other than Brais that increases wyvern HP.
-      -- Supposedly unused Wyvern HP+ gear added potency, that is 991 current + unused +50 HP > 991 + no HP+ gear.  I have not seen proof of this though.
-   -- Source 1, HB IV multiplier: http://www.bluegartr.com/threads/108543-Wyvern-Breath-Testing?p=5017811&viewfull=1#post5017811
-   -- Source 2, Lots of info: http://www.bluegartr.com/threads/108543-Wyvern-Breath-Testing?p=5357018&viewfull=1#post5357018
-   -- Source for max HP instead of current: http://www.bluegartr.com/threads/108543-Wyvern-Breath-Testing?p=4995110&viewfull=1#post4995110
+   -- Wyvern HP or HP% gear has no effect (Not handled here)
 
    ---------- Deep Breathing ----------
    -- 0 for none
-   -- 1 for first merit
-   -- 0.25 for each merit after the first
-   -- TODO: 0.1 per merit for augmented AF2 (10663 *w/ augment*)
+   -- 50 for first merit
+   -- 5 for each merit after the first
+   -- TODO: 5 per merit for augmented AF2 (10663 *w/ augment*)
    local deep = 0;
    if (pet:hasStatusEffect(EFFECT_MAGIC_ATK_BOOST) == true) then
-      deep = 1+((master:getMerit(MERIT_DEEP_BREATHING)-1)*0.25);
+      deep = 50 + (master:getMerit(MERIT_DEEP_BREATHING)-1)*5;
       pet:delStatusEffect(EFFECT_MAGIC_ATK_BOOST);
    end
 
-   local gear = master:getMod(MOD_WYVERN_BREATH)/256; -- Master gear that enhances breath
+   local gear = master:getMod(MOD_WYVERN_BREATH); -- Master gear that enhances breath
 
-   local base = math.floor((45/256)*(gear+(pet:getTP()/1024)+deep+1)*(pet:getMaxHP())+42);
+   local tp = math.floor(skill:getTP()/20)/1.165; -- HP only increases for every 20% TP
+
+   local base = math.floor(((45+tp+gear+deep)/256)*(pet:getMaxHP())+42);
    if(target:getHP()+base > target:getMaxHP()) then
       base = target:getMaxHP() - target:getHP(); --cap it
    end

--- a/scripts/globals/abilities/pets/healing_breath_iv.lua
+++ b/scripts/globals/abilities/pets/healing_breath_iv.lua
@@ -1,0 +1,47 @@
+---------------------------------------------------
+-- Healing Breath IV
+---------------------------------------------------
+
+require("scripts/globals/settings");
+require("scripts/globals/status");
+require("scripts/globals/monstertpmoves");
+
+---------------------------------------------------
+
+function onAbilityCheck(player, target, ability)
+    return 0,0;
+end;
+
+function onPetAbility(target, pet, skill, master)
+
+   -- Info:
+   -- Breath Formula: http://www.bluegartr.com/threads/108543-Wyvern-Breath-Testing?p=5357018&viewfull=1#post5357018
+
+   -- TODO:
+   -- Wyvern Exp Bonus is +6% HP per 200 exp gained until 1,000 exp cap, granting a max 30% (0.3 works in the formula)
+      -- Exp bonus wears off at zone, dismiss, etc, and shouldn't be handled here, as it also adds to other stats.
+   -- Wyvern HP or HP% gear has no effect (Not handled here)
+
+   ---------- Deep Breathing ----------
+   -- 0 for none
+   -- 50 for first merit
+   -- 5 for each merit after the first
+   -- TODO: 5 per merit for augmented AF2 (10663 *w/ augment*)
+   local deep = 0;
+   if (pet:hasStatusEffect(EFFECT_MAGIC_ATK_BOOST) == true) then
+      deep = 50 + (master:getMerit(MERIT_DEEP_BREATHING)-1)*5;
+      pet:delStatusEffect(EFFECT_MAGIC_ATK_BOOST);
+   end
+
+   local gear = master:getMod(MOD_WYVERN_BREATH); -- Master gear that enhances breath
+
+   local tp = math.floor(skill:getTP()/20)/1.165; -- HP only increases for every 20% TP
+
+   local base = math.floor(((53+tp+gear+deep)/256)*(pet:getMaxHP())+42);
+   if(target:getHP()+base > target:getMaxHP()) then
+      base = target:getMaxHP() - target:getHP(); --cap it
+   end
+   skill:setMsg(MSG_SELF_HEAL);
+   target:addHP(base);
+   return base;
+end

--- a/scripts/globals/abilities/spirit_link.lua
+++ b/scripts/globals/abilities/spirit_link.lua
@@ -32,6 +32,9 @@ function onUseAbility(player,target,ability)
 
     local playerHP = player:getHP();
     local drainamount = (math.random(25,35) / 100) * playerHP;
+	if (player:getPet():getHP() == player:getPet():getMaxHP()) then
+		drainamount = 0; -- Prevents player HP lose if wyvern is at full HP
+	end
     
     if (player:hasStatusEffect(EFFECT_STONESKIN)) then
         local skin = player:getMod(MOD_STONESKIN);


### PR DESCRIPTION
Corrected Deep Breathing values to those for healing breath not elemental breath

Updated TP to skill:getTP, corrected values based on retail data and to only increase for every 20% TP

Corrected main formula so that gear is properly calculated

Updated Spirit Link so that player no longer loses HP if wyvern is at full HP with Empathy merits.