### PR TITLE
Scripts: BLU enfeeble standardization + fixes

### DIFF
--- a/scripts/globals/spells/bluemagic/Yawn.lua
+++ b/scripts/globals/spells/bluemagic/Yawn.lua
@@ -32,26 +32,21 @@ end;
 
 function onSpellCast(caster,target,spell)
 
-    local duration = 90;
     local typeEffect = EFFECT_SLEEP_II;
-    local pINT = caster:getStat(MOD_INT);
-    local mINT = target:getStat(MOD_INT);
-    local dINT = (pINT - mINT);
-    local resm = applyResistance(caster,spell,target,dINT,BLUE_SKILL,0);
-    
-    if(resm < 0.5) then
-        spell:setMsg(85);--resist message
-        return typeEffect;
-    end
+    local dINT = (caster:getStat(MOD_INT) - target:getStat(MOD_INT));
+    local resist = applyResistanceEffect(caster,spell,target,dINT,BLUE_SKILL,0,typeEffect);
+    local duration = 90 * resist;
 
-    duration = duration * resm;
-
-
-    if(target:addStatusEffect(typeEffect,2,0,duration)) then
-        spell:setMsg(236);
+    -- TODO: Check for mob looking at player (NOT gaze). Does not apply for enemies using the spell?
+    if(resist > 0.5) then -- Do it!
+        if(target:addStatusEffect(typeEffect,2,0,duration)) then
+            spell:setMsg(236);
+        else
+            spell:setMsg(75);
+        end
     else
-        spell:setMsg(75);
-    end
+        spell:setMsg(85);
+    end;
 
-    return typeEffect;
+    return typeEffect; 
 end;

--- a/scripts/globals/spells/bluemagic/actinic_burst.lua
+++ b/scripts/globals/spells/bluemagic/actinic_burst.lua
@@ -32,19 +32,21 @@ end;
 
 function onSpellCast(caster,target,spell)
 
-    -- Pull base stats.
+    local typeEffect = EFFECT_FLASH;
     local dINT = (caster:getStat(MOD_MND) - target:getStat(MOD_MND));
     local resist = applyResistance(caster,spell,target,dINT,BLUE_SKILL, 150);
     local duration = 20 * resist;
+    local power = 200;
 
-    if(resist > 0.0625) then
-        if(target:addStatusEffect(EFFECT_FLASH,200,0,duration)) then
+    if(resist > 0.0625) then -- Do it!
+        if(target:addStatusEffect(typeEffect,power,0,duration)) then
             spell:setMsg(236);
         else
             spell:setMsg(75);
         end
     else
         spell:setMsg(85);
-    end
-    return EFFECT_FLASH;
+    end;
+
+    return typeEffect;
 end;

--- a/scripts/globals/spells/bluemagic/chaotic_eye.lua
+++ b/scripts/globals/spells/bluemagic/chaotic_eye.lua
@@ -29,34 +29,21 @@ end;
 -----------------------------------------
 
 function onSpellCast(caster,target,spell)
+    local typeEffect = EFFECT_SILENCE;
+    local dINT = (caster:getStat(MOD_INT) - target:getStat(MOD_INT));
+    local resist = applyResistanceEffect(caster,spell,target,dINT,BLUE_SKILL,0,typeEffect);
+    local duration = 180 * resist;
 
-    local effectType = EFFECT_SILENCE;
-
-    if(target:hasStatusEffect(effectType)) then
-        spell:setMsg(75); -- no effect
-        return effectType;
-    end
-
-    if(1000 * math.random() >= target:getMod(MOD_SILENCERES)) then
-        --Pull base stats.
-        local dINT = (caster:getStat(MOD_INT) - target:getStat(MOD_INT));
-
-        --Duration, including resistance.  May need more research.
-        local duration = 180;
-
-        --Resist
-        local resist = applyResistanceEffect(caster,spell,target,dINT,BLUE_SKILL,0, EFFECT_SILENCE);
-        
-        if(resist >= 0.5) then --Do it!
-            target:addStatusEffect(effectType,1,0,duration * resist);
+    -- TODO: Gaze check
+    if(resist > 0.5) then --Do it!
+        if(target:addStatusEffect(typeEffect,1,0,duration)) then
             spell:setMsg(236);
         else
