### PR TITLE
Scripts: BLU buff spell standardization + fixes

### DIFF
--- a/scripts/globals/spells/bluemagic/amplification.lua
+++ b/scripts/globals/spells/bluemagic/amplification.lua
@@ -31,25 +31,31 @@ end;
 -----------------------------------------
 
 function onSpellCast(caster,target,spell)
-    
+
+    local typeEffectOne = EFFECT_MAGIC_ATK_BOOST
+    local typeEffectTwo = EFFECT_MAGIC_DEF_BOOST
+    local power = 10;
     local duration = 90;
-    
+    local returnEffect = typeEffectOne;
+
     if (caster:hasStatusEffect(EFFECT_DIFFUSION)) then
         local diffMerit = caster:getMerit(MERIT_DIFFUSION);
-        
+
         if (diffMerit > 0) then
             duration = duration + (duration/100)* diffMerit;
-        end
-        
-        caster:delStatusEffect(EFFECT_DIFFUSION);
-    end
-    
-    if (caster:hasStatusEffect(EFFECT_MAGIC_ATK_BOOST) and caster:hasStatusEffect(EFFECT_MAGIC_DEF_BOOST) == true) then
-        spell:setMsg(75);
-    else
-        caster:addStatusEffect(EFFECT_MAGIC_ATK_BOOST,10,0,duration);
-        caster:addStatusEffect(EFFECT_MAGIC_DEF_BOOST,10,0,duration);
-    end
+        end;
 
-    return EFFECT_MAGIC_ATK_BOOST;
+        caster:delStatusEffect(EFFECT_DIFFUSION);
+    end;
+
+    if (target:addStatusEffect(typeEffectOne,power,0,duration) == false and target:addStatusEffect(typeEffectTwo,power,0,duration) == false) then -- both statuses fail to apply
+        spell:setMsg(75);
+    elseif (target:addStatusEffect(typeEffectOne,power,0,duration) == false) then -- the first status fails to apply
+        spell:setMsg(230);
+        returnEffect = typeEffectTwo;
+    else -- either second status or neither status fails
+        spell:setMsg(230);
+    end;
+
+    return returnEffect;
 end;

--- a/scripts/globals/spells/bluemagic/animating_wail.lua
+++ b/scripts/globals/spells/bluemagic/animating_wail.lua
@@ -29,6 +29,8 @@ end;
 
 function onSpellCast(caster,target,spell)
 
+    local typeEffect = EFFECT_HASTE;
+    local power = 153;
     local duration = 300;
 
     if (caster:hasStatusEffect(EFFECT_DIFFUSION)) then
@@ -36,14 +38,14 @@ function onSpellCast(caster,target,spell)
 
         if (diffMerit > 0) then
             duration = duration + (duration/100)* diffMerit;
-        end
+        end;
 
         caster:delStatusEffect(EFFECT_DIFFUSION);
-    end
+    end;
 
-    if (target:addStatusEffect(EFFECT_HASTE,153,0,duration) == false) then
+    if (target:addStatusEffect(typeEffect,power,0,duration) == false) then
         spell:setMsg(75);
-    end
+    end;
 
-    return EFFECT_HASTE;
+    return typeEffect;
 end;

--- a/scripts/globals/spells/bluemagic/battery_charge.lua
+++ b/scripts/globals/spells/bluemagic/battery_charge.lua
@@ -32,16 +32,27 @@ end;
 
 function onSpellCast(caster,target,spell)
 
+    local typeEffect = EFFECT_REFRESH;
+    local power = 3;
+    local duration = 300;
+
+    if (caster:hasStatusEffect(EFFECT_DIFFUSION)) then
+        local diffMerit = caster:getMerit(MERIT_DIFFUSION);
+
+        if (diffMerit > 0) then
+            duration = duration + (duration/100)* diffMerit;
+        end;
+
+        caster:delStatusEffect(EFFECT_DIFFUSION);
+    end;
+
     if (target:hasStatusEffect(EFFECT_REFRESH)) then
         target:delStatusEffect(EFFECT_REFRESH);
     end
 
