### PR TITLE
Scripts/SQL: Enhances Rice Ball effect + Hachiman TP latent fix

### DIFF
--- a/scripts/globals/equipment.lua
+++ b/scripts/globals/equipment.lua
@@ -7,77 +7,59 @@ require("scripts/globals/status");
 -----------------------------------
 
 function isArtifactArmor(itemid)
-	retval = false;
-	if    ((itemid >= 12511 and itemid <= 12520) or (itemid >= 13855 and itemid <= 13857) or (itemid >= 13868 and itemid <= 13869)) then retval = true; -- normal head sets
-	elseif((itemid >= 12638 and itemid <= 12650) or (itemid >= 13781 and itemid <= 13782)) then retval = true; -- normal body sets
-	elseif(itemid >= 13961 and itemid <= 13975) then retval = true; -- normal hand sets
-	elseif(itemid >= 14089 and itemid <= 14103) then retval = true; -- normal feet sets
-	elseif(itemid >= 14214 and itemid <= 14228) then retval = true; -- normal legs sets
-	
-	elseif(itemid >= 15265 and itemid <= 15267) then retval = true; -- ToAU head sets
-	elseif(itemid >= 14521 and itemid <= 14523) then retval = true; -- ToAU body sets
-	elseif(itemid >= 14928 and itemid <= 14930) then retval = true; -- ToAU hand sets
-	elseif(itemid >= 15684 and itemid <= 15686) then retval = true; -- ToAU feet sets
-	elseif(itemid >= 15600 and itemid <= 15602) then retval = true; -- ToAU legs sets
-	
-	elseif(itemid >= 16138 and itemid <= 16140) then retval = true; -- WotG head sets
-	elseif(itemid >= 14578 and itemid <= 14580) then retval = true; -- WotG body sets
-	elseif(itemid >= 15002 and itemid <= 15004) then retval = true; -- WotG hand sets
-	elseif(itemid >= 15746 and itemid <= 15748) then retval = true; -- WotG feet sets
-	elseif(itemid >= 15659 and itemid <= 15661) then retval = true; -- WotG legs sets
-	end
-	return retval;
-end;
+    retval = false;
+    if    ((itemid >= 12511 and itemid <= 12520) or (itemid >= 13855 and itemid <= 13857) or (itemid >= 13868 and itemid <= 13869)) then retval = true; -- normal head sets
+    elseif((itemid >= 12638 and itemid <= 12650) or (itemid >= 13781 and itemid <= 13782)) then retval = true; -- normal body sets
+    elseif(itemid >= 13961 and itemid <= 13975) then retval = true; -- normal hand sets
+    elseif(itemid >= 14089 and itemid <= 14103) then retval = true; -- normal feet sets
+    elseif(itemid >= 14214 and itemid <= 14228) then retval = true; -- normal legs sets
 
--- Provides a count for the number of pieces of equipment that "enhance the effect of rice balls"
-function RiceBalls(player)
-   local hands = player:getEquipID(SLOT_HANDS);
-   local head = player:getEquipID(SLOT_HEAD);
-   local feet = player:getEquipID(SLOT_FEET);
-   local power = 0;
-   if (hands == 13972 or hands == 14901) then -- Myochin Kote
-      power = power + 1;
-   end
-   if (head == 13910 or head == 13949) then -- Roshi Jinpachi
-      power = power + 1;
-   end
-   if (feet == 11367) then -- Nobushi Kyahan
-      power = power + 1;
-   end
-   return power;
+    elseif(itemid >= 15265 and itemid <= 15267) then retval = true; -- ToAU head sets
+    elseif(itemid >= 14521 and itemid <= 14523) then retval = true; -- ToAU body sets
+    elseif(itemid >= 14928 and itemid <= 14930) then retval = true; -- ToAU hand sets
+    elseif(itemid >= 15684 and itemid <= 15686) then retval = true; -- ToAU feet sets
+    elseif(itemid >= 15600 and itemid <= 15602) then retval = true; -- ToAU legs sets
+
+    elseif(itemid >= 16138 and itemid <= 16140) then retval = true; -- WotG head sets
+    elseif(itemid >= 14578 and itemid <= 14580) then retval = true; -- WotG body sets
+    elseif(itemid >= 15002 and itemid <= 15004) then retval = true; -- WotG hand sets
+    elseif(itemid >= 15746 and itemid <= 15748) then retval = true; -- WotG feet sets
+    elseif(itemid >= 15659 and itemid <= 15661) then retval = true; -- WotG legs sets
+    end
+    return retval;
 end;
 
 -- Provides a power for using a chocobo shirt with bunch of gysahl greens
 function ChocoboShirt(player)
-   local body = player:getEquipID(SLOT_BODY);
-   local power = 0;
-   if (body == 10293) then -- Chocobo Shirt
-      power = power + 1;
-   end
-   return power;
+    local body = player:getEquipID(SLOT_BODY);
+    local power = 0;
+    if (body == 10293) then -- Chocobo Shirt
+        power = power + 1;
+    end
+    return power;
 end;
 
 -- Provides a power for using a equipment modifiers with bunch of wild pamamas or pamamas
 function PamamasEquip(player)
-   local head = target:getEquipID(SLOT_HEAD);
-   local main = target:getEquipID(SLOT_MAIN);
-   local power = 0;
+    local head = target:getEquipID(SLOT_HEAD);
+    local main = target:getEquipID(SLOT_MAIN);
+    local power = 0;
    
-   if (head == 13870) then -- Opo-Opo Crown
-   	power = 1;		
-   end
-   if (main == 17592 or main == 17590) then -- Kinkobo - Primate Staff
-   	power = 2;		
-   elseif (main == 17591) then -- Primate Staff +1
-   	power = 3;		
-   end
+    if (head == 13870) then -- Opo-Opo Crown
+        power = 1;
+    end
+    if (main == 17592 or main == 17590) then -- Kinkobo - Primate Staff
+        power = 2;
+    elseif (main == 17591) then -- Primate Staff +1
+        power = 3;
+    end
    
