### PR TITLE
Scripts/SQL: Gurfurlur, Tiamat, and Charm

### DIFF
--- a/scripts/globals/effects/magic_shield.lua
+++ b/scripts/globals/effects/magic_shield.lua
@@ -1,6 +1,6 @@
 -----------------------------------
 --
--- 	Magic Shield BLOCKS all magic attacks
+-- Magic Shield BLOCKS all magic attacks
 --
 -----------------------------------
 
@@ -11,11 +11,20 @@ require("scripts/globals/status");
 -----------------------------------
 
 function onEffectGain(target,effect)
-    if (effect:getPower() < 2) then
+    if (effect:getPower() == 3) then -- arcane stomp
+        target:addMod(MOD_FIRE_ABSORB, 100);
+        target:addMod(MOD_EARTH_ABSORB, 100);
+        target:addMod(MOD_WATER_ABSORB, 100);
+        target:addMod(MOD_WIND_ABSORB, 100);
+        target:addMod(MOD_ICE_ABSORB, 100);
+        target:addMod(MOD_LTNG_ABSORB, 100);
+        target:addMod(MOD_LIGHT_ABSORB, 100);
+        target:addMod(MOD_DARK_ABSORB, 100);
+    elseif (effect:getPower() < 2) then
         target:addMod(MOD_UDMGMAGIC, -256);
     else
         target:addMod(MOD_MAGIC_ABSORB, 100);
-    end
+    end;
 end;
 
 -----------------------------------
@@ -30,9 +39,18 @@ end;
 -----------------------------------
 
 function onEffectLose(target,effect)
-    if (effect:getPower() < 2) then
+    if (effect:getPower() == 3) then -- arcane stomp
+        target:delMod(MOD_FIRE_ABSORB, 100);
+        target:delMod(MOD_EARTH_ABSORB, 100);
+        target:delMod(MOD_WATER_ABSORB, 100);
+        target:delMod(MOD_WIND_ABSORB, 100);
+        target:delMod(MOD_ICE_ABSORB, 100);
+        target:delMod(MOD_LTNG_ABSORB, 100);
+        target:delMod(MOD_LIGHT_ABSORB, 100);
+        target:delMod(MOD_DARK_ABSORB, 100);
+    elseif (effect:getPower() < 2) then
         target:delMod(MOD_UDMGMAGIC, -256);
     else
         target:delMod(MOD_MAGIC_ABSORB, 100);
-    end
+    end;
 end;

--- a/scripts/globals/mobskills/Arcane_Stomp.lua
+++ b/scripts/globals/mobskills/Arcane_Stomp.lua
@@ -19,19 +19,11 @@ function onMobSkillCheck(target,mob,skill)
 end;
 
 function onMobWeaponSkill(target, mob, skill)
---[[
-    power = 1;
-    tic = 0;
-    duration = 60;
-
-    typeEffect = EFFECT_NAME;
-    skill:setMsg(MSG_BUFF);
-    if(mob:hasStatusEffect(typeEffect) == true) then
-        oldEffect = mob:getStatusEffect(typeEffect);
-        oldEffect:setPower(power);
-        oldEffect:setDuration(duration);
-    else
-        mob:addStatusEffect(typeEffect,power,tic,duration);
+    
+    local duration = 300;
+    local typeEffect = EFFECT_MAGIC_SHIELD;
+    local msg = MobBuffMove(mob,typeEffect,3,0,duration);
+	
+    skill:setMsg(msg);
     return typeEffect;
-	]]
 end;

--- a/scripts/globals/mobskills/Danse_Macabre.lua
+++ b/scripts/globals/mobskills/Danse_Macabre.lua
@@ -1,5 +1,11 @@
 ---------------------------------------------------
--- Charm enemy
+--  Danse Macabre
+-- 
+--  Description: Charms a single target.
+--  Type: Enfeebling
+--  Utsusemi/Blink absorb: N/A
+--  Range: Single target
+--  Notes:
 ---------------------------------------------------
 
 require("scripts/globals/settings");
@@ -9,14 +15,15 @@ require("scripts/globals/monstertpmoves");
 ---------------------------------------------------
 
 function onMobSkillCheck(target,mob,skill)
-	return 0;
+    return 0;
 end;
 
 function onMobWeaponSkill(target, mob, skill)
-	local typeEffect = EFFECT_CHARM_I;
-    skill:setMsg(MobStatusEffectMove(mob, target, typeEffect, 1, 0, 60));
+    local typeEffect = EFFECT_CHARM_I;
+    local msg = MobStatusEffectMove(mob, target, typeEffect, 0, 0, 60)
 
