### PR TITLE
Partially cleanup some Dynamis nonsense.

### DIFF
--- a/scripts/zones/Dynamis-Xarcabard/mobs/Dynamis_Lord.lua
+++ b/scripts/zones/Dynamis-Xarcabard/mobs/Dynamis_Lord.lua
@@ -1,33 +1,40 @@
 -----------------------------------
 -- Area: Dynamis Xarcabard
--- NPC:  Dynamis_Lord
+--  NM:  Dynamis_Lord
+-- 
+-- In OLD Dynamis, he is spawned by killing 15 Kindred NMs..
+-- ..NOT by killing Ying and Yang.
+--
+-- In Neo Dynamis, he is spawned by trading
+-- a Shrouded Bijou to the ??? in front of Castle Zvahl. 
+--
+-- Suggested method for old school Dyna: mask bits
+-- Duke Berith        bit 0
+-- Marquis Decarabia  bit 1
+-- Count Zaebos       bit 2
+-- Duke Gomory        bit 3
+-- Marquis Andras     bit 4
+-- Prince Seere       bit 5
+-- Count Raum         bit 6
+-- Marquis Nebiros    bit 7
+-- Marquis Sabnak     bit 8
+-- Duke Scox          bit 9
+-- Marquis Orias      bit 10
+-- Marquis Gamygyn    bit 11
+-- Count Vine         bit 12
+-- Marquis Cimeries   bit 13
+-- King Zagan         bit 14
+-- Mask full = pop Dyna Lord
 -----------------------------------
 
 require("scripts/globals/status");
-
------------------------------------
-
 require("scripts/globals/titles");
 
 -----------------------------------
 -- onMobInitialize Action
 -----------------------------------
 
-function onMobInitialize(mob,target)
-end;
-
------------------------------------
--- onMobRoam
------------------------------------
-
-function onMobRoam(mob)
-	--[[
-	if (mob:getExtraVar(1) <= os.time()) then
-		DespawnMob(17330177); -- Despawn after 30min
-		DespawnMob(17330183);
-		DespawnMob(17330184);
-	end
-	]]
+function onMobInitialize(mob)
 end;
 
 -----------------------------------
@@ -35,10 +42,6 @@ end;
 -----------------------------------
 
 function onMobEngaged(mob,target)
-	
-	SpawnMob(17330183):updateEnmity(target); -- Spawn Ying
-	SpawnMob(17330184):updateEnmity(target); -- Spawn Yang
-	
 end;
 
 -----------------------------------
@@ -46,22 +49,17 @@ end;
 -----------------------------------
 
 function onMobFight(mob,target)
-	
-	if (mob:getLocalVar("timeLimit") <= os.time()) then
-		DespawnMob(17330177); -- Despawn after 30min
-		DespawnMob(17330183);
-		DespawnMob(17330184);
-	end
-	
-	if (mob:getBattleTime() % 90 == 0) then
-		if (GetMobAction(17330183) == 0) then
-			SpawnMob(17330183):updateEnmity(target); -- Respawn Ying after 90sec
-		end
-		if (GetMobAction(17330184) == 0) then
-			SpawnMob(17330184):updateEnmity(target); -- Respawn Yang after 90sec
-		end
-	end
-	
+    local YingID = 17330183;
+    local YangID = 17330184;
+
+    if (mob:getBattleTime() % 90 == 0) then
+        if (GetMobAction(YingID) == ACTION_NONE) then
+            SpawnMob(YingID):updateEnmity(target); -- Respawn Ying after 90sec
+        end
+        if (GetMobAction(YangID) == ACTION_NONE) then
+            SpawnMob(YangID):updateEnmity(target); -- Respawn Yang after 90sec
+        end
+    end
 end;
 
 -----------------------------------
@@ -69,11 +67,8 @@ end;
 -----------------------------------
 
 function onMobDeath(mob,killer)
-	
-	killer:addTitle(LIFTER_OF_SHADOWS);
-	
-	local npc = GetNPCByID(17330778); -- Spawn ???
-	npc:setPos(mob:getXPos(),mob:getYPos(),mob:getZPos());
-	npc:setStatus(0);
-	
+    local npc = GetNPCByID(17330778); -- ID of the '???' target.
+    killer:addTitle(LIFTER_OF_SHADOWS);
+    npc:setPos(mob:getXPos(),mob:getYPos(),mob:getZPos());
+    npc:setStatus(0); -- Spawn the '???'
 end;

--- a/scripts/zones/Dynamis-Xarcabard/mobs/Yang.lua
+++ b/scripts/zones/Dynamis-Xarcabard/mobs/Yang.lua
@@ -1,6 +1,6 @@
 -----------------------------------
 -- Area: Dynamis Xarcabard
--- NPC:  Yang
+--  NM:  Yang
 -----------------------------------
 
 require("scripts/globals/status");
@@ -17,12 +17,12 @@ end;
 -----------------------------------
 
 function onMobFight(mob,target)
