### PR TITLE
Scripts/SQL: Qiqurn TP moves, minor fixes for other mobskills

### DIFF
--- a/scripts/globals/mobskills/Danse_Macabre.lua
+++ b/scripts/globals/mobskills/Danse_Macabre.lua
@@ -1,17 +1,15 @@
 ---------------------------------------------------
 --  Danse Macabre
--- 
+--  Family: Corse
 --  Description: Charms a single target.
 --  Type: Enfeebling
 --  Utsusemi/Blink absorb: N/A
 --  Range: Single target
 --  Notes:
 ---------------------------------------------------
-
 require("scripts/globals/settings");
 require("scripts/globals/status");
 require("scripts/globals/monstertpmoves");
-
 ---------------------------------------------------
 
 function onMobSkillCheck(target,mob,skill)
@@ -20,10 +18,18 @@ end;
 
 function onMobWeaponSkill(target, mob, skill)
     local typeEffect = EFFECT_CHARM_I;
-    local msg = MobStatusEffectMove(mob, target, typeEffect, 0, 0, 60)
+    local power = 0;
 
+    if (not target:isPC()) then
+        skill:setMsg(MSG_MISS);
+        return typeEffect;
+    end;
+
+    local msg = MobStatusEffectMove(mob, target, typeEffect, power, 3, 60)
+    if (msg == MSG_ENFEEB_IS) then
+        mob:charm(target);
+    end;
     skill:setMsg(msg);
-    mob:resetEnmity(target);
 
     return typeEffect;
 end

--- a/scripts/globals/mobskills/Deadeye.lua
+++ b/scripts/globals/mobskills/Deadeye.lua
@@ -1,0 +1,39 @@
+---------------------------------------------
+--  Deadeye
+--  Family: Qiqurn
+--  Description: Lowers the defense and magical defense of enemies within range.
+--  Type: Magical
+--  Utsusemi/Blink absorb: Ignores shadows
+--  Range: Unknown
+--  Notes: Used only by certain Notorious Monsters. Strong effect.
+---------------------------------------------
+require("scripts/globals/settings");
+require("scripts/globals/status");
+require("scripts/globals/monstertpmoves");
+---------------------------------------------
+
+function onMobSkillCheck(target,mob,skill)
+    return 0;
+end;
+
+function onMobWeaponSkill(target, mob, skill)
+
+    local defDown = false;
+    local mDefDown = false;
+
+    defDown = MobStatusEffectMove(mob, target, EFFECT_DEFENSE_DOWN, 50, 0, 120);
+    mDefDown = MobStatusEffectMove(mob, target, EFFECT_MAGIC_DEF_DOWN, 50, 0, 120);
+
+    skill:setMsg(MSG_ENFEEB_IS);
+
+    -- display defense down first, else magic defense down
+    if (defDown == MSG_ENFEEB_IS) then
+        typeEffect = EFFECT_DEFENSE_DOWN;
+    elseif (mDefDown == MSG_ENFEEB_IS) then
+        typeEffect = EFFECT_MAGIC_DEF_DOWN;
+    else
+        skill:setMsg(MSG_MISS);
+    end;
+
+    return typeEffect;
+end;

--- a/scripts/globals/mobskills/Fanatic_Dance.lua
+++ b/scripts/globals/mobskills/Fanatic_Dance.lua
@@ -1,21 +1,19 @@
 ---------------------------------------------------
 --  Fanatic Dance
---
+--  Family: Orc
 --  Description: Charms all targets in an area of effect.
 --  Type: Enfeebling
 --  Utsusemi/Blink absorb: N/A
 --  Range: AoE around user
---  Notes:
+--  Notes: Dynamis NM Orcs only
 ---------------------------------------------------
-
 require("scripts/globals/settings");
 require("scripts/globals/status");
 require("scripts/globals/monstertpmoves");
-
 ---------------------------------------------------
 
 function onMobSkillCheck(target,mob,skill)
-    if(mob:isInDynamis() and mob:isMobType(MOBTYPE_NOTORIOUS)) then
+    if (mob:isInDynamis() and mob:isMobType(MOBTYPE_NOTORIOUS)) then
         return 0;
     end
     return 1;
@@ -23,10 +21,18 @@ end;
 
 function onMobWeaponSkill(target, mob, skill)
     local typeEffect = EFFECT_CHARM_I;
-    local msg = MobStatusEffectMove(mob, target, typeEffect, 0, 0, 60);
+    local power = 0;
 
+    if (not target:isPC()) then
+        skill:setMsg(MSG_MISS);
+        return typeEffect;
+    end;
+
+    local msg = MobStatusEffectMove(mob, target, typeEffect, power, 3, 60)
+    if (msg == MSG_ENFEEB_IS) then
+        mob:charm(target);
+    end
     skill:setMsg(msg);
-    mob:resetEnmity(target);
 
     return typeEffect;
 end