-            spell:setMsg(85);
+            spell:setMsg(75);
         end
     else
-        spell:setMsg(85); -- resist
-    end
+        spell:setMsg(85);
+    end;
 
-
-    return effectType;
+    return typeEffect;
 end;

--- a/scripts/globals/spells/bluemagic/cold_wave.lua
+++ b/scripts/globals/spells/bluemagic/cold_wave.lua
@@ -30,33 +30,39 @@ end;
 -----------------------------------------
 
 function onSpellCast(caster,target,spell)
-    
+
+    local typeEffect = EFFECT_FROST;
+    local dINT = caster:getStat(MOD_INT)-target:getStat(MOD_INT);
+    local resist = applyResistance(caster,spell,target,dINT,BLUE_SKILL,0);
+
     if(target:getStatusEffect(EFFECT_BURN) ~= nil) then
         spell:setMsg(75); -- no effect
-    else        
-        local dINT = caster:getStat(MOD_INT)-target:getStat(MOD_INT);
-        local resist = applyResistance(caster,spell,target,dINT,BLUE_SKILL,0);
-        if(resist <= 0.0) then
-            spell:setMsg(85);
+    elseif(resist > 0.5) then
+        if(target:getStatusEffect(EFFECT_CHOKE) ~= nil) then
+            target:delStatusEffect(EFFECT_CHOKE);
+        end;
+        local sINT = caster:getStat(MOD_INT);
+        local DOT = getElementalDebuffDOT(sINT);
+        local effect = target:getStatusEffect(typeEffect);
+        local noeffect = false;
+        if(effect ~= nil) then
+            if(effect:getPower() >= DOT) then
+                noeffect = true;
+            end;
+        end;
+        if(noeffect) then
+            spell:setMsg(75); -- no effect
         else
-            if(target:getStatusEffect(EFFECT_CHOKE) ~= nil) then
-                target:delStatusEffect(EFFECT_CHOKE);
-            end;            local sINT = caster:getStat(MOD_INT);
-            local DOT = getElementalDebuffDOT(sINT);
-            local effect = target:getStatusEffect(EFFECT_FROST);
-            local noeffect = false;
             if(effect ~= nil) then
-                if(effect:getPower() >= DOT) then
-                    noeffect = true;
-                end;            end;            if(noeffect) then
-                spell:setMsg(75); -- no effect
-            else
-                if(effect ~= nil) then
-                    target:delStatusEffect(EFFECT_FROST);
-                end;                spell:setMsg(237);
-                local duration = math.floor(ELEMENTAL_DEBUFF_DURATION * resist);
-                target:addStatusEffect(EFFECT_FROST,DOT, 3, ELEMENTAL_DEBUFF_DURATION,FLAG_ERASBLE);
-            end;        end;    end;    
-    return EFFECT_FROST;
+                target:delStatusEffect(typeEffect);
+            end;
+                spell:setMsg(237);
+            local duration = math.floor(ELEMENTAL_DEBUFF_DURATION * resist);
+            target:addStatusEffect(typeEffect,DOT,3,ELEMENTAL_DEBUFF_DURATION,FLAG_ERASBLE);
+        end;
+    else
+        spell:setMsg(85);
+    end;
     
+    return typeEffect;
 end;

--- a/scripts/globals/spells/bluemagic/enervation.lua
+++ b/scripts/globals/spells/bluemagic/enervation.lua
@@ -31,19 +31,28 @@ end;
 
 function onSpellCast(caster,target,spell)
 
+    local typeEffectOne = EFFECT_DEFENSE_DOWN;
+    local typeEffectTwo = EFFECT_MAGIC_DEF_DOWN;
     local resist = applyResistance(caster,spell,target,caster:getStat(MOD_INT) - target:getStat(MOD_INT),BLUE_SKILL,1.0);
+    local duration = 30 * resist;
+    local returnEffect = typeEffectOne;
 
