### PR TITLE
Scripts/SQL: Wamouracampa TP moves, Cannonball spell def mod.

### DIFF
--- a/scripts/globals/bluemagic.lua
+++ b/scripts/globals/bluemagic.lua
@@ -123,7 +123,11 @@ function BluePhysicalSpell(caster, target, spell, params)
     ----------------------------------------------
     -- Get the possible pDIF range and hit rate --
     ----------------------------------------------
-    local cratio = BluecRatio(caster:getStat(MOD_ATT) / target:getStat(MOD_DEF), caster:getMainLvl(), target:getMainLvl());
+    if (params.offcratiomod == nil) then -- default to attack. Pretty much every physical spell will use this, Cannonball being the exception.
+        params.offcratiomod = caster:getStat(MOD_ATT)
+    end;
+    -- print(params.offcratiomod)
+    local cratio = BluecRatio(params.offcratiomod / target:getStat(MOD_DEF), caster:getMainLvl(), target:getMainLvl());
     local hitrate = BlueGetHitRate(caster,target,true);
 
     --print("Hit rate "..hitrate);

--- a/scripts/globals/mobskills/Amber_scutum.lua
+++ b/scripts/globals/mobskills/Amber_scutum.lua
@@ -1,0 +1,26 @@
+---------------------------------------------
+--  Amber Scutum
+--  Family: Wamouracampa
+--  Description: Increases defense.
+--  Type: Enhancing
+--  Utsusemi/Blink absorb: N/A
+--  Range: Self
+--  Notes: 
+---------------------------------------------
+require("scripts/globals/settings");
+require("scripts/globals/status");
+require("scripts/globals/monstertpmoves");
+---------------------------------------------------
+
+function onMobSkillCheck(target,mob,skill)
+    return 0;
+end;
+
+function onMobWeaponSkill(target, mob, skill)
+
+    local typeEffect = EFFECT_DEFENSE_BOOST;
+
+    skill:setMsg(MobBuffMove(mob, typeEffect, 50, 0, 60));
+
+    return typeEffect;
+end;

--- a/scripts/globals/mobskills/Cannonball.lua
+++ b/scripts/globals/mobskills/Cannonball.lua
@@ -1,0 +1,32 @@
+---------------------------------------------
+--  Cannonball
+--  Family: Wamouracampa
+--  Description: Damage varies with TP.
+--  Type: Physical
+--  Utsusemi/Blink absorb: One shadow
+--  Range: 20
+--  Notes: Uses defense instead of attack. Curled form only.
+---------------------------------------------
+require("scripts/globals/settings");
+require("scripts/globals/status");
+require("scripts/globals/monstertpmoves");
+---------------------------------------------------
+
+function onMobSkillCheck(target,mob,skill)
+    if (mob:AnimationSub() ~=1) then
+        return 1;
+    else
+        return 0;
+    end
+end;
+
+function onMobWeaponSkill(target, mob, skill)
+    local numhits = 1;
+    local accmod = 1;
+    local dmgmod = 1.75;
+    local offcratio = mob:getStat(MOD_DEF);
+    local info = MobPhysicalMove(mob,target,skill,numhits,accmod,dmgmod,TP_DMG_VARIES,1.75,2.125,2.75,offcratio);
+    local dmg = MobFinalAdjustments(info.dmg,mob,skill,target,MOBSKILL_PHYSICAL,MOBPARAM_BLUNT,info.hitslanded);
+    target:delHP(dmg);
+    return dmg;
+end;

--- a/scripts/globals/mobskills/Heat_barrier.lua
+++ b/scripts/globals/mobskills/Heat_barrier.lua
@@ -1,0 +1,28 @@
+---------------------------------------------
+--  Heat Barrier
+--  Family: Wamouracampa
+--  Description: Applies a thermal barrier, granting fiery spikes and fire damage on melee hits. 
+--  Type: Enhancing
+--  Utsusemi/Blink absorb: N/A
+--  Range: Self
+--  Notes: 
+---------------------------------------------
+require("scripts/globals/settings");
+require("scripts/globals/status");
+require("scripts/globals/monstertpmoves");
+---------------------------------------------------
+
+function onMobSkillCheck(target,mob,skill)
+    return 0;
+end;
+
+function onMobWeaponSkill(target, mob, skill)
+    -- TODO: Enfire power, Blaze Spikes reduced power in Salvage zones
+    local typeEffectOne = EFFECT_BLAZE_SPIKES;
+    -- local typeEffectTwo = EFFECT_ENFIRE;
+    local randy = math.random(50,67);
+    skill:setMsg(MobBuffMove(mob, typeEffectOne, randy, 0, 180));
+    -- MobBuffMove(mob, typeEffectTwo, ???, 0, 180);
+
+    return typeEffectOne;
+end;

--- a/scripts/globals/mobskills/Thermal_Pulse.lua
+++ b/scripts/globals/mobskills/Thermal_Pulse.lua
@@ -1,0 +1,33 @@
+---------------------------------------------
+--  Thermal Pulse
+--  Family: Wamouracampa
+--  Description: Deals Fire damage to enemies within area of effect. Additional effect: Blindness 
+--  Type: Magical
+--  Utsusemi/Blink absorb: Ignores shadow
+--  Range: 12.5
+--  Notes: Open form only.
+---------------------------------------------
+require("scripts/globals/settings");
+require("scripts/globals/status");
+require("scripts/globals/monstertpmoves");
+---------------------------------------------
+
+function onMobSkillCheck(target,mob,skill)
+    if (mob:AnimationSub() ~=0) then
+        return 1;
+    else
+        return 0;
+    end
+end;
+
+function onMobWeaponSkill(target, mob, skill)
+    local typeEffect = EFFECT_BLINDNESS;
+
+    MobStatusEffectMove(mob, target, typeEffect, 20, 0, 60);
+
+    local dmgmod = 1;
+    local info = MobMagicalMove(mob,target,skill,mob:getWeaponDmg()*3,ELE_FIRE,dmgmod,TP_NO_EFFECT);
+    local dmg = MobFinalAdjustments(info.dmg,mob,skill,target,MOBSKILL_MAGICAL,MOBPARAM_FIRE,MOBPARAM_IGNORE_SHADOWS);
+    target:delHP(dmg);
+    return dmg;
+end;

