### PR TITLE
Scripts/SQL: Martyr/Devotion/Shikikoyo target + message

### DIFF
--- a/scripts/globals/abilities/devotion.lua
+++ b/scripts/globals/abilities/devotion.lua
@@ -8,18 +8,20 @@
 -----------------------------------
 
 require("scripts/globals/status");
+require("scripts/globals/utils");
 
 -----------------------------------
 -- onAbilityCheck
 -----------------------------------
 
 function onAbilityCheck(player,target,ability)
-        -- Fails if HP < 4
-        if (player:getHP() < 4) then
-            return MSGBASIC_UNABLE_TO_USE_JA,0;
-        else
-            return 0,0;
-        end
+    if (player:getID() == target:getID()) then
+        return MSGBASIC_CANNOT_PERFORM_TARG,0;
+    elseif (player:getHP() < 4) then -- Fails if HP < 4
+        return MSGBASIC_UNABLE_TO_USE_JA,0;
+    else
+        return 0,0;
+    end
 end;
 
 -----------------------------------
@@ -27,23 +29,26 @@ end;
 -----------------------------------
 
 function onUseAbility(player,target,ability)
-    --Plus 5 percent mp recovers per extra devotion merit
+    -- Plus 5 percent mp recovers per extra devotion merit
     local meritBonus = player:getMerit(MERIT_DEVOTION) - 5;
-    --printf("Devotion Merit Bonus: %d", meritBonus);
+    -- printf("Devotion Merit Bonus: %d", meritBonus);
 
     local mpPercent = (25 + meritBonus) / 100;
-    --printf("Devotion MP Percent: %f", mpPercent);
+    -- printf("Devotion MP Percent: %f", mpPercent);
 
     local damageHP = math.floor(player:getHP() * 0.25);
-    --printf("Devotion HP Damage: %d", damageHP);
+    -- printf("Devotion HP Damage: %d", damageHP);
 
-    --If stoneskin is present, it should absorb damage...
+    -- If stoneskin is present, it should absorb damage...
     damageHP = utils.stoneskin(player, damageHP);
-    --printf("Devotion HP Damage (after Stoneskin): %d", damageHP);
+    -- printf("Devotion HP Damage (after Stoneskin): %d", damageHP);
 
     local healMP = player:getHP() * mpPercent;
-    --printf("Devotion MP Healed: %d", healMP);
+    healMP = utils.clamp(healMP, 0,target:getMaxMP() - target:getMP());
+    -- printf("Devotion MP Healed: %d", healMP);
 
     player:delHP(damageHP);
     target:addMP(healMP);
+
+    return healMP;
 end;

--- a/scripts/globals/abilities/martyr.lua
+++ b/scripts/globals/abilities/martyr.lua
@@ -4,21 +4,24 @@
 -- Obtained: White Mage Level 75
 -- Recast Time: 0:10:00
 -- Duration: Instant
+-- Target: Party member, cannot target self.
 -----------------------------------
 
 require("scripts/globals/status");
+require("scripts/globals/utils");
 
 -----------------------------------
 -- onAbilityCheck
 -----------------------------------
 
 function onAbilityCheck(player,target,ability)
-        -- Fails if HP < 4
-        if (player:getHP() < 4) then
-            return MSGBASIC_UNABLE_TO_USE_JA,0;
-        else
-            return 0,0;
-        end
+    if (player:getID() == target:getID()) then
+        return MSGBASIC_CANNOT_PERFORM_TARG,0;
+    elseif (player:getHP() < 4) then -- Fails if HP < 4
+        return MSGBASIC_UNABLE_TO_USE_JA,0;
+    else
+        return 0,0;
+    end
 end;
 
 -----------------------------------
@@ -26,26 +29,29 @@ end;
 -----------------------------------
 
 function onUseAbility(player,target,ability)
-    --Plus 5 percent hp recovers per extra martyr merit
+    -- Plus 5 percent hp recovers per extra martyr merit
     local meritBonus = player:getMerit(MERIT_MARTYR) - 5;
-    --printf("Martyr Merit Bonus: %d", meritBonus);
+    -- printf("Martyr Merit Bonus: %d", meritBonus);
 
     local hpPercent = (200 + meritBonus) / 100;