-    if(damage > 0 and resist > 0) then
-        local typeEffect = EFFECT_DEFENSE_DOWN;
-        target:delStatusEffect(typeEffect);
-        target:addStatusEffect(typeEffect,10,0,getBlueEffectDuration(caster,resist,typeEffect));
-    end
-    
-    if(damage > 0 and resist > 0) then    
-        local typeEffect = EFFECT_MAGIC_DEF_DOWN;
-        target:delStatusEffect(typeEffect);
-        target:addStatusEffect(typeEffect,8,0,getBlueEffectDuration(caster,resist,typeEffect));
-    end
+    if(resist >= 0.5) then
+        if(target:hasStatusEffect(typeEffectOne) and target:hasStatusEffect(typeEffectTwo)) then -- the def/mag def down does not overwrite the same debuff from any other source
+            spell:setMsg(75); -- no effect
+        elseif (target:hasStatusEffect(typeEffectOne)) then
+            target:addStatusEffect(typeEffectTwo,8,0,duration);
+            returnEffect = typeEffectTwo;
+            spell:setMsg(236);
+        elseif (target:hasStatusEffect(typeEffectTwo)) then
+            target:addStatusEffect(typeEffectOne,10,0,duration);
+            spell:setMsg(236);
+        else
+            target:addStatusEffect(typeEffectOne,10,0,duration);
+            target:addStatusEffect(typeEffectTwo,8,0,duration);
+            spell:setMsg(236);
+        end;
+    end;
 
-    return EFFECT_DEFENSE_DOWN;
+    return returnEffect;
 end;

--- a/scripts/globals/spells/bluemagic/feather_tickle.lua
+++ b/scripts/globals/spells/bluemagic/feather_tickle.lua
@@ -31,12 +31,14 @@ end;
 
 function onSpellCast(caster,target,spell)
 
-    local tp = 15;
+    local dINT = caster:getStat(MOD_MND) - target:getStat(MOD_MND);
+    local resist = applyResistance(caster,spell,target,dINT,BLUE_SKILL);
+    local power = 30 * resist;
     
     if(target:getTP() == 0) then
-        spell:setMsg(75); 
+        spell:setMsg(75);
     else
-        target:delTP(tp);
+        target:delTP(power);
         spell:setMsg(431);
     end
     

--- a/scripts/globals/spells/bluemagic/filamented_hold.lua
+++ b/scripts/globals/spells/bluemagic/filamented_hold.lua
@@ -31,22 +31,21 @@ end;
 
 function onSpellCast(caster,target,spell)
 
+    local typeEffect = EFFECT_SLOW
     local dINT = caster:getStat(MOD_MND) - target:getStat(MOD_MND);
-    local resist = applyResistanceEffect(caster,spell,target,dINT,BLUE_SKILL, 0, EFFECT_SLOW);
+    local resist = applyResistanceEffect(caster,spell,target,dINT,BLUE_SKILL,0,typeEffect);
+    local duration = 90 * resist;
+    local power = 25;
     
-    if(resist > (0.0652)) then
-        -- resisted!
-        spell:setMsg(85);
-        return 0;
-    end
-
-    if(target:hasStatusEffect(EFFECT_SLOW) == true) then
-        -- no effect
-        spell:setMsg(75);
+    if(resist > 0.5) then -- Do it!
+        if(target:addStatusEffect(typeEffect,power,0,duration)) then
+            spell:setMsg(236);
+        else
+            spell:setMsg(75);
+        end
     else
-        target:addStatusEffect(EFFECT_SLOW,15,0,60);
-        spell:setMsg(236);
-    end
+        spell:setMsg(85);
+    end;
 
-    return EFFECT_SLOW;
+    return typeEffect;
 end;

--- a/scripts/globals/spells/bluemagic/frightful_roar.lua
+++ b/scripts/globals/spells/bluemagic/frightful_roar.lua
@@ -31,22 +31,21 @@ end;
 
 function onSpellCast(caster,target,spell)
 
-    local duration = 60;
+    local typeEffect = EFFECT_DEFENSE_DOWN;
     local dINT = caster:getStat(MOD_MND) - target:getStat(MOD_MND);
     local resist = applyResistance(caster,spell,target,dINT,BLUE_SKILL);
+    local duration = 60 * resist;
+    local power = 10;
     
-    if(resist > (0.0652)) then
-        -- resisted!
-        spell:setMsg(85);
-        return 0;
-    end
-
-    if(target:hasStatusEffect(EFFECT_DEFENSE_DOWN) == true) then
+    if(resist > 0.5) then -- Do it!
+        if(target:addStatusEffect(typeEffect,power,0,duration)) then
+            spell:setMsg(236);
+        else
             spell:setMsg(75);