--- a/scripts/globals/mobskills/Vitriolic_spray.lua
+++ b/scripts/globals/mobskills/Vitriolic_spray.lua
@@ -1,0 +1,31 @@
+---------------------------------------------
+--  Vitriolic Spray
+--  Family: Wamouracampa
+--  Description: Expels a caustic stream at targets in a fan-shaped area of effect. Additional effect: Burn
+--  Type: Magical
+--  Utsusemi/Blink absorb: Wipes shadow
+--  Range: Cone
+--  Notes: Burn is 10-30/tic
+---------------------------------------------
+require("scripts/globals/settings");
+require("scripts/globals/status");
+require("scripts/globals/monstertpmoves");
+---------------------------------------------
+
+function onMobSkillCheck(target,mob,skill)
+    return 0;
+end;
+
+function onMobWeaponSkill(target, mob, skill)
+	local typeEffect = EFFECT_BURN;
+	local power = math.random(10,30);
+
+
+	MobStatusEffectMove(mob, target, typeEffect, power, 3, 60);
+
+	local dmgmod = 1;
+	local info = MobMagicalMove(mob,target,skill,mob:getWeaponDmg()*2.7,ELE_FIRE,dmgmod,TP_NO_EFFECT);
+	local dmg = MobFinalAdjustments(info.dmg,mob,skill,target,MOBSKILL_MAGICAL,MOBPARAM_FIRE,MOBPARAM_WIPE_SHADOWS);
+	target:delHP(dmg);
+	return dmg;
+end;

--- a/scripts/globals/monstertpmoves.lua
+++ b/scripts/globals/monstertpmoves.lua
@@ -103,34 +103,38 @@ end;
 -- if TP_ATK_VARIES -> three values are attack multiplier (1.5x 0.5x etc)
 -- if TP_DMG_VARIES -> three values are
 
-function MobPhysicalMove(mob,target,skill,numberofhits,accmod,dmgmod,tpeffect,mtp000,mtp150,mtp300)
-	local returninfo = {};
+function MobPhysicalMove(mob,target,skill,numberofhits,accmod,dmgmod,tpeffect,mtp000,mtp150,mtp300,offcratiomod)
+    local returninfo = {};
 
-	--get dstr (bias to monsters, so no fSTR)
-	local dstr = mob:getStat(MOD_STR) - target:getStat(MOD_VIT);
-	if (dstr < -10) then
-		dstr = -10;
-	end
+    --get dstr (bias to monsters, so no fSTR)
+    local dstr = mob:getStat(MOD_STR) - target:getStat(MOD_VIT);
+    if (dstr < -10) then
+        dstr = -10;
+    end
 
-	if (dstr > 10) then
-		dstr = 10;
-	end
+    if (dstr > 10) then
+        dstr = 10;
+    end
 
-	local lvluser = mob:getMainLvl();
-	local lvltarget = target:getMainLvl();
-	local acc = mob:getACC();
-	local eva = target:getEVA();
-	--apply WSC
-	local base = mob:getWeaponDmg() + dstr; --todo: change to include WSC
-	if (base < 1) then
-		base = 1;
-	end
+    local lvluser = mob:getMainLvl();
+    local lvltarget = target:getMainLvl();
+    local acc = mob:getACC();
+    local eva = target:getEVA();
+    --apply WSC
+    local base = mob:getWeaponDmg() + dstr; --todo: change to include WSC
+    if (base < 1) then
+        base = 1;
+    end
 
-	--work out and cap ratio
-	local ratio = mob:getStat(MOD_ATT)/target:getStat(MOD_DEF);
+    --work out and cap ratio
+    if (offcratiomod == nil) then -- default to attack. Pretty much every physical mobskill will use this, Cannonball being the exception.
+        offcratiomod = mob:getStat(MOD_ATT);
+        -- print ("Nothing passed, defaulting to attack");
+    end;
+    local ratio = offcratiomod/target:getStat(MOD_DEF);
     ratio = utils.clamp(ratio, 0, 2);
 
-	local lvldiff = lvluser - lvltarget;
+    local lvldiff = lvluser - lvltarget;
     if lvldiff < 0 then
         lvldiff = 0;
     end;