-    if (target:addStatusEffect(EFFECT_REFRESH,3,3,300)) then
-        spell:setMsg(230);
-    else
-        spell:setMsg(75); -- no effect
-    end
+    if (target:addStatusEffect(typeEffect,power,3,duration) == false) then
+        spell:setMsg(75);
+    end;
 
-    return EFFECT_REFRESH;
-
+    return typeEffect;
 end;

--- a/scripts/globals/spells/bluemagic/cocoon.lua
+++ b/scripts/globals/spells/bluemagic/cocoon.lua
@@ -32,24 +32,23 @@ end;
 
 function onSpellCast(caster,target,spell)
 
+    local typeEffect = EFFECT_DEFENSE_BOOST;
     local power = 50; -- Percentage, not amount.    
     local duration = 90;
 
     if (caster:hasStatusEffect(EFFECT_DIFFUSION)) then
         local diffMerit = caster:getMerit(MERIT_DIFFUSION);
-        
+
         if (diffMerit > 0) then
             duration = duration + (duration/100)* diffMerit;
-        end
-        
-        caster:delStatusEffect(EFFECT_DIFFUSION);
-    end
-    
-    if (target:addStatusEffect(EFFECT_DEFENSE_BOOST,power,0,duration)) then
-        spell:setMsg(230);
-    else
-        spell:setMsg(75);
-    end
+        end;
 
-    return EFFECT_DEFENSE_BOOST;
+        caster:delStatusEffect(EFFECT_DIFFUSION);
+    end;
+    
+    if (target:addStatusEffect(typeEffect,power,0,duration) == false) then
+        spell:setMsg(75);
+    end;
+
+    return typeEffect;
 end;

--- a/scripts/globals/spells/bluemagic/diamondhide.lua
+++ b/scripts/globals/spells/bluemagic/diamondhide.lua
@@ -32,14 +32,14 @@ end;
 
 function onSpellCast(caster,target,spell)
 
+    local typeEffect = EFFECT_STONESKIN;
     local blueskill = caster:getSkillLevel(BLUE_SKILL);
     local power = ((blueskill)/3) *2;
+    local duration = 300;
 
-    if (target:addStatusEffect(EFFECT_STONESKIN,power,0,300)) then
-        spell:setMsg(230);
-    else
+    if (target:addStatusEffect(typeEffect,power,0,duration) == false) then
         spell:setMsg(75);
-    end
+    end;
 
-    return EFFECT_STONESKIN;
+    return typeEffect;
 end;

--- a/scripts/globals/spells/bluemagic/feather_barrier.lua
+++ b/scripts/globals/spells/bluemagic/feather_barrier.lua
@@ -31,24 +31,24 @@ end;
 -----------------------------------------
 
 function onSpellCast(caster,target,spell)
-    
+
+    local typeEffect = EFFECT_EVASION_BOOST;
+    local power = 10;
     local duration = 30;
-    
+
     if (caster:hasStatusEffect(EFFECT_DIFFUSION)) then
         local diffMerit = caster:getMerit(MERIT_DIFFUSION);
-        
+
         if (diffMerit > 0) then
             duration = duration + (duration/100)* diffMerit;
-        end
-        
-        caster:delStatusEffect(EFFECT_DIFFUSION);
-    end
-    
-    if (caster:hasStatusEffect(EFFECT_EVASION_BOOST) == true) then
-        spell:setMsg(75);
-    else
-        caster:addStatusEffect(EFFECT_EVASION_BOOST,10,0,duration);
-    end
+        end;
 
-    return EFFECT_EVASION_BOOST;
+        caster:delStatusEffect(EFFECT_DIFFUSION);
+    end;
+
+    if (target:addStatusEffect(typeEffect,power,0,duration) == false) then
+        spell:setMsg(75);
+    end;
+
+    return typeEffect;
 end;

--- a/scripts/globals/spells/bluemagic/memento_mori.lua
+++ b/scripts/globals/spells/bluemagic/memento_mori.lua
@@ -30,24 +30,24 @@ end;
 -----------------------------------------
 
 function onSpellCast(caster,target,spell)
