### PR TITLE
SCRIPTS: San d'Oria mission 2-1

### DIFF
--- a/scripts/zones/La_Theine_Plateau/npcs/Vicorpasse.lua
+++ b/scripts/zones/La_Theine_Plateau/npcs/Vicorpasse.lua
@@ -27,7 +27,7 @@ function onTrigger(player,npc)
 	if(player:getCurrentMission(SANDORIA) == THE_RESCUE_DRILL) then
 		local MissionStatus = player:getVar("MissionStatus");
 		
-		if(MissionStatus >= 0 and MissionStatus == 4) then
+		if(MissionStatus >= 0 and MissionStatus <= 4) then
 			player:startEvent(0x006c);
 		elseif(MissionStatus >= 5 and MissionStatus <= 7) then
 			player:showText(npc, RESCUE_DRILL + 19);

--- a/scripts/zones/La_Theine_Plateau/npcs/Vicorpasse.lua
+++ b/scripts/zones/La_Theine_Plateau/npcs/Vicorpasse.lua
@@ -27,7 +27,7 @@ function onTrigger(player,npc)
 	if(player:getCurrentMission(SANDORIA) == THE_RESCUE_DRILL) then
 		local MissionStatus = player:getVar("MissionStatus");
 		
-		if(MissionStatus == 4) then
+		if(MissionStatus >= 0 and MissionStatus == 4) then
 			player:startEvent(0x006c);
 		elseif(MissionStatus >= 5 and MissionStatus <= 7) then
 			player:showText(npc, RESCUE_DRILL + 19);


### PR DESCRIPTION
Making it like retail and preventing ppl from having trouble with this mission.
[Before]  have to speak to "Galaihaurat → Equesobillot → Deaufrain → Vicorpasse" to proceed.
[After] Players can directly speak to Vicorpasse to proceed. (just like retail)