### PR TITLE
Scripts: Gaze check for BLU enfeebles + fix for #1772

### DIFF
--- a/scripts/globals/spells/bluemagic/Yawn.lua
+++ b/scripts/globals/spells/bluemagic/Yawn.lua
@@ -37,13 +37,16 @@ function onSpellCast(caster,target,spell)
     local resist = applyResistanceEffect(caster,spell,target,dINT,BLUE_SKILL,0,typeEffect);
     local duration = 90 * resist;
 
-    -- TODO: Check for mob looking at player (NOT gaze). Does not apply for enemies using the spell?
     if(resist > 0.5) then -- Do it!
-        if(target:addStatusEffect(typeEffect,2,0,duration)) then
-            spell:setMsg(236);
+        if ((target:isFacing(caster))) then -- TODO: Apparently this check shouldn't exist for enemies using this spell? Need more info.
+            if(target:addStatusEffect(typeEffect,2,0,duration)) then
+                spell:setMsg(236);
+            else
+                spell:setMsg(75);
+            end;
         else
             spell:setMsg(75);
-        end
+        end;
     else
         spell:setMsg(85);
     end;

--- a/scripts/globals/spells/bluemagic/awful_eye.lua
+++ b/scripts/globals/spells/bluemagic/awful_eye.lua
@@ -33,16 +33,18 @@ function onSpellCast(caster,target,spell)
     
     if(target:hasStatusEffect(EFFECT_STR_DOWN)) then
         spell:setMsg(75); 
-    else        
+    elseif (target:isFacing(caster)) then      
         local dINT = caster:getStat(MOD_INT) - target:getStat(MOD_INT);
-        local resist = applyResistance(caster,spell,target,dINT,37,0);
+        local resist = applyResistance(caster,spell,target,dINT,BLUE_SKILL,0);
         if(resist <= 0) then
             spell:setMsg(85);
         else
             spell:setMsg(329);
             target:addStatusEffect(EFFECT_STR_DOWN,ABSORB_SPELL_AMOUNT*resist, ABSORB_SPELL_TICK, ABSORB_SPELL_AMOUNT*ABSORB_SPELL_TICK,FLAG_ERASBLE); -- target loses STR
-        end
-    end
+        end;
+    else
+        spell:setMsg(75);
+    end;
     
     return EFFECT_STR_DOWN;
 end;

--- a/scripts/globals/spells/bluemagic/blank_gaze.lua
+++ b/scripts/globals/spells/bluemagic/blank_gaze.lua
@@ -36,11 +36,15 @@ function onSpellCast(caster,target,spell)
     local effect = EFFECT_NONE;
 
     if(resist > 0.0625) then
-        spell:setMsg(341);
-        effect = target:dispelStatusEffect();
-        if(effect == EFFECT_NONE) then
+        if (target:isFacing(caster)) then
+            spell:setMsg(341);
+            effect = target:dispelStatusEffect();
+            if(effect == EFFECT_NONE) then
+                spell:setMsg(75);
+            end;
+        else
             spell:setMsg(75);
-        end
+        end;
     else
         spell:setMsg(85);
     end

--- a/scripts/globals/spells/bluemagic/chaotic_eye.lua
+++ b/scripts/globals/spells/bluemagic/chaotic_eye.lua
@@ -34,13 +34,16 @@ function onSpellCast(caster,target,spell)
     local resist = applyResistanceEffect(caster,spell,target,dINT,BLUE_SKILL,0,typeEffect);
     local duration = 180 * resist;
 
-    -- TODO: Gaze check
-    if(resist > 0.5) then --Do it!
-        if(target:addStatusEffect(typeEffect,1,0,duration)) then
-            spell:setMsg(236);
+    if(resist > 0.5) then -- Do it!
+        if (target:isFacing(caster)) then
+            if(target:addStatusEffect(typeEffect,1,0,duration)) then
+                spell:setMsg(236);
+            else
+                spell:setMsg(75);
+            end;
         else
             spell:setMsg(75);
-        end
+        end;
     else
         spell:setMsg(85);
     end;

--- a/scripts/globals/spells/bluemagic/jettatura.lua
+++ b/scripts/globals/spells/bluemagic/jettatura.lua
@@ -36,13 +36,16 @@ function onSpellCast(caster,target,spell)
     local resist = applyResistance(caster,spell,target,dINT,BLUE_SKILL);
     local duration = 5 * resist;
 
-    -- TODO: Gaze check
     if(resist > 0.5) then -- Do it!
-        if(target:addStatusEffect(typeEffect,power,0,duration)) then
-            spell:setMsg(236);
+        if (target:isFacing(caster)) then
+            if(target:addStatusEffect(typeEffect,1,0,duration)) then
+                spell:setMsg(236);
+            else
+                spell:setMsg(75);
+            end;
         else
             spell:setMsg(75);
-        end
+        end;
     else
         spell:setMsg(85);
     end;

--- a/scripts/globals/spells/bluemagic/light_of_penance.lua
+++ b/scripts/globals/spells/bluemagic/light_of_penance.lua
@@ -38,23 +38,26 @@ function onSpellCast(caster,target,spell)
     local power = 10 * resist;
     local returnEffect = typeEffectOne;
 
-    -- TODO: Gaze check
     if(resist >= 0.5) then
-        if(target:hasStatusEffect(typeEffectOne) and target:hasStatusEffect(typeEffectTwo) and target:getTP() == 0) then
-            spell:setMsg(75); -- no effect
-        elseif(target:hasStatusEffect(typeEffectOne) and target:hasStatusEffect(typeEffectTwo)) then
-            target:delTP(power);
-            spell:setMsg(431); -- tp reduced
-        elseif (target:hasStatusEffect(typeEffectOne)) then
-            target:addStatusEffect(typeEffectTwo,1,0,duration);
-            target:delTP(power);
-            returnEffect = typeEffectTwo; -- make it return bind message if blind can't be inflicted
-            spell:setMsg(236);
+        if (target:isFacing(caster)) then
+            if(target:hasStatusEffect(typeEffectOne) and target:hasStatusEffect(typeEffectTwo) and target:getTP() == 0) then
+                spell:setMsg(75); -- no effect
+            elseif(target:hasStatusEffect(typeEffectOne) and target:hasStatusEffect(typeEffectTwo)) then
+                target:delTP(power);
+                spell:setMsg(431); -- tp reduced
+            elseif (target:hasStatusEffect(typeEffectOne)) then
+                target:addStatusEffect(typeEffectTwo,1,0,duration);
+                target:delTP(power);
+                returnEffect = typeEffectTwo; -- make it return bind message if blind can't be inflicted
+                spell:setMsg(236);
+            else
+                target:addStatusEffect(typeEffectOne,50,0,duration);
+                target:addStatusEffect(typeEffectTwo,1,0,duration);
+                target:delTP(power);
+                spell:setMsg(236);
+            end;
         else
-            target:addStatusEffect(typeEffectOne,50,0,duration);
-            target:addStatusEffect(typeEffectTwo,1,0,duration);
-            target:delTP(power);
-            spell:setMsg(236);
+            spell:setMsg(75);
         end;
     end;
 


### PR DESCRIPTION
Awful Eye, Blank Gaze, Chaotic Eye, Jettatura, and Light of Penance check if both caster is facing target and if target is facing caster.
Yawn is different - it only needs to check if the target is facing the caster.
Set the power for the terror on Jettatura to 1 instead of an undefined variable.