-    
+
+    local typeEffect = EFFECT_MAGIC_ATK_BOOST;
+    local power = 20;
     local duration = 30;
-    
+
     if (caster:hasStatusEffect(EFFECT_DIFFUSION)) then
         local diffMerit = caster:getMerit(MERIT_DIFFUSION);
-        
+
         if (diffMerit > 0) then
             duration = duration + (duration/100)* diffMerit;
-        end
-        
-        caster:delStatusEffect(EFFECT_DIFFUSION);
-    end
-    
-    if (caster:hasStatusEffect(EFFECT_MAGIC_ATK_BOOST) == true) then
-        spell:setMsg(75);
-    else
-        caster:addStatusEffect(EFFECT_MAGIC_ATK_BOOST,20,0,duration);
-    end
+        end;
 
-    return EFFECT_MAGIC_ATK_BOOST;
+        caster:delStatusEffect(EFFECT_DIFFUSION);
+    end;
+
+    if (target:addStatusEffect(typeEffect,power,0,duration) == false) then
+        spell:setMsg(75);
+    end;
+
+    return typeEffect;
 end;

--- a/scripts/globals/spells/bluemagic/metallic_body.lua
+++ b/scripts/globals/spells/bluemagic/metallic_body.lua
@@ -32,29 +32,28 @@ end;
 
 function onSpellCast(caster,target,spell)
 
+    local typeEffect = EFFECT_STONESKIN
     local blueskill = caster:getSkillLevel(BLUE_SKILL);
     local power = (blueskill/3) + (caster:getMainLvl()/3) + 10;
     local duration = 300;
 
     if (power > 150) then
         power = 150;
-    end
-        
+    end;
+
     if (caster:hasStatusEffect(EFFECT_DIFFUSION)) then
         local diffMerit = caster:getMerit(MERIT_DIFFUSION);
-        
+
         if (diffMerit > 0) then
             duration = duration + (duration/100)* diffMerit;
-        end
-        
-        caster:delStatusEffect(EFFECT_DIFFUSION);
-    end
-    
-    if (target:addStatusEffect(EFFECT_STONESKIN,power,0,duration)) then
-        spell:setMsg(230);
-    else
-        spell:setMsg(75);
-    end
+        end;
 
-    return EFFECT_STONESKIN;
+        caster:delStatusEffect(EFFECT_DIFFUSION);
+    end;
+    
+    if (target:addStatusEffect(typeEffect,power,0,duration) == false) then
+        spell:setMsg(75);
+    end;
+
+    return typeEffect;
 end;

--- a/scripts/globals/spells/bluemagic/occultation.lua
+++ b/scripts/globals/spells/bluemagic/occultation.lua
@@ -27,32 +27,31 @@ end;-----------------------------------------
 
 function onSpellCast(caster,target,spell)
 
+    local typeEffect = EFFECT_BLINK;
     local skill = caster:getSkillLevel(BLUE_SKILL);
-    local shadows = 2;
+    local power = (skill / 50);
     local duration = 300;
 
     -- 400 skill = 8 shadows, 450 = 9 shadows, so I am assuming every 50 skill is a shadow.
     -- Also assuming minimum of 2 shadows.
     -- I've never seen the spell cast with under 100 skill, so I could be wrong.
-    if (skill > 100) then
-        shadows = (skill / 50);
-    end
+    if (skill < 100) then
+        power = 2;
+    end;
 
     if (caster:hasStatusEffect(EFFECT_DIFFUSION)) then
         local diffMerit = caster:getMerit(MERIT_DIFFUSION);
 
         if (diffMerit > 0) then
             duration = duration + (duration/100)* diffMerit;
-        end
+        end;
 
         caster:delStatusEffect(EFFECT_DIFFUSION);
-    end
+    end;
 
-    if (target:addStatusEffect(EFFECT_BLINK, shadows, 0, duration)) then
-        spell:setMsg(230);
-    else
+    if (target:addStatusEffect(typeEffect,power,0,duration) == false) then
         spell:setMsg(75);
