### PR TITLE
Scripts: ZM4 Hanging issue fix

### DIFF
--- a/scripts/zones/Kazham/npcs/Magriffon.lua
+++ b/scripts/zones/Kazham/npcs/Magriffon.lua
@@ -1,25 +1,49 @@
 -----------------------------------
 -- Area: Kazham
 -- NPC: Magriffon
--- Standard Info NPC
+-- Involved in Quest: Gullible's Travels, Even More Gullible's Travels,
+-- Location: (I-7)
 -----------------------------------
 
 package.loaded["scripts/zones/Kazham/TextIDs"] = nil;
+require("scripts/globals/settings");
+require("scripts/globals/quests");
+require("scripts/globals/titles");
 require("scripts/zones/Kazham/TextIDs");
+
 
 -----------------------------------
 -- onTrade Action
 -----------------------------------
 
 function onTrade(player,npc,trade)
-end; 
+    if(player:getQuestStatus(OUTLANDS, GULLIBLES_TRAVELS) == QUEST_ACCEPTED) then
+        if(trade:getGil() >= player:getVar("MAGRIFFON_GIL_REQUEST")) then
+            player:startEvent(0x0092);
+        end
+    end
+end;
 
 -----------------------------------
 -- onTrigger Action
 -----------------------------------
 
 function onTrigger(player,npc)
-	player:startEvent(0x008F);
+    local gulliblesTravelsStatus = player:getQuestStatus(OUTLANDS, GULLIBLES_TRAVELS);
+
+    if(gulliblesTravelsStatus == QUEST_ACCEPTED) then        -- Gullible's Travels: 'In progress' check
+        local magriffonGilRequest = player:getVar("MAGRIFFON_GIL_REQUEST");
+        player:startEvent(0x0091, 0, magriffonGilRequest);
+    elseif(gulliblesTravelsStatus == QUEST_AVAILABLE         -- Gullible's Travels: Fame check and quest available check
+            and player:getFameLevel(KAZHAM) >= 6) then
+        local gil = math.random(10, 30) * 1000;              -- # 10,000 - 30,000 in ticks of 1k
+        player:setVar("MAGRIFFON_GIL_REQUEST", gil);
+        player:startEvent(0x0090, 0, gil);
+    elseif(gulliblesTravelsStatus == QUEST_COMPLETED) then   -- Gullible's Travels: 'Complete' check
+        player:startEvent(0x0093);
+    else
+        player:startEvent(0x008F);
+    end
 end;
 -----------------------------------
 -- onEventUpdate
@@ -35,9 +59,14 @@ end;
 -----------------------------------
 
 function onEventFinish(player,csid,option)
---printf("CSID: %u",csid);
---printf("RESULT: %u",option);
+    if(csid == 0x0090 and option == 1)  then                 -- Gullible's Travels: First CS
+        player:addQuest(OUTLANDS, GULLIBLES_TRAVELS);
+    elseif(csid == 0x0092) then                              -- Gullible's Travels: Final CS
+        player:confirmTrade();
+        player:delGil(player:getVar("MAGRIFFON_GIL_REQUEST"));
+        player:setVar("MAGRIFFON_GIL_REQUEST", 0);
+        player:addFame(KAZHAM, WIN_FAME*30);
+        player:setTitle(285);                                -- Global Variable not working for this quest
+        player:completeQuest(OUTLANDS, GULLIBLES_TRAVELS);
+    end
 end;
-
-
-

--- a/scripts/zones/Sacrificial_Chamber/bcnms/temple_of_uggalepih.lua
+++ b/scripts/zones/Sacrificial_Chamber/bcnms/temple_of_uggalepih.lua
@@ -28,17 +28,17 @@ end;
 
 function onBcnmLeave(player,instance,leavecode)
 -- print("leave code "..leavecode);
-	
+
 	if(leavecode == 2) then -- play end CS. Need time and battle id for record keeping + storage
 		if(player:getCurrentMission(ZILART) == THE_TEMPLE_OF_UGGALEPIH) then
-			player:startEvent(0x7d01,1,1,1,0,1,0,0);
+			player:startEvent(0x7d01,2,1,1,1,1,0,0);
 		else
 			player:startEvent(0x7d01,1,1,1,0,1,1,0);
 		end
 	elseif(leavecode == 4) then
 		player:startEvent(0x7d02);
 	end
-	
+
 end;
 
 function onEventUpdate(player,csid,option)
@@ -47,12 +47,12 @@ end;
 
 function onEventFinish(player,csid,option)
 -- print("bc finish csid "..csid.." and option "..option);
-	
+
 	if(csid == 0x7d01) then
 		player:addTitle(BEARER_OF_THE_WISEWOMANS_HOPE);
 		if(player:getCurrentMission(ZILART) == THE_TEMPLE_OF_UGGALEPIH) then
 			player:startEvent(0x0007);
 		end
 	end
-	
+
 end;


### PR DESCRIPTION
This should fix the issues mentioned in issue  #1425 in which the cutscene after the BCNM would hang on a black screen. Modifying the event arguments for the cutscene returns the desired result.