### PR TITLE
Scripts: Fix for Switchstix eating 10k currency pieces.

### DIFF
--- a/scripts/zones/Castle_Zvahl_Baileys/npcs/Switchstix.lua
+++ b/scripts/zones/Castle_Zvahl_Baileys/npcs/Switchstix.lua
@@ -181,7 +181,9 @@ function onTrade(player,npc,trade)
       elseif (count == eventParams[6] * 3 and eventParams[5] == 0) then
          -- Has currencyamount of all three currencies
          if (trade:hasItemQty(1450,eventParams[6]) and trade:hasItemQty(1453,eventParams[6]) and trade:hasItemQty(1456,eventParams[6])) then
-            tradeOK = true;
+            if (eventParams[5] ~= 1451 and eventParams[5] ~= 1454 and eventParams[5] ~= 1457) then -- disallow trade of 10k piece, else the gob will eat it.
+               tradeOK = true;
+            end
          end
       end
 


### PR DESCRIPTION
Since you do not actually trade a 10k currency piece to Switchstix for your relic weapon (you trade it to the corresponding blank spot instead), I simply made a check to block the trade of each of the 10k pieces.

It's necessary for the 10k piece to be in each relic's subarray because Switchstix calls that data when you talk after having seen the stage 4 CS. However, it existing in the subarray is why it would be accepted (and subsequently eaten) prior to this fix.