### PR TITLE
Adds all items Lv76-99 currently in AH.

### DIFF
--- a/sql/item_mods.sql
+++ b/sql/item_mods.sql
@@ -1024,6 +1024,16 @@ INSERT INTO `item_mods` VALUES (10451, 421, 5); -- Increases critical hit damage
 INSERT INTO `item_mods` VALUES (10452, 369, 1);
 
 -- -------------------------------------------------------
+-- Praeco Doublet
+-- -------------------------------------------------------
+INSERT INTO `item_mods` VALUES (10453, 1, 50); -- Defense + 50
+INSERT INTO `item_mods` VALUES (10453, 12, 15); -- INT + 15
+INSERT INTO `item_mods` VALUES (10453, 13, 15); -- MND + 15
+INSERT INTO `item_mods` VALUES (10453, 14, 15); -- CHR + 15
+INSERT INTO `item_mods` VALUES (10453, 30, 5); -- Magic Accuracy + 5
+INSERT INTO `item_mods` VALUES (10453, 455, 10); -- Song Spellcasting Time + 10
+
+-- -------------------------------------------------------
 -- Asura Samue
 -- -------------------------------------------------------
 INSERT INTO `item_mods` VALUES (10454, 1, 60); -- DEF:60
@@ -1032,7 +1042,70 @@ INSERT INTO `item_mods` VALUES (10454, 27, 5); -- Enmity+5
 INSERT INTO `item_mods` VALUES (10454, 73, 4); -- "Store TP"+4
 INSERT INTO `item_mods` VALUES (10454, 289, 5); -- "Subtle Blow"+5
 
-INSERT INTO `item_mods` VALUES (10455, 73, 8);
+-- -------------------------------------------------------
+-- Asura Samue +1
+-- -------------------------------------------------------
+INSERT INTO `item_mods` VALUES (10455, 1, 60); -- Defense + 60
+INSERT INTO `item_mods` VALUES (10455, 10, 7); -- VIT + 7
+INSERT INTO `item_mods` VALUES (10455, 73, 8); -- Store TP + 8
+INSERT INTO `item_mods` VALUES (10455, 289, 10); -- Subtle Blow + 10
+INSERT INTO `item_mods` VALUES (10455, 27, 4); -- Enmity + 4
+
+-- -------------------------------------------------------
+-- Avant Mail
+-- -------------------------------------------------------
+INSERT INTO `item_mods` VALUES (10456, 1, 66); -- Defense + 66
+INSERT INTO `item_mods` VALUES (10456, 2, 20); -- HP + 20
+INSERT INTO `item_mods` VALUES (10456, 8, 9); -- STR + 9
+INSERT INTO `item_mods` VALUES (10456, 23, 15); -- Attack + 15
+
+-- -------------------------------------------------------
+-- Avant Mail +1
+-- -------------------------------------------------------
+INSERT INTO `item_mods` VALUES (10457, 1, 67); -- Defense + 67
+INSERT INTO `item_mods` VALUES (10457, 2, 25); -- HP + 25
+INSERT INTO `item_mods` VALUES (10457, 8, 10); -- STR + 10
+INSERT INTO `item_mods` VALUES (10457, 23, 20); -- Attack + 20
+INSERT INTO `item_mods` VALUES (10457, 288, 3); -- Double Attack + 3
+
+-- -------------------------------------------------------
+-- Kacura Harness
+-- -------------------------------------------------------
+INSERT INTO `item_mods` VALUES (10458, 1, 62); -- Defense + 62
+INSERT INTO `item_mods` VALUES (10458, 2, 15); -- HP + 15
+INSERT INTO `item_mods` VALUES (10458, 8, 7); -- STR + 7
+INSERT INTO `item_mods` VALUES (10458, 11, 5); -- AGI + 5
+INSERT INTO `item_mods` VALUES (10458, 25, 7); -- Accuracy + 7
+INSERT INTO `item_mods` VALUES (10458, 26, 7); -- Ranged Accuracy + 7
+
+-- -------------------------------------------------------
+-- Kacura Harness +1
+-- -------------------------------------------------------
+INSERT INTO `item_mods` VALUES (10459, 1, 63); -- Defense + 63
+INSERT INTO `item_mods` VALUES (10459, 2, 20); -- HP + 20
+INSERT INTO `item_mods` VALUES (10459, 8, 7); -- STR + 7
+INSERT INTO `item_mods` VALUES (10459, 11, 7); -- AGI + 7
+INSERT INTO `item_mods` VALUES (10459, 25, 12); -- Accuracy + 12
+INSERT INTO `item_mods` VALUES (10459, 26, 12); -- Ranged Accuracy + 12
+INSERT INTO `item_mods` VALUES (10459, 165, 3); -- Critical Chance + 3
+
+-- -------------------------------------------------------
+-- Sweven Coat
+-- -------------------------------------------------------
+INSERT INTO `item_mods` VALUES (10460, 1, 49); -- Defense + 49
+INSERT INTO `item_mods` VALUES (10460, 12, 5); -- INT + 5
+INSERT INTO `item_mods` VALUES (10460, 13, 5); -- MND + 5
+INSERT INTO `item_mods` VALUES (10460, 30, 10); -- Magic Accuracy + 10
+
+-- -------------------------------------------------------
+-- Sweven Coat +1
+-- -------------------------------------------------------
+INSERT INTO `item_mods` VALUES (10461, 1, 50); -- Defense + 50
+INSERT INTO `item_mods` VALUES (10461, 12, 6); -- INT + 6
+INSERT INTO `item_mods` VALUES (10461, 13, 6); -- MND + 6
+INSERT INTO `item_mods` VALUES (10461, 30, 12); -- Magic Accuracy + 12
+-- INSERT INTO `item_mods` VALUES (10461, ?, 3); -- Magic Crit Rate + 3
+
 INSERT INTO `item_mods` VALUES (10467, 369, 1);
 INSERT INTO `item_mods` VALUES (10468, 370, 3);
 
@@ -1260,12 +1333,82 @@ INSERT INTO `item_mods` VALUES (10493, 384, 40); -- Haste+4%
 INSERT INTO `item_mods` VALUES (10500, 73, 10);
 
 -- -------------------------------------------------------
+-- Brego Gloves
+-- -------------------------------------------------------
+INSERT INTO `item_mods` VALUES (10503, 1, 26); -- Defense + 26
+INSERT INTO `item_mods` VALUES (10503, 8, 5); -- STR + 5
+INSERT INTO `item_mods` VALUES (10503, 11, 5); -- AGI + 5
+INSERT INTO `item_mods` VALUES (10503, 25, 9); -- Accuracy + 9
+INSERT INTO `item_mods` VALUES (10503, 384, 40); -- Haste + 40
+
+-- -------------------------------------------------------
+-- Iuvenalis Mittens
+-- -------------------------------------------------------
+INSERT INTO `item_mods` VALUES (10504, 1, 20); -- Defense + 20
+INSERT INTO `item_mods` VALUES (10504, 5, -15); -- MP + -15
+INSERT INTO `item_mods` VALUES (10504, 8, 7); -- STR + 7
+INSERT INTO `item_mods` VALUES (10504, 10, 7); -- VIT + 7
+INSERT INTO `item_mods` VALUES (10504, 13, 7); -- MND + 7
+INSERT INTO `item_mods` VALUES (10504, 384, 51); -- Haste + 51
+
+-- -------------------------------------------------------
 -- Nomkahpa Mittens
 -- -------------------------------------------------------
 INSERT INTO `item_mods` VALUES (10505, 1, 28); -- DEF:28
 INSERT INTO `item_mods` VALUES (10505, 8, 5); -- STR+5
 INSERT INTO `item_mods` VALUES (10505, 288, 3); -- "Double Attack"+3%
 INSERT INTO `item_mods` VALUES (10505, 384, 30); -- Haste+3%
+
+-- -------------------------------------------------------
+-- Avant Gauntlets
+-- -------------------------------------------------------
+INSERT INTO `item_mods` VALUES (10506, 1, 30); -- Defense + 30
+INSERT INTO `item_mods` VALUES (10506, 8, 6); -- STR + 6
+INSERT INTO `item_mods` VALUES (10506, 9, 6); -- DEX + 6
+INSERT INTO `item_mods` VALUES (10506, 25, 5); -- Accuracy + 5
+
+-- -------------------------------------------------------
+-- Avant Gauntlets +1
+-- -------------------------------------------------------
+INSERT INTO `item_mods` VALUES (10507, 1, 31); -- Defense + 31
+INSERT INTO `item_mods` VALUES (10507, 8, 7); -- STR + 7
+INSERT INTO `item_mods` VALUES (10507, 9, 7); -- DEX + 7
+INSERT INTO `item_mods` VALUES (10507, 25, 10); -- Accuracy + 10
+INSERT INTO `item_mods` VALUES (10507, 288, 2); -- Double Attack + 2
+
+-- -------------------------------------------------------
+-- Kacura Mittens
+-- -------------------------------------------------------
+INSERT INTO `item_mods` VALUES (10508, 1, 25); -- Defense + 25
+INSERT INTO `item_mods` VALUES (10508, 9, 4); -- DEX + 4
+INSERT INTO `item_mods` VALUES (10508, 11, 4); -- AGI + 4
+INSERT INTO `item_mods` VALUES (10508, 68, 7); -- Evasion + 7
+
+-- -------------------------------------------------------
+-- Kacura Mittens +1
+-- -------------------------------------------------------
+INSERT INTO `item_mods` VALUES (10509, 1, 26); -- Defense + 26
+INSERT INTO `item_mods` VALUES (10509, 9, 5); -- DEX + 5
+INSERT INTO `item_mods` VALUES (10509, 11, 5); -- AGI + 5
+INSERT INTO `item_mods` VALUES (10509, 68, 12); -- Evasion + 12
+INSERT INTO `item_mods` VALUES (10509, 165, 2); -- Critical Chance + 2
+
+-- -------------------------------------------------------
+-- Sweven Mitts
+-- -------------------------------------------------------
+INSERT INTO `item_mods` VALUES (10510, 1, 20); -- Defense + 20
+INSERT INTO `item_mods` VALUES (10510, 5, 25); -- MP + 25
+INSERT INTO `item_mods` VALUES (10510, 14, 8); -- CHR + 8
+INSERT INTO `item_mods` VALUES (10510, 30, 6); -- Magic Accuracy + 6
+
+-- -------------------------------------------------------
+-- Sweven Mitts +1
+-- -------------------------------------------------------
+INSERT INTO `item_mods` VALUES (10511, 1, 21); -- Defense + 21
+INSERT INTO `item_mods` VALUES (10511, 5, 30); -- MP + 30
+INSERT INTO `item_mods` VALUES (10511, 14, 9); -- CHR + 9
+INSERT INTO `item_mods` VALUES (10511, 30, 8); -- Magic Accuracy + 8
+
 -- -------------------------------------------------------
 -- Phorcys Mitts
 -- -------------------------------------------------------
@@ -1285,7 +1428,7 @@ INSERT INTO `item_mods` VALUES (10528, 10, 8); -- VIT+8
 INSERT INTO `item_mods` VALUES (10528, 11, 8); -- AGI+8
 INSERT INTO `item_mods` VALUES (10528, 25, 9); -- Accuracy+9
 INSERT INTO `item_mods` VALUES (10528, 170, 3); -- Enhance "Fast Cast" effect+3
-INSERT INTO `item_mods` VALUES (10528, 384, 3); -- Haste+3%
+INSERT INTO `item_mods` VALUES (10528, 384, 30); -- Haste+3%
 
 -- -------------------------------------------------------
 -- Nares Cuffs
@@ -1350,6 +1493,68 @@ INSERT INTO `item_mods` VALUES (10595, 1, 2); -- def 2
 -- Decennial Hose +1
 -- -------------------------------------------------------
 INSERT INTO `item_mods` VALUES (10596, 1, 2); -- def 2
+
+-- -------------------------------------------------------
+-- Scopuli Nails
+-- -------------------------------------------------------
+INSERT INTO `item_mods` VALUES (10603, 1, 23); -- Defense + 23
+INSERT INTO `item_mods` VALUES (10603, 9, 10); -- DEX + 10
+INSERT INTO `item_mods` VALUES (10603, 11, 10); -- AGI + 10
+
+-- -------------------------------------------------------
+-- Avant Leggings
+-- -------------------------------------------------------
+INSERT INTO `item_mods` VALUES (10604, 1, 24); -- Defense + 24
+INSERT INTO `item_mods` VALUES (10604, 8, 5); -- STR + 5
+INSERT INTO `item_mods` VALUES (10604, 11, 5); -- AGI + 5
+INSERT INTO `item_mods` VALUES (10604, 68, 7); -- Evasion + 7
+
+-- -------------------------------------------------------
+-- Avant Leggings +1
+-- -------------------------------------------------------
+INSERT INTO `item_mods` VALUES (10605, 1, 25); -- Defense + 25
+INSERT INTO `item_mods` VALUES (10605, 8, 6); -- STR + 6
+INSERT INTO `item_mods` VALUES (10605, 11, 6); -- AGI + 6
+INSERT INTO `item_mods` VALUES (10605, 68, 10); -- Evasion + 10
+INSERT INTO `item_mods` VALUES (10605, 288, 1); -- Double Attack + 1
+
+-- -------------------------------------------------------
+-- Kacura Leggings
+-- -------------------------------------------------------
+INSERT INTO `item_mods` VALUES (10606, 1, 20); -- Defense + 20
+INSERT INTO `item_mods` VALUES (10606, 2, 20); -- HP + 20
+INSERT INTO `item_mods` VALUES (10606, 8, 4); -- STR + 4
+INSERT INTO `item_mods` VALUES (10606, 9, 6); -- DEX + 6
+INSERT INTO `item_mods` VALUES (10606, 68, 5); -- Evasion + 5
+
+-- -------------------------------------------------------
+-- Kacura Leggings +1
+-- -------------------------------------------------------
+INSERT INTO `item_mods` VALUES (10607, 1, 21); -- Defense + 21
+INSERT INTO `item_mods` VALUES (10607, 2, 25); -- HP + 25
+INSERT INTO `item_mods` VALUES (10607, 8, 6); -- STR + 6
+INSERT INTO `item_mods` VALUES (10607, 9, 6); -- DEX + 6
+INSERT INTO `item_mods` VALUES (10607, 68, 10); -- Evasion + 10
+INSERT INTO `item_mods` VALUES (10607, 165, 2); -- Critical Chance + 2
+
+-- -------------------------------------------------------
+-- Sweven Boots
+-- -------------------------------------------------------
+INSERT INTO `item_mods` VALUES (10608, 1, 16); -- Defense + 16
+INSERT INTO `item_mods` VALUES (10608, 2, 20); -- HP + 20
+INSERT INTO `item_mods` VALUES (10608, 13, 6); -- MND + 6
+INSERT INTO `item_mods` VALUES (10608, 14, 6); -- CHR + 6
+INSERT INTO `item_mods` VALUES (10608, 30, 5); -- Magic Accuracy + 5
+
+-- -------------------------------------------------------
+-- Sweven Boots +1
+-- -------------------------------------------------------
+INSERT INTO `item_mods` VALUES (10609, 1, 17); -- Defense + 17
+INSERT INTO `item_mods` VALUES (10609, 2, 25); -- HP + 25
+INSERT INTO `item_mods` VALUES (10609, 13, 7); -- MND + 7
+INSERT INTO `item_mods` VALUES (10609, 14, 7); -- CHR + 7
+INSERT INTO `item_mods` VALUES (10609, 30, 7); -- Magic Accuracy + 7
+-- INSERT INTO `item_mods` VALUES (10609, ?, 2); -- Magic Critical + 2
 
 -- -------------------------------------------------------
 -- Phorcys Schuhs
@@ -1471,7 +1676,6 @@ INSERT INTO `item_mods` VALUES (10657, 8, 9); -- STR+9
 INSERT INTO `item_mods` VALUES (10657, 10, 9); -- VIT+9
 INSERT INTO `item_mods` VALUES (10657, 23, 15); -- Attack+15
 INSERT INTO `item_mods` VALUES (10657, 395, 80); -- Black magic casting time-8%
-
 
 -- ------------------------------------------
 -- Monster Helm +2
@@ -1896,7 +2100,7 @@ INSERT INTO `item_mods` VALUES (10701, 23, 15); -- Attack+15
 -- ------------------------------------------
 INSERT INTO `item_mods` VALUES (10702, 1, 23); -- DEF:23
 INSERT INTO `item_mods` VALUES (10702, 8, 13); -- STR+13
-INSERT INTO `item_mods` VALUES (10703, 384, 40); -- Haste+4
+INSERT INTO `item_mods` VALUES (10702, 384, 40); -- Haste+4
 INSERT INTO `item_mods` VALUES (10702, 289, 5); -- Subtle Blow+5
 INSERT INTO `item_mods` VALUES (10702, 308, 30); -- Ninja Tool Expertise
 
@@ -2327,8 +2531,51 @@ INSERT INTO `item_mods` VALUES (10749, 5, 35); -- MP+35
 INSERT INTO `item_mods` VALUES (10749, 112, 12); -- Healing Skill+12
 INSERT INTO `item_mods` VALUES (10749, 170, 5); -- Enhances Fast cast
 
+-- -------------------------------------------------------
+-- Tyrant's Ring
+-- -------------------------------------------------------
+INSERT INTO `item_mods` VALUES (10750, 11, -4); -- AGI + -4
+INSERT INTO `item_mods` VALUES (10750, 23, 8); -- Attack + 8
+INSERT INTO `item_mods` VALUES (10750, 73, 4); -- Store TP + 4
+
+-- -------------------------------------------------------
+-- Valseur's Ring
+-- -------------------------------------------------------
+INSERT INTO `item_mods` VALUES (10751, 25, 3); -- Accuracy + 3
+INSERT INTO `item_mods` VALUES (10751, 491, 3); -- Waltz Effectiveness + 3
+
+-- -------------------------------------------------------
+-- Prolix Ring
+-- -------------------------------------------------------
+INSERT INTO `item_mods` VALUES (10752, 5, 20); -- MP + 20
+INSERT INTO `item_mods` VALUES (10752, 27, -3); -- Enmity + -3
+INSERT INTO `item_mods` VALUES (10752, 170, 2); -- Fast Cast + 2
+
+INSERT INTO `item_mods` VALUES (10753, 1, 20); -- Defense + 20
 INSERT INTO `item_mods` VALUES (10753, 370, 2);
+
+-- -------------------------------------------------------
+-- Angha Ring
+-- -------------------------------------------------------
+INSERT INTO `item_mods` VALUES (10762, 30, 4); -- Magic Accuracy + 4
+INSERT INTO `item_mods` VALUES (10762, 71, 2); -- MP while Healing + 2
+
+-- -------------------------------------------------------
+-- Poeas' Ring
+-- -------------------------------------------------------
+INSERT INTO `item_mods` VALUES (10763, 24, 8); -- Ranged Attack + 8
+INSERT INTO `item_mods` VALUES (10763, 73, -4); -- Store TP + -4
+
 INSERT INTO `item_mods` VALUES (10764, 370, 1);
+-- INSERT INTO `item_mods` VALUES (10764, ?, ?); -- Enhances Protect and Shell Received + ?
+
+-- -------------------------------------------------------
+-- Arvina Ringlet
+-- -------------------------------------------------------
+INSERT INTO `item_mods` VALUES (10765, 11, 4); -- AGI + 4
+INSERT INTO `item_mods` VALUES (10765, 105, 3); -- Marksmanship + 3
+INSERT INTO `item_mods` VALUES (10765, 30, 2); -- Magic Accuracy + 2
+
 INSERT INTO `item_mods` VALUES (10787, 375, 3);
 
 -- -------------------------------------------------------
@@ -2337,6 +2584,49 @@ INSERT INTO `item_mods` VALUES (10787, 375, 3);
 INSERT INTO `item_mods` VALUES (10798, 2, 70); -- HP+70
 INSERT INTO `item_mods` VALUES (10798, 27, 5); -- Enmity+5
 INSERT INTO `item_mods` VALUES (10798, 255, 5); -- Enhances resistance against "Death"
+
+-- -------------------------------------------------------
+-- Castellan's Shield
+-- -------------------------------------------------------
+INSERT INTO `item_mods` VALUES (10800, 1, 28); -- Defense + 28
+INSERT INTO `item_mods` VALUES (10800, 10, 15); -- VIT + 15
+INSERT INTO `item_mods` VALUES (10800, 68, -6); -- Evasion + -6
+-- INSERT INTO `item_mods` VALUES (10800, ?, ?); -- Shield Def Bonus + ?
+
+-- -------------------------------------------------------
+-- Psychist Shield
+-- -------------------------------------------------------
+INSERT INTO `item_mods` VALUES (10801, 1, 17); -- Defense + 17
+INSERT INTO `item_mods` VALUES (10801, 5, 50); -- MP + 50
+INSERT INTO `item_mods` VALUES (10801, 13, 4); -- MND + 4
+
+-- -------------------------------------------------------
+-- Majorelle Shield
+-- -------------------------------------------------------
+INSERT INTO `item_mods` VALUES (10802, 1, 30); -- Defense + 30
+INSERT INTO `item_mods` VALUES (10802, 5, 30); -- MP + 30
+-- INSERT INTO `item_mods` VALUES (10802, 170, ?); -- Fast Cast + ?
+
+-- -------------------------------------------------------
+-- Weathering Shield
+-- -------------------------------------------------------
+INSERT INTO `item_mods` VALUES (10803, 1, 36); -- Defense + 36
+INSERT INTO `item_mods` VALUES (10803, 54, -10); -- Fire Resistance + -10
+INSERT INTO `item_mods` VALUES (10803, 59, -10); -- Water Resistance + -10
+INSERT INTO `item_mods` VALUES (10803, 56, -10); -- Wind Resistance + -10
+INSERT INTO `item_mods` VALUES (10803, 55, -10); -- Ice Resistance + -10
+INSERT INTO `item_mods` VALUES (10803, 58, -10); -- Thunder Resistance + -10
+INSERT INTO `item_mods` VALUES (10803, 57, -10); -- Earth Resistance + -10
+INSERT INTO `item_mods` VALUES (10803, 60, -10); -- Light Resistance + -10
+INSERT INTO `item_mods` VALUES (10803, 61, -10); -- Dark Resistance + -10
+INSERT INTO `item_mods` VALUES (10803, 163, -25); -- Percent Magic Damage Taken + -25
+
+-- -------------------------------------------------------
+-- Thuellaic Ecu
+-- -------------------------------------------------------
+INSERT INTO `item_mods` VALUES (10804, 1, 30); -- Defense + 30
+INSERT INTO `item_mods` VALUES (10804, 68, 8); -- Evasion + 8
+INSERT INTO `item_mods` VALUES (10804, 384, 20); -- Haste + 2
 
 INSERT INTO `item_mods` VALUES (10806, 375, 15);
 
@@ -2371,11 +2661,195 @@ INSERT INTO `item_mods` VALUES (10811, 1, 1); -- DEF:1
 -- -------------------------------------------------------
 INSERT INTO `item_mods` VALUES (10812, 1, 2); -- DEF:2
 
+-- -------------------------------------------------------
+-- Corvax Sash
+-- -------------------------------------------------------
+INSERT INTO `item_mods` VALUES (10814, 1, 5); -- Defense + 5
+INSERT INTO `item_mods` VALUES (10814, 14, -4); -- CHR + -4
+-- INSERT INTO `item_mods` VALUES (10814, ?, 2); -- Song Recast Delay + 2
+
 INSERT INTO `item_mods` VALUES (10816, 1, 9);
 INSERT INTO `item_mods` VALUES (10816, 2, 30);
 INSERT INTO `item_mods` VALUES (10816, 402, 5);