-    --printf("Martyr HP Bonus Percent: %f", hpPercent);
+    -- printf("Martyr HP Bonus Percent: %f", hpPercent);
 
     local damageHP = math.floor(player:getHP() * 0.25);
-    --printf("Martyr HP Damage: %d", damageHP);
-
+    -- printf("Martyr HP Damage: %d", damageHP);
+ 
     --We need to capture this here because the base damage is the basis for the heal
     local healHP = damageHP * hpPercent;
+    healHP = utils.clamp(healHP, 0,target:getMaxHP() - target:getHP());
 
-    --If stoneskin is present, it should absorb damage...
+    -- If stoneskin is present, it should absorb damage...
     damageHP = utils.stoneskin(player, damageHP);
-    --printf("Martyr Final HP Damage (After Stoneskin): %d", damageHP);
+    -- printf("Martyr Final HP Damage (After Stoneskin): %d", damageHP);
 
-    --Log HP Headed for Debug
-    --printf("Martyr Healed HP: %d", healHP);
+    -- Log HP Headed for Debug
+    -- printf("Martyr Healed HP: %d", healHP);
 
     player:delHP(damageHP);
     target:addHP(healHP);
+
+    return healHP;
 end;

--- a/scripts/globals/abilities/shikikoyo.lua
+++ b/scripts/globals/abilities/shikikoyo.lua
@@ -4,20 +4,25 @@
 -- Obtained: Samurai Level 75
 -- Recast Time: 5:00
 -- Duration: Instant
+-- Target: Party member, cannot target self.
 -----------------------------------
 
 require("scripts/globals/settings");
 require("scripts/globals/status");
+require("scripts/globals/utils");
 
 -----------------------------------
 -- onAbilityCheck
 -----------------------------------
 
 function onAbilityCheck(player,target,ability)
-    if (player:getTP() < 100) then
+    if (player:getID() == target:getID()) then
+        return MSGBASIC_CANNOT_PERFORM_TARG,0;
+    elseif (player:getTP() < 100) then
         return MSGBASIC_NOT_ENOUGH_TP, 0;
+    else
+        return 0,0;
     end
-    return 0,0;
 end;
 
 -----------------------------------
@@ -25,11 +30,11 @@ end;
 -----------------------------------
 
 function onUseAbility(player,target,ability)
-    local pTP = player:getTP() - 100;
+    local pTP = player:getTP() - 100 + (player:getMerit(MERIT_SHIKIKOYO) - 12);
+    pTP = utils.clamp(pTP, 0,300 - target:getTP());
 
-    if (pTP > 0) then
-        player:setTP(100);
-        target:setTP(target:getTP() + pTP + (player:getMerit(MERIT_SHIKIKOYO) - 12));
-    end
+    player:setTP(100);
+    target:setTP(target:getTP() + pTP);
 
+    return pTP;
 end;

--- a/scripts/globals/status.lua
+++ b/scripts/globals/status.lua
@@ -1722,6 +1722,7 @@ MSGBASIC_ALREADY_CLAIMED        = 12 -- Cannot attack. Your target is already cl
 MSGBASIC_IS_INTERRUPTED         = 16 -- The <player>'s casting is interrupted.
 MSGBASIC_UNABLE_TO_CAST         = 18 -- Unable to cast spells at this time.
 MSGBASIC_CANNOT_PERFORM         = 71 -- The <player> cannot perform that action.
+MSGBASIC_CANNOT_PERFORM_TARG    = 72 -- That action cannot be performed on <target>.
 MSGBASIC_UNABLE_TO_USE_JA       = 87 -- Unable to use job ability.
 MSGBASIC_UNABLE_TO_USE_JA2      = 88 -- Unable to use job ability.
 MSGBASIC_IS_PARALYZED           = 29 -- The <player> is paralyzed.

