### PR TITLE
Core/SQL: Jailer weapon additional swings

### DIFF
--- a/scripts/globals/gear_sets.lua
+++ b/scripts/globals/gear_sets.lua
@@ -81,6 +81,13 @@ local GearSets =  {
              
              {id = 53, items = {16006,18450,18499,18861,18862,18952,19111,19217,19272}, matches = 2, matchType = matchtype.earring_weapon, mods = {{MOD_EVA, 10, 0, 0}, {MOD_HPHEAL, 10, 0, 0}, {MOD_ENMITY, -5, 0, 0}} }, --  Brilliant Earring Set. Set Bonus: Evasion, HP Recovered while healing, Reduces Emnity. Active with any 2 items(Earring+Weapon)
              {id = 56, items = {11798,11362}, matches = 2, matchType = matchtype.any, mods = {{MOD_RERAISE_III, 1, 0, 0}} },        -- Twilight Mail Set. Set Bonus: Auto-Reraise
+             {id = 57, items = {18244,17595}, matches = 2, matchType = matchtype.any, mods = {{MOD_AMMO_SWING, 50, 0, 0}} },        -- Begin Jailer weapons: Set is weapon + Virtue stone, bonus 50% extra melee swing.
+             {id = 58, items = {18244,17710}, matches = 2, matchType = matchtype.any, mods = {{MOD_AMMO_SWING, 50, 0, 0}} },
+             {id = 59, items = {18244,17948}, matches = 2, matchType = matchtype.any, mods = {{MOD_AMMO_SWING, 50, 0, 0}} },
+             {id = 60, items = {18244,18100}, matches = 2, matchType = matchtype.any, mods = {{MOD_AMMO_SWING, 50, 0, 0}} },
+             {id = 61, items = {18244,18222}, matches = 2, matchType = matchtype.any, mods = {{MOD_AMMO_SWING, 50, 0, 0}} },
+             {id = 62, items = {18244,18360}, matches = 2, matchType = matchtype.any, mods = {{MOD_AMMO_SWING, 50, 0, 0}} },
+             {id = 63, items = {18244,18397}, matches = 2, matchType = matchtype.any, mods = {{MOD_AMMO_SWING, 50, 0, 0}} },        -- End Jailer weapons
         }
              -- increment id by (number of mods in previous gearset - 1)
 

--- a/scripts/globals/status.lua
+++ b/scripts/globals/status.lua
@@ -1230,6 +1230,7 @@ MOD_SHARPSHOT       = 0x13A -- Sharpshot accuracy bonus (modId = 314)
 MOD_ENH_DRAIN_ASPIR = 0x13B -- % damage boost to Drain and Aspir(modId = 315)
 MOD_TRICK_ATK_AGI   = 0x208 -- % AGI boost to Trick Attack (if gear mod, needs to be equipped on hit) (modId = 520)
 MOD_NIN_NUKE_BONUS  = 0x20A -- magic attack bonus for NIN nukes (modId = 522)
+MOD_AMMO_SWING      = 0x20B -- Extra swing rate w/ ammo (ie. Jailer weapons). Use gearsets, and does nothing for non-players. (modId = 523)
 
 -- Mythic Weapon Mods
 MOD_AUGMENTS_ABSORB    = 0x209  -- Direct Absorb spell increase while Liberator is equipped (percentage based) (modId = 521)
@@ -1237,8 +1238,8 @@ MOD_AUGMENTS_ABSORB    = 0x209  -- Direct Absorb spell increase while Liberator 
 -- The entire mod list is in desperate need of kind of some organizing.
 -- The spares take care of finding the next ID to use so long as we don't forget to list IDs that have been freed up by refactoring.
 
--- MOD_SPARE = 0x20B -- (modId = 523)
 -- MOD_SPARE = 0x20C -- (modId = 524)
+-- MOD_SPARE = 0x20D -- (modId = 525)
 
 ------------------------------------
 -- Merit Definitions

