### PR TITLE
Scripts/SQL: Some Flan TP moves, Crystal Weapon AoE type fix

### DIFF
--- a/scripts/globals/mobskills/Amorphic_spikes.lua
+++ b/scripts/globals/mobskills/Amorphic_spikes.lua
@@ -1,0 +1,29 @@
+---------------------------------------------
+--  Amorphic Spikes
+--
+--  Description: Delivers a fivefold attack. Damage varies with TP.
+--  Type: Physical
+--  Utsusemi/Blink absorb: 5 shadows
+--  Range: Unknown
+--  Notes:
+---------------------------------------------
+
+require("scripts/globals/settings");
+require("scripts/globals/status");
+require("scripts/globals/monstertpmoves");
+
+---------------------------------------------
+
+function onMobSkillCheck(target,mob,skill)
+    return 0;
+end;
+
+function onMobWeaponSkill(target, mob, skill)
+    local numhits = 5;
+    local accmod = 1;
+    local dmgmod = 1;
+    local info = MobPhysicalMove(mob,target,skill,numhits,accmod,dmgmod,TP_DMG_VARIES,1,1.2,1.5);
+    local dmg = MobFinalAdjustments(info.dmg,mob,skill,target,MOBSKILL_PHYSICAL,MOBPARAM_PIERCE,info.hitslanded);
+    target:delHP(dmg);
+    return dmg;
+end;

--- a/scripts/globals/mobskills/Amplification.lua
+++ b/scripts/globals/mobskills/Amplification.lua
@@ -1,0 +1,40 @@
+---------------------------------------------------
+-- Amplification
+-- Enhances Magic Attack and Magic Defense. Bonus stacks when used by mobs.
+---------------------------------------------------
+
+require("scripts/globals/settings");
+require("scripts/globals/status");
+require("scripts/globals/monstertpmoves");
+
+---------------------------------------------------
+
+function onMobSkillCheck(target,mob,skill)
+    return 0;
+end;
+
+function onMobWeaponSkill(target, mob, skill)
+
+    local typeEffect1 = EFFECT_MAGIC_ATK_BOOST;
+    local typeEffect2 = EFFECT_MAGIC_DEF_BOOST;
+    local mabTotal = mob:getStatusEffect(EFFECT_MAGIC_ATK_BOOST);
+    local mdbTotal = mob:getStatusEffect(EFFECT_MAGIC_DEF_BOOST);
+
+    if (mob:getStatusEffect(EFFECT_MAGIC_ATK_BOOST) ~= nil) then -- mag atk bonus stacking
+        mabTotal = mabTotal:getPower() + 10;
+    else
+        mabTotal = 10;
+    end;
+    if (mob:getStatusEffect(EFFECT_MAGIC_DEF_BOOST) ~= nil) then -- mag def bonus stacking
+        mdbTotal = mdbTotal:getPower() + 10;
+    else
+        mdbTotal = 10;
+    end;
+    -- print(mabTotal)
+    -- print(mdbTotal)
+
+    skill:setMsg(MobBuffMove(mob, typeEffect1, mabTotal, 0, 180));
+    MobBuffMove(mob, typeEffect2, mdbTotal, 0, 180);
+
+    return typeEffect1;
+end;

--- a/scripts/globals/mobskills/Boiling_point.lua
+++ b/scripts/globals/mobskills/Boiling_point.lua
@@ -1,0 +1,22 @@
+---------------------------------------------
+--  Boiling Point
+--
+--  Description: Reduces magic defense in a fan-shaped area of effect.
+--  Type: Magical
+---------------------------------------------
+
+require("scripts/globals/settings");
+require("scripts/globals/status");
+require("scripts/globals/monstertpmoves");
+
+---------------------------------------------
+
+function onMobSkillCheck(target,mob,skill)
+    return 0;
+end;
+
+function onMobWeaponSkill(target, mob, skill)
+    local typeEffect = EFFECT_MAGIC_DEF_DOWN;
+    skill:setMsg(MobStatusEffectMove(mob, target, typeEffect, 20, 0, 180));
+    return typeEffect;
+end;

