### PR TITLE
Scripts/SQL: Implement Hpemde family TP moves

### DIFF
--- a/scripts/globals/mobskills/Ichor_stream.lua
+++ b/scripts/globals/mobskills/Ichor_stream.lua
@@ -1,0 +1,25 @@
+---------------------------------------------
+--  Ichor Stream
+--  Family: Hpemde
+--  Description: Spews venomous ichor at targets in a fan-shaped area of effect.
+--  Type: Enfeebling
+--  Utsusemi/Blink absorb: Ignores shadows
+--  Range: Cone
+--  Notes: Poison is about 5/tic.
+---------------------------------------------
+require("scripts/globals/settings");
+require("scripts/globals/status");
+require("scripts/globals/monstertpmoves");
+---------------------------------------------
+
+function onMobSkillCheck(target,mob,skill)
+    return 0;
+end;
+
+function onMobWeaponSkill(target, mob, skill)
+    local typeEffect = EFFECT_POISON;
+
+    skill:setMsg(MobStatusEffectMove(mob, target, typeEffect, 5, 0, 120));
+
+    return typeEffect;
+end;

--- a/scripts/globals/mobskills/Rapid_molt.lua
+++ b/scripts/globals/mobskills/Rapid_molt.lua
@@ -1,0 +1,33 @@
+---------------------------------------------
+--  Rapid Molt
+--  Family: Hpemde
+--  Description: Erases all negative effects on the mob, and adds a Regen effect.
+--  Can be dispelled: Yes (regen)
+--  Utsusemi/Blink absorb: N/A
+--  Range: Self
+--  Notes: Hpemde will generally not attempt to use this ability if no erasable effects exist on them.
+---------------------------------------------
+require("scripts/globals/settings");
+require("scripts/globals/status");
+require("scripts/globals/monstertpmoves");
+---------------------------------------------
+
+function onMobSkillCheck(target,mob,skill)
+    
+    local dispel = target:eraseStatusEffect();
+
+    if(dispel ~= EFFECT_NONE) then
+        return 0;
+    end;
+
+    return 1;
+end;
+
+function onMobWeaponSkill(target, mob, skill)
+
+    mob:eraseAllStatusEffect();
+    local typeEffect = EFFECT_REGEN;
+
+    skill:setMsg(MobBuffMove(mob, typeEffect, 10, 3, 180));
+    return typeEffect;
+end;

--- a/scripts/globals/mobskills/Sinuate_rush.lua
+++ b/scripts/globals/mobskills/Sinuate_rush.lua
@@ -1,0 +1,29 @@
+---------------------------------------------
+--  Sinuate Rush
+--  Family: Hpemde
+--  Description: Damages nearby targets with an undulating attack.
+--  Type: Physical
+--  Utsusemi/Blink absorb: 2-3 shadows
+--  Range: Unknown
+--  Notes:
+---------------------------------------------
+require("scripts/globals/settings");
+require("scripts/globals/status");
+require("scripts/globals/monstertpmoves");
+---------------------------------------------
+
+function onMobSkillCheck(target,mob,skill)
+    return 0;
+end;
+
+function onMobWeaponSkill(target, mob, skill)
+
+    local numhits = 1;
+    local accmod = 1;
+    local dmgmod = 2.0;
+    local info = MobPhysicalMove(mob,target,skill,numhits,accmod,dmgmod,TP_NO_EFFECT);
+    local dmg = MobFinalAdjustments(info.dmg,mob,skill,target,MOBSKILL_PHYSICAL,MOBPARAM_SLASH,MOBPARAM_3_SHADOW);
+
+    target:delHP(dmg);
+    return dmg;
+end;

--- a/scripts/globals/mobskills/Tail_thrust.lua
+++ b/scripts/globals/mobskills/Tail_thrust.lua
@@ -1,0 +1,32 @@
+---------------------------------------------
+--  Tail Thrust
+--  Family: Hpemde
+--  Description: Strikes a single target with its tail.
+--  Type: Physical
+--  Utsusemi/Blink absorb: One shadow
+--  Range: Unknown
+--  Notes: Additional effect - paralyze
+---------------------------------------------
+require("scripts/globals/settings");
+require("scripts/globals/status");
+require("scripts/globals/monstertpmoves");
+---------------------------------------------
+
+function onMobSkillCheck(target,mob,skill)
+    return 0;
+end;
+
+function onMobWeaponSkill(target, mob, skill)
+
+    local numhits = 1;
+    local accmod = 1;
+    local dmgmod = 2.4;
+    local info = MobPhysicalMove(mob,target,skill,numhits,accmod,dmgmod,TP_NO_EFFECT);
+    local dmg = MobFinalAdjustments(info.dmg,mob,skill,target,MOBSKILL_PHYSICAL,MOBPARAM_PIERCE,info.hitslanded);
+
+    local typeEffect = EFFECT_PARALYSIS;
+    MobPhysicalStatusEffectMove(mob, target, skill, typeEffect, 15, 0, 120);
+
+    target:delHP(dmg);
+    return dmg;
+end;