--- a/sql/item_armor.sql
+++ b/sql/item_armor.sql
@@ -7425,7 +7425,7 @@ INSERT INTO `item_armor` VALUES (17706,'vulcan_blade',47,0,36257,263,0,0,3,0);
 INSERT INTO `item_armor` VALUES (17707,'martial_anelace',72,0,2195665,274,0,0,3,0);
 INSERT INTO `item_armor` VALUES (17708,'auriga_xiphos',19,0,209,264,0,0,3,0);
 INSERT INTO `item_armor` VALUES (17709,'swan_bilbo',60,0,512,181,0,0,3,0);
-INSERT INTO `item_armor` VALUES (17710,'justice_sword',73,0,112,249,0,0,3,0);
+INSERT INTO `item_armor` VALUES (17710,'justice_sword',73,0,112,254,0,0,3,0);
 INSERT INTO `item_armor` VALUES (17711,'shivas_shotel',72,0,43233,358,0,0,3,0);
 INSERT INTO `item_armor` VALUES (17712,'kaskara_+1',71,0,2097345,278,0,0,3,0);
 INSERT INTO `item_armor` VALUES (17713,'macuahuitl',65,0,2195665,381,0,0,3,0);

--- a/src/map/attackround.cpp
+++ b/src/map/attackround.cpp
@@ -22,6 +22,7 @@
 */
 
 #include "attackround.h"
+#include "packets/inventory_finish.h"
 
 
 /************************************************************************
@@ -31,9 +32,9 @@
 ************************************************************************/
 CAttackRound::CAttackRound(CBattleEntity* attacker)
 {
-	m_attacker = attacker;
-	m_kickAttackOccured = false;
-	m_sataOccured = false;
+    m_attacker = attacker;
+    m_kickAttackOccured = false;
+    m_sataOccured = false;
     m_subWeaponType = 0;
 
     if (attacker->m_Weapons[SLOT_SUB]->isType(ITEM_WEAPON))
@@ -41,35 +42,35 @@ CAttackRound::CAttackRound(CBattleEntity* attacker)
         m_subWeaponType = attacker->m_Weapons[SLOT_SUB]->getDmgType();
     }
 
-	// Grab a trick attack assistant.
-	m_taEntity = battleutils::getAvailableTrickAttackChar(attacker, attacker->PBattleAI->GetBattleTarget());
+    // Grab a trick attack assistant.
+    m_taEntity = battleutils::getAvailableTrickAttackChar(attacker, attacker->PBattleAI->GetBattleTarget());
 
-	// Build main weapon attacks.
-	CreateAttacks(attacker->m_Weapons[SLOT_MAIN], RIGHTATTACK);
+    // Build main weapon attacks.
+    CreateAttacks(attacker->m_Weapons[SLOT_MAIN], RIGHTATTACK);
 
-	// Build dual wield off hand weapon attacks.
-	if ((m_subWeaponType > 0 && m_subWeaponType < 4))
-	{
-		CreateAttacks(attacker->m_Weapons[SLOT_SUB], LEFTATTACK);
-	}
+    // Build dual wield off hand weapon attacks.
+    if ((m_subWeaponType > 0 && m_subWeaponType < 4))
+    {
+        CreateAttacks(attacker->m_Weapons[SLOT_SUB], LEFTATTACK);
+    }
 
-	if (IsH2H())
-	{
-		// Build left hand H2H attacks.
-		CreateAttacks(attacker->m_Weapons[SLOT_MAIN], LEFTATTACK);
+    if (IsH2H())
+    {
+        // Build left hand H2H attacks.
+        CreateAttacks(attacker->m_Weapons[SLOT_MAIN], LEFTATTACK);
 
-		// Build kick attacks.
-		CreateKickAttacks();
-	}
+        // Build kick attacks.
+        CreateKickAttacks();
+    }
 