-    end
+    end;
 
-    return EFFECT_BLINK;
+    return typeEffect;
 end;

--- a/scripts/globals/spells/bluemagic/plasma_charge.lua
+++ b/scripts/globals/spells/bluemagic/plasma_charge.lua
@@ -31,22 +31,24 @@ end;
 -----------------------------------------
 
 function onSpellCast(caster,target,spell)
-    
-    local duration = 50;
+
     local typeEffect = EFFECT_SHOCK_SPIKES;
+    local power = 5;
+    local duration = 60;
 
     if (caster:hasStatusEffect(EFFECT_DIFFUSION)) then
         local diffMerit = caster:getMerit(MERIT_DIFFUSION);
 
         if (diffMerit > 0) then
             duration = duration + (duration/100)* diffMerit;
-        end
-        
-        caster:delStatusEffect(EFFECT_DIFFUSION);
-    end
+        end;
 
-        caster:addStatusEffect(typeEffect,5,0,duration);
-        spell:setMsg(230);
+        caster:delStatusEffect(EFFECT_DIFFUSION);
+    end;
+
+    if (target:addStatusEffect(typeEffect,power,0,duration) == false) then
+        spell:setMsg(75);
+    end;
 
     return typeEffect;
 end;

--- a/scripts/globals/spells/bluemagic/reactor_cool.lua
+++ b/scripts/globals/spells/bluemagic/reactor_cool.lua
@@ -31,26 +31,32 @@ end;
 -----------------------------------------
 
 function onSpellCast(caster,target,spell)
-        
+
+    local typeEffectOne = EFFECT_ICE_SPIKES
+    local typeEffectTwo = EFFECT_DEFENSE_BOOST
+    local powerOne = 5;
+    local powerTwo = 12
     local duration = 120;
-    
+    local returnEffect = typeEffectOne;
+
     if (caster:hasStatusEffect(EFFECT_DIFFUSION)) then
         local diffMerit = caster:getMerit(MERIT_DIFFUSION);
-        
+
         if (diffMerit > 0) then
             duration = duration + (duration/100)* diffMerit;
-        end
-        
-        caster:delStatusEffect(EFFECT_DIFFUSION);
-    end
-    
-    if (caster:hasStatusEffect(EFFECT_DEFENSE_BOOST) and caster:hasStatusEffect(EFFECT_ICE_SPIKES) == true) then
-        spell:setMsg(75);
-    else
-        caster:addStatusEffect(EFFECT_DEFENSE_BOOST,12,0,duration);
-        caster:addStatusEffect(EFFECT_ICE_SPIKES,5,0,duration);
-        spell:setMsg(230);
-    end
+        end;
 
-    return EFFECT_ICE_SPIKES;
+        caster:delStatusEffect(EFFECT_DIFFUSION);
+    end;
+
+    if (target:addStatusEffect(typeEffectOne,powerOne,0,duration) == false and target:addStatusEffect(typeEffectTwo,powerTwo,0,duration) == false) then
+        spell:setMsg(75);
+    elseif (target:addStatusEffect(typeEffectOne,powerOne,0,duration) == false) then
+        spell:setMsg(230);
+        returnEffect = typeEffectTwo;
+    else
+        spell:setMsg(230);
+    end;
+
+    return returnEffect;
 end;

--- a/scripts/globals/spells/bluemagic/refueling.lua
+++ b/scripts/globals/spells/bluemagic/refueling.lua
@@ -30,21 +30,23 @@ end;
 
 function onSpellCast(caster,target,spell)
 
+    local typeEffect = EFFECT_HASTE;
+    local power = 102;
     local duration = 300;
-    
+
     if (caster:hasStatusEffect(EFFECT_DIFFUSION)) then
         local diffMerit = caster:getMerit(MERIT_DIFFUSION);
-        
+
         if (diffMerit > 0) then
             duration = duration + (duration/100)* diffMerit;