+        end
     else
-        target:addStatusEffect(EFFECT_DEFENSE_DOWN,10,0,duration);
-        spell:setMsg(236);
-    end
+        spell:setMsg(85);
+    end;
 
-    return EFFECT_DEFENSE_DOWN;
+    return typeEffect;
 end;

--- a/scripts/globals/spells/bluemagic/infrasonics.lua
+++ b/scripts/globals/spells/bluemagic/infrasonics.lua
@@ -31,23 +31,21 @@ end;
 
 function onSpellCast(caster,target,spell)
 
-    local duration = 60;
+    local typeEffect = EFFECT_EVASION_DOWN;
     local dINT = caster:getStat(MOD_MND) - target:getStat(MOD_MND);
     local resist = applyResistance(caster,spell,target,dINT,BLUE_SKILL);
+    local duration = 60 * resist;
+    local power = 20;
     
-    if(resist > 0.0625) then
-        -- resisted!
-        spell:setMsg(85);
-        return 0;
-    end
-
-    if(target:hasStatusEffect(EFFECT_EVASION_DOWN) == true) then
-        -- no effect
-        spell:setMsg(75);
+    if(resist > 0.5) then -- Do it!
+        if(target:addStatusEffect(typeEffect,power,0,duration)) then
+            spell:setMsg(236);
+        else
+            spell:setMsg(75);
+        end
     else
-        target:addStatusEffect(EFFECT_EVASION_DOWN,20,0,duration);
-        spell:setMsg(236);
-    end
+        spell:setMsg(85);
+    end;
 
-    return EFFECT_EVASION_DOWN;
+    return typeEffect;
 end;

--- a/scripts/globals/spells/bluemagic/jettatura.lua
+++ b/scripts/globals/spells/bluemagic/jettatura.lua
@@ -31,23 +31,21 @@ end;
 
 function onSpellCast(caster,target,spell)
 
-    local duration = 5;
+    local typeEffect = EFFECT_TERROR;
     local dINT = caster:getStat(MOD_MND) - target:getStat(MOD_MND);
     local resist = applyResistance(caster,spell,target,dINT,BLUE_SKILL);
-    
-    if(resist > 0.0625) then
-        -- resisted!
-        spell:setMsg(85);
-        return 0;
-    end
+    local duration = 5 * resist;
 
-    if(target:hasStatusEffect(EFFECT_TERROR) == true) then
-        -- no effect
-        spell:setMsg(75);
+    -- TODO: Gaze check
+    if(resist > 0.5) then -- Do it!
+        if(target:addStatusEffect(typeEffect,power,0,duration)) then
+            spell:setMsg(236);
+        else
+            spell:setMsg(75);
+        end
     else
-        target:addStatusEffect(EFFECT_TERROR,1,0,duration);
-        spell:setMsg(236);
-    end
+        spell:setMsg(85);
+    end;
 
-    return EFFECT_TERROR;
+    return typeEffect;
 end;

--- a/scripts/globals/spells/bluemagic/light_of_penance.lua
+++ b/scripts/globals/spells/bluemagic/light_of_penance.lua
@@ -31,19 +31,32 @@ end;
 
 function onSpellCast(caster,target,spell)
 
+    local typeEffectOne = EFFECT_BLINDNESS;
+    local typeEffectTwo = EFFECT_BIND;
     local resist = applyResistance(caster,spell,target,caster:getStat(MOD_INT) - target:getStat(MOD_INT),BLUE_SKILL,1.0);
+    local duration = 30 * resist;
+    local power = 10 * resist;
+    local returnEffect = typeEffectOne;
 