-INSERT INTO `item_mods` VALUES (10864, 370, 1);
-INSERT INTO `item_mods` VALUES (10867, 370, 1);
+-- INSERT INTO `item_mods` VALUES (10816, ?, ?); --Increases breath damage
+
+-- -------------------------------------------------------
+-- Moepapa Stone
+-- -------------------------------------------------------
+INSERT INTO `item_mods` VALUES (10817, 1, 5); -- Defense + 5
+INSERT INTO `item_mods` VALUES (10817, 14, 5); -- CHR + 5
+INSERT INTO `item_mods` VALUES (10817, 384, 51); -- Haste + 51
+-- INSERT INTO `item_mods` VALUES (10817, ?, 51); -- Pet Haste + 51
+
+-- -------------------------------------------------------
+-- Flume Belt
+-- -------------------------------------------------------
+INSERT INTO `item_mods` VALUES (10819, 1, 12); -- Defense + 12
+INSERT INTO `item_mods` VALUES (10819, 161, -4); -- Percent Physical Damage Taken + -4
+INSERT INTO `item_mods` VALUES (10819, 516, 2); -- Converts Damage to MP + 2
+
+-- -------------------------------------------------------
+-- Bishop's Sash
+-- -------------------------------------------------------
+INSERT INTO `item_mods` VALUES (10820, 1, 5); -- Defense + 5
+INSERT INTO `item_mods` VALUES (10820, 111, 5); -- Divine Magic + 5
+INSERT INTO `item_mods` VALUES (10820, 112, 5); -- Healing Magic + 5
+
+-- -------------------------------------------------------
+-- Olympus Sash
+-- -------------------------------------------------------
+INSERT INTO `item_mods` VALUES (10821, 1, 5); -- Defense + 5
+INSERT INTO `item_mods` VALUES (10821, 113, 5); -- Enhancing Magic + 5
+INSERT INTO `item_mods` VALUES (10821, 115, 5); -- Elemental Magic + 5
+
+-- -------------------------------------------------------
+-- Harfner's Sash
+-- -------------------------------------------------------
+INSERT INTO `item_mods` VALUES (10822, 1, 5); -- Defense + 5
+INSERT INTO `item_mods` VALUES (10822, 120, 5); -- String Instruments + 5
+INSERT INTO `item_mods` VALUES (10822, 121, 5); -- Wind Instruments + 5
+
+-- -------------------------------------------------------
+-- Cimmerian Sash
+-- -------------------------------------------------------
+INSERT INTO `item_mods` VALUES (10823, 1, 5); -- Defense + 5
+INSERT INTO `item_mods` VALUES (10823, 117, 5); -- Summoning Magic + 5
+INSERT INTO `item_mods` VALUES (10823, 118, 5); -- Ninjutsu + 5
+
+-- -------------------------------------------------------
+-- Casso Sash
+-- -------------------------------------------------------
+INSERT INTO `item_mods` VALUES (10824, 1, 5); -- Defense + 5
+INSERT INTO `item_mods` VALUES (10824, 114, 5); -- Enfeebling Magic + 5
+INSERT INTO `item_mods` VALUES (10824, 116, 5); -- Dark Magic + 5
+
+-- -------------------------------------------------------
+-- Chiner's Belt
+-- -------------------------------------------------------
+INSERT INTO `item_mods` VALUES (10825, 1, 8); -- Defense + 8
+INSERT INTO `item_mods` VALUES (10825, 9, 7); -- DEX + 7
+-- INSERT INTO `item_mods` VALUES (10825, ?, ?); -- Increases Triple Attack Damage + ?
+
+-- -------------------------------------------------------
+-- Witful Belt
+-- -------------------------------------------------------
+INSERT INTO `item_mods` VALUES (10826, 1, 8); -- Defense + 8
+INSERT INTO `item_mods` VALUES (10826, 170, 3); -- Fast Cast + 6
+INSERT INTO `item_mods` VALUES (10826, 384, 30); -- Haste + 30
+-- INSERT INTO `item_mods` VALUES (10826, ?, 3); -- Occasionaly Quickens Spellcasting + 3
+
+-- -------------------------------------------------------
+-- Prosilio Belt
+-- -------------------------------------------------------
+INSERT INTO `item_mods` VALUES (10827, 1, 9); -- Defense + 9
+INSERT INTO `item_mods` VALUES (10827, 8, 9); -- STR + 9
+INSERT INTO `item_mods` VALUES (10827, 23, 25); -- Attack + 25
+INSERT INTO `item_mods` VALUES (10827, 288, -5); -- Double Attack + -5
+
+-- -------------------------------------------------------
+-- Windbuffet Belt
+-- -------------------------------------------------------
+INSERT INTO `item_mods` VALUES (10828, 1, 7); -- Defense + 7
+INSERT INTO `item_mods` VALUES (10828, 302, 2); -- Triple Attack + 2
+INSERT INTO `item_mods` VALUES (10828, 430, 1); -- Quadruple Attack + 1
+
+-- -------------------------------------------------------
+-- Artful Belt
+-- -------------------------------------------------------
+INSERT INTO `item_mods` VALUES (10829, 1, 10); -- Defense + 10
+INSERT INTO `item_mods` VALUES (10829, 9, 9); -- DEX + 9
+INSERT INTO `item_mods` VALUES (10829, 11, -7); -- AGI + -7
+
+-- -------------------------------------------------------
+-- Artful Belt +1
+-- -------------------------------------------------------
+INSERT INTO `item_mods` VALUES (10830, 1, 11); -- Defense + 11
+INSERT INTO `item_mods` VALUES (10830, 9, 10); -- DEX + 10
+
+-- -------------------------------------------------------
+-- Ocelomeh Headpiece
+-- -------------------------------------------------------
+INSERT INTO `item_mods` VALUES (10864, 1, 31); -- Defense + 31
+INSERT INTO `item_mods` VALUES (10864, 9, 12); -- DEX + 12
+INSERT INTO `item_mods` VALUES (10864, 11, 12); -- AGI + 12
+INSERT INTO `item_mods` VALUES (10864, 384, 61); -- Haste + 61
+INSERT INTO `item_mods` VALUES (10864, 370, 1); -- Regen + 1
+
+-- -------------------------------------------------------
+-- Nefer Khat
+-- -------------------------------------------------------
+INSERT INTO `item_mods` VALUES (10865, 1, 30); -- Defense + 30
+INSERT INTO `item_mods` VALUES (10865, 5, 20); -- MP + 20
+INSERT INTO `item_mods` VALUES (10865, 30, 5); -- Magic Accuracy + 5
+INSERT INTO `item_mods` VALUES (10865, 28, 5); -- Magic Attack Bonus + 5
+INSERT INTO `item_mods` VALUES (10865, 27, -4); -- Enmity + -4
+
+-- -------------------------------------------------------
+-- Mekira-Oto
+-- -------------------------------------------------------
+INSERT INTO `item_mods` VALUES (10866, 1, 40); -- Defense + 40
+INSERT INTO `item_mods` VALUES (10866, 8, 15); -- STR + 15
+INSERT INTO `item_mods` VALUES (10866, 23, 25); -- Attack + 25
+-- INSERT INTO `item_mods` VALUES (10866, ?, ?); -- Elemental WS by Day + ?
+
+-- -------------------------------------------------------
+-- Ocelomeh Headpiece +1
+-- -------------------------------------------------------
+INSERT INTO `item_mods` VALUES (10867, 1, 32); -- Defense + 32
+INSERT INTO `item_mods` VALUES (10867, 9, 13); -- DEX + 13
+INSERT INTO `item_mods` VALUES (10867, 11, 13); -- AGI + 13
+INSERT INTO `item_mods` VALUES (10867, 384, 71); -- Haste + 71
+INSERT INTO `item_mods` VALUES (10867, 370, 2); -- Regen + 2
+
+-- -------------------------------------------------------
+-- Nefer Khat +1
+-- -------------------------------------------------------
+INSERT INTO `item_mods` VALUES (10868, 1, 31); -- Defense + 31
+INSERT INTO `item_mods` VALUES (10868, 5, 25); -- MP + 25
+INSERT INTO `item_mods` VALUES (10868, 30, 6); -- Magic Accuracy + 6
+INSERT INTO `item_mods` VALUES (10868, 28, 6); -- Magic Attack Bonus + 6
+INSERT INTO `item_mods` VALUES (10868, 27, -5); -- Enmity + -5
+
+-- -------------------------------------------------------
+-- Mekira-Oto +1
+-- -------------------------------------------------------
+INSERT INTO `item_mods` VALUES (10869, 1, 41); -- Defense + 41
+INSERT INTO `item_mods` VALUES (10869, 8, 16); -- STR + 16
+INSERT INTO `item_mods` VALUES (10869, 23, 30); -- Attack + 30
+-- INSERT INTO `item_mods` VALUES (10869, ?, ?); -- Elemental WS by Day + ?
+
+-- -------------------------------------------------------
+-- Pandinus Beret
+-- -------------------------------------------------------
+INSERT INTO `item_mods` VALUES (10871, 1, 33); -- Defense + 33
+INSERT INTO `item_mods` VALUES (10871, 11, 6); -- AGI + 6
+INSERT INTO `item_mods` VALUES (10871, 24, 6); -- Ranged Attack + 6
+INSERT INTO `item_mods` VALUES (10871, 28, 6); -- Magic Attack Bonus + 6
+
+-- -------------------------------------------------------
+-- Ruach Crown
+-- -------------------------------------------------------
+INSERT INTO `item_mods` VALUES (10872, 1, 27); -- Defense + 27
+INSERT INTO `item_mods` VALUES (10872, 13, 12); -- MND + 12
+INSERT INTO `item_mods` VALUES (10872, 30, -4); -- Magic Accuracy + -4
+INSERT INTO `item_mods` VALUES (10872, 27, -4); -- Enmity + -4
+
+-- -------------------------------------------------------
+-- Theia's Hairpin
+-- -------------------------------------------------------
+INSERT INTO `item_mods` VALUES (10873, 9, 6); -- DEX + 6
+INSERT INTO `item_mods` VALUES (10873, 11, 6); -- AGI + 6
+INSERT INTO `item_mods` VALUES (10873, 25, 9); -- Accuracy + 9
+INSERT INTO `item_mods` VALUES (10873, 68, 9); -- Evasion + 9
+
+-- -------------------------------------------------------
+-- Chersos Helm
+-- -------------------------------------------------------
+INSERT INTO `item_mods` VALUES (10874, 1, 42); -- Defense + 42
+INSERT INTO `item_mods` VALUES (10874, 10, 7); -- VIT + 7
+INSERT INTO `item_mods` VALUES (10874, 68, -7); -- Evasion + -7
+INSERT INTO `item_mods` VALUES (10874, 161, -4); -- Percent Physical Damage Taken + -4
+INSERT INTO `item_mods` VALUES (10874, 384, 40); -- Haste + 40
 
 -- -------------------------------------------------------
 -- Snowman Cap
@@ -2384,7 +2858,100 @@ INSERT INTO `item_mods` VALUES (10875, 1, 1); -- DEF:1
 INSERT INTO `item_mods` VALUES (10875, 54, -12); -- [Element: Fire]-12
 INSERT INTO `item_mods` VALUES (10875, 55, 12); -- [Element: Ice]+12
 
-INSERT INTO `item_mods` VALUES (10879, 73, 7);
+-- -------------------------------------------------------
+-- Hreysti Helm
+-- -------------------------------------------------------
+INSERT INTO `item_mods` VALUES (10879, 1, 42); -- Defense + 42
+INSERT INTO `item_mods` VALUES (10879, 8, 10); -- STR + 10
+INSERT INTO `item_mods` VALUES (10879, 73, 7); -- Store TP + 7
+INSERT INTO `item_mods` VALUES (10879, 242, 2); -- Paralysis Resistance + 2
+
+-- -------------------------------------------------------
+-- Praeco Beret
+-- -------------------------------------------------------
+INSERT INTO `item_mods` VALUES (10880, 1, 27); -- Defense + 27
+INSERT INTO `item_mods` VALUES (10880, 14, 7); -- CHR + 7
+INSERT INTO `item_mods` VALUES (10880, 30, 3); -- Magic Accuracy + 3
+INSERT INTO `item_mods` VALUES (10880, 455, 5); -- Song Spellcasting Time + 5
+
+-- -------------------------------------------------------
+-- Brego Helm
+-- -------------------------------------------------------
+INSERT INTO `item_mods` VALUES (10881, 1, 32); -- Defense + 32
+INSERT INTO `item_mods` VALUES (10881, 8, 6); -- STR + 6
+INSERT INTO `item_mods` VALUES (10881, 9, 6); -- DEX + 6
+INSERT INTO `item_mods` VALUES (10881, 384, 51); -- Haste + 51
+INSERT INTO `item_mods` VALUES (10881, 289, 4); -- Subtle Blow + 4
+
+-- -------------------------------------------------------
+-- Smilodon Mask
+-- -------------------------------------------------------
+INSERT INTO `item_mods` VALUES (10882, 1, 35); -- Defense + 35
+INSERT INTO `item_mods` VALUES (10882, 2, 25); -- HP + 25
+INSERT INTO `item_mods` VALUES (10882, 8, 8); -- STR + 8
+INSERT INTO `item_mods` VALUES (10882, 10, 8); -- VIT + 8
+INSERT INTO `item_mods` VALUES (10882, 107, 10); -- Guard + 10
+INSERT INTO `item_mods` VALUES (10882, 291, 3); -- Counter + 3
+
+-- -------------------------------------------------------
+-- Gallian Helm
+-- -------------------------------------------------------
+INSERT INTO `item_mods` VALUES (10883, 1, 43); -- Defense + 43
+INSERT INTO `item_mods` VALUES (10883, 2, 55); -- HP + 55
+INSERT INTO `item_mods` VALUES (10883, 8, 13); -- STR + 13
+INSERT INTO `item_mods` VALUES (10883, 10, 13); -- VIT + 13
+INSERT INTO `item_mods` VALUES (10883, 59, 20); -- Water Resistance + 20
+INSERT INTO `item_mods` VALUES (10883, 25, -20); -- Accuracy + -20
+
+-- -------------------------------------------------------
+-- Avant Helm
+-- -------------------------------------------------------
+INSERT INTO `item_mods` VALUES (10884, 1, 41); -- Defense + 41
+INSERT INTO `item_mods` VALUES (10884, 8, 4); -- STR + 4
+INSERT INTO `item_mods` VALUES (10884, 10, 2); -- VIT + 2
+INSERT INTO `item_mods` VALUES (10884, 23, 13); -- Attack + 13
+
+-- -------------------------------------------------------
+-- Avant Helm +1
+-- -------------------------------------------------------
+INSERT INTO `item_mods` VALUES (10885, 1, 42); -- Defense + 42
+INSERT INTO `item_mods` VALUES (10885, 8, 5); -- STR + 5
+INSERT INTO `item_mods` VALUES (10885, 10, 3); -- VIT + 3
+INSERT INTO `item_mods` VALUES (10885, 23, 15); -- Attack + 15
+INSERT INTO `item_mods` VALUES (10885, 288, 2); -- Double Attack + 2
+
+-- -------------------------------------------------------
+-- Kacura Cap
+-- -------------------------------------------------------
+INSERT INTO `item_mods` VALUES (10886, 1, 35); -- Defense + 35
+INSERT INTO `item_mods` VALUES (10886, 9, 8); -- DEX + 8
+INSERT INTO `item_mods` VALUES (10886, 68, 5); -- Evasion + 5
+
+-- -------------------------------------------------------
+-- Kacura Cap +1
+-- -------------------------------------------------------
+INSERT INTO `item_mods` VALUES (10887, 1, 36); -- Defense + 36
+INSERT INTO `item_mods` VALUES (10887, 9, 8); -- DEX + 8
+INSERT INTO `item_mods` VALUES (10887, 68, 10); -- Evasion + 10
+INSERT INTO `item_mods` VALUES (10887, 288, 2); -- Double Attack + 2
+
+-- -------------------------------------------------------
+-- Sweven Corona
+-- -------------------------------------------------------
+INSERT INTO `item_mods` VALUES (10888, 1, 25); -- Defense + 25
+INSERT INTO `item_mods` VALUES (10888, 5, 20); -- MP + 20
+INSERT INTO `item_mods` VALUES (10888, 13, 7); -- MND + 7
+INSERT INTO `item_mods` VALUES (10888, 30, 5); -- Magic Accuracy + 5
+
+-- -------------------------------------------------------
+-- Sweven Corona +1
+-- -------------------------------------------------------
+INSERT INTO `item_mods` VALUES (10889, 1, 26); -- Defense + 26
+INSERT INTO `item_mods` VALUES (10889, 5, 25); -- MP + 25
+INSERT INTO `item_mods` VALUES (10889, 13, 8); -- MND + 8
+INSERT INTO `item_mods` VALUES (10889, 30, 7); -- Magic Accuracy + 7
+-- INSERT INTO `item_mods` VALUES (10889, ?, 2); -- Magic Critical Rate + 2
+
 -- -------------------------------------------------------
 -- Phorcys Salade
 -- -------------------------------------------------------
@@ -2392,7 +2959,7 @@ INSERT INTO `item_mods` VALUES (10901, 1, 36); -- DEF:36
 INSERT INTO `item_mods` VALUES (10901, 25, 10); -- Accuracy+10
 INSERT INTO `item_mods` VALUES (10901, 23, 10); -- ATTACK+10
 INSERT INTO `item_mods` VALUES (10901, 73, 5); -- "Store TP"+5
-INSERT INTO `item_mods` VALUES (10901, 384, 7); -- "Haste+7%
+INSERT INTO `item_mods` VALUES (10901, 384, 71); -- "Haste+7%
 INSERT INTO `item_mods` VALUES (10901, 289, 5); -- "Subtle Blow"+5
 
 -- -------------------------------------------------------
@@ -2471,10 +3038,90 @@ INSERT INTO `item_mods` VALUES (10931, 25, 6);
 -- INSERT INTO `item_mods` VALUES (10931, ???, ?); TODO: Tonberry's Grudge
 INSERT INTO `item_mods` VALUES (10932, 68, 5);
 INSERT INTO `item_mods` VALUES (10932, 161, -2);
-INSERT INTO `item_mods` VALUES (10936, 370, 2);
-INSERT INTO `item_mods` VALUES (10946, 369, 1);
 
 -- -------------------------------------------------------
+-- Justiciar's Torque
+-- -------------------------------------------------------
+INSERT INTO `item_mods` VALUES (10934, 1, 10); -- Defense + 10
+INSERT INTO `item_mods` VALUES (10934, 8, 4); -- STR + 4
+INSERT INTO `item_mods` VALUES (10934, 23, 15); -- Attack + 15
+INSERT INTO `item_mods` VALUES (10934, 384, -51); -- Haste + -51
+
+-- -------------------------------------------------------
+-- Phrenic Torque
+-- -------------------------------------------------------
+INSERT INTO `item_mods` VALUES (10935, 61, 20); -- Dark Resistance + 20
+INSERT INTO `item_mods` VALUES (10935, 27, -7); -- Enmity + -7
+INSERT INTO `item_mods` VALUES (10935, 7, 30); -- Converts HP to MP + 30
+
+-- -------------------------------------------------------
+-- Wiglen Gorget
+-- -------------------------------------------------------
+INSERT INTO `item_mods` VALUES (10936, 161, -6); -- Percent Physical Damage Taken + -6
+INSERT INTO `item_mods` VALUES (10936, 163, 15); -- Percent Magic Damage Taken + 15
+INSERT INTO `item_mods` VALUES (10936, 370, 3); -- Regen + 3
+
+-- -------------------------------------------------------
+-- Calcitrant Stole
+-- -------------------------------------------------------
+INSERT INTO `item_mods` VALUES (10937, 1, 7); -- Defense + 7
+INSERT INTO `item_mods` VALUES (10937, 23, 9); -- Attack + 9
+-- INSERT INTO `item_mods` VALUES (10937, ?, ?); -- Kick Attacks' Attack + ?
+
+-- -------------------------------------------------------
+-- Dualism Collar
+-- -------------------------------------------------------
+INSERT INTO `item_mods` VALUES (10939, 2, 45); -- HP + 45
+INSERT INTO `item_mods` VALUES (10939, 5, 45); -- MP + 45
+INSERT INTO `item_mods` VALUES (10939, 14, 6); -- CHR + 6
+INSERT INTO `item_mods` VALUES (10939, 60, 10); -- Light Resistance + 10
+INSERT INTO `item_mods` VALUES (10939, 61, 10); -- Dark Resistance + 10
+
+-- -------------------------------------------------------
+-- Tjukurrpa Medal
+-- -------------------------------------------------------
+INSERT INTO `item_mods` VALUES (10941, 8, 6); -- STR + 6
+INSERT INTO `item_mods` VALUES (10941, 10, 6); -- VIT + 6
+INSERT INTO `item_mods` VALUES (10941, 54, 10); -- Fire Resistance + 10
+INSERT INTO `item_mods` VALUES (10941, 57, 10); -- Earth Resistance + 10
+
+-- -------------------------------------------------------
+-- Aife's Medal
+-- -------------------------------------------------------
+INSERT INTO `item_mods` VALUES (10942, 12, 6); -- INT + 6
+INSERT INTO `item_mods` VALUES (10942, 13, 6); -- MND + 6
+INSERT INTO `item_mods` VALUES (10942, 55, 10); -- Ice Resistance + 10
+INSERT INTO `item_mods` VALUES (10942, 59, 10); -- Water Resistance + 10
+
+-- -------------------------------------------------------
+-- Moepapa Medal
+-- -------------------------------------------------------
+INSERT INTO `item_mods` VALUES (10943, 9, 6); -- DEX + 6
+INSERT INTO `item_mods` VALUES (10943, 11, 6); -- AGI + 6
+INSERT INTO `item_mods` VALUES (10943, 56, 10); -- Wind Resistance + 10
+INSERT INTO `item_mods` VALUES (10943, 58, 10); -- Thunder Resistance + 10
+
+-- -------------------------------------------------------
+-- Waylayer's Scarf
+-- -------------------------------------------------------
+INSERT INTO `item_mods` VALUES (10945, 1, 5); -- Defense + 5
+INSERT INTO `item_mods` VALUES (10945, 26, 7); -- Ranged Accuracy + 7
+INSERT INTO `item_mods` VALUES (10945, 30, 4); -- Magic Accuracy + 4
+
+-- -------------------------------------------------------
+-- Coatl Gorget
+-- -------------------------------------------------------
+INSERT INTO `item_mods` VALUES (10946, 1, 9); -- Defense + 9
+INSERT INTO `item_mods` VALUES (10946, 29, 3); -- Magic Defense Bonus + 3
+INSERT INTO `item_mods` VALUES (10946, 369, 1); -- Refresh + 1
+
+-- -------------------------------------------------------
+-- Saevus Pendant
+-- -------------------------------------------------------
+INSERT INTO `item_mods` VALUES (10947, 30, -3); -- Magic Accuracy + -3
+INSERT INTO `item_mods` VALUES (10947, 28, 9); -- Magic Attack Bonus + 9
+
+--- -------------------------------------------------------
 -- Carver's Torque
 -- -------------------------------------------------------
 INSERT INTO `item_mods` VALUES (10948, 128, 2); -- Woodworking skill +2
@@ -2513,6 +3160,20 @@ INSERT INTO `item_mods` VALUES (10954, 134, 2); -- Alchemy skill +2
 --  Culin. Torque
 -- -------------------------------------------------------
 INSERT INTO `item_mods` VALUES (10955, 135, 2); -- Cooking skill +2
+
+-- -------------------------------------------------------
+-- Stoicheion Medal
+-- -------------------------------------------------------
+INSERT INTO `item_mods` VALUES (10957, 30, 2); -- Magic Accuracy + 2
+INSERT INTO `item_mods` VALUES (10957, 28, 8); -- Magic Attack Bonus + 8
+-- INSERT INTO `item_mods` VALUES (10957, ?, 3); -- Elemental Cast Time + 3
+
+-- -------------------------------------------------------
+-- Nefarious Collar
+-- -------------------------------------------------------
+INSERT INTO `item_mods` VALUES (10958, 165, 3); -- Critical Chance + 3
+-- INSERT INTO `item_mods` VALUES (10958, ?, 3); -- Magic Crit Rate + 3
+-- INSERT INTO `item_mods` VALUES (10958, ?, ?); -- Magic Crit Damage + ?
 
 INSERT INTO `item_mods` VALUES (10960, 374, 4);
 INSERT INTO `item_mods` VALUES (10960, 375, 4);
@@ -2554,8 +3215,128 @@ INSERT INTO `item_mods` VALUES (10973, 233, 1); -- TODO: Confirm Amount
 INSERT INTO `item_mods` VALUES (10974, 1, 9);
 INSERT INTO `item_mods` VALUES (10974, 31, 5);
 -- INSERT INTO `item_mods` VALUES (10974, ???, -1); TODO: Ninjutsu Recast
-INSERT INTO `item_mods` VALUES (10986, 374, 4);
-INSERT INTO `item_mods` VALUES (10989, 374, 4);
+
+-- -------------------------------------------------------
+-- Kaikias' Cape
+-- -------------------------------------------------------
+INSERT INTO `item_mods` VALUES (10976, 1, 7); -- Defense + 7
+INSERT INTO `item_mods` VALUES (10976, 12, 6); -- INT + 6
+INSERT INTO `item_mods` VALUES (10976, 13, 6); -- MND + 6
+INSERT INTO `item_mods` VALUES (10976, 42, 4); -- Wind Accuracy + 4
+INSERT INTO `item_mods` VALUES (10976, 34, 4); -- Wind Attack + 4
+
+-- -------------------------------------------------------
+-- Romanus Cape
+-- -------------------------------------------------------
+INSERT INTO `item_mods` VALUES (10977, 1, 8); -- Defense + 8
+INSERT INTO `item_mods` VALUES (10977, 12, 4); -- INT + 4
+INSERT INTO `item_mods` VALUES (10977, 28, 4); -- Magic Attack Bonus + 4
+-- INSERT INTO `item_mods` VALUES (10977, ?, 6); -- Addle + 6
+
+-- -------------------------------------------------------
+-- Misuuchi Kappa
+-- -------------------------------------------------------
+INSERT INTO `item_mods` VALUES (10978, 1, 12); -- Defense + 12
+INSERT INTO `item_mods` VALUES (10978, 73, 3); -- Store TP + 3
+INSERT INTO `item_mods` VALUES (10978, 288, 3); -- Double Attack + 3
+
+-- -------------------------------------------------------
+-- Balladeer's Cape
+-- -------------------------------------------------------
+INSERT INTO `item_mods` VALUES (10979, 1, 8); -- Defense + 8
+INSERT INTO `item_mods` VALUES (10979, 14, 9); -- CHR + 9
+INSERT INTO `item_mods` VALUES (10979, 121, 6); -- Wind Instruments + 6
+
+-- -------------------------------------------------------
+-- Mollusca Mantle
+-- -------------------------------------------------------
+INSERT INTO `item_mods` VALUES (10980, 1, 19); -- Defense + 19
+INSERT INTO `item_mods` VALUES (10980, 160, -5); -- Percent Damage Taken + -5
+INSERT INTO `item_mods` VALUES (10980, 169, -3); -- Movement Speed + -3
+
+-- -------------------------------------------------------
+-- Chela Cape
+-- -------------------------------------------------------
+INSERT INTO `item_mods` VALUES (10981, 1, 10); -- Defense + 10
+INSERT INTO `item_mods` VALUES (10981, 13, 4); -- MND + 4
+INSERT INTO `item_mods` VALUES (10981, 30, 4); -- Magic Accuracy + 4
+
+-- -------------------------------------------------------
+-- Vimukti Mantle
+-- -------------------------------------------------------
+INSERT INTO `item_mods` VALUES (10982, 1, 14); -- Defense + 14
+INSERT INTO `item_mods` VALUES (10982, 23, 25); -- Attack + 25
+INSERT INTO `item_mods` VALUES (10982, 289, 3); -- Subtle Blow + 3
+
+-- -------------------------------------------------------
+-- Aife's Mantle
+-- -------------------------------------------------------
+INSERT INTO `item_mods` VALUES (10983, 1, 13); -- Defense + 13
+INSERT INTO `item_mods` VALUES (10983, 9, 6); -- DEX + 6
+INSERT INTO `item_mods` VALUES (10983, 11, 6); -- AGI + 6
+INSERT INTO `item_mods` VALUES (10983, 25, 8); -- Accuracy + 8
+
+-- -------------------------------------------------------
+-- Tjukurrpa Mantle
+-- -------------------------------------------------------
+INSERT INTO `item_mods` VALUES (10984, 1, 9); -- Defense + 9
+INSERT INTO `item_mods` VALUES (10984, 11, 4); -- AGI + 4
+INSERT INTO `item_mods` VALUES (10984, 28, 4); -- Magic Attack Bonus + 4
+
+-- -------------------------------------------------------
+-- Moondoe Mantle
+-- -------------------------------------------------------
+INSERT INTO `item_mods` VALUES (10985, 1, 11); -- Defense + 11
+INSERT INTO `item_mods` VALUES (10985, 26, 9); -- Ranged Accuracy + 9
+INSERT INTO `item_mods` VALUES (10985, 24, 9); -- Ranged Attack + 9
+INSERT INTO `item_mods` VALUES (10985, 27, -5); -- Enmity + -5
+
+-- -------------------------------------------------------
+-- Oretania's Cape
+-- -------------------------------------------------------
+INSERT INTO `item_mods` VALUES (10986, 1, 7); -- Defense + 7
+INSERT INTO `item_mods` VALUES (10986, 2, 20); -- HP + 20
+INSERT INTO `item_mods` VALUES (10986, 374, 4); -- Cure Potency + 4
+
+-- -------------------------------------------------------
+-- Meanagh Cape
+-- -------------------------------------------------------
+INSERT INTO `item_mods` VALUES (10987, 1, 11); -- Defense + 11
+INSERT INTO `item_mods` VALUES (10987, 9, 3); -- DEX + 3
+INSERT INTO `item_mods` VALUES (10987, 11, 3); -- AGI + 3
+INSERT INTO `item_mods` VALUES (10987, 26, 7); -- Ranged Accuracy + 7
+INSERT INTO `item_mods` VALUES (10987, 68, 7); -- Evasion + 7
+
+-- -------------------------------------------------------
+-- Blithe Mantle
+-- -------------------------------------------------------
+INSERT INTO `item_mods` VALUES (10988, 1, 11); -- Defense + 11
+INSERT INTO `item_mods` VALUES (10988, 11, 5); -- AGI + 5
+INSERT INTO `item_mods` VALUES (10988, 56, 15); -- Wind Resistance + 15
+INSERT INTO `item_mods` VALUES (10988, 68, 5); -- Evasion + 5
+INSERT INTO `item_mods` VALUES (10988, 288, 2); -- Double Attack + 2
+
+-- -------------------------------------------------------
+-- Blithe Mantle
+-- -------------------------------------------------------
+INSERT INTO `item_mods` VALUES (10989, 1, 9); -- Defense + 9
+INSERT INTO `item_mods` VALUES (10989, 112, 4); -- Healing Magic + 4
+INSERT INTO `item_mods` VALUES (10989, 374, 4); -- Cure Potency + 4
+
+-- -------------------------------------------------------
+-- Engulfer Cape
+-- -------------------------------------------------------
+INSERT INTO `item_mods` VALUES (10990, 1, 10); -- Defense + 10
+INSERT INTO `item_mods` VALUES (10990, 5, 30); -- MP + 30
+-- INSERT INTO `item_mods` VALUES (10990, 475, ?); -- Absorb Magic + ?
+
+-- -------------------------------------------------------
+-- Rancorous Mantle
+-- -------------------------------------------------------
+INSERT INTO `item_mods` VALUES (10991, 1, 15); -- Defense + 15
+INSERT INTO `item_mods` VALUES (10991, 23, 17); -- Attack + 17
+-- INSERT INTO `item_mods` VALUES (10991, ?, ?); -- Tonberry's Grudge + ?
+
 INSERT INTO `item_mods` VALUES (11005, 374, 2);
 INSERT INTO `item_mods` VALUES (11008, 374, 2);
 