--- a/scripts/globals/mobskills/Faze.lua
+++ b/scripts/globals/mobskills/Faze.lua
@@ -1,11 +1,11 @@
 ---------------------------------------------
---  Actinic Burst
---  Family: Ghrah
---  Description: Greatly lowers the accuracy of enemies within range for a brief period of time.
---  Type: Magical (Light)
+--  Faze
+--  Family: Qiqurn
+--  Description: Scares a single target.
+--  Type: Magical
 --  Utsusemi/Blink absorb: Ignores shadows
---  Range: Unknown
---  Notes:
+--  Range: Melee
+--  Notes: Target has to be facing user
 ---------------------------------------------
 require("scripts/globals/settings");
 require("scripts/globals/status");
@@ -17,11 +17,10 @@ function onMobSkillCheck(target,mob,skill)
 end;
 
 function onMobWeaponSkill(target, mob, skill)
-    local typeEffect = EFFECT_FLASH;
-    local power = 200;
-    local duration = 20;
+    local typeEffect = EFFECT_TERROR;
+    local duration = 5;
 
-    skill:setMsg(MobStatusEffectMove(mob, target, typeEffect, power, 0, duration));
+    skill:setMsg(MobGazeMove(mob, target, typeEffect, 1, 0, duration));
 
     return typeEffect;
 end;

--- a/scripts/globals/mobskills/Kibosh.lua
+++ b/scripts/globals/mobskills/Kibosh.lua
@@ -1,10 +1,10 @@
 ---------------------------------------------
---  Actinic Burst
---  Family: Ghrah
---  Description: Greatly lowers the accuracy of enemies within range for a brief period of time.
---  Type: Magical (Light)
+--  Kibosh
+--  Family: Qiqurn
+--  Description: Inflicts amnesia on a single target.
+--  Type: Magical
 --  Utsusemi/Blink absorb: Ignores shadows
---  Range: Unknown
+--  Range: Melee
 --  Notes:
 ---------------------------------------------
 require("scripts/globals/settings");
@@ -17,9 +17,9 @@ function onMobSkillCheck(target,mob,skill)
 end;
 
 function onMobWeaponSkill(target, mob, skill)
-    local typeEffect = EFFECT_FLASH;
-    local power = 200;
-    local duration = 20;
+    local typeEffect = EFFECT_AMNESIA;
+    local power = 1;
+    local duration = 60;
 
     skill:setMsg(MobStatusEffectMove(mob, target, typeEffect, power, 0, duration));
 

--- a/scripts/globals/mobskills/Luminous_Drape.lua
+++ b/scripts/globals/mobskills/Luminous_Drape.lua
@@ -1,17 +1,15 @@
 ---------------------------------------------------
 --  Luminous Drape
---
+--  Family: Yovra
 --  Description: A glowing curtain charms all nearby targets.
 --  Type: Enfeebling
 --  Utsusemi/Blink absorb: Ignores shadows
 --  Range: AoE 10'
 --  Notes: 
 ---------------------------------------------------
-
 require("scripts/globals/settings");
 require("scripts/globals/status");
 require("scripts/globals/monstertpmoves");
-
 ---------------------------------------------------
 
 function onMobSkillCheck(target,mob,skill)
@@ -20,10 +18,18 @@ end;
 
 function onMobWeaponSkill(target, mob, skill)
     local typeEffect = EFFECT_CHARM_I;
-    local msg = MobStatusEffectMove(mob, target, typeEffect, 0, 0, 60);
-	
+    local power = 0;
+
+    if (not target:isPC()) then
+        skill:setMsg(MSG_MISS);
+        return typeEffect;
+    end;
+
+    local msg = MobStatusEffectMove(mob, target, typeEffect, power, 3, 60)
+    if (msg == MSG_ENFEEB_IS) then
+        mob:charm(target);
+    end;
     skill:setMsg(msg);
-    mob:resetEnmity(target);
 
     return typeEffect;
 end

--- a/scripts/globals/mobskills/Sandspray.lua
+++ b/scripts/globals/mobskills/Sandspray.lua
@@ -1,8 +1,8 @@
 ---------------------------------------------
---  Actinic Burst
---  Family: Ghrah
---  Description: Greatly lowers the accuracy of enemies within range for a brief period of time.
---  Type: Magical (Light)
+--  Sandspray
+--  Family: Qiqurn
+--  Description: Blinds enemies within a fan-shaped area originating from the user.
+--  Type: Magical
 --  Utsusemi/Blink absorb: Ignores shadows
 --  Range: Unknown
 --  Notes:
@@ -17,9 +17,9 @@ function onMobSkillCheck(target,mob,skill)
 end;
 
 function onMobWeaponSkill(target, mob, skill)
-    local typeEffect = EFFECT_FLASH;
-    local power = 200;
-    local duration = 20;
+    local typeEffect = EFFECT_BLINDNESS;
+    local power = 25;
+    local duration = 90;
 
     skill:setMsg(MobStatusEffectMove(mob, target, typeEffect, power, 0, duration));
 