-        end
-        
-        caster:delStatusEffect(EFFECT_DIFFUSION);
-    end
-    
-    if (target:addStatusEffect(EFFECT_HASTE,102,0,duration) == false) then
-        spell:setMsg(75);
-    end
+        end;
 
-    return EFFECT_HASTE;
+        caster:delStatusEffect(EFFECT_DIFFUSION);
+    end;
+    
+    if (target:addStatusEffect(typeEffect,power,0,duration) == false) then
+        spell:setMsg(75);
+    end;
+
+    return typeEffect;
 end;

--- a/scripts/globals/spells/bluemagic/regeneration.lua
+++ b/scripts/globals/spells/bluemagic/regeneration.lua
@@ -32,15 +32,27 @@ end;
 
 function onSpellCast(caster,target,spell)
 
+    local typeEffect = EFFECT_REGEN;
+    local power = 25;
+    local duration = 90;
+
+    if (caster:hasStatusEffect(EFFECT_DIFFUSION)) then
+        local diffMerit = caster:getMerit(MERIT_DIFFUSION);
+
+        if (diffMerit > 0) then
+            duration = duration + (duration/100)* diffMerit;
+        end;
+
+        caster:delStatusEffect(EFFECT_DIFFUSION);
+    end;
+
     if (target:hasStatusEffect(EFFECT_REGEN) and target:getStatusEffect(EFFECT_REGEN):getTier() == 1) then
         target:delStatusEffect(EFFECT_REGEN);
     end
 
-    if (target:addStatusEffect(EFFECT_REGEN,10,3,90,0,0,0)) then
-        spell:setMsg(230);
-    else
-        spell:setMsg(75); -- no effect
-    end
+    if (target:addStatusEffect(typeEffect,power,3,duration,0,0,0) == false) then
+        spell:setMsg(75);
+    end;
 
-    return EFFECT_REGEN;
+    return typeEffect;
 end;

--- a/scripts/globals/spells/bluemagic/saline_coat.lua
+++ b/scripts/globals/spells/bluemagic/saline_coat.lua
@@ -32,23 +32,23 @@ end;
 
 function onSpellCast(caster,target,spell)
 
+    local typeEffect = EFFECT_MAGIC_DEF_BOOST;
+    local power = 40;
     local duration = 60;
-    
+
     if (caster:hasStatusEffect(EFFECT_DIFFUSION)) then
         local diffMerit = caster:getMerit(MERIT_DIFFUSION);
-        
+
         if (diffMerit > 0) then
             duration = duration + (duration/100)* diffMerit;
-        end
-        
-        caster:delStatusEffect(EFFECT_DIFFUSION);
-    end
-    
-    if (caster:hasStatusEffect(EFFECT_MAGIC_DEF_BOOST) == true) then
-        spell:setMsg(75);
-    else
-        caster:addStatusEffect(EFFECT_MAGIC_DEF_BOOST,40,0,duration);
-    end
+        end;
 
-    return EFFECT_MAGIC_DEF_BOOST;
+        caster:delStatusEffect(EFFECT_DIFFUSION);
+    end;
+
+    if (target:addStatusEffect(typeEffect,power,0,duration) == false) then
+        spell:setMsg(75);
+    end;
+
+    return typeEffect;
 end;

--- a/scripts/globals/spells/bluemagic/triumphant_roar.lua
+++ b/scripts/globals/spells/bluemagic/triumphant_roar.lua
@@ -31,26 +31,23 @@ end;
 
 function onSpellCast(caster,target,spell)
 
+    local typeEffect = EFFECT_ATTACK_BOOST
     local power = 15    
     local duration = 90;
-    
+
     if (caster:hasStatusEffect(EFFECT_DIFFUSION)) then
         local diffMerit = caster:getMerit(MERIT_DIFFUSION);
-        
+
         if (diffMerit > 0) then
             duration = duration + (duration/100)* diffMerit;
-        end
-        
+        end;
+
         caster:delStatusEffect(EFFECT_DIFFUSION);