-   if (head == 13870 and (main == 17592 or main == 17590)) then -- Opo-Opo Crown and Kinkobo or Primate Staff
-      	power = 4;		
-   end
+    if (head == 13870 and (main == 17592 or main == 17590)) then -- Opo-Opo Crown and Kinkobo or Primate Staff
+        power = 4;
+    end
    
-   if (head == 13870 and main == 17591) then -- Opo-Opo Crown and Primate Staff +1
-       	power = 5;		
-   end
-   return power;
+    if (head == 13870 and main == 17591) then -- Opo-Opo Crown and Primate Staff +1
+        power = 5;
+    end
+    return power;
 end;

--- a/scripts/globals/items/himesama_rice_ball.lua
+++ b/scripts/globals/items/himesama_rice_ball.lua
@@ -3,29 +3,28 @@
 -- Item: Himesama Rice Ball
 -- Food Effect: 30 Mins, All Races
 -----------------------------------------
--- HP 25
--- Dexterity 4
--- Vitality 4
--- Character 4
--- Effect with enhancing equipment
+-- HP +25
+-- Dexterity +4
+-- Vitality +4
+-- Character +4
+-- Effect with enhancing equipment (Note: these are latents on gear with the effect)
 -- Attack +60
 -- Defense +40
--- Triple Attack 1
+-- Triple Attack +1%
 -----------------------------------------
 
 require("scripts/globals/status");
-require("scripts/globals/equipment");
 
 -----------------------------------------
 -- OnItemCheck
 -----------------------------------------
 
 function onItemCheck(target)
-   local result = 0;
-	if (target:hasStatusEffect(EFFECT_FOOD) == true or target:hasStatusEffect(EFFECT_FIELD_SUPPORT_FOOD) == true) then
-		result = 246;
-	end
-return result;
+    local result = 0;
+    if (target:hasStatusEffect(EFFECT_FOOD) == true or target:hasStatusEffect(EFFECT_FIELD_SUPPORT_FOOD) == true) then
+        result = 246;
+    end
+    return result;
 end;
 
 -----------------------------------------
@@ -33,7 +32,7 @@ end;
 -----------------------------------------
 
 function onItemUse(target)
-	target:addStatusEffect(EFFECT_FOOD,RiceBalls(target),0,1800,5928);
+    target:addStatusEffect(EFFECT_FOOD,0,0,1800,5928);
 end;
 
 -----------------------------------
@@ -41,14 +40,10 @@ end;
 -----------------------------------
 
 function onEffectGain(target,effect)
-   local power = effect:getPower();
-	target:addMod(MOD_HP, 25);
-   target:addMod(MOD_DEX, 4);
-   target:addMod(MOD_VIT, 4);
-   target:addMod(MOD_CHR, 4);
-   target:addMod(MOD_ATT, 60*power);
-   target:addMod(MOD_DEF, 40*power);
-   target:addMod(MOD_TRIPLE_ATTACK,1*power);
+    target:addMod(MOD_HP, 25);
+    target:addMod(MOD_DEX, 4);
+    target:addMod(MOD_VIT, 4);
+    target:addMod(MOD_CHR, 4);
 end;
 
 -----------------------------------------
@@ -56,12 +51,8 @@ end;
 -----------------------------------------
 
 function onEffectLose(target,effect)
-   local power = effect:getPower();
-	target:delMod(MOD_HP, 25);
-   target:delMod(MOD_DEX, 4);
-   target:delMod(MOD_VIT, 4);
-   target:delMod(MOD_CHR, 4);
-   target:delMod(MOD_ATT, 60*power);
-   target:delMod(MOD_DEF, 40*power);
-   target:delMod(MOD_TRIPLE_ATTACK,1*power);
+    target:delMod(MOD_HP, 25);
+    target:delMod(MOD_DEX, 4);
+    target:delMod(MOD_VIT, 4);
+    target:delMod(MOD_CHR, 4);
 end;

--- a/scripts/globals/items/naval_rice_ball.lua
+++ b/scripts/globals/items/naval_rice_ball.lua
@@ -1,24 +1,30 @@
 -----------------------------------------
 -- ID: 4605
--- Item: naval_rice_ball
+-- Item: Naval Rice Ball
 -- Food Effect: 30Min, All Races
 -----------------------------------------
--- HP +26, Dex +3, Vit +4, hHP +2 (Atk +40, Def +40, Arcana Killer)*enhances rice ball effect
+-- HP +26
+-- Dex +3
+-- Vit +4
+-- hHP +2 
+-- Effect with enhancing equipment (Note: these are latents on gear with the effect)
+-- Atk +40
+-- Def +40
+-- Arcana Killer (guesstimated 5%)
 -----------------------------------------
 
 require("scripts/globals/status");
-require("scripts/globals/equipment");
 
 -----------------------------------------
 -- OnItemCheck
 -----------------------------------------
 
 function onItemCheck(target)
-   local result = 0;
-	if (target:hasStatusEffect(EFFECT_FOOD) == true or target:hasStatusEffect(EFFECT_FIELD_SUPPORT_FOOD) == true) then
-		result = 246;
-	end
-return result;
+    local result = 0;
+    if (target:hasStatusEffect(EFFECT_FOOD) == true or target:hasStatusEffect(EFFECT_FIELD_SUPPORT_FOOD) == true) then
+        result = 246;
+    end
+    return result;
 end;
 
 -----------------------------------------
@@ -26,7 +32,7 @@ end;
 -----------------------------------------
 
 function onItemUse(target)
-	target:addStatusEffect(EFFECT_FOOD,RiceBalls(target),0,1800,4605);
+    target:addStatusEffect(EFFECT_FOOD,0,0,1800,4605);
 end;
 
 -----------------------------------
@@ -34,14 +40,10 @@ end;
 -----------------------------------
 
 function onEffectGain(target,effect)