--- a/sql/mob_skill.sql
+++ b/sql/mob_skill.sql
@@ -1119,10 +1119,10 @@ INSERT INTO `mob_skill` VALUES (419,135,419,'Heavy_Strike',0,7.0,2000,1500,4,0,0
 INSERT INTO `mob_skill` VALUES (420,135,420,'Ice_Break',1,15.0,2000,1500,4,0,0,0);
 INSERT INTO `mob_skill` VALUES (421,135,421,'Thunder_Break',1,15.0,2000,1500,4,0,0,0);
 INSERT INTO `mob_skill` VALUES (422,135,422,'Crystal_Rain',1,15.0,2000,1500,4,0,0,0);
-INSERT INTO `mob_skill` VALUES (423,135,423,'Crystal_Weapon_Fire',1,15.0,2000,1500,4,0,0,0);
-INSERT INTO `mob_skill` VALUES (424,135,424,'Crystal_Weapon_Stone',1,15.0,2000,1500,4,0,0,0);
-INSERT INTO `mob_skill` VALUES (425,135,425,'Crystal_Weapon_Water',1,15.0,2000,1500,4,0,0,0);
-INSERT INTO `mob_skill` VALUES (426,135,426,'Crystal_Weapon_Wind',1,15.0,2000,1500,4,0,0,0);
+INSERT INTO `mob_skill` VALUES (423,135,423,'Crystal_Weapon_Fire',0,15.0,2000,1500,4,0,0,0);
+INSERT INTO `mob_skill` VALUES (424,135,424,'Crystal_Weapon_Stone',0,15.0,2000,1500,4,0,0,0);
+INSERT INTO `mob_skill` VALUES (425,135,425,'Crystal_Weapon_Water',0,15.0,2000,1500,4,0,0,0);
+INSERT INTO `mob_skill` VALUES (426,135,426,'Crystal_Weapon_Wind',0,15.0,2000,1500,4,0,0,0);
 
 -- Sapling
 INSERT INTO `mob_skill` VALUES (429,216,429,'Sprout_Spin',1,15.0,2000,1500,4,0,0,0);
@@ -1599,10 +1599,10 @@ INSERT INTO `mob_skill` VALUES (1524,205,1207,'Leaping_Cleave',0,7.0,2000,1500,4
 -- INSERT INTO `mob_skill` VALUES (2634,?,2025,'Gen'ei_Ryodan',1,15,2000,2000,4,0,0,0); -- Unique to Dimgruzub only @ certain % HP or below
 
 -- Flan
-INSERT INTO `mob_skill` VALUES (1565,112,1283,'Amplification',4,10.0,2000,1500,4,0,0,0);
-INSERT INTO `mob_skill` VALUES (1566,112,1284,'Boiling_point',4,10.0,2000,1500,4,0,0,0);
-INSERT INTO `mob_skill` VALUES (1568,112,1286,'Amorphic_spikes',4,10.0,2000,1500,4,0,0,0);
-INSERT INTO `mob_skill` VALUES (1570,112,1288,'Synergism',4,10.0,2000,1500,4,0,0,0);
+INSERT INTO `mob_skill` VALUES (1565,112,1283,'Amplification',0,7.0,2000,1500,1,0,0,0);
+INSERT INTO `mob_skill` VALUES (1566,112,1284,'Boiling_Point',4,16.0,2000,1500,4,0,0,0);
+INSERT INTO `mob_skill` VALUES (1568,112,1286,'Amorphic_spikes',0,7.0,2000,1500,4,0,0,0);
+-- INSERT INTO `mob_skill` VALUES (1570,112,1288,'Synergism',4,10.0,2000,1500,4,0,0,0);
 -- INSERT INTO `mob_skill` VALUES (1571,112,1289,'Metastasis',4,10.0,2000,1500,4,0,0,0); -- lack of info online as to who uses this move.
 
 -- INSERT INTO `mob_skill` VALUES (1567,?,1285,'Xenoglossia',0,7.0,2000,1500,1,0,0,0); -- Certain NMs only
@@ -2855,8 +2855,9 @@ INSERT INTO `mob_skill` VALUES (390,298,390,'Heavy_Stomp',1,10.0,2000,1500,4,0,0
 -- INSERT INTO `mob_skill` VALUES (0,298,0,'Petro_Eyes',0,7.0,2000,1500,4,0,0,0);
 
 -- Dextrose (299)
--- INSERT INTO `mob_skill` VALUES (1565,299,1283,'Amplification',0,7.0,2000,1500,1,0,0,0);
--- INSERT INTO `mob_skill` VALUES (1566,299,1284,'Boiling_Point',4,16.0,2000,1500,4,0,0,0);
+INSERT INTO `mob_skill` VALUES (1565,299,1283,'Amplification',0,7.0,2000,1500,1,0,0,0);
+INSERT INTO `mob_skill` VALUES (1566,299,1284,'Boiling_Point',4,16.0,2000,1500,4,0,0,0);
+-- INSERT INTO `mob_skill` VALUES (1568,299,1286,'Amorphic_spikes',0,7.0,2000,1500,4,0,0,0); -- uses this move as a counter to weaponskills instantly against the person who used the WS. Leaving it out for now.
 -- INSERT INTO `mob_skill` VALUES (1570,299,1288,'Synergism',1,7.0,2000,1500,4,0,0,0);
 -- INSERT INTO `mob_skill` VALUES (1567,299,1285,'Xenoglossia',0,7.0,2000,1500,1,0,0,0);
 


### PR DESCRIPTION
Implemented Amorphic Spikes, Amplification, and Boiling Point. Note that the mob version of Amplification stacks the MAB/MDB bonuses on multiple uses.
Enabled those three moves for Flans. Dextrose has only the latter two moves, as it's only supposed to use Amorphic Spikes as a counter to the player who uses a Weapon Skill on it.
Changed the four Crystal Weapon moves to be single target instead of AoE. http://ffxiclopedia.wikia.com/wiki/Crystal_Weapon