-    end
-    
-    if (caster:hasStatusEffect(EFFECT_ATTACK_BOOST) == true) then
-        local effect = caster:getStatusEffect(EFFECT_ATTACK_BOOST);
-        effect:setPower(effect:getPower() + power);
-        caster:addMod(MOD_ATTP,power);
-    else
-        caster:addStatusEffect(EFFECT_ATTACK_BOOST,power,1,duration);
-    end
-    
-    return EFFECT_ATTACK_BOOST;
+    end;
+
+    if (target:addStatusEffect(typeEffect,power,1,duration) == false) then
+        spell:setMsg(75);
+    end;
+
+    return typeEffect;
 end;

--- a/scripts/globals/spells/bluemagic/warm-up.lua
+++ b/scripts/globals/spells/bluemagic/warm-up.lua
@@ -32,24 +32,30 @@ end;
 
 function onSpellCast(caster,target,spell)
 
+    local typeEffectOne = EFFECT_ACCURACY_BOOST
+    local typeEffectTwo = EFFECT_EVASION_BOOST
+    local power = 10;
     local duration = 180;
-    
+    local returnEffect = typeEffectOne;
+
     if (caster:hasStatusEffect(EFFECT_DIFFUSION)) then
         local diffMerit = caster:getMerit(MERIT_DIFFUSION);
-        
+
         if (diffMerit > 0) then
             duration = duration + (duration/100)* diffMerit;
-        end
-        
-        caster:delStatusEffect(EFFECT_DIFFUSION);
-    end
-    
-    if (caster:hasStatusEffect(EFFECT_ACCURACY_BOOST) and caster:hasStatusEffect(EFFECT_EVASION_BOOST) == true) then
-        spell:setMsg(75);
-    else
-        caster:addStatusEffect(EFFECT_EVASION_BOOST,10,0,duration);
-        caster:addStatusEffect(EFFECT_ACCURACY_BOOST,10,0,duration);
-    end
+        end;
 
-    return EFFECT_EVASION_BOOST;
+        caster:delStatusEffect(EFFECT_DIFFUSION);
+    end;
+
+    if (target:addStatusEffect(typeEffectOne,power,0,duration) == false and target:addStatusEffect(typeEffectTwo,power,0,duration) == false) then
+        spell:setMsg(75);
+    elseif (target:addStatusEffect(typeEffectOne,power,0,duration) == false) then
+        spell:setMsg(230);
+        returnEffect = typeEffectTwo;
+    else
+        spell:setMsg(230);
+    end;
+
+    return returnEffect;
 end;

--- a/scripts/globals/spells/bluemagic/zephyr_mantle.lua
+++ b/scripts/globals/spells/bluemagic/zephyr_mantle.lua
@@ -30,23 +30,23 @@ end;
 
 function onSpellCast(caster,target,spell)
 
+    local typeEffect = EFFECT_BLINK;
+    local power = 4;
     local duration = 300;
     
     if (caster:hasStatusEffect(EFFECT_DIFFUSION)) then
         local diffMerit = caster:getMerit(MERIT_DIFFUSION);
-        
+
         if (diffMerit > 0) then
             duration = duration + (duration/100)* diffMerit;
-        end
-        
-        caster:delStatusEffect(EFFECT_DIFFUSION);
-    end
-    
-    if (target:addStatusEffect(EFFECT_BLINK, 4, 0, duration)) then
-        spell:setMsg(230);
-    else
-        spell:setMsg(75);
-    end
+        end;
 
-    return EFFECT_BLINK;
+        caster:delStatusEffect(EFFECT_DIFFUSION);
+    end;
+    
+    if (target:addStatusEffect(typeEffect,power,0,duration) == false) then
+        spell:setMsg(75);
+    end;
+
+    return typeEffect;
 end;


### PR DESCRIPTION
Many buff spells were applying the buff to the caster. This prevented others from receiving the buff via Diffusion. Now all spells apply the buff to the target.
Adjusted the power of Regeneration, and added the Diffusion check. https://www.bg-wiki.com/bg/Regeneration
Removed the stacking from Triumphant Roar. It's not Boost.
Corrected the duration of Plasma Charge (50 seconds -> 60 seconds)