@@ -2614,12 +3395,49 @@ INSERT INTO `item_mods` VALUES (11029, 5, 24);
 INSERT INTO `item_mods` VALUES (11029, 27, 4);
 INSERT INTO `item_mods` VALUES (11029, 61, 17);
 INSERT INTO `item_mods` VALUES (11030, 2, 15);
-INSERT INTO `item_mods` VALUES (11030, 374, 5);
+-- INSERT INTO `item_mods` VALUES (11030, 374, 5);
 INSERT INTO `item_mods` VALUES (11030, 375, 5); -- Cure Received +5%
 INSERT INTO `item_mods` VALUES (11031, 24, 3);
 INSERT INTO `item_mods` VALUES (11031, 27, -2);
 INSERT INTO `item_mods` VALUES (11032, 29, 2);
 INSERT INTO `item_mods` VALUES (11032, 289, 4);
+
+-- -------------------------------------------------------
+-- Bruiser's Earring
+-- -------------------------------------------------------
+INSERT INTO `item_mods` VALUES (11033, 80, 3); -- Hand to Hand + 3
+INSERT INTO `item_mods` VALUES (11033, 289, -10); -- Subtle Blow + -10
+
+-- -------------------------------------------------------
+-- Evergreen Earring
+-- -------------------------------------------------------
+INSERT INTO `item_mods` VALUES (11034, 25, 3); -- Accuracy + 3
+INSERT INTO `item_mods` VALUES (11034, 68, 3); -- Evasion + 3
+INSERT INTO `item_mods` VALUES (11034, 289, 3); -- Subtle Blow + 3
+
+-- -------------------------------------------------------
+-- Enchanter's Earring
+-- -------------------------------------------------------
+INSERT INTO `item_mods` VALUES (11036, 14, 4); -- CHR + 4
+INSERT INTO `item_mods` VALUES (11036, 30, 2); -- Magic Accuracy + 2
+
+-- -------------------------------------------------------
+-- Earthcry Earring
+-- -------------------------------------------------------
+INSERT INTO `item_mods` VALUES (11037, 57, 10); -- Earth Resistance + 10
+INSERT INTO `item_mods` VALUES (11037, 300, 10); -- Stoneskin Improved + 10
+
+-- -------------------------------------------------------
+-- Dragonkin Earring
+-- -------------------------------------------------------
+INSERT INTO `item_mods` VALUES (11038, 23, 7); -- Attack + 7
+-- INSERT INTO `item_mods` VALUES (11038, ?, -2); -- Wyvern Physical Damage Taken + -2
+
+-- -------------------------------------------------------
+-- Brachyura Earring
+-- -------------------------------------------------------
+INSERT INTO `item_mods` VALUES (11039, 5, 20); -- MP + 20
+-- INSERT INTO `item_mods` VALUES (11039, ?, ?); -- Enhances Protect and Shell Received + ?
 
 -- -------------------------------------------------------
 -- Rebel Earring
@@ -3626,7 +4444,7 @@ INSERT INTO `item_mods` VALUES (11415, 13, 6);
 INSERT INTO `item_mods` VALUES (11415, 14, 6);
 INSERT INTO `item_mods` VALUES (11415, 27, -4);
 INSERT INTO `item_mods` VALUES (11418, 1, 15);
--- INSERT INTO `item_mods` VALUES (11418, 386, ???); TODO: Kick Attack DMG, Confirm Boost
+INSERT INTO `item_mods` VALUES (11418, 386, 35); -- TODO: Kick Attack DMG, Confirm Boost
 INSERT INTO `item_mods` VALUES (11419, 1, 20);
 INSERT INTO `item_mods` VALUES (11419, 9, 6);
 INSERT INTO `item_mods` VALUES (11419, 11, 6);
@@ -3671,11 +4489,11 @@ INSERT INTO `item_mods` VALUES (11428, 1, 11);
 INSERT INTO `item_mods` VALUES (11428, 5, 11);
 INSERT INTO `item_mods` VALUES (11428, 27, -5);
 INSERT INTO `item_mods` VALUES (11428, 68, -3);
-INSERT INTO `item_mods` VALUES (11428, 163, -1);
+INSERT INTO `item_mods` VALUES (11428, 163, -2);
 INSERT INTO `item_mods` VALUES (11429, 1, 12);
 INSERT INTO `item_mods` VALUES (11429, 5, 12);
 INSERT INTO `item_mods` VALUES (11429, 27, -6);
-INSERT INTO `item_mods` VALUES (11429, 68, -2);
+INSERT INTO `item_mods` VALUES (11429, 68, -5);
 INSERT INTO `item_mods` VALUES (11429, 163, -2);
 
 -- ------------------------------------------
@@ -3749,6 +4567,33 @@ INSERT INTO `item_mods` VALUES (11456, 1, 20);
 INSERT INTO `item_mods` VALUES (11456, 10, 7);
 INSERT INTO `item_mods` VALUES (11456, 25, 10);
 INSERT INTO `item_mods` VALUES (11456, 384, 30);
+
+-- ------------------------------------------
+-- Eurus' Ledelsens
+-- ------------------------------------------
+INSERT INTO `item_mods` VALUES (11457, 1, 22); -- Defense + 22
+INSERT INTO `item_mods` VALUES (11457, 11, 8); -- AGI + 8
+INSERT INTO `item_mods` VALUES (11457, 110, 8); -- Parrying + 8
+INSERT INTO `item_mods` VALUES (11457, 73, -3); -- Store TP + -3
+INSERT INTO `item_mods` VALUES (11457, 384, 40); -- Haste + 40
+
+-- ------------------------------------------
+-- Savateur's Gaiters
+-- ------------------------------------------
+INSERT INTO `item_mods` VALUES (11459, 1, 20); -- Defense + 20
+INSERT INTO `item_mods` VALUES (11459, 25, 8); -- Accuracy + 8
+INSERT INTO `item_mods` VALUES (11459, 292, 3); -- Kick Attacks + 3
+INSERT INTO `item_mods` VALUES (11459, 289, 8); -- Subtle Blow + 8
+INSERT INTO `item_mods` VALUES (11459, 384, 20); -- Haste + 20
+
+-- ------------------------------------------
+-- Gigantes Boots
+-- ------------------------------------------
+INSERT INTO `item_mods` VALUES (11462, 1, 25); -- Defense + 25
+INSERT INTO `item_mods` VALUES (11462, 8, 11); -- STR + 11
+INSERT INTO `item_mods` VALUES (11462, 9, -5); -- DEX + -5
+INSERT INTO `item_mods` VALUES (11462, 10, -5); -- VIT + -5
+
 INSERT INTO `item_mods` VALUES (11464, 1, 24);
 INSERT INTO `item_mods` VALUES (11464, 5, 25);
 INSERT INTO `item_mods` VALUES (11464, 12, 5);
@@ -3896,16 +4741,20 @@ INSERT INTO `item_mods` VALUES (11502, 58, -15); -- thunder -15
 INSERT INTO `item_mods` VALUES (11502, 59, 15); -- water +15
 INSERT INTO `item_mods` VALUES (11502, 384, 61); -- haste 6%
 
+-- -------------------------------------------------------
+-- Perle Salade
+-- -------------------------------------------------------
 INSERT INTO `item_mods` VALUES (11503, 1, 37);
 INSERT INTO `item_mods` VALUES (11503, 8, 5);
 INSERT INTO `item_mods` VALUES (11503, 10, 5);
 INSERT INTO `item_mods` VALUES (11503, 23, 7);
 INSERT INTO `item_mods` VALUES (11503, 384, 30);
--- INSERT INTO `item_mods` VALUES (11503, ???, 30); TODO: Enhances Snapshot Effect
+
 INSERT INTO `item_mods` VALUES (11504, 1, 29);
 INSERT INTO `item_mods` VALUES (11504, 9, 4);
 INSERT INTO `item_mods` VALUES (11504, 11, 4);
 INSERT INTO `item_mods` VALUES (11504, 384, 40);
+-- INSERT INTO `item_mods` VALUES (11504, ???, ??); TODO: Enhances Snapshot Effect
 INSERT INTO `item_mods` VALUES (11505, 1, 22);
 INSERT INTO `item_mods` VALUES (11505, 2, 17);
 INSERT INTO `item_mods` VALUES (11505, 12, 6);
@@ -4263,28 +5112,33 @@ INSERT INTO `item_mods` VALUES (11653, 23, 7);
 INSERT INTO `item_mods` VALUES (11653, 25, 3);
 INSERT INTO `item_mods` VALUES (11656, 8, 7);
 INSERT INTO `item_mods` VALUES (11656, 13, -3);
+INSERT INTO `item_mods` VALUES (11656, 242, 2); -- Paralysis Resistance + 5
 
 -- -------------------------------------------------------
 -- Icesoul Ring
 -- -------------------------------------------------------
 INSERT INTO `item_mods` VALUES (11657, 8, -3); -- STR -3
 INSERT INTO `item_mods` VALUES (11657, 12, 7); -- INT +7
-INSERT INTO `item_mods` VALUES (11657, 244, 5); -- Enhances "Resist Silence" effect
+INSERT INTO `item_mods` VALUES (11657, 244, 2); -- Enhances "Resist Silence" effect
 
 INSERT INTO `item_mods` VALUES (11658, 11, 7);
 INSERT INTO `item_mods` VALUES (11658, 12, -3);
+INSERT INTO `item_mods` VALUES (11658, 246, 2); -- Petrification Resistance + 5
 INSERT INTO `item_mods` VALUES (11659, 10, 7);
 INSERT INTO `item_mods` VALUES (11659, 11, -3);
+INSERT INTO `item_mods` VALUES (11659, 251, 2); -- Stun Resistance + 5
 INSERT INTO `item_mods` VALUES (11660, 9, 7);
 INSERT INTO `item_mods` VALUES (11660, 10, -3);
+INSERT INTO `item_mods` VALUES (11660, 241, 2); -- Poison Resistance + 5
 INSERT INTO `item_mods` VALUES (11661, 9, -3);
 INSERT INTO `item_mods` VALUES (11661, 13, 7);
+INSERT INTO `item_mods` VALUES (11661, 245, 2); -- Virus Resistance + 5
 INSERT INTO `item_mods` VALUES (11662, 5, -15);
 INSERT INTO `item_mods` VALUES (11662, 14, 7);
-INSERT INTO `item_mods` VALUES (11662, 248, 1); -- TODO: Curse Resist Confirm Amount
+INSERT INTO `item_mods` VALUES (11662, 248, 2); -- TODO: Curse Resist Confirm Amount
 INSERT INTO `item_mods` VALUES (11663, 2, -15);
 INSERT INTO `item_mods` VALUES (11663, 5, 35);
-INSERT INTO `item_mods` VALUES (11663, 252, 1); -- TODO: Charm Resist Confirm Amount
+INSERT INTO `item_mods` VALUES (11663, 252, 2); -- TODO: Charm Resist Confirm Amount
 INSERT INTO `item_mods` VALUES (11664, 2, 12);
 INSERT INTO `item_mods` VALUES (11664, 5, -12);
 INSERT INTO `item_mods` VALUES (11665, 2, 13);
@@ -4466,14 +5320,20 @@ INSERT INTO `item_mods` VALUES (11764, 9, -7);
 INSERT INTO `item_mods` VALUES (11765, 1, 5);
 INSERT INTO `item_mods` VALUES (11765, 12, 5);
 INSERT INTO `item_mods` VALUES (11765, 27, -3);
-INSERT INTO `item_mods` VALUES (11765, 168, -8);
+INSERT INTO `item_mods` VALUES (11765, 168, 8);
 INSERT INTO `item_mods` VALUES (11766, 1, 6);
 INSERT INTO `item_mods` VALUES (11766, 12, 6);
 INSERT INTO `item_mods` VALUES (11766, 27, -4);
 INSERT INTO `item_mods` VALUES (11766, 168, 10);
+
+-- -------------------------------------------------------
+-- Accursed Belt
+-- -------------------------------------------------------
 INSERT INTO `item_mods` VALUES (11770, 2, -10);
 INSERT INTO `item_mods` VALUES (11770, 5, -10);
 INSERT INTO `item_mods` VALUES (11770, 384, 71);
+-- INSERT INTO `item_mods` VALUES (11770, ?, ?); -- Zombie + ?
+
 INSERT INTO `item_mods` VALUES (11771, 1, 9);
 INSERT INTO `item_mods` VALUES (11771, 8, 6);
 INSERT INTO `item_mods` VALUES (11771, 9, 6);
@@ -4505,24 +5365,35 @@ INSERT INTO `item_mods` VALUES (11779, 24, 6);
 INSERT INTO `item_mods` VALUES (11779, 26, -2);
 INSERT INTO `item_mods` VALUES (11779, 68, 9);
 INSERT INTO `item_mods` VALUES (11779, 73, 2);
+
+-- -------------------------------------------------------
+-- Versa Celata
+-- -------------------------------------------------------
 INSERT INTO `item_mods` VALUES (11780, 1, 39);
-INSERT INTO `item_mods` VALUES (11780, 12, -4);
+INSERT INTO `item_mods` VALUES (11780, 12, -6);
 INSERT INTO `item_mods` VALUES (11780, 23, 8);
 INSERT INTO `item_mods` VALUES (11780, 27, 5);
+INSERT INTO `item_mods` VALUES (11780, 161, -2); -- Percent Physical Damage Taken + -2
+
+-- -------------------------------------------------------
+-- Versa Celata +1
+-- -------------------------------------------------------
 INSERT INTO `item_mods` VALUES (11781, 1, 49);
 INSERT INTO `item_mods` VALUES (11781, 12, -5);
 INSERT INTO `item_mods` VALUES (11781, 23, 9);
 INSERT INTO `item_mods` VALUES (11781, 27, 6);
+INSERT INTO `item_mods` VALUES (11781, 161, -3); -- Percent Physical Damage Taken + -3
+
 INSERT INTO `item_mods` VALUES (11782, 1, 13);
 INSERT INTO `item_mods` VALUES (11782, 5, 12);
 INSERT INTO `item_mods` VALUES (11782, 27, -8);
 INSERT INTO `item_mods` VALUES (11782, 68, -3);
-INSERT INTO `item_mods` VALUES (11782, 163, -1);
+INSERT INTO `item_mods` VALUES (11782, 163, -3);
 INSERT INTO `item_mods` VALUES (11783, 1, 14);
 INSERT INTO `item_mods` VALUES (11783, 5, 13);
 INSERT INTO `item_mods` VALUES (11783, 27, -9);
 INSERT INTO `item_mods` VALUES (11783, 68, -2);
-INSERT INTO `item_mods` VALUES (11783, 163, -2);
+INSERT INTO `item_mods` VALUES (11783, 163, -5);
 INSERT INTO `item_mods` VALUES (11798, 1, 41);
 INSERT INTO `item_mods` VALUES (11798, 8, 10);
 INSERT INTO `item_mods` VALUES (11798, 9, 10);
@@ -4568,7 +5439,7 @@ INSERT INTO `item_mods` VALUES (11806, 5, -15);
 INSERT INTO `item_mods` VALUES (11806, 13, 5);
 INSERT INTO `item_mods` VALUES (11806, 27, 3);
 INSERT INTO `item_mods` VALUES (11806, 30, 5);
-INSERT INTO `item_mods` VALUES (11807, 1, 22);
+INSERT INTO `item_mods` VALUES (11807, 1, 23);
 INSERT INTO `item_mods` VALUES (11807, 13, 5);
 INSERT INTO `item_mods` VALUES (11807, 30, 5);
 -- INSERT INTO `item_mods` VALUES (11807, ???, 3); TODO: Magic Critical Hit Rate
@@ -4646,6 +5517,14 @@ INSERT INTO `item_mods` VALUES (11826, 27, -5);
 INSERT INTO `item_mods` VALUES (11826, 111, 11);
 INSERT INTO `item_mods` VALUES (11826, 112, 11);
 INSERT INTO `item_mods` VALUES (11826, 114, 11);
+
+-- -------------------------------------------------------
+-- Lenore's Hairpin
+-- -------------------------------------------------------
+INSERT INTO `item_mods` VALUES (11827, 11, 9); -- AGI + 9
+INSERT INTO `item_mods` VALUES (11827, 289, 9); -- Subtle Blow + 9
+INSERT INTO `item_mods` VALUES (11827, 27, -9); -- Enmity + -9
+
 INSERT INTO `item_mods` VALUES (11828, 1, 47);
 INSERT INTO `item_mods` VALUES (11828, 24, 8);
 INSERT INTO `item_mods` VALUES (11828, 26, -6);
@@ -4672,12 +5551,12 @@ INSERT INTO `item_mods` VALUES (11832, 1, 40);
 INSERT INTO `item_mods` VALUES (11832, 5, 16);
 INSERT INTO `item_mods` VALUES (11832, 27, -9);
 INSERT INTO `item_mods` VALUES (11832, 71, 6);
-INSERT INTO `item_mods` VALUES (11832, 163, -2);
+INSERT INTO `item_mods` VALUES (11832, 163, -5);
 INSERT INTO `item_mods` VALUES (11833, 1, 41);
 INSERT INTO `item_mods` VALUES (11833, 5, 17);
 INSERT INTO `item_mods` VALUES (11833, 27, -10);
 INSERT INTO `item_mods` VALUES (11833, 71, 7);
-INSERT INTO `item_mods` VALUES (11833, 163, -3);
+INSERT INTO `item_mods` VALUES (11833, 163, -7);
 INSERT INTO `item_mods` VALUES (11844, 1, 50);
 INSERT INTO `item_mods` VALUES (11844, 10, -8);
 INSERT INTO `item_mods` VALUES (11844, 25, 11);
@@ -4774,11 +5653,57 @@ INSERT INTO `item_mods` VALUES (11861, 1, 1); -- DEF:1
 -- -------------------------------------------------------
 INSERT INTO `item_mods` VALUES (11862, 1, 1); -- DEF:1
 
-INSERT INTO `item_mods` VALUES (11864, 374, 10);
+-- -------------------------------------------------------
+-- Ocelomeh Harness
+-- -------------------------------------------------------
+INSERT INTO `item_mods` VALUES (11863, 1, 58); -- Defense + 58
+INSERT INTO `item_mods` VALUES (11863, 8, 11); -- STR + 11
+INSERT INTO `item_mods` VALUES (11863, 9, 11); -- DEX + 11
+INSERT INTO `item_mods` VALUES (11863, 288, 2); -- Double Attack + 2
+
+-- -------------------------------------------------------
+-- Nefer Kalasiris
+-- -------------------------------------------------------
+INSERT INTO `item_mods` VALUES (11864, 1, 49); -- Defense + 49
+INSERT INTO `item_mods` VALUES (11864, 13, 15); -- MND + 15
+INSERT INTO `item_mods` VALUES (11864, 374, 10); -- Cure Potency + 10
+INSERT INTO `item_mods` VALUES (11864, 519, 10); -- Cure Casting Time + 10
+
+-- -------------------------------------------------------
+-- Mekira Toshugai
+-- -------------------------------------------------------
+INSERT INTO `item_mods` VALUES (11865, 1, 68); -- Defense + 68
+INSERT INTO `item_mods` VALUES (11865, 10, 15); -- VIT + 15
+INSERT INTO `item_mods` VALUES (11865, 161, -7); -- Percent Physical Damage Taken + -7
+INSERT INTO `item_mods` VALUES (11865, 426, 1); -- Physical Damage to MP + 1
+
 INSERT INTO `item_mods` VALUES (11867, 369, 1);
 INSERT INTO `item_mods` VALUES (11867, 374, 15);
-INSERT INTO `item_mods` VALUES (11870, 369, 1);
-INSERT INTO `item_mods` VALUES (11870, 374, 12);
+
+-- -------------------------------------------------------
+-- Ocelomeh Harness +1
+-- -------------------------------------------------------
+INSERT INTO `item_mods` VALUES (11869, 1, 59); -- Defense + 59
+INSERT INTO `item_mods` VALUES (11869, 8, 12); -- STR + 12
+INSERT INTO `item_mods` VALUES (11869, 9, 12); -- DEX + 12
+INSERT INTO `item_mods` VALUES (11869, 288, 3); -- Double Attack + 3
+
+-- -------------------------------------------------------
+-- Nefer Kalasiris +1
+-- -------------------------------------------------------
+INSERT INTO `item_mods` VALUES (11870, 1, 50); -- Defense + 50
+INSERT INTO `item_mods` VALUES (11870, 13, 16); -- MND + 16
+INSERT INTO `item_mods` VALUES (11870, 374, 12); -- Cure Potency + 12
+INSERT INTO `item_mods` VALUES (11870, 519, 12); -- Cure Casting Time + 12
+
+-- -------------------------------------------------------
+-- Mekira Toshugai +1
+-- -------------------------------------------------------
+INSERT INTO `item_mods` VALUES (11871, 1, 69); -- Defense + 69
+INSERT INTO `item_mods` VALUES (11871, 10, 16); -- VIT + 16
+INSERT INTO `item_mods` VALUES (11871, 161, -8); -- Percent Physical Damage Taken + -8
+INSERT INTO `item_mods` VALUES (11871, 426, 1.2); -- Physical Damage to MP + 1.2
+
 INSERT INTO `item_mods` VALUES (11875, 370, 1);
 INSERT INTO `item_mods` VALUES (11876, 369, 1);
 INSERT INTO `item_mods` VALUES (11878, 1, 16);
@@ -4805,12 +5730,12 @@ INSERT INTO `item_mods` VALUES (11882, 1, 13);
 INSERT INTO `item_mods` VALUES (11882, 5, 13);
 INSERT INTO `item_mods` VALUES (11882, 27, -5);
 INSERT INTO `item_mods` VALUES (11882, 68, -2);
-INSERT INTO `item_mods` VALUES (11882, 163, -1);
+INSERT INTO `item_mods` VALUES (11882, 163, -2);
 INSERT INTO `item_mods` VALUES (11883, 1, 14);
 INSERT INTO `item_mods` VALUES (11883, 5, 14);
 INSERT INTO `item_mods` VALUES (11883, 27, -6);
 INSERT INTO `item_mods` VALUES (11883, 68, -1);
-INSERT INTO `item_mods` VALUES (11883, 163, -2);
+INSERT INTO `item_mods` VALUES (11883, 163, -5);
 INSERT INTO `item_mods` VALUES (11898, 1, 16);
 INSERT INTO `item_mods` VALUES (11898, 2, 50);
 INSERT INTO `item_mods` VALUES (11898, 5, -40);
@@ -4916,6 +5841,41 @@ INSERT INTO `item_mods` VALUES (11920, 1, 19);
 INSERT INTO `item_mods` VALUES (11920, 13, 3);
 INSERT INTO `item_mods` VALUES (11920, 161, -3);
 INSERT INTO `item_mods` VALUES (11920, 225, 5);
+
+-- -------------------------------------------------------
+-- Magma Gauntlets
+-- -------------------------------------------------------
+INSERT INTO `item_mods` VALUES (11921, 1, 34); -- Defense + 34
+INSERT INTO `item_mods` VALUES (11921, 54, 30); -- Fire Resistance + 30
+INSERT INTO `item_mods` VALUES (11921, 161, -4); -- Percent Physical Damage Taken + -4
+-- INSERT INTO `item_mods` VALUES (11921, 499, 1); -- Spikes Type + 1 NEEDS OTHER SETTINGS
+-- INSERT INTO `item_mods` VALUES (11921, 500, ?); -- Spikes Damage + ?
+-- INSERT INTO `item_mods` VALUES (11921, 501, ?); -- Spikes Chance + ?
+
+-- -------------------------------------------------------
+-- Pavor Gauntlets
+-- -------------------------------------------------------
+INSERT INTO `item_mods` VALUES (11922, 1, 33); -- Defense + 33
+INSERT INTO `item_mods` VALUES (11922, 5, 33); -- MP + 33
+INSERT INTO `item_mods` VALUES (11922, 116, 10); -- Dark Magic + 10
+-- INSERT INTO `item_mods` VALUES (11922, ?, 10); -- Augments Absorb Spells + 10
+
+-- -------------------------------------------------------
+-- Tjukurrpa Gauntlets
+-- -------------------------------------------------------
+INSERT INTO `item_mods` VALUES (11923, 1, 30); -- Defense + 30
+INSERT INTO `item_mods` VALUES (11923, 27, 8); -- Enmity + 8
+INSERT INTO `item_mods` VALUES (11923, 163, -10); -- Percent Magic Damage Taken + -10
+
+-- -------------------------------------------------------
+-- Alruna's Gloves
+-- -------------------------------------------------------
+INSERT INTO `item_mods` VALUES (11925, 1, 24); -- Defense + 24
+INSERT INTO `item_mods` VALUES (11925, 11, 9); -- AGI + 9
+INSERT INTO `item_mods` VALUES (11925, 26, 9); -- Ranged Accuracy + 9
+INSERT INTO `item_mods` VALUES (11925, 24, 9); -- Ranged Attack + 9
+-- INSERT INTO `item_mods` VALUES (11925, 365, ?); -- Snapshot + ?
+
 INSERT INTO `item_mods` VALUES (11927, 385, 250);
 INSERT INTO `item_mods` VALUES (11928, 1, 29);
 INSERT INTO `item_mods` VALUES (11928, 24, 6);
@@ -5033,7 +5993,24 @@ INSERT INTO `item_mods` VALUES (11961, 71, 5);
 INSERT INTO `item_mods` VALUES (11961, 114, 5);
 
 -- -------------------------------------------------------