-   local power = effect:getPower();
-	target:addMod(MOD_HP, 26);
-   target:addMod(MOD_DEX, 3);
-   target:addMod(MOD_VIT, 3);
-   target:addMod(MOD_HPHEAL, 2);
-   target:addMod(MOD_ATT, 40*power);
-   target:addMod(MOD_DEF, 40*power);
-   target:addMod(MOD_ARCANA_KILLER,5*power); -- TODO: This power is sort of made up.
+    target:addMod(MOD_HP, 26);
+    target:addMod(MOD_DEX, 3);
+    target:addMod(MOD_VIT, 3);
+    target:addMod(MOD_HPHEAL, 2);
 end;
 
 -----------------------------------------
@@ -49,12 +51,8 @@ end;
 -----------------------------------------
 
 function onEffectLose(target,effect)
-   local power = effect:getPower();
-	target:delMod(MOD_HP, 26);
-   target:delMod(MOD_DEX, 3);
-   target:delMod(MOD_VIT, 3);
-   target:delMod(MOD_HPHEAL, 2);
-   target:delMod(MOD_ATT, 40*power);
-   target:delMod(MOD_DEF, 40*power);
-   target:delMod(MOD_ARCANA_KILLER,5*power);
+    target:delMod(MOD_HP, 26);
+    target:delMod(MOD_DEX, 3);
+    target:delMod(MOD_VIT, 3);
+    target:delMod(MOD_HPHEAL, 2);
 end;

--- a/scripts/globals/items/ojo_rice_ball.lua
+++ b/scripts/globals/items/ojo_rice_ball.lua
@@ -3,29 +3,28 @@
 -- Item: Ojo Rice Ball
 -- Food Effect: 60 Mins, All Races
 -----------------------------------------
--- HP 50
--- Dexterity 5
--- Vitality 5
--- Character 5
--- Effect with enhancing equipment
+-- HP +50
+-- Dexterity +5
+-- Vitality +5
+-- Character +5
+-- Effect with enhancing equipment (Note: these are latents on gear with the effect)
 -- Attack +60
 -- Defense +40
--- Triple Attack 2
+-- Triple Attack +2%
 -----------------------------------------
 
 require("scripts/globals/status");
-require("scripts/globals/equipment");
 
 -----------------------------------------
 -- OnItemCheck
 -----------------------------------------
 
 function onItemCheck(target)
-   local result = 0;
-	if (target:hasStatusEffect(EFFECT_FOOD) == true or target:hasStatusEffect(EFFECT_FIELD_SUPPORT_FOOD) == true) then
-		result = 246;
-	end
-return result;
+    local result = 0;
+    if (target:hasStatusEffect(EFFECT_FOOD) == true or target:hasStatusEffect(EFFECT_FIELD_SUPPORT_FOOD) == true) then
+        result = 246;
+    end
+    return result;
 end;
 
 -----------------------------------------
@@ -33,7 +32,7 @@ end;
 -----------------------------------------
 
 function onItemUse(target)
-	target:addStatusEffect(EFFECT_FOOD,RiceBalls(target),0,3600,5929);
+    target:addStatusEffect(EFFECT_FOOD,0,0,3600,5929);
 end;
 
 -----------------------------------
@@ -41,14 +40,10 @@ end;
 -----------------------------------
 
 function onEffectGain(target,effect)
-   local power = effect:getPower();
-	target:addMod(MOD_HP, 50);
-   target:addMod(MOD_DEX, 5);
-   target:addMod(MOD_VIT, 5);
-   target:addMod(MOD_CHR, 5);
-   target:addMod(MOD_ATT, 60*power);
-   target:addMod(MOD_DEF, 40*power);
-   target:addMod(MOD_TRIPLE_ATTACK,2*power);
+    target:addMod(MOD_HP, 50);
+    target:addMod(MOD_DEX, 5);
+    target:addMod(MOD_VIT, 5);
+    target:addMod(MOD_CHR, 5);
 end;
 
 -----------------------------------------
@@ -56,12 +51,8 @@ end;
 -----------------------------------------
 
 function onEffectLose(target,effect)
-   local power = effect:getPower();
-	target:delMod(MOD_HP, 50);
-   target:delMod(MOD_DEX, 5);
-   target:delMod(MOD_VIT, 5);
-   target:delMod(MOD_CHR, 5);
-   target:delMod(MOD_ATT, 60*power);
-   target:delMod(MOD_DEF, 40*power);
-   target:delMod(MOD_TRIPLE_ATTACK,2*power);
+    target:delMod(MOD_HP, 50);
+    target:delMod(MOD_DEX, 5);
+    target:delMod(MOD_VIT, 5);
+    target:delMod(MOD_CHR, 5);
 end;

--- a/scripts/globals/items/rice_ball.lua
+++ b/scripts/globals/items/rice_ball.lua
@@ -1,13 +1,17 @@
 -----------------------------------------
 -- ID: 4405
--- Item: rice_ball
+-- Item: Rice Ball
 -- Food Effect: 30Min, All Races
 -----------------------------------------
--- HP 10, Vit +2, Dex -1, hHP +1 (Def +50)*enhances rice ball effect
+-- HP 10,
+-- Vit +2
+-- Dex -1
+-- hHP +1
+-- Effect with enhancing equipment (Note: these are latents on gear with the effect)
+-- Def +50
 -----------------------------------------
 
 require("scripts/globals/status");
-require("scripts/globals/equipment");
 
 -----------------------------------------
 -- OnItemCheck
@@ -15,10 +19,10 @@ require("scripts/globals/equipment");
 
 function onItemCheck(target)
    local result = 0;
-	if (target:hasStatusEffect(EFFECT_FOOD) == true or target:hasStatusEffect(EFFECT_FIELD_SUPPORT_FOOD) == true) then
-		result = 246;
-	end
-return result;
+    if (target:hasStatusEffect(EFFECT_FOOD) == true or target:hasStatusEffect(EFFECT_FIELD_SUPPORT_FOOD) == true) then
+        result = 246;
+    end
+    return result;
 end;
 
 -----------------------------------------
@@ -26,7 +30,7 @@ end;
 -----------------------------------------
 
 function onItemUse(target)
