### PR TITLE
Scripts/SQL: Implement Elemental Siphon

### DIFF
--- a/scripts/globals/abilities/elemental_siphon.lua
+++ b/scripts/globals/abilities/elemental_siphon.lua
@@ -1,0 +1,78 @@
+-----------------------------------
+-- Ability: Elemental Siphon
+-- Drains MP from your summoned spirit.
+-- Obtained: Summoner level 50
+-- Recast Time: 5:00
+-- Duration: Instant
+-----------------------------------
+require("scripts/globals/settings");
+require("scripts/globals/status");
+require("scripts/globals/pets");
+require("scripts/globals/magic")
+require("scripts/globals/utils")
+-----------------------------------
+-- onAbilityCheck
+-----------------------------------
+
+function onAbilityCheck(player,target,ability)
+    local pet = player:getPetID();
+    if (pet >= 0 and pet <= 7) then -- spirits
+        return 0,0;
+    else
+        return MSGBASIC_UNABLE_TO_USE_JA,0;
+    end
+end;
+
+-----------------------------------
+-- onUseAbility
+-----------------------------------
+
+function onUseAbility(player,target,ability)
+    local spiritEle = player:getPetID() + 1; -- get the spirit's ID, then make it line up with element value for the day order.
+    -- pet order: fire, ice, air, earth, thunder, water, light, dark
+    -- day order: fire, earth, water, wind, ice, thunder, light, dark
+    if (spiritEle == 2) then
+        spiritEle = 5
+    elseif (spiritEle == 3) then
+        spiritEle = 4
+    elseif (spiritEle == 4) then
+        spiritEle = 2
+    elseif (spiritEle == 5) then
+        spiritEle = 6
+    elseif (spiritEle == 6) then
+        spiritEle = 3
+    end;
+
+    local basePower = player:getSkillLevel(SKILL_SUM) - 50;
+    if (basePower < 0) then -- skill your summoning magic you lazy bastard !
+        basePower = 0;
+    end;
+    local weatherDayBonus = 1;
+    local dayElement = VanadielDayElement();
+    local weather = player:getWeather();
+
+    -- Day bonus/penalty
+    if (dayElement == dayStrong[spiritEle]) then
+        weatherDayBonus = weatherDayBonus + 0.1;
+    elseif (dayElement == dayWeak[spiritEle]) then
+        weatherDayBonus = weatherDayBonus - 0.1;
+    end
+    -- Weather bonus/penalty
+    if (weather == singleWeatherStrong[spiritEle]) then
+        weatherDayBonus = weatherDayBonus + 0.1;
+    elseif (weather == singleWeatherWeak[spiritEle]) then
+        weatherDayBonus = weatherDayBonus - 0.1;
+    elseif (weather == doubleWeatherStrong[spiritEle]) then
+        weatherDayBonus = weatherDayBonus + 0.25;
+    elseif (weather == doubleWeatherWeak[spiritEle]) then
+        weatherDayBonus = weatherDayBonus - 0.25;
+    end
+    
+    local power = math.floor(basePower * weatherDayBonus);
+    local spirit = player:getPet();
+    power = utils.clamp(power, 0, spirit:getMP()); -- cap MP drained at spirit's MP
+    power = utils.clamp(power, 0, player:getMaxMP() - player:getMP()); -- cap MP drained at the max MP - current MP
+
+    spirit:delMP(power);
+    return player:addMP(power);
+end;

--- a/sql/abilities.sql
+++ b/sql/abilities.sql
@@ -254,7 +254,7 @@ INSERT INTO `abilities` VALUES ('210', 'retaliation', '1', '60', '1', '180', '8'
 INSERT INTO `abilities` VALUES ('211', 'footwork', '2', '65', '1', '300', '21', '0', '0', '197', '20.0', '0', '1', '80', '0', '0','WOTG');
 INSERT INTO `abilities` VALUES ('213', 'pianissimo', '10', '20', '1', '15', '112', '0', '0', '194', '20.0', '0', '1', '80', '0', '0','WOTG');
 INSERT INTO `abilities` VALUES ('214', 'sekkanoki', '12', '40', '1', '300', '140', '0', '0', '199', '20.0', '0', '1', '80', '0', '0','WOTG');
-INSERT INTO `abilities` VALUES ('216', 'elemental_siphon', '15', '50', '1', '300', '175', '0', '0', '201', '20.0', '0', '1', '0', '0', '0','WOTG');
+INSERT INTO `abilities` VALUES ('216', 'elemental_siphon', '15', '50', '1', '300', '175', '451', '0', '201', '20.0', '0', '1', '0', '0', '0','WOTG');
 INSERT INTO `abilities` VALUES ('217', 'sublimation', '20', '35', '1', '30', '234', '0', '0', '189', '20.0', '0', '1', '80', '0', '0','WOTG');
 INSERT INTO `abilities` VALUES ('218', 'addendum_white', '20', '10', '1', '0', '231', '0', '0', '191', '20.0', '0', '1', '80', '0', '16','WOTG');
 INSERT INTO `abilities` VALUES ('219', 'addendum_black', '20', '30', '1', '0', '231', '0', '0', '192', '20.0', '0', '1', '80', '0', '32','WOTG');


### PR DESCRIPTION
Changed the message in abilities.sql to match the retail message ([Player] regains [mp] MP)
Elemental Siphon has a pet check on use to make sure it's a spirit, then on ability use it checks the element of the spirit (bit of shuffling here), the day/weather, spirit's MP, and the difference between player's max and current MP.