--- a/scripts/globals/mobskills/Temporal_Shift.lua
+++ b/scripts/globals/mobskills/Temporal_Shift.lua
@@ -1,0 +1,25 @@
+---------------------------------------------
+--  Temporal Shift
+--  Family: Hpemde
+--  Description: Enemies within range are temporarily prevented from acting.
+--  Type: Magical
+--  Utsusemi/Blink absorb: Ignores shadows
+--  Range: 15 yalms
+--  Notes:
+---------------------------------------------
+require("scripts/globals/settings");
+require("scripts/globals/status");
+require("scripts/globals/monstertpmoves");
+---------------------------------------------
+
+function onMobSkillCheck(target,mob,skill)
+    return 0;
+end;
+
+function onMobWeaponSkill(target, mob, skill)
+    local typeEffect = EFFECT_STUN;
+
+    skill:setMsg(MobStatusEffectMove(mob, target, typeEffect, 1, 0, 5));
+
+    return typeEffect;
+end;

--- a/sql/blue_spell_list.sql
+++ b/sql/blue_spell_list.sql
@@ -102,7 +102,7 @@ INSERT INTO `blue_spell_list` VALUES ('612','1185','4','14','4','0','0'); -- Act
 INSERT INTO `blue_spell_list` VALUES ('613','1207','5','6','1','0','0'); -- Reactor Cool
 INSERT INTO `blue_spell_list` VALUES ('614','1096','3','11','1','0','0'); -- Saline Coat
 INSERT INTO `blue_spell_list` VALUES ('615','1102','5','14','4','0','0'); -- Plasma Charge
-INSERT INTO `blue_spell_list` VALUES ('616','1111','5','8','1','0','0'); -- Temporal Shift
+INSERT INTO `blue_spell_list` VALUES ('616','1110','5','8','1','0','0'); -- Temporal Shift
 INSERT INTO `blue_spell_list` VALUES ('617','1191','3','11','1','9','0'); -- Vertical Cleave
 INSERT INTO `blue_spell_list` VALUES ('618','382','2','0','1','0','0'); -- Blastbomb
 INSERT INTO `blue_spell_list` VALUES ('620','353','3','8','1','8','0'); -- Battle Dance

--- a/sql/mob_skill.sql
+++ b/sql/mob_skill.sql
@@ -1820,11 +1820,11 @@ INSERT INTO `mob_skill` VALUES (1095,269,1002,'Molluscous_Mutation',0,7.0,2000,1
 INSERT INTO `mob_skill` VALUES (1096,269,1003,'Saline_Coat',4,10.0,2000,1000,4,0,0,0);
 
 -- Hpemde
-INSERT INTO `mob_skill` VALUES (1113,144,1027,'Ichor_stream',4,10.0,2000,1000,4,0,0,0);
-INSERT INTO `mob_skill` VALUES (1112,144,1028,'Rapid_molt',0,7.0,2000,1000,1,0,0,0);
-INSERT INTO `mob_skill` VALUES (1111,144,1031,'Temporal_Shift',1,15.0,2000,1000,4,0,0,0);
-INSERT INTO `mob_skill` VALUES (1110,144,1030,'Sinuate_rush',1,15.0,2000,1000,4,0,0,0);
-INSERT INTO `mob_skill` VALUES (1109,144,1029,'Tail_thrust',0,7.0,2000,1000,4,0,0,0);
+INSERT INTO `mob_skill` VALUES (1109,144,1043,'Tail_thrust',0,7.0,2000,1000,4,0,0,0);
+INSERT INTO `mob_skill` VALUES (1110,144,1044,'Temporal_Shift',1,15.0,2000,1000,4,0,0,0);
+INSERT INTO `mob_skill` VALUES (1111,144,1031,'Sinuate_rush',1,15.0,2000,1000,4,0,0,0);
+INSERT INTO `mob_skill` VALUES (1112,144,1030,'Rapid_molt',0,7.0,2000,1000,1,0,0,0);
+INSERT INTO `mob_skill` VALUES (1113,144,1045,'Ichor_stream',4,10.0,2000,1000,4,0,0,0);
 
 -- Trolls (light-armored model)
 -- INSERT INTO `mob_skill` VALUES (1485,246,1230,'Potent_Lunge',0,7.0,2000,1500,4,0,0,3);


### PR DESCRIPTION
Corrected the animations that were used, as only Sinuate Rush was using the correct one. For some reason, they're separated by other animations like player WS ones. Strange...
Swapped the mob skill ID of Sinuate Rush and Temporal Shift - this fixes the issue where one of those moves would call the script of the other. This meant I also had to change the ID in blue_spell_list.sql so Temporal Shift would be learned from the correct move.