-	// Set the first attack flag
-	m_attackSwings[0].SetAsFirstSwing();
+    // Set the first attack flag
+    m_attackSwings[0].SetAsFirstSwing();
 
-	// Delete the haste samba effect.
+    // Delete the haste samba effect.
     attacker->StatusEffectContainer->DelStatusEffect(EFFECT_HASTE_SAMBA_HASTE);
 
-	// Clear the action list.
-	attacker->m_ActionList.clear();
+    // Clear the action list.
+    attacker->m_ActionList.clear();
 }
 
 /************************************************************************
@@ -89,7 +90,7 @@ CAttackRound::~CAttackRound()
 ************************************************************************/
 uint8 CAttackRound::GetAttackSwingCount()
 {
-	return m_attackSwings.size();
+    return m_attackSwings.size();
 }
 
 /************************************************************************
@@ -99,7 +100,7 @@ uint8 CAttackRound::GetAttackSwingCount()
 ************************************************************************/
 CAttack CAttackRound::GetAttack(uint8 index)
 {
-	return m_attackSwings[index];
+    return m_attackSwings[index];
 }
 
 /************************************************************************
@@ -109,7 +110,7 @@ CAttack CAttackRound::GetAttack(uint8 index)
 ************************************************************************/
 CAttack CAttackRound::GetCurrentAttack()
 {
-	return m_attackSwings[0];
+    return m_attackSwings[0];
 }
 
 /************************************************************************
@@ -119,7 +120,7 @@ CAttack CAttackRound::GetCurrentAttack()
 ************************************************************************/
 void CAttackRound::SetSATA(bool value)
 {
-	m_sataOccured = value; 
+    m_sataOccured = value; 
 }
 
 /************************************************************************
@@ -129,7 +130,7 @@ void CAttackRound::SetSATA(bool value)
 ************************************************************************/
 bool CAttackRound::GetSATAOccured()
 {
-	return m_sataOccured; 
+    return m_sataOccured; 
 }
 
 /************************************************************************
@@ -139,7 +140,7 @@ bool CAttackRound::GetSATAOccured()
 ************************************************************************/
 CBattleEntity*	CAttackRound::GetTAEntity()
 {
-	return m_taEntity;
+    return m_taEntity;
 }
 
 /************************************************************************
@@ -149,7 +150,7 @@ CBattleEntity*	CAttackRound::GetTAEntity()
 ************************************************************************/
 bool CAttackRound::IsH2H()
 {
-	return m_attacker->m_Weapons[SLOT_MAIN]->getDmgType() == DAMAGE_HTH ? true : false;
+    return m_attacker->m_Weapons[SLOT_MAIN]->getDmgType() == DAMAGE_HTH ? true : false;
 }
 
 /************************************************************************
@@ -159,19 +160,19 @@ bool CAttackRound::IsH2H()
 ************************************************************************/
 void CAttackRound::AddAttackSwing(PHYSICAL_ATTACK_TYPE type, PHYSICAL_ATTACK_DIRECTION direction, uint8 count)
 {
-	if (m_attackSwings.size() < MAX_ATTACKS)
-	{
-		for (uint8 i = 0; i < count; ++i)
-		{
-			CAttack attack(m_attacker, type, direction, this);
-			m_attackSwings.push_back(attack);
+    if (m_attackSwings.size() < MAX_ATTACKS)
+    {
+        for (uint8 i = 0; i < count; ++i)
+        {
+            CAttack attack(m_attacker, type, direction, this);
+            m_attackSwings.push_back(attack);
 
-			if (m_attackSwings.size() == MAX_ATTACKS)
-			{
-				return;
-			}
-		}
-	}
+            if (m_attackSwings.size() == MAX_ATTACKS)
+            {
+                return;
+            }
+        }
+    }
 }
 
 /************************************************************************
@@ -181,7 +182,7 @@ void CAttackRound::AddAttackSwing(PHYSICAL_ATTACK_TYPE type, PHYSICAL_ATTACK_DIR
 ************************************************************************/
 void CAttackRound::DeleteAttackSwing()
 {
-	m_attackSwings.erase(m_attackSwings.begin());
+    m_attackSwings.erase(m_attackSwings.begin());
 }
 
 /************************************************************************
@@ -193,54 +194,77 @@ void CAttackRound::CreateAttacks(CItemWeapon* PWeapon, PHYSICAL_ATTACK_DIRECTION
 {
     uint8 num = 1;
 
-	// Checking the players weapon hit count
+    // Checking the players weapon hit count
     if (PWeapon->getReqLvl() <= m_attacker->GetMLevel())
     {
         num = PWeapon->getHitCount();
     }
 
-	AddAttackSwing(ATTACK_NORMAL, direction, num);
+    AddAttackSwing(ATTACK_NORMAL, direction, num);
 
-	// Checking the players triple, double and quadruple attack
-	int16 tripleAttack = m_attacker->getMod(MOD_TRIPLE_ATTACK);
-	int16 doubleAttack = m_attacker->getMod(MOD_DOUBLE_ATTACK);
-	int16 quadAttack = m_attacker->getMod(MOD_QUAD_ATTACK);
+    // Checking the players triple, double and quadruple attack
+    int16 tripleAttack = m_attacker->getMod(MOD_TRIPLE_ATTACK);
+    int16 doubleAttack = m_attacker->getMod(MOD_DOUBLE_ATTACK);
+    int16 quadAttack = m_attacker->getMod(MOD_QUAD_ATTACK);
 
-	//check for merit upgrades
-	if (m_attacker->objtype == TYPE_PC)
-	{
-		CCharEntity* PChar = (CCharEntity*)m_attacker;
+    //check for merit upgrades
+    if (m_attacker->objtype == TYPE_PC)
+    {
+        CCharEntity* PChar = (CCharEntity*)m_attacker;
 
-		//merit chance only applies if player has the job trait
-		if (charutils::hasTrait(PChar, TRAIT_TRIPLE_ATTACK)) tripleAttack += PChar->PMeritPoints->GetMeritValue(MERIT_TRIPLE_ATTACK_RATE, PChar);
-		if (charutils::hasTrait(PChar, TRAIT_DOUBLE_ATTACK)) doubleAttack += PChar->PMeritPoints->GetMeritValue(MERIT_DOUBLE_ATTACK_RATE, PChar);
-		// TODO: Quadruple attack merits when SE release them.
-	}
+        //merit chance only applies if player has the job trait
+        if (charutils::hasTrait(PChar, TRAIT_TRIPLE_ATTACK)) tripleAttack += PChar->PMeritPoints->GetMeritValue(MERIT_TRIPLE_ATTACK_RATE, PChar);
+        if (charutils::hasTrait(PChar, TRAIT_DOUBLE_ATTACK)) doubleAttack += PChar->PMeritPoints->GetMeritValue(MERIT_DOUBLE_ATTACK_RATE, PChar);
+        // TODO: Quadruple attack merits when SE release them.
+    }
 
-	quadAttack = dsp_cap(quadAttack,0,100);
+    quadAttack = dsp_cap(quadAttack,0,100);
     doubleAttack = dsp_cap(doubleAttack,0,100);
     tripleAttack = dsp_cap(tripleAttack,0,100);
 
-	// Checking Mikage Effect - Hits Vary With Num of Utsusemi Shadows for Main Weapon
-	if (m_attacker->StatusEffectContainer->HasStatusEffect(EFFECT_MIKAGE) && m_attacker->m_Weapons[SLOT_MAIN]->getID() == PWeapon->getID()){
-		int16 shadows = m_attacker->getMod(MOD_UTSUSEMI);
-		//ShowDebug(CL_CYAN"Create Attacks: Mikage Active, Rolling Attack Chance for %d Shadowss...\n" CL_RESET, shadows);
-		AddAttackSwing(ATTACK_NORMAL, direction, shadows);
-	}
-	else if (num == 1 && dsprand::GetRandomNumber(100) < quadAttack)
-		AddAttackSwing(QUAD_ATTACK, direction, 3);
-	
+    // Checking Mikage Effect - Hits Vary With Num of Utsusemi Shadows for Main Weapon
+    if (m_attacker->StatusEffectContainer->HasStatusEffect(EFFECT_MIKAGE) && m_attacker->m_Weapons[SLOT_MAIN]->getID() == PWeapon->getID())
+    {
+        int16 shadows = m_attacker->getMod(MOD_UTSUSEMI);
+        //ShowDebug(CL_CYAN"Create Attacks: Mikage Active, Rolling Attack Chance for %d Shadowss...\n" CL_RESET, shadows);
+        AddAttackSwing(ATTACK_NORMAL, direction, shadows);
+    }
+    else if (num == 1 && dsprand::GetRandomNumber(100) < quadAttack)
+        AddAttackSwing(QUAD_ATTACK, direction, 3);
+    
     else if (num == 1 && dsprand::GetRandomNumber(100) < tripleAttack)
-		AddAttackSwing(TRIPLE_ATTACK, direction, 2);
-	
+        AddAttackSwing(TRIPLE_ATTACK, direction, 2);
+    
     else if (num == 1 && dsprand::GetRandomNumber(100) < doubleAttack)
-		AddAttackSwing(DOUBLE_ATTACK, direction, 1);
+        AddAttackSwing(DOUBLE_ATTACK, direction, 1);
 
-	// TODO: Possible Lua function for the nitty gritty stuff below.
+    // Ammo extra swing - players only
+    if (m_attacker->objtype == TYPE_PC && m_attacker->getMod(MOD_AMMO_SWING) > 0)
+    {
+        // Check for ammo
+        CCharEntity* PChar = (CCharEntity*)m_attacker;
+        CItemArmor* PAmmo = PChar->getEquip(SLOT_AMMO);
+        uint8 slot = PChar->equip[SLOT_AMMO];
+        uint8 loc = PChar->equipLoc[SLOT_AMMO];
+        if (dsprand::GetRandomNumber(100) < m_attacker->getMod(MOD_AMMO_SWING))
+        {
+            // Add swing, then subtract an ammo item, unequip if there's one left.
+            AddAttackSwing(ATTACK_NORMAL, direction, 1);
+            if (PAmmo->getQuantity() == 1)
+            {
+                charutils::UnequipItem(PChar, SLOT_AMMO);
+                charutils::SaveCharEquip(PChar);
+            }
+            charutils::UpdateItem(PChar, loc, slot, -1);
+            PChar->pushPacket(new CInventoryFinishPacket());
+        }
+    }
 
-	// Iga mod: Extra attack chance whilst dual wield is on.
+    // TODO: Possible Lua function for the nitty gritty stuff below.
+
+    // Iga mod: Extra attack chance whilst dual wield is on.
     if (direction == LEFTATTACK && dsprand::GetRandomNumber(100) < m_attacker->getMod(MOD_EXTRA_DUAL_WIELD_ATTACK))
-		AddAttackSwing(ATTACK_NORMAL, RIGHTATTACK, 1);
+        AddAttackSwing(ATTACK_NORMAL, RIGHTATTACK, 1);
 
 }
 
@@ -251,30 +275,30 @@ void CAttackRound::CreateAttacks(CItemWeapon* PWeapon, PHYSICAL_ATTACK_DIRECTION
 ************************************************************************/
 void CAttackRound::CreateKickAttacks()
 {
-	if (m_attacker->objtype == TYPE_PC)
-	{
-		// kick attack mod (All jobs)
-		uint16 kickAttack = m_attacker->getMod(MOD_KICK_ATTACK); 
+    if (m_attacker->objtype == TYPE_PC)
+    {
+        // kick attack mod (All jobs)
+        uint16 kickAttack = m_attacker->getMod(MOD_KICK_ATTACK); 
 
-		if (m_attacker->GetMJob() == JOB_MNK) // MNK (Main job)
-		{
-			kickAttack += ((CCharEntity*)m_attacker)->PMeritPoints->GetMeritValue(MERIT_KICK_ATTACK_RATE, (CCharEntity*)m_attacker);
-		}
+        if (m_attacker->GetMJob() == JOB_MNK) // MNK (Main job)
+        {
+            kickAttack += ((CCharEntity*)m_attacker)->PMeritPoints->GetMeritValue(MERIT_KICK_ATTACK_RATE, (CCharEntity*)m_attacker);
+        }
 
-		kickAttack = dsp_cap(kickAttack, 0, 100);
+        kickAttack = dsp_cap(kickAttack, 0, 100);
 
         if (dsprand::GetRandomNumber(100) < kickAttack)
-		{
-			AddAttackSwing(KICK_ATTACK, RIGHTATTACK, 1);
-			m_kickAttackOccured = true;
-		}
+        {
+            AddAttackSwing(KICK_ATTACK, RIGHTATTACK, 1);
+            m_kickAttackOccured = true;
+        }
 
-		// TODO: Possible Lua function for the nitty gritty stuff below.
+        // TODO: Possible Lua function for the nitty gritty stuff below.
 
-		// Mantra set mod: Try an extra left kick attack.
+        // Mantra set mod: Try an extra left kick attack.
         if (m_kickAttackOccured && dsprand::GetRandomNumber(100) < m_attacker->getMod(MOD_EXTRA_KICK_ATTACK))
-		{
-			AddAttackSwing(KICK_ATTACK, LEFTATTACK, 1);
-		}
-	}
+        {
+            AddAttackSwing(KICK_ATTACK, LEFTATTACK, 1);
+        }
+    }
 }