---  Dream Trousers
+-- Galvanic Slops
+-- -------------------------------------------------------
+INSERT INTO `item_mods` VALUES (11962, 1, 39); -- Defense + 39
+INSERT INTO `item_mods` VALUES (11962, 12, 11); -- INT + 11
+
+-- -------------------------------------------------------
+-- Affronter Cuisses
+-- -------------------------------------------------------
+INSERT INTO `item_mods` VALUES (11963, 1, 55); -- Defense + 55
+INSERT INTO `item_mods` VALUES (11963, 5, 40); -- MP + 40
+INSERT INTO `item_mods` VALUES (11963, 12, 5); -- INT + 5
+INSERT INTO `item_mods` VALUES (11963, 13, 5); -- MND + 5
+INSERT INTO `item_mods` VALUES (11963, 14, 5); -- CHR + 5
+INSERT INTO `item_mods` VALUES (11963, 29, 6); -- Magic Defense Bonus + 6
+INSERT INTO `item_mods` VALUES (11963, 27, 6); -- Enmity + 6
+
+-- -------------------------------------------------------
+-- Dream Trousers
 -- -------------------------------------------------------
 INSERT INTO `item_mods` VALUES (11965, 1, 2); -- DEF:2
 
@@ -5052,7 +6029,76 @@ INSERT INTO `item_mods` VALUES (11967, 1, 2); -- DEF:2
 -- -------------------------------------------------------
 INSERT INTO `item_mods` VALUES (11968, 1, 3); -- DEF:3
 
-INSERT INTO `item_mods` VALUES (11972, 374, 4);
+-- -------------------------------------------------------
+-- Praeco Slacks
+-- -------------------------------------------------------
+INSERT INTO `item_mods` VALUES (11972, 1, 39); -- Defense + 39
+INSERT INTO `item_mods` VALUES (11972, 5, 20); -- MP + 20
+INSERT INTO `item_mods` VALUES (11972, 374, 4); -- Cure Potency + 4
+INSERT INTO `item_mods` VALUES (11972, 519, 3); -- Cure Casting Time + 3
+INSERT INTO `item_mods` VALUES (11972, 27, -8); -- Enmity + -8
+
+-- -------------------------------------------------------
+-- Hidalgo Slops
+-- -------------------------------------------------------
+INSERT INTO `item_mods` VALUES (11973, 1, 44); -- Defense + 44
+INSERT INTO `item_mods` VALUES (11973, 13, 7); -- MND + 7
+INSERT INTO `item_mods` VALUES (11973, 14, 7); -- CHR + 7
+INSERT INTO `item_mods` VALUES (11973, 114, 10); -- Enfeebling Magic + 10
+INSERT INTO `item_mods` VALUES (11973, 119, 5); -- Singing Skill + 5
+INSERT INTO `item_mods` VALUES (11973, 384, 20); -- Haste + 20
+
+-- -------------------------------------------------------
+-- Avant Cuisses
+-- -------------------------------------------------------
+INSERT INTO `item_mods` VALUES (11974, 1, 50); -- Defense + 50
+INSERT INTO `item_mods` VALUES (11974, 2, 20); -- HP + 20
+INSERT INTO `item_mods` VALUES (11974, 8, 7); -- STR + 7
+INSERT INTO `item_mods` VALUES (11974, 23, 10); -- Attack + 10
+
+-- -------------------------------------------------------
+-- Avant Cuisses +1
+-- -------------------------------------------------------
+INSERT INTO `item_mods` VALUES (11975, 1, 51); -- Defense + 51
+INSERT INTO `item_mods` VALUES (11975, 2, 25); -- HP + 25
+INSERT INTO `item_mods` VALUES (11975, 8, 8); -- STR + 8
+INSERT INTO `item_mods` VALUES (11975, 23, 15); -- Attack + 15
+INSERT INTO `item_mods` VALUES (11975, 288, 2); -- Double Attack + 2
+
+-- -------------------------------------------------------
+-- Kacura Subligar
+-- -------------------------------------------------------
+INSERT INTO `item_mods` VALUES (11976, 1, 47); -- Defense + 47
+INSERT INTO `item_mods` VALUES (11976, 9, 4); -- DEX + 4
+INSERT INTO `item_mods` VALUES (11976, 11, 7); -- AGI + 7
+INSERT INTO `item_mods` VALUES (11976, 68, 10); -- Evasion + 10
+
+-- -------------------------------------------------------
+-- Kacura Subligar +1
+-- -------------------------------------------------------
+INSERT INTO `item_mods` VALUES (11977, 1, 48); -- Defense + 48
+INSERT INTO `item_mods` VALUES (11977, 9, 5); -- DEX + 5
+INSERT INTO `item_mods` VALUES (11977, 11, 8); -- AGI + 8
+INSERT INTO `item_mods` VALUES (11977, 68, 15); -- Evasion + 15
+INSERT INTO `item_mods` VALUES (11977, 165, 1); -- Critical Chance + 1
+
+-- -------------------------------------------------------
+-- Sweven Slacks
+-- -------------------------------------------------------
+INSERT INTO `item_mods` VALUES (11978, 1, 40); -- Defense + 40
+INSERT INTO `item_mods` VALUES (11978, 12, 7); -- INT + 7
+INSERT INTO `item_mods` VALUES (11978, 13, 7); -- MND + 7
+INSERT INTO `item_mods` VALUES (11978, 30, 5); -- Magic Accuracy + 5
+
+-- -------------------------------------------------------
+-- Sweven Slacks +1
+-- -------------------------------------------------------
+INSERT INTO `item_mods` VALUES (11979, 1, 41); -- Defense + 41
+INSERT INTO `item_mods` VALUES (11979, 12, 8); -- INT + 8
+INSERT INTO `item_mods` VALUES (11979, 13, 8); -- MND + 8
+INSERT INTO `item_mods` VALUES (11979, 30, 7); -- Magic Accuracy + 7
+-- INSERT INTO `item_mods` VALUES (11979, ?, 1); -- Magic Critical + 1
+
 INSERT INTO `item_mods` VALUES (11982, 374, 4);
 
 -- -------------------------------------------------------
@@ -6042,15 +7088,19 @@ INSERT INTO `item_mods` VALUES (12317, 499, 1); -- Blaze Spikes
 INSERT INTO `item_mods` VALUES (12317, 500, 20); -- Spikes DMG
 INSERT INTO `item_mods` VALUES (12317, 501, 20); -- Spikes Proc Rate
 
-INSERT INTO `item_mods` VALUES (12318, 1, 25);
-INSERT INTO `item_mods` VALUES (12318, 54, 25);
-INSERT INTO `item_mods` VALUES (12318, 55, 25);
-INSERT INTO `item_mods` VALUES (12318, 56, 25);
-INSERT INTO `item_mods` VALUES (12318, 57, 25);
-INSERT INTO `item_mods` VALUES (12318, 58, 25);
-INSERT INTO `item_mods` VALUES (12318, 59, 25);
-INSERT INTO `item_mods` VALUES (12318, 60, 25);
-INSERT INTO `item_mods` VALUES (12318, 61, 25);
+-- ------------------------------------------
+-- Argos Shield
+-- ------------------------------------------
+INSERT INTO `item_mods` VALUES (12318, 1, 25); -- Defense + 25
+INSERT INTO `item_mods` VALUES (12318, 54, 25); -- Fire Resistance + 25
+INSERT INTO `item_mods` VALUES (12318, 55, 25); -- Ice Resistance + 25
+INSERT INTO `item_mods` VALUES (12318, 56, 25); -- Wind Resistance + 25
+INSERT INTO `item_mods` VALUES (12318, 57, 25); -- Earth Resistance + 25
+INSERT INTO `item_mods` VALUES (12318, 58, 25); -- Thunder Resistance + 25
+INSERT INTO `item_mods` VALUES (12318, 59, 25); -- Water Resistance + 25
+INSERT INTO `item_mods` VALUES (12318, 60, 25); -- Light Resistance + 25
+INSERT INTO `item_mods` VALUES (12318, 61, 25); -- Dark Resistance + 25
+
 INSERT INTO `item_mods` VALUES (12319, 1, 4);
 INSERT INTO `item_mods` VALUES (12321, 1, 15);
 INSERT INTO `item_mods` VALUES (12321, 13, 3);
@@ -6844,6 +7894,16 @@ INSERT INTO `item_mods` VALUES (12612, 1, 44);
 INSERT INTO `item_mods` VALUES (12612, 2, 12);
 INSERT INTO `item_mods` VALUES (12612, 60, 9);
 INSERT INTO `item_mods` VALUES (12612, 61, -9);
+
+-- ------------------------------------------
+-- Jurfu Cloak
+-- ------------------------------------------
+INSERT INTO `item_mods` VALUES (12613, 1, 49); -- Defense + 49
+INSERT INTO `item_mods` VALUES (12613, 2, 150); -- HP + 150
+INSERT INTO `item_mods` VALUES (12613, 57, 25); -- Earth Resistance + 25
+INSERT INTO `item_mods` VALUES (12613, 246, 2); -- Petrification Resistance + 2
+INSERT INTO `item_mods` VALUES (12613, 250, 2); -- Slow Resistance + 2
+
 INSERT INTO `item_mods` VALUES (12614, 1, 32);
 INSERT INTO `item_mods` VALUES (12614, 8, 2);
 INSERT INTO `item_mods` VALUES (12614, 12, 2);
@@ -6864,7 +7924,7 @@ INSERT INTO `item_mods` VALUES (12620, 1, 65);
 INSERT INTO `item_mods` VALUES (12620, 8, 16);
 INSERT INTO `item_mods` VALUES (12620, 23, 32);
 INSERT INTO `item_mods` VALUES (12620, 161, -6);
-INSERT INTO `item_mods` VALUES (12620, 163, 6);
+INSERT INTO `item_mods` VALUES (12620, 163, 15);
 INSERT INTO `item_mods` VALUES (12621, 1, 45);
 INSERT INTO `item_mods` VALUES (12621, 54, 9);
 INSERT INTO `item_mods` VALUES (12621, 241, 2);
@@ -9752,7 +10812,7 @@ INSERT INTO `item_mods` VALUES (13792, 1, 64);
 INSERT INTO `item_mods` VALUES (13792, 8, 15);
 INSERT INTO `item_mods` VALUES (13792, 23, 30);
 INSERT INTO `item_mods` VALUES (13792, 161, -5);
-INSERT INTO `item_mods` VALUES (13792, 163, 5);
+INSERT INTO `item_mods` VALUES (13792, 163, 12);
 INSERT INTO `item_mods` VALUES (13793, 1, 48);
 INSERT INTO `item_mods` VALUES (13793, 8, 6);
 INSERT INTO `item_mods` VALUES (13793, 9, 6);
@@ -16983,7 +18043,20 @@ INSERT INTO `item_mods` VALUES (15907, 71, 2);
 INSERT INTO `item_mods` VALUES (15908, 1, 5);
 INSERT INTO `item_mods` VALUES (15908, 5, 14);
 INSERT INTO `item_mods` VALUES (15908, 71, 3);
-INSERT INTO `item_mods` VALUES (15910, 14, 5);
+
+-- -------------------------------------------------------
+-- Cascade Belt
+-- -------------------------------------------------------
+INSERT INTO `item_mods` VALUES (15909, 13, 7); -- MND + 7
+INSERT INTO `item_mods` VALUES (15909, 113, 3); -- Enhancing Magic + 3
+
+-- -------------------------------------------------------
+-- Primal Belt
+-- -------------------------------------------------------
+INSERT INTO `item_mods` VALUES (15910, 14, 5); -- CHR + 5
+-- INSERT INTO `item_mods` VALUES (15910, ?, 5); -- Pet Defense + 5
+-- INSERT INTO `item_mods` VALUES (15910, ?, 3); -- Pet Enmity + 3
+
 INSERT INTO `item_mods` VALUES (15911, 1, 4);
 INSERT INTO `item_mods` VALUES (15911, 8, 4);
 INSERT INTO `item_mods` VALUES (15911, 26, 7);
@@ -17213,7 +18286,14 @@ INSERT INTO `item_mods` VALUES (15995, 296, 1);
 INSERT INTO `item_mods` VALUES (16001, 2, 5);
 INSERT INTO `item_mods` VALUES (16001, 5, -5);
 INSERT INTO `item_mods` VALUES (16001, 28, 2);
+
+-- -------------------------------------------------------
+-- Roundel Earring
+-- -------------------------------------------------------
+INSERT INTO `item_mods` VALUES (16002, 374, 5);
+INSERT INTO `item_mods` VALUES (16002, 491, 5);
 INSERT INTO `item_mods` VALUES (16002, 1, 1);
+
 INSERT INTO `item_mods` VALUES (16009, 2, 15);
 INSERT INTO `item_mods` VALUES (16009, 11, 2);
 INSERT INTO `item_mods` VALUES (16010, 2, 17);
@@ -17714,10 +18794,18 @@ INSERT INTO `item_mods` VALUES (16187, 1, 15);
 -- -------------------------------------------------------
 INSERT INTO `item_mods` VALUES (16188, 1, 1); -- DEF:1
 
+-- -------------------------------------------------------
+-- Gleaming Shield
+-- -------------------------------------------------------
 INSERT INTO `item_mods` VALUES (16189, 1, 31);
+
+-- -------------------------------------------------------
+-- Bloom Buckler
+-- -------------------------------------------------------
 INSERT INTO `item_mods` VALUES (16190, 1, 22);
 INSERT INTO `item_mods` VALUES (16190, 2, 15);
 INSERT INTO `item_mods` VALUES (16190, 370, 1);
+
 INSERT INTO `item_mods` VALUES (16195, 385, 210);
 INSERT INTO `item_mods` VALUES (16196, 385, 220);
 INSERT INTO `item_mods` VALUES (16197, 385, 230);
@@ -17734,6 +18822,9 @@ INSERT INTO `item_mods` VALUES (16201, 499, 4); -- Curse Spikes
 INSERT INTO `item_mods` VALUES (16201, 500, 0); -- Spikes DMG
 INSERT INTO `item_mods` VALUES (16201, 501, 20); -- Spikes Proc Rate
 
+-- ------------------------------------------
+-- Dagda's Shield
+-- ------------------------------------------
 INSERT INTO `item_mods` VALUES (16202, 1, 29);
 INSERT INTO `item_mods` VALUES (16202, 27, 6);
 INSERT INTO `item_mods` VALUES (16202, 374, 5);
@@ -18231,6 +19322,16 @@ INSERT INTO `item_mods` VALUES (16382, 1, 25);
 INSERT INTO `item_mods` VALUES (16382, 2, -30);
 INSERT INTO `item_mods` VALUES (16382, 5, 75);
 INSERT INTO `item_mods` VALUES (16382, 168, 5);
+
+-- -------------------------------------------------------
+-- Mirador Trousers
+-- -------------------------------------------------------
+INSERT INTO `item_mods` VALUES (16383, 1, 44); -- Defense + 44
+INSERT INTO `item_mods` VALUES (16383, 8, 6); -- STR + 6
+INSERT INTO `item_mods` VALUES (16383, 11, 6); -- AGI + 6
+INSERT INTO `item_mods` VALUES (16383, 26, 14); -- Ranged Accuracy + 14
+INSERT INTO `item_mods` VALUES (16383, 27, -5); -- Enmity + -5
+
 INSERT INTO `item_mods` VALUES (16385, 25, 3);
 INSERT INTO `item_mods` VALUES (16386, 25, 3);
 
@@ -18364,8 +19465,22 @@ INSERT INTO `item_mods` VALUES (16478, 431, 1); -- Additional Effect: Poison
 INSERT INTO `item_mods` VALUES (16479, 431, 1); -- Additional Effect: Weakens Defense
 
 INSERT INTO `item_mods` VALUES (16480, 303, 1);
+
+-- -------------------------------------------------------
+-- Yataghan +1
+-- -------------------------------------------------------
+INSERT INTO `item_mods` VALUES (16481, 2, 26); -- HP + 26
+INSERT INTO `item_mods` VALUES (16481, 68, 7); -- Evasion + 7
+
 INSERT INTO `item_mods` VALUES (16484, 9, 2);
 INSERT INTO `item_mods` VALUES (16484, 13, -3);
+
+-- -------------------------------------------------------
+-- Yataghan
+-- -------------------------------------------------------
+INSERT INTO `item_mods` VALUES (16485, 2, 24); -- HP + 24
+INSERT INTO `item_mods` VALUES (16485, 68, 6); -- Evasion + 6
+
 INSERT INTO `item_mods` VALUES (16486, 9, 1);
 INSERT INTO `item_mods` VALUES (16486, 11, 1);
 INSERT INTO `item_mods` VALUES (16487, 14, 5);
@@ -18406,9 +19521,22 @@ INSERT INTO `item_mods` VALUES (16496, 431, 1); -- Additional Effect: Poison
 INSERT INTO `item_mods` VALUES (16497, 431, 1); -- Additional Effect: Sleep
 
 -- -------------------------------------------------------
+-- Carabineer's Dagger
+-- -------------------------------------------------------
+INSERT INTO `item_mods` VALUES (16498, 8, 5); -- STR + 5
+INSERT INTO `item_mods` VALUES (16498, 24, 12); -- Ranged Attack + 12
+INSERT INTO `item_mods` VALUES (16498, 27, 4); -- Enmity + 4
+
+-- -------------------------------------------------------
 -- Acid Knife
 -- -------------------------------------------------------
 INSERT INTO `item_mods` VALUES (16501, 431, 1); -- Additional Effect: Weakens Defense
+
+-- -------------------------------------------------------
+-- Oynos Knife
+-- -------------------------------------------------------
+INSERT INTO `item_mods` VALUES (16504, 250, 2); -- Slow Resistance + 2
+INSERT INTO `item_mods` VALUES (16504, 431, 1); -- Added Effect Haste
 
 -- -------------------------------------------------------
 -- Item: Silence Dagger +1
@@ -18514,6 +19642,12 @@ INSERT INTO `item_mods` VALUES (16620, 59, 9);
 INSERT INTO `item_mods` VALUES (16621, 431, 1); -- Additional Effect: Fire Damage
 
 INSERT INTO `item_mods` VALUES (16629, 9, 2);
+
+-- -------------------------------------------------------
+-- Striker Sword
+-- -------------------------------------------------------
+INSERT INTO `item_mods` VALUES (16630, 11, 7); -- AGI + 7
+
 INSERT INTO `item_mods` VALUES (16637, 1, -6);
 INSERT INTO `item_mods` VALUES (16637, 23, 8);
 INSERT INTO `item_mods` VALUES (16653, 2, 10);
@@ -18526,6 +19660,19 @@ INSERT INTO `item_mods` VALUES (16656, 14, -1);
 INSERT INTO `item_mods` VALUES (16659, 2, 10);
 INSERT INTO `item_mods` VALUES (16659, 9, 2);
 INSERT INTO `item_mods` VALUES (16659, 10, 2);
+
+-- -------------------------------------------------------
+-- Doom Tabar
+-- -------------------------------------------------------
+INSERT INTO `item_mods` VALUES (16660, 9, 3); -- DEX + 3
+INSERT INTO `item_mods` VALUES (16660, 11, 3); -- AGI + 3
+
+-- -------------------------------------------------------
+-- Doom Tabar +1
+-- -------------------------------------------------------
+INSERT INTO `item_mods` VALUES (16662, 9, 4); -- DEX + 4
+INSERT INTO `item_mods` VALUES (16662, 11, 4); -- AGI + 4
+
 INSERT INTO `item_mods` VALUES (16669, 23, 5);
 INSERT INTO `item_mods` VALUES (16673, 8, 1);
 INSERT INTO `item_mods` VALUES (16673, 9, 1);
@@ -18914,9 +20061,23 @@ INSERT INTO `item_mods` VALUES (16955, 10, 3);
 INSERT INTO `item_mods` VALUES (16956, 25, 3);
 INSERT INTO `item_mods` VALUES (16961, 3, -5);
 INSERT INTO `item_mods` VALUES (16961, 54, 16);
+
+-- -------------------------------------------------------
+-- Taimakuniyuki
+-- -------------------------------------------------------
+INSERT INTO `item_mods` VALUES (16963, 9, 4); -- DEX + 4
+INSERT INTO `item_mods` VALUES (16963, 23, 4); -- Attack + 4
+
 INSERT INTO `item_mods` VALUES (16965, 8, 1);
 INSERT INTO `item_mods` VALUES (16965, 25, 2);
 INSERT INTO `item_mods` VALUES (16968, 25, 5);
+
+-- -------------------------------------------------------
+-- Yukitsugu
+-- -------------------------------------------------------
+INSERT INTO `item_mods` VALUES (16971, 8, 3); -- STR + 3
+INSERT INTO `item_mods` VALUES (16971, 10, 3); -- VIT + 3
+
 INSERT INTO `item_mods` VALUES (16972, 14, 2);
 
 -- -------------------------------------------------------
@@ -18928,6 +20089,12 @@ INSERT INTO `item_mods` VALUES (16973, 431, 1); -- Additional Effect: Fire Damag
 -- Dotanuki
 -- -------------------------------------------------------
 INSERT INTO `item_mods` VALUES (16974, 431, 1); -- Additional Effect
+
+-- -------------------------------------------------------
+-- Yukitsugu +1
+-- -------------------------------------------------------
+INSERT INTO `item_mods` VALUES (16977, 8, 4); -- STR + 4
+INSERT INTO `item_mods` VALUES (16977, 10, 4); -- VIT + 4
 
 INSERT INTO `item_mods` VALUES (16980, 23, 7);
 INSERT INTO `item_mods` VALUES (16980, 288, 1);
@@ -18958,7 +20125,14 @@ INSERT INTO `item_mods` VALUES (17054, 13, 6);
 INSERT INTO `item_mods` VALUES (17056, 12, 8);
 INSERT INTO `item_mods` VALUES (17056, 13, 8);
 INSERT INTO `item_mods` VALUES (17056, 61, 15);
-INSERT INTO `item_mods` VALUES (17057, 374, 15);
+
+-- -------------------------------------------------------
+-- Tefnut Wand
+-- -------------------------------------------------------
+INSERT INTO `item_mods` VALUES (17057, 13, 10); -- MND + 10
+INSERT INTO `item_mods` VALUES (17057, 112, 5); -- Healing Magic + 5
+INSERT INTO `item_mods` VALUES (17057, 374, 15); -- Cure Potency + 15
+
 INSERT INTO `item_mods` VALUES (17058, 134, 1);
 INSERT INTO `item_mods` VALUES (17059, 2, 3);
 INSERT INTO `item_mods` VALUES (17060, 2, 6);
@@ -18972,6 +20146,12 @@ INSERT INTO `item_mods` VALUES (17065, 2, 18);
 INSERT INTO `item_mods` VALUES (17067, 2, 18);
 INSERT INTO `item_mods` VALUES (17067, 13, 1);
 INSERT INTO `item_mods` VALUES (17067, 14, 1);
+
+-- -------------------------------------------------------
+-- Moepapa Mace
+-- -------------------------------------------------------
+INSERT INTO `item_mods` VALUES (17069, 431, 1); -- Added Effect Flash
+
 INSERT INTO `item_mods` VALUES (17070, 2, 21);
 
 -- -------------------------------------------------------
@@ -19029,6 +20209,15 @@ INSERT INTO `item_mods` VALUES (17102, 25, 4);
 INSERT INTO `item_mods` VALUES (17108, 5, 50);
 INSERT INTO `item_mods` VALUES (17108, 374, 10);
 INSERT INTO `item_mods` VALUES (17111, 2, 4);
+
+-- -------------------------------------------------------
+-- Fulcrum Pole
+-- -------------------------------------------------------
+INSERT INTO `item_mods` VALUES (17112, 8, 15); -- STR + 15
+INSERT INTO `item_mods` VALUES (17112, 9, 15); -- DEX + 15
+INSERT INTO `item_mods` VALUES (17112, 10, 15); -- VIT + 15
+INSERT INTO `item_mods` VALUES (17112, 11, 15); -- AGI + 15
+
 INSERT INTO `item_mods` VALUES (17113, 369, 4);
 
 -- -------------------------------------------------------
@@ -19062,6 +20251,13 @@ INSERT INTO `item_mods` VALUES (17129, 23, 3);
 INSERT INTO `item_mods` VALUES (17129, 25, 3);
 INSERT INTO `item_mods` VALUES (17130, 2, 6);
 INSERT INTO `item_mods` VALUES (17130, 5, 6);
+
+-- -------------------------------------------------------
+-- Lituus
+-- -------------------------------------------------------
+INSERT INTO `item_mods` VALUES (17131, 11, 3); -- AGI + 3
+INSERT INTO `item_mods` VALUES (17131, 12, 3); -- INT + 3
+
 INSERT INTO `item_mods` VALUES (17132, 2, 5);
 INSERT INTO `item_mods` VALUES (17132, 5, 5);
 INSERT INTO `item_mods` VALUES (17132, 10, -5);
@@ -19860,8 +21056,22 @@ INSERT INTO `item_mods` VALUES (17659, 68, 5);
 INSERT INTO `item_mods` VALUES (17659, 229, 2);
 INSERT INTO `item_mods` VALUES (17660, 5, 15);
 INSERT INTO `item_mods` VALUES (17663, 5, 20);
+
+-- -------------------------------------------------------
+-- Firmament
+-- -------------------------------------------------------
+INSERT INTO `item_mods` VALUES (17664, 8, 3); -- STR + 3
+INSERT INTO `item_mods` VALUES (17664, 10, 3); -- VIT + 3
+
 INSERT INTO `item_mods` VALUES (17665, 8, 3);
 INSERT INTO `item_mods` VALUES (17665, 23, 10);
+
+-- -------------------------------------------------------
+-- Firmament +1
+-- -------------------------------------------------------
+INSERT INTO `item_mods` VALUES (17668, 8, 4); -- STR + 4
+INSERT INTO `item_mods` VALUES (17668, 10, 4); -- VIT + 4
+
 INSERT INTO `item_mods` VALUES (17672, 23, 4);
 INSERT INTO `item_mods` VALUES (17672, 25, 3);
 INSERT INTO `item_mods` VALUES (17673, 23, 4);
@@ -20163,6 +21373,7 @@ INSERT INTO `item_mods` VALUES (17853, 443, 2);
 INSERT INTO `item_mods` VALUES (17854, 14, 1);
 INSERT INTO `item_mods` VALUES (17854, 440, 2);
 INSERT INTO `item_mods` VALUES (17855, 444, 2);
+INSERT INTO `item_mods` VALUES (17855, 60, 5); -- Light Resistance + 5
 INSERT INTO `item_mods` VALUES (17856, 433, 3);
 INSERT INTO `item_mods` VALUES (17856, 447, 3);
 INSERT INTO `item_mods` VALUES (17925, 24, 7);
@@ -20955,6 +22166,13 @@ INSERT INTO `item_mods` VALUES (18439, 8, 2);
 INSERT INTO `item_mods` VALUES (18439, 12, 2);
 INSERT INTO `item_mods` VALUES (18440, 8, 3);
 INSERT INTO `item_mods` VALUES (18440, 12, 3);
+
+-- -------------------------------------------------------
+-- Taimakuniyuki +1
+-- -------------------------------------------------------
+INSERT INTO `item_mods` VALUES (18442, 9, 5); -- DEX + 5
+INSERT INTO `item_mods` VALUES (18442, 23, 5); -- Attack + 5
+
 INSERT INTO `item_mods` VALUES (18446, 23, 12);
 INSERT INTO `item_mods` VALUES (18446, 25, -6);
 INSERT INTO `item_mods` VALUES (18446, 73, 2);
