### PR TITLE
SCRIPTS: Quest "A Taste for Meat" fixed

### DIFF
--- a/scripts/zones/Port_San_dOria/npcs/Antreneau.lua
+++ b/scripts/zones/Port_San_dOria/npcs/Antreneau.lua
@@ -39,7 +39,7 @@ function onTrigger(player,npc)
 	elseif (player:getQuestStatus(SANDORIA, A_TASTE_FOR_MEAT) == QUEST_AVAILABLE and player:getVar("aTasteForMeat") == 0) then
 		player:startEvent(0x020f);
 	else	
-		player:startEvent(0x020d);
+		player:startEvent(0x0215);
 	end;
 	
 end; 

--- a/scripts/zones/Port_San_dOria/npcs/Thierride.lua
+++ b/scripts/zones/Port_San_dOria/npcs/Thierride.lua
@@ -48,7 +48,6 @@ function onTrigger(player,npc)
 	if (aTasteForMeat == QUEST_AVAILABLE and player:getVar("aTasteForMeat") == 1 or aTasteForMeat == QUEST_ACCEPTED) then
 		player:startEvent(0x020e);
 	else
-		player:delQuest(SANDORIA, A_TASTE_FOR_MEAT);
 		player:startEvent(0x020c);
 	end;
 	


### PR DESCRIPTION
Making this quest can be completed and hence can proceed to next quest "The Dismayed Customer."
[Before] This quest can be repeated and screw up quest list.
[After] This quest can be fully completed just like retail.