-	target:addStatusEffect(EFFECT_FOOD,RiceBalls(target),0,1800,4405);
+    target:addStatusEffect(EFFECT_FOOD,0,0,1800,4405);
 end;
 
 -----------------------------------
@@ -34,11 +38,9 @@ end;
 -----------------------------------
 
 function onEffectGain(target,effect)
-   local power = effect:getPower();
-	target:addMod(MOD_HP, 10);
-   target:addMod(MOD_VIT, 2);
-   target:addMod(MOD_DEX, -1);
-   target:addMod(MOD_DEF, 40*power);
+    target:addMod(MOD_HP, 10);
+    target:addMod(MOD_VIT, 2);
+    target:addMod(MOD_DEX, -1);
 end;
 
 -----------------------------------------
@@ -46,9 +48,7 @@ end;
 -----------------------------------------
 
 function onEffectLose(target,effect)
-   local power = effect:getPower();
-	target:delMod(MOD_HP, 10);
-   target:delMod(MOD_VIT, 2);
-   target:delMod(MOD_DEX, -1);
-   target:delMod(MOD_DEF, 40*power);
+    target:delMod(MOD_HP, 10);
+    target:delMod(MOD_VIT, 2);
+    target:delMod(MOD_DEX, -1);
 end;

--- a/scripts/globals/items/rogue_rice_ball.lua
+++ b/scripts/globals/items/rogue_rice_ball.lua
@@ -1,24 +1,28 @@
 -----------------------------------------
 -- ID: 4604
--- Item: rogue_rice_ball
+-- Item: Rogue Rice Ball
 -- Food Effect: 30Min, All Races
 -----------------------------------------
--- HP +12, Vit +3, hHP +2, (Def +50, Beast Killer)*enhances rice ball effect
+-- HP +12
+-- Vit +3
+-- hHP +2
+-- Effect with enhancing equipment (Note: these are latents on gear with the effect)
+-- Def +50
+-- Beast Killer (guesstimated 5%)
 -----------------------------------------
 
 require("scripts/globals/status");
-require("scripts/globals/equipment");
 
 -----------------------------------------
 -- OnItemCheck
 -----------------------------------------
 
 function onItemCheck(target)
-   local result = 0;
-	if (target:hasStatusEffect(EFFECT_FOOD) == true or target:hasStatusEffect(EFFECT_FIELD_SUPPORT_FOOD) == true) then
-		result = 246;
-	end
-return result;
+    local result = 0;
+    if (target:hasStatusEffect(EFFECT_FOOD) == true or target:hasStatusEffect(EFFECT_FIELD_SUPPORT_FOOD) == true) then
+        result = 246;
+    end
+    return result;
 end;
 
 -----------------------------------------
@@ -26,7 +30,7 @@ end;
 -----------------------------------------
 
 function onItemUse(target)
-	target:addStatusEffect(EFFECT_FOOD,RiceBalls(target),0,3600,4604);
+    target:addStatusEffect(EFFECT_FOOD,0,0,3600,4604);
 end;
 
 -----------------------------------
@@ -34,12 +38,9 @@ end;
 -----------------------------------
 
 function onEffectGain(target,effect)
-   local power = effect:getPower();
-	target:addMod(MOD_HP, 12);
-   target:addMod(MOD_VIT, 3);
-   target:addMod(MOD_HPHEAL, 2);
-   target:addMod(MOD_DEF, 50*power);
-   target:addMod(MOD_BEAST_KILLER,5*power); -- TODO: This power is sort of made up.
+    target:addMod(MOD_HP, 12);
+    target:addMod(MOD_VIT, 3);
+    target:addMod(MOD_HPHEAL, 2);
 end;
 
 -----------------------------------------
@@ -47,10 +48,7 @@ end;
 -----------------------------------------
 
 function onEffectLose(target,effect)
-   local power = effect:getPower();
-	target:delMod(MOD_HP, 12);
-   target:delMod(MOD_VIT, 3);
-   target:delMod(MOD_HPHEAL, 2);
-   target:delMod(MOD_DEF, 50*power);
-   target:delMod(MOD_BEAST_KILLER,5*power); -- TODO: This power is sort of made up.
+    target:delMod(MOD_HP, 12);
+    target:delMod(MOD_VIT, 3);
+    target:delMod(MOD_HPHEAL, 2);
 end;

--- a/scripts/globals/items/salmon_rice_ball.lua
+++ b/scripts/globals/items/salmon_rice_ball.lua
@@ -1,24 +1,30 @@
 -----------------------------------------
 -- ID: 4590
--- Item: salmon_rice_ball
+-- Item: Salmon Rice Ball
 -- Food Effect: 30Min, All Races
 -----------------------------------------
--- HP +25, Dex +2, Vit +2, Mnd -1, hHP +1 (Atk +40, Def +40)*enhances rice ball effect
+-- HP +25
+-- Dex +2
+-- Vit +2
+-- Mnd -1
+-- hHP +1
+-- Effect with enhancing equipment (Note: these are latents on gear with the effect)
+-- Atk +40
+-- Def +40
 -----------------------------------------
 
 require("scripts/globals/status");
-require("scripts/globals/equipment");
 
 -----------------------------------------
 -- OnItemCheck
 -----------------------------------------
 
 function onItemCheck(target)
-   local result = 0;
-	if (target:hasStatusEffect(EFFECT_FOOD) == true or target:hasStatusEffect(EFFECT_FIELD_SUPPORT_FOOD) == true) then
-		result = 246;
-	end
-return result;
+    local result = 0;
+    if (target:hasStatusEffect(EFFECT_FOOD) == true or target:hasStatusEffect(EFFECT_FIELD_SUPPORT_FOOD) == true) then
+        result = 246;
+    end
+    return result;
 end;
 
 -----------------------------------------
@@ -26,7 +32,7 @@ end;
 -----------------------------------------
 
 function onItemUse(target)