@@ -20997,13 +22215,88 @@ INSERT INTO `item_mods` VALUES (18504, 11, 4);
 INSERT INTO `item_mods` VALUES (18504, 229, 2);
 INSERT INTO `item_mods` VALUES (18506, 288, 1);
 INSERT INTO `item_mods` VALUES (18509, 288, 1);
+
+-- -------------------------------------------------------
+-- Dolor Bhuj
+-- -------------------------------------------------------
+INSERT INTO `item_mods` VALUES (18511, 9, 3); -- DEX + 3
+INSERT INTO `item_mods` VALUES (18511, 10, 3); -- VIT + 3
+
+-- -------------------------------------------------------
+-- Dolor Bhuj +1
+-- -------------------------------------------------------
+INSERT INTO `item_mods` VALUES (18512, 9, 4); -- DEX + 4
+INSERT INTO `item_mods` VALUES (18512, 10, 4); -- VIT + 4
+
+-- -------------------------------------------------------
+-- Elephas Axe
+-- -------------------------------------------------------
+INSERT INTO `item_mods` VALUES (18517, 10, 4); -- VIT + 4
+INSERT INTO `item_mods` VALUES (18517, 25, 4); -- Accuracy + 4
+
+-- -------------------------------------------------------
+-- Elephas Axe +1
+-- -------------------------------------------------------
+INSERT INTO `item_mods` VALUES (18518, 10, 5); -- VIT + 5
+INSERT INTO `item_mods` VALUES (18518, 25, 5); -- Accuracy + 5
+
+-- -------------------------------------------------------
+-- Laceratrice
+-- -------------------------------------------------------
+INSERT INTO `item_mods` VALUES (1850, 165, 4); -- Critical Chance + 4
+
 INSERT INTO `item_mods` VALUES (18531, 24, 4);
+
+-- -------------------------------------------------------
+-- Maiden Tabar
+-- -------------------------------------------------------
+INSERT INTO `item_mods` VALUES (18537, 9, 4); -- DEX + 4
+INSERT INTO `item_mods` VALUES (18537, 68, 4); -- Evasion + 4
+
+-- -------------------------------------------------------
+-- Maiden Tabar +1
+-- -------------------------------------------------------
+INSERT INTO `item_mods` VALUES (18538, 9, 5); -- DEX + 5
+INSERT INTO `item_mods` VALUES (18538, 68, 5); -- Evasion + 5
+
+-- -------------------------------------------------------
+-- Tonatiuh Axe
+-- -------------------------------------------------------
+INSERT INTO `item_mods` VALUES (18539, 289, 5); -- Subtle Blow + 5
+
+-- -------------------------------------------------------
+-- Barbican Axe
+-- -------------------------------------------------------
+INSERT INTO `item_mods` VALUES (18540, 10, 7); -- VIT + 7
+
+-- -------------------------------------------------------
+-- Tjukurrpa Axe
+-- -------------------------------------------------------
+INSERT INTO `item_mods` VALUES (18541, 384, 20); -- Haste + 20
 
 -- -------------------------------------------------------
 -- Twilight Scythe
 -- -------------------------------------------------------
 INSERT INTO `item_mods` VALUES (18551, 8, 8); -- STR+8
 INSERT INTO `item_mods` VALUES (18551, 431, 1); -- Additional Effect: DEATH
+
+-- -------------------------------------------------------
+-- Sectum Sickle
+-- -------------------------------------------------------
+INSERT INTO `item_mods` VALUES (18555, 12, 4); -- INT + 4
+INSERT INTO `item_mods` VALUES (18555, 25, 4); -- Accuracy + 4
+
+-- -------------------------------------------------------
+-- Sectum Sickle +1
+-- -------------------------------------------------------
+INSERT INTO `item_mods` VALUES (18556, 12, 5); -- INT + 5
+INSERT INTO `item_mods` VALUES (18556, 25, 5); -- Accuracy + 5
+
+-- -------------------------------------------------------
+-- Sortilege Scythe
+-- -------------------------------------------------------
+INSERT INTO `item_mods` VALUES (18557, 30, 5); -- Magic Accuracy + 5
+INSERT INTO `item_mods` VALUES (18557, 170, 5); -- Fast Cast + 5
 
 INSERT INTO `item_mods` VALUES (18571, 453, 2);
 INSERT INTO `item_mods` VALUES (18571, 454, 30);
@@ -21058,6 +22351,25 @@ INSERT INTO `item_mods` VALUES (18611, 28, 3);
 INSERT INTO `item_mods` VALUES (18615, 13, 2);
 INSERT INTO `item_mods` VALUES (18615, 30, 4);
 INSERT INTO `item_mods` VALUES (18616, 28, 4);
+
+-- -------------------------------------------------------
+-- Warmage's Pole
+-- -------------------------------------------------------
+INSERT INTO `item_mods` VALUES (18621, 11, 4); -- AGI + 4
+INSERT INTO `item_mods` VALUES (18621, 28, 4); -- Magic Attack Bonus + 4
+
+-- -------------------------------------------------------
+-- Warmage's Pole +1
+-- -------------------------------------------------------
+INSERT INTO `item_mods` VALUES (18622, 11, 5); -- AGI + 5
+INSERT INTO `item_mods` VALUES (18622, 28, 5); -- Magic Attack Bonus + 5
+
+-- -------------------------------------------------------
+-- Numen Staff
+-- -------------------------------------------------------
+INSERT INTO `item_mods` VALUES (18624, 5, 45); -- MP + 45
+INSERT INTO `item_mods` VALUES (18624, 71, 14); -- MP while Healing + 14
+
 INSERT INTO `item_mods` VALUES (18630, 374, 14);
 INSERT INTO `item_mods` VALUES (18631, 374, 15);
 INSERT INTO `item_mods` VALUES (18632, 8, 4);
@@ -21198,10 +22510,107 @@ INSERT INTO `item_mods` VALUES (18770, 25, 4);
 INSERT INTO `item_mods` VALUES (18770, 165, 3);
 INSERT INTO `item_mods` VALUES (18773, 8, 2);
 INSERT INTO `item_mods` VALUES (18773, 9, 1);
+
+-- -------------------------------------------------------
+-- Savate Fists
+-- -------------------------------------------------------
+INSERT INTO `item_mods` VALUES (18774, 25, 5); -- Accuracy + 5
+INSERT INTO `item_mods` VALUES (18774, 68, 4); -- Evasion + 4
+
+-- -------------------------------------------------------
+-- Savate Fists +1
+-- -------------------------------------------------------
+INSERT INTO `item_mods` VALUES (18775, 25, 6); -- Accuracy + 6
+INSERT INTO `item_mods` VALUES (18775, 68, 5); -- Evasion + 5
+
+-- -------------------------------------------------------
+-- Eyra Baghnakhs
+-- -------------------------------------------------------
+INSERT INTO `item_mods` VALUES (18782, 9, 4); -- DEX + 4
+INSERT INTO `item_mods` VALUES (18782, 68, 4); -- Evasion + 4
+
+-- -------------------------------------------------------
+-- Eyra Baghnakhs +1
+-- -------------------------------------------------------
+INSERT INTO `item_mods` VALUES (18783, 9, 5); -- DEX + 5
+INSERT INTO `item_mods` VALUES (18783, 68, 5); -- Evasion + 5
+
+-- -------------------------------------------------------
+-- Metasoma Katars
+-- -------------------------------------------------------
+INSERT INTO `item_mods` VALUES (18784, 23, 12); -- Attack + 12
+INSERT INTO `item_mods` VALUES (18784, 431, 1); -- Added Effect (poison, paralyze, bind)
+
+-- -------------------------------------------------------
+-- Grotesque Cesti
+-- -------------------------------------------------------
+INSERT INTO `item_mods` VALUES (18785, 10, 7); -- VIT + 7
+INSERT INTO `item_mods` VALUES (18785, 431, 1); -- Added Effect (HP drain)
+
 INSERT INTO `item_mods` VALUES (18786, 8, 10);
 INSERT INTO `item_mods` VALUES (18786, 9, 10);
 INSERT INTO `item_mods` VALUES (18786, 291, 5);
+
+-- -------------------------------------------------------
+-- Danger Grip
+-- -------------------------------------------------------
+INSERT INTO `item_mods` VALUES (18801, 25, 5); -- Accuracy + 5
+INSERT INTO `item_mods` VALUES (18801, 23, 5); -- Attack + 5
+
+-- -------------------------------------------------------
+-- Vallus Grip
+-- -------------------------------------------------------
+INSERT INTO `item_mods` VALUES (18802, 161, 5); -- Percent Physical Damage Taken + 5
+INSERT INTO `item_mods` VALUES (18802, 163, -12); -- Percent Magic Damage Taken + -12
+
+-- -------------------------------------------------------
+-- Pax Grip
+-- -------------------------------------------------------
+INSERT INTO `item_mods` VALUES (18803, 2, -10); -- HP + -10
+INSERT INTO `item_mods` VALUES (18803, 27, -4); -- Enmity + -4
+
+-- -------------------------------------------------------
+-- Amicus Grip
+-- -------------------------------------------------------
+INSERT INTO `item_mods` VALUES (18805, 14, 4); -- CHR + 4
+INSERT INTO `item_mods` VALUES (18805, 27, -3); -- Enmity + -3
+
+-- -------------------------------------------------------
+-- Gatta Strap
+-- -------------------------------------------------------
+INSERT INTO `item_mods` VALUES (18806, 8, 2); -- STR + 2
+INSERT INTO `item_mods` VALUES (18806, 9, 2); -- DEX + 2
+
+-- -------------------------------------------------------
+-- Gatta Strap +1
+-- -------------------------------------------------------
+INSERT INTO `item_mods` VALUES (18807, 8, 3); -- STR + 3
+INSERT INTO `item_mods` VALUES (18807, 9, 3); -- DEX + 3
+
+-- -------------------------------------------------------
+-- Verse Strap
+-- -------------------------------------------------------
+INSERT INTO `item_mods` VALUES (18808, 13, 2); -- MND + 2
+INSERT INTO `item_mods` VALUES (18808, 27, -2); -- Enmity + -2
+
+-- -------------------------------------------------------
+-- Verse Strap +1
+-- -------------------------------------------------------
+INSERT INTO `item_mods` VALUES (18809, 13, 3); -- MND + 3
+INSERT INTO `item_mods` VALUES (18809, 27, -3); -- Enmity + -3
+
+-- -------------------------------------------------------
+-- Cadushi Grip
+-- -------------------------------------------------------
+INSERT INTO `item_mods` VALUES (18810, 431, 1); -- Added Effect HP Drain
+
 INSERT INTO `item_mods` VALUES (18811, 370, 1);
+
+-- -------------------------------------------------------
+-- Ossa Grip
+-- -------------------------------------------------------
+INSERT INTO `item_mods` VALUES (18812, 55, 10); -- Ice Resistance + 10
+
 INSERT INTO `item_mods` VALUES (18831, 442, 1);
 INSERT INTO `item_mods` VALUES (18832, 434, 3);
 INSERT INTO `item_mods` VALUES (18833, 438, 3);
@@ -21277,11 +22686,67 @@ INSERT INTO `item_mods` VALUES (18873, 10, 3);
 INSERT INTO `item_mods` VALUES (18874, 2, 38);
 INSERT INTO `item_mods` VALUES (18874, 8, 4);
 INSERT INTO `item_mods` VALUES (18874, 10, 4);
+
+-- -------------------------------------------------------
+-- Vodun Mace
+-- -------------------------------------------------------
+INSERT INTO `item_mods` VALUES (18875, 10, 3); -- VIT + 3
+INSERT INTO `item_mods` VALUES (18875, 13, 3); -- MND + 3
+
+-- -------------------------------------------------------
+-- Robur Mace
+-- -------------------------------------------------------
+INSERT INTO `item_mods` VALUES (18877, 10, 4); -- VIT + 4
+INSERT INTO `item_mods` VALUES (18877, 30, 4); -- Magic Accuracy + 4
+
+-- -------------------------------------------------------
+-- Robur Mace +1
+-- -------------------------------------------------------
+INSERT INTO `item_mods` VALUES (18878, 10, 5); -- VIT + 5
+INSERT INTO `item_mods` VALUES (18878, 30, 5); -- Magic Accuracy + 5
+
+-- -------------------------------------------------------
+-- Runic Anelace
+-- -------------------------------------------------------
+INSERT INTO `item_mods` VALUES (18899, 5, 30); -- MP + 30
+INSERT INTO `item_mods` VALUES (18899, 71, 7); -- MP while Healing + 7
+
+-- -------------------------------------------------------
+-- Skeld Sword
+-- -------------------------------------------------------
+INSERT INTO `item_mods` VALUES (18900, 10, 3); -- VIT + 3
+INSERT INTO `item_mods` VALUES (18900, 109, 6); -- Shield + 6
+
+-- -------------------------------------------------------
+-- Falcata
+-- -------------------------------------------------------
+INSERT INTO `item_mods` VALUES (18901, 8, 4); -- STR + 4
+INSERT INTO `item_mods` VALUES (18901, 25, 4); -- Accuracy + 4
+
+-- -------------------------------------------------------
+-- Falcata +1
+-- -------------------------------------------------------
+INSERT INTO `item_mods` VALUES (18902, 8, 5); -- STR + 5
+INSERT INTO `item_mods` VALUES (18902, 25, 5); -- Accuracy + 5
+
 INSERT INTO `item_mods` VALUES (18903, 2, 50);
 INSERT INTO `item_mods` VALUES (18903, 5, 50);
 INSERT INTO `item_mods` VALUES (18903, 8, 10);
 INSERT INTO `item_mods` VALUES (18903, 10, 10);
+INSERT INTO `item_mods` VALUES (18906, 5, 25);
 INSERT INTO `item_mods` VALUES (18906, 374, 10);
+
+-- -------------------------------------------------------
+-- Devourer
+-- -------------------------------------------------------
+INSERT INTO `item_mods` VALUES (18907, 8, -2); -- STR + -2
+INSERT INTO `item_mods` VALUES (18907, 9, -2); -- DEX + -2
+INSERT INTO `item_mods` VALUES (18907, 10, 14); -- VIT + 14
+INSERT INTO `item_mods` VALUES (18907, 11, -2); -- AGI + -2
+INSERT INTO `item_mods` VALUES (18907, 12, -2); -- INT + -2
+INSERT INTO `item_mods` VALUES (18907, 13, -2); -- MND + -2
+INSERT INTO `item_mods` VALUES (18907, 14, -2); -- CHR + -2
+
 INSERT INTO `item_mods` VALUES (18909, 374, 13);
 INSERT INTO `item_mods` VALUES (18909, 375, 10);
 INSERT INTO `item_mods` VALUES (18946, 25, 7);
@@ -21305,6 +22770,23 @@ INSERT INTO `item_mods` VALUES (18952, 161, -5);
 INSERT INTO `item_mods` VALUES (18953, 2, 12); -- Max HP
 INSERT INTO `item_mods` VALUES (18953, 5, 12); -- Max MP
 INSERT INTO `item_mods` VALUES (18953, 431, 1); -- Additional Effect: Water Damage
+
+-- -------------------------------------------------------
+-- Dire Scythe
+-- -------------------------------------------------------
+INSERT INTO `item_mods` VALUES (18964, 9, 3); -- DEX + 3
+INSERT INTO `item_mods` VALUES (18964, 12, 3); -- INT + 3
+
+-- -------------------------------------------------------
+-- Dire Scythe +1
+-- -------------------------------------------------------
+INSERT INTO `item_mods` VALUES (18965, 9, 4); -- DEX + 4
+INSERT INTO `item_mods` VALUES (18965, 12, 4); -- INT + 4
+
+-- -------------------------------------------------------
+-- Bounty Sickle
+-- -------------------------------------------------------
+-- INSERT INTO `item_mods` VALUES (18968, ?, 15); -- Enhances Drain and Aspir + 15
 
 -- -------------------------------------------------------
 -- Terpsichore
@@ -21498,6 +22980,46 @@ INSERT INTO `item_mods` VALUES (19051, 12, 1);
 INSERT INTO `item_mods` VALUES (19051, 170, 1);
 
 -- -------------------------------------------------------
+-- Divinus Grip
+-- -------------------------------------------------------
+INSERT INTO `item_mods` VALUES (19052, 111, 3); -- Divine Magic + 3
+
+-- -------------------------------------------------------
+-- Curatio Grip
+-- -------------------------------------------------------
+INSERT INTO `item_mods` VALUES (19053, 112, 3); -- Healing Magic + 3
+
+-- -------------------------------------------------------
+-- Fulcio Grip
+-- -------------------------------------------------------
+INSERT INTO `item_mods` VALUES (19054, 113, 3); -- Enhancing Magic + 3
+
+-- -------------------------------------------------------
+-- Macero Grip
+-- -------------------------------------------------------
+INSERT INTO `item_mods` VALUES (19055, 114, 3); -- Enfeebling Magic + 3
+
+-- -------------------------------------------------------
+-- Elementa Grip
+-- -------------------------------------------------------
+INSERT INTO `item_mods` VALUES (19056, 115, 3); -- Elemental Magic + 3
+
+-- -------------------------------------------------------
+-- Caecus Grip
+-- -------------------------------------------------------
+INSERT INTO `item_mods` VALUES (19057, 116, 3); -- Dark Magic + 3
+
+-- -------------------------------------------------------
+-- Vox Grip
+-- -------------------------------------------------------
+INSERT INTO `item_mods` VALUES (19058, 117, 3); -- Summoning Magic + 3
+
+-- -------------------------------------------------------
+-- Quire Grip
+-- -------------------------------------------------------
+INSERT INTO `item_mods` VALUES (19059, 119, 3); -- Singing Skill + 3
+
+-- -------------------------------------------------------
 -- Gastraphetes (80)
 -- -------------------------------------------------------
 INSERT INTO `item_mods` VALUES (19070, 365, 5); -- Snap shot (Ranged delay decrease)
@@ -21538,6 +23060,34 @@ INSERT INTO `item_mods` VALUES (19124, 11, 3);
 INSERT INTO `item_mods` VALUES (19124, 14, -5);
 INSERT INTO `item_mods` VALUES (19124, 30, 3);
 INSERT INTO `item_mods` VALUES (19127, 26, 7);
+
+-- -------------------------------------------------------
+-- Verus Knife
+-- -------------------------------------------------------
+INSERT INTO `item_mods` VALUES (19138, 11, 4); -- AGI + 4
+INSERT INTO `item_mods` VALUES (19138, 25, 4); -- Accuracy + 4
+
+-- -------------------------------------------------------
+-- Verus Knife +1
+-- -------------------------------------------------------
+INSERT INTO `item_mods` VALUES (19139, 11, 5); -- AGI + 5
+INSERT INTO `item_mods` VALUES (19139, 25, 5); -- Accuracy + 5
+
+-- -------------------------------------------------------
+-- Mantodea Harpe
+-- -------------------------------------------------------
+INSERT INTO `item_mods` VALUES (19140, 8, 8); -- STR + 8
+INSERT INTO `item_mods` VALUES (19140, 11, 8); -- AGI + 8
+INSERT INTO `item_mods` VALUES (19140, 431, 1); -- Added Effect Gravity
+
+-- -------------------------------------------------------
+-- Gnadgott
+-- -------------------------------------------------------
+INSERT INTO `item_mods` VALUES (19142, 61, 20); -- Dark Resistance + 20
+INSERT INTO `item_mods` VALUES (19142, 241, 2); -- Poison Resistance + 2
+INSERT INTO `item_mods` VALUES (19142, 242, 2); -- Paralysis Resistance + 2
+INSERT INTO `item_mods` VALUES (19142, 245, 2); -- Virus Resistance + 2
+
 INSERT INTO `item_mods` VALUES (19150, 5, 8);
 INSERT INTO `item_mods` VALUES (19150, 23, 7);
 INSERT INTO `item_mods` VALUES (19151, 2, 10);
@@ -21568,13 +23118,102 @@ INSERT INTO `item_mods` VALUES (19160, 431, 1); -- Additional Effect: TP Drain
 -- -------------------------------------------------------
 INSERT INTO `item_mods` VALUES (19163, 368, 100); -- Regain
 
-INSERT INTO `item_mods` VALUES (19173, 369, 1);
+-- -------------------------------------------------------
+-- Cratus Sword
+-- -------------------------------------------------------
+INSERT INTO `item_mods` VALUES (19165, 10, 3); -- VIT + 3
+INSERT INTO `item_mods` VALUES (19165, 11, 3); -- AGI + 3
+
+-- -------------------------------------------------------
+-- Cratus Sword +1
+-- -------------------------------------------------------
+INSERT INTO `item_mods` VALUES (19166, 10, 4); -- VIT + 4
+INSERT INTO `item_mods` VALUES (19166, 11, 4); -- AGI + 4
+
+-- -------------------------------------------------------
+-- Kardia Faussar
+-- -------------------------------------------------------
+INSERT INTO `item_mods` VALUES (19170, 10, 4); -- VIT + 4
+INSERT INTO `item_mods` VALUES (19170, 25, 4); -- Accuracy + 4
+
+-- -------------------------------------------------------
+-- Kardia Faussar +1
+-- -------------------------------------------------------
+INSERT INTO `item_mods` VALUES (19171, 10, 5); -- VIT + 5
+INSERT INTO `item_mods` VALUES (19171, 25, 5); -- Accuracy + 5
+
+-- -------------------------------------------------------
+-- Jingang Greatsword
+-- -------------------------------------------------------
+INSERT INTO `item_mods` VALUES (19172, 165, 5); -- Critical Chance + 5
+INSERT INTO `item_mods` VALUES (19172, 306, 1); -- Zanshin + 1
+
+-- -------------------------------------------------------
+-- Gram
+-- -------------------------------------------------------
+INSERT INTO `item_mods` VALUES (19173, 162, -12); -- Percent Breath Damage Taken + -12
+INSERT INTO `item_mods` VALUES (19173, 369, 1); -- Refresh + 1
+
+-- 19182 Ruszor Arrow, no effects
+-- 19183 Dark Adaman Bolt, no effects
+-- 19184 Dark Adaman Bullet, no effects
 
 -- -------------------------------------------------------
 -- Tiny Tathlum
 -- -------------------------------------------------------
 INSERT INTO `item_mods` VALUES (19186, 2, 3); -- HP+3
 INSERT INTO `item_mods` VALUES (19186, 23, 1); -- Attack+1
+
+-- -------------------------------------------------------
+-- Killer Shortbow
+-- -------------------------------------------------------
+INSERT INTO `item_mods` VALUES (19188, 224, 2); -- Vermin Killer + 2
+INSERT INTO `item_mods` VALUES (19188, 225, 2); -- Bird Killer + 2
+INSERT INTO `item_mods` VALUES (19188, 226, 2); -- Amorph Killer + 2
+INSERT INTO `item_mods` VALUES (19188, 227, 2); -- Lizard Killer + 2
+INSERT INTO `item_mods` VALUES (19188, 228, 2); -- Aquan Killer + 2
+INSERT INTO `item_mods` VALUES (19188, 229, 2); -- Plantoid Killer + 2
+INSERT INTO `item_mods` VALUES (19188, 230, 2); -- Beast Killer + 2
+INSERT INTO `item_mods` VALUES (19188, 231, 2); -- Undead Killer + 2
+INSERT INTO `item_mods` VALUES (19188, 232, 2); -- Arcana Killer + 2
+INSERT INTO `item_mods` VALUES (19188, 234, 2); -- Demon Killer + 2
+INSERT INTO `item_mods` VALUES (19188, 233, 2); -- Dragon Killer + 2
+INSERT INTO `item_mods` VALUES (19188, 235, 2); -- Empty Killer + 2
+INSERT INTO `item_mods` VALUES (19188, 236, 2); -- Humanoid Killer + 2
+INSERT INTO `item_mods` VALUES (19188, 237, 2); -- Lumorian Killer + 2
+INSERT INTO `item_mods` VALUES (19188, 238, 2); -- Luminion Killer + 2
+INSERT INTO `item_mods` VALUES (19188, 240, 2); -- Sleep Resistance + 2
+INSERT INTO `item_mods` VALUES (19188, 241, 2); -- Poison Resistance + 2
+INSERT INTO `item_mods` VALUES (19188, 242, 2); -- Paralysis Resistance + 2
+INSERT INTO `item_mods` VALUES (19188, 243, 2); -- Blind Resistance + 2
+INSERT INTO `item_mods` VALUES (19188, 244, 2); -- Silence Resistance + 2
+INSERT INTO `item_mods` VALUES (19188, 245, 2); -- Virus Resistance + 2
+INSERT INTO `item_mods` VALUES (19188, 246, 2); -- Petrification Resistance + 2
+INSERT INTO `item_mods` VALUES (19188, 247, 2); -- Bind Resistance + 2
+INSERT INTO `item_mods` VALUES (19188, 248, 2); -- Curse Resistance + 2
+INSERT INTO `item_mods` VALUES (19188, 249, 2); -- Gravity Resistance + 2
+INSERT INTO `item_mods` VALUES (19188, 250, 2); -- Slow Resistance + 2
+INSERT INTO `item_mods` VALUES (19188, 251, 2); -- Stun Resistance + 2
+INSERT INTO `item_mods` VALUES (19188, 252, 2); -- Charm Resistance + 2
+INSERT INTO `item_mods` VALUES (19188, 253, 2); -- Amnesia Resistance + 2
+
+-- -------------------------------------------------------
+-- Darkling Bolt
+-- -------------------------------------------------------
+INSERT INTO `item_mods` VALUES (19196, 431, 1); -- Added Effect Dark damage
+
+-- -------------------------------------------------------
+-- Antlion Arrow
+-- -------------------------------------------------------
+INSERT INTO `item_mods` VALUES (19195, 24, 5); -- Ranged Attack + 5
+
+-- 19197 Fusion Bolt, no effects
+-- 19198 Dweomer Bullet, no effects
+
+-- -------------------------------------------------------
+-- Oberon's Bullet
+-- -------------------------------------------------------
+INSERT INTO `item_mods` VALUES (19199, 26, 6); -- Ranged Accuracy + 6
 
 INSERT INTO `item_mods` VALUES (19202, 26, -4);
 INSERT INTO `item_mods` VALUES (19203, 14, 3);
@@ -21638,11 +23277,96 @@ INSERT INTO `item_mods` VALUES (19245, 2, -15); -- HP-15
 -- [NOT CODED] INSERT INTO `item_mods` VALUES (19245, 1, 1); -- Magic critical hit rate +1%
 
 -- -------------------------------------------------------
+-- Thew Bomblet
+-- -------------------------------------------------------
+INSERT INTO `item_mods` VALUES (19249, 8, 2); -- STR + 2
+INSERT INTO `item_mods` VALUES (19249, 23, 8); -- Attack + 8
+
+-- -------------------------------------------------------
+-- Witchstone
+-- -------------------------------------------------------
+INSERT INTO `item_mods` VALUES (19250, 28, 2); -- Magic Attack Bonus + 2
+
+-- -------------------------------------------------------
 -- Tantra Tathlum
 -- -------------------------------------------------------
 INSERT INTO `item_mods` VALUES (19254, 8, 3); -- STR
 INSERT INTO `item_mods` VALUES (19254, 10, 3); -- VIT
 INSERT INTO `item_mods` VALUES (19254, 25, 6); -- accuracy