+    skill:setMsg(msg);
     mob:resetEnmity(target);
 
-	return typeEffect;
+    return typeEffect;
 end

--- a/scripts/globals/mobskills/Fanatic_Dance.lua
+++ b/scripts/globals/mobskills/Fanatic_Dance.lua
@@ -1,6 +1,11 @@
 ---------------------------------------------------
--- Sandstorm
--- Kicks up a blinding dust cloud on targets in an area of effect.
+--  Fanatic Dance
+--
+--  Description: Charms all targets in an area of effect.
+--  Type: Enfeebling
+--  Utsusemi/Blink absorb: N/A
+--  Range: AoE around user
+--  Notes:
 ---------------------------------------------------
 
 require("scripts/globals/settings");
@@ -10,17 +15,18 @@ require("scripts/globals/monstertpmoves");
 ---------------------------------------------------
 
 function onMobSkillCheck(target,mob,skill)
-	if(mob:isInDynamis() and mob:isMobType(MOBTYPE_NOTORIOUS)) then
-		return 0;
-	end
-	return 1;
+    if(mob:isInDynamis() and mob:isMobType(MOBTYPE_NOTORIOUS)) then
+        return 0;
+    end
+    return 1;
 end;
 
 function onMobWeaponSkill(target, mob, skill)
-	local typeEffect = EFFECT_CHARM_I;
-    skill:setMsg(MobStatusEffectMove(mob, target, typeEffect, 1, 0, 60));
+    local typeEffect = EFFECT_CHARM_I;
+    local msg = MobStatusEffectMove(mob, target, typeEffect, 0, 0, 60);
 
+    skill:setMsg(msg);
     mob:resetEnmity(target);
 
-	return typeEffect;
+    return typeEffect;
 end

--- a/scripts/globals/mobskills/Fulmination.lua
+++ b/scripts/globals/mobskills/Fulmination.lua
@@ -3,7 +3,7 @@
 --
 --  Description: Deals heavy magical damage in an area of effect. Additional effect: Paralysis + Stun
 --  Type: Magical
---  Wipes Shadows
+--  Utsusemi/Blink absorb: Wipes Shadows
 --  Range: 30 yalms
 ---------------------------------------------
 require("scripts/globals/settings");
@@ -12,27 +12,29 @@ require("scripts/globals/monstertpmoves");
 
 ---------------------------------------------
 function onMobSkillCheck(target,mob,skill)
-   local family = mob:getFamily();
-   local mobhp = mob:getHPP();
+    local family = mob:getFamily();
+    local mobhp = mob:getHPP();
+    local result = 1
 
-   if (family == 168 and mobhp <= 35) then -- Khimera < 35%
-      return 0;
-   elseif (family == 315 and mobhp <= 50) then -- Tyger < 50%
-      return 0;
-   end
+    if (family == 168 and mobhp <= 35) then -- Khimera < 35%
+        result = 0;
+    elseif (family == 315 and mobhp <= 50) then -- Tyger < 50%
+        result = 0;
+    end
 
-   return 1;
+    return result;
 end;
 
 function onMobWeaponSkill(target, mob, skill)
 
 -- TODO: Hits all players near Khimaira, not just alliance.
 
-	local dmgmod = 3;
-	local info = MobMagicalMove(mob,target,skill,mob:getWeaponDmg() * 4,ELE_LIGHTNING,dmgmod,TP_MAB_BONUS,1);
-	local dmg = MobFinalAdjustments(info.dmg,mob,skill,target,MOBSKILL_MAGICAL,MOBPARAM_THUNDER,MOBPARAM_WIPE_SHADOWS);
-   MobStatusEffectMove(mob,target,EFFECT_PARALYSIS, 40, 0, 60);
-   MobStatusEffectMove(mob,target,EFFECT_STUN, 1, 0, 4);
-	target:delHP(dmg);
-	return dmg;
+    local dmgmod = 3;
+    local info = MobMagicalMove(mob,target,skill,mob:getWeaponDmg() * 4,ELE_LIGHTNING,dmgmod,TP_MAB_BONUS,1);
+    local dmg = MobFinalAdjustments(info.dmg,mob,skill,target,MOBSKILL_MAGICAL,MOBPARAM_THUNDER,MOBPARAM_WIPE_SHADOWS);
+    MobStatusEffectMove(mob,target,EFFECT_PARALYSIS, 40, 0, 60);
+    MobStatusEffectMove(mob,target,EFFECT_STUN, 1, 0, 4);
+
+    target:delHP(dmg);
+    return dmg;
 end;

