### PR TITLE
SCRIPTS: San d'Oria mission 2-1 & 2-3

### DIFF
--- a/scripts/zones/Chateau_dOraguille/npcs/Halver.lua
+++ b/scripts/zones/Chateau_dOraguille/npcs/Halver.lua
@@ -110,7 +110,7 @@ function onTrigger(player,npc)
 		-- Mission San D'Oria 2-3 Journey Abroad 
 		elseif(currentMission == JOURNEY_ABROAD and MissionStatus == 11) then
 			player:startEvent(0x01fb);
-		elseif(currentMission == JOURNEY_ABROAD and MissionStatus == 0) then
+		elseif(currentMission == JOURNEY_ABROAD and MissionStatus == 1) then
 			player:startEvent(0x01f9);		
 		elseif(currentMission == JOURNEY_ABROAD) then
 			player:startEvent(0x0214);	

--- a/scripts/zones/La_Theine_Plateau/npcs/Vicorpasse.lua
+++ b/scripts/zones/La_Theine_Plateau/npcs/Vicorpasse.lua
@@ -27,7 +27,7 @@ function onTrigger(player,npc)
 	if(player:getCurrentMission(SANDORIA) == THE_RESCUE_DRILL) then
 		local MissionStatus = player:getVar("MissionStatus");
 		
-		if(MissionStatus == 4) then
+		if(MissionStatus >= 0 and MissionStatus <= 4) then
 			player:startEvent(0x006c);
 		elseif(MissionStatus >= 5 and MissionStatus <= 7) then
 			player:showText(npc, RESCUE_DRILL + 19);


### PR DESCRIPTION
2-1: Making it like retail and preventing ppl from having trouble with this mission.
[Before] have to speak to "Galaihaurat → Equesobillot → Deaufrain → Vicorpasse" to proceed.
[After] players can directly speak to Vicorpasse to proceed. (just like retail)

2-3: 
[Before] can't proceed.
[After] fixed.