### PR TITLE
Scripts/SQL: Gargouille TP moves

### DIFF
--- a/scripts/globals/mobskills/Bloody_claw.lua
+++ b/scripts/globals/mobskills/Bloody_claw.lua
@@ -1,0 +1,36 @@
+---------------------------------------------
+--  Terror Eye
+--  Family: Gargouille
+--  Description: Steals an enemy's HP. Additional effect: Reduces a random stat.
+--  Type: Physical
+--  Utsusemi/Blink absorb: Ignores shadows 
+--  Range: Melee
+--  Notes: Despite the attack ignoring Utsusemi, it is physical, and therefore capable of missing entirely. 
+---------------------------------------------
+require("scripts/globals/settings");
+require("scripts/globals/status");
+require("scripts/globals/monstertpmoves");
+---------------------------------------------
+
+function onMobSkillCheck(target,mob,skill)
+    return 0;
+end;
+
+function onMobWeaponSkill(target, mob, skill)
+
+    local numhits = 3;
+    local accmod = 1;
+    local dmgmod = 0.9;
+    local typeEffect = 136 + math.random(0,6); -- 136 is EFFECT_STR_DOWN; add 0 to 6 for all 7 of the possible attribute reductions
+
+    local info = MobPhysicalMove(mob,target,skill,numhits,accmod,dmgmod,TP_NO_EFFECT);
+    local dmg = MobFinalAdjustments(info.dmg,mob,skill,target,MOBSKILL_PHYSICAL,MOBPARAM_SLASH,MOBPARAM_IGNORE_SHADOWS);
+    target:delHP(dmg);
+    if (target:isUndead() == false) then
+        mob:addHP(dmg);
+    end
+
+    MobPhysicalStatusEffectMove(mob, target, skill, typeEffect, 20, 3, 120);
+
+    return dmg;
+end;

--- a/scripts/globals/mobskills/Dark_mist.lua
+++ b/scripts/globals/mobskills/Dark_mist.lua
@@ -1,0 +1,34 @@
+---------------------------------------------
+--  Dark Mist
+--  Family: Gargouille
+--  Description: Deals dark damage to an enemy. Additional effect: Weight
+--  Type: Magical (dark)
+--  Utsusemi/Blink absorb: Ignores shadows 
+--  Range: Radial
+--  Notes: Only used when flying
+---------------------------------------------
+require("scripts/globals/settings");
+require("scripts/globals/status");
+require("scripts/globals/monstertpmoves");
+---------------------------------------------
+
+function onMobSkillCheck(target,mob,skill)
+    if (mob:AnimationSub() ~=1) then
+        return 1;
+    else
+        return 0;
+    end
+end;
+
+function onMobWeaponSkill(target, mob, skill)
+    local numhits = 1;
+    local dmgmod = 1;
+    local typeEffect = EFFECT_WEIGHT;
+
+    local info = MobMagicalMove(mob,target,skill,mob:getWeaponDmg()*4.0,ELE_DARK,dmgmod,TP_MAB_BONUS);
+    local dmg = MobFinalAdjustments(info.dmg,mob,skill,target,MOBSKILL_MAGICAL,MOBPARAM_DARK,MOBPARAM_IGNORE_SHADOWS);
+    target:delHP(dmg);
+    MobStatusEffectMove(mob, target, typeEffect, 50, 0, 60);
+
+    return dmg;
+end;

--- a/scripts/globals/mobskills/Dark_orb.lua
+++ b/scripts/globals/mobskills/Dark_orb.lua
@@ -1,0 +1,31 @@
+---------------------------------------------
+--  Dark Orb
+--  Family: Gargouille
+--  Description: Deals dark damage to an enemy.
+--  Type: Magical (dark)
+--  Utsusemi/Blink absorb: Ignores shadows 
+--  Range: Radial
+--  Notes: Only used when flying
+---------------------------------------------
+require("scripts/globals/settings");
+require("scripts/globals/status");
+require("scripts/globals/monstertpmoves");
+---------------------------------------------
+
+function onMobSkillCheck(target,mob,skill)
+    if (mob:AnimationSub() ~=1) then
+        return 1;
+    else
+        return 0;
+    end
+end;
+
+function onMobWeaponSkill(target, mob, skill)
+    local numhits = 1;
+    local dmgmod = 1;
+    local info = MobMagicalMove(mob,target,skill,mob:getWeaponDmg()*5.5,ELE_DARK,dmgmod,TP_MAB_BONUS);
+    local dmg = MobFinalAdjustments(info.dmg,mob,skill,target,MOBSKILL_MAGICAL,MOBPARAM_DARK,MOBPARAM_IGNORE_SHADOWS);
+
+    target:delHP(dmg);
+    return dmg;
+end;