--- a/scripts/globals/mobskills/Incessant_Fists.lua
+++ b/scripts/globals/mobskills/Incessant_Fists.lua
@@ -1,0 +1,31 @@
+---------------------------------------------
+--  Incessant Fists
+--
+--  Description: Delivers a fivefold punching attack to a single target.
+--  Type: Physical
+--  Utsusemi/Blink absorb: 5 shadows
+--  Range: Unknown
+--  Notes:
+---------------------------------------------
+
+require("scripts/globals/settings");
+require("scripts/globals/status");
+require("scripts/globals/monstertpmoves");
+
+---------------------------------------------
+
+function onMobSkillCheck(target,mob,skill)
+    return 0;
+end;
+
+function onMobWeaponSkill(target, mob, skill)
+
+    local numhits = 5;
+    local accmod = 1;
+    local dmgmod = 1.3;
+    local info = MobPhysicalMove(mob,target,skill,numhits,accmod,dmgmod,TP_NO_EFFECT);
+    local dmg = MobFinalAdjustments(info.dmg,mob,skill,target,MOBSKILL_PHYSICAL,MOBPARAM_BLUNT,info.hitslanded);
+
+    target:delHP(dmg);
+    return dmg;
+end;

--- a/scripts/globals/mobskills/Luminous_Drape.lua
+++ b/scripts/globals/mobskills/Luminous_Drape.lua
@@ -20,7 +20,7 @@ end;
 
 function onMobWeaponSkill(target, mob, skill)
     local typeEffect = EFFECT_CHARM_I;
-    local msg = MobStatusEffectMove(mob, target, typeEffect, 1, 0, 60);
+    local msg = MobStatusEffectMove(mob, target, typeEffect, 0, 0, 60);
 	
     skill:setMsg(msg);
     mob:resetEnmity(target);

--- a/scripts/globals/mobskills/PW_Brainjack.lua
+++ b/scripts/globals/mobskills/PW_Brainjack.lua
@@ -25,7 +25,7 @@ function onMobWeaponSkill(target, mob, skill)
     local dmg = MobFinalAdjustments(info.dmg,mob,skill,target,MOBSKILL_PHYSICAL,MOBPARAM_BLUNT,info.hitslanded);
     local typeEffect = EFFECT_CHARM;
 
-    MobPhysicalStatusEffectMove(mob, target, skill, typeEffect, 1, 0, 60);
+    MobPhysicalStatusEffectMove(mob, target, skill, typeEffect, 0, 0, 60);
     target:delHP(dmg);
 
     return dmg;

--- a/scripts/globals/mobskills/Pleiades_Ray.lua
+++ b/scripts/globals/mobskills/Pleiades_Ray.lua
@@ -15,23 +15,30 @@ require("scripts/globals/monstertpmoves");
 ---------------------------------------------
 
 function onMobSkillCheck(target,mob,skill)
-	return 0;
+    local result = 1;
+    local mobhp = mob:getHPP();
+
+    if (mobhp <= 20) then
+        result = 0;
+    end;
+
+    return result;
 end;
 
 function onMobWeaponSkill(target, mob, skill)
-	local duration = 120;
+    local duration = 120;
 
-	MobStatusEffectMove(mob, target, EFFECT_PARALYSIS, 40, 3, duration);
-	MobStatusEffectMove(mob, target, EFFECT_BLINDNESS, 40, 3, duration);
-	MobStatusEffectMove(mob, target, EFFECT_POISON, 10, 3, duration);
-	MobStatusEffectMove(mob, target, EFFECT_PLAGUE, 5, 3, duration);
-	MobStatusEffectMove(mob, target, EFFECT_BIND, 1, 0, duration);
-	MobStatusEffectMove(mob, target, EFFECT_SILENCE, 1, 0, duration);
-	MobStatusEffectMove(mob, target, EFFECT_SLOW, 128, 0, duration);
+    MobStatusEffectMove(mob, target, EFFECT_PARALYSIS, 40, 3, duration);
+    MobStatusEffectMove(mob, target, EFFECT_BLINDNESS, 40, 3, duration);
+    MobStatusEffectMove(mob, target, EFFECT_POISON, 10, 3, duration);
+    MobStatusEffectMove(mob, target, EFFECT_PLAGUE, 5, 3, duration);
+    MobStatusEffectMove(mob, target, EFFECT_BIND, 1, 0, duration);
+    MobStatusEffectMove(mob, target, EFFECT_SILENCE, 1, 0, duration);
+    MobStatusEffectMove(mob, target, EFFECT_SLOW, 128, 0, duration);
 