+
+-- -------------------------------------------------------
+-- Incantor Stone
+-- -------------------------------------------------------
+INSERT INTO `item_mods` VALUES (19257, 5, 10); -- MP + 10
+INSERT INTO `item_mods` VALUES (19257, 170, 2); -- Fast Cast + 2
+
+-- -------------------------------------------------------
+-- Qirmiz Tathlum
+-- -------------------------------------------------------
+INSERT INTO `item_mods` VALUES (19258, 23, 3); -- Attack + 3
+INSERT INTO `item_mods` VALUES (19258, 421, 5); -- Critical Damage + 5
+
+-- -------------------------------------------------------
+-- Clarus Stone
+-- -------------------------------------------------------
+INSERT INTO `item_mods` VALUES (19259, 296, 3); -- Conserve MP + 3
+INSERT INTO `item_mods` VALUES (19259, 71, 2); -- MP while Healing + 2
+
+-- -------------------------------------------------------
+-- Jinx Discus
+-- -------------------------------------------------------
+INSERT INTO `item_mods` VALUES (19261, 106, 10); -- Throwing + 10
+INSERT INTO `item_mods` VALUES (19261, 431, 1); -- Added Effect Curse
+
+-- -------------------------------------------------------
+-- Amazon Bow
+-- -------------------------------------------------------
+INSERT INTO `item_mods` VALUES (19263, 8, 3); -- STR + 3
+INSERT INTO `item_mods` VALUES (19263, 10, 3); -- VIT + 3
+
+-- -------------------------------------------------------
+-- Amazon Bow +1
+-- -------------------------------------------------------
+INSERT INTO `item_mods` VALUES (19264, 8, 4); -- STR + 4
+INSERT INTO `item_mods` VALUES (19264, 10, 4); -- VIT + 4
+INSERT INTO `item_mods` VALUES (19264, 26, 5); -- Ranged Accuracy + 5
+
+-- -------------------------------------------------------
+-- Darkwing
+-- -------------------------------------------------------
+INSERT INTO `item_mods` VALUES (19265, 11, 3); -- AGI + 3
+INSERT INTO `item_mods` VALUES (19265, 13, 3); -- MND + 3
+
+-- -------------------------------------------------------
+-- Darkwing +1
+-- -------------------------------------------------------
+INSERT INTO `item_mods` VALUES (19266, 11, 4); -- AGI + 4
+INSERT INTO `item_mods` VALUES (19266, 13, 4); -- MND + 4
+INSERT INTO `item_mods` VALUES (19266, 24, 20); -- Ranged Attack + 20
+
+-- -------------------------------------------------------
+-- Ribauldequin
+-- -------------------------------------------------------
+INSERT INTO `item_mods` VALUES (19267, 10, 3); -- VIT + 3
+INSERT INTO `item_mods` VALUES (19267, 11, 3); -- AGI + 3
+
+-- -------------------------------------------------------
+-- Ribauldequin +1
+-- -------------------------------------------------------
+INSERT INTO `item_mods` VALUES (19268, 10, 4); -- VIT + 4
+INSERT INTO `item_mods` VALUES (19268, 11, 4); -- AGI + 4
+
+-- -------------------------------------------------------
+-- Leisure Musk
+-- -------------------------------------------------------
+INSERT INTO `item_mods` VALUES (19269, 68, -7); -- Evasion + -7
+INSERT INTO `item_mods` VALUES (19269, 27, -3); -- Enmity + -3
+
+-- -------------------------------------------------------
+-- Quartz Tathlum
+-- -------------------------------------------------------
+INSERT INTO `item_mods` VALUES (19270, 5, 5); -- MP + 5
+INSERT INTO `item_mods` VALUES (19270, 13, 2); -- MND + 2
 
 INSERT INTO `item_mods` VALUES (19271, 1, 10);
 INSERT INTO `item_mods` VALUES (19273, 68, 5);
@@ -21654,9 +23378,62 @@ INSERT INTO `item_mods` VALUES (19280, 68, 5);
 INSERT INTO `item_mods` VALUES (19280, 163, -12);
 INSERT INTO `item_mods` VALUES (19281, 68, 2);
 INSERT INTO `item_mods` VALUES (19285, 8,3);
+-- 19284 Hiwa, no effects
 INSERT INTO `item_mods` VALUES (19285, 11,3);
 INSERT INTO `item_mods` VALUES (19286, 8,4);
 INSERT INTO `item_mods` VALUES (19286, 11,4);
+-- 19290 Aizenkunitoshi, latent only
+
+-- -------------------------------------------------------
+-- Ichi-An
+-- -------------------------------------------------------
+INSERT INTO `item_mods` VALUES (19293, 8, 4); -- STR + 4
+INSERT INTO `item_mods` VALUES (19293, 68, 4); -- Evasion + 4
+
+-- -------------------------------------------------------
+-- Ichi-An +1
+-- -------------------------------------------------------
+INSERT INTO `item_mods` VALUES (19294, 8, 5); -- STR + 5
+INSERT INTO `item_mods` VALUES (19294, 68, 5); -- Evasion + 5
+
+-- -------------------------------------------------------
+-- Ban
+-- -------------------------------------------------------
+INSERT INTO `item_mods` VALUES (19296, 54, 12); -- Fire Resistance + 12
+INSERT INTO `item_mods` VALUES (19296, 431, 1); -- Added Effect Fire Damage
+
+-- -------------------------------------------------------
+-- Kakesu
+-- -------------------------------------------------------
+INSERT INTO `item_mods` VALUES (19297, 9, 5); -- DEX + 5
+INSERT INTO `item_mods` VALUES (19297, 11, 5); -- AGI + 5
+-- INSERT INTO `item_mods` VALUES (19297, ?, ?); -- Enhances Attack by Utsusemi Images + ?
+
+-- -------------------------------------------------------
+-- Guisarme
+-- -------------------------------------------------------
+INSERT INTO `item_mods` VALUES (19310, 9, 3); -- DEX + 3
+INSERT INTO `item_mods` VALUES (19310, 11, 3); -- AGI + 3
+
+-- 19314 Quint Spear, no effects
+
+-- -------------------------------------------------------
+-- Erebus's Lance
+-- -------------------------------------------------------
+INSERT INTO `item_mods` VALUES (19315, 25, 12); -- Accuracy + 12
+INSERT INTO `item_mods` VALUES (19315, 431, 1); -- Added Effect Bonus Damage with TP Against Empty
+
+-- -------------------------------------------------------
+-- Fetter Lance
+-- -------------------------------------------------------
+INSERT INTO `item_mods` VALUES (19316, 250, 2); -- Slow Resistance + 2
+INSERT INTO `item_mods` VALUES (19316, 431, 1); -- Added Effect Addle
+
+-- -------------------------------------------------------
+-- Borian Spear
+-- -------------------------------------------------------
+INSERT INTO `item_mods` VALUES (19317, 8, 4); -- STR + 4
+INSERT INTO `item_mods` VALUES (19317, 25, 4); -- Accuracy + 4
 
 -- -------------------------------------------------------
 -- Gastraphetes (90)