--- a/scripts/globals/mobskills/Terror_eye.lua
+++ b/scripts/globals/mobskills/Terror_eye.lua
@@ -1,0 +1,30 @@
+---------------------------------------------
+--  Terror Eye
+--  Family: Gargouille
+--  Description: Bestows a terrifying glance.
+--  Type: Enfeebling
+--  Utsusemi/Blink absorb: Ignores shadows 
+--  Range: Cone gaze
+--  Notes: Only used when standing
+---------------------------------------------
+require("scripts/globals/settings");
+require("scripts/globals/status");
+require("scripts/globals/monstertpmoves");
+---------------------------------------------
+
+function onMobSkillCheck(target,mob,skill)
+    if (mob:AnimationSub() ~=0) then
+        return 1;
+    else
+        return 0;
+    end
+end;
+
+function onMobWeaponSkill(target, mob, skill)
+    local typeEffect = EFFECT_TERROR;
+    local duration = 30;
+
+    skill:setMsg(MobGazeMove(mob, target, typeEffect, 1, 0, duration));
+
+    return typeEffect;
+end;

--- a/scripts/globals/mobskills/Triumphant_roar.lua
+++ b/scripts/globals/mobskills/Triumphant_roar.lua
@@ -1,0 +1,31 @@
+---------------------------------------------
+--  Triumphant Roar
+--  Family: Gargouille
+--  Description: Enhances Attack.
+--  Type: Enhancing
+--  Utsusemi/Blink absorb: N/A
+--  Range: Self
+--  Notes: Only used when standing
+-----------------------------------------------
+require("scripts/globals/settings");
+require("scripts/globals/status");
+require("scripts/globals/monstertpmoves");
+---------------------------------------------
+
+function onMobSkillCheck(target,mob,skill)
+    if (mob:AnimationSub() ~=0) then
+        return 1;
+    else
+        return 0;
+    end
+end;
+
+function onMobWeaponSkill(target, mob, skill)
+    local power = 15;
+    local duration = 90;
+    local typeEffect = EFFECT_ATTACK_BOOST;
+
+    skill:setMsg(MobBuffMove(mob, typeEffect, power, 0, duration));
+
+    return typeEffect;
+end;

--- a/sql/mob_skill.sql
+++ b/sql/mob_skill.sql
@@ -3274,11 +3274,11 @@ INSERT INTO `mob_skill` VALUES (2183,211,1701,'Hydro_Wave',1,18.0,2000,1000,4,0,
 -- INSERT INTO `mob_skill` VALUES (2185,?,1703,'Aqua_Cannon',1,18.0,2000,1000,4,0,0,0); -- Exclusive to Scylla? Replaces Aqua Blast
 
 -- Gargouilles
-INSERT INTO `mob_skill` VALUES (2165,117,1682,'Dark_orb',1,15.0,2000,1000,4,0,0,0); -- Flying only.
-INSERT INTO `mob_skill` VALUES (2166,117,1678,'Dark_mist',1,14.0,2000,1000,4,0,0,0); -- Flying Only.
-INSERT INTO `mob_skill` VALUES (2167,117,1680,'Triumphant_roar',0,7.0,2000,1000,1,0,0,0); -- Standing Only.
-INSERT INTO `mob_skill` VALUES (2168,117,1681,'Terror_eye',4,10.0,2000,1000,4,0,0,0); -- Standing Only.
-INSERT INTO `mob_skill` VALUES (2169,117,1679,'Bloody_claw',0,7.0,2000,1000,4,0,0,0);
+INSERT INTO `mob_skill` VALUES (2165,118,1682,'Dark_orb',1,15.0,2000,1000,4,0,0,0); -- Flying only.
+INSERT INTO `mob_skill` VALUES (2166,118,1678,'Dark_mist',1,14.0,2000,1000,4,0,0,0); -- Flying Only.
+INSERT INTO `mob_skill` VALUES (2167,118,1680,'Triumphant_roar',0,7.0,2000,1000,1,0,0,0); -- Standing Only.
+INSERT INTO `mob_skill` VALUES (2168,118,1681,'Terror_eye',4,10.0,2000,1000,4,0,0,0); -- Standing Only.
+INSERT INTO `mob_skill` VALUES (2169,118,1679,'Bloody_claw',0,7.0,2000,1000,4,0,0,0);
 
 -- INSERT INTO `mob_skill` VALUES (2170,?,1683,'Shadow_burst',1,15.0,2000,1000,4,0,0,0); -- Certain NM only
 


### PR DESCRIPTION
Added all five TP moves. Note that since they don't have form changing scripted (I don't know the conditions for that), Dark Mist and Dark Orb will end up not being used by them under normal circumstances.

Changed the family in mob_skill.sql from 117 to 118 because that's what all of the Gargouille in mob_pools.sql are set to, and nothing appears to be set to family 117.