-	target:addStatusEffect(EFFECT_FOOD,RiceBalls(target),0,1800,4590);
+    target:addStatusEffect(EFFECT_FOOD,0,0,1800,4590);
 end;
 
 -----------------------------------
@@ -34,14 +40,11 @@ end;
 -----------------------------------
 
 function onEffectGain(target,effect)
-   local power = effect:getPower();
-	target:addMod(MOD_HP, 25);
-   target:addMod(MOD_DEX, 2);
-   target:addMod(MOD_VIT, 2);
-   target:addMod(MOD_MND, -1);
-   target:addMod(MOD_HPHEAL, 1);
-   target:addMod(MOD_ATT, 40*power);
-   target:addMod(MOD_DEF, 40*power);
+    target:addMod(MOD_HP, 25);
+    target:addMod(MOD_DEX, 2);
+    target:addMod(MOD_VIT, 2);
+    target:addMod(MOD_MND, -1);
+    target:addMod(MOD_HPHEAL, 1);
 end;
 
 -----------------------------------------
@@ -49,12 +52,9 @@ end;
 -----------------------------------------
 
 function onEffectLose(target,effect)
-   local power = effect:getPower();
-	target:delMod(MOD_HP, 25);
-   target:delMod(MOD_DEX, 2);
-   target:delMod(MOD_VIT, 2);
-   target:delMod(MOD_MND, -1);
-   target:delMod(MOD_HPHEAL, 1);
-   target:delMod(MOD_ATT, 40*power);
-   target:delMod(MOD_DEF, 40*power);
+    target:delMod(MOD_HP, 25);
+    target:delMod(MOD_DEX, 2);
+    target:delMod(MOD_VIT, 2);
+    target:delMod(MOD_MND, -1);
+    target:delMod(MOD_HPHEAL, 1);
 end;

--- a/scripts/globals/items/shogun_rice_ball.lua
+++ b/scripts/globals/items/shogun_rice_ball.lua
@@ -1,24 +1,30 @@
 -----------------------------------------
 -- ID: 4278
--- Item: shogun_rice_ball
+-- Item: Shogun Rice Ball
 -- Food Effect: 60Min, All Races
 -----------------------------------------
--- HP +20, Dex +4, Vit +4, Chr +4.  (Atk +50, Def +30, DA% +5) * number of enhancing gear
+-- HP +20
+-- Dex +4
+-- Vit +4
+-- Chr +4
+-- Effect with enhancing equipment (Note: these are latents on gear with the effect) 
+-- Atk +50
+-- Def +30
+-- Double Attack +5%
 -----------------------------------------
 
 require("scripts/globals/status");
-require("scripts/globals/equipment");
 
 -----------------------------------------
 -- OnItemCheck
 -----------------------------------------
 
 function onItemCheck(target)
-   local result = 0;
-	if (target:hasStatusEffect(EFFECT_FOOD) == true or target:hasStatusEffect(EFFECT_FIELD_SUPPORT_FOOD) == true) then
-		result = 246;
-	end
-return result;
+    local result = 0;
+    if (target:hasStatusEffect(EFFECT_FOOD) == true or target:hasStatusEffect(EFFECT_FIELD_SUPPORT_FOOD) == true) then
+        result = 246;
+    end
+    return result;
 end;
 
 -----------------------------------------
@@ -26,7 +32,7 @@ end;
 -----------------------------------------
 
 function onItemUse(target)
-	target:addStatusEffect(EFFECT_FOOD,RiceBalls(target),0,3600,4278);
+    target:addStatusEffect(EFFECT_FOOD,0,0,3600,4278);
 end;
 
 -----------------------------------
@@ -34,14 +40,11 @@ end;
 -----------------------------------
 
 function onEffectGain(target,effect)
-   local power = effect:getPower();
-	target:addMod(MOD_HP, 20);
-   target:addMod(MOD_DEX, 4);
-   target:addMod(MOD_VIT, 4);
-   target:addMod(MOD_CHR, 4);
-   target:addMod(MOD_ATT, 50*power);
-   target:addMod(MOD_DEF, 30*power);
-   target:addMod(MOD_DOUBLE_ATTACK,5*power);
+    target:addMod(MOD_HP, 20);
+    target:addMod(MOD_DEX, 4);
+    target:addMod(MOD_VIT, 4);
+    target:addMod(MOD_CHR, 4);
+
 end;
 
 -----------------------------------------
@@ -49,12 +52,8 @@ end;
 -----------------------------------------
 
 function onEffectLose(target,effect)
-   local power = effect:getPower();
-	target:delMod(MOD_HP, 20);
-   target:delMod(MOD_DEX, 4);
-   target:delMod(MOD_VIT, 4);
-   target:delMod(MOD_CHR, 4);
-   target:delMod(MOD_ATT, 50*power);
-   target:delMod(MOD_DEF, 30*power);
-   target:delMod(MOD_DOUBLE_ATTACK,5*power);
+    target:delMod(MOD_HP, 20);
+    target:delMod(MOD_DEX, 4);
+    target:delMod(MOD_VIT, 4);
+    target:delMod(MOD_CHR, 4);
 end;

--- a/scripts/globals/items/tonosama_rice_ball.lua
+++ b/scripts/globals/items/tonosama_rice_ball.lua
@@ -1,24 +1,30 @@
 -----------------------------------------
 -- ID: 4277
--- Item: tonosama_rice_ball
+-- Item: Tonosama Rice Ball
 -- Food Effect: 30Min, All Races
 -----------------------------------------
--- HP +15, Dex +3, Vit +3, Chr +3.  (Atk +50, Def +30, DA% +1) * number of enhancing gear
+-- HP +15
+-- Dex +3
+-- Vit +3
+-- Chr +3
+-- Effect with enhancing equipment (Note: these are latents on gear with the effect)
+-- Atk +50
+-- Def +30
+-- Double Attack +1%
 -----------------------------------------
 
 require("scripts/globals/status");
-require("scripts/globals/equipment");
 
 -----------------------------------------
 -- OnItemCheck
 -----------------------------------------
 
 function onItemCheck(target)