-    if(damage > 0 and resist > 0.3) then
-        local typeEffect = EFFECT_BLINDNESS;
-        target:delStatusEffect(typeEffect);
-        target:addStatusEffect(typeEffect,10,0,getBlueEffectDuration(caster,resist,typeEffect));
-    end
-    
-    if(damage > 0 and resist > 0.3) then    
-        local typeEffect = EFFECT_BIND;
-        target:delStatusEffect(typeEffect);
-        target:addStatusEffect(typeEffect,1,0,getBlueEffectDuration(caster,resist,typeEffect));
-    end
+    -- TODO: Gaze check
+    if(resist >= 0.5) then
+        if(target:hasStatusEffect(typeEffectOne) and target:hasStatusEffect(typeEffectTwo) and target:getTP() == 0) then
+            spell:setMsg(75); -- no effect
+        elseif(target:hasStatusEffect(typeEffectOne) and target:hasStatusEffect(typeEffectTwo)) then
+            target:delTP(power);
+            spell:setMsg(431); -- tp reduced
+        elseif (target:hasStatusEffect(typeEffectOne)) then
+            target:addStatusEffect(typeEffectTwo,1,0,duration);
+            target:delTP(power);
+            returnEffect = typeEffectTwo; -- make it return bind message if blind can't be inflicted
+            spell:setMsg(236);
+        else
+            target:addStatusEffect(typeEffectOne,50,0,duration);
+            target:addStatusEffect(typeEffectTwo,1,0,duration);
+            target:delTP(power);
+            spell:setMsg(236);
+        end;
+    end;
 
-    return EFFECT_BLINDNESS;
+    return returnEffect;
 end;

--- a/scripts/globals/spells/bluemagic/lowing.lua
+++ b/scripts/globals/spells/bluemagic/lowing.lua
@@ -31,18 +31,21 @@ end;
 
 function onSpellCast(caster,target,spell)
 
-    local duration = 60;    
+    local typeEffect = EFFECT_PLAGUE;
     local dINT = caster:getStat(MOD_MND) - target:getStat(MOD_MND);
     local resist = applyResistance(caster,spell,target,dINT,BLUE_SKILL);
+    local duration = 60 * resist;
+    local power = 5;
     
-    if(resist > 0.0625) then
-    -- resisted!
+    if(resist > 0.5) then -- Do it!
+        if(target:addStatusEffect(typeEffect,power,0,duration)) then
+            spell:setMsg(236);
+        else
+            spell:setMsg(75);
+        end
+    else
         spell:setMsg(85);
-        return 0;
-    end
+    end;
 
-        target:addStatusEffect(EFFECT_PLAGUE,5,0,duration);
-        spell:setMsg(236);
-
-    return EFFECT_PLAGUE;    
+    return typeEffect; 
 end;

--- a/scripts/globals/spells/bluemagic/sandspray.lua
+++ b/scripts/globals/spells/bluemagic/sandspray.lua
@@ -31,23 +31,21 @@ end;
 
 function onSpellCast(caster,target,spell)
 
-    local duration = 60;
+    local typeEffect = EFFECT_BLINDNESS;
     local dINT = caster:getStat(MOD_MND) - target:getStat(MOD_MND);
-    local resist = applyResistanceEffect(caster,spell,target,dINT,BLUE_SKILL,0,EFFECT_BLINDNESS);
+    local resist = applyResistanceEffect(caster,spell,target,dINT,BLUE_SKILL,0,typeEffect);
+    local duration = 120 * resist;
+    local power = 25;
     
-    if(resist > 0.0625) then
-        -- resisted!
-        spell:setMsg(85);
-        return 0;
-    end
-
-    if(target:hasStatusEffect(EFFECT_BLINDNESS) == true) then
-        -- no effect
-        spell:setMsg(75);
+    if(resist > 0.5) then -- Do it!
+        if(target:addStatusEffect(typeEffect,power,0,duration)) then
+            spell:setMsg(236);
+        else
+            spell:setMsg(75);
+        end
     else
-        target:addStatusEffect(EFFECT_BLINDNESS,7,0,duration);
-        spell:setMsg(236);
-    end
+        spell:setMsg(85);
+    end;
 
-    return EFFECT_BLINDNESS;
+    return typeEffect;
 end;

--- a/scripts/globals/spells/bluemagic/sheep_song.lua
+++ b/scripts/globals/spells/bluemagic/sheep_song.lua
@@ -31,24 +31,20 @@ end;
 
 function onSpellCast(caster,target,spell)
 
