### PR TITLE
Scripts: AF hands quest + BLM AF3 start requirements fix

### DIFF
--- a/scripts/zones/Heavens_Tower/npcs/Chumimi.lua
+++ b/scripts/zones/Heavens_Tower/npcs/Chumimi.lua
@@ -58,7 +58,7 @@ function onTrigger(player,npc)
 		player:startEvent(0x010E,0,1105); -- Start Quest "Recollections"
 	elseif(recollections == QUEST_ACCEPTED and player:hasKeyItem(FOE_FINDER_MK_I)) then
 		player:startEvent(0x0113); -- Finish Quest "Recollections"
-	elseif(rootProblem == QUEST_AVAILABLE and mJob == 4 and mLvl >= 50 and player:needToZone() == false) then
+	elseif(recollections == QUEST_COMPLETED and rootProblem == QUEST_AVAILABLE and mJob == 4 and mLvl >= 50 and player:needToZone() == false) then
 			player:startEvent(0x114,0,829); -- Start Quest "The Root of The problem"
 	elseif(rootProblem == QUEST_ACCEPTED) then
 		if (player:getVar("rootProblem") == 1) then

--- a/scripts/zones/Upper_Jeuno/npcs/Guslam.lua
+++ b/scripts/zones/Upper_Jeuno/npcs/Guslam.lua
@@ -46,63 +46,63 @@ function onTrigger(player,npc)
 	
 	if(player:getMainLvl() >= 50 and player:getVar("BorghertzAlreadyActiveWithJob") == 0) then
 		if(player:getMainJob() == 1 and 
-		   player:getQuestStatus(BASTOK,THE_TALEKEEPER_S_TRUTH) ~= QUEST_AVAILABLE and 
+		   player:getQuestStatus(BASTOK,THE_TALEKEEPER_S_TRUTH) == QUEST_COMPLETED and 
 		   player:getQuestStatus(JEUNO,BORGHERTZ_S_WARRING_HANDS) == QUEST_AVAILABLE) then 
 			player:startEvent(0x009b); -- Start Quest for WAR
 		elseif(player:getMainJob() == 2 and 
-			   player:getQuestStatus(BASTOK,THE_FIRST_MEETING) ~= QUEST_AVAILABLE and 
+			   player:getQuestStatus(BASTOK,THE_FIRST_MEETING) == QUEST_COMPLETED and 
 			   player:getQuestStatus(JEUNO,BORGHERTZ_S_STRIKING_HANDS) == QUEST_AVAILABLE) then 
 			player:startEvent(0x009b); -- Start Quest for MNK
 		elseif(player:getMainJob() == 3 and 
-			   player:getQuestStatus(SANDORIA,PRELUDE_OF_BLACK_AND_WHITE) ~= QUEST_AVAILABLE and 
+			   player:getQuestStatus(SANDORIA,PRELUDE_OF_BLACK_AND_WHITE) == QUEST_COMPLETED and 
 			   player:getQuestStatus(JEUNO,BORGHERTZ_S_HEALING_HANDS) == QUEST_AVAILABLE) then 
 			player:startEvent(0x009b); -- Start Quest for WHM
 		elseif(player:getMainJob() == 4 and 
-			   player:getQuestStatus(WINDURST,RECOLLECTIONS) ~= QUEST_AVAILABLE and 
+			   player:getQuestStatus(WINDURST,RECOLLECTIONS) == QUEST_COMPLETED and 
 			   player:getQuestStatus(JEUNO,BORGHERTZ_S_SORCEROUS_HANDS) == QUEST_AVAILABLE) then 
 			player:startEvent(0x009b); -- Start Quest for BLM
 		elseif(player:getMainJob() == 5 and 
-			   player:getQuestStatus(SANDORIA,ENVELOPED_IN_DARKNESS) ~= QUEST_AVAILABLE and 
+			   player:getQuestStatus(SANDORIA,ENVELOPED_IN_DARKNESS) == QUEST_COMPLETED and 
 			   player:getQuestStatus(JEUNO,BORGHERTZ_S_VERMILLION_HANDS) == QUEST_AVAILABLE) then 
 			player:startEvent(0x009b); -- Start Quest for RDM
 		elseif(player:getMainJob() == 6 and 
-			   player:getQuestStatus(WINDURST,AS_THICK_AS_THIEVES) ~= QUEST_AVAILABLE and 
+			   player:getQuestStatus(WINDURST,AS_THICK_AS_THIEVES) == QUEST_COMPLETED and 
 			   player:getQuestStatus(JEUNO,BORGHERTZ_S_SNEAKY_HANDS) == QUEST_AVAILABLE) then 
 			player:startEvent(0x009b); -- Start Quest for THF
 		elseif(player:getMainJob() == 7 and 
-			   player:getQuestStatus(SANDORIA,A_BOY_S_DREAM) ~= QUEST_AVAILABLE and 
+			   player:getQuestStatus(SANDORIA,A_BOY_S_DREAM) == QUEST_COMPLETED and 
 			   player:getQuestStatus(JEUNO,BORGHERTZ_S_STALWART_HANDS) == QUEST_AVAILABLE) then 
 			player:startEvent(0x009b); -- Start Quest for PLD
 		elseif(player:getMainJob() == 8 and 
-			   player:getQuestStatus(BASTOK,DARK_PUPPET) ~= QUEST_AVAILABLE and 
+			   player:getQuestStatus(BASTOK,DARK_PUPPET) == QUEST_COMPLETED and 
 			   player:getQuestStatus(JEUNO,BORGHERTZ_S_SHADOWY_HANDS) == QUEST_AVAILABLE) then 
 			player:startEvent(0x009b); -- Start Quest for DRK
 		elseif(player:getMainJob() == 9 and 
-			   player:getQuestStatus(JEUNO,SCATTERED_INTO_SHADOW) ~= QUEST_AVAILABLE and 
+			   player:getQuestStatus(JEUNO,SCATTERED_INTO_SHADOW) == QUEST_COMPLETED and 
 			   player:getQuestStatus(JEUNO,BORGHERTZ_S_WILD_HANDS) == QUEST_AVAILABLE) then 
 			player:startEvent(0x009b); -- Start Quest for BST
 		elseif(player:getMainJob() == 10 and 
-			   player:getQuestStatus(JEUNO,THE_REQUIEM) ~= QUEST_AVAILABLE and 
+			   player:getQuestStatus(JEUNO,THE_REQUIEM) == QUEST_COMPLETED and 
 			   player:getQuestStatus(JEUNO,BORGHERTZ_S_HARMONIOUS_HANDS) == QUEST_AVAILABLE) then 
 			player:startEvent(0x009b); -- Start Quest for BRD
 		elseif(player:getMainJob() == 11 and 
-			   player:getQuestStatus(WINDURST,FIRE_AND_BRIMSTONE) ~= QUEST_AVAILABLE and 
+			   player:getQuestStatus(WINDURST,FIRE_AND_BRIMSTONE) == QUEST_COMPLETED and 
 			   player:getQuestStatus(JEUNO,BORGHERTZ_S_CHASING_HANDS) == QUEST_AVAILABLE) then 
 			player:startEvent(0x009b); -- Start Quest for RNG
 		elseif(player:getMainJob() == 12 and 
-			   player:getQuestStatus(OUTLANDS,YOMI_OKURI) ~= QUEST_AVAILABLE and 
+			   player:getQuestStatus(OUTLANDS,YOMI_OKURI) == QUEST_COMPLETED and 
 			   player:getQuestStatus(JEUNO,BORGHERTZ_S_LOYAL_HANDS) == QUEST_AVAILABLE) then 
 			player:startEvent(0x009b); -- Start Quest for SAM
 		elseif(player:getMainJob() == 13 and 
-			   player:getQuestStatus(OUTLANDS,I_LL_TAKE_THE_BIG_BOX) ~= QUEST_AVAILABLE and 
+			   player:getQuestStatus(OUTLANDS,I_LL_TAKE_THE_BIG_BOX) == QUEST_COMPLETED and 
 			   player:getQuestStatus(JEUNO,BORGHERTZ_S_LURKING_HANDS) == QUEST_AVAILABLE) then 
 			player:startEvent(0x009b); -- Start Quest for NIN
 		elseif(player:getMainJob() == 14 and 
-			   player:getQuestStatus(SANDORIA,CHASING_QUOTAS) ~= QUEST_AVAILABLE and 
+			   player:getQuestStatus(SANDORIA,CHASING_QUOTAS) == QUEST_COMPLETED and 
 			   player:getQuestStatus(JEUNO,BORGHERTZ_S_DRAGON_HANDS) == QUEST_AVAILABLE) then 
 			player:startEvent(0x009b); -- Start Quest for DRG
 		elseif(player:getMainJob() == 15 and 
-			   player:getQuestStatus(WINDURST,CLASS_REUNION) ~= QUEST_AVAILABLE and 
+			   player:getQuestStatus(WINDURST,CLASS_REUNION) == QUEST_COMPLETED and 
 			   player:getQuestStatus(JEUNO,BORGHERTZ_S_CALLING_HANDS) == QUEST_AVAILABLE) then 
 			player:startEvent(0x009b); -- Start Quest for SMN
 		else


### PR DESCRIPTION
For whatever reason, players were able to start AF hands quest without having the corresponding AF2 quest completed. I've changed the check to make sure AF2 is completed before allowing hands to start.

BLM AF3 quest could be started when AF2 quest is accepted. This is not right - AF2 needs to be completed before AF3 can begin, so I added a check for that as well.