### PR TITLE
Scripts: Esuna fix, Sacrifice target

### DIFF
--- a/scripts/globals/spells/esuna.lua
+++ b/scripts/globals/spells/esuna.lua
@@ -10,44 +10,69 @@ require("scripts/globals/magic");
 -----------------------------------------
 
 function onMagicCastingCheck(caster,target,spell)
-	return 0;
+    if (caster:getID() ~= target:getID()) then
+        return MSGBASIC_CANNOT_PERFORM_TARG;
+    else
+        return 0;
+    end;
 end;
 
 function onSpellCast(caster,target,spell)
-    local count = 1;
 
-    local removables = {EFFECT_FLASH, EFFECT_BLINDNESS, EFFECT_PARALYSIS, EFFECT_POISON, EFFECT_CURSE_I, EFFECT_CURSE_II, EFFECT_DISEASE, EFFECT_PLAGUE};
-    
-    if (caster:hasStatusEffect(EFFECT_AFFLATUS_MISERY)) then
-        printf("AFFLATUS MISERY BONUS: Removing 2 Effects, Additional Effects Eligible");
-        count = 2
-        removables = {EFFECT_FLASH, EFFECT_BLINDNESS, EFFECT_PARALYSIS, EFFECT_POISON, EFFECT_CURSE_I, EFFECT_CURSE_II, EFFECT_DISEASE, EFFECT_PLAGUE, EFFECT_BIO, EFFECT_DIA, EFFECT_BURN, EFFECT_FROST, EFFECT_CHOKE, EFFECT_RASP, EFFECT_SHOCK, EFFECT_DROWN, EFFECT_STR_DOWN, EFFECT_DEX_DOWN, EFFECT_VIT_DOWN, EFFECT_AGI_DOWN, EFFECT_INT_DOWN, EFFECT_MND_DOWN, EFFECT_CHR_DOWN, EFFECT_GRAVITY, EFFECT_ADDLE, EFFECT_SLOW, EFFECT_REQUIEM, EFFECT_ELEGY, EFFECT_HELIX};
-    end
+    if (caster:getID() == target:getID()) then -- much of this should only run once per cast, otherwise it would only delete the debuffs from the caster.
 
-    local has = {};
+        local statusNum = -1;
+        local removables = {EFFECT_FLASH, EFFECT_BLINDNESS, EFFECT_PARALYSIS, EFFECT_POISON, EFFECT_CURSE_I, EFFECT_CURSE_II, EFFECT_DISEASE, EFFECT_PLAGUE};
 
-    -- collect a list of what caster currently has
-    for i, effect in ipairs(removables) do
-        if (caster:hasStatusEffect(effect)) then
-            has[i] = true;
-        end
-    end
+        if (caster:hasStatusEffect(EFFECT_AFFLATUS_MISERY)) then -- add extra statuses to the list of removables. Elegy and Requiem are specifically absent.
+            removables = {EFFECT_FLASH, EFFECT_BLINDNESS, EFFECT_PARALYSIS, EFFECT_POISON, EFFECT_CURSE_I, EFFECT_CURSE_II, EFFECT_DISEASE, EFFECT_PLAGUE, EFFECT_WEIGHT, EFFECT_BIND, EFFECT_BIO, EFFECT_DIA, EFFECT_BURN, EFFECT_FROST, EFFECT_CHOKE, EFFECT_RASP, EFFECT_SHOCK, EFFECT_DROWN, EFFECT_STR_DOWN, EFFECT_DEX_DOWN, EFFECT_VIT_DOWN, EFFECT_AGI_DOWN, EFFECT_INT_DOWN, EFFECT_MND_DOWN, EFFECT_CHR_DOWN, EFFECT_ADDLE, EFFECT_SLOW, EFFECT_HELIX, EFFECT_ACCURACY_DOWN, EFFECT_ATTACK_DOWN, EFFECT_EVASION_DOWN, EFFECT_DEFENSE_DOWN, EFFECT_MAGIC_ACC_DOWN, EFFECT_MAGIC_ATK_DOWN, EFFECT_MAGIC_EVASION_DOWN, EFFECT_MAGIC_DEF_DOWN, EFFECT_MAX_TP_DOWN, EFFECT_MAX_MP_DOWN, EFFECT_MAX_HP_DOWN};
+        end;
 
-    -- remove effects only if cast has it as well
-    for i, effect in ipairs(removables) do
-        if (has[i] and target:hasStatusEffect(effect)) then            
-            target:delStatusEffect(effect);  
-	    count = count - 1;
-	    
-	    if (count == 0) then
-	       return effect;
-	    end;
-        end
-    end
+        local has = {};
 
-    if (count > 0) then
+        -- collect a list of what caster currently has
+        for i, effect in ipairs(removables) do
+            if (caster:hasStatusEffect(effect)) then
+                statusNum = statusNum + 1
+                has[statusNum] = removables[i];
+            end;
+        end;
+
+        if (statusNum >= 0) then -- make sure this happens once instead of for every target
+            local delEff = math.random(0,statusNum); -- pick a random status to delete
+            esunaDelEff = has[delEff]; -- this can't be a local because it would only delete from the caster if it were.
+        else -- clear it if the caster has no eligible statuses, otherwise it will remove the status from others if it was previously removed.
+            esunaDelEff = 0;
+            esunaDelEffMis = 0;  -- again, this can't be a local because it would only delete from the caster if it were. For extra status deletion under Misery
+        end;
+        
+        if (statusNum >= 1 and caster:hasStatusEffect(EFFECT_AFFLATUS_MISERY)) then -- Misery second status removal.
+            caster:delStatusEffect(esunaDelEff); -- delete the first selected effect so it doesn't get selected again. Won't impact the ability to delete it from others at this point.
+            local statusNumMis =  - 1 -- need a new var to track the amount of debuffs for the array
+            
+            -- collect a list of what caster currently has, again
+            for i, effect in ipairs(removables) do
+                if (caster:hasStatusEffect(effect)) then
+                    statusNumMis = statusNumMis + 1
+                    has[statusNumMis] = removables[i];
+                end;
+            end;
+
+            local delEffMis = math.random(0,statusNumMis); -- pick another random status to delete
+            esunaDelEffMis = has[delEffMis];
+        else
+            esunaDelEffMis = 0;
+        end;
+    end;
+
+    if (esunaDelEff == 0) then -- this gets set to 0 if there's no status to delete.
         spell:setMsg(75); -- no effect
-    end
+    elseif (esunaDelEffMis ~= 0) then -- no need to check for esunaDelEff because it can't be 0 if this isn't
+        target:delStatusEffect(esunaDelEff);
+        target:delStatusEffect(esunaDelEffMis);
+    else
+        target:delStatusEffect(esunaDelEff);
+    end;
 
-    return 0;
+    return esunaDelEff;
 end;

--- a/scripts/globals/spells/sacrifice.lua
+++ b/scripts/globals/spells/sacrifice.lua
@@ -10,7 +10,11 @@ require("scripts/globals/magic");
 -----------------------------------------
 
 function onMagicCastingCheck(caster,target,spell)
-	return 0;
+    if (caster:getID() == target:getID()) then
+        return MSGBASIC_CANNOT_PERFORM_TARG;
+    else
+        return 0;
+    end;
 end;
 
 function onSpellCast(caster,target,spell)


### PR DESCRIPTION
Made it so Esuna can only be cast on self, and Sacrifice on others only.
Redid the stored statuses as non-locals so they'll actually delete the statuses from others hit by the spell.
Made the effects deleted actually random instead of going in a set order.