@@ -138,118 +142,118 @@ function MobPhysicalMove(mob,target,skill,numberofhits,accmod,dmgmod,tpeffect,mt
     ratio = ratio + lvldiff * 0.05;
     ratio = utils.clamp(ratio, 0, 4);
     
-	--work out hit rate for mobs (bias towards them)
-	local hitrate = (acc*accmod) - eva + (lvldiff*3) + 85;
+    --work out hit rate for mobs (bias towards them)
+    local hitrate = (acc*accmod) - eva + (lvldiff*3) + 85;
 
-	-- printf("acc: %f, eva: %f, hitrate: %f", acc, eva, hitrate);
-	if (hitrate > 95) then
-		hitrate = 95;
-	elseif (hitrate < 20) then
-		hitrate = 20;
-	end
+    -- printf("acc: %f, eva: %f, hitrate: %f", acc, eva, hitrate);
+    if (hitrate > 95) then
+        hitrate = 95;
+    elseif (hitrate < 20) then
+        hitrate = 20;
+    end
 
 
-	--work out the base damage for a single hit
-	local hitdamage = (base + lvldiff);
-	if (hitdamage < 1) then
-		hitdamage = 1;
-	end
+    --work out the base damage for a single hit
+    local hitdamage = (base + lvldiff);
+    if (hitdamage < 1) then
+        hitdamage = 1;
+    end
 
-	hitdamage = hitdamage * dmgmod * MobTPMod(skill:getTP());
+    hitdamage = hitdamage * dmgmod * MobTPMod(skill:getTP());
 
-	--work out min and max cRatio
-	local maxRatio = 1;
-	local minRatio = 0;
+    --work out min and max cRatio
+    local maxRatio = 1;
+    local minRatio = 0;
     
-	if (ratio < 0.5) then
-		maxRatio = ratio + 1;
-	elseif ((0.5 <= ratio) and (ratio <= 0.7)) then
-		maxRatio = 1;
-	elseif ((0.7 < ratio) and (ratio <= 1.2)) then
-		maxRatio = ratio + 0.3;
-	elseif ((1.2 < ratio) and (ratio <= 1.5)) then
+    if (ratio < 0.5) then
+        maxRatio = ratio + 1;
+    elseif ((0.5 <= ratio) and (ratio <= 0.7)) then
+        maxRatio = 1;
+    elseif ((0.7 < ratio) and (ratio <= 1.2)) then
+        maxRatio = ratio + 0.3;
+    elseif ((1.2 < ratio) and (ratio <= 1.5)) then
         maxRatio = (ratio * 0.25) + ratio;
-	elseif ((1.5 < ratio) and (ratio <= 2.625)) then
+    elseif ((1.5 < ratio) and (ratio <= 2.625)) then
         maxRatio = ratio + 0.375;
-	elseif ((2.625 < ratio) and (ratio <= 3.25)) then
+    elseif ((2.625 < ratio) and (ratio <= 3.25)) then
         maxRatio = 3;
     else 
         maxRatio = ratio;
     end
     
 
-	if (ratio < 0.38) then
-		minRatio =  0;
-	elseif ((0.38 <= ratio) and (ratio <= 1.25)) then
-		minRatio = ratio * (1176 / 1024) - (448 / 1024);
-	elseif ((1.25 < ratio) and (ratio <= 1.51)) then
-		minRatio = 1;
+    if (ratio < 0.38) then
+        minRatio =  0;
+    elseif ((0.38 <= ratio) and (ratio <= 1.25)) then
+        minRatio = ratio * (1176 / 1024) - (448 / 1024);
+    elseif ((1.25 < ratio) and (ratio <= 1.51)) then
+        minRatio = 1;
     elseif ((1.51 < ratio) and (ratio <= 2.44)) then
         minRatio = ratio * (1176 / 1024) - (775 / 1024);
     else
         minRatio = ratio - 0.375;
     end
 
-	--apply ftp (assumes 1~3 scalar linear mod)
-	if (tpeffect==TP_DMG_BONUS) then
-		hitdamage = hitdamage * fTP(skill:getTP(), mtp000, mtp150, mtp300);
-	end
+    --apply ftp (assumes 1~3 scalar linear mod)
+    if (tpeffect==TP_DMG_BONUS) then
+        hitdamage = hitdamage * fTP(skill:getTP(), mtp000, mtp150, mtp300);
+    end
 
-	--Applying pDIF
-	local pdif = 0;
+    --Applying pDIF
+    local pdif = 0;
 
-	-- start the hits
-	local hitchance = math.random();
-	local finaldmg = 0;
-	local hitsdone = 1;
-	local hitslanded = 0;
+    -- start the hits
+    local hitchance = math.random();
+    local finaldmg = 0;
+    local hitsdone = 1;
+    local hitslanded = 0;
 
-	local chance = math.random();
+    local chance = math.random();
 
-	-- first hit has a higher chance to land
-	local firstHitChance = hitrate * 1.5;
+    -- first hit has a higher chance to land
+    local firstHitChance = hitrate * 1.5;
 
-	if (tpeffect==TP_RANGED) then
-		firstHitChance = hitrate * 1.2;
-	end
+    if (tpeffect==TP_RANGED) then
+        firstHitChance = hitrate * 1.2;
+    end
 
-	firstHitChance = utils.clamp(firstHitChance, 60, 95);
+    firstHitChance = utils.clamp(firstHitChance, 60, 95);
 
-	if ((chance*100) <= firstHitChance) then
-		pdif = math.random((minRatio*1000),(maxRatio*1000)) --generate random PDIF
-		pdif = pdif/1000; --multiplier set.
-		finaldmg = finaldmg + hitdamage * pdif;
-		hitslanded = hitslanded + 1;
-	end
-	while (hitsdone < numberofhits) do
-		chance = math.random();
-		if ((chance*100)<=hitrate) then --it hit
-			pdif = math.random((minRatio*1000),(maxRatio*1000)) --generate random PDIF
-			pdif = pdif/1000; --multiplier set.
-			finaldmg = finaldmg + hitdamage * pdif;
-			hitslanded = hitslanded + 1;
-		end
-		hitsdone = hitsdone + 1;
-	end
+    if ((chance*100) <= firstHitChance) then
+        pdif = math.random((minRatio*1000),(maxRatio*1000)) --generate random PDIF
+        pdif = pdif/1000; --multiplier set.
+        finaldmg = finaldmg + hitdamage * pdif;
+        hitslanded = hitslanded + 1;
+    end
+    while (hitsdone < numberofhits) do
+        chance = math.random();
+        if ((chance*100)<=hitrate) then --it hit
+            pdif = math.random((minRatio*1000),(maxRatio*1000)) --generate random PDIF
+            pdif = pdif/1000; --multiplier set.
+            finaldmg = finaldmg + hitdamage * pdif;
+            hitslanded = hitslanded + 1;
+        end
+        hitsdone = hitsdone + 1;
+    end
 
-	-- printf("final: %f, hits: %f, acc: %f", finaldmg, hitslanded, hitrate);
+    -- printf("final: %f, hits: %f, acc: %f", finaldmg, hitslanded, hitrate);
 
-	-- if an attack landed it must do at least 1 damage
-	if (hitslanded >= 1 and finaldmg < 1) then
-		finaldmg = 1;
-	end
+    -- if an attack landed it must do at least 1 damage
+    if (hitslanded >= 1 and finaldmg < 1) then
+        finaldmg = 1;
+    end
 
-	-- all hits missed
-	if (hitslanded == 0 or finaldmg == 0) then
-		finaldmg = 0;
-		hitslanded = 0;
-		skill:setMsg(MSG_MISS);
-	end
+    -- all hits missed
+    if (hitslanded == 0 or finaldmg == 0) then
+        finaldmg = 0;
+        hitslanded = 0;
+        skill:setMsg(MSG_MISS);
+    end
 
-	returninfo.dmg = finaldmg;
-	returninfo.hitslanded = hitslanded;
+    returninfo.dmg = finaldmg;
+    returninfo.hitslanded = hitslanded;
 
-	return returninfo;
+    return returninfo;
 
 end
 
@@ -275,48 +279,48 @@ end
 -- TP_DMG_BONUS and TP=200, tpvalue = 2, assume V=150  --> damage is now 150*(TP*2)/100 = 600
 
 function MobMagicalMove(mob,target,skill,damage,element,dmgmod,tpeffect,tpvalue)
-	returninfo = {};
-	--get all the stuff we need
-	local resist = 1;
+    returninfo = {};
+    --get all the stuff we need
+    local resist = 1;
 
-	-- plus 100 forces it to be a number
-	mab = (100+mob:getMod(MOD_MATT)) / (100+target:getMod(MOD_MDEF));
-	
-	if (mab > 1.3) then
-		mab = 1.3;
-	end
+    -- plus 100 forces it to be a number
+    mab = (100+mob:getMod(MOD_MATT)) / (100+target:getMod(MOD_MDEF));
+    
+    if (mab > 1.3) then
+        mab = 1.3;
+    end
 
-	if (mab < 0.7) then
-		mab = 0.7;
-	end
+    if (mab < 0.7) then
+        mab = 0.7;
+    end
 
-	if (tpeffect==TP_DMG_BONUS) then
-		damage = damage * ((skill:getTP()*tpvalue)/100);
-	end
+    if (tpeffect==TP_DMG_BONUS) then
+        damage = damage * ((skill:getTP()*tpvalue)/100);
+    end
 
-	-- printf("power: %f, bonus: %f", damage, mab);
-	-- resistence is added last
-	finaldmg = damage * mab * dmgmod;
+    -- printf("power: %f, bonus: %f", damage, mab);
+    -- resistence is added last
+    finaldmg = damage * mab * dmgmod;
 
-	-- get resistence
-	resist = applyPlayerResistance(mob,-1,target,mob:getStat(MOD_INT)-target:getStat(MOD_INT),0,element);
+    -- get resistence
+    resist = applyPlayerResistance(mob,-1,target,mob:getStat(MOD_INT)-target:getStat(MOD_INT),0,element);
 
-	-- get elemental damage reduction
-	local defense = 1;
-	if (element > 0) then
-		defense = 1 + (target:getMod(defenseMod[element]) / -1000);
+    -- get elemental damage reduction
+    local defense = 1;
+    if (element > 0) then
+        defense = 1 + (target:getMod(defenseMod[element]) / -1000);
 
-		-- max defense is 50%
-		if (defense < 0.5) then
-			defense = 0.5;
-		end
-	end
+        -- max defense is 50%
+        if (defense < 0.5) then
+            defense = 0.5;
+        end
+    end
 
-	finaldmg = finaldmg * resist * defense;
+    finaldmg = finaldmg * resist * defense;
 
-	returninfo.dmg = finaldmg;
+    returninfo.dmg = finaldmg;
 
-	return returninfo;
+    return returninfo;
 
 end
 
@@ -329,100 +333,100 @@ function applyPlayerResistance(mob,effect,target,diff,bonus,element)
     resist = 1.0;
     magicaccbonus = 0;
 
-	--get the base acc (just skill plus magic acc mod)
-	magicacc = getSkillLvl(1, mob:getMainLvl()) + bonus;
+    --get the base acc (just skill plus magic acc mod)
+    magicacc = getSkillLvl(1, mob:getMainLvl()) + bonus;
 
-	--difference in int/mnd
-	if diff > 10 then
-		magicacc = magicacc + 10 + (diff - 10)/2;
-	else
-		magicacc = magicacc + diff;
-	end
+    --difference in int/mnd
+    if diff > 10 then
+        magicacc = magicacc + 10 + (diff - 10)/2;
+    else
+        magicacc = magicacc + diff;
+    end
 
-	--base magic evasion (base magic evasion plus resistances(players), plus elemental defense(mobs)
-	local magiceva = target:getMod(MOD_MEVA);
+    --base magic evasion (base magic evasion plus resistances(players), plus elemental defense(mobs)
+    local magiceva = target:getMod(MOD_MEVA);
 
-	-- add elemental resistence
-	if (element > 0) then
-		magiceva = magiceva + target:getMod(resistMod[element]);
-	end
+    -- add elemental resistence
+    if (element > 0) then
+        magiceva = magiceva + target:getMod(resistMod[element]);
+    end
 
-	p = magicacc - (magiceva * 0.8);
+    p = magicacc - (magiceva * 0.8);
 
-	--printf("acc: %f, eva: %f, bonus: %f", magicacc, magiceva, magicaccbonus);
-	--double any acc over 50 if it's over 50
-	if (p > 5) then
-		p = 5 + (p - 5) * 2;
-	end
+    --printf("acc: %f, eva: %f, bonus: %f", magicacc, magiceva, magicaccbonus);
+    --double any acc over 50 if it's over 50
+    if (p > 5) then
+        p = 5 + (p - 5) * 2;
+    end
 
-	--add a flat bonus that won't get doubled in the previous step
-	p = p + 45;
+    --add a flat bonus that won't get doubled in the previous step
+    p = p + 45;
 
-	--add a scaling bonus or penalty based on difference of targets level from caster
-	leveldiff = mob:getMainLvl() - target:getMainLvl();
-	if leveldiff > 0 then
-		p = p - (25 * ( (mob:getMainLvl()) / 75 )) + leveldiff;
-	else
-		p = p + (25 * ( (mob:getMainLvl()) / 75 )) + leveldiff;
-	end
+    --add a scaling bonus or penalty based on difference of targets level from caster
+    leveldiff = mob:getMainLvl() - target:getMainLvl();
+    if leveldiff > 0 then
+        p = p - (25 * ( (mob:getMainLvl()) / 75 )) + leveldiff;
+    else
+        p = p + (25 * ( (mob:getMainLvl()) / 75 )) + leveldiff;
+    end
 
-	-- printf("final power: %f", p);
-	--cap accuracy
+    -- printf("final power: %f", p);
+    --cap accuracy
     if (p > 95) then
         p = 95;
     elseif (p < 5) then
         p = 5;
     end
 
-	p = p / 100;
+    p = p / 100;
 
     -- Resistance thresholds based on p.  A higher p leads to lower resist rates, and a lower p leads to higher resist rates.
     half = (1 - p);
 
-	-- add effect resistence
-	if (effect ~= nil and effect > 0) then
-		local effectres = 0;
-		if (effect == EFFECT_SLEEP_I or effect == EFFECT_SLEEP_II or effect == EFFECT_LULLABY) then
-			effectres = MOD_SLEEPRES;
-		elseif (effect == EFFECT_POISON) then
-			effectres = MOD_POISONRES;
-		elseif (effect == EFFECT_PARALYZE) then
-			effectres = MOD_PARALYZERES;
-		elseif (effect == EFFECT_BLIND) then
-			effectres = MOD_BLINDRES
-		elseif (effect == EFFECT_SILENCE) then
-			effectres = MOD_SILENCERES;
-		elseif (effect == EFFECT_PLAGUE or effect == EFFECT_DISEASE) then
-			effectres = MOD_VIRUSRES;
-		elseif (effect == EFFECT_PETRIFICATION) then
-			effectres = MOD_PETRIFYRES;
-		elseif (effect == EFFECT_BIND) then
-			effectres = MOD_BINDRES;
-		elseif (effect == EFFECT_CURSE_I or effect == EFFECT_CURSE_II or effect == EFFECT_BANE) then
-			effectres = MOD_CURSERES;
-		elseif (effect == EFFECT_WEIGHT) then
-			effectres = MOD_GRAVITYRES;
-		elseif (effect == EFFECT_SLOW) then
-			effectres = MOD_SLOWRES;
-		elseif (effect == EFFECT_STUN) then
-			effectres = MOD_STUNRES;
-		elseif (effect == EFFECT_CHARM) then
-			effectres = MOD_CHARMRES;
-		elseif (effect == EFFECT_AMNESIA) then
-			effectres = MOD_AMNESIARES;
-		end
+    -- add effect resistence
+    if (effect ~= nil and effect > 0) then
+        local effectres = 0;
+        if (effect == EFFECT_SLEEP_I or effect == EFFECT_SLEEP_II or effect == EFFECT_LULLABY) then
+            effectres = MOD_SLEEPRES;
+        elseif (effect == EFFECT_POISON) then
+            effectres = MOD_POISONRES;
+        elseif (effect == EFFECT_PARALYZE) then
+            effectres = MOD_PARALYZERES;
+        elseif (effect == EFFECT_BLIND) then
+            effectres = MOD_BLINDRES
+        elseif (effect == EFFECT_SILENCE) then
+            effectres = MOD_SILENCERES;
+        elseif (effect == EFFECT_PLAGUE or effect == EFFECT_DISEASE) then
+            effectres = MOD_VIRUSRES;
+        elseif (effect == EFFECT_PETRIFICATION) then
+            effectres = MOD_PETRIFYRES;
+        elseif (effect == EFFECT_BIND) then
+            effectres = MOD_BINDRES;
+        elseif (effect == EFFECT_CURSE_I or effect == EFFECT_CURSE_II or effect == EFFECT_BANE) then
+            effectres = MOD_CURSERES;
+        elseif (effect == EFFECT_WEIGHT) then
+            effectres = MOD_GRAVITYRES;
+        elseif (effect == EFFECT_SLOW) then
+            effectres = MOD_SLOWRES;
+        elseif (effect == EFFECT_STUN) then
+            effectres = MOD_STUNRES;
+        elseif (effect == EFFECT_CHARM) then
+            effectres = MOD_CHARMRES;
+        elseif (effect == EFFECT_AMNESIA) then
+            effectres = MOD_AMNESIARES;
+        end
 
-		if (effectres > 0) then
-			local resrate = 1+(target:getMod(effectres)/20);
-			if (resrate > 1.5) then
-				resrate = 1.5;
-			end
+        if (effectres > 0) then
+            local resrate = 1+(target:getMod(effectres)/20);
+            if (resrate > 1.5) then
+                resrate = 1.5;
+            end
 
-			-- printf("Resist percentage: %f", resrate);
-			-- increase resistance based on effect
-			half = half * resrate;
-		end
-	end
+            -- printf("Resist percentage: %f", resrate);
+            -- increase resistance based on effect
+            half = half * resrate;
+        end
+    end
 
     -- Resistance thresholds based on p.  A higher p leads to lower resist rates, and a lower p leads to higher resist rates.
     --half = (1 - p); defined and possibly modified above
@@ -460,69 +464,69 @@ end;
 
 function mobAddBonuses(caster, spell, target, dmg, ele)
 
-	speciesReduction = target:getMod(defenseMod[ele]);
-	speciesReduction = 1.00 - (speciesReduction/1000);
-	dmg = math.floor(dmg * speciesReduction);
+    speciesReduction = target:getMod(defenseMod[ele]);
+    speciesReduction = 1.00 - (speciesReduction/1000);
+    dmg = math.floor(dmg * speciesReduction);
 
-	dayWeatherBonus = 1.00;
+    dayWeatherBonus = 1.00;
 
-	if caster:getWeather() == singleWeatherStrong[ele] then
-		if math.random() < 0.33 then
-			dayWeatherBonus = dayWeatherBonus + 0.10;
-		end
-	elseif caster:getWeather() == singleWeatherWeak[ele] then
-		if math.random() < 0.33 then
-			dayWeatherBonus = dayWeatherBonus - 0.10;
-		end
-	elseif caster:getWeather() == doubleWeatherStrong[ele] then
-		if math.random() < 0.33 then
-			dayWeatherBonus = dayWeatherBonus + 0.25;
-		end
-	elseif caster:getWeather() == doubleWeatherWeak[ele] then
-		if math.random() < 0.33 then
-			dayWeatherBonus = dayWeatherBonus - 0.25;
-		end
-	end
+    if caster:getWeather() == singleWeatherStrong[ele] then
+        if math.random() < 0.33 then
+            dayWeatherBonus = dayWeatherBonus + 0.10;
+        end
+    elseif caster:getWeather() == singleWeatherWeak[ele] then
+        if math.random() < 0.33 then
+            dayWeatherBonus = dayWeatherBonus - 0.10;
+        end
+    elseif caster:getWeather() == doubleWeatherStrong[ele] then
+        if math.random() < 0.33 then
+            dayWeatherBonus = dayWeatherBonus + 0.25;
+        end
+    elseif caster:getWeather() == doubleWeatherWeak[ele] then
+        if math.random() < 0.33 then
+            dayWeatherBonus = dayWeatherBonus - 0.25;
+        end
+    end
 
-	if VanadielDayElement() == dayStrong[ele] then
-		if math.random() < 0.33 then
-			dayWeatherBonus = dayWeatherBonus + 0.10;
-		end
-	elseif VanadielDayElement() == dayWeak[ele] then
-		if math.random() < 0.33 then
-			dayWeatherBonus = dayWeatherBonus + 0.10;
-		end
-	end
+    if VanadielDayElement() == dayStrong[ele] then
+        if math.random() < 0.33 then
+            dayWeatherBonus = dayWeatherBonus + 0.10;
+        end
+    elseif VanadielDayElement() == dayWeak[ele] then
+        if math.random() < 0.33 then
+            dayWeatherBonus = dayWeatherBonus + 0.10;
+        end
+    end
 
-	if dayWeatherBonus > 1.35 then
-		dayWeatherBonus = 1.35;
-	end
+    if dayWeatherBonus > 1.35 then
+        dayWeatherBonus = 1.35;
+    end
 
-	dmg = math.floor(dmg * dayWeatherBonus);
+    dmg = math.floor(dmg * dayWeatherBonus);
 
     burst = calculateMobMagicBurst(caster, ele, target);
 
-	-- not sure what to do for this yet
+    -- not sure what to do for this yet
     -- if (burst > 1.0) then
-		-- spell:setMsg(spell:getMagicBurstMessage()); -- "Magic Burst!"
-	-- end
+        -- spell:setMsg(spell:getMagicBurstMessage()); -- "Magic Burst!"
+    -- end
 
-	dmg = math.floor(dmg * burst);
+    dmg = math.floor(dmg * burst);
 
     mab = (100 + caster:getMod(MOD_MATT)) / (100 + target:getMod(MOD_MDEF)) ;
 
-	dmg = math.floor(dmg * mab);
+    dmg = math.floor(dmg * mab);
 
-	magicDmgMod = (256 + target:getMod(MOD_DMGMAGIC)) / 256;
+    magicDmgMod = (256 + target:getMod(MOD_DMGMAGIC)) / 256;
 
-	dmg = math.floor(dmg * magicDmgMod);
+    dmg = math.floor(dmg * magicDmgMod);
 
-	-- print(affinityBonus);
-	-- print(speciesReduction);
-	-- print(dayWeatherBonus);
-	-- print(burst);
-	-- print(mab);
-	-- print(magicDmgMod);
+    -- print(affinityBonus);
+    -- print(speciesReduction);
+    -- print(dayWeatherBonus);
+    -- print(burst);
+    -- print(mab);
+    -- print(magicDmgMod);
 
     return dmg;
 end
@@ -534,20 +538,20 @@ function calculateMobMagicBurst(caster, ele, target)
     local skillchainTier, skillchainCount = MobFormMagicBurst(ele, target);
 
     if (skillchainTier > 0) then
-		if (skillchainCount == 1) then
-			burst = 1.3;
-		elseif (skillchainCount == 2) then
-			burst = 1.35;
-		elseif (skillchainCount == 3) then
-			 burst = 1.40;
-		elseif (skillchainCount == 4) then
-			burst = 1.45;
-		elseif (skillchainCount == 5) then
-			burst = 1.50;
-		else
-			-- Something strange is going on if this occurs.
-			burst = 1.0;
-		end
+        if (skillchainCount == 1) then
+            burst = 1.3;
+        elseif (skillchainCount == 2) then
+            burst = 1.35;
+        elseif (skillchainCount == 3) then
+             burst = 1.40;
+        elseif (skillchainCount == 4) then
+            burst = 1.45;
+        elseif (skillchainCount == 5) then
+            burst = 1.50;
+        else
+            -- Something strange is going on if this occurs.
+            burst = 1.0;
+        end
     end
 
     return burst;
@@ -560,133 +564,133 @@ end;
 -- Equation: (HP * percent) + (LVL / base)
 -- cap is optional, defines a maximum damage
 function MobBreathMove(mob, target, percent, base, element, cap)
-	local damage = (mob:getHP() * percent) + (mob:getMainLvl() / base);
+    local damage = (mob:getHP() * percent) + (mob:getMainLvl() / base);
 
-	if (cap == nil) then
-		-- super cap for high health mobs
-		if (damage > 700) then
-			damage = 700 + math.random(200);
-		end
+    if (cap == nil) then
+        -- super cap for high health mobs
+        if (damage > 700) then
+            damage = 700 + math.random(200);
+        end
 
-		-- cap max damage
-		if (damage > mob:getHP()/5) then
-			damage = math.floor(mob:getHP()/5);
-		end
-	else
-		if (damage > cap) then
-			damage = cap;
-		end
-	end
+        -- cap max damage
+        if (damage > mob:getHP()/5) then
+            damage = math.floor(mob:getHP()/5);
+        end
+    else
+        if (damage > cap) then
+            damage = cap;
+        end
+    end
 
-	-- elemental resistence
-	if (element ~= nil and element > 0) then
-		-- no skill available, pass nil
-		-- breath moves get a bonus accuracy because they are hard to resist
-		local resist = applyPlayerResistance(mob,nil,target,mob:getStat(MOD_INT)-target:getStat(MOD_INT),mob:getMainLvl(),element);
+    -- elemental resistence
+    if (element ~= nil and element > 0) then
+        -- no skill available, pass nil
+        -- breath moves get a bonus accuracy because they are hard to resist
+        local resist = applyPlayerResistance(mob,nil,target,mob:getStat(MOD_INT)-target:getStat(MOD_INT),mob:getMainLvl(),element);
 
-		-- get elemental damage reduction
-		local defense = 1 - (target:getMod(resistMod[element]) + target:getMod(defenseMod[element])) / 256;
+        -- get elemental damage reduction
+        local defense = 1 - (target:getMod(resistMod[element]) + target:getMod(defenseMod[element])) / 256;
 
-		-- max defense is 50%
-		if (defense < 0.5) then
-			defense = 0.5;
-		end
+        -- max defense is 50%
+        if (defense < 0.5) then
+            defense = 0.5;
+        end
 
-		damage = damage * resist * defense;
-	end
+        damage = damage * resist * defense;
+    end
 
-	return damage;
+    return damage;
 end;
 
 function MobFinalAdjustments(dmg,mob,skill,target,skilltype,skillparam,shadowbehav)
 
-	-- physical attack missed, skip rest
-	if (skill:hasMissMsg()) then
-		return 0;
-	end
+    -- physical attack missed, skip rest
+    if (skill:hasMissMsg()) then
+        return 0;
+    end
 
-	--handle pd
-	if ((target:hasStatusEffect(EFFECT_PERFECT_DODGE) or target:hasStatusEffect(EFFECT_ALL_MISS) )
+    --handle pd
+    if ((target:hasStatusEffect(EFFECT_PERFECT_DODGE) or target:hasStatusEffect(EFFECT_ALL_MISS) )
             and skilltype==MOBSKILL_PHYSICAL) then
-		skill:setMsg(MSG_MISS);
-		return 0;
-	end
+        skill:setMsg(MSG_MISS);
+        return 0;
+    end
 
-	-- set message to damage
-	-- this is for AoE because its only set once
-	skill:setMsg(MSG_DAMAGE);
+    -- set message to damage
+    -- this is for AoE because its only set once
+    skill:setMsg(MSG_DAMAGE);
 
-	--Handle shadows depending on shadow behaviour / skilltype
-	if (shadowbehav ~= MOBPARAM_WIPE_SHADOWS and shadowbehav ~= MOBPARAM_IGNORE_SHADOWS) then --remove 'shadowbehav' shadows.
+    --Handle shadows depending on shadow behaviour / skilltype
+    if (shadowbehav ~= MOBPARAM_WIPE_SHADOWS and shadowbehav ~= MOBPARAM_IGNORE_SHADOWS) then --remove 'shadowbehav' shadows.
 
-		if (skill:isAoE() or skill:isConal()) then
-			shadowbehav = MobTakeAoEShadow(mob, target, shadowbehav);
-		end
+        if (skill:isAoE() or skill:isConal()) then
+            shadowbehav = MobTakeAoEShadow(mob, target, shadowbehav);
+        end
 
-		dmg = utils.takeShadows(target, dmg, shadowbehav);
+        dmg = utils.takeShadows(target, dmg, shadowbehav);
 
-		-- dealt zero damage, so shadows took hit
-		if (dmg == 0) then
-			skill:setMsg(MSG_SHADOW);
-			return shadowbehav;
-		end
+        -- dealt zero damage, so shadows took hit
+        if (dmg == 0) then
+            skill:setMsg(MSG_SHADOW);
+            return shadowbehav;
+        end
 
-	elseif (shadowbehav == MOBPARAM_WIPE_SHADOWS) then --take em all!
-		target:delStatusEffect(EFFECT_COPY_IMAGE);
-		target:delStatusEffect(EFFECT_BLINK);
-		target:delStatusEffect(EFFECT_THIRD_EYE);
-	end
+    elseif (shadowbehav == MOBPARAM_WIPE_SHADOWS) then --take em all!
+        target:delStatusEffect(EFFECT_COPY_IMAGE);
+        target:delStatusEffect(EFFECT_BLINK);
+        target:delStatusEffect(EFFECT_THIRD_EYE);
+    end
 
-	if (skilltype == MOBSKILL_PHYSICAL and skill:isSingle() == false) then
-		target:delStatusEffect(EFFECT_THIRD_EYE);
-	end
+    if (skilltype == MOBSKILL_PHYSICAL and skill:isSingle() == false) then
+        target:delStatusEffect(EFFECT_THIRD_EYE);
+    end
 
-	--handle Third Eye using shadowbehav as a guide
-	if (skilltype == MOBSKILL_PHYSICAL and utils.thirdeye(target)) then
-	    skill:setMsg(MSG_ANTICIPATE);
-	    return 0;
-	end
+    --handle Third Eye using shadowbehav as a guide
+    if (skilltype == MOBSKILL_PHYSICAL and utils.thirdeye(target)) then
+        skill:setMsg(MSG_ANTICIPATE);
+        return 0;
+    end
 
-	if (skilltype == MOBSKILL_PHYSICAL) then
+    if (skilltype == MOBSKILL_PHYSICAL) then
 
-		dmg = target:physicalDmgTaken(dmg);
+        dmg = target:physicalDmgTaken(dmg);
 
-	elseif (skilltype == MOBSKILL_MAGICAL) then
+    elseif (skilltype == MOBSKILL_MAGICAL) then
 
-		dmg = target:magicDmgTaken(dmg);
+        dmg = target:magicDmgTaken(dmg);
 
-	elseif (skilltype == MOBSKILL_BREATH) then
+    elseif (skilltype == MOBSKILL_BREATH) then
 
-		dmg = target:breathDmgTaken(dmg);
+        dmg = target:breathDmgTaken(dmg);
 
-	elseif (skilltype == MOBSKILL_RANGED) then
+    elseif (skilltype == MOBSKILL_RANGED) then
 
-		dmg = target:rangedDmgTaken(dmg);
+        dmg = target:rangedDmgTaken(dmg);
 
-	end
+    end
 
-	--handling phalanx
-	dmg = dmg - target:getMod(MOD_PHALANX);
+    --handling phalanx
+    dmg = dmg - target:getMod(MOD_PHALANX);
 
-	if (dmg < 0) then
-		return 0;
-	end
+    if (dmg < 0) then
+        return 0;
+    end
 
-	dmg = utils.stoneskin(target, dmg);
+    dmg = utils.stoneskin(target, dmg);
 
-	if (dmg > 0) then
-		target:wakeUp();
-		target:updateEnmityFromDamage(mob,dmg);
-	end
+    if (dmg > 0) then
+        target:wakeUp();
+        target:updateEnmityFromDamage(mob,dmg);
+    end
 
-	return dmg;
+    return dmg;
 end;
 
 -- returns true if mob attack hit
 -- used to stop tp move status effects
 function MobPhysicalHit(skill)
-	-- if message is not the default. Then there was a miss, shadow taken etc
-	return skill:hasMissMsg() == false;
+    -- if message is not the default. Then there was a miss, shadow taken etc
+    return skill:hasMissMsg() == false;
 end;
 
 -- function MobHit()
@@ -704,20 +708,20 @@ end;
 -- Adds a status effect to a target
 function MobStatusEffectMove(mob, target, typeEffect, power, tick, duration)
 
-	if (target:canGainStatusEffect(typeEffect, power)) then
-		local statmod = MOD_INT;
-		local element = mob:getStatusEffectElement(typeEffect);
+    if (target:canGainStatusEffect(typeEffect, power)) then
+        local statmod = MOD_INT;
+        local element = mob:getStatusEffectElement(typeEffect);
 
-		local resist = applyPlayerResistance(mob,typeEffect,target,mob:getStat(statmod)-target:getStat(statmod),0,element);
+        local resist = applyPlayerResistance(mob,typeEffect,target,mob:getStat(statmod)-target:getStat(statmod),0,element);
 
-		if (resist >= 0.5) then
-			target:addStatusEffect(typeEffect,power,tick,duration*resist);
-			return MSG_ENFEEB_IS;
-		end
+        if (resist >= 0.5) then
+            target:addStatusEffect(typeEffect,power,tick,duration*resist);
+            return MSG_ENFEEB_IS;
+        end
 
-		return MSG_MISS; -- resist !
-	end
-	return MSG_NO_EFFECT; -- no effect
+        return MSG_MISS; -- resist !
+    end
+    return MSG_NO_EFFECT; -- no effect
 end;
 
 -- similar to status effect move except, this will not land if the attack missed
@@ -730,74 +734,74 @@ end;
 
 -- similar to statuseffect move except it will only take effect if facing
 function MobGazeMove(mob, target, typeEffect, power, tick, duration)
-	if (target:isFacing(mob)) then
-		return MobStatusEffectMove(mob, target, typeEffect, power, tick, duration);
-	end
-	return MSG_NO_EFFECT;
+    if (target:isFacing(mob)) then
+        return MobStatusEffectMove(mob, target, typeEffect, power, tick, duration);
+    end
+    return MSG_NO_EFFECT;
 end;
 
 function MobBuffMove(mob, typeEffect, power, tick, duration)
 
     if (mob:addStatusEffect(typeEffect,power,tick,duration)) then
-	    return MSG_BUFF;
+        return MSG_BUFF;
     end
-	return MSG_NO_EFFECT;
+    return MSG_NO_EFFECT;
 end;
 
 function MobHealMove(target, heal)
 
-	local mobHP = target:getHP();
-	local mobMaxHP = target:getMaxHP();
+    local mobHP = target:getHP();
+    local mobMaxHP = target:getMaxHP();
 
-	if (mobHP+heal > mobMaxHP) then
-		heal = mobMaxHP - mobHP;
-	end
+    if (mobHP+heal > mobMaxHP) then
+        heal = mobMaxHP - mobHP;
+    end
 
-	target:wakeUp();
+    target:wakeUp();
 
-	target:addHP(heal);
+    target:addHP(heal);
 
-	return heal;
+    return heal;
 end
 
 function MobTakeAoEShadow(mob, target, max)
 
-	-- local chance = 75;
+    -- local chance = 75;
 
-	-- local targetSkill = target:getSkillLevel(NINJUTSU_SKILL);
-	-- local mobSkill = getSkillLvl(3, mob:getMainLvl());
+    -- local targetSkill = target:getSkillLevel(NINJUTSU_SKILL);
+    -- local mobSkill = getSkillLvl(3, mob:getMainLvl());
 
-	-- this is completely crap and should be using actual nin skill
-	-- TODO fix this
-	if (target:getMainJob() == JOB_NIN and math.random() < 0.6) then
-		max = max - 1;
-		if (max < 1) then
-			max = 1;
-		end
-	end
+    -- this is completely crap and should be using actual nin skill
+    -- TODO fix this
+    if (target:getMainJob() == JOB_NIN and math.random() < 0.6) then
+        max = max - 1;
+        if (max < 1) then
+            max = 1;
+        end
+    end
 
-	return math.random(1, max);
+    return math.random(1, max);
 end;
 
 function MobTPMod(tp)
-	-- increase damage based on tp
-	if (tp >= 300) then
-		return 2;
-	elseif (tp >= 200) then
-		return 1.5;
-	end
-	return 1;
+    -- increase damage based on tp
+    if (tp >= 300) then
+        return 2;
+    elseif (tp >= 200) then
+        return 1.5;
+    end
+    return 1;
 end;
 
 function fTP(tp,ftp1,ftp2,ftp3)
-	if (tp<100) then
-		tp=100;
-	end
-	if (tp>=100 and tp<150) then
-		return ftp1 + ( ((ftp2-ftp1)/50) * (tp-100));
-	elseif (tp>=150 and tp<=300) then
-		--generate a straight line between ftp2 and ftp3 and find point @ tp
-		return ftp2 + ( ((ftp3-ftp2)/150) * (tp-150));
-	end
-	return 1; --no ftp mod
+    if (tp<100) then
+        tp=100;
+    end
+    if (tp>=100 and tp<150) then
+        return ftp1 + ( ((ftp2-ftp1)/50) * (tp-100));
+    elseif (tp>=150 and tp<=300) then
+        --generate a straight line between ftp2 and ftp3 and find point @ tp
+        return ftp2 + ( ((ftp3-ftp2)/150) * (tp-150));
+    end
+    return 1; --no ftp mod
 end;

--- a/scripts/globals/spells/bluemagic/cannonball.lua
+++ b/scripts/globals/spells/bluemagic/cannonball.lua
@@ -49,9 +49,9 @@ function onSpellCast(caster,target,spell)
         params.int_wsc = 0.0;
         params.mnd_wsc = 0.0;
         params.chr_wsc = 0.0;
+        params.offcratiomod = caster:getStat(MOD_DEF);
     damage = BluePhysicalSpell(caster, target, spell, params);
     damage = BlueFinalAdjustments(caster, target, spell, damage, params);
-   -- Missing Bonus damage from defense?
    
     return damage;
 end;

--- a/scripts/zones/Halvung/mobs/Wamouracampa.lua
+++ b/scripts/zones/Halvung/mobs/Wamouracampa.lua
@@ -1,10 +1,10 @@
 -----------------------------------
 -- Area: Halvung
--- MOB:  Wheel Wamoura
+-- MOB:  Wamouracampa
 -----------------------------------
 require("scripts/globals/status");
 
--- TODO: Damage resistances in streched and curled stances. Halting movement during stance change.
+-- TODO: Damage resistances in streched and curled stances. Halting movement during stance change. Morph into Wamoura.
 
 -----------------------------------
 -- OnMobSpawn Action

--- a/scripts/zones/Mount_Zhayolm/mobs/Brass_Borer.lua
+++ b/scripts/zones/Mount_Zhayolm/mobs/Brass_Borer.lua
@@ -1,6 +1,6 @@
 -----------------------------------
--- Area: Halvung
--- MOB:  Wheel Wamoura
+-- Area: Mount Zhayolm
+-- MOB:  Brass Borer
 -----------------------------------
 require("scripts/globals/status");
 

--- a/scripts/zones/Mount_Zhayolm/mobs/Wamoura_Prince.lua
+++ b/scripts/zones/Mount_Zhayolm/mobs/Wamoura_Prince.lua
@@ -1,10 +1,10 @@
 -----------------------------------
--- Area: Halvung
--- MOB:  Wheel Wamoura
+-- Area: Mount Zhayolm
+-- MOB:  Wamoura Prince
 -----------------------------------
 require("scripts/globals/status");
 
--- TODO: Damage resistances in streched and curled stances. Halting movement during stance change.
+-- TODO: Damage resistances in streched and curled stances. Halting movement during stance change. Morph into Wamoura.
 
 -----------------------------------
 -- OnMobSpawn Action

--- a/sql/mob_skill.sql
+++ b/sql/mob_skill.sql
@@ -1614,10 +1614,10 @@ INSERT INTO `mob_skill` VALUES (1568,112,1286,'Amorphic_spikes',0,7.0,2000,1500,
 -- Wamouracampa
 INSERT INTO `mob_skill` VALUES (1559,254,1290,'Amber_scutum',0,10.0,2000,1000,1,0,0,0);
 INSERT INTO `mob_skill` VALUES (1560,254,1291,'Vitriolic_spray',4,10.0,2000,1000,4,0,0,0);
-INSERT INTO `mob_skill` VALUES (1561,254,1292,'Thermal_Pulse',1,15.0,2000,1000,4,0,0,0); -- Open form only
-INSERT INTO `mob_skill` VALUES (1562,254,1293,'Cannonball',0,7.0,2000,1000,4,0,0,0); -- Curled form only
+INSERT INTO `mob_skill` VALUES (1561,254,1292,'Thermal_Pulse',1,12.5,2000,1000,4,0,0,0); -- Open form only
+INSERT INTO `mob_skill` VALUES (1562,254,1293,'Cannonball',0,20,2000,1000,4,0,0,0); -- Curled form only
 INSERT INTO `mob_skill` VALUES (1563,254,1294,'Heat_barrier',0,7.0,2000,1000,1,0,0,0);
-INSERT INTO `mob_skill` VALUES (1564,254,1295,'Vitriolic_shower',4,10.0,2000,1000,4,0,0,0);
+-- INSERT INTO `mob_skill` VALUES (1564,254,1295,'Vitriolic_shower',4,10.0,2000,1000,4,0,0,0); -- No page on any wiki for this move??? Seems to be NM only.
 
 -- Wamoura
 INSERT INTO `mob_skill` VALUES (1695,253,1345,'Magma_fan',4,10.0,2000,1000,4,0,0,0);
@@ -2794,11 +2794,11 @@ INSERT INTO `mob_skill` VALUES (1474,288,1203,'Deadeye',1,18,2000,1500,4,0,0,0);
 -- INSERT INTO `mob_skill` VALUES (2103,288,1200,'Strap_Cutter',0,7,2000,1500,4,0,0,0);
 
 -- Brass Borer (289)
--- INSERT INTO `mob_skill` VALUES (1559,289,1290,'Amber_scutum',0,10.0,2000,1000,1,0,0,0);
--- INSERT INTO `mob_skill` VALUES (1560,289,1291,'Vitriolic_spray',4,10.0,2000,1000,4,0,0,0);
--- INSERT INTO `mob_skill` VALUES (1561,289,1292,'Thermal_Pulse',1,15.0,2000,1000,4,0,0,0); -- Open form only
--- INSERT INTO `mob_skill` VALUES (1562,289,1293,'Cannonball',0,7.0,2000,1000,4,0,0,0); -- Curled form only
--- INSERT INTO `mob_skill` VALUES (1563,289,1294,'Heat_barrier',0,7.0,2000,1000,1,0,0,0);
+INSERT INTO `mob_skill` VALUES (1559,289,1290,'Amber_scutum',0,10.0,2000,1000,1,0,0,0);
+INSERT INTO `mob_skill` VALUES (1560,289,1291,'Vitriolic_spray',4,10.0,2000,1000,4,0,0,0);
+INSERT INTO `mob_skill` VALUES (1561,289,1292,'Thermal_Pulse',1,12.5,2000,1000,4,0,0,0); -- Open form only
+INSERT INTO `mob_skill` VALUES (1562,289,1293,'Cannonball',0,20,2000,1000,4,0,0,0); -- Curled form only
+INSERT INTO `mob_skill` VALUES (1563,289,1294,'Heat_barrier',0,7.0,2000,1000,1,0,0,0);
 -- INSERT INTO `mob_skill` VALUES (1564,289,1295,'Vitriolic_shower',4,10.0,2000,1000,4,0,0,0);
 
 -- Claret (290)


### PR DESCRIPTION
Mob: Implemented Amber Scutum, Heat Barrier, Vitriolic Spray, Cannonball, and Heat Barrier. The last two have a form check.
Scripted the stance changing. They change after roughly 45 seconds.
Corrected the range of some of the mobskills, and enabled them for Brass Borer.
Added param offcratiomod to monstertpmoves.lua - if it's nil (which it will be for pretty much everything), it will default to the standard mob attack. Else it will use what's pass on. So for Cannonball, it passes mob defense instead.

Spell: Passed on param.offcratiomod as part of params - if it's nil, it will default to caster's attack. For Cannonball, it passes caster's defense instead.