### PR TITLE
Scripts: BP Ward duration bonus

### DIFF
--- a/scripts/globals/abilities/pets/crimson_howl.lua
+++ b/scripts/globals/abilities/pets/crimson_howl.lua
@@ -5,6 +5,7 @@
 require("scripts/globals/settings");
 require("scripts/globals/status");
 require("scripts/globals/monstertpmoves");
+require("scripts/globals/utils");
 
 ---------------------------------------------------
 
@@ -13,8 +14,10 @@ function onAbilityCheck(player, target, ability)
 end;
 
 function onPetAbility(target, pet, skill, summoner)
-	local duration = 30 + summoner:getMod(MOD_SUMMONING);
-	target:addStatusEffect(EFFECT_WARCRY,9,0,duration);
-	skill:setMsg(MSG_BUFF);
-	return EFFECT_WARCRY;
+    local bonusTime = utils.clamp(summoner:getSkillLevel(SKILL_SUM) - 300, 0, 200);
+    local duration = 60 + bonusTime;
+
+    target:addStatusEffect(EFFECT_WARCRY,9,0,duration);
+    skill:setMsg(MSG_BUFF);
+    return EFFECT_WARCRY;
 end

--- a/scripts/globals/abilities/pets/ecliptic_growl.lua
+++ b/scripts/globals/abilities/pets/ecliptic_growl.lua
@@ -5,6 +5,7 @@
 require("scripts/globals/settings");
 require("scripts/globals/status");
 require("scripts/globals/monstertpmoves");
+require("scripts/globals/utils");
 
 ---------------------------------------------------
 
@@ -12,38 +13,41 @@ function onAbilityCheck(player, target, ability)
     return 0,0;
 end;
 
-function onPetAbility(target, pet, skill)
-	local moon = VanadielMoonPhase();
-	local buffvalue = 0;
-	if moon > 90 then
-		buffvalue = 7;
-	elseif moon > 75 then
-		buffvalue = 6;
-	elseif moon > 60 then
-		buffvalue = 5;
-	elseif moon > 40 then
-		buffvalue = 4;
-	elseif moon > 25 then
-		buffvalue = 3;
-	elseif moon > 10 then
-		buffvalue = 2;
-	else
-		buffvalue = 1;
-	end
-	target:delStatusEffect(EFFECT_STR_BOOST);
-	target:delStatusEffect(EFFECT_DEX_BOOST);
-	target:delStatusEffect(EFFECT_VIT_BOOST);
-	target:delStatusEffect(EFFECT_AGI_BOOST);
-	target:delStatusEffect(EFFECT_MND_BOOST);
-	target:delStatusEffect(EFFECT_CHR_BOOST);
+function onPetAbility(target, pet, skill, summoner)
+    local bonusTime = utils.clamp(summoner:getSkillLevel(SKILL_SUM) - 300, 0, 200);
+    local duration = 180 + bonusTime;
 
-	target:addStatusEffect(EFFECT_STR_BOOST,buffvalue,0,180);
-	target:addStatusEffect(EFFECT_DEX_BOOST,buffvalue,0,180);
-	target:addStatusEffect(EFFECT_VIT_BOOST,buffvalue,0,180);
-	target:addStatusEffect(EFFECT_AGI_BOOST,8-buffvalue,0,180);
-	target:addStatusEffect(EFFECT_INT_BOOST,8-buffvalue,0,180);
-	target:addStatusEffect(EFFECT_MND_BOOST,8-buffvalue,0,180);
-	target:addStatusEffect(EFFECT_CHR_BOOST,8-buffvalue,0,180);
-	skill:setMsg(0);
-	return 0;
+    local moon = VanadielMoonPhase();
+    local buffvalue = 0;
+    if moon > 90 then
+        buffvalue = 7;
+    elseif moon > 75 then
+        buffvalue = 6;
+    elseif moon > 60 then
+        buffvalue = 5;
+    elseif moon > 40 then
+        buffvalue = 4;
+    elseif moon > 25 then
+        buffvalue = 3;
+    elseif moon > 10 then
+        buffvalue = 2;
+    else
+        buffvalue = 1;
+    end
+    target:delStatusEffect(EFFECT_STR_BOOST);
+    target:delStatusEffect(EFFECT_DEX_BOOST);
+    target:delStatusEffect(EFFECT_VIT_BOOST);
+    target:delStatusEffect(EFFECT_AGI_BOOST);
+    target:delStatusEffect(EFFECT_MND_BOOST);
+    target:delStatusEffect(EFFECT_CHR_BOOST);
+
+    target:addStatusEffect(EFFECT_STR_BOOST,buffvalue,0,duration);
+    target:addStatusEffect(EFFECT_DEX_BOOST,buffvalue,0,duration);
+    target:addStatusEffect(EFFECT_VIT_BOOST,buffvalue,0,duration);
+    target:addStatusEffect(EFFECT_AGI_BOOST,8-buffvalue,0,duration);
+    target:addStatusEffect(EFFECT_INT_BOOST,8-buffvalue,0,duration);
+    target:addStatusEffect(EFFECT_MND_BOOST,8-buffvalue,0,duration);
+    target:addStatusEffect(EFFECT_CHR_BOOST,8-buffvalue,0,duration);
+    skill:setMsg(0);
+    return 0;
 end