--- a/src/map/modifier.h
+++ b/src/map/modifier.h
@@ -570,10 +570,11 @@ enum MODIFIER
     MOD_SHIELDBLOCKRATE           = 0x206, // Affects shield block rate, percent based (modID = 518)
     MOD_DIA_DOT                   = 0x139, //Increases the DoT damage of Dia (modId = 313)
     MOD_ENH_DRAIN_ASPIR           = 0x13B, // % damage boost to Drain and Aspir(modId = 315)
-    MOD_AUGMENTS_ABSORB           = 0x209  // Direct Absorb spell increase while Liberator is equipped (percentage based) (modId = 521)
+    MOD_AUGMENTS_ABSORB           = 0x209, // Direct Absorb spell increase while Liberator is equipped (percentage based) (modId = 521)
+    MOD_AMMO_SWING                = 0x20B  // Extra swing rate w/ ammo (ie. Jailer weapons). Use gearsets, and does nothing for non-players. (modId = 523)
 
-    // MOD_SPARE = 0x20B, // (modId = 523)
     // MOD_SPARE = 0x20C, // (modId = 524)
+    // MOD_SPARE = 0x20D, // (modId = 525)
 
 };
 


### PR DESCRIPTION
Added an extra swing in AddAttackSwing, with it checking if a Virtue Stone is equipped and if the weapon has the modifier for it. This swing stacks with Double/Triple/Quad Attack traits, and decrements Virtue Stones for the swing. Faith Baghnakhs can swing two times per attack round (one per hand), consuming two Virtue Stones.

Jump does not proc the extra swing as per http://www.bluegartr.com/threads/94701-Random-Question-Thread-XI-You-re-Wrong?p=3879961&highlight=jailer#post3879961

Also corrected the model for Justice Sword. http://i.imgur.com/613VXpw.png