-	
-	-- Spawn ying after 21sec if lord is not spawned, else he's respawned by dyna lord
-	if (mob:getBattleTime() % 21 == 0 and GetMobAction(17330183) == 0) then
-		SpawnMob(17330183):updateEnmity(target);
-	end
-	
+    local YingID = 17330183;
+    local YingToD = mob:getLocalVar("YingToD");
+    -- Repop Ying every 30 seconds if Yang is up and Ying is not.
+    if (mob:getBattleTime() > YingToD+30 and GetMobAction(YingID) == ACTION_NONE) then
+        SpawnMob(YingID):updateEnmity(target);
+    end
 end;
 
 -----------------------------------
@@ -30,10 +30,13 @@ end;
 -----------------------------------
 
 function onMobDeath(mob,killer)
-	
-	if (GetMobAction(17330177) == 0 and GetMobAction(17330183) == 0) then
-		GetMobByID(17330177):setLocalVar("timeLimit", os.time() + 1800); -- Time for the 30min limit
-		SpawnMob(17330177); -- Dynamis Lord
-	end
-	
+    local YingID = 17330183;
+    -- localVars clear on death, so setting it on its partner
+    GetMobByID(YingID):setLocalVar("YangToD", os.time());
+
+    -- This is not retail, this is not how you pop DynaLord:
+    if (GetMobAction(17330177) == ACTION_NONE and GetMobAction(YingID) == ACTION_NONE) then
+        -- GetMobByID(17330177):setLocalVar("timeLimit", os.time() + 1800); -- Time for the 30min limit
+        SpawnMob(17330177); -- Dynamis Lord
+    end
 end;

--- a/scripts/zones/Dynamis-Xarcabard/mobs/Ying.lua
+++ b/scripts/zones/Dynamis-Xarcabard/mobs/Ying.lua
@@ -1,6 +1,6 @@
 -----------------------------------
 -- Area: Dynamis Xarcabard
--- NPC:  Ying
+--  NM:  Ying
 -----------------------------------
 
 require("scripts/globals/status");
@@ -17,12 +17,12 @@ end;
 -----------------------------------
 
 function onMobFight(mob,target)
-	
-	-- Spawn ying after 21sec if lord is not spawned, else he's respawned by dyna lord
-	if (mob:getBattleTime() % 21 == 0 and GetMobAction(17330184) == 0) then
-		SpawnMob(17330184):updateEnmity(target);
-	end
-	
+    local YangID = 17330184;
+    local YangToD = GetMobByID(YingID):getLocalVar("YangToD");
+    -- Repop Yang every 30 seconds if Ying is up and Yang is not.
+    if (mob:getBattleTime() > YangToD+30 and GetMobAction(YangID) == ACTION_NONE) then
+        SpawnMob(YangID):updateEnmity(target);
+    end
 end;
 
 -----------------------------------
@@ -30,10 +30,13 @@ end;
 -----------------------------------
 
 function onMobDeath(mob,killer)
-	
-	if (GetMobAction(17330177) == 0 and GetMobAction(17330184) == 0) then
-		GetMobByID(17330177):setLocalVar("timeLimit", os.time() + 1800); -- Time for the 30min limit
-		SpawnMob(17330177); -- Dynamis Lord
-	end
-	
+    local YangID = 17330184;
+    -- localVars clear on death, so setting it on its partner
+    GetMobByID(YangID):setLocalVar("YingToD", os.time());
+
+    -- This is not retail, this is not how you pop DynaLord:
+    if (GetMobAction(17330177) == ACTION_NONE and GetMobAction(YangID) == ACTION_NONE) then
+        -- GetMobByID(17330177):setLocalVar("timeLimit", os.time() + 1800); -- Time for the 30min limit
+        SpawnMob(17330177); -- Dynamis Lord
+    end
 end;


### PR DESCRIPTION
Only thing I really corrected was Dynamis Lord's instant self depop and the timing on Ying and Yang repopping each other. Its 30 seconds, not 21. I killed the timer on Dynamis Lord because it : 

**A)** wasn't actually working as you can't setLocalVar on a mob that is not even up yet resulting on comparing os.time() with zero meaning always depop Dynamis Lord every tick of onMobFight... 

and **B)** I couldn't even find any source for it (only time I ever saw a Dyna lord fight, it was over well before this timer would have been up). I almost corrected his spawn requirements but decided I just don't care about *non* Neo Dynamis.

I didn't correct his spawn conditions but I commented in [Dynamis_Lord.lua](https://github.com/DarkstarProject/darkstar/commit/7a78eaa4f6598aa8e99f40e4fc40f2785f9c6d3f#diff-6f1961dac1835fbfc64de0a537dba6cdR5) if anyone else wants to. I just can't bring myself to care enough to do all that for *non* Neo Dynamis.

If someone else wants to re-implement the timer and or correct the spawn conditions, have at it!