### PR TITLE
Scripts/SQL: Slug TP moves + Corrosive Ooze spell param fixes

### DIFF
--- a/scripts/globals/mobskills/Corrosive_ooze.lua
+++ b/scripts/globals/mobskills/Corrosive_ooze.lua
@@ -1,0 +1,33 @@
+---------------------------------------------------
+--  Corrosive Ooze
+--  Family: Slugs
+--  Description: Deals water damage to an enemy. Additional Effect: Attack Down and Defense Down.
+--  Type: Magical
+--  Utsusemi/Blink absorb: Ignores shadows 
+--  Range: Radial
+--  Notes:
+---------------------------------------------------
+require("scripts/globals/settings");
+require("scripts/globals/status");
+require("scripts/globals/monstertpmoves");
+---------------------------------------------------
+
+function onMobSkillCheck(target,mob,skill)
+    return 0;
+end;
+
+function onMobWeaponSkill(target, mob, skill)
+    local typeEffectOne = EFFECT_ATTACK_DOWN;
+    local typeEffectTwo = EFFECT_DEFENSE_DOWN;
+    local duration = 120;
+
+    MobStatusEffectMove(mob, target, typeEffectOne, 15, 0, duration);
+    MobStatusEffectMove(mob, target, typeEffectTwo, 15, 0, duration);
+
+    local dmgmod = 1;
+    local baseDamage = mob:getWeaponDmg()*4.2;
+    local info = MobMagicalMove(mob,target,skill,baseDamage,ELE_WATER,dmgmod,TP_NO_EFFECT);
+    local dmg = MobFinalAdjustments(info.dmg,mob,skill,target,MOBSKILL_MAGICAL,MOBPARAM_WATER,MOBPARAM_IGNORE_SHADOWS);
+    target:delHP(dmg);
+    return dmg;
+end;

--- a/scripts/globals/mobskills/Fuscous_ooze.lua
+++ b/scripts/globals/mobskills/Fuscous_ooze.lua
@@ -1,0 +1,32 @@
+---------------------------------------------------
+--  Fuscous Ooze
+--  Family: Slugs
+--  Description: A dusky slime inflicts encumberance and weight.
+--  Type: Magical
+--  Utsusemi/Blink absorb: Ignores shadows 
+--  Range: Cone
+--  Notes:
+---------------------------------------------------
+require("scripts/globals/settings");
+require("scripts/globals/status");
+require("scripts/globals/monstertpmoves");
+---------------------------------------------------
+
+function onMobSkillCheck(target,mob,skill)
+    return 0;
+end;
+
+function onMobWeaponSkill(target, mob, skill)
+    -- TODO: Encumberance seems to do nothing?
+    local typeEffect = EFFECT_WEIGHT;
+    local duration = 45;
+
+    MobStatusEffectMove(mob, target, typeEffect, 50, 0, duration);
+
+    local dmgmod = 1;
+    local baseDamage = mob:getWeaponDmg()*3.7;
+    local info = MobMagicalMove(mob,target,skill,baseDamage,ELE_WATER,dmgmod,TP_NO_EFFECT);
+    local dmg = MobFinalAdjustments(info.dmg,mob,skill,target,MOBSKILL_MAGICAL,MOBPARAM_WATER,MOBPARAM_IGNORE_SHADOWS);
+    target:delHP(dmg);
+    return dmg;
+end;

--- a/scripts/globals/mobskills/Purulent_ooze.lua
+++ b/scripts/globals/mobskills/Purulent_ooze.lua
@@ -1,0 +1,33 @@
+---------------------------------------------------
+--  Purulent Ooze
+--  Family: Slugs
+--  Description: Deals Water damage in a fan-shaped area of effect. Additional effect: Bio and Max HP Down 
+--  Type: Magical
+--  Utsusemi/Blink absorb: Wipes shadows 
+--  Range: Cone
+--  Notes:
+---------------------------------------------------
+require("scripts/globals/settings");
+require("scripts/globals/status");
+require("scripts/globals/monstertpmoves");
+---------------------------------------------------
+
+function onMobSkillCheck(target,mob,skill)
+    return 0;
+end;
+
+function onMobWeaponSkill(target, mob, skill)
+    local typeEffectOne = EFFECT_BIO;
+    local typeEffectTwo = EFFECT_MAX_HP_DOWN;
+    local duration = 120;
+
+    MobStatusEffectMove(mob, target, typeEffectOne, 5, 3, duration, FLAG_ERASABLE, 10);
+    MobStatusEffectMove(mob, target, typeEffectTwo, 10, 0, duration);
+
+    local dmgmod = 1;
+    local baseDamage = mob:getWeaponDmg()*3;
+    local info = MobMagicalMove(mob,target,skill,damage,ELE_WATER,dmgmod,TP_NO_EFFECT);
+    local dmg = MobFinalAdjustments(info.dmg,mob,skill,target,MOBSKILL_MAGICAL,MOBPARAM_WATER,MOBPARAM_WIPE_SHADOWS);
+    target:delHP(dmg);
+    return dmg;
+end;