-    local duration = 60;
-    local pINT = caster:getStat(MOD_INT);
-    local mINT = target:getStat(MOD_INT);
-    local dINT = (pINT - mINT);
-    local resm = applyResistance(caster,spell,target,dINT,BLUE_SKILL,0);
+    local typeEffect = EFFECT_SLEEP_I;
+    local dINT = (caster:getStat(MOD_INT) - target:getStat(MOD_INT));
+    local resist = applyResistanceEffect(caster,spell,target,dINT,BLUE_SKILL,0,typeEffect);
+    local duration = 60 * resist;
     
-    if(resm < 0.5) then
-        spell:setMsg(85);--resist message
-        return EFFECT_SLEEP_I;
-    end
-
-    duration = duration * resm;
-
-    if(target:addStatusEffect(EFFECT_SLEEP_I,1,0,duration)) then
-        spell:setMsg(236);
+    if(resist > 0.5) then -- Do it!
+        if(target:addStatusEffect(typeEffect,1,0,duration)) then
+            spell:setMsg(236);
+        else
+            spell:setMsg(75);
+        end
     else
-        spell:setMsg(75);
-    end
+        spell:setMsg(85);
+    end;
 
-    return EFFECT_SLEEP_I;
+    return typeEffect;
 end;

--- a/scripts/globals/spells/bluemagic/soporific.lua
+++ b/scripts/globals/spells/bluemagic/soporific.lua
@@ -32,27 +32,20 @@ end;
 
 function onSpellCast(caster,target,spell)
 
-    local duration = 90;
     local typeEffect = EFFECT_SLEEP_II;
-    local pINT = caster:getStat(MOD_INT);
-    local mINT = target:getStat(MOD_INT);
-    local dINT = (pINT - mINT);
-    local resm = applyResistance(caster,spell,target,dINT,BLUE_SKILL,0);
+    local dINT = (caster:getStat(MOD_INT) - target:getStat(MOD_INT));
+    local resist = applyResistanceEffect(caster,spell,target,dINT,BLUE_SKILL,0,typeEffect);
+    local duration = 90 * resist;
     
-    if(resm < 0.5) then
-        spell:setMsg(85);--resist message
-        return typeEffect;
-    end
-
-    duration = duration * resm;
-
-
-    if(target:hasStatusEffect(typeEffect) == true) then
-        spell:setMsg(75);
+    if(resist > 0.5) then -- Do it!
+        if(target:addStatusEffect(typeEffect,2,0,duration)) then
+            spell:setMsg(236);
+        else
+            spell:setMsg(75);
+        end
     else
-        target:addStatusEffect(typeEffect,2,0,duration)
-        spell:setMsg(236);
-    end
+        spell:setMsg(85);
+    end;
 
     return typeEffect;
 end;

--- a/scripts/globals/spells/bluemagic/sound_blast.lua
+++ b/scripts/globals/spells/bluemagic/sound_blast.lua
@@ -31,23 +31,21 @@ end;
 
 function onSpellCast(caster,target,spell)
 
-    local duration = 30;
+    local typeEffect = EFFECT_INT_DOWN;
     local dINT = caster:getStat(MOD_MND) - target:getStat(MOD_MND);
     local resist = applyResistance(caster,spell,target,dINT,BLUE_SKILL);
-    
-    if(resist > (0.0652)) then
-        -- resisted!
-        spell:setMsg(85);
-        return 0;
-    end
+    local duration = 30 * resist;
+    local power = 6;
 
-    if(target:hasStatusEffect(EFFECT_INT_DOWN) == true) then
-        -- no effect
-        spell:setMsg(75);
+    if(resist > 0.5) then -- Do it!
+        if(target:addStatusEffect(typeEffect,power,0,duration)) then
+            spell:setMsg(236);
+        else
+            spell:setMsg(75);
+        end
     else
-        target:addStatusEffect(EFFECT_INT_DOWN,6,0,duration);
-        spell:setMsg(236);
-    end
+        spell:setMsg(85);
+    end;
 
-    return EFFECT_INT_DOWN;
+    return typeEffect;
 end;    

--- a/scripts/globals/spells/bluemagic/stinking_gas.lua
+++ b/scripts/globals/spells/bluemagic/stinking_gas.lua
@@ -31,23 +31,21 @@ end;
 
 function onSpellCast(caster,target,spell)
 
-    local duration = 60;
+    local typeEffect = EFFECT_VIT_DOWN;
     local dINT = caster:getStat(MOD_MND) - target:getStat(MOD_MND);
     local resist = applyResistance(caster,spell,target,dINT,BLUE_SKILL);