-   local result = 0;
-	if (target:hasStatusEffect(EFFECT_FOOD) == true or target:hasStatusEffect(EFFECT_FIELD_SUPPORT_FOOD) == true) then
-		result = 246;
-	end
-return result;
+    local result = 0;
+    if (target:hasStatusEffect(EFFECT_FOOD) == true or target:hasStatusEffect(EFFECT_FIELD_SUPPORT_FOOD) == true) then
+        result = 246;
+    end
+    return result;
 end;
 
 -----------------------------------------
@@ -26,7 +32,7 @@ end;
 -----------------------------------------
 
 function onItemUse(target)
-	target:addStatusEffect(EFFECT_FOOD,RiceBalls(target),0,1800,4277);
+    target:addStatusEffect(EFFECT_FOOD,0,0,1800,4277);
 end;
 
 -----------------------------------
@@ -34,14 +40,10 @@ end;
 -----------------------------------
 
 function onEffectGain(target,effect)
-   local power = effect:getPower();
-	target:addMod(MOD_HP, 15);
-   target:addMod(MOD_DEX, 3);
-   target:addMod(MOD_VIT, 3);
-   target:addMod(MOD_CHR, 3);
-   target:addMod(MOD_ATT, 50*power);
-   target:addMod(MOD_DEF, 30*power);
-   target:addMod(MOD_DOUBLE_ATTACK,1*power);
+    target:addMod(MOD_HP, 15);
+    target:addMod(MOD_DEX, 3);
+    target:addMod(MOD_VIT, 3);
+    target:addMod(MOD_CHR, 3);
 end;
 
 -----------------------------------------
@@ -49,12 +51,8 @@ end;
 -----------------------------------------
 
 function onEffectLose(target,effect)
-   local power = effect:getPower();
-	target:delMod(MOD_HP, 15);
-   target:delMod(MOD_DEX, 3);
-   target:delMod(MOD_VIT, 3);
-   target:delMod(MOD_CHR, 3);
-   target:delMod(MOD_ATT, 50*power);
-   target:delMod(MOD_DEF, 30*power);
-   target:delMod(MOD_DOUBLE_ATTACK,1*power);
+    target:delMod(MOD_HP, 15);
+    target:delMod(MOD_DEX, 3);
+    target:delMod(MOD_VIT, 3);
+    target:delMod(MOD_CHR, 3);
 end;

--- a/sql/item_latents.sql
+++ b/sql/item_latents.sql
@@ -474,32 +474,32 @@ INSERT INTO `item_latents` VALUES(18491, 23, 10, 6, 1000); -- Attack+10 while TP
 -- -------------------------------------------------------
 -- Hachiman Jinpachi    
 -- -------------------------------------------------------
-INSERT INTO `item_latents` VALUES(15188, 288, 2, 7, 100); -- "Double Attack"+2% while TP >=100%
+INSERT INTO `item_latents` VALUES(15188, 288, 2, 7, 1000); -- "Double Attack"+2% while TP >=100%
 
 -- -------------------------------------------------------
 -- Hachiman Jinpachi +1
 -- -------------------------------------------------------
-INSERT INTO `item_latents` VALUES(15187, 288, 3, 7, 100); -- "Double Attack"+3% while TP >=100%
+INSERT INTO `item_latents` VALUES(15187, 288, 3, 7, 1000); -- "Double Attack"+3% while TP >=100%
 
 -- -------------------------------------------------------
 -- Hachiman Kote    
 -- -------------------------------------------------------
-INSERT INTO `item_latents` VALUES(14876, 23, 10, 7, 100); -- Attack+10 while TP >=100%
+INSERT INTO `item_latents` VALUES(14876, 23, 10, 7, 1000); -- Attack+10 while TP >=100%
 
 -- -------------------------------------------------------
 -- Hachiman Kote +1
 -- -------------------------------------------------------
-INSERT INTO `item_latents` VALUES(14878, 23, 12, 7, 100); -- Attack+12 while TP >=100%
+INSERT INTO `item_latents` VALUES(14878, 23, 12, 7, 1000); -- Attack+12 while TP >=100%
 
 -- -------------------------------------------------------
 -- Hachiman Hakama    
 -- -------------------------------------------------------
-INSERT INTO `item_latents` VALUES(15392, 24, 7, 7, 100); -- Ranged Attack+7 while TP >=100%
+INSERT INTO `item_latents` VALUES(15392, 24, 7, 7, 1000); -- Ranged Attack+7 while TP >=100%
 
 -- -------------------------------------------------------
 -- Hachiman Hakama +1
 -- -------------------------------------------------------
-INSERT INTO `item_latents` VALUES(15394, 24, 8, 7, 100); -- Ranged Attack+8 while TP >=100%
+INSERT INTO `item_latents` VALUES(15394, 24, 8, 7, 1000); -- Ranged Attack+8 while TP >=100%
 
 -- -------------------------------------------------------
 -- Rambler's Cloak
@@ -2414,3 +2414,156 @@ INSERT INTO `item_latents` VALUES(18352, 54, 15, 28, 0); -- [Element: Fire]+15
 
 INSERT INTO `item_latents` VALUES(18374, 366, 9, 28, 0); -- Mighty Sword DMG+9 on Firesday
 INSERT INTO `item_latents` VALUES(18374, 54, 15, 28, 0); -- [Element: Fire]+15