--- a/sql/mob_skill.sql
+++ b/sql/mob_skill.sql
@@ -2128,10 +2128,10 @@ INSERT INTO `mob_skill` VALUES (2376,5,1832,'Vacuole_Discharge',1,15.0,2000,1500
 -- INSERT INTO `mob_skill` VALUES (2572,141,911,'Jettatura',4,10,2000,3000,4,0,0,0);
 
 -- Qiqirn -- Need Scripts
--- INSERT INTO `mob_skill` VALUES (1469,199,1200,'Kibosh',0,7,2000,1500,4,0,0,0);
+INSERT INTO `mob_skill` VALUES (1469,199,1200,'Kibosh',0,7,2000,1500,4,0,0,0);
 -- INSERT INTO `mob_skill` VALUES (1470,199,1201,'Cutpurse',4,10,2000,1500,4,0,0,0);
--- INSERT INTO `mob_skill` VALUES (1471,199,1202,'Sandspray',4,7,2000,1500,4,0,0,0);
--- INSERT INTO `mob_skill` VALUES (1472,199,1203,'Faze',0,7,2000,1500,4,0,0,0);
+INSERT INTO `mob_skill` VALUES (1471,199,1202,'Sandspray',4,7,2000,1500,4,0,0,0);
+INSERT INTO `mob_skill` VALUES (1472,199,1203,'Faze',0,7,2000,1500,4,0,0,0);
 
 -- Siege Turrets
 -- INSERT INTO `mob_skill` VALUES (2038,?,1616,'Basilisk_Cannon',1,?,2000,?,4,0,0,0);
@@ -2786,11 +2786,11 @@ INSERT INTO `mob_skill` VALUES (1443,287,1176,'Pecking_Flurry',0,7.0,2000,1500,4
 -- INSERT INTO `mob_skill` VALUES (1446,287,1177,'Wisecrack',1,10.0,2000,1500,4,0,0,0);
 
 -- Cheese Hoarder Gigiroon (288) - Qiqirn
--- INSERT INTO `mob_skill` VALUES (1469,288,1200,'Kibosh',0,7,2000,1500,4,0,0,0);
+INSERT INTO `mob_skill` VALUES (1469,288,1200,'Kibosh',0,7,2000,1500,4,0,0,0);
 -- INSERT INTO `mob_skill` VALUES (1470,199,1201,'Cutpurse',4,10,2000,1500,4,0,0,0);
--- INSERT INTO `mob_skill` VALUES (1471,288,1202,'Sandspray',4,7,2000,1500,4,0,0,0);
--- INSERT INTO `mob_skill` VALUES (1472,288,1203,'Faze',0,7,2000,1500,4,0,0,0);
--- INSERT INTO `mob_skill` VALUES (1474,288,1203,'Deadeye',1,18,2000,1500,4,0,0,0);
+INSERT INTO `mob_skill` VALUES (1471,288,1202,'Sandspray',4,7,2000,1500,4,0,0,0);
+INSERT INTO `mob_skill` VALUES (1472,288,1203,'Faze',0,7,2000,1500,4,0,0,0);
+INSERT INTO `mob_skill` VALUES (1474,288,1203,'Deadeye',1,18,2000,1500,4,0,0,0);
 -- INSERT INTO `mob_skill` VALUES (2103,288,1200,'Strap_Cutter',0,7,2000,1500,4,0,0,0);
 
 -- Brass Borer (289)
@@ -2804,7 +2804,7 @@ INSERT INTO `mob_skill` VALUES (1443,287,1176,'Pecking_Flurry',0,7.0,2000,1500,4
 -- Claret (290)
 INSERT INTO `mob_skill` VALUES (176,290,176,'Fluid_Toss',0,18.0,2000,1500,4,0,0,0);
 INSERT INTO `mob_skill` VALUES (175,290,175,'Fluid_Spread',1,10.0,2000,1500,4,0,0,0);
--- INSERT INTO `mob_skill` VALUES (177,290,176,'Digest',0,10.0,2000,1500,4,0,0,0);
+INSERT INTO `mob_skill` VALUES (177,290,176,'Digest',0,10.0,2000,1500,4,0,0,0);
 -- INSERT INTO `mob_skill` VALUES (1061,290,175,'Mucus_Spread',1,10.0,2000,1500,4,0,0,0);
 -- INSERT INTO `mob_skill` VALUES (1063,290,175,'Epoxy_Spread',1,10.0,2000,1500,4,0,0,0);
 


### PR DESCRIPTION
Scripted Faze, Kibosh, and Sandspray for Qiqurn; also scripted and enabled Deadeye with the three aforementioned moves for Cheese Hoarder Gigiroon.
Changed the accuracy down effect on Actinic Burst to Flash. Power modified to suit the change in status.
Fixed Charm mobskills - properly this time.
Enabled Digest on Claret, because it was disabled for some reason. It is supposed to use the move.