--- a/scripts/globals/abilities/pets/ecliptic_howl.lua
+++ b/scripts/globals/abilities/pets/ecliptic_howl.lua
@@ -5,6 +5,7 @@
 require("scripts/globals/settings");
 require("scripts/globals/status");
 require("scripts/globals/monstertpmoves");
+require("scripts/globals/utils");
 
 ---------------------------------------------------
 
@@ -12,28 +13,31 @@ function onAbilityCheck(player, target, ability)
     return 0,0;
 end;
 
-function onPetAbility(target, pet, skill)
-	local moon = VanadielMoonPhase();
-	local buffvalue = 0;
-	if moon > 90 then
-		buffvalue = 25;
-	elseif moon > 75 then
-		buffvalue = 21;
-	elseif moon > 60 then
-		buffvalue = 17;
-	elseif moon > 40 then
-		buffvalue = 13;
-	elseif moon > 25 then
-		buffvalue = 9;
-	elseif moon > 10 then
-		buffvalue = 5;
-	else
-		buffvalue = 1;
-	end
-	target:delStatusEffect(EFFECT_ACCURACY_BOOST);
-	target:delStatusEffect(EFFECT_EVASION_BOOST);
-	target:addStatusEffect(EFFECT_ACCURACY_BOOST,buffvalue,0,180);
-	target:addStatusEffect(EFFECT_EVASION_BOOST,25-buffvalue,0,180);
-	skill:setMsg(0);
-	return 0;
+function onPetAbility(target, pet, skill, summoner)
+    local bonusTime = utils.clamp(summoner:getSkillLevel(SKILL_SUM) - 300, 0, 200);
+    local duration = 180 + bonusTime;
+
+    local moon = VanadielMoonPhase();
+    local buffvalue = 0;
+    if moon > 90 then
+        buffvalue = 25;
+    elseif moon > 75 then
+        buffvalue = 21;
+    elseif moon > 60 then
+        buffvalue = 17;
+    elseif moon > 40 then
+        buffvalue = 13;
+    elseif moon > 25 then
+        buffvalue = 9;
+    elseif moon > 10 then
+        buffvalue = 5;
+    else
+        buffvalue = 1;
+    end
+    target:delStatusEffect(EFFECT_ACCURACY_BOOST);
+    target:delStatusEffect(EFFECT_EVASION_BOOST);
+    target:addStatusEffect(EFFECT_ACCURACY_BOOST,buffvalue,0,duration);
+    target:addStatusEffect(EFFECT_EVASION_BOOST,25-buffvalue,0,duration);
+    skill:setMsg(0);
+    return 0;
 end

--- a/scripts/globals/abilities/pets/frost_armor.lua
+++ b/scripts/globals/abilities/pets/frost_armor.lua
@@ -5,6 +5,7 @@
 require("scripts/globals/settings");
 require("scripts/globals/status");
 require("scripts/globals/monstertpmoves");
+require("scripts/globals/utils");
 
 ---------------------------------------------------
 
@@ -13,9 +14,11 @@ function onAbilityCheck(player, target, ability)
 end;
 
 function onPetAbility(target, pet, skill, summoner)
-	local duration = 90 + 3 * summoner:getMod(MOD_SUMMONING);
+    local bonusTime = utils.clamp(summoner:getSkillLevel(SKILL_SUM) - 300, 0, 200);
+    local duration = 180 + bonusTime;
 
-	target:addStatusEffect(EFFECT_ICE_SPIKES,15,0,duration);
-	skill:setMsg(MSG_BUFF);
-	return EFFECT_ICE_SPIKES;
+    target:delStatusEffect(EFFECT_ICE_SPIKES);
+    target:addStatusEffect(EFFECT_ICE_SPIKES,15,0,duration);
+    skill:setMsg(MSG_BUFF);
+    return EFFECT_ICE_SPIKES;
 end

--- a/scripts/globals/abilities/pets/hastega.lua
+++ b/scripts/globals/abilities/pets/hastega.lua
@@ -5,6 +5,7 @@
 require("scripts/globals/settings");
 require("scripts/globals/status");
 require("scripts/globals/monstertpmoves");
+require("scripts/globals/utils");
 
 ---------------------------------------------------
 
@@ -13,14 +14,14 @@ function onAbilityCheck(player, target, ability)
 end;
 
 function onPetAbility(target, pet, skill, summoner)