-    
-    if(resist > 0.0625) then
-        -- resisted!
-        spell:setMsg(85);
-        return 0;
-    end
+    local duration = 60 * resist;
+    local power = 5;
 
-    if(target:hasStatusEffect(EFFECT_VIT_DOWN) == true) then
-        -- no effect
-        spell:setMsg(75);
+    if(resist > 0.5) then -- Do it!
+        if(target:addStatusEffect(typeEffect,power,0,duration)) then
+            spell:setMsg(236);
+        else
+            spell:setMsg(75);
+        end
     else
-        target:addStatusEffect(EFFECT_VIT_DOWN,5,0,duration);
-        spell:setMsg(236);
-    end
+        spell:setMsg(85);
+    end;
 
-    return EFFECT_VIT_DOWN;
+    return typeEffect; 
 end;

--- a/scripts/globals/spells/bluemagic/temporal_shift.lua
+++ b/scripts/globals/spells/bluemagic/temporal_shift.lua
@@ -31,23 +31,20 @@ end;
 
 function onSpellCast(caster,target,spell)
 
-    local duration = 5;
+    local typeEffect = EFFECT_STUN;
     local dINT = caster:getStat(MOD_INT) - target:getStat(MOD_INT);
     local resist = applyResistanceEffect(caster,spell,target,dINT,BLUE_SKILL,0,EFFECT_STUN);
+    local duration = 5 * resist;
     
-    if(resist <= (1/16)) then
-        -- resisted!
-        spell:setMsg(85);
-        return 0;
-    end
-
-    if(target:hasStatusEffect(EFFECT_STUN)) then
-        -- no effect
-        spell:setMsg(75);
+    if(resist > 0.0625) then -- Do it!
+        if(target:addStatusEffect(typeEffect,2,0,duration)) then
+            spell:setMsg(236);
+        else
+            spell:setMsg(75);
+        end
     else
-        target:addStatusEffect(EFFECT_STUN,2,0,duration*resist);
-        spell:setMsg(236);
-    end
+        spell:setMsg(85);
+    end;
 
-    return EFFECT_STUN;
+    return typeEffect;
 end;

--- a/scripts/globals/spells/bluemagic/venom_shell.lua
+++ b/scripts/globals/spells/bluemagic/venom_shell.lua
@@ -31,22 +31,21 @@ end;
 
 function onSpellCast(caster,target,spell)
 
-    local duration = 30;
+    local typeEffect = EFFECT_POISON
     local dINT = caster:getStat(MOD_MND) - target:getStat(MOD_MND);
-    local resist = applyResistanceEffect(caster,spell,target,dINT,BLUE_SKILL,0,EFFECT_POISON);
-    if(resist > (0.0652)) then
-        -- resisted!
-        spell:setMsg(85);
-        return 0;
-    end
+    local resist = applyResistanceEffect(caster,spell,target,dINT,BLUE_SKILL,0,typeEffect);
+    local duration = 180 * resist;
+    local power = 6;
 
-    if(target:hasStatusEffect(EFFECT_POISON) == true) then
-        -- no effect
-        spell:setMsg(75);
+    if(resist > 0.5) then -- Do it!
+        if(target:addStatusEffect(typeEffect,power,0,duration)) then
+            spell:setMsg(236);
+        else
+            spell:setMsg(75);
+        end
     else
-        target:addStatusEffect(EFFECT_POISON,6,0,duration);
-        spell:setMsg(236);
-    end
+        spell:setMsg(85);
+    end;
 
-    return EFFECT_POISON;
+    return typeEffect;
 end;


### PR DESCRIPTION
A couple of spells like Filamented Hold could only land if there was a 1/16th resist - while it sounds ass backwards, this allowed it to land when most BLU enfeebles were using a skill other than Blue Magic skill.
I updated a couple of the spells with whatever info I could find on a wiki. I took info from bgwiki over ffxiclopedia if both had info.
I did not touch Awful Eye because I couldn't get a good enough source for the amount of STR down it inflicts.

Edit: For clarity, with them using Blue Skill and resist greater than 1/2 (or 1/16th for some), they land. Ie. done proper.