-	local dmgmod = 1;
-	local info = MobMagicalMove(mob,target,skill,mob:getWeaponDmg()*7,ELE_FIRE,dmgmod,TP_NO_EFFECT);
-	local dmg = MobFinalAdjustments(info.dmg,mob,skill,target,MOBSKILL_MAGICAL,MOBPARAM_FIRE,MOBPARAM_WIPE_SHADOWS);
-	target:delHP(dmg);
-	return dmg;
+    local dmgmod = 1;
+    local info = MobMagicalMove(mob,target,skill,mob:getWeaponDmg()*7,ELE_FIRE,dmgmod,TP_NO_EFFECT);
+    local dmg = MobFinalAdjustments(info.dmg,mob,skill,target,MOBSKILL_MAGICAL,MOBPARAM_FIRE,MOBPARAM_WIPE_SHADOWS);
+    target:delHP(dmg);
+    return dmg;
 end;

--- a/scripts/zones/Attohwa_Chasm/mobs/Tiamat.lua
+++ b/scripts/zones/Attohwa_Chasm/mobs/Tiamat.lua
@@ -11,8 +11,6 @@ require("scripts/globals/status");
 -----------------------------------
 
 function onMobInitialize(mob)
-    mob:addMod(MOD_DMGMAGIC, -50);
-    mob:addMod(MOD_DMGRANGE, -50);
 end;
 
 -----------------------------------
@@ -20,14 +18,14 @@ end;
 -----------------------------------
 
 function onMobFight(mob,target)
-	
-	-- Gains a large attack boost when health is under 25% which cannot be Dispelled. 
-	if(mob:getHP() < ((mob:getMaxHP() / 10) * 2.5)) then
-		if(mob:hasStatusEffect(EFFECT_ATTACK_BOOST) == false) then
-			mob:addStatusEffect(EFFECT_ATTACK_BOOST,75,0,0);
+
+    -- Gains a large attack boost when health is under 25% which cannot be Dispelled. 
+    if(mob:getHP() < ((mob:getMaxHP() / 10) * 2.5)) then
+        if(mob:hasStatusEffect(EFFECT_ATTACK_BOOST) == false) then
+            mob:addStatusEffect(EFFECT_ATTACK_BOOST,75,0,0);
             mob:getStatusEffect(EFFECT_ATTACK_BOOST):setFlag(32);
-		end
-	end
+        end;
+    end;
     if (mob:hasStatusEffect(EFFECT_MIGHTY_STRIKES) == false and mob:actionQueueEmpty() == true) then
         local changeTime = mob:getLocalVar("changeTime")
         local twohourTime = mob:getLocalVar("twohourTime")
@@ -36,7 +34,7 @@ function onMobFight(mob,target)
         if (twohourTime == 0) then
             twohourTime = math.random(8, 14);
             mob:setLocalVar("twohourTime", twohourTime);
-        end
+        end;
         
         if (mob:AnimationSub() == 2 and mob:getBattleTime()/15 > twohourTime) then
             mob:useMobAbility(432);
@@ -62,8 +60,8 @@ function onMobFight(mob,target)
             mob:SetMobSkillAttack(true);
             mob:setLocalVar("changeTime", mob:getBattleTime());
             mob:setLocalVar("changeHP", mob:getHP()/1000);
-        end
-	end
+        end;
+    end;
 end;
 
 -----------------------------------
@@ -71,6 +69,6 @@ end;
 -----------------------------------
 
 function onMobDeath(mob, killer)
-	killer:addTitle(TIAMAT_TROUNCER);
-    mob:setRespawnTime(math.random((259200),(432000)));	-- 3 to 5 days	
+    killer:addTitle(TIAMAT_TROUNCER);
+    mob:setRespawnTime(math.random((259200),(432000))); -- 3 to 5 days
 end;

--- a/scripts/zones/Halvung/mobs/Gurfurlur_the_Menacing.lua
+++ b/scripts/zones/Halvung/mobs/Gurfurlur_the_Menacing.lua
@@ -18,11 +18,39 @@ end;
 
 function onMobEngaged(mob,target)
 
-	SpawnMob(17031593,180):updateEnmity(target);
-	SpawnMob(17031594,180):updateEnmity(target);
-	SpawnMob(17031595,180):updateEnmity(target);
-	SpawnMob(17031596,180):updateEnmity(target);
+    local gurfurlur = mob:getID()
+    SpawnMob(gurfurlur+1,180):updateEnmity(target);
+    SpawnMob(gurfurlur+2,180):updateEnmity(target);
+    SpawnMob(gurfurlur+3,180):updateEnmity(target);
+    SpawnMob(gurfurlur+4,180):updateEnmity(target);
 