-	local duration = 180 + summoner:getMod(MOD_SUMMONING);
-	if duration > 350 then
-		duration = 350;
-	end;
+    local bonusTime = utils.clamp(summoner:getSkillLevel(SKILL_SUM) - 300, 0, 200);
+    local duration = 180 + bonusTime;
+    print(bonusTime)
+    print(duration)
 
-	-- Garuda's Hastega is a weird exception and uses 153 instead of 15%
-   -- That's why it overwrites some things regular haste won't.
-   target:addStatusEffect(EFFECT_HASTE,153,0,duration);
-	skill:setMsg(MSG_BUFF);
-	return EFFECT_HASTE;
+    -- Garuda's Hastega is a weird exception and uses 153 instead of 15%
+    -- That's why it overwrites some things regular haste won't.
+    target:addStatusEffect(EFFECT_HASTE,153,0,duration);
+    skill:setMsg(MSG_BUFF);
+    return EFFECT_HASTE;
 end

--- a/scripts/globals/abilities/pets/lightning_armor.lua
+++ b/scripts/globals/abilities/pets/lightning_armor.lua
@@ -5,6 +5,7 @@
 require("scripts/globals/settings");
 require("scripts/globals/status");
 require("scripts/globals/monstertpmoves");
+require("scripts/globals/utils");
 
 ---------------------------------------------------
 
@@ -13,9 +14,11 @@ function onAbilityCheck(player, target, ability)
 end;
 
 function onPetAbility(target, pet, skill, summoner)
-	local duration = 90 + 3 * summoner:getMod(MOD_SUMMONING);
-	target:delStatusEffect(EFFECT_SHOCK_SPIKES);
-	target:addStatusEffect(EFFECT_SHOCK_SPIKES,15,0,duration);
-	skill:setMsg(MSG_BUFF);
-	return EFFECT_SHOCK_SPIKES;
+    local bonusTime = utils.clamp(summoner:getSkillLevel(SKILL_SUM) - 300, 0, 200);
+    local duration = 180 + bonusTime;
+
+    target:delStatusEffect(EFFECT_SHOCK_SPIKES);
+    target:addStatusEffect(EFFECT_SHOCK_SPIKES,15,0,duration);
+    skill:setMsg(MSG_BUFF);
+    return EFFECT_SHOCK_SPIKES;
 end

--- a/scripts/globals/abilities/pets/rolling_thunder.lua
+++ b/scripts/globals/abilities/pets/rolling_thunder.lua
@@ -5,6 +5,7 @@
 require("scripts/globals/settings");
 require("scripts/globals/status");
 require("scripts/globals/monstertpmoves");
+require("scripts/globals/utils");
 
 ---------------------------------------------------
 
@@ -13,7 +14,8 @@ function onAbilityCheck(player, target, ability)
 end;
 
 function onPetAbility(target, pet, skill, summoner)
-    local duration = 60 + 2 * summoner:getMod(MOD_SUMMONING);
+    local bonusTime = utils.clamp(summoner:getSkillLevel(SKILL_SUM) - 300, 0, 200);
+    local duration = 120 + bonusTime;
 
     local magicskill = getSkillLvl(1, target:getMainLvl());
 

--- a/scripts/globals/abilities/pets/shining_ruby.lua
+++ b/scripts/globals/abilities/pets/shining_ruby.lua
@@ -5,6 +5,7 @@
 require("scripts/globals/settings");
 require("scripts/globals/status");
 require("scripts/globals/monstertpmoves");
+require("scripts/globals/utils");
 
 ---------------------------------------------------
 
@@ -12,9 +13,12 @@ function onAbilityCheck(player, target, ability)
     return 0,0;
 end;
 
-function onPetAbility(target, pet, skill)
-	target:delStatusEffect(EFFECT_SHINING_RUBY);
-	target:addStatusEffect(EFFECT_SHINING_RUBY,1,0,180);
-	skill:setMsg(MSG_BUFF);
-	return EFFECT_SHINING_RUBY;
+function onPetAbility(target, pet, skill, summoner)
+    local bonusTime = utils.clamp(summoner:getSkillLevel(SKILL_SUM) - 300, 0, 200);
+    local duration = 180 + bonusTime;
+
+    target:delStatusEffect(EFFECT_SHINING_RUBY);
+    target:addStatusEffect(EFFECT_SHINING_RUBY,1,0,duration);
+    skill:setMsg(MSG_BUFF);
+    return EFFECT_SHINING_RUBY;
 end


### PR DESCRIPTION
The way the skill was being obtained previously as always returning a value of 0, so I changed it. Now it grabs the master's summoning magic skill. Each BP ward has a base duration, and a bonus of one second for every point of skill above 300, capping out at 500 skill.

Source: http://forum.square-enix.com/ffxi/threads/20767-Blood-Pact-Ward-testing