+
+-- -------------------------------------------------------
+-- Enhances Rice Ball gear
+-- -------------------------------------------------------
+-- Myochin Kote
+-- Tonosama Rice Ball
+INSERT INTO `item_latents` VALUES(13972, 23, 50, 49, 4277); -- atk+50
+INSERT INTO `item_latents` VALUES(13972, 1, 30, 49, 4277); -- def+30
+INSERT INTO `item_latents` VALUES(13972, 288, 1, 49, 4277); -- double attack 1%
+-- Shogun Rice Ball
+INSERT INTO `item_latents` VALUES(13972, 23, 50, 49, 4278); -- atk+50
+INSERT INTO `item_latents` VALUES(13972, 1, 30, 49, 4278); -- def+30
+INSERT INTO `item_latents` VALUES(13972, 288, 5, 49, 4278); -- double attack 5%
+-- Rice Ball
+INSERT INTO `item_latents` VALUES(13972, 1, 50, 49, 4405); -- def+50
+-- Salmon Rice Ball
+INSERT INTO `item_latents` VALUES(13972, 23, 40, 49, 4590); -- atk+40
+INSERT INTO `item_latents` VALUES(13972, 1, 40, 49, 4590); -- def+40
+-- Rogue Rice Ball
+INSERT INTO `item_latents` VALUES(13972, 1, 50, 49, 4604); -- def+50
+INSERT INTO `item_latents` VALUES(13972, 230, 5, 49, 4604); -- beast killer 5% (guesstimated)
+-- Naval Rice Ball
+INSERT INTO `item_latents` VALUES(13972, 23, 40, 49, 4605); -- atk+40
+INSERT INTO `item_latents` VALUES(13972, 1, 40, 49, 4605); -- def+40
+INSERT INTO `item_latents` VALUES(13972, 232, 5, 49, 4604); -- arcana killer 5% (guesstimated)
+-- Hinesama Rice Ball
+INSERT INTO `item_latents` VALUES(13972, 23, 60, 49, 5928); -- atk+60
+INSERT INTO `item_latents` VALUES(13972, 1, 40, 49, 5928); -- def+40
+INSERT INTO `item_latents` VALUES(13972, 302, 1, 49, 5928); -- triple attack 1%
+-- Ojo Rice Ball
+INSERT INTO `item_latents` VALUES(13972, 23, 60, 49, 5929); -- atk+60
+INSERT INTO `item_latents` VALUES(13972, 1, 40, 49, 5929); -- def+40
+INSERT INTO `item_latents` VALUES(13972, 302, 2, 49, 5929); -- triple attack 2%
+
+-- Myochin Kote +1
+-- Tonosama Rice Ball
+INSERT INTO `item_latents` VALUES(14901, 23, 50, 49, 4277); -- atk+50
+INSERT INTO `item_latents` VALUES(14901, 1, 30, 49, 4277); -- def+30
+INSERT INTO `item_latents` VALUES(14901, 288, 1, 49, 4277); -- double attack 1%
+-- Shogun Rice Ball
+INSERT INTO `item_latents` VALUES(14901, 23, 50, 49, 4278); -- atk+50
+INSERT INTO `item_latents` VALUES(14901, 1, 30, 49, 4278); -- def+30
+INSERT INTO `item_latents` VALUES(14901, 288, 5, 49, 4278); -- double attack 5%
+-- Rice Ball
+INSERT INTO `item_latents` VALUES(14901, 1, 50, 49, 4405); -- def+50
+-- Salmon Rice Ball
+INSERT INTO `item_latents` VALUES(14901, 23, 40, 49, 4590); -- atk+40
+INSERT INTO `item_latents` VALUES(14901, 1, 40, 49, 4590); -- def+40
+-- Rogue Rice Ball
+INSERT INTO `item_latents` VALUES(14901, 1, 50, 49, 4604); -- def+50
+INSERT INTO `item_latents` VALUES(14901, 230, 5, 49, 4604); -- beast killer 5% (guesstimated)
+-- Naval Rice Ball
+INSERT INTO `item_latents` VALUES(14901, 23, 40, 49, 4605); -- atk+40
+INSERT INTO `item_latents` VALUES(14901, 1, 40, 49, 4605); -- def+40
+INSERT INTO `item_latents` VALUES(14901, 232, 5, 49, 4604); -- arcana killer 5% (guesstimated)
+-- Hinesama Rice Ball
+INSERT INTO `item_latents` VALUES(14901, 23, 60, 49, 5928); -- atk+60
+INSERT INTO `item_latents` VALUES(14901, 1, 40, 49, 5928); -- def+40
+INSERT INTO `item_latents` VALUES(14901, 302, 1, 49, 5928); -- triple attack 1%
+-- Ojo Rice Ball
+INSERT INTO `item_latents` VALUES(14901, 23, 60, 49, 5929); -- atk+60
+INSERT INTO `item_latents` VALUES(14901, 1, 40, 49, 5929); -- def+40
+INSERT INTO `item_latents` VALUES(14901, 302, 2, 49, 5929); -- triple attack 2%
+
+-- Roshi Jinpachi
+-- Tonosama Rice Ball
+INSERT INTO `item_latents` VALUES(13910, 23, 50, 49, 4277); -- atk+50
+INSERT INTO `item_latents` VALUES(13910, 1, 30, 49, 4277); -- def+30
+INSERT INTO `item_latents` VALUES(13910, 288, 1, 49, 4277); -- double attack 1%
+-- Shogun Rice Ball
+INSERT INTO `item_latents` VALUES(13910, 23, 50, 49, 4278); -- atk+50
+INSERT INTO `item_latents` VALUES(13910, 1, 30, 49, 4278); -- def+30
+INSERT INTO `item_latents` VALUES(13910, 288, 5, 49, 4278); -- double attack 5%
+-- Rice Ball
+INSERT INTO `item_latents` VALUES(13910, 1, 50, 49, 4405); -- def+50
+-- Salmon Rice Ball
+INSERT INTO `item_latents` VALUES(13910, 23, 40, 49, 4590); -- atk+40
+INSERT INTO `item_latents` VALUES(13910, 1, 40, 49, 4590); -- def+40
+-- Rogue Rice Ball
+INSERT INTO `item_latents` VALUES(13910, 1, 50, 49, 4604); -- def+50
+INSERT INTO `item_latents` VALUES(13910, 230, 5, 49, 4604); -- beast killer 5% (guesstimated)
+-- Naval Rice Ball
+INSERT INTO `item_latents` VALUES(13910, 23, 40, 49, 4605); -- atk+40
+INSERT INTO `item_latents` VALUES(13910, 1, 40, 49, 4605); -- def+40
+INSERT INTO `item_latents` VALUES(13910, 232, 5, 49, 4604); -- arcana killer 5% (guesstimated)
+-- Hinesama Rice Ball
+INSERT INTO `item_latents` VALUES(13910, 23, 60, 49, 5928); -- atk+60
+INSERT INTO `item_latents` VALUES(13910, 1, 40, 49, 5928); -- def+40
+INSERT INTO `item_latents` VALUES(13910, 302, 1, 49, 5928); -- triple attack 1%
+-- Ojo Rice Ball
+INSERT INTO `item_latents` VALUES(13910, 23, 60, 49, 5929); -- atk+60
+INSERT INTO `item_latents` VALUES(13910, 1, 40, 49, 5929); -- def+40
+INSERT INTO `item_latents` VALUES(13910, 302, 2, 49, 5929); -- triple attack 2%
+
+-- Roshi Jinpachi +1
+-- Tonosama Rice Ball
+INSERT INTO `item_latents` VALUES(13949, 23, 50, 49, 4277); -- atk+50
+INSERT INTO `item_latents` VALUES(13949, 1, 30, 49, 4277); -- def+30
+INSERT INTO `item_latents` VALUES(13949, 288, 1, 49, 4277); -- double attack 1%
+-- Shogun Rice Ball
+INSERT INTO `item_latents` VALUES(13949, 23, 50, 49, 4278); -- atk+50
+INSERT INTO `item_latents` VALUES(13949, 1, 30, 49, 4278); -- def+30
+INSERT INTO `item_latents` VALUES(13949, 288, 5, 49, 4278); -- double attack 5%
+-- Rice Ball
+INSERT INTO `item_latents` VALUES(13949, 1, 50, 49, 4405); -- def+50
+-- Salmon Rice Ball
+INSERT INTO `item_latents` VALUES(13949, 23, 40, 49, 4590); -- atk+40
+INSERT INTO `item_latents` VALUES(13949, 1, 40, 49, 4590); -- def+40
+-- Rogue Rice Ball
+INSERT INTO `item_latents` VALUES(13949, 1, 50, 49, 4604); -- def+50
+INSERT INTO `item_latents` VALUES(13949, 230, 5, 49, 4604); -- beast killer 5% (guesstimated)
+-- Naval Rice Ball
+INSERT INTO `item_latents` VALUES(13949, 23, 40, 49, 4605); -- atk+40
+INSERT INTO `item_latents` VALUES(13949, 1, 40, 49, 4605); -- def+40
+INSERT INTO `item_latents` VALUES(13949, 232, 5, 49, 4604); -- arcana killer 5% (guesstimated)
+-- Hinesama Rice Ball
+INSERT INTO `item_latents` VALUES(13949, 23, 60, 49, 5928); -- atk+60
+INSERT INTO `item_latents` VALUES(13949, 1, 40, 49, 5928); -- def+40
+INSERT INTO `item_latents` VALUES(13949, 302, 1, 49, 5928); -- triple attack 1%
+-- Ojo Rice Ball
+INSERT INTO `item_latents` VALUES(13949, 23, 60, 49, 5929); -- atk+60
+INSERT INTO `item_latents` VALUES(13949, 1, 40, 49, 5929); -- def+40
+INSERT INTO `item_latents` VALUES(13949, 302, 2, 49, 5929); -- triple attack 2%
+
+-- Nobushi Kyahan
+-- Tonosama Rice Ball
+INSERT INTO `item_latents` VALUES(11367, 23, 50, 49, 4277); -- atk+50
+INSERT INTO `item_latents` VALUES(11367, 1, 30, 49, 4277); -- def+30
+INSERT INTO `item_latents` VALUES(11367, 288, 1, 49, 4277); -- double attack 1%
+-- Shogun Rice Ball
+INSERT INTO `item_latents` VALUES(11367, 23, 50, 49, 4278); -- atk+50
+INSERT INTO `item_latents` VALUES(11367, 1, 30, 49, 4278); -- def+30
+INSERT INTO `item_latents` VALUES(11367, 288, 5, 49, 4278); -- double attack 5%
+-- Rice Ball
+INSERT INTO `item_latents` VALUES(11367, 1, 50, 49, 4405); -- def+50
+-- Salmon Rice Ball
+INSERT INTO `item_latents` VALUES(11367, 23, 40, 49, 4590); -- atk+40
+INSERT INTO `item_latents` VALUES(11367, 1, 40, 49, 4590); -- def+40
+-- Rogue Rice Ball
+INSERT INTO `item_latents` VALUES(11367, 1, 50, 49, 4604); -- def+50
+INSERT INTO `item_latents` VALUES(11367, 230, 5, 49, 4604); -- beast killer 5% (guesstimated)
+-- Naval Rice Ball
+INSERT INTO `item_latents` VALUES(11367, 23, 40, 49, 4605); -- atk+40
+INSERT INTO `item_latents` VALUES(11367, 1, 40, 49, 4605); -- def+40
+INSERT INTO `item_latents` VALUES(11367, 232, 5, 49, 4604); -- arcana killer 5% (guesstimated)
+-- Hinesama Rice Ball
+INSERT INTO `item_latents` VALUES(11367, 23, 60, 49, 5928); -- atk+60
+INSERT INTO `item_latents` VALUES(11367, 1, 40, 49, 5928); -- def+40
+INSERT INTO `item_latents` VALUES(11367, 302, 1, 49, 5928); -- triple attack 1%
+-- Ojo Rice Ball
+INSERT INTO `item_latents` VALUES(11367, 23, 60, 49, 5929); -- atk+60
+INSERT INTO `item_latents` VALUES(11367, 1, 40, 49, 5929); -- def+40
+INSERT INTO `item_latents` VALUES(11367, 302, 2, 49, 5929); -- triple attack 2%


### PR DESCRIPTION
I've added the bonus effects of each rice ball to each piece of gear as food-activated latents using food ID as the parameter. I removed the old system for the rice ball as it was granting the boost when the gear was not equipped - that was not retail behaviour. Fix for issue #1963.