--- a/scripts/globals/spells/bluemagic/corrosive_ooze.lua
+++ b/scripts/globals/spells/bluemagic/corrosive_ooze.lua
@@ -33,34 +33,31 @@ function onSpellCast(caster,target,spell)
 
     local params = {};
     -- This data should match information on http://wiki.ffxiclopedia.org/wiki/Calculating_Blue_Magic_Damage
-    local multi = 2.08;
+    local multi = 2.125;
     if (caster:hasStatusEffect(EFFECT_AZURE_LORE)) then
         multi = multi + 0.50;
     end
         params.multiplier = multi;
-        params.tMultiplier = 1.5;
+        params.tMultiplier = 2.0;
         params.duppercap = 69;
         params.str_wsc = 0.0;
         params.dex_wsc = 0.0;
         params.vit_wsc = 0.0;
         params.agi_wsc = 0.0;
-        params.int_wsc = 0.0;
-        params.mnd_wsc = 0.3;
+        params.int_wsc = 0.2;
+        params.mnd_wsc = 0.0;
         params.chr_wsc = 0.0;
-    damage = BlueMagicalSpell(caster, target, spell, params, MND_BASED);
+    damage = BlueMagicalSpell(caster, target, spell, params, INT_BASED);
     damage = BlueFinalAdjustments(caster, target, spell, damage, params);
 
     local resist = applyResistance(caster,spell,target,caster:getStat(MOD_INT) - target:getStat(MOD_INT),BLUE_SKILL,1.0);
+    local typeEffectOne = EFFECT_DEFENSE_DOWN;
+    local typeEffectTwo = EFFECT_ATTACK_DOWN;
+    local duration = 60;
 
     if (damage > 0 and resist > 0.3) then
-        local typeEffect = EFFECT_DEFENSE_DOWN;
-        target:delStatusEffect(typeEffect);
-        target:addStatusEffect(typeEffect,8,0,getBlueEffectDuration(caster,resist,typeEffect));
-    end
-    if (damage > 0 and resist > 0.3) then
-        local typeEffect = EFFECT_ATTACK_DOWN;
-        target:delStatusEffect(typeEffect);
-        target:addStatusEffect(typeEffect,8,0,getBlueEffectDuration(caster,resist,typeEffect));
+        target:addStatusEffect(typeEffectOne,5,0,duration);
+        target:addStatusEffect(typeEffectTwo,5,0,duration);
     end
     
     return damage;

--- a/sql/mob_skill.sql
+++ b/sql/mob_skill.sql
@@ -3202,8 +3202,8 @@ INSERT INTO `mob_skill` VALUES (2113,39,1652,'Scintillant_lance',4,10.0,2000,100
 -- Slugs
 INSERT INTO `mob_skill` VALUES (1927,231,1572,'Fuscous_ooze',4,10.0,2000,1000,4,0,0,0);
 INSERT INTO `mob_skill` VALUES (1928,231,1573,'Purulent_ooze',4,10.0,2000,1000,4,0,0,0);
-INSERT INTO `mob_skill` VALUES (1929,0,1574,'Mucilaginous_ooze',1,15.0,2000,1000,4,0,0,0); -- Certain NM only
-INSERT INTO `mob_skill` VALUES (1930,231,1575,'Corrosive_ooze',1,15.0,2000,1000,4,0,0,0);
+INSERT INTO `mob_skill` VALUES (1929,231,1574,'Corrosive_ooze',1,15.0,2000,1000,4,0,0,0);
+-- INSERT INTO `mob_skill` VALUES (1930,???,1575,'Mucilaginous_ooze',1,15.0,2000,1000,4,0,0,0); -- Certain NM only
 
 -- Sandworms
 INSERT INTO `mob_skill` VALUES (1931,215,1537,'Dustvoid',1,18.0,2000,1000,4,0,0,0);


### PR DESCRIPTION
Implemented Corrosive Ooze, Fuscous Ooze, and Purulent Ooze mobskills for Slugs.
Corrected the swapping of Corrosive Ooze and Mucilaginous Ooze in mob_skill.sql.
Corrected the parameters in the spell version of Corrosive Ooze to match retail. https://www.bg-wiki.com/bg/Corrosive_Ooze