+end;
+
+-----------------------------------
+-- onMobFight
+-----------------------------------
+
+function onMobFight(mob,target)
+
+   -- Summons a guard every 15 seconds.
+   -- TODO: Summon animations
+
+    local gurfurlur = mob:getID()
+    if (mob:getBattleTime() % 15 < 2 and mob:getBattleTime() > 2) then
+        if (GetMobAction(gurfurlur+1) == 0) then
+            GetMobByID(gurfurlur+1):setSpawn(mob:getXPos()+math.random(1,5), mob:getYPos(), mob:getZPos()+math.random(1,5));
+            SpawnMob(gurfurlur+1, 300):updateEnmity(target);
+        elseif (GetMobAction(gurfurlur+2) == 0) then
+            GetMobByID(gurfurlur+2):setSpawn(mob:getXPos()+math.random(1,5), mob:getYPos(), mob:getZPos()+math.random(1,5));
+            SpawnMob(gurfurlur+2, 300):updateEnmity(target);
+        elseif (GetMobAction(gurfurlur+3) == 0) then
+            GetMobByID(gurfurlur+3):setSpawn(mob:getXPos()+math.random(1,5), mob:getYPos(), mob:getZPos()+math.random(1,5));
+            SpawnMob(gurfurlur+3, 300):updateEnmity(target);
+        elseif (GetMobAction(gurfurlur+4) == 0) then
+            GetMobByID(gurfurlur+4):setSpawn(mob:getXPos()+math.random(1,5), mob:getYPos(), mob:getZPos()+math.random(1,5));
+            SpawnMob(gurfurlur+4, 300):updateEnmity(target);
+        end;
+    end;
 end;
 
 -----------------------------------
@@ -30,5 +58,5 @@ end;
 -----------------------------------
 
 function onMobDeath(mob, killer)
-	killer:addTitle(TROLL_SUBJUGATOR);
+    killer:addTitle(TROLL_SUBJUGATOR);
 end;

--- a/scripts/zones/King_Ranperres_Tomb/mobs/Vrtra.lua
+++ b/scripts/zones/King_Ranperres_Tomb/mobs/Vrtra.lua
@@ -13,7 +13,6 @@ local offsets = {1, 3, 5, 2, 4, 6};
 -----------------------------------
 
 function onMobInitialize(mob)
-    mob:addMod(MOD_REGEN, 30);
 end;
 
 function onMobEngaged(mob)

--- a/sql/mob_pool_mods.sql
+++ b/sql/mob_pool_mods.sql
@@ -58,6 +58,7 @@ INSERT INTO `mob_pool_mods` VALUES (2790,168,50,0);
 INSERT INTO `mob_pool_mods` VALUES (3549,370,50,0);
 INSERT INTO `mob_pool_mods` VALUES (1648,17,1,1);
 INSERT INTO `mob_pool_mods` VALUES (3916,370,50,0);
+INSERT INTO `mob_pool_mods` VALUES (3916,164,-50,0);
 INSERT INTO `mob_pool_mods` VALUES (3916,29,50,0);
 INSERT INTO `mob_pool_mods` VALUES (3796,21,97,1);
 INSERT INTO `mob_pool_mods` VALUES (4396,16,1,1);
@@ -189,6 +190,8 @@ INSERT INTO `mob_pool_mods` VALUES (3124,48,434,1);
 INSERT INTO `mob_pool_mods` VALUES (2105,48,434,1);
 INSERT INTO `mob_pool_mods` VALUES (70,48,434,1);
 INSERT INTO `mob_pool_mods` VALUES (1270,39,-1,1);
+INSERT INTO `mob_pool_mods` VALUES (1851,16,1,1);
+INSERT INTO `mob_pool_mods` VALUES (1851,32,1,1);
 
 -- -------------------------
 --  Antlion MOBMOD_SPECIAL_SKILL Pit_Ambush 


### PR DESCRIPTION
-Added Incessant Fists, and scripted Arcane Stomp. Since it applies Magic Shield status, I handled the absorption there.
-Added an HP check on Pleiades Ray.
-Made Gurfurlur's guards respawn indefinitely while engaged.
-Added his two hour and the ability to use it multiple times.
-Changed the power of Charm moves to 0, as that enables charmed players to be controlled by AI. (looks like this fixes part of issue #1452 - still missing the ability to act against charmed players though.
-Moved Tiamat's ranged defence mod to Mob Pools from scripts. Deleted her duplicate magic defence mod. Magic damage taken is now about as much as people who have experience fighting Tiamat on retail expect.