--- a/sql/abilities.sql
+++ b/sql/abilities.sql
@@ -177,8 +177,8 @@ INSERT INTO `abilities` VALUES ('133', 'warriors_charge', '1', '75', '1', '300',
 INSERT INTO `abilities` VALUES ('134', 'tomahawk', '1', '75', '4', '180', '7', '0', '0', '244', '20.0', '0', '1', '600', '2050', '1','TOAU');
 INSERT INTO `abilities` VALUES ('135', 'mantra', '2', '75', '1', '600', '19', '441', '0', '155', '20.0', '1', '1', '60', '2112', '1','TOAU');
 INSERT INTO `abilities` VALUES ('136', 'formless_strikes', '2', '75', '1', '600', '20', '0', '0', '156', '20.0', '0', '1', '300', '2114', '1','TOAU');
-INSERT INTO `abilities` VALUES ('137', 'martyr', '3', '75', '2', '600', '27', '119', '0', '157', '20.0', '0', '1', '300', '2176', '1','TOAU');
-INSERT INTO `abilities` VALUES ('138', 'devotion', '3', '75', '2', '600', '28', '119', '0', '158', '10.0', '0', '1', '300', '2178', '1','TOAU');
+INSERT INTO `abilities` VALUES ('137', 'martyr', '3', '75', '2', '600', '27', '102', '0', '157', '20.0', '0', '1', '300', '2176', '1','TOAU');
+INSERT INTO `abilities` VALUES ('138', 'devotion', '3', '75', '2', '600', '28', '224', '0', '158', '10.0', '0', '1', '300', '2178', '1','TOAU');
 INSERT INTO `abilities` VALUES ('139', 'assassins_charge', '6', '75', '1', '300', '67', '0', '0', '160', '20.0', '0', '1', '300', '2368', '1','TOAU');
 INSERT INTO `abilities` VALUES ('140', 'feint', '6', '75', '1', '600', '68', '0', '0', '159', '20.0', '0', '1', '300', '2370', '1','TOAU');
 INSERT INTO `abilities` VALUES ('141', 'fealty', '7', '75', '1', '600', '78', '0', '0', '148', '20.0', '0', '1', '300', '2432', '1','TOAU');
@@ -191,7 +191,7 @@ INSERT INTO `abilities` VALUES ('147', 'nightingale', '10', '75', '1', '600', '1
 INSERT INTO `abilities` VALUES ('148', 'troubadour', '10', '75', '1', '600', '110', '0', '0', '162', '20.0', '0', '1', '300', '2626', '1','TOAU');
 INSERT INTO `abilities` VALUES ('149', 'stealth_shot', '11', '75', '1', '300', '127', '0', '0', '150', '20.0', '0', '1', '3000', '2688', '1','TOAU');
 INSERT INTO `abilities` VALUES ('150', 'flashy_shot', '11', '75', '1', '600', '128', '0', '0', '151', '20.0', '0', '1', '300', '2690', '1','TOAU');
-INSERT INTO `abilities` VALUES ('151', 'shikikoyo', '12', '75', '2', '300', '136', '0', '0', '152', '20.0', '0', '1', '80', '2752', '1','TOAU');
+INSERT INTO `abilities` VALUES ('151', 'shikikoyo', '12', '75', '2', '300', '136', '452', '0', '152', '20.0', '0', '1', '80', '2752', '1','TOAU');
 INSERT INTO `abilities` VALUES ('152', 'blade_bash', '12', '75', '4', '180', '137', '110', '0', '202', '4.4', '0', '0', '0', '2754', '1','TOAU');
 INSERT INTO `abilities` VALUES ('153', 'deep_breathing', '14', '75', '1', '300', '164', '0', '0', '153', '20.0', '0', '0', '0', '2880', '1','TOAU');
 INSERT INTO `abilities` VALUES ('154', 'angon', '14', '75', '4', '180', '165', '0', '0', '245', '20.0', '0', '0', '0', '2882', '1','TOAU');


### PR DESCRIPTION
Made it so players cannot use those three abilities on themselves - while they can't use it on themselves while solo, they can use it on themselves when in a party. (currently)
Set the message upon using the ability (recovers HP/MP, regains TP), and the message when a player tries to use the ability on themselves. This required a message to be added in status.lua, as well as capping the amount of HP/MP given at max HP/MP - current HP/MP, or TP given at 300 - current TP.