@@ -21671,11 +23448,189 @@ INSERT INTO `item_mods` VALUES (19720, 365, 5); -- Snap shot (Ranged delay decre
 INSERT INTO `item_mods` VALUES (19720, 420, 30); -- Barrage accuracy
 
 -- -------------------------------------------------------
+-- Miramar Gun
+-- -------------------------------------------------------
+INSERT INTO `item_mods` VALUES (19732, 26, 7); -- Ranged Accuracy + 7
+INSERT INTO `item_mods` VALUES (19732, 30, 7); -- Magic Accuracy + 7
+
+-- -------------------------------------------------------
+-- Beursault Bow
+-- -------------------------------------------------------
+INSERT INTO `item_mods` VALUES (19733, 11, 4); -- AGI + 4
+INSERT INTO `item_mods` VALUES (19733, 24, 4); -- Ranged Attack + 4
+
+-- -------------------------------------------------------
+-- Beursault Bow +1
+-- -------------------------------------------------------
+INSERT INTO `item_mods` VALUES (19734, 11, 5); -- AGI + 5
+INSERT INTO `item_mods` VALUES (19734, 24, 5); -- Ranged Attack + 5
+
+-- -------------------------------------------------------
+-- Cecchino's Fucile
+-- -------------------------------------------------------
+INSERT INTO `item_mods` VALUES (19735, 8, 4); -- STR + 4
+INSERT INTO `item_mods` VALUES (19735, 26, 4); -- Ranged Accuracy + 4
+
+-- -------------------------------------------------------
+-- Cecchino's Fucile +1
+-- -------------------------------------------------------
+INSERT INTO `item_mods` VALUES (19736, 8, 5); -- STR + 5
+INSERT INTO `item_mods` VALUES (19736, 26, 5); -- Ranged Accuracy + 5
+
+-- -------------------------------------------------------
+-- Percept Bow
+-- -------------------------------------------------------
+INSERT INTO `item_mods` VALUES (19737, 11, 7); -- AGI + 7
+INSERT INTO `item_mods` VALUES (19737, 24, 14); -- Ranged Attack + 14
+INSERT INTO `item_mods` VALUES (19737, 421, 2); -- Critical Damage + 2
+
+-- -------------------------------------------------------
+-- Aife's Bow
+-- -------------------------------------------------------
+INSERT INTO `item_mods` VALUES (19738, 289, 8); -- Subtle Blow + 8
+INSERT INTO `item_mods` VALUES (19738, 27, -6); -- Enmity + -6
+
+-- -------------------------------------------------------
+-- Moros Crossbow
+-- -------------------------------------------------------
+INSERT INTO `item_mods` VALUES (19739, 24, 12); -- Ranged Attack + 12
+INSERT INTO `item_mods` VALUES (19739, 73, 4); -- Store TP + 4
+
+-- -------------------------------------------------------
+-- Stoertebeker
+-- -------------------------------------------------------
+INSERT INTO `item_mods` VALUES (19740, 26, 7); -- Ranged Accuracy + 7
+-- INSERT INTO `item_mods` VALUES (19740, ?, ?); -- Occasionally Enhances Ranged Attack + ?
+
+-- -------------------------------------------------------
+-- Impatiens
+-- -------------------------------------------------------
+INSERT INTO `item_mods` VALUES (19761, 168, 10); -- Spell Interruption Rate Down + 10
+-- INSERT INTO `item_mods` VALUES (19761, ?, 2); -- Occasionally Quickens Spellcasting + 2
+
+-- -------------------------------------------------------
+-- Oneiros Tathlum
+-- -------------------------------------------------------
+INSERT INTO `item_mods` VALUES (19762, 84, 2); -- Axe + 2
+
+-- -------------------------------------------------------
+-- Demonry Core
+-- -------------------------------------------------------
+INSERT INTO `item_mods` VALUES (19764, 9, 4); -- DEX + 4
+-- INSERT INTO `item_mods` VALUES (19764, ?, 4); -- Pet Accuracy + 4
+
+-- -------------------------------------------------------
+-- Demonry Stone
+-- -------------------------------------------------------
+INSERT INTO `item_mods` VALUES (19765, 5, 20); -- MP + 20
+INSERT INTO `item_mods` VALUES (19765, 29, 2); -- Magic Defense Bonus + 2
+
+-- -------------------------------------------------------
+-- Fracas Grenade
+-- -------------------------------------------------------
+INSERT INTO `item_mods` VALUES (19766, 8, 5); -- STR + 5
+INSERT INTO `item_mods` VALUES (19766, 54, -50); -- Fire Resistance + -50
+
+-- -------------------------------------------------------
+-- Oneiros Pebble
+-- -------------------------------------------------------
+INSERT INTO `item_mods` VALUES (19767, 10, 5); -- VIT + 5
+INSERT INTO `item_mods` VALUES (19767, 25, 4); -- Accuracy + 4
+
+-- -------------------------------------------------------
+-- Egoist's Tathlum
+-- -------------------------------------------------------
+INSERT INTO `item_mods` VALUES (19768, 2, 45); -- HP + 45
+INSERT INTO `item_mods` VALUES (19768, 12, -2); -- INT + -2
+
+-- -------------------------------------------------------
+-- Strobilus
+-- -------------------------------------------------------
+INSERT INTO `item_mods` VALUES (19771, 5, 45); -- MP + 45
+INSERT INTO `item_mods` VALUES (19771, 61, 10); -- Dark Resistance + 10
+
+-- -------------------------------------------------------
+-- Esper Stone
+-- -------------------------------------------------------
+INSERT INTO `item_mods` VALUES (19772, 27, -2); -- Enmity + -2
+INSERT INTO `item_mods` VALUES (19772, 28, 1); -- Magic Attack Bonus + 1
+
+-- -------------------------------------------------------
+-- Hagneia Stone
+-- -------------------------------------------------------
+INSERT INTO `item_mods` VALUES (19773, 23, 3); -- Attack + 3
+INSERT INTO `item_mods` VALUES (19773, 73, 3); -- Store TP + 3
+
+-- -------------------------------------------------------
+-- Angha Gem
+-- -------------------------------------------------------
+INSERT INTO `item_mods` VALUES (19774, 161, -2); -- Percent Physical Damage Taken + -2
+
+-- -------------------------------------------------------
+-- Memoria Sachet
+-- -------------------------------------------------------
+INSERT INTO `item_mods` VALUES (19775, 30, 2); -- Magic Accuracy + 2
+INSERT INTO `item_mods` VALUES (19775, 28, 2); -- Magic Attack Bonus + 2
+
+-- -------------------------------------------------------
+-- Ombre Tathlum
+-- -------------------------------------------------------
+INSERT INTO `item_mods` VALUES (19777, 12, 4); -- INT + 4
+INSERT INTO `item_mods` VALUES (19777, 296, 2); -- Conserve MP + 2
+
+-- -------------------------------------------------------
+-- Hasty Pinion
+-- -------------------------------------------------------
+INSERT INTO `item_mods` VALUES (19778, 384, 10); -- Haste + 10
+INSERT INTO `item_mods` VALUES (19778, 73, -5); -- Store TP + -5
+
+-- -------------------------------------------------------
+-- Protestas Bomblet
+-- -------------------------------------------------------
+INSERT INTO `item_mods` VALUES (19779, 23, 15); -- Attack + 15
+
+-- -------------------------------------------------------
+-- Mana Ampulla
+-- -------------------------------------------------------
+INSERT INTO `item_mods` VALUES (19780, 5, 20); -- MP + 20
+INSERT INTO `item_mods` VALUES (19780, 13, 3); -- MND + 3
+INSERT INTO `item_mods` VALUES (19780, 71, 2); -- MP while Healing + 2
+
+-- -------------------------------------------------------
+-- Draca Couse
+-- -------------------------------------------------------
+INSERT INTO `item_mods` VALUES (19791, 8, 7); -- STR + 7
+
+-- -------------------------------------------------------
+-- Drachenstich
+-- -------------------------------------------------------
+INSERT INTO `item_mods` VALUES (19792, 13, 10); -- MND + 10
+-- INSERT INTO `item_mods` VALUES (19792, ?, -5); -- Wyvern Damage Taken + -5
+
+-- -------------------------------------------------------
+-- Patientia Lance
+-- -------------------------------------------------------
+INSERT INTO `item_mods` VALUES (19793, 11, 10); -- AGI + 10
+INSERT INTO `item_mods` VALUES (19793, 23, 15); -- Attack + 15
+-- INSERT INTO `item_mods` VALUES (19793, ?, 7); -- Conserve TP + 7
+
+-- -------------------------------------------------------
+-- Gargouille Arrow
+-- -------------------------------------------------------
+INSERT INTO `item_mods` VALUES (19800, 26, 5); -- Ranged Accuracy + 5
+
+-- -------------------------------------------------------
+-- Orichalcum Bullet
+-- -------------------------------------------------------
+INSERT INTO `item_mods` VALUES (19802, 28, 2); -- Magic Attack Bonus + 2
+
+-- 19803 Adaman Bullet, no effects
+
+-- -------------------------------------------------------
 -- Gastraphetes (99)
 -- -------------------------------------------------------
 INSERT INTO `item_mods` VALUES (19829, 365, 5); -- Snap shot (Ranged delay decrease)
 INSERT INTO `item_mods` VALUES (19829, 420, 35); -- Barrage accuracy
-
 
 -- -------------------------------------------------------
 -- Redemption
@@ -21690,6 +23645,121 @@ INSERT INTO `item_mods` VALUES (19958, 365, 5); -- Snap shot (Ranged delay decre
 INSERT INTO `item_mods` VALUES (19958, 450, 35); -- Barrage accuracy
 
 -- -------------------------------------------------------
+-- Ohrmazd
+-- -------------------------------------------------------
+INSERT INTO `item_mods` VALUES (20530, 80, 242); -- Hand to Hand + 242
+INSERT INTO `item_mods` VALUES (20530, 107, 242); -- Guard + 242
+INSERT INTO `item_mods` VALUES (20530, 103, 188); -- Magic Accuracy Skill + 188
+
+-- -------------------------------------------------------
+-- Tinhaspa
+-- -------------------------------------------------------
+INSERT INTO `item_mods` VALUES (20536, 8, 3); -- STR + 3
+INSERT INTO `item_mods` VALUES (20536, 25, 5); -- Accuracy + 5
+INSERT INTO `item_mods` VALUES (20536, 80, 242); -- Hand to Hand + 242
+INSERT INTO `item_mods` VALUES (20536, 107, 242); -- Guard + 242
+INSERT INTO `item_mods` VALUES (20536, 103, 188); -- Magic Accuracy Skill + 188
+-- INSERT INTO `item_mods` VALUES (20536, ?, 15); -- Automaton Attack + 15
+-- INSERT INTO `item_mods` VALUES (20536, ?, 15); -- Automaton Ranged Attack + 15
+-- INSERT INTO `item_mods` VALUES (20536, ?, 15); -- Automaton Magic Attack + 15
+
+-- -------------------------------------------------------
+-- Ipetam
+-- -------------------------------------------------------
+INSERT INTO `item_mods` VALUES (20616, 68, 22); -- Evasion + 22
+INSERT INTO `item_mods` VALUES (20616, 81, 242); -- Dagger + 242
+INSERT INTO `item_mods` VALUES (20616, 110, 242); -- Parrying + 242
+INSERT INTO `item_mods` VALUES (20616, 103, 188); -- Magic Accuracy Skill + 188
+
+-- -------------------------------------------------------
+-- Arendsi Fleuret
+-- -------------------------------------------------------
+INSERT INTO `item_mods` VALUES (20717, 25, 27); -- Accuracy + 27
+INSERT INTO `item_mods` VALUES (20717, 30, 15); -- Magic Accuracy + 15
+INSERT INTO `item_mods` VALUES (20717, 311, 90); -- Magic Damage Bonus + 90
+INSERT INTO `item_mods` VALUES (20717, 68, 13); -- Evasion + 13
+INSERT INTO `item_mods` VALUES (20717, 82, 228); -- Sword + 228
+INSERT INTO `item_mods` VALUES (20717, 110, 228); -- Parrying + 228
+INSERT INTO `item_mods` VALUES (20717, 113, 10); -- Enhancing Magic + 10
+INSERT INTO `item_mods` VALUES (20717, 114, 10); -- Enfeebling Magic + 10
+
+-- -------------------------------------------------------
+-- Claidheamh Soluis
+-- -------------------------------------------------------
+INSERT INTO `item_mods` VALUES (20718, 82, 242); -- Sword + 242
+INSERT INTO `item_mods` VALUES (20718, 110, 242); -- Parrying + 242
+INSERT INTO `item_mods` VALUES (20718, 103, 188); -- Magic Accuracy Skill + 188
+
+-- -------------------------------------------------------
+-- Mimesis
+-- -------------------------------------------------------
+INSERT INTO `item_mods` VALUES (20721, 2, 50); -- HP + 50
+INSERT INTO `item_mods` VALUES (20721, 8, 10); -- STR + 10
+INSERT INTO `item_mods` VALUES (20721, 9, 10); -- DEX + 10
+INSERT INTO `item_mods` VALUES (20721, 10, 10); -- VIT + 10
+INSERT INTO `item_mods` VALUES (20721, 11, 10); -- AGI + 10
+INSERT INTO `item_mods` VALUES (20721, 12, 10); -- INT + 10
+INSERT INTO `item_mods` VALUES (20721, 13, 10); -- MND + 10
+INSERT INTO `item_mods` VALUES (20721, 14, 10); -- CHR + 10
+INSERT INTO `item_mods` VALUES (20721, 82, 242); -- Sword + 242
+INSERT INTO `item_mods` VALUES (20721, 110, 242); -- Parrying + 242
+INSERT INTO `item_mods` VALUES (20721, 103, 188); -- Magic Accuracy Skill + 188
+INSERT INTO `item_mods` VALUES (20721, 27, -10); -- Enmity + -10
+
+-- -------------------------------------------------------
+-- Mekosuchus Blade
+-- -------------------------------------------------------
+INSERT INTO `item_mods` VALUES (20758, 8, 13); -- STR + 13
+INSERT INTO `item_mods` VALUES (20758, 23, 35); -- Attack + 35
+INSERT INTO `item_mods` VALUES (20758, 83, 228); -- Great Sword + 228
+INSERT INTO `item_mods` VALUES (20758, 110, 228); -- Parrying + 228
+INSERT INTO `item_mods` VALUES (20758, 103, 188); -- Magic Accuracy Skill + 188
+INSERT INTO `item_mods` VALUES (20758, 392, 30); -- Weapon Bash + 30
+-- INSERT INTO `item_mods` VALUES (20758, ?, 10); -- Absorb Potency + 10
+
+-- -------------------------------------------------------
+-- Macbain
+-- -------------------------------------------------------
+INSERT INTO `item_mods` VALUES (20759, 83, 242); -- Great Sword + 242
+INSERT INTO `item_mods` VALUES (20759, 110, 242); -- Parrying + 242
+INSERT INTO `item_mods` VALUES (20759, 103, 188); -- Magic Accuracy Skill + 188
+
+-- -------------------------------------------------------
+-- Kbiroj
+-- -------------------------------------------------------
+INSERT INTO `item_mods` VALUES (20763, 2, 20); -- HP + 20
+INSERT INTO `item_mods` VALUES (20763, 23, 8); -- Attack + 8
+INSERT INTO `item_mods` VALUES (20763, 83, 242); -- Great Sword + 242
+INSERT INTO `item_mods` VALUES (20763, 110, 242); -- Parrying + 242
+INSERT INTO `item_mods` VALUES (20763, 103, 188); -- Magic Accuracy Skill + 188
+
+-- -------------------------------------------------------
+-- Voay Sword -1
+-- -------------------------------------------------------
+INSERT INTO `item_mods` VALUES (20772, 25, -50); -- Accuracy + -50
+INSERT INTO `item_mods` VALUES (20772, 83, 51); -- Great Sword + 51
+INSERT INTO `item_mods` VALUES (20772, 110, 51); -- Parrying + 51
+INSERT INTO `item_mods` VALUES (20772, 103, 42); -- Magic Accuracy Skill + 42
+
+-- -------------------------------------------------------
+-- Voay Sword
+-- -------------------------------------------------------
+INSERT INTO `item_mods` VALUES (20773, 23, 22); -- Attack + 22
+INSERT INTO `item_mods` VALUES (20773, 83, 76); -- Great Sword + 76
+INSERT INTO `item_mods` VALUES (20773, 110, 76); -- Parrying + 76
+INSERT INTO `item_mods` VALUES (20773, 103, 63); -- Magic Accuracy Skill + 63
+INSERT INTO `item_mods` VALUES (20773, 27, 15); -- Enmity + 15
+
+-- -------------------------------------------------------
+-- Voay Sword +1
+-- -------------------------------------------------------
+INSERT INTO `item_mods` VALUES (20774, 23, 30); -- Attack + 30
+INSERT INTO `item_mods` VALUES (20774, 83, 89); -- Great Sword + 89
+INSERT INTO `item_mods` VALUES (20774, 110, 89); -- Parrying + 89
+INSERT INTO `item_mods` VALUES (20774, 103, 73); -- Magic Accuracy Skill + 73
+INSERT INTO `item_mods` VALUES (20774, 27, 20); -- Enmity + 20
+
+-- -------------------------------------------------------
 -- Sowilo Claymore
 -- -------------------------------------------------------
 INSERT INTO `item_mods` VALUES (20781, 2, 5); -- HP+5
@@ -21701,9 +23771,358 @@ INSERT INTO `item_mods` VALUES (20784, 23, 9); -- Attack+9
 INSERT INTO `item_mods` VALUES (20784, 29, 5); -- "Magic Def. Bonus"+5
 
 -- -------------------------------------------------------
+-- Kumbhakarna
+-- -------------------------------------------------------
+INSERT INTO `item_mods` VALUES (20809, 84, 242); -- Axe + 242
+INSERT INTO `item_mods` VALUES (20809, 110, 242); -- Parrying + 242
+INSERT INTO `item_mods` VALUES (20809, 103, 188); -- Magic Accuracy Skill + 188
+
+-- -------------------------------------------------------
+-- Svarga
+-- -------------------------------------------------------
+INSERT INTO `item_mods` VALUES (20857, 85, 242); -- Great Axe + 242
+INSERT INTO `item_mods` VALUES (20857, 110, 242); -- Parrying + 242
+INSERT INTO `item_mods` VALUES (20857, 103, 188); -- Magic Accuracy Skill + 188
+
+-- -------------------------------------------------------
+-- Minos
+-- -------------------------------------------------------
+INSERT INTO `item_mods` VALUES (20860, 23, 15); -- Attack + 15
+INSERT INTO `item_mods` VALUES (20860, 85, 242); -- Great Axe + 242
+INSERT INTO `item_mods` VALUES (20860, 110, 242); -- Parrying + 242
+INSERT INTO `item_mods` VALUES (20860, 103, 188); -- Magic Accuracy Skill + 188
+INSERT INTO `item_mods` VALUES (20860, 27, -10); -- Enmity + -10
+INSERT INTO `item_mods` VALUES (20860, 288, 4); -- Double Attack + 4
+
+-- -------------------------------------------------------
+-- Inanna
+-- -------------------------------------------------------
+INSERT INTO `item_mods` VALUES (20901, 86, 242); -- Scythe + 242
+INSERT INTO `item_mods` VALUES (20901, 110, 242); -- Parrying + 242
+INSERT INTO `item_mods` VALUES (20901, 103, 188); -- Magic Accuracy Skill + 188
+
+-- -------------------------------------------------------
+-- Cronus
+-- -------------------------------------------------------
+INSERT INTO `item_mods` VALUES (20904, 25, 15); -- Accuracy + 15
+INSERT INTO `item_mods` VALUES (20904, 23, 15); -- Attack + 15
+INSERT INTO `item_mods` VALUES (20904, 86, 242); -- Scythe + 242
+INSERT INTO `item_mods` VALUES (20904, 110, 242); -- Parrying + 242
+INSERT INTO `item_mods` VALUES (20904, 103, 188); -- Magic Accuracy Skill + 188
+INSERT INTO `item_mods` VALUES (20904, 27, -10); -- Enmity + -10
+INSERT INTO `item_mods` VALUES (20904, 431, 1); -- Added Effect HP Drain
+
+-- -------------------------------------------------------
+-- Olyndicus
+-- -------------------------------------------------------
+INSERT INTO `item_mods` VALUES (20946, 87, 242); -- Polearm + 242
+INSERT INTO `item_mods` VALUES (20946, 110, 242); -- Parrying + 242
+INSERT INTO `item_mods` VALUES (20946, 103, 188); -- Magic Accuracy Skill + 188
+
+-- -------------------------------------------------------
+-- Eminent Lance
+-- -------------------------------------------------------
+INSERT INTO `item_mods` VALUES (20954, 87, 215); -- Polearm + 215
+INSERT INTO `item_mods` VALUES (20954, 110, 215); -- Parrying + 215
+INSERT INTO `item_mods` VALUES (20954, 103, 167); -- Magic Accuracy Skill + 167
+
+-- -------------------------------------------------------
+-- Kikoku (119-2)
+-- -------------------------------------------------------
+INSERT INTO `item_mods` VALUES (20971, 23, 40); -- Attack
+INSERT INTO `item_mods` VALUES (20971, 355, 137); -- Adds WS
+INSERT INTO `item_mods` VALUES (20971, 431, 1); -- Add. Effect (Paralysis)
+INSERT INTO `item_mods` VALUES (20971, 506, 160); -- 16% chance of extra dmg.
+INSERT INTO `item_mods` VALUES (20971, 507, 300); -- Occ. 3x dmg
+INSERT INTO `item_mods` VALUES (20971, 356, 153); -- Adds WS in Dynamis
+INSERT INTO `item_mods` VALUES (20971, 88, 242); -- Katana skill
+INSERT INTO `item_mods` VALUES (20971, 110, 242); -- Parrying skill
+INSERT INTO `item_mods` VALUES (20971, 103, 215); -- Magic Accuracy skill
+-- INSERT INTO `item_mods` VALUES (20971, ?, ?); -- Afterglow effect
+
+-- -------------------------------------------------------
+-- Izuna
+-- -------------------------------------------------------
+INSERT INTO `item_mods` VALUES (20989, 68, 22); -- Evasion + 22
+INSERT INTO `item_mods` VALUES (20989, 88, 242); -- Katana + 242
+INSERT INTO `item_mods` VALUES (20989, 110, 242); -- Parrying + 242
+INSERT INTO `item_mods` VALUES (20989, 103, 188); -- Magic Accuracy Skill + 188
+
+-- -------------------------------------------------------
+-- Shigi
+-- -------------------------------------------------------
+INSERT INTO `item_mods` VALUES (20994, 25, 27); -- Accuracy + 27
+INSERT INTO `item_mods` VALUES (20994, 68, 27); -- Evasion + 27
+INSERT INTO `item_mods` VALUES (20994, 88, 228); -- Katana + 228
+INSERT INTO `item_mods` VALUES (20994, 110, 228); -- Parrying + 228
+INSERT INTO `item_mods` VALUES (20994, 103, 215); -- Magic Accuracy Skill + 215
+INSERT INTO `item_mods` VALUES (20994, 118, 10); -- Ninjutsu + 10
+INSERT INTO `item_mods` VALUES (20994, 27, -10); -- Enmity + -10
+INSERT INTO `item_mods` VALUES (20994, 308, 5); -- Ninja Tool Expertise + 5
+-- INSERT INTO `item_mods` VALUES (20994, ?, 3); -- Ninjutsu Recast Reduction + 3
+
+-- -------------------------------------------------------
+-- Senkuto
+-- -------------------------------------------------------
+INSERT INTO `item_mods` VALUES (21038, 25, 24); -- Accuracy + 24
+INSERT INTO `item_mods` VALUES (21038, 89, 203); -- Great Katana + 203
+INSERT INTO `item_mods` VALUES (21038, 110, 203); -- Parrying + 203
+INSERT INTO `item_mods` VALUES (21038, 103, 167); -- Magic Accuracy Skill + 167
+-- INSERT INTO `item_mods` VALUES (21038, ?, 400); -- Reives: Conserve TP + 400
+
+-- -------------------------------------------------------
+-- Shokudaikiri
+-- -------------------------------------------------------
+INSERT INTO `item_mods` VALUES (21040, 8, 4); -- STR + 4
+INSERT INTO `item_mods` VALUES (21040, 23, 4); -- Attack + 4
+INSERT INTO `item_mods` VALUES (21040, 89, 242); -- Great Katana + 242
+INSERT INTO `item_mods` VALUES (21040, 110, 242); -- Parrying + 242
+INSERT INTO `item_mods` VALUES (21040, 103, 188); -- Magic Accuracy Skill + 188
+
+-- -------------------------------------------------------
+-- Bolelabunga
+-- -------------------------------------------------------
+INSERT INTO `item_mods` VALUES (21111, 12, 6); -- INT + 6
+INSERT INTO `item_mods` VALUES (21111, 13, 6); -- MND + 6
+INSERT INTO `item_mods` VALUES (21111, 28, 16); -- Magic Attack Bonus + 16
+INSERT INTO `item_mods` VALUES (21111, 311, 124); -- Magic Damage Bonus + 124
+INSERT INTO `item_mods` VALUES (21111, 90, 242); -- Club + 242
+INSERT INTO `item_mods` VALUES (21111, 110, 242); -- Parrying + 242
+INSERT INTO `item_mods` VALUES (21111, 103, 215); -- Magic Accuracy Skill + 215
+INSERT INTO `item_mods` VALUES (21111, 338, 10); -- Regen Effectiveness + 10
+-- INSERT INTO `item_mods` VALUES (21111, ?, 1); -- Regen + 1
+-- INSERT INTO `item_mods` VALUES (21111, ?, 1); -- Refresh + 1
+
+-- -------------------------------------------------------
+-- Keraunos
+-- -------------------------------------------------------
+INSERT INTO `item_mods` VALUES (21169, 12, 12); -- INT + 12
+INSERT INTO `item_mods` VALUES (21169, 13, 12); -- MND + 12
+INSERT INTO `item_mods` VALUES (21169, 28, 28); -- Magic Attack Bonus + 28
+INSERT INTO `item_mods` VALUES (21169, 311, 217); -- Magic Damage Bonus + 217
+INSERT INTO `item_mods` VALUES (21169, 91, 242); -- Staff + 242
+INSERT INTO `item_mods` VALUES (21169, 110, 242); -- Parrying + 242
+INSERT INTO `item_mods` VALUES (21169, 103, 228); -- Magic Accuracy Skill + 228
+-- INSERT INTO `item_mods` VALUES (21169, ?, 20); -- Avatar Magic Accuracy + 20
+-- INSERT INTO `item_mods` VALUES (21169, ?, 100); -- Avatar Magic Attack Bonus + 100
+
+-- -------------------------------------------------------
+-- Kaladanda
+-- -------------------------------------------------------
+INSERT INTO `item_mods` VALUES (21173, 12, 12); -- INT + 12
+INSERT INTO `item_mods` VALUES (21173, 13, 12); -- MND + 12
+INSERT INTO `item_mods` VALUES (21173, 30, 20); -- Magic Accuracy + 20
+INSERT INTO `item_mods` VALUES (21173, 28, 20); -- Magic Attack Bonus + 20
+INSERT INTO `item_mods` VALUES (21173, 311, 224); -- Magic Damage Bonus + 224
+INSERT INTO `item_mods` VALUES (21173, 91, 242); -- Staff + 242
+INSERT INTO `item_mods` VALUES (21173, 110, 242); -- Parrying + 242
+INSERT INTO `item_mods` VALUES (21173, 103, 228); -- Magic Accuracy Skill + 228
+INSERT INTO `item_mods` VALUES (21173, 27, -10); -- Enmity + -10
+
+-- -------------------------------------------------------
+-- Voay Staff -1
+-- -------------------------------------------------------
+INSERT INTO `item_mods` VALUES (21191, 12, 6); -- INT + 6
+INSERT INTO `item_mods` VALUES (21191, 13, 6); -- MND + 6
+INSERT INTO `item_mods` VALUES (21191, 25, -50); -- Accuracy + -50
+INSERT INTO `item_mods` VALUES (21191, 30, -50); -- Magic Accuracy + -50
+INSERT INTO `item_mods` VALUES (21191, 28, 4); -- Magic Attack Bonus + 4
+INSERT INTO `item_mods` VALUES (21191, 311, 65); -- Magic Damage Bonus + 65
+INSERT INTO `item_mods` VALUES (21191, 91, 54); -- Staff + 54
+INSERT INTO `item_mods` VALUES (21191, 110, 54); -- Parrying + 54
+INSERT INTO `item_mods` VALUES (21191, 103, 51); -- Magic Accuracy Skill + 51
+
+-- -------------------------------------------------------
+-- Voay Staff
+-- -------------------------------------------------------
+INSERT INTO `item_mods` VALUES (21192, 12, 7); -- INT + 7
+INSERT INTO `item_mods` VALUES (21192, 13, 7); -- MND + 7
+INSERT INTO `item_mods` VALUES (21192, 25, -30); -- Accuracy + -30
+INSERT INTO `item_mods` VALUES (21192, 30, -60); -- Magic Accuracy + -60
+INSERT INTO `item_mods` VALUES (21192, 28, 60); -- Magic Attack Bonus + 60
+INSERT INTO `item_mods` VALUES (21192, 311, 86); -- Magic Damage Bonus + 86
+INSERT INTO `item_mods` VALUES (21192, 91, 81); -- Staff + 81
+INSERT INTO `item_mods` VALUES (21192, 110, 81); -- Parrying + 81
+INSERT INTO `item_mods` VALUES (21192, 103, 81); -- Magic Accuracy Skill + 81
+
+-- -------------------------------------------------------
+-- Voay Staff +1
+-- -------------------------------------------------------
+INSERT INTO `item_mods` VALUES (21193, 12, 7); -- INT + 7
+INSERT INTO `item_mods` VALUES (21193, 13, 7); -- MND + 7
+INSERT INTO `item_mods` VALUES (21193, 25, -20); -- Accuracy + -20
+INSERT INTO `item_mods` VALUES (21193, 30, -70); -- Magic Accuracy + -70
+INSERT INTO `item_mods` VALUES (21193, 28, 70); -- Magic Attack Bonus + 70
+INSERT INTO `item_mods` VALUES (21193, 311, 97); -- Magic Damage Bonus + 97
+INSERT INTO `item_mods` VALUES (21193, 91, 94); -- Staff + 94
+INSERT INTO `item_mods` VALUES (21193, 110, 94); -- Parrying + 94
+INSERT INTO `item_mods` VALUES (21193, 103, 89); -- Magic Accuracy Skill + 89
+
+-- -------------------------------------------------------
+-- Cibitshavore
+-- -------------------------------------------------------
+INSERT INTO `item_mods` VALUES (21229, 11, 3); -- AGI + 3
+INSERT INTO `item_mods` VALUES (21229, 26, 6); -- Ranged Accuracy + 6
+INSERT INTO `item_mods` VALUES (21229, 104, 242); -- Archery + 242
+
+-- -------------------------------------------------------
+-- One-Eyed
+-- -------------------------------------------------------
+INSERT INTO `item_mods` VALUES (21252, 26, 12); -- Ranged Accuracy + 12
+INSERT INTO `item_mods` VALUES (21252, 105, 102); -- Marksmanship + 102
+
+-- -------------------------------------------------------
+-- Raaz Arrow
+-- -------------------------------------------------------
+INSERT INTO `item_mods` VALUES (21304, 24, 10); -- Ranged Attack + 10
+
+-- -------------------------------------------------------
+-- Tulfaire Arrow
+-- -------------------------------------------------------
+INSERT INTO `item_mods` VALUES (21305, 26, 10); -- Ranged Accuracy + 10
+INSERT INTO `item_mods` VALUES (21305, 24, 10); -- Ranged Attack + 10
+
+-- -------------------------------------------------------
+-- Adlivun Arrow
+-- -------------------------------------------------------
+INSERT INTO `item_mods` VALUES (21306, 26, 15); -- Ranged Accuracy + 15
+
+-- -------------------------------------------------------
+-- Achiyalabopa Arrow
+-- -------------------------------------------------------
+INSERT INTO `item_mods` VALUES (21307, 26, 20); -- Ranged Accuracy + 20
+INSERT INTO `item_mods` VALUES (21307, 24, 20); -- Ranged Attack + 20
+
+-- -------------------------------------------------------
+-- Mantid Arrow
+-- -------------------------------------------------------
+INSERT INTO `item_mods` VALUES (21308, 26, 5); -- Ranged Accuracy + 5
+
+-- -------------------------------------------------------
+-- Chapuli Arrow
+-- -------------------------------------------------------
+INSERT INTO `item_mods` VALUES (21309, 26, 5); -- Ranged Accuracy + 5
+
+-- -------------------------------------------------------
+-- Bismuth Bolt
+-- -------------------------------------------------------
+INSERT INTO `item_mods` VALUES (21318, 26, 5); -- Ranged Accuracy + 5
+INSERT INTO `item_mods` VALUES (21318, 24, 5); -- Ranged Attack + 5
+
+-- -------------------------------------------------------
+-- Titanium Bolt
+-- -------------------------------------------------------
+INSERT INTO `item_mods` VALUES (21319, 26, 10); -- Ranged Accuracy + 10
+INSERT INTO `item_mods` VALUES (21319, 24, 10); -- Ranged Attack + 10
+
+-- -------------------------------------------------------
+-- Adlivun Bolt
+-- -------------------------------------------------------
+INSERT INTO `item_mods` VALUES (21320, 26, 15); -- Ranged Accuracy + 15
+
+-- -------------------------------------------------------
+-- Achiyalabopa Bolt
+-- -------------------------------------------------------
+INSERT INTO `item_mods` VALUES (21321, 26, 20); -- Ranged Accuracy + 20
+INSERT INTO `item_mods` VALUES (21321, 24, 20); -- Ranged Attack + 20
+
+-- -------------------------------------------------------
+-- Bismuth Bullet
+-- -------------------------------------------------------
+INSERT INTO `item_mods` VALUES (21333, 26, 5); -- Ranged Accuracy + 5
+INSERT INTO `item_mods` VALUES (21333, 24, 5); -- Ranged Attack + 5
+
+-- -------------------------------------------------------
+-- Animikii Bullet
+-- -------------------------------------------------------
+INSERT INTO `item_mods` VALUES (21334, 26, 40); -- Ranged Accuracy + 40
+INSERT INTO `item_mods` VALUES (21334, 30, 30); -- Magic Accuracy + 30
+INSERT INTO `item_mods` VALUES (21334, 28, 30); -- Magic Attack Bonus + 30
+
+-- -------------------------------------------------------
+-- Titanium Bullet
+-- -------------------------------------------------------
+INSERT INTO `item_mods` VALUES (21335, 26, 10); -- Ranged Accuracy + 10
+INSERT INTO `item_mods` VALUES (21335, 24, 10); -- Ranged Attack + 10
+
+-- -------------------------------------------------------
+-- Adlivun Bullet
+-- -------------------------------------------------------
+INSERT INTO `item_mods` VALUES (21336, 26, 15); -- Ranged Accuracy + 15
+
+-- -------------------------------------------------------
+-- Achiyalabopa Bullet
+-- -------------------------------------------------------
+INSERT INTO `item_mods` VALUES (21337, 26, 20); -- Ranged Accuracy + 20
+INSERT INTO `item_mods` VALUES (21337, 24, 20); -- Ranged Attack + 20
+
+-- 21338 Damascus Bullet, no effects
+-- 21339 Midrium Bullet, no effects
+
+-- -------------------------------------------------------
+-- Dosis Tathlum
+-- -------------------------------------------------------
+INSERT INTO `item_mods` VALUES (21382, 311, 13); -- Magic Damage Bonus + 13
+
+-- -------------------------------------------------------
+-- Kalboron Stone
+-- -------------------------------------------------------
+INSERT INTO `item_mods` VALUES (21384, 5, 30); -- MP + 30
+INSERT INTO `item_mods` VALUES (21384, 13, 1); -- MND + 1
+INSERT INTO `item_mods` VALUES (21384, 30, 4); -- Magic Accuracy + 4
+
+-- -------------------------------------------------------
+-- Aqreaqa Bomblet
+-- -------------------------------------------------------
+INSERT INTO `item_mods` VALUES (21385, 2, 20); -- HP + 20
+INSERT INTO `item_mods` VALUES (21385, 8, 5); -- STR + 5
+INSERT INTO `item_mods` VALUES (21385, 27, 2); -- Enmity + 2
+
+-- -------------------------------------------------------
+-- Jukukik Feather
+-- -------------------------------------------------------
+INSERT INTO `item_mods` VALUES (21386, 9, 4); -- DEX + 4
+INSERT INTO `item_mods` VALUES (21386, 25, 4); -- Accuracy + 4
+
+-- -------------------------------------------------------
+-- Zuuxowu Grip
+-- -------------------------------------------------------
+INSERT INTO `item_mods` VALUES (21424, 311, 10); -- Magic Damage Bonus + 10
+
+-- -------------------------------------------------------
+-- Achaq Grip
+-- -------------------------------------------------------
+INSERT INTO `item_mods` VALUES (21426, 5, 15); -- MP + 15
+INSERT INTO `item_mods` VALUES (21426, 13, 4); -- MND + 4
+INSERT INTO `item_mods` VALUES (21426, 27, -4); -- Enmity + -4
+
+-- -------------------------------------------------------
 -- Matre Bell
 -- -------------------------------------------------------
 INSERT INTO `item_mods` VALUES (21460, 5, 5); -- MP+5
+
+-- -------------------------------------------------------
+-- Mochi Chainmail +1
+-- -------------------------------------------------------
+INSERT INTO `item_mods` VALUES (26825, 1, 134); -- Defense 134
+INSERT INTO `item_mods` VALUES (26825, 2, 59); -- HP +59
+INSERT INTO `item_mods` VALUES (26825, 8, 24); -- STR+24
+INSERT INTO `item_mods` VALUES (26825, 9, 25); -- DEX+25
+INSERT INTO `item_mods` VALUES (26825, 10, 21); -- VIT+21
+INSERT INTO `item_mods` VALUES (26825, 11, 25); -- AGI+25
+INSERT INTO `item_mods` VALUES (26825, 12, 24); -- INT+24
+INSERT INTO `item_mods` VALUES (26825, 13, 24); -- MND+24
+INSERT INTO `item_mods` VALUES (26825, 14, 24); -- CHR+24
+INSERT INTO `item_mods` VALUES (26825, 25, 22); -- Accuracy +22
+INSERT INTO `item_mods` VALUES (26825, 23, 22); -- Attack +22
+INSERT INTO `item_mods` VALUES (26825, 24, 14); -- RAcc +14
+INSERT INTO `item_mods` VALUES (26825, 26, 14); -- Ratt + 14
+INSERT INTO `item_mods` VALUES (26825, 68, 52); -- Evasion +52
+INSERT INTO `item_mods` VALUES (26825, 31, 53); -- Magic Evasion +53
+INSERT INTO `item_mods` VALUES (26825, 29, 4); -- Magic Def Bonus + 4
+INSERT INTO `item_mods` VALUES (26825, 384, 40); -- Haste 4%
+INSERT INTO `item_mods` VALUES (26825, 259, 7); -- Dual Wield +7
+-- INSERT INTO `item_mods` VALUES (26825, ?, 10); -- Utsusemi spellcasting + 10
 
 -- -------------------------------------------------------
 -- Sakonji Haidate
@@ -21722,6 +24141,38 @@ INSERT INTO `item_mods` VALUES (27174, 31, 51);
 INSERT INTO `item_mods` VALUES (27174, 68, 25);
 INSERT INTO `item_mods` VALUES (27174, 384, 51);
 INSERT INTO `item_mods` VALUES (27174, 508, 35);
+
+-- -------------------------------------------------------
+-- Mochi Hakama +1
+-- -------------------------------------------------------
+INSERT INTO `item_mods` VALUES (27177, 1, 114); -- Defense + 114
+INSERT INTO `item_mods` VALUES (27177, 2, 62); -- HP + 62
+INSERT INTO `item_mods` VALUES (27177, 8, 32); -- STR + 32
+INSERT INTO `item_mods` VALUES (27177, 10, 14); -- VIT + 14
+INSERT INTO `item_mods` VALUES (27177, 11, 26); -- AGI + 26
+INSERT INTO `item_mods` VALUES (27177, 12, 32); -- INT + 32
+INSERT INTO `item_mods` VALUES (27177, 13, 17); -- MND + 17
+INSERT INTO `item_mods` VALUES (27177, 14, 10); -- CHR + 10
+INSERT INTO `item_mods` VALUES (27177, 68, 43); -- Evasion + 43
+INSERT INTO `item_mods` VALUES (27177, 31, 64); -- Magic Evasion + 64
+INSERT INTO `item_mods` VALUES (27177, 29, 3); -- Magic Defense Bonus + 3
+INSERT INTO `item_mods` VALUES (27177, 384, 61); -- Haste + 6
+INSERT INTO `item_mods` VALUES (27177, 259, 8); -- Dual Wield + 8
+
+-- -------------------------------------------------------
+-- Ifrit Ring +1
+-- -------------------------------------------------------
+INSERT INTO `item_mods` VALUES (27565, 8, 9); -- STR + 9
+INSERT INTO `item_mods` VALUES (27565, 54, 16); -- Fire Resistance + 16
+INSERT INTO `item_mods` VALUES (27565, 23, 5); -- Attack + 5
+
+-- -------------------------------------------------------
+-- Shiva Ring +1
+-- -------------------------------------------------------
+INSERT INTO `item_mods` VALUES (27575, 12, 9); -- INT + 9
+INSERT INTO `item_mods` VALUES (27575, 55, 16); -- Ice Resistance + 16
+INSERT INTO `item_mods` VALUES (27575, 28, 3); -- Magic Attack Bonus + 3
+
 -- -------------------------------------------------------
 -- Ares' Mask +1
 -- -------------------------------------------------------
@@ -21820,6 +24271,26 @@ INSERT INTO `item_mods` VALUES (27662, 1, 15); -- DEF:15
 INSERT INTO `item_mods` VALUES (27662, 12, 2); -- INT+2
 INSERT INTO `item_mods` VALUES (27662, 13, 2); -- MND+2
 INSERT INTO `item_mods` VALUES (27662, 30, 1); -- Magic Accuracy+1
+
+-- -------------------------------------------------------
+-- Enedron Glasses
+-- -------------------------------------------------------
+INSERT INTO `item_mods` VALUES (27735, 1, 50); -- Defense + 50
+INSERT INTO `item_mods` VALUES (27735, 2, 13); -- HP + 13
+INSERT INTO `item_mods` VALUES (27735, 5, 26); -- MP + 26
+INSERT INTO `item_mods` VALUES (27735, 8, 10); -- STR + 10
+INSERT INTO `item_mods` VALUES (27735, 9, 10); -- DEX + 10
+INSERT INTO `item_mods` VALUES (27735, 10, 10); -- VIT + 10
+INSERT INTO `item_mods` VALUES (27735, 11, 10); -- AGI + 10
+INSERT INTO `item_mods` VALUES (27735, 12, 13); -- INT + 13
+INSERT INTO `item_mods` VALUES (27735, 13, 13); -- MND + 13
+INSERT INTO `item_mods` VALUES (27735, 14, 19); -- CHR + 19
+INSERT INTO `item_mods` VALUES (27735, 60, 40); -- Light Resistance + 40
+INSERT INTO `item_mods` VALUES (27735, 68, 12); -- Evasion + 12
+INSERT INTO `item_mods` VALUES (27735, 31, 51); -- Magic Evasion + 51
+INSERT INTO `item_mods` VALUES (27735, 29, 2); -- Magic Defense Bonus + 2
+INSERT INTO `item_mods` VALUES (27735, 384, 51); -- Haste + 51
+INSERT INTO `item_mods` VALUES (27735, 243, 2); -- Blind Resistance + 2
 
 -- -------------------------------------------------------
 -- Slime Cap
@@ -21938,6 +24409,24 @@ INSERT INTO `item_mods` VALUES (27802, 30, 2); -- Magic Accuracy+2
 INSERT INTO `item_mods` VALUES (27802, 28, 2); -- "Magic Atk. Bonus"+2
 INSERT INTO `item_mods` VALUES (27802, 114, 2); -- Enfeebling magic skill +2
 INSERT INTO `item_mods` VALUES (27802, 113, 2); -- Elemental magic skill +2
+
+-- -------------------------------------------------------
+-- Mes'yohi Haubergeon
+-- -------------------------------------------------------
+INSERT INTO `item_mods` VALUES (27886, 1, 140); -- Defense + 140
+INSERT INTO `item_mods` VALUES (27886, 2, 63); -- HP + 63
+INSERT INTO `item_mods` VALUES (27886, 5, 35); -- MP + 35
+INSERT INTO `item_mods` VALUES (27886, 8, 29); -- STR + 29
+INSERT INTO `item_mods` VALUES (27886, 9, 29); -- DEX + 29
+INSERT INTO `item_mods` VALUES (27886, 10, 29); -- VIT + 29
+INSERT INTO `item_mods` VALUES (27886, 11, 6); -- AGI + 6
+INSERT INTO `item_mods` VALUES (27886, 12, 6); -- INT + 6
+INSERT INTO `item_mods` VALUES (27886, 13, 6); -- MND + 6
+INSERT INTO `item_mods` VALUES (27886, 14, 6); -- CHR + 6
+INSERT INTO `item_mods` VALUES (27886, 25, 30); -- Accuracy + 30
+INSERT INTO `item_mods` VALUES (27886, 23, 30); -- Attack + 30
+INSERT INTO `item_mods` VALUES (27886, 384, 30); -- Haste + 30
+INSERT INTO `item_mods` VALUES (27886, 288, 2); -- Double Attack + 2
 
 -- -------------------------------------------------------
 -- Ares' Gauntlets +1
@@ -22074,7 +24563,7 @@ INSERT INTO `item_mods` VALUES (28072, 23, 17); -- Attack+17
 INSERT INTO `item_mods` VALUES (28072, 26, 7); -- Ranged ACC+7
 INSERT INTO `item_mods` VALUES (28072, 24, 17); -- Ranged Attack+17
 INSERT INTO `item_mods` VALUES (28072, 73, 8); -- "Store TP"+8
-INSERT INTO `item_mods` VALUES (28072, 384, 60); -- Haste +6%
+INSERT INTO `item_mods` VALUES (28072, 384, 61); -- Haste +6%
 INSERT INTO `item_mods` VALUES (28072, 165, 1); -- Critical Hit Rate
 
 -- -------------------------------------------------------
@@ -22084,7 +24573,7 @@ INSERT INTO `item_mods` VALUES (28073, 1, 50); -- DEF:50
 INSERT INTO `item_mods` VALUES (28073, 8, 7); -- STR+7
 INSERT INTO `item_mods` VALUES (28073, 9, 7); -- DEX+7
 INSERT INTO `item_mods` VALUES (28073, 23, 20); -- Attack+20
-INSERT INTO `item_mods` VALUES (28073, 384, 60); -- Haste+6%
+INSERT INTO `item_mods` VALUES (28073, 384, 61); -- Haste+6%
 
 -- -------------------------------------------------------
 -- Marduk's Shalwar +1
@@ -22151,6 +24640,42 @@ INSERT INTO `item_mods` VALUES (28085, 3, 8); -- HP+8
 INSERT INTO `item_mods` VALUES (28085, 5, 8); -- MP+8
 INSERT INTO `item_mods` VALUES (28085, 13, 2); -- MND+2
 INSERT INTO `item_mods` VALUES (28085, 170, 1); -- Enhances "Fast Cast" effect
+
+-- -------------------------------------------------------
+-- Laktisma Hose
+-- -------------------------------------------------------
+INSERT INTO `item_mods` VALUES (28165, 1, 75); -- Defense + 75
+INSERT INTO `item_mods` VALUES (28165, 2, 57); -- HP + 57
+INSERT INTO `item_mods` VALUES (28165, 8, 21); -- STR + 21
+INSERT INTO `item_mods` VALUES (28165, 10, 10); -- VIT + 10
+INSERT INTO `item_mods` VALUES (28165, 11, 12); -- AGI + 12
+INSERT INTO `item_mods` VALUES (28165, 12, 18); -- INT + 18
+INSERT INTO `item_mods` VALUES (28165, 13, 10); -- MND + 10
+INSERT INTO `item_mods` VALUES (28165, 14, 5); -- CHR + 5
+INSERT INTO `item_mods` VALUES (28165, 68, 11); -- Evasion + 11
+INSERT INTO `item_mods` VALUES (28165, 31, 39); -- Magic Evasion + 39
+INSERT INTO `item_mods` VALUES (28165, 29, 1); -- Magic Defense Bonus + 1
+INSERT INTO `item_mods` VALUES (28165, 384, 61); -- Haste + 61
+INSERT INTO `item_mods` VALUES (28165, 292, 7); -- Kick Attacks + 7
+
+-- -------------------------------------------------------
+-- Mes'yohi Slacks
+-- -------------------------------------------------------
+INSERT INTO `item_mods` VALUES (28172, 1, 107); -- Defense + 107
+INSERT INTO `item_mods` VALUES (28172, 2, 43); -- HP + 43
+INSERT INTO `item_mods` VALUES (28172, 5, 29); -- MP + 29
+INSERT INTO `item_mods` VALUES (28172, 8, 25); -- STR + 25
+INSERT INTO `item_mods` VALUES (28172, 10, 12); -- VIT + 12
+INSERT INTO `item_mods` VALUES (28172, 11, 17); -- AGI + 17
+INSERT INTO `item_mods` VALUES (28172, 12, 39); -- INT + 39
+INSERT INTO `item_mods` VALUES (28172, 13, 29); -- MND + 29
+INSERT INTO `item_mods` VALUES (28172, 14, 19); -- CHR + 19
+INSERT INTO `item_mods` VALUES (28172, 30, 20); -- Magic Accuracy + 20
+INSERT INTO `item_mods` VALUES (28172, 68, 27); -- Evasion + 27
+INSERT INTO `item_mods` VALUES (28172, 31, 107); -- Magic Evasion + 107
+INSERT INTO `item_mods` VALUES (28172, 29, 8); -- Magic Defense Bonus + 8
+INSERT INTO `item_mods` VALUES (28172, 384, 50); -- Haste + 50
+-- INSERT INTO `item_mods` VALUES (28172, ?, 25); -- Magic Accuracy by Day + 25
 
 -- -------------------------------------------------------
 -- Ares' Sollerets +1
@@ -22252,6 +24777,27 @@ INSERT INTO `item_mods` VALUES (28222, 23, 2); -- Attack+2
 INSERT INTO `item_mods` VALUES (28222, 25, 2); -- Accuracy+2
 
 -- -------------------------------------------------------
+-- Litany Clogs
+-- -------------------------------------------------------
+INSERT INTO `item_mods` VALUES (28304, 1, 40); -- Defense + 40
+INSERT INTO `item_mods` VALUES (28304, 2, 5); -- HP + 5
+INSERT INTO `item_mods` VALUES (28304, 5, 11); -- MP + 11
+INSERT INTO `item_mods` VALUES (28304, 8, 5); -- STR + 5
+INSERT INTO `item_mods` VALUES (28304, 9, 6); -- DEX + 6
+INSERT INTO `item_mods` VALUES (28304, 10, 5); -- VIT + 5
+INSERT INTO `item_mods` VALUES (28304, 11, 18); -- AGI + 18
+INSERT INTO `item_mods` VALUES (28304, 12, 10); -- INT + 10
+INSERT INTO `item_mods` VALUES (28304, 13, 10); -- MND + 10
+INSERT INTO `item_mods` VALUES (28304, 14, 10); -- CHR + 10
+INSERT INTO `item_mods` VALUES (28304, 113, 5); -- Enhancing Magic + 5
+INSERT INTO `item_mods` VALUES (28304, 68, 19); -- Evasion + 19
+INSERT INTO `item_mods` VALUES (28304, 31, 66); -- Magic Evasion + 66
+INSERT INTO `item_mods` VALUES (28304, 384, 30); -- Haste + 30
+INSERT INTO `item_mods` VALUES (28304, 29, 2); -- Magic Defense Bonus + 2
+INSERT INTO `item_mods` VALUES (28304, 374, 4); -- Cure Potency + 4
+INSERT INTO `item_mods` VALUES (28304, 519, -10); -- Cure Casting Time + -10
+
+-- -------------------------------------------------------
 -- Manibozho Boots
 -- -------------------------------------------------------
 INSERT INTO `item_mods` VALUES (28339, 1, 51); -- DEF+51
@@ -22285,6 +24831,49 @@ INSERT INTO `item_mods` VALUES (28340, 29, 3); -- "Magic Def. Bonus"+3
 INSERT INTO `item_mods` VALUES (28340, 384, 30); -- Haste+3%
 INSERT INTO `item_mods` VALUES (28340, 31, 76); -- Magic Evasion+76
 INSERT INTO `item_mods` VALUES (28340, 455, 6); -- Song casting time -6%
+
+-- -------------------------------------------------------
+-- Pentalagus Charm
+-- -------------------------------------------------------
+INSERT INTO `item_mods` VALUES (28383, 9, 5); -- DEX + 5
+INSERT INTO `item_mods` VALUES (28383, 11, 5); -- AGI + 5
+INSERT INTO `item_mods` VALUES (28383, 68, 5); -- Evasion + 5
+INSERT INTO `item_mods` VALUES (28383, 298, 2); -- Steal + 2
+
+-- -------------------------------------------------------
+-- Huani Collar
+-- -------------------------------------------------------
+INSERT INTO `item_mods` VALUES (28384, 11, 6); -- AGI + 6
+INSERT INTO `item_mods` VALUES (28384, 26, 6); -- Ranged Accuracy + 6
+INSERT INTO `item_mods` VALUES (28384, 56, 20); -- Wind Resistance + 20
+INSERT INTO `item_mods` VALUES (28384, 27, -3); -- Enmity + -3
+
+-- -------------------------------------------------------
+-- Atzintli Necklace
+-- -------------------------------------------------------
+INSERT INTO `item_mods` VALUES (28385, 30, 2); -- Magic Accuracy + 2
+INSERT INTO `item_mods` VALUES (28385, 28, 5); -- Magic Attack Bonus + 5
+INSERT INTO `item_mods` VALUES (28385, 27, 5); -- Enmity + 5
+
+-- -------------------------------------------------------
+-- Cuamiz Collar
+-- -------------------------------------------------------
+INSERT INTO `item_mods` VALUES (28386, 2, 50); -- HP + 50
+INSERT INTO `item_mods` VALUES (28386, 5, 25); -- MP + 25
+INSERT INTO `item_mods` VALUES (28386, 8, 3); -- STR + 3
+
+-- -------------------------------------------------------
+-- Quanpur Necklace
+-- -------------------------------------------------------
+INSERT INTO `item_mods` VALUES (28387, 5, 10); -- MP + 10
+INSERT INTO `item_mods` VALUES (28387, 28, 7); -- Magic Attack Bonus + 7
+INSERT INTO `item_mods` VALUES (28387, 35, 5); -- Earth Attack + 5
+
+-- -------------------------------------------------------
+-- Tlamiztli Collar
+-- -------------------------------------------------------
+INSERT INTO `item_mods` VALUES (28388, 23, 20); -- Attack + 20
+INSERT INTO `item_mods` VALUES (28388, 288, -1); -- Double Attack + -1
 
 -- -------------------------------------------------------
 -- Fiend Torque
@@ -22326,6 +24915,52 @@ INSERT INTO `item_mods` VALUES (28405, 25, 16); -- Accuracy+16
 INSERT INTO `item_mods` VALUES (28405, 26, 16); -- Ranged Accuracy+16
 INSERT INTO `item_mods` VALUES (28405, 68, 16); -- Evasion+16
 
+-- -------------------------------------------------------
+-- Ovate Rope
+-- -------------------------------------------------------
+INSERT INTO `item_mods` VALUES (28455, 1, 11); -- Defense + 11
+INSERT INTO `item_mods` VALUES (28455, 13, 4); -- MND + 4
+INSERT INTO `item_mods` VALUES (28455, 30, 8); -- Magic Accuracy + 8
+INSERT INTO `item_mods` VALUES (28455, 28, -10); -- Magic Attack Bonus + -10
+
+-- -------------------------------------------------------
+-- Kasiri Belt
+-- -------------------------------------------------------
+INSERT INTO `item_mods` VALUES (28456, 1, 13); -- Defense + 13
+INSERT INTO `item_mods` VALUES (28456, 2, 30); -- HP + 30
+INSERT INTO `item_mods` VALUES (28456, 68, 13); -- Evasion + 13
+INSERT INTO `item_mods` VALUES (28456, 27, 3); -- Enmity + 3
+INSERT INTO `item_mods` VALUES (28456, 384, 40); -- Haste + 40
+
+-- -------------------------------------------------------
+-- Kuku Stone
+-- -------------------------------------------------------
+INSERT INTO `item_mods` VALUES (28457, 1, 10); -- Defense + 10
+INSERT INTO `item_mods` VALUES (28457, 25, 5); -- Accuracy + 5
+INSERT INTO `item_mods` VALUES (28457, 68, 5); -- Evasion + 5
+INSERT INTO `item_mods` VALUES (28457, 384, 61); -- Haste + 61
+-- INSERT INTO `item_mods` VALUES (28457, ?, 40); -- Pet Haste + 40
+
+-- -------------------------------------------------------
+-- Jaq'ij Sash
+-- -------------------------------------------------------
+INSERT INTO `item_mods` VALUES (28458, 5, 30); -- MP + 30
+-- INSERT INTO `item_mods` VALUES (28458, ?, 5); -- Blood Boon + 5
+
+-- -------------------------------------------------------
+-- Chuq'aba Belt
+-- -------------------------------------------------------
+INSERT INTO `item_mods` VALUES (28459, 8, 7); -- STR + 7
+INSERT INTO `item_mods` VALUES (28459, 10, 5); -- VIT + 5
+INSERT INTO `item_mods` VALUES (28459, 384, 51); -- Haste + 51
+INSERT INTO `item_mods` VALUES (28459, 375, 5); -- Received Cure Potency + 5
+
+-- -------------------------------------------------------
+-- Cetl Belt
+-- -------------------------------------------------------
+INSERT INTO `item_mods` VALUES (28460, 1, 14); -- Defense + 14
+INSERT INTO `item_mods` VALUES (28460, 288, 4); -- Double Attack + 4
+INSERT INTO `item_mods` VALUES (28460, 384, 51); -- Haste + 51
 
 -- -------------------------------------------------------
 -- Hurch'lan Sash
@@ -22361,6 +24996,24 @@ INSERT INTO `item_mods` VALUES (28465, 384, 102); -- Haste+10%
 -- Slime Earring
 -- -------------------------------------------------------
 INSERT INTO `item_mods` VALUES (28511, 2, 1); -- HP+1
+
+-- -------------------------------------------------------
+-- Dawn Earring
+-- -------------------------------------------------------
+INSERT INTO `item_mods` VALUES (28512, 9, 3); -- DEX + 3
+INSERT INTO `item_mods` VALUES (28512, 11, 3); -- AGI + 3
+
+-- -------------------------------------------------------
+-- Phawaylla Earring
+-- -------------------------------------------------------
+INSERT INTO `item_mods` VALUES (28513, 11, 2); -- AGI + 2
+INSERT INTO `item_mods` VALUES (28513, 68, 7); -- Evasion + 7
+
+-- -------------------------------------------------------
+-- Friomisi Earring
+-- -------------------------------------------------------
+INSERT INTO `item_mods` VALUES (28514, 28, 10); -- Magic Attack Bonus + 10
+INSERT INTO `item_mods` VALUES (28514, 27, 2); -- Enmity + 2
 
 -- -------------------------------------------------------
 -- Steelflash Earring
@@ -22413,6 +25066,62 @@ INSERT INTO `item_mods` VALUES (28527, 23, 16); -- Attack+16
 INSERT INTO `item_mods` VALUES (28527, 68, -8); -- Evasion-8
 
 -- -------------------------------------------------------
+-- Waterfall Ring
+-- -------------------------------------------------------
+INSERT INTO `item_mods` VALUES (28571, 1, 10); -- Defense + 10
+INSERT INTO `item_mods` VALUES (28571, 56, 20); -- Wind Resistance + 20
+INSERT INTO `item_mods` VALUES (28571, 59, 20); -- Water Resistance + 20
+INSERT INTO `item_mods` VALUES (28571, 244, 2); -- Silence Resistance + 2
+INSERT INTO `item_mods` VALUES (28571, 241, 2); -- Poison Resistance + 2
+
+-- -------------------------------------------------------
+-- Jwalamukhi Ring
+-- -------------------------------------------------------
+INSERT INTO `item_mods` VALUES (28572, 1, 10); -- Defense + 10
+INSERT INTO `item_mods` VALUES (28572, 56, 20); -- Wind Resistance + 20
+INSERT INTO `item_mods` VALUES (28572, 59, 20); -- Water Resistance + 20
+INSERT INTO `item_mods` VALUES (28572, 250, 2); -- Slow Resistance + 2
+INSERT INTO `item_mods` VALUES (28572, 245, 2); -- Virus Resistance + 2
+
+-- -------------------------------------------------------
+-- Wuji Ring
+-- -------------------------------------------------------
+INSERT INTO `item_mods` VALUES (28573, 1, 10); -- Defense + 10
+INSERT INTO `item_mods` VALUES (28573, 60, 20); -- Light Resistance + 20
+INSERT INTO `item_mods` VALUES (28573, 61, 20); -- Dark Resistance + 20
+INSERT INTO `item_mods` VALUES (28573, 252, 2); -- Charm Resistance + 2
+INSERT INTO `item_mods` VALUES (28573, 240, 2); -- Sleep Resistance + 2
+
+-- -------------------------------------------------------
+-- Icecrack Ring
+-- -------------------------------------------------------
+INSERT INTO `item_mods` VALUES (28574, 1, 10); -- Defense + 10
+INSERT INTO `item_mods` VALUES (28574, 56, 20); -- Wind Resistance + 20
+INSERT INTO `item_mods` VALUES (28574, 59, 20); -- Water Resistance + 20
+INSERT INTO `item_mods` VALUES (28574, 242, 2); -- Paralysis Resistance + 2
+INSERT INTO `item_mods` VALUES (28574, 251, 2); -- Stun Resistance + 2
+
+-- -------------------------------------------------------
+-- Cho'j Band
+-- -------------------------------------------------------
+INSERT INTO `item_mods` VALUES (28575, 23, 14); -- Attack + 14
+INSERT INTO `item_mods` VALUES (28575, 27, -3); -- Enmity + -3
+
+-- -------------------------------------------------------
+-- Paqichikaji Ring
+-- -------------------------------------------------------
+INSERT INTO `item_mods` VALUES (28576, 26, 14); -- Ranged Accuracy + 14
+INSERT INTO `item_mods` VALUES (28576, 289, 5); -- Subtle Blow + 5
+INSERT INTO `item_mods` VALUES (28576, 27, -3); -- Enmity + -3
+
+-- -------------------------------------------------------
+-- Kunaji Ring
+-- -------------------------------------------------------
+INSERT INTO `item_mods` VALUES (28577, 2, 40); -- HP + 40
+INSERT INTO `item_mods` VALUES (28577, 57, 20); -- Earth Resistance + 20
+INSERT INTO `item_mods` VALUES (28577, 375, 5); -- Received Cure Potency + 5
+
+-- -------------------------------------------------------
 -- K'ayres Ring
 -- -------------------------------------------------------
 INSERT INTO `item_mods` VALUES (28579, 2, 70); -- HP+70
@@ -22448,7 +25157,71 @@ INSERT INTO `item_mods` VALUES (28587, 150, 1); -- Alchemy Success Rate 1%
 INSERT INTO `item_mods` VALUES (28587, 151, 1); -- Cooking Success Rate 1%
 
 -- -------------------------------------------------------
---  Vespid Mantle
+-- Earthcry Mantle
+-- -------------------------------------------------------
+INSERT INTO `item_mods` VALUES (28608, 1, 18); -- Defense + 18
+INSERT INTO `item_mods` VALUES (28608, 2, 30); -- HP + 30
+INSERT INTO `item_mods` VALUES (28608, 10, 7); -- VIT + 7
+INSERT INTO `item_mods` VALUES (28608, 57, 25); -- Earth Resistance + 25
+INSERT INTO `item_mods` VALUES (28608, 27, 7); -- Enmity + 7
+
+-- -------------------------------------------------------
+-- Ik Cape
+-- -------------------------------------------------------
+INSERT INTO `item_mods` VALUES (28610, 1, 10); -- Defense + 10
+INSERT INTO `item_mods` VALUES (28610, 11, 8); -- AGI + 8
+INSERT INTO `item_mods` VALUES (28610, 68, 8); -- Evasion + 8
+INSERT INTO `item_mods` VALUES (28610, 56, 20); -- Wind Resistance + 20
+-- INSERT INTO `item_mods` VALUES (28610, 462, ?); -- Absorb Wind + ?
+
+-- -------------------------------------------------------
+-- Tuilha Cape
+-- -------------------------------------------------------
+INSERT INTO `item_mods` VALUES (28611, 1, 10); -- Defense + 10
+INSERT INTO `item_mods` VALUES (28611, 13, 8); -- MND + 8
+INSERT INTO `item_mods` VALUES (28611, 59, 20); -- Water Resistance + 20
+-- INSERT INTO `item_mods` VALUES (28611, 461, ?); -- Absorb Water + ?
+
+-- -------------------------------------------------------
+-- Buquwik Cape
+-- -------------------------------------------------------
+INSERT INTO `item_mods` VALUES (28612, 1, 10); -- Defense + 10
+INSERT INTO `item_mods` VALUES (28612, 8, 8); -- STR + 8
+INSERT INTO `item_mods` VALUES (28612, 23, 10); -- Attack + 10
+INSERT INTO `item_mods` VALUES (28612, 24, 10); -- Ranged Attack + 10
+INSERT INTO `item_mods` VALUES (28612, 54, 20); -- Fire Resistance + 20
+-- INSERT INTO `item_mods` VALUES (28612, 459, ?); -- Absorb Fire + ?
+
+-- -------------------------------------------------------
+-- Kayapa Cape
+-- -------------------------------------------------------
+INSERT INTO `item_mods` VALUES (28613, 1, 10); -- Defense + 10
+INSERT INTO `item_mods` VALUES (28613, 9, 8); -- DEX + 8
+INSERT INTO `item_mods` VALUES (28613, 25, 10); -- Accuracy + 10
+INSERT INTO `item_mods` VALUES (28613, 26, 10); -- Ranged Accuracy + 10
+INSERT INTO `item_mods` VALUES (28613, 58, 20); -- Thunder Resistance + 20
+-- INSERT INTO `item_mods` VALUES (28613, 464, ?); -- Absorb Thunder + ?
+
+-- -------------------------------------------------------
+-- Iximulew Cape
+-- -------------------------------------------------------
+INSERT INTO `item_mods` VALUES (28614, 1, 10); -- Defense + 10
+INSERT INTO `item_mods` VALUES (28614, 10, 8); -- VIT + 8
+INSERT INTO `item_mods` VALUES (28614, 161, -4); -- Percent Physical Damage Taken + -4
+INSERT INTO `item_mods` VALUES (28614, 57, 20); -- Earth Resistance + 20
+-- INSERT INTO `item_mods` VALUES (28614, 460, ?); -- Absorb Earth + ?
+
+-- -------------------------------------------------------
+-- Toro Cape
+-- -------------------------------------------------------
+INSERT INTO `item_mods` VALUES (28615, 1, 10); -- Defense + 10
+INSERT INTO `item_mods` VALUES (28615, 12, 8); -- INT + 8
+INSERT INTO `item_mods` VALUES (28615, 28, 10); -- Magic Attack Bonus + 10
+INSERT INTO `item_mods` VALUES (28615, 55, 20); -- Ice Resistance + 20
+-- INSERT INTO `item_mods` VALUES (28615, 463, ?); -- Absorb Ice + ?
+
+-- -------------------------------------------------------
+-- Vespid Mantle
 -- -------------------------------------------------------
 INSERT INTO `item_mods` VALUES (28641, 1, 20); -- DEF:20
 INSERT INTO `item_mods` VALUES (28641, 23, 35); -- Attack+35
@@ -22491,6 +25264,38 @@ INSERT INTO `item_mods` VALUES (28655, 2, 3); -- HP+3
 INSERT INTO `item_mods` VALUES (28655, 1, 1); -- DEF:1
 
 -- -------------------------------------------------------
+-- Kaidate
+-- -------------------------------------------------------
+INSERT INTO `item_mods` VALUES (28657, 1, 30); -- Defense + 30
+INSERT INTO `item_mods` VALUES (28657, 2, 10); -- HP + 10
+INSERT INTO `item_mods` VALUES (28657, 5, 24); -- MP + 24
+INSERT INTO `item_mods` VALUES (28657, 109, 48); -- Shield + 48
+INSERT INTO `item_mods` VALUES (28657, 8, 8); -- STR + 8
+INSERT INTO `item_mods` VALUES (28657, 68, 10); -- Evasion + 10
+INSERT INTO `item_mods` VALUES (28657, 224, 2); -- Vermin Killer + 2
+INSERT INTO `item_mods` VALUES (28657, 225, 2); -- Bird Killer + 2
+INSERT INTO `item_mods` VALUES (28657, 226, 2); -- Amorph Killer + 2
+INSERT INTO `item_mods` VALUES (28657, 227, 2); -- Lizard Killer + 2
+INSERT INTO `item_mods` VALUES (28657, 228, 2); -- Aquan Killer + 2
+INSERT INTO `item_mods` VALUES (28657, 229, 2); -- Plantoid Killer + 2
+INSERT INTO `item_mods` VALUES (28657, 230, 2); -- Beast Killer + 2
+INSERT INTO `item_mods` VALUES (28657, 231, 2); -- Undead Killer + 2
+INSERT INTO `item_mods` VALUES (28657, 232, 2); -- Arcana Killer + 2
+INSERT INTO `item_mods` VALUES (28657, 233, 2); -- Dragon Killer + 2
+INSERT INTO `item_mods` VALUES (28657, 234, 2); -- Demon Killer + 2
+
+-- -------------------------------------------------------
+-- Sors Shield
+-- -------------------------------------------------------
+INSERT INTO `item_mods` VALUES (28658, 1, 20); -- Defense + 20
+INSERT INTO `item_mods` VALUES (28658, 2, 10); -- HP + 10
+INSERT INTO `item_mods` VALUES (28658, 5, 54); -- MP + 54
+INSERT INTO `item_mods` VALUES (28658, 109, 48); -- Shield + 48
+INSERT INTO `item_mods` VALUES (28658, 27, -5); -- Enmity + -5
+INSERT INTO `item_mods` VALUES (28658, 374, 3); -- Cure Potency + 3
+INSERT INTO `item_mods` VALUES (28658, 519, 5); -- Cure Casting Time + 5
+
+-- -------------------------------------------------------
 -- Steadfast Shield
 -- -------------------------------------------------------
 INSERT INTO `item_mods` VALUES (28663, 1, 50); -- DEF:50
@@ -22522,9 +25327,3 @@ INSERT INTO `item_mods` VALUES (28665, 161, -8); -- Physical damage taken -8%
 -- Leafkin Shield
 -- -------------------------------------------------------
 INSERT INTO `item_mods` VALUES (28670, 1, 1); -- DEF:1
-
--- -------------------------------------------------------
--- Roundel Earring
--- -------------------------------------------------------
-INSERT INTO `item_mods` VALUES (16002, 374, 5);
-INSERT INTO `item_mods` VALUES (16002, 491, 5);

--- a/sql/item_mods.sql
+++ b/sql/item_mods.sql
@@ -3121,7 +3121,7 @@ INSERT INTO `item_mods` VALUES (10946, 369, 1); -- Refresh + 1
 INSERT INTO `item_mods` VALUES (10947, 30, -3); -- Magic Accuracy + -3
 INSERT INTO `item_mods` VALUES (10947, 28, 9); -- Magic Attack Bonus + 9
 
---- -------------------------------------------------------
+-- -------------------------------------------------------
 -- Carver's Torque
 -- -------------------------------------------------------
 INSERT INTO `item_mods` VALUES (10948, 128, 2); -- Woodworking skill +2
@@ -23682,6 +23682,8 @@ INSERT INTO `item_mods` VALUES (20717, 82, 228); -- Sword + 228
 INSERT INTO `item_mods` VALUES (20717, 110, 228); -- Parrying + 228
 INSERT INTO `item_mods` VALUES (20717, 113, 10); -- Enhancing Magic + 10
 INSERT INTO `item_mods` VALUES (20717, 114, 10); -- Enfeebling Magic + 10
+INSERT INTO `item_mods` VALUES (20717, 103, 188); -- Magic Accuracy Skill + 188
+-- INSERT INTO `item_mods` VALUES (20717, ?, 30); -- Occult Acumen +30
 
 -- -------------------------------------------------------
 -- Claidheamh Soluis
@@ -23944,6 +23946,7 @@ INSERT INTO `item_mods` VALUES (21192, 311, 86); -- Magic Damage Bonus + 86
 INSERT INTO `item_mods` VALUES (21192, 91, 81); -- Staff + 81
 INSERT INTO `item_mods` VALUES (21192, 110, 81); -- Parrying + 81
 INSERT INTO `item_mods` VALUES (21192, 103, 81); -- Magic Accuracy Skill + 81
+INSERT INTO `item_mods` VALUES (21192, 27, -15); -- Enmity + -15
 
 -- -------------------------------------------------------
 -- Voay Staff +1
@@ -23957,6 +23960,7 @@ INSERT INTO `item_mods` VALUES (21193, 311, 97); -- Magic Damage Bonus + 97
 INSERT INTO `item_mods` VALUES (21193, 91, 94); -- Staff + 94
 INSERT INTO `item_mods` VALUES (21193, 110, 94); -- Parrying + 94
 INSERT INTO `item_mods` VALUES (21193, 103, 89); -- Magic Accuracy Skill + 89
+INSERT INTO `item_mods` VALUES (21193, 27, -20); -- Enmity + -20
 
 -- -------------------------------------------------------
 -- Cibitshavore


### PR DESCRIPTION
Edits item_mods.sql to add all items currently showing on the Auction House for Lv76-99.
Includes nonfunctional or incorrectly categorized items (ref: Ranged category showing a dagger and greatswords, and Lv.99 items that appear at the bottom of categories).
Made a few small fixes here and there for issues that I encountered while working.