### PR TITLE
De-Hex ModID lists in modifier.h and status.lua because

### DIFF
--- a/scripts/globals/status.lua
+++ b/scripts/globals/status.lua
@@ -82,12 +82,12 @@ SUBEFFECT_TP_DRAIN          = 22;  -- Verified this should look exactly like Asp
 SUBEFFECT_HASTE             = 23;
 
 -- SPIKES
-SUBEFFECT_BLAZE_SPIKES      = 1;    -- 01-1000       6
-SUBEFFECT_ICE_SPIKES        = 2;    -- 01-0100      10
-SUBEFFECT_DREAD_SPIKES      = 3;    -- 01-1100      14
-SUBEFFECT_CURSE_SPIKES      = 4;    -- 01-0010      18
-SUBEFFECT_SHOCK_SPIKES      = 5;    -- 01-1010      22
-SUBEFFECT_REPRISAL          = 6;    -- 01-0110      26
+SUBEFFECT_BLAZE_SPIKES      = 1;   -- 01-1000       6
+SUBEFFECT_ICE_SPIKES        = 2;   -- 01-0100      10
+SUBEFFECT_DREAD_SPIKES      = 3;   -- 01-1100      14
+SUBEFFECT_CURSE_SPIKES      = 4;   -- 01-0010      18
+SUBEFFECT_SHOCK_SPIKES      = 5;   -- 01-1010      22
+SUBEFFECT_REPRISAL          = 6;   -- 01-0110      26
 SUBEFFECT_WIND_SPIKES       = 7;
 SUBEFFECT_STONE_SPIKES      = 8;
 SUBEFFECT_COUNTER           = 63;
@@ -795,456 +795,464 @@ end;
 -- Note that the above will ignore base statistics, and that getStat() should be used for stats, Attack, and Defense, while getACC(), getRACC(), and getEVA() also exist.
 ------------------------------------
 
-MOD_NONE       = 0x00
-MOD_DEF        = 0x01
-MOD_HP         = 0x02
-MOD_HPP        = 0x03
-MOD_CONVMPTOHP = 0x04
-MOD_MP         = 0x05
-MOD_MPP        = 0x06
-MOD_CONVHPTOMP = 0x07
-MOD_STR        = 0x08
-MOD_DEX        = 0x09
-MOD_VIT        = 0x0A
-MOD_AGI        = 0x0B
-MOD_INT        = 0x0C
-MOD_MND        = 0x0D
-MOD_CHR        = 0x0E
-MOD_FIREDEF    = 0x0F
-MOD_ICEDEF     = 0x10
-MOD_WINDDEF    = 0x11
-MOD_EARTHDEF   = 0x12
-MOD_THUNDERDEF = 0x13
-MOD_WATERDEF   = 0x14
-MOD_LIGHTDEF   = 0x15
-MOD_DARKDEF    = 0x16
-MOD_ATT        = 0x17
-MOD_RATT       = 0x18
-MOD_ACC        = 0x19
-MOD_RACC       = 0x1A
-MOD_ENMITY     = 0x1B
-MOD_ENMITY_LOSS_REDUCTION = 0x1F6
-MOD_MATT              = 0x1C
-MOD_MDEF              = 0x1D
-MOD_MACC              = 0x1E
-MOD_MEVA              = 0x1F
-MOD_FIREATT           = 0x20
-MOD_ICEATT            = 0x21
-MOD_WINDATT           = 0x22
-MOD_EARTHATT          = 0x23
-MOD_THUNDERATT        = 0x24
-MOD_WATERATT          = 0x25
-MOD_LIGHTATT          = 0x26
-MOD_DARKATT           = 0x27
-MOD_FIREACC           = 0x28
-MOD_ICEACC            = 0x29
-MOD_WINDACC           = 0x2A
-MOD_EARTHACC          = 0x2B
-MOD_THUNDERACC        = 0x2C
-MOD_WATERACC          = 0x2D
-MOD_LIGHTACC          = 0x2E
-MOD_DARKACC           = 0x2F
-MOD_WSACC             = 0x30
-MOD_SLASHRES          = 0x31
-MOD_PIERCERES         = 0x32
-MOD_IMPACTRES         = 0x33
-MOD_HTHRES            = 0x34
-MOD_FIRERES           = 0x36
-MOD_ICERES            = 0x37
-MOD_WINDRES           = 0x38
-MOD_EARTHRES          = 0x39
-MOD_THUNDERRES        = 0x3A
-MOD_WATERRES          = 0x3B
-MOD_LIGHTRES          = 0x3C
-MOD_DARKRES           = 0x3D
-MOD_ATTP              = 0x3E
-MOD_DEFP              = 0x3F
-MOD_ACCP              = 0x40
-MOD_EVAP              = 0x41
-MOD_RATTP             = 0x42
-MOD_RACCP             = 0x43
-MOD_EVA               = 0x44
-MOD_RDEF              = 0x45
-MOD_REVA              = 0x46
-MOD_MPHEAL            = 0x47
-MOD_HPHEAL            = 0x48
-MOD_STORETP           = 0x49
-MOD_HTH               = 0x50
-MOD_DAGGER            = 0x51
-MOD_SWORD             = 0x52
-MOD_GSWORD            = 0x53
-MOD_AXE               = 0x54
-MOD_GAXE              = 0x55
-MOD_SCYTHE            = 0x56
-MOD_POLEARM           = 0x57
-MOD_KATANA            = 0x58
-MOD_GKATANA           = 0x59
-MOD_CLUB              = 0x5A
-MOD_STAFF             = 0x5B
-MOD_AUTO_MELEE_SKILL  = 0x65
-MOD_AUTO_RANGED_SKILL = 0x66
-MOD_AUTO_MAGIC_SKILL  = 0x67
-MOD_ARCHERY           = 0x68
-MOD_MARKSMAN          = 0x69
-MOD_THROW             = 0x6A
-MOD_GUARD             = 0x6B
-MOD_EVASION           = 0x6C
-MOD_SHIELD            = 0x6D
-MOD_PARRY             = 0x6E
-MOD_DIVINE            = 0x6F
-MOD_HEALING           = 0x70
-MOD_ENHANCE           = 0x71
-MOD_ENFEEBLE          = 0x72
-MOD_ELEM              = 0x73
-MOD_DARK              = 0x74
-MOD_SUMMONING         = 0x75
-MOD_NINJUTSU          = 0x76
-MOD_SINGING           = 0x77
-MOD_STRING            = 0x78
-MOD_WIND              = 0x79
-MOD_BLUE              = 0x7A
-MOD_FISH              = 0x7F
-MOD_WOOD              = 0x80
-MOD_SMITH             = 0x81
-MOD_GOLDSMITH         = 0x82
-MOD_CLOTH             = 0x83
-MOD_LEATHER           = 0x84
-MOD_BONE              = 0x85
-MOD_ALCHEMY           = 0x86
-MOD_COOK              = 0x87
-MOD_SYNERGY           = 0x88
-MOD_RIDING            = 0x89
-MOD_ANTIHQ_WOOD       = 0x90
-MOD_ANTIHQ_SMITH      = 0x91
-MOD_ANTIHQ_GOLDSMITH  = 0x92
-MOD_ANTIHQ_CLOTH      = 0x93
-MOD_ANTIHQ_LEATHER    = 0x94
-MOD_ANTIHQ_BONE       = 0x95
-MOD_ANTIHQ_ALCHEMY    = 0x96
-MOD_ANTIHQ_COOK       = 0x97
-MOD_DMG               = 0xA0
-MOD_DMGPHYS           = 0xA1
-MOD_DMGBREATH         = 0xA2
-MOD_DMGMAGIC          = 0xA3
-MOD_DMGRANGE          = 0xA4
-MOD_UDMGPHYS          = 0x183
-MOD_UDMGBREATH        = 0x184
-MOD_UDMGMAGIC         = 0x185
-MOD_UDMGRANGE         = 0x186
-MOD_CRITHITRATE       = 0xA5
-MOD_CRIT_DMG_INCREASE = 0x1A5
-MOD_ENEMYCRITRATE     = 0xA6
-MOD_HASTE_MAGIC       = 0xA7
-MOD_SPELLINTERRUPT    = 0xA8
-MOD_MOVE              = 0xA9
-MOD_FASTCAST          = 0xAA
-MOD_UFASTCAST         = 0x197
-MOD_CURE_CAST_TIME    = 0x207
-MOD_DELAY             = 0xAB
-MOD_RANGED_DELAY      = 0xAC
-MOD_MARTIAL_ARTS      = 0xAD
-MOD_SKILLCHAINBONUS   = 0xAE
-MOD_SKILLCHAINDMG     = 0xAF
-MOD_FOOD_HPP          = 0xB0
-MOD_FOOD_HP_CAP       = 0xB1
-MOD_FOOD_MPP          = 0xB2
-MOD_FOOD_MP_CAP       = 0xB3
-MOD_FOOD_ATTP         = 0xB4
-MOD_FOOD_ATT_CAP      = 0xB5
-MOD_FOOD_DEFP         = 0xB6
-MOD_FOOD_DEF_CAP      = 0xB7
-MOD_FOOD_ACCP         = 0xB8
-MOD_FOOD_ACC_CAP      = 0xB9
-MOD_FOOD_RATTP        = 0xBA
-MOD_FOOD_RATT_CAP     = 0xBB
-MOD_FOOD_RACCP        = 0xBC
-MOD_FOOD_RACC_CAP     = 0xBD
-MOD_VERMIN_KILLER     = 0xE0
-MOD_BIRD_KILLER       = 0xE1
-MOD_AMORPH_KILLER     = 0xE2
-MOD_LIZARD_KILLER     = 0xE3
-MOD_AQUAN_KILLER      = 0xE4
-MOD_PLANTOID_KILLER   = 0xE5
-MOD_BEAST_KILLER      = 0xE6
-MOD_UNDEAD_KILLER     = 0xE7
-MOD_ARCANA_KILLER     = 0xE8
-MOD_DRAGON_KILLER     = 0xE9
-MOD_DEMON_KILLER      = 0xEA
-MOD_EMPTY_KILLER      = 0xEB
-MOD_HUMANOID_KILLER   = 0xEC
-MOD_LUMORIAN_KILLER   = 0xED
-MOD_LUMINION_KILLER   = 0xEE
-MOD_SLEEPRES          = 0xF0
-MOD_POISONRES         = 0xF1
-MOD_PARALYZERES       = 0xF2
-MOD_BLINDRES          = 0xF3
-MOD_SILENCERES        = 0xF4
-MOD_VIRUSRES          = 0xF5
-MOD_PETRIFYRES        = 0xF6
-MOD_BINDRES           = 0xF7
-MOD_CURSERES          = 0xF8
-MOD_GRAVITYRES        = 0xF9
-MOD_SLOWRES           = 0xFA
-MOD_STUNRES           = 0xFB
-MOD_CHARMRES          = 0xFC
-MOD_AMNESIARES        = 0xFD
--- PLACEHOLDER           = 0xFE
-MOD_DEATHRES           = 0xFF
-MOD_PARALYZE           = 0x101
-MOD_MIJIN_GAKURE       = 0x102
-MOD_DUAL_WIELD         = 0x103
-MOD_DOUBLE_ATTACK      = 0x120
-MOD_SUBTLE_BLOW        = 0x121
-MOD_COUNTER            = 0x123
-MOD_KICK_ATTACK        = 0x124
-MOD_AFFLATUS_SOLACE    = 0x125
-MOD_AFFLATUS_MISERY    = 0x126
-MOD_CLEAR_MIND         = 0x127
-MOD_CONSERVE_MP        = 0x128
-MOD_STEAL              = 0x12A
-MOD_BLINK              = 0x12B
-MOD_STONESKIN          = 0x12C
-MOD_PHALANX            = 0x12D
-MOD_TRIPLE_ATTACK      = 0x12E
-MOD_TREASURE_HUNTER    = 0x12F
-MOD_TAME               = 0x130
-MOD_RECYCLE            = 0x131
-MOD_ZANSHIN            = 0x132
-MOD_UTSUSEMI           = 0x133
-MOD_NINJA_TOOL         = 0x134
-MOD_BLUE_POINTS        = 0x135
-MOD_DMG_REFLECT        = 0x13C
-MOD_ROLL_ROGUES        = 0x13D
-MOD_ROLL_GALLANTS      = 0x13E
-MOD_ROLL_CHAOS         = 0x13F
-MOD_ROLL_BEAST         = 0x140
-MOD_ROLL_CHORAL        = 0x141
-MOD_ROLL_HUNTERS       = 0x142
-MOD_ROLL_SAMURAI       = 0x143
-MOD_ROLL_NINJA         = 0x144
-MOD_ROLL_DRACHEN       = 0x145
-MOD_ROLL_EVOKERS       = 0x146
-MOD_ROLL_MAGUS         = 0x147
-MOD_ROLL_CORSAIRS      = 0x148
-MOD_ROLL_PUPPET        = 0x149
-MOD_ROLL_DANCERS       = 0x14A
-MOD_ROLL_SCHOLARS      = 0x14B
-MOD_BUST               = 0x14C
-MOD_FINISHING_MOVES    = 0x14D
-MOD_SAMBA_DURATION     = 0x1EA -- Samba duration bonus(modId = 490)
-MOD_WALTZ_POTENTCY     = 0x1EB -- Waltz Potentcy Bonus(modId = 491)
-MOD_CHOCO_JIG_DURATION = 0x1EC -- Chocobo Jig duration bonus (modId = 492)
-MOD_VFLOURISH_MACC     = 0x1ED -- Violent Flourish accuracy bonus (modId = 493)
-MOD_STEP_FINISH        = 0x1EE -- Bonus finishing moves from steps (modId = 494)
-MOD_STEP_ACCURACY      = 0x193 -- Accuracy bonus for steps (modID = 403)
-MOD_SPECTRAL_JIG       = 0x1EF -- Spectral Jig duration modifier (percent increase) (modId = 495)
-MOD_WALTZ_RECAST       = 0x1F1 -- (modID = 497) Waltz recast modifier (percent)
-MOD_SAMBA_PDURATION    = 0x1F2 -- (modID = 498) Samba percent duration bonus
-MOD_WIDESCAN           = 0x154
-MOD_BARRAGE_ACC        = 0x1A4 -- (modID = 420)
-MOD_ENSPELL            = 0x155
-MOD_SPIKES             = 0x156
-MOD_ENSPELL_DMG        = 0x157
-MOD_SPIKES_DMG         = 0x158
-MOD_TP_BONUS           = 0x159
-MOD_PERPETUATION_REDUCTION = 0x15A
-MOD_FIRE_AFFINITY    = 0x15B
-MOD_EARTH_AFFINITY   = 0x15C
-MOD_WATER_AFFINITY   = 0x15D
-MOD_ICE_AFFINITY     = 0x15E
-MOD_THUNDER_AFFINITY = 0x15F
-MOD_WIND_AFFINITY    = 0x160
-MOD_LIGHT_AFFINITY   = 0x161
-MOD_DARK_AFFINITY    = 0x162
-MOD_ADDS_WEAPONSKILL = 0x163
-MOD_ADDS_WEAPONSKILL_DYN = 0x164
-MOD_BP_DELAY       = 0x165
-MOD_STEALTH        = 0x166
-MOD_RAPID_SHOT     = 0x167
-MOD_CHARM_TIME     = 0x168
-MOD_JUMP_TP_BONUS  = 0x169
-MOD_JUMP_ATT_BONUS = 0x16A
-MOD_HIGH_JUMP_ENMITY_REDUCTION = 0x16B
-MOD_REWARD_HP_BONUS = 0x16C
-MOD_SNAP_SHOT       = 0x16D
-MOD_MAIN_DMG_RATING = 0x16E
-MOD_SUB_DMG_RATING  = 0x16F
-MOD_REGAIN          = 0x170
-MOD_REFRESH         = 0x171
-MOD_REGEN           = 0x172
-MOD_AVATAR_PERPETUATION = 0x173
-MOD_WEATHER_REDUCTION   = 0x174
-MOD_DAY_REDUCTION       = 0x175
-MOD_CURE_POTENCY        = 0x176
-MOD_CURE_POTENCY_RCVD   = 0x177
-MOD_DELAYP              = 0x17C
-MOD_RANGED_DELAYP       = 0x17D
-MOD_EXP_BONUS           = 0x17E
-MOD_HASTE_ABILITY       = 0x17F
-MOD_HASTE_GEAR          = 0x180
-MOD_SHIELD_BASH         = 0x181
-MOD_KICK_DMG            = 0x182
-MOD_CHARM_CHANCE        = 0x187
-MOD_WEAPON_BASH         = 0x188
-MOD_BLACK_MAGIC_COST    = 0x189
-MOD_WHITE_MAGIC_COST    = 0x18A
-MOD_BLACK_MAGIC_CAST    = 0x18B
-MOD_WHITE_MAGIC_CAST    = 0x18C
-MOD_BLACK_MAGIC_RECAST  = 0x18D
-MOD_WHITE_MAGIC_RECAST  = 0x18E
-MOD_ALACRITY_CELERITY_EFFECT = 0x18F
-MOD_LIGHT_ARTS_EFFECT   = 0x14E
-MOD_DARK_ARTS_EFFECT    = 0x14F
-MOD_LIGHT_ARTS_SKILL    = 0x150
-MOD_DARK_ARTS_SKILL     = 0x151
-MOD_REGEN_EFFECT        = 0x152
-MOD_REGEN_DURATION      = 0x153
-MOD_HELIX_EFFECT        = 0x1DE
-MOD_HELIX_DURATION      = 0x1DD
-MOD_STORMSURGE_EFFECT   = 0x190
-MOD_SUBLIMATION_BONUS   = 0x191
-MOD_GRIMOIRE_SPELLCASTING = 0x1E9 -- (modID = 489) "Grimoire: Reduces spellcasting time" bonus
-MOD_WYVERN_BREATH         = 0x192
-MOD_REGEN_DOWN            = 0x194 -- poison
-MOD_REFRESH_DOWN          = 0x195 -- plague, reduce mp
-MOD_REGAIN_DOWN           = 0x196 -- plague, reduce tp
-MOD_MAGIC_DAMAGE          = 0x137 --  Magic damage added directly to the spell's base damage (modId = 311)
+MOD_NONE       = 0
+MOD_DEF        = 1
+MOD_HP         = 2
+MOD_HPP        = 3
+MOD_CONVMPTOHP = 4
+MOD_MP         = 5
+MOD_MPP        = 6
+MOD_CONVHPTOMP = 7
+MOD_STR        = 8
+MOD_DEX        = 9
+MOD_VIT        = 10
+MOD_AGI        = 11
+MOD_INT        = 12
+MOD_MND        = 13
+MOD_CHR        = 14
+MOD_FIREDEF    = 15
+MOD_ICEDEF     = 16
+MOD_WINDDEF    = 17
+MOD_EARTHDEF   = 18
+MOD_THUNDERDEF = 19
+MOD_WATERDEF   = 20
+MOD_LIGHTDEF   = 21
+MOD_DARKDEF    = 22
+MOD_ATT        = 23
+MOD_RATT       = 24
+MOD_ACC        = 25
+MOD_RACC       = 26
+MOD_ENMITY     = 27
+MOD_ENMITY_LOSS_REDUCTION = 502
+MOD_MATT              = 28
+MOD_MDEF              = 29
+MOD_MACC              = 30
+MOD_MEVA              = 31
+MOD_FIREATT           = 32
+MOD_ICEATT            = 33
+MOD_WINDATT           = 34
+MOD_EARTHATT          = 35
+MOD_THUNDERATT        = 36
+MOD_WATERATT          = 37
+MOD_LIGHTATT          = 38
+MOD_DARKATT           = 39
+MOD_FIREACC           = 40
+MOD_ICEACC            = 41
+MOD_WINDACC           = 42
+MOD_EARTHACC          = 43
+MOD_THUNDERACC        = 44
+MOD_WATERACC          = 45
+MOD_LIGHTACC          = 46
+MOD_DARKACC           = 47
+MOD_WSACC             = 48
+MOD_SLASHRES          = 49
+MOD_PIERCERES         = 50
+MOD_IMPACTRES         = 51
+MOD_HTHRES            = 52
+MOD_FIRERES           = 54
+MOD_ICERES            = 55
+MOD_WINDRES           = 59
+MOD_EARTHRES          = 57
+MOD_THUNDERRES        = 58
+MOD_WATERRES          = 59
+MOD_LIGHTRES          = 60
+MOD_DARKRES           = 61
+MOD_ATTP              = 62
+MOD_DEFP              = 63
+MOD_ACCP              = 64
+MOD_EVAP              = 65
+MOD_RATTP             = 66
+MOD_RACCP             = 67
+MOD_EVA               = 68
+MOD_RDEF              = 69
+MOD_REVA              = 70
+MOD_MPHEAL            = 71
+MOD_HPHEAL            = 72
+MOD_STORETP           = 73
+MOD_HTH               = 80
+MOD_DAGGER            = 81
+MOD_SWORD             = 82
+MOD_GSWORD            = 83
+MOD_AXE               = 84
+MOD_GAXE              = 85
+MOD_SCYTHE            = 86
+MOD_POLEARM           = 87
+MOD_KATANA            = 88
+MOD_GKATANA           = 89
+MOD_CLUB              = 90
+MOD_STAFF             = 91
+MOD_AUTO_MELEE_SKILL  = 101
+MOD_AUTO_RANGED_SKILL = 102
+MOD_AUTO_MAGIC_SKILL  = 103
+MOD_ARCHERY           = 104
+MOD_MARKSMAN          = 105
+MOD_THROW             = 106
+MOD_GUARD             = 107
+MOD_EVASION           = 108
+MOD_SHIELD            = 109
+MOD_PARRY             = 110
+MOD_DIVINE            = 111
+MOD_HEALING           = 112
+MOD_ENHANCE           = 113
+MOD_ENFEEBLE          = 114
+MOD_ELEM              = 115
+MOD_DARK              = 116
+MOD_SUMMONING         = 117
+MOD_NINJUTSU          = 118
+MOD_SINGING           = 119
+MOD_STRING            = 120
+MOD_WIND              = 121
+MOD_BLUE              = 122
+MOD_FISH              = 127
+MOD_WOOD              = 128
+MOD_SMITH             = 129
+MOD_GOLDSMITH         = 130
+MOD_CLOTH             = 131
+MOD_LEATHER           = 132
+MOD_BONE              = 133
+MOD_ALCHEMY           = 134
+MOD_COOK              = 135
+MOD_SYNERGY           = 136
+MOD_RIDING            = 137
+MOD_ANTIHQ_WOOD       = 144
+MOD_ANTIHQ_SMITH      = 145
+MOD_ANTIHQ_GOLDSMITH  = 146
+MOD_ANTIHQ_CLOTH      = 147
+MOD_ANTIHQ_LEATHER    = 148
+MOD_ANTIHQ_BONE       = 149
+MOD_ANTIHQ_ALCHEMY    = 150
+MOD_ANTIHQ_COOK       = 151
+MOD_DMG               = 160
+MOD_DMGPHYS           = 161
+MOD_DMGBREATH         = 162
+MOD_DMGMAGIC          = 163
+MOD_DMGRANGE          = 164
+MOD_UDMGPHYS          = 387
+MOD_UDMGBREATH        = 388
+MOD_UDMGMAGIC         = 389
+MOD_UDMGRANGE         = 390
+MOD_CRITHITRATE       = 165
+MOD_CRIT_DMG_INCREASE = 421
+MOD_ENEMYCRITRATE     = 166
+MOD_HASTE_MAGIC       = 167
+MOD_SPELLINTERRUPT    = 168
+MOD_MOVE              = 169
+MOD_FASTCAST          = 170
+MOD_UFASTCAST         = 407
+MOD_CURE_CAST_TIME    = 519
+MOD_DELAY             = 171
+MOD_RANGED_DELAY      = 172
+MOD_MARTIAL_ARTS      = 173
+MOD_SKILLCHAINBONUS   = 174
+MOD_SKILLCHAINDMG     = 175
+MOD_FOOD_HPP          = 176
+MOD_FOOD_HP_CAP       = 177
+MOD_FOOD_MPP          = 178
+MOD_FOOD_MP_CAP       = 179
+MOD_FOOD_ATTP         = 180
+MOD_FOOD_ATT_CAP      = 181
+MOD_FOOD_DEFP         = 182
+MOD_FOOD_DEF_CAP      = 183
+MOD_FOOD_ACCP         = 184
+MOD_FOOD_ACC_CAP      = 185
+MOD_FOOD_RATTP        = 186
+MOD_FOOD_RATT_CAP     = 187
+MOD_FOOD_RACCP        = 188
+MOD_FOOD_RACC_CAP     = 189
+MOD_VERMIN_KILLER     = 224
+MOD_BIRD_KILLER       = 225
+MOD_AMORPH_KILLER     = 226
+MOD_LIZARD_KILLER     = 227
+MOD_AQUAN_KILLER      = 228
+MOD_PLANTOID_KILLER   = 229
+MOD_BEAST_KILLER      = 230
+MOD_UNDEAD_KILLER     = 231
+MOD_ARCANA_KILLER     = 232
+MOD_DRAGON_KILLER     = 233
+MOD_DEMON_KILLER      = 234
+MOD_EMPTY_KILLER      = 235
+MOD_HUMANOID_KILLER   = 236
+MOD_LUMORIAN_KILLER   = 237
+MOD_LUMINION_KILLER   = 238
+MOD_SLEEPRES          = 240
+MOD_POISONRES         = 241
+MOD_PARALYZERES       = 242
+MOD_BLINDRES          = 243
+MOD_SILENCERES        = 244
+MOD_VIRUSRES          = 245
+MOD_PETRIFYRES        = 246
+MOD_BINDRES           = 247
+MOD_CURSERES          = 248
+MOD_GRAVITYRES        = 249
+MOD_SLOWRES           = 250
+MOD_STUNRES           = 251
+MOD_CHARMRES          = 252
+MOD_AMNESIARES        = 253
+-- PLACEHOLDER           = 254
+MOD_DEATHRES           = 255
+MOD_PARALYZE           = 257
+MOD_MIJIN_GAKURE       = 258
+MOD_DUAL_WIELD         = 259
+MOD_DOUBLE_ATTACK      = 288
+MOD_SUBTLE_BLOW        = 289
+MOD_COUNTER            = 291
+MOD_KICK_ATTACK        = 292
+MOD_AFFLATUS_SOLACE    = 293
+MOD_AFFLATUS_MISERY    = 294
+MOD_CLEAR_MIND         = 295
+MOD_CONSERVE_MP        = 296
+MOD_STEAL              = 298
+MOD_BLINK              = 299
+MOD_STONESKIN          = 300
+MOD_PHALANX            = 301
+MOD_TRIPLE_ATTACK      = 302
+MOD_TREASURE_HUNTER    = 303
+MOD_TAME               = 304
+MOD_RECYCLE            = 305
+MOD_ZANSHIN            = 306
+MOD_UTSUSEMI           = 307
+MOD_NINJA_TOOL         = 308
+MOD_BLUE_POINTS        = 309
+MOD_DMG_REFLECT        = 316
+MOD_ROLL_ROGUES        = 317
+MOD_ROLL_GALLANTS      = 318
+MOD_ROLL_CHAOS         = 319
+MOD_ROLL_BEAST         = 320
+MOD_ROLL_CHORAL        = 321
+MOD_ROLL_HUNTERS       = 322
+MOD_ROLL_SAMURAI       = 323
+MOD_ROLL_NINJA         = 324
+MOD_ROLL_DRACHEN       = 325
+MOD_ROLL_EVOKERS       = 326
+MOD_ROLL_MAGUS         = 327
+MOD_ROLL_CORSAIRS      = 328
+MOD_ROLL_PUPPET        = 329
+MOD_ROLL_DANCERS       = 330
+MOD_ROLL_SCHOLARS      = 331
+MOD_BUST               = 332
+MOD_FINISHING_MOVES    = 333
+MOD_SAMBA_DURATION     = 490 -- Samba duration bonus
+MOD_WALTZ_POTENTCY     = 491 -- Waltz Potentcy Bonus
+MOD_CHOCO_JIG_DURATION = 492 -- Chocobo Jig duration bonus
+MOD_VFLOURISH_MACC     = 493 -- Violent Flourish accuracy bonus
+MOD_STEP_FINISH        = 494 -- Bonus finishing moves from steps
+MOD_STEP_ACCURACY      = 403 -- Accuracy bonus for steps
+MOD_SPECTRAL_JIG       = 495 -- Spectral Jig duration modifier (percent increase)
+MOD_WALTZ_RECAST       = 497 -- Waltz recast modifier (percent)
+MOD_SAMBA_PDURATION    = 498 -- Samba percent duration bonus
+MOD_WIDESCAN           = 340
+MOD_BARRAGE_ACC        = 420 --
+MOD_ENSPELL            = 341
+MOD_SPIKES             = 342
+MOD_ENSPELL_DMG        = 343
+MOD_SPIKES_DMG         = 344
+MOD_TP_BONUS           = 345
+MOD_PERPETUATION_REDUCTION = 346
+MOD_FIRE_AFFINITY    = 347
+MOD_EARTH_AFFINITY   = 348
+MOD_WATER_AFFINITY   = 349
+MOD_ICE_AFFINITY     = 350
+MOD_THUNDER_AFFINITY = 351
+MOD_WIND_AFFINITY    = 352
+MOD_LIGHT_AFFINITY   = 353
+MOD_DARK_AFFINITY    = 354
+MOD_ADDS_WEAPONSKILL = 355
+MOD_ADDS_WEAPONSKILL_DYN = 356
+MOD_BP_DELAY       = 357
+MOD_STEALTH        = 358
+MOD_RAPID_SHOT     = 359
+MOD_CHARM_TIME     = 360
+MOD_JUMP_TP_BONUS  = 361
+MOD_JUMP_ATT_BONUS = 362
+MOD_HIGH_JUMP_ENMITY_REDUCTION = 363
+MOD_REWARD_HP_BONUS = 364
+MOD_SNAP_SHOT       = 365
+MOD_MAIN_DMG_RATING = 366
+MOD_SUB_DMG_RATING  = 367
+MOD_REGAIN          = 368
+MOD_REFRESH         = 369
+MOD_REGEN           = 370
+MOD_AVATAR_PERPETUATION = 371
+MOD_WEATHER_REDUCTION   = 372
+MOD_DAY_REDUCTION       = 373
+MOD_CURE_POTENCY        = 374
+MOD_CURE_POTENCY_RCVD   = 375
+MOD_DELAYP              = 380
+MOD_RANGED_DELAYP       = 381
+MOD_EXP_BONUS           = 382
+MOD_HASTE_ABILITY       = 383
+MOD_HASTE_GEAR          = 384
+MOD_SHIELD_BASH         = 385
+MOD_KICK_DMG            = 386
+MOD_CHARM_CHANCE        = 391
+MOD_WEAPON_BASH         = 392
+MOD_BLACK_MAGIC_COST    = 393
+MOD_WHITE_MAGIC_COST    = 394
+MOD_BLACK_MAGIC_CAST    = 395
+MOD_WHITE_MAGIC_CAST    = 396
+MOD_BLACK_MAGIC_RECAST  = 397
+MOD_WHITE_MAGIC_RECAST  = 398
+MOD_ALACRITY_CELERITY_EFFECT = 399
+MOD_LIGHT_ARTS_EFFECT   = 334
+MOD_DARK_ARTS_EFFECT    = 335
+MOD_LIGHT_ARTS_SKILL    = 336
+MOD_DARK_ARTS_SKILL     = 337
+MOD_REGEN_EFFECT        = 338
+MOD_REGEN_DURATION      = 339
+MOD_HELIX_EFFECT        = 478
+MOD_HELIX_DURATION      = 477
+MOD_STORMSURGE_EFFECT   = 400
+MOD_SUBLIMATION_BONUS   = 401
+MOD_GRIMOIRE_SPELLCASTING = 489 -- "Grimoire: Reduces spellcasting time" bonus
+MOD_WYVERN_BREATH         = 402
+MOD_REGEN_DOWN            = 404 -- poison
+MOD_REFRESH_DOWN          = 405 -- plague, reduce mp
+MOD_REGAIN_DOWN           = 406 -- plague, reduce tp
+MOD_MAGIC_DAMAGE          = 311 --  Magic damage added directly to the spell's base damage
 
 -- Gear set modifiers
-MOD_DA_DOUBLE_DAMAGE         = 0x198 -- Double attack's double damage chance %.
-MOD_TA_TRIPLE_DAMAGE         = 0x199 -- Triple attack's triple damage chance %.
-MOD_ZANSHIN_DOUBLE_DAMAGE    = 0x19A -- Zanshin's double damage chance %.
-MOD_RAPID_SHOT_DOUBLE_DAMAGE = 0x1DF -- Rapid shot's double damage chance %.
-MOD_ABSORB_DMG_CHANCE        = 0x1E0 -- Chance to absorb damage %
-MOD_EXTRA_DUAL_WIELD_ATTACK  = 0x1E1 -- Chance to land an extra attack when dual wielding
-MOD_EXTRA_KICK_ATTACK        = 0x1E2 -- Occasionally allows a second Kick Attack during an attack round without the use of Footwork.
-MOD_SAMBA_DOUBLE_DAMAGE      = 0x19F -- Double damage chance when samba is up.
-MOD_NULL_PHYSICAL_DAMAGE     = 0x1A0 -- Chance to null physical damage.
-MOD_QUICK_DRAW_TRIPLE_DAMAGE = 0x1A1 -- Chance to do triple damage with quick draw.
-MOD_BAR_ELEMENT_NULL_CHANCE  = 0x1A2 -- Bar Elemental spells will occasionally nullify damage of the same element.
-MOD_GRIMOIRE_INSTANT_CAST    = 0x1A3 -- Spells that match your current Arts will occasionally cast instantly, without recast.
+MOD_DA_DOUBLE_DAMAGE         = 408 -- Double attack's double damage chance %.
+MOD_TA_TRIPLE_DAMAGE         = 409 -- Triple attack's triple damage chance %.
+MOD_ZANSHIN_DOUBLE_DAMAGE    = 410 -- Zanshin's double damage chance %.
+MOD_RAPID_SHOT_DOUBLE_DAMAGE = 479 -- Rapid shot's double damage chance %.
+MOD_ABSORB_DMG_CHANCE        = 480 -- Chance to absorb damage %
+MOD_EXTRA_DUAL_WIELD_ATTACK  = 481 -- Chance to land an extra attack when dual wielding
+MOD_EXTRA_KICK_ATTACK        = 482 -- Occasionally allows a second Kick Attack during an attack round without the use of Footwork.
+MOD_SAMBA_DOUBLE_DAMAGE      = 415 -- Double damage chance when samba is up.
+MOD_NULL_PHYSICAL_DAMAGE     = 416 -- Chance to null physical damage.
+MOD_QUICK_DRAW_TRIPLE_DAMAGE = 417 -- Chance to do triple damage with quick draw.
+MOD_BAR_ELEMENT_NULL_CHANCE  = 418 -- Bar Elemental spells will occasionally nullify damage of the same element.
+MOD_GRIMOIRE_INSTANT_CAST    = 419 -- Spells that match your current Arts will occasionally cast instantly, without recast.
 
-MOD_DOUBLE_SHOT_RATE          = 0x1A6 -- The rate that double shot can proc
-MOD_VELOCITY_SNAPSHOT_BONUS   = 0x1A7 -- Increases Snapshot whilst Velocity Shot is up.
-MOD_VELOCITY_RATT_BONUS       = 0x1A8 -- Increases Ranged Attack whilst Velocity Shot is up.
-MOD_SHADOW_BIND_EXT           = 0x1A9 -- Extends the time of shadowbind
-MOD_ABSORB_PHYSDMG_TO_MP      = 0x1AA -- Absorbs a percentage of physical damage taken to MP.
-MOD_ENMITY_REDUCTION_PHYSICAL = 0x1AB -- Reduces Enmity decrease when taking physical damage
-MOD_SHIELD_MASTERY_TP         = 0x1E5 -- Shield mastery TP bonus when blocking with a shield (modId = 485)
-MOD_PERFECT_COUNTER_ATT       = 0x1AC -- Raises weapon damage by 20 when countering while under the Perfect Counter effect. This also affects Weapon Rank (though not if fighting barehanded).
-MOD_FOOTWORK_ATT_BONUS        = 0x1AD -- Raises the attack bonus of Footwork. (Tantra Gaiters +2 raise 100/1024 to 152/1024)
+MOD_DOUBLE_SHOT_RATE          = 422 -- The rate that double shot can proc
+MOD_VELOCITY_SNAPSHOT_BONUS   = 423 -- Increases Snapshot whilst Velocity Shot is up.
+MOD_VELOCITY_RATT_BONUS       = 424 -- Increases Ranged Attack whilst Velocity Shot is up.
+MOD_SHADOW_BIND_EXT           = 425 -- Extends the time of shadowbind
+MOD_ABSORB_PHYSDMG_TO_MP      = 426 -- Absorbs a percentage of physical damage taken to MP.
+MOD_ENMITY_REDUCTION_PHYSICAL = 427 -- Reduces Enmity decrease when taking physical damage
+MOD_SHIELD_MASTERY_TP         = 485 -- Shield mastery TP bonus when blocking with a shield
+MOD_PERFECT_COUNTER_ATT       = 428 -- Raises weapon damage by 20 when countering while under the Perfect Counter effect. This also affects Weapon Rank (though not if fighting barehanded).
+MOD_FOOTWORK_ATT_BONUS        = 429 -- Raises the attack bonus of Footwork. (Tantra Gaiters +2 raise 100/1024 to 152/1024)
 
-MOD_MINNE_EFFECT        = 0x1B1 -- (modId = 433)
-MOD_MINUET_EFFECT       = 0x1B2 -- (modId = 434)
-MOD_PAEON_EFFECT        = 0x1B3 -- (modId = 435)
-MOD_REQUIEM_EFFECT      = 0x1B4 -- (modId = 436)
-MOD_THRENODY_EFFECT     = 0x1B5 -- (modId = 437)
-MOD_MADRIGAL_EFFECT     = 0x1B6 -- (modId = 438)
-MOD_MAMBO_EFFECT        = 0x1B7 -- (modId = 439)
-MOD_LULLABY_EFFECT      = 0x1B8 -- (modId = 440)
-MOD_ETUDE_EFFECT        = 0x1B9 -- (modId = 441)
-MOD_BALLAD_EFFECT       = 0x1BA -- (modId = 442)
-MOD_MARCH_EFFECT        = 0x1BB -- (modId = 443)
-MOD_FINALE_EFFECT       = 0x1BC -- (modId = 444)
-MOD_CAROL_EFFECT        = 0x1BD -- (modId = 445)
-MOD_MAZURKA_EFFECT      = 0x1BE -- (modId = 446)
-MOD_ELEGY_EFFECT        = 0x1BF -- (modId = 447)
-MOD_PRELUDE_EFFECT      = 0x1C0 -- (modId = 448)
-MOD_HYMNUS_EFFECT       = 0x1C1 -- (modId = 449)
-MOD_VIRELAI_EFFECT      = 0x1C2 -- (modId = 450)
-MOD_SCHERZO_EFFECT      = 0x1C3 -- (modId = 451)
-MOD_ALL_SONGS_EFFECT    = 0x1C4 -- (modId = 452)
-MOD_MAXIMUM_SONGS_BONUS = 0x1C5 -- (modId = 453)
-MOD_SONG_DURATION_BONUS = 0x1C6 -- (modId = 454)
+MOD_MINNE_EFFECT        = 433 --
+MOD_MINUET_EFFECT       = 434 --
+MOD_PAEON_EFFECT        = 435 --
+MOD_REQUIEM_EFFECT      = 436 --
+MOD_THRENODY_EFFECT     = 437 --
+MOD_MADRIGAL_EFFECT     = 438 --
+MOD_MAMBO_EFFECT        = 439 --
+MOD_LULLABY_EFFECT      = 440 --
+MOD_ETUDE_EFFECT        = 441 --
+MOD_BALLAD_EFFECT       = 442 --
+MOD_MARCH_EFFECT        = 443 --
+MOD_FINALE_EFFECT       = 444 --
+MOD_CAROL_EFFECT        = 445 --
+MOD_MAZURKA_EFFECT      = 446 --
+MOD_ELEGY_EFFECT        = 447 --
+MOD_PRELUDE_EFFECT      = 448 --
+MOD_HYMNUS_EFFECT       = 449 --
+MOD_VIRELAI_EFFECT      = 450 --
+MOD_SCHERZO_EFFECT      = 451 --
+MOD_ALL_SONGS_EFFECT    = 452 --
+MOD_MAXIMUM_SONGS_BONUS = 453 --
+MOD_SONG_DURATION_BONUS = 454 --
 
-MOD_QUICK_DRAW_DMG            = 0x19B -- (modId = 411)
-MOD_QUAD_ATTACK               = 0x1AE -- Quadruple attack chance.
+MOD_QUICK_DRAW_DMG            = 411 --
+MOD_QUAD_ATTACK               = 430 -- Quadruple attack chance.
 
-MOD_ADDITIONAL_EFFECT         = 0x1AF -- All additional effects (modId = 431)
-MOD_ENSPELL_DMG_BONUS         = 0x1B0
+MOD_ADDITIONAL_EFFECT         = 431 -- All additional effects
+MOD_ENSPELL_DMG_BONUS         = 432
 
-MOD_FIRE_ABSORB  = 0x1CB -- (modId = 459)
-MOD_EARTH_ABSORB = 0x1CC -- (modId = 460)
-MOD_WATER_ABSORB = 0x1CD -- (modId = 461)
-MOD_WIND_ABSORB  = 0x1CE -- (modId = 462)
-MOD_ICE_ABSORB   = 0x1CF -- (modId = 463)
-MOD_LTNG_ABSORB  = 0x1D0 -- (modId = 464)
-MOD_LIGHT_ABSORB = 0x1D1 -- (modId = 465)
-MOD_DARK_ABSORB  = 0x1D2 -- (modId = 466)
+MOD_FIRE_ABSORB  = 459 --
+MOD_EARTH_ABSORB = 460 --
+MOD_WATER_ABSORB = 461 --
+MOD_WIND_ABSORB  = 462 --
+MOD_ICE_ABSORB   = 463 --
+MOD_LTNG_ABSORB  = 464 --
+MOD_LIGHT_ABSORB = 465 --
+MOD_DARK_ABSORB  = 466 --
 
-MOD_FIRE_NULL  = 0x1D3 -- (modId = 467)
-MOD_EARTH_NULL = 0x1D4 -- (modId = 468)
-MOD_WATER_NULL = 0x1D5 -- (modId = 469)
-MOD_WIND_NULL  = 0x1D6 -- (modId = 470)
-MOD_ICE_NULL   = 0x1D7 -- (modId = 471)
-MOD_LTNG_NULL  = 0x1D8 -- (modId = 472)
-MOD_LIGHT_NULL = 0x1D9 -- (modId = 473)
-MOD_DARK_NULL  = 0x1DA -- (modId = 474)
+MOD_FIRE_NULL  = 467 --
+MOD_EARTH_NULL = 468 --
+MOD_WATER_NULL = 469 --
+MOD_WIND_NULL  = 470 --
+MOD_ICE_NULL   = 471 --
+MOD_LTNG_NULL  = 472 --
+MOD_LIGHT_NULL = 473 --
+MOD_DARK_NULL  = 474 --
 
-MOD_MAGIC_ABSORB     = 0x1DB -- (modId = 475)
-MOD_MAGIC_NULL       = 0x1DC -- (modId = 476)
-MOD_PHYS_ABSORB      = 0x200 -- (modId = 512)
-MOD_ABSORB_DMG_TO_MP = 0x204 -- Unlike PLD gear mod, works on all damage types (Ethereal Earring) (modId = 516)
+MOD_MAGIC_ABSORB     = 475 --
+MOD_MAGIC_NULL       = 476 --
+MOD_PHYS_ABSORB      = 512 --
+MOD_ABSORB_DMG_TO_MP = 516 -- Unlike PLD gear mod, works on all damage types (Ethereal Earring)
 
-MOD_WARCRY_DURATION = 0x1E3 -- Warcy duration bonus from gear
-MOD_AUSPICE_EFFECT  = 0x1E4 -- Auspice Subtle Blow Bonus (modId = 484)
-MOD_TACTICAL_PARRY  = 0x1E6 -- Tactical Parry TP Bonus (modid = 486)
-MOD_MAG_BURST_BONUS = 0x1E7 -- Magic Burst Bonus (modid = 487)
-MOD_INHIBIT_TP      = 0x1E8 -- Inhibits TP Gain (percent) (modId = 488)
+MOD_WARCRY_DURATION = 483 -- Warcy duration bonus from gear
+MOD_AUSPICE_EFFECT  = 484 -- Auspice Subtle Blow Bonus
+MOD_TACTICAL_PARRY  = 486 -- Tactical Parry TP Bonus
+MOD_MAG_BURST_BONUS = 487 -- Magic Burst Bonus
+MOD_INHIBIT_TP      = 488 -- Inhibits TP Gain (percent)
 
-MOD_GOV_CLEARS      = 0x1F0 -- Tracks GoV page completion (for 4% bonus on rewards).
+MOD_GOV_CLEARS      = 496 -- Tracks GoV page completion (for 4% bonus on rewards).
 
 -- Reraise (Auto Reraise, will be used by ATMA)
-MOD_RERAISE_I       = 0x1C8 -- Reraise. (modId = 456)
-MOD_RERAISE_II      = 0x1C9 -- Reraise II. (modId = 457)
-MOD_RERAISE_III     = 0x1CA -- Reraise III. (modId = 458)
+MOD_RERAISE_I       = 456 -- Reraise.
+MOD_RERAISE_II      = 457 -- Reraise II.
+MOD_RERAISE_III     = 458 -- Reraise III.
 
-MOD_ITEM_SPIKES_TYPE   = 0x1F3 -- Type spikes an item has (modId = 499)
-MOD_ITEM_SPIKES_DMG    = 0x1F4 -- Damage of an items spikes (modId = 500)
-MOD_ITEM_SPIKES_CHANCE = 0x1F5 -- Chance of an items spike proc (modId = 501)
+MOD_ITEM_SPIKES_TYPE   = 499 -- Type spikes an item has
+MOD_ITEM_SPIKES_DMG    = 500 -- Damage of an items spikes
+MOD_ITEM_SPIKES_CHANCE = 501 -- Chance of an items spike proc
 
-MOD_FERAL_HOWL_DURATION = 0x1F7 -- +20% duration per merit when wearing augmented Monster Jackcoat +2 (modId = 503)
-MOD_MANEUVER_BONUS      = 0x1F8 -- Maneuver Stat Bonus
-MOD_OVERLOAD_THRESH     = 0x1F9 -- Overload Threshold Bonus
-MOD_EXTRA_DMG_CHANCE    = 0x1FA -- Proc rate of MOD_OCC_DO_EXTRA_DMG. 111 would be 11.1% (modId = 506)
-MOD_OCC_DO_EXTRA_DMG    = 0x1FB -- Multiplier for "Occasionally do x times normal damage". 250 would be 2.5 times damage. (modId = 507)
+MOD_FERAL_HOWL_DURATION = 503 -- +20% duration per merit when wearing augmented Monster Jackcoat +2
+MOD_MANEUVER_BONUS      = 504 -- Maneuver Stat Bonus
+MOD_OVERLOAD_THRESH     = 505 -- Overload Threshold Bonus
+MOD_EXTRA_DMG_CHANCE    = 506 -- Proc rate of MOD_OCC_DO_EXTRA_DMG. 111 would be 11.1%
+MOD_OCC_DO_EXTRA_DMG    = 507 -- Multiplier for "Occasionally do x times normal damage". 250 would be 2.5 times damage.
 
-MOD_EAT_RAW_FISH       = 0x19C -- (modId = 412)
-MOD_EAT_RAW_MEAT       = 0x19D -- (modId = 413)
-MOD_ENHANCES_CURSNA    = 0x136 -- Raises success rate of Cursna when removing effect (like Doom) that are not 100% chance to remove (modId = 310)
-MOD_RETALIATION        = 0x19E -- Increases damage of Retaliation hits (modId = 414)
-MOD_AUGMENTS_THIRD_EYE = 0x1FC -- Adds counter to 3rd eye anticipates & if using Seigan counter rate is increased by 15% (modId = 508)
+MOD_EAT_RAW_FISH       = 412 --
+MOD_EAT_RAW_MEAT       = 413 --
+MOD_ENHANCES_CURSNA    = 310 -- Raises success rate of Cursna when removing effect (like Doom) that are not 100% chance to remove
+MOD_RETALIATION        = 414 -- Increases damage of Retaliation hits
+MOD_AUGMENTS_THIRD_EYE = 508 -- Adds counter to 3rd eye anticipates & if using Seigan counter rate is increased by 15%
 
-MOD_CLAMMING_IMPROVED_RESULTS  = 0x1FD -- (modId = 509)
-MOD_CLAMMING_REDUCED_INCIDENTS = 0x1FE -- (modId = 510)
-MOD_CHOCOBO_RIDING_TIME = 0x1FF -- Increases chocobo riding time (modId = 511)
-MOD_HARVESTING_RESULT   = 0x201 -- Improves harvesting results (modId = 513)
-MOD_LOGGING_RESULT      = 0x202 -- Improves logging results (modId = 514)
-MOD_MINNING_RESULT      = 0x203 -- Improves mining results (modId = 515)
-MOD_EGGHELM             = 0x205 -- Egg Helm (Chocobo Digging)
+MOD_CLAMMING_IMPROVED_RESULTS  = 509 --
+MOD_CLAMMING_REDUCED_INCIDENTS = 510 --
+MOD_CHOCOBO_RIDING_TIME = 511 -- Increases chocobo riding time
+MOD_HARVESTING_RESULT   = 513 -- Improves harvesting results
+MOD_LOGGING_RESULT      = 514 -- Improves logging results
+MOD_MINNING_RESULT      = 515 -- Improves mining results
+MOD_EGGHELM             = 517 -- Egg Helm (Chocobo Digging)
 
-MOD_SHIELDBLOCKRATE = 0x206 -- Affects shield block rate, percent based (modID = 518))
-MOD_SCAVENGE_EFFECT = 0x138 -- (modId = 312)
-MOD_DIA_DOT         = 0x139 -- Increases the DoT damage of Dia (modId = 313)
-MOD_SHARPSHOT       = 0x13A -- Sharpshot accuracy bonus (modId = 314)
-MOD_ENH_DRAIN_ASPIR = 0x13B -- % damage boost to Drain and Aspir(modId = 315)
-MOD_TRICK_ATK_AGI   = 0x208 -- % AGI boost to Trick Attack (if gear mod, needs to be equipped on hit) (modId = 520)
-MOD_NIN_NUKE_BONUS  = 0x20A -- magic attack bonus for NIN nukes (modId = 522)
-MOD_AMMO_SWING      = 0x20B -- Extra swing rate w/ ammo (ie. Jailer weapons). Use gearsets, and does nothing for non-players. (modId = 523)
+MOD_SHIELDBLOCKRATE = 518 -- Affects shield block rate, percent based
+MOD_SCAVENGE_EFFECT = 312 --
+MOD_DIA_DOT         = 313 -- Increases the DoT damage of Dia
+MOD_SHARPSHOT       = 314 -- Sharpshot accuracy bonus
+MOD_ENH_DRAIN_ASPIR = 315 -- % damage boost to Drain and Aspir
+MOD_TRICK_ATK_AGI   = 520 -- % AGI boost to Trick Attack (if gear mod, needs to be equipped on hit)
+MOD_NIN_NUKE_BONUS  = 522 -- magic attack bonus for NIN nukes
+MOD_AMMO_SWING      = 523 -- Extra swing rate w/ ammo (ie. Jailer weapons). Use gearsets, and does nothing for non-players.
 
 -- Mythic Weapon Mods
-MOD_AUGMENTS_ABSORB    = 0x209  -- Direct Absorb spell increase while Liberator is equipped (percentage based) (modId = 521)
-MOD_AOE_NA             = 0x20C  -- Set to 1 to make -na spells/erase always AoE w/ Divine Veil (modId = 524)
-MOD_AUGMENTS_CONVERT   = 0x20D  -- Convert HP to MP Ratio Multiplier. Value = MP multiplier rate. (modId = 525)
-MOD_AUGMENTS_SA        = 0x20E  -- Adds Critical Attack Bonus to Sneak Attack, percentage based. (modId = 526)
-MOD_AUGMENTS_TA        = 0x20F  -- Adds Critical Attack Bonus to Trick Attack, percentage based. (modId = 527)
-MOD_ROLL_RANGE         = 0x210  -- Additional range for COR roll abilities. (modId = 528)
+MOD_AUGMENTS_ABSORB    = 521 -- Direct Absorb spell increase while Liberator is equipped (percentage based)
+MOD_AOE_NA             = 524 -- Set to 1 to make -na spells/erase always AoE w/ Divine Veil
+MOD_AUGMENTS_CONVERT   = 525 -- Convert HP to MP Ratio Multiplier. Value = MP multiplier rate.
+MOD_AUGMENTS_SA        = 526 -- Adds Critical Attack Bonus to Sneak Attack, percentage based.
+MOD_AUGMENTS_TA        = 527 -- Adds Critical Attack Bonus to Trick Attack, percentage based.
+MOD_ROLL_RANGE         = 528 -- Additional range for COR roll abilities.
 
 -- The entire mod list is in desperate need of kind of some organizing.
 -- The spares take care of finding the next ID to use so long as we don't forget to list IDs that have been freed up by refactoring.
 
--- MOD_SPARE = 0x210 -- (modId = 528)
--- MOD_SPARE = 0x211 -- (modId = 529)
+-- MOD_SPARE = 92, -- stuff
+-- MOD_SPARE = 93, -- stuff
+-- MOD_SPARE = 94, -- stuff
+-- MOD_SPARE = 95, -- stuff
+-- MOD_SPARE = 96, -- stuff
+-- MOD_SPARE = 97, -- stuff
+-- MOD_SPARE = 98, -- stuff
+-- MOD_SPARE = 99, -- stuff
+-- MOD_SPARE = 100, -- stuff
+-- MOD_SPARE = 530, -- stuff
 
 ------------------------------------
 -- Merit Definitions

--- a/src/map/modifier.h
+++ b/src/map/modifier.h
@@ -21,10 +21,6 @@
 ===========================================================================
 */
 
-/*
-    MOD_NAME                      =0xHEX#, // MOD DESCRIPTION (modId = DEC#)
-*/
-
 #ifndef _CMODIFIER_H
 #define _CMODIFIER_H
 
@@ -32,554 +28,559 @@
 
 enum MODIFIER
 {
-    MOD_NONE                      = 0x00,
+    MOD_NONE                      = 0, // Essential, but does nothing :)
+    // MOD_ NAME                  = ID, // Comment
+    MOD_DEF                       = 1, // Target's Defense
+    MOD_HP                        = 2, // Target's HP
+    MOD_HPP                       = 3, // HP Percentage
+    MOD_CONVMPTOHP                = 4, // MP -> HP (Cassie Earring)
+    MOD_MP                        = 5, // MP +/-
+    MOD_MPP                       = 6, // MP Percentage
+    MOD_CONVHPTOMP                = 7, // HP -> MP
 
-    MOD_DEF                       = 0x01,  // Target's Defense (modId = 1)
-    MOD_HP                        = 0x02,  // Target's HP (modId = 2)
-    MOD_HPP                       = 0x03,  // HP Percentage (modId = 3)
-    MOD_CONVMPTOHP                = 0x04,  // MP -> HP (Cassie Earring) (modId = 4)
-    MOD_MP                        = 0x05,  // MP +/- (modId = 5)
-    MOD_MPP                       = 0x06,  // MP Percentage (modId = 6)
-    MOD_CONVHPTOMP                = 0x07,  // HP -> MP (modId = 7)
-
-    MOD_STR                       = 0x08,  // Strength (modId = 8)
-    MOD_DEX                       = 0x09,  // Dexterity (modId = 9)
-    MOD_VIT                       = 0x0A,  // Vitality (modId = 10)
-    MOD_AGI                       = 0x0B,  // Agility (modId = 11)
-    MOD_INT                       = 0x0C,  // Intelligence (modId = 12)
-    MOD_MND                       = 0x0D,  // Mind (modId = 13)
-    MOD_CHR                       = 0x0E,  // Charisma (modId = 14)
+    MOD_STR                       = 8, // Strength
+    MOD_DEX                       = 9, // Dexterity
+    MOD_VIT                       = 10, // Vitality
+    MOD_AGI                       = 11, // Agility
+    MOD_INT                       = 12, // Intelligence
+    MOD_MND                       = 13, // Mind
+    MOD_CHR                       = 14, // Charisma
 
     // Elemental Defenses
-    MOD_FIREDEF                   = 0x0F,  // Fire Defense (modId = 15)
-    MOD_ICEDEF                    = 0x10,  // Ice Defense (modId = 16)
-    MOD_WINDDEF                   = 0x11,  // Wind Defense (modId = 17)
-    MOD_EARTHDEF                  = 0x12,  // Earth Defense (modId = 18)
-    MOD_THUNDERDEF                = 0x13,  // Thunder Defense (modId = 19)
-    MOD_WATERDEF                  = 0x14,  // Water Defense (modId = 20)
-    MOD_LIGHTDEF                  = 0x15,  // Light Defense (modId = 21)
-    MOD_DARKDEF                   = 0x16,  // Dark Defense (modId = 22)
+    MOD_FIREDEF                   = 15, // Fire Defense
+    MOD_ICEDEF                    = 16, // Ice Defense
+    MOD_WINDDEF                   = 17, // Wind Defense
+    MOD_EARTHDEF                  = 18, // Earth Defense
+    MOD_THUNDERDEF                = 19, // Thunder Defense
+    MOD_WATERDEF                  = 20, // Water Defense
+    MOD_LIGHTDEF                  = 21, // Light Defense
+    MOD_DARKDEF                   = 22, // Dark Defense
 
-    MOD_ATT                       = 0x17,  // Attack (modId = 23)
-    MOD_RATT                      = 0x18,  // Ranged Attack (modId = 24)
+    MOD_ATT                       = 23, // Attack
+    MOD_RATT                      = 24, // Ranged Attack
 
-    MOD_ACC                       = 0x19,  // Accuracy (modId = 25)
-    MOD_RACC                      = 0x1A,  // Ranged Accuracy (modId = 26)
+    MOD_ACC                       = 25, // Accuracy
+    MOD_RACC                      = 26, // Ranged Accuracy
 
-    MOD_ENMITY                    = 0x1B,  // Enmity (modId = 27)
-    MOD_ENMITY_LOSS_REDUCTION     = 0x1F6, // Reduces Enmity lost when taking damage
+    MOD_ENMITY                    = 27, // Enmity
+    MOD_ENMITY_LOSS_REDUCTION     = 502, // Reduces Enmity lost when taking damage
 
-    MOD_MATT                      = 0x1C,  // Magic Attack (modId = 28)
-    MOD_MDEF                      = 0x1D,  // Magic Defense (modId = 29)
-    MOD_MACC                      = 0x1E,  // Magic Accuracy (modId = 30)
-    MOD_MEVA                      = 0x1F,  // Magic Evasion (modId = 31)
+    MOD_MATT                      = 28, // Magic Attack
+    MOD_MDEF                      = 29, // Magic Defense
+    MOD_MACC                      = 30, // Magic Accuracy
+    MOD_MEVA                      = 31, // Magic Evasion
 
     // Magic Accuracy and Elemental Attacks
-    MOD_FIREATT                   = 0x20,  // Fire Damage (modId = 32)
-    MOD_ICEATT                    = 0x21,  // Ice Damage (modId = 33)
-    MOD_WINDATT                   = 0x22,  // Wind Damage (modId = 34)
-    MOD_EARTHATT                  = 0x23,  // Earth Damage (modId = 35)
-    MOD_THUNDERATT                = 0x24,  // Thunder Damage (modId = 36)
-    MOD_WATERATT                  = 0x25,  // Water Damage (modId = 37)
-    MOD_LIGHTATT                  = 0x26,  // Light Damage (modId = 38)
-    MOD_DARKATT                   = 0x27,  // Dark Damage (modId = 39)
-    MOD_FIREACC                   = 0x28,  // Fire Accuracy (modId = 40)
-    MOD_ICEACC                    = 0x29,  // Ice Accuracy (modId = 41)
-    MOD_WINDACC                   = 0x2A,  // Wind Accuracy (modId = 42)
-    MOD_EARTHACC                  = 0x2B,  // Earth Accuracy (modId = 43)
-    MOD_THUNDERACC                = 0x2C,  // Thunder Accuracy (modId = 44)
-    MOD_WATERACC                  = 0x2D,  // Water Accuracy (modId = 45)
-    MOD_LIGHTACC                  = 0x2E,  // Light Accuracy (modId = 46)
-    MOD_DARKACC                   = 0x2F,  // Dark Accuracy (modId = 47)
+    MOD_FIREATT                   = 32, // Fire Damage
+    MOD_ICEATT                    = 33, // Ice Damage
+    MOD_WINDATT                   = 34, // Wind Damage
+    MOD_EARTHATT                  = 35, // Earth Damage
+    MOD_THUNDERATT                = 36, // Thunder Damage
+    MOD_WATERATT                  = 37, // Water Damage
+    MOD_LIGHTATT                  = 38, // Light Damage
+    MOD_DARKATT                   = 39, // Dark Damage
+    MOD_FIREACC                   = 40, // Fire Accuracy
+    MOD_ICEACC                    = 41, // Ice Accuracy
+    MOD_WINDACC                   = 42, // Wind Accuracy
+    MOD_EARTHACC                  = 43, // Earth Accuracy
+    MOD_THUNDERACC                = 44, // Thunder Accuracy
+    MOD_WATERACC                  = 45, // Water Accuracy
+    MOD_LIGHTACC                  = 46, // Light Accuracy
+    MOD_DARKACC                   = 47, // Dark Accuracy
 
-    MOD_WSACC                     = 0x30,  // Weaponskill Accuracy (modId = 48)
+    MOD_WSACC                     = 48, // Weaponskill Accuracy
 
     // Resistance to damage type
     // Value is stored as a percentage of damage reduction (to within 1000)
-    // Example: 1000              = 100%, 875= 87.5%
-    MOD_SLASHRES                  = 0x31,  // Slash Resistance (modId = 49)
-    MOD_PIERCERES                 = 0x32,  // Piercing Resistance (modId = 50)
-    MOD_IMPACTRES                 = 0x33,  // Impact Resistance (modId = 51)
-    MOD_HTHRES                    = 0x34,  // Hand-To-Hand Resistance (modId = 52)
-
+    // Example: 1000 = 100%, 875= 87.5%
+    MOD_SLASHRES                  = 49, // Slash Resistance
+    MOD_PIERCERES                 = 50, // Piercing Resistance
+    MOD_IMPACTRES                 = 51, // Impact Resistance
+    MOD_HTHRES                    = 52, // Hand-To-Hand Resistance
 
     // Damage Reduction to Elements
     // Value is stored as a percentage of damage reduction (to within 1000)
-    // Example: 1000              = 100%, 875= 87.5%
-    MOD_FIRERES                   = 0x36,  // % Fire Resistance (modId = 54)
-    MOD_ICERES                    = 0x37,  // % Ice Resistance (modId = 55)
-    MOD_WINDRES                   = 0x38,  // % Wind Resistance (modId = 56)
-    MOD_EARTHRES                  = 0x39,  // % Earth Resistance (modId = 57)
-    MOD_THUNDERRES                = 0x3A,  // % Thunder Resistance (modId = 58)
-    MOD_WATERRES                  = 0x3B,  // % Water Resistance (modId = 59)
-    MOD_LIGHTRES                  = 0x3C,  // % Light Resistance (modId = 60)
-    MOD_DARKRES                   = 0x3D,  // % Dark Resistance (modId = 61)
+    // Example: 1000 = 100%, 875= 87.5%
+    MOD_FIRERES                   = 54, // % Fire Resistance
+    MOD_ICERES                    = 55, // % Ice Resistance
+    MOD_WINDRES                   = 56, // % Wind Resistance
+    MOD_EARTHRES                  = 57, // % Earth Resistance
+    MOD_THUNDERRES                = 58, // % Thunder Resistance
+    MOD_WATERRES                  = 59, // % Water Resistance
+    MOD_LIGHTRES                  = 60, // % Light Resistance
+    MOD_DARKRES                   = 61, // % Dark Resistance
 
-    MOD_ATTP                      = 0x3E,  // % Attack (modId = 62)
-    MOD_DEFP                      = 0x3F,  // % Defense (modId = 63)
-    MOD_ACCP                      = 0x40,  // % Accuracy (modId = 64)
-    MOD_EVAP                      = 0x41,  // % Evasion (modId = 65)
-    MOD_RATTP                     = 0x42,  // % Ranged Attack (modId = 66)
-    MOD_RACCP                     = 0x43,  // % Ranged Attack Accuracy (modId = 67)
+    MOD_ATTP                      = 62, // % Attack
+    MOD_DEFP                      = 63, // % Defense
+    MOD_ACCP                      = 64, // % Accuracy
+    MOD_EVAP                      = 65, // % Evasion
+    MOD_RATTP                     = 66, // % Ranged Attack
+    MOD_RACCP                     = 67, // % Ranged Attack Accuracy
 
-    MOD_EVA                       = 0x44,  // Evasion (modId = 68)
-    MOD_RDEF                      = 0x45,  // Ranged Defense (modId = 69)
-    MOD_REVA                      = 0x46,  // Ranged Evasion (modId = 70)
-    MOD_MPHEAL                    = 0x47,  // MP Recovered while healing (modId = 71)
-    MOD_HPHEAL                    = 0x48,  // HP Recovered while healing (modId = 72)
-    MOD_STORETP                   = 0x49,  // Increases the rate at which TP is gained (modId = 73)
-    MOD_TACTICAL_PARRY            = 0x1E6, // Tactical Parry Tp Bonus (modId = 486)
-    MOD_MAG_BURST_BONUS           = 0x1E7, // Magic Burst Bonus Modifier (percent) (modId = 487)
-    MOD_INHIBIT_TP                = 0x1E8, // Inhibits TP Gain (percent) (modId = 488)
+    MOD_EVA                       = 68, // Evasion
+    MOD_RDEF                      = 69, // Ranged Defense
+    MOD_REVA                      = 70, // Ranged Evasion
+    MOD_MPHEAL                    = 71, // MP Recovered while healing
+    MOD_HPHEAL                    = 72, // HP Recovered while healing
+    MOD_STORETP                   = 73, // Increases the rate at which TP is gained
+    MOD_TACTICAL_PARRY            = 486, // Tactical Parry Tp Bonus
+    MOD_MAG_BURST_BONUS           = 487, // Magic Burst Bonus Modifier (percent)
+    MOD_INHIBIT_TP                = 488, // Inhibits TP Gain (percent)
 
     // Working Skills (weapon combat skills)
-    MOD_HTH                       = 0x50,  // Hand To Hand Skill (modId = 80)
-    MOD_DAGGER                    = 0x51,  // Dagger Skill (modId = 81)
-    MOD_SWORD                     = 0x52,  // Sword Skill (modId = 82)
-    MOD_GSWORD                    = 0x53,  // Great Sword Skill (modId = 83)
-    MOD_AXE                       = 0x54,  // Axe Skill (modId = 84)
-    MOD_GAXE                      = 0x55,  // Great Axe Skill (modId = 85)
-    MOD_SCYTHE                    = 0x56,  // Scythe Skill (modId = 86)
-    MOD_POLEARM                   = 0x57,  // Polearm Skill (modId = 87)
-    MOD_KATANA                    = 0x58,  // Katana Skill (modId = 88)
-    MOD_GKATANA                   = 0x59,  // Great Katana Skill (modId = 89)
-    MOD_CLUB                      = 0x5A,  // Club Skill (modId = 90)
-    MOD_STAFF                     = 0x5B,  // Staff Skill (modId = 91)
-    MOD_AUTO_MELEE_SKILL          = 0x65,  // Automaton Melee Skill (modId = 101)
-    MOD_AUTO_RANGED_SKILL         = 0x66,  // Automaton Range Skill (modId = 102)
-    MOD_AUTO_MAGIC_SKILL          = 0x67,  // Automaton Magic Skill (modId = 103)
-    MOD_ARCHERY                   = 0x68,  // Archery Skill (modId = 104)
-    MOD_MARKSMAN                  = 0x69,  // Marksman Skill (modId = 105)
-    MOD_THROW                     = 0x6A,  // Throw Skill (modId = 106)
-    MOD_GUARD                     = 0x6B,  // Guard Skill (modId = 107)
-    MOD_EVASION                   = 0x6C,  // Evasion Skill (modId = 108)
-    MOD_SHIELD                    = 0x6D,  // Shield Skill (modId = 109)
-    MOD_PARRY                     = 0x6E,  // Parry Skill (modId = 110)
+    MOD_HTH                       = 80, // Hand To Hand Skill
+    MOD_DAGGER                    = 81, // Dagger Skill
+    MOD_SWORD                     = 82, // Sword Skill
+    MOD_GSWORD                    = 83, // Great Sword Skill
+    MOD_AXE                       = 84, // Axe Skill
+    MOD_GAXE                      = 85, // Great Axe Skill
+    MOD_SCYTHE                    = 86, // Scythe Skill
+    MOD_POLEARM                   = 87, // Polearm Skill
+    MOD_KATANA                    = 88, // Katana Skill
+    MOD_GKATANA                   = 89, // Great Katana Skill
+    MOD_CLUB                      = 90, // Club Skill
+    MOD_STAFF                     = 91, // Staff Skill
+    MOD_AUTO_MELEE_SKILL          = 101, // Automaton Melee Skill
+    MOD_AUTO_RANGED_SKILL         = 102, // Automaton Range Skill
+    MOD_AUTO_MAGIC_SKILL          = 103, // Automaton Magic Skill
+    MOD_ARCHERY                   = 104, // Archery Skill
+    MOD_MARKSMAN                  = 105, // Marksman Skill
+    MOD_THROW                     = 106, // Throw Skill
+    MOD_GUARD                     = 107, // Guard Skill
+    MOD_EVASION                   = 108, // Evasion Skill
+    MOD_SHIELD                    = 109, // Shield Skill
+    MOD_PARRY                     = 110, // Parry Skill
 
     // Magic Skills
-    MOD_DIVINE                    = 0x6F,  // Divine Magic Skill (modId = 111)
-    MOD_HEALING                   = 0x70,  // Healing Magic Skill (modId = 112)
-    MOD_ENHANCE                   = 0x71,  // Enhancing Magic Skill (modId = 113)
-    MOD_ENFEEBLE                  = 0x72,  // Enfeebling Magic Skill (modId = 114)
-    MOD_ELEM                      = 0x73,  // Elemental Magic Skill (modId = 115)
-    MOD_DARK                      = 0x74,  // Dark Magic Skill (modId = 116)
-    MOD_SUMMONING                 = 0x75,  // Summoning Magic Skill (modId = 117)
-    MOD_NINJUTSU                  = 0x76,  // Ninjutsu Magic Skill (modId = 118)
-    MOD_SINGING                   = 0x77,  // Singing Magic Skill (modId = 119)
-    MOD_STRING                    = 0x78,  // String Magic Skill (modId = 120)
-    MOD_WIND                      = 0x79,  // Wind Magic Skill (modId = 121)
-    MOD_BLUE                      = 0x7A,  // Blue Magic Skill (modId = 122)
+    MOD_DIVINE                    = 111, // Divine Magic Skill
+    MOD_HEALING                   = 112, // Healing Magic Skill
+    MOD_ENHANCE                   = 113, // Enhancing Magic Skill
+    MOD_ENFEEBLE                  = 114, // Enfeebling Magic Skill
+    MOD_ELEM                      = 115, // Elemental Magic Skill
+    MOD_DARK                      = 116, // Dark Magic Skill
+    MOD_SUMMONING                 = 117, // Summoning Magic Skill
+    MOD_NINJUTSU                  = 118, // Ninjutsu Magic Skill
+    MOD_SINGING                   = 119, // Singing Magic Skill
+    MOD_STRING                    = 120, // String Magic Skill
+    MOD_WIND                      = 121, // Wind Magic Skill
+    MOD_BLUE                      = 122, // Blue Magic Skill
 
     // Synthesis Skills
-    MOD_FISH                      = 0x7F,  // Fishing Skill (modId = 127)
-    MOD_WOOD                      = 0x80,  // Woodworking Skill (modId = 128)
-    MOD_SMITH                     = 0x81,  // Smithing Skill (modId = 129)
-    MOD_GOLDSMITH                 = 0x82,  // Goldsmithing Skill (modId = 130)
-    MOD_CLOTH                     = 0x83,  // Clothcraft Skill (modId = 131)
-    MOD_LEATHER                   = 0x84,  // Leathercraft Skill (modId = 132)
-    MOD_BONE                      = 0x85,  // Bonecraft Skill (modId = 133)
-    MOD_ALCHEMY                   = 0x86,  // Alchemy Skill (modId = 134)
-    MOD_COOK                      = 0x87,  // Cooking Skill (modId = 135)
-    MOD_SYNERGY                   = 0x88,  // Synergy Skill (modId = 136)
-    MOD_RIDING                    = 0x89,  // Riding Skill (modId = 137)
+    MOD_FISH                      = 127, // Fishing Skill
+    MOD_WOOD                      = 128, // Woodworking Skill
+    MOD_SMITH                     = 129, // Smithing Skill
+    MOD_GOLDSMITH                 = 130, // Goldsmithing Skill
+    MOD_CLOTH                     = 131, // Clothcraft Skill
+    MOD_LEATHER                   = 132, // Leathercraft Skill
+    MOD_BONE                      = 133, // Bonecraft Skill
+    MOD_ALCHEMY                   = 134, // Alchemy Skill
+    MOD_COOK                      = 135, // Cooking Skill
+    MOD_SYNERGY                   = 136, // Synergy Skill
+    MOD_RIDING                    = 137, // Riding Skill
 
     // Chance you will not make an hq synth (Impossibility of HQ synth)
-    MOD_ANTIHQ_WOOD               = 0x90,  // Woodworking Success Rate % (modId = 144)
-    MOD_ANTIHQ_SMITH              = 0x91,  // Smithing Success Rate % (modId = 145)
-    MOD_ANTIHQ_GOLDSMITH          = 0x92,  // Goldsmithing Success Rate % (modId = 146)
-    MOD_ANTIHQ_CLOTH              = 0x93,  // Clothcraft Success Rate % (modId = 147)
-    MOD_ANTIHQ_LEATHER            = 0x94,  // Leathercraft Success Rate % (modId = 148)
-    MOD_ANTIHQ_BONE               = 0x95,  // Bonecraft Success Rate % (modId = 149)
-    MOD_ANTIHQ_ALCHEMY            = 0x96,  // Alchemy Success Rate % (modId = 150)
-    MOD_ANTIHQ_COOK               = 0x97,  // Cooking Success Rate % (modId = 151)
+    MOD_ANTIHQ_WOOD               = 144, // Woodworking Success Rate %
+    MOD_ANTIHQ_SMITH              = 145, // Smithing Success Rate %
+    MOD_ANTIHQ_GOLDSMITH          = 146, // Goldsmithing Success Rate %
+    MOD_ANTIHQ_CLOTH              = 147, // Clothcraft Success Rate %
+    MOD_ANTIHQ_LEATHER            = 148, // Leathercraft Success Rate %
+    MOD_ANTIHQ_BONE               = 149, // Bonecraft Success Rate %
+    MOD_ANTIHQ_ALCHEMY            = 150, // Alchemy Success Rate %
+    MOD_ANTIHQ_COOK               = 151, // Cooking Success Rate %
 
     // Damage / Crit Damage / Delay
-    MOD_DMG                       = 0xA0,  // Damage Taken % (modId = 160)
-    MOD_DMGPHYS                   = 0xA1,  // Physical Damage Taken % (modId = 161)
-    MOD_DMGBREATH                 = 0xA2,  // Breath Damage Taken % (modId = 162)
-    MOD_DMGMAGIC                  = 0xA3,  // Magic Damage Taken % - 256 base! (value of -24 means -24/256 magic damage taken) (modId = 163)
-    MOD_DMGRANGE                  = 0xA4,  // Range Damage Taken % (modId = 164)
+    MOD_DMG                       = 160, // Damage Taken %
+    MOD_DMGPHYS                   = 161, // Physical Damage Taken %
+    MOD_DMGBREATH                 = 162, // Breath Damage Taken %
+    MOD_DMGMAGIC                  = 163, // Magic Damage Taken % - 256 base! (value of -24 means -24/256 magic damage taken)
+    MOD_DMGRANGE                  = 164, // Range Damage Taken %
 
-    MOD_UDMGPHYS                  = 0x183, // Uncapped Damage Multipliers (modId = 387)
-    MOD_UDMGBREATH                = 0x184, // Used in sentinal, invincible, physical shield etc (modId = 388)
-    MOD_UDMGMAGIC                 = 0x185, // (modId = 389)
-    MOD_UDMGRANGE                 = 0x186, // (modId = 390)
+    MOD_UDMGPHYS                  = 387, // Uncapped Damage Multipliers
+    MOD_UDMGBREATH                = 388, // Used in sentinal, invincible, physical shield etc
+    MOD_UDMGMAGIC                 = 389, //
+    MOD_UDMGRANGE                 = 390, //
 
-    MOD_CRITHITRATE               = 0xA5,  // Raises chance to crit (modId = 165)
-    MOD_CRIT_DMG_INCREASE         = 0x1A5, // Raises the damage of critcal hit by percent % (modId = 421)
-    MOD_ENEMYCRITRATE             = 0xA6,  // Raises chance enemy will crit (modId = 166)
+    MOD_CRITHITRATE               = 165, // Raises chance to crit
+    MOD_CRIT_DMG_INCREASE         = 421, // Raises the damage of critcal hit by percent %
+    MOD_ENEMYCRITRATE             = 166, // Raises chance enemy will crit
 
-    MOD_HASTE_MAGIC               = 0xA7,  // Haste (and Slow) from magic - 1024 base! (448 cap) (modId = 167)
-    MOD_HASTE_ABILITY             = 0x17F, // Haste (and Slow) from abilities - 1024 base! (256 cap?) (modId = 383)
-    MOD_HASTE_GEAR                = 0x180, // Haste (and Slow) from equipment - 1024 base! (256 cap) (modId = 384)
-    MOD_SPELLINTERRUPT            = 0xA8,  // % Spell Interruption Rate (modId = 168)
-    MOD_MOVE                      = 0xA9,  // % Movement Speed (modId = 169)
-    MOD_FASTCAST                  = 0xAA,  // Increases Spell Cast Time (TRAIT) (modId = 170)
-    MOD_UFASTCAST                 = 0x197, // uncapped fast cast (modId = 407)
-    MOD_CURE_CAST_TIME            = 0x207, // cure cast time reduction (modId = 519)
-    MOD_DELAY                     = 0xAB,  // Increase/Decrease Delay (modId = 171)
-    MOD_RANGED_DELAY              = 0xAC,  // Increase/Decrease Ranged Delay (modId = 172)
-    MOD_MARTIAL_ARTS              = 0xAD,  // The integer amount of delay to reduce from H2H weapons' base delay. (TRAIT) (modId = 173)
-    MOD_SKILLCHAINBONUS           = 0xAE,  // Damage bonus applied to skill chain damage.  Modifier from effects/traits (modId = 174)
-    MOD_SKILLCHAINDMG             = 0xAF,  // Damage bonus applied to skill chain damage.  Modifier from gear (multiplicative after effect/traits) (modId = 175)
+    MOD_HASTE_MAGIC               = 167, // Haste (and Slow) from magic - 1024 base! (448 cap)
+    MOD_HASTE_ABILITY             = 383, // Haste (and Slow) from abilities - 1024 base! (256 cap?)
+    MOD_HASTE_GEAR                = 384, // Haste (and Slow) from equipment - 1024 base! (256 cap)
+    MOD_SPELLINTERRUPT            = 168, // % Spell Interruption Rate
+    MOD_MOVE                      = 169, // % Movement Speed
+    MOD_FASTCAST                  = 170, // Increases Spell Cast Time (TRAIT)
+    MOD_UFASTCAST                 = 407, // uncapped fast cast
+    MOD_CURE_CAST_TIME            = 519, // cure cast time reduction
+    MOD_DELAY                     = 171, // Increase/Decrease Delay
+    MOD_RANGED_DELAY              = 172, // Increase/Decrease Ranged Delay
+    MOD_MARTIAL_ARTS              = 173, // The integer amount of delay to reduce from H2H weapons' base delay. (TRAIT)
+    MOD_SKILLCHAINBONUS           = 174, // Damage bonus applied to skill chain damage.  Modifier from effects/traits
+    MOD_SKILLCHAINDMG             = 175, // Damage bonus applied to skill chain damage.  Modifier from gear (multiplicative after effect/traits)
 
-    MOD_MAGIC_DAMAGE             = 0x137, // Magic damage added directly to the spell's base damage (modId = 311)
+    MOD_MAGIC_DAMAGE             = 311, // Magic damage added directly to the spell's base damage
 
     // FOOD!
-    MOD_FOOD_HPP                  = 0xB0,  // (modId = 176)
-    MOD_FOOD_HP_CAP               = 0xB1,  // (modId = 177)
-    MOD_FOOD_MPP                  = 0xB2,  // (modId = 178)
-    MOD_FOOD_MP_CAP               = 0xB3,  // (modId = 179)
-    MOD_FOOD_ATTP                 = 0xB4,  // (modId = 180)
-    MOD_FOOD_ATT_CAP              = 0xB5,  // (modId = 181)
-    MOD_FOOD_DEFP                 = 0xB6,  // (modId = 182)
-    MOD_FOOD_DEF_CAP              = 0xB7,  // (modId = 183)
-    MOD_FOOD_ACCP                 = 0xB8,  // (modId = 184)
-    MOD_FOOD_ACC_CAP              = 0xB9,  // (modId = 185)
-    MOD_FOOD_RATTP                = 0xBA,  // (modId = 186)
-    MOD_FOOD_RATT_CAP             = 0xBB,  // (modId = 187)
-    MOD_FOOD_RACCP                = 0xBC,  // (modId = 188)
-    MOD_FOOD_RACC_CAP             = 0xBD,  // (modId = 190)
+    MOD_FOOD_HPP                  = 176, //
+    MOD_FOOD_HP_CAP               = 177, //
+    MOD_FOOD_MPP                  = 178, //
+    MOD_FOOD_MP_CAP               = 179, //
+    MOD_FOOD_ATTP                 = 180, //
+    MOD_FOOD_ATT_CAP              = 181, //
+    MOD_FOOD_DEFP                 = 182, //
+    MOD_FOOD_DEF_CAP              = 183, //
+    MOD_FOOD_ACCP                 = 184, //
+    MOD_FOOD_ACC_CAP              = 185, //
+    MOD_FOOD_RATTP                = 186, //
+    MOD_FOOD_RATT_CAP             = 187, //
+    MOD_FOOD_RACCP                = 188, //
+    MOD_FOOD_RACC_CAP             = 189, //
 
     // Killer-Effects - (Most by Traits/JobAbility)
-    MOD_VERMIN_KILLER             = 0xE0,  // Enhances "Vermin Killer" effect (modId = 224)
-    MOD_BIRD_KILLER               = 0xE1,  // Enhances "Bird Killer" effect (modId = 225)
-    MOD_AMORPH_KILLER             = 0xE2,  // Enhances "Amorph Killer" effect (modId = 226)
-    MOD_LIZARD_KILLER             = 0xE3,  // Enhances "Lizard Killer" effect (modId = 227)
-    MOD_AQUAN_KILLER              = 0xE4,  // Enhances "Aquan Killer" effect (modId = 228)
-    MOD_PLANTOID_KILLER           = 0xE5,  // Enhances "Plantiod Killer" effect (modId = 229)
-    MOD_BEAST_KILLER              = 0xE6,  // Enhances "Beast Killer" effect (modId = 230)
-    MOD_UNDEAD_KILLER             = 0xE7,  // Enhances "Undead Killer" effect (modId = 231)
-    MOD_ARCANA_KILLER             = 0xE8,  // Enhances "Arcana Killer" effect (modId = 232)
-    MOD_DRAGON_KILLER             = 0xE9,  // Enhances "Dragon Killer" effect (modId = 233)
-    MOD_DEMON_KILLER              = 0xEA,  // Enhances "Demon Killer" effect (modId = 234)
-    MOD_EMPTY_KILLER              = 0xEB,  // Enhances "Empty Killer" effect (modId = 235)
-    MOD_HUMANOID_KILLER           = 0xEC,  // Enhances "Humanoid Killer" effect (modId = 236)
-    MOD_LUMORIAN_KILLER           = 0xED,  // Enhances "Lumorian Killer" effect (modId = 237)
-    MOD_LUMINION_KILLER           = 0xEE,  // Enhances "Luminion Killer" effect (modId = 238)
+    MOD_VERMIN_KILLER             = 224, // Enhances "Vermin Killer" effect
+    MOD_BIRD_KILLER               = 225, // Enhances "Bird Killer" effect
+    MOD_AMORPH_KILLER             = 226, // Enhances "Amorph Killer" effect
+    MOD_LIZARD_KILLER             = 227, // Enhances "Lizard Killer" effect
+    MOD_AQUAN_KILLER              = 228, // Enhances "Aquan Killer" effect
+    MOD_PLANTOID_KILLER           = 229, // Enhances "Plantiod Killer" effect
+    MOD_BEAST_KILLER              = 230, // Enhances "Beast Killer" effect
+    MOD_UNDEAD_KILLER             = 231, // Enhances "Undead Killer" effect
+    MOD_ARCANA_KILLER             = 232, // Enhances "Arcana Killer" effect
+    MOD_DRAGON_KILLER             = 233, // Enhances "Dragon Killer" effect
+    MOD_DEMON_KILLER              = 234, // Enhances "Demon Killer" effect
+    MOD_EMPTY_KILLER              = 235, // Enhances "Empty Killer" effect
+    MOD_HUMANOID_KILLER           = 236, // Enhances "Humanoid Killer" effect
+    MOD_LUMORIAN_KILLER           = 237, // Enhances "Lumorian Killer" effect
+    MOD_LUMINION_KILLER           = 238, // Enhances "Luminion Killer" effect
 
     // Resistances to enfeebles - Traits/Job Ability
-    MOD_SLEEPRES                  = 0xF0,  // Enhances "Resist Sleep" effect (modId = 240)
-    MOD_POISONRES                 = 0xF1,  // Enhances "Resist Poison" effect (modId = 241)
-    MOD_PARALYZERES               = 0xF2,  // Enhances "Resist Paralyze" effect (modId = 242)
-    MOD_BLINDRES                  = 0xF3,  // Enhances "Resist Blind" effect (modId = 243)
-    MOD_SILENCERES                = 0xF4,  // Enhances "Resist Silence" effect (modId = 244)
-    MOD_VIRUSRES                  = 0xF5,  // Enhances "Resist Virus" effect (modId = 245)
-    MOD_PETRIFYRES                = 0xF6,  // Enhances "Resist Petrify" effect (modId = 246)
-    MOD_BINDRES                   = 0xF7,  // Enhances "Resist Bind" effect (modId = 247)
-    MOD_CURSERES                  = 0xF8,  // Enhances "Resist Curse" effect (modId = 248)
-    MOD_GRAVITYRES                = 0xF9,  // Enhances "Resist Gravity" effect (modId = 249)
-    MOD_SLOWRES                   = 0xFA,  // Enhances "Resist Slow" effect (modId = 250)
-    MOD_STUNRES                   = 0xFB,  // Enhances "Resist Stun" effect (modId = 251)
-    MOD_CHARMRES                  = 0xFC,  // Enhances "Resist Charm" effect (modId = 252)
-    MOD_AMNESIARES                = 0xFD,  // Enhances "Resist Amnesia" effect (modId = 253)
-    // PLACEHOLDER                   = 0xFE,  // placeholder for future resist effect (modId = 254)
-    MOD_DEATHRES                  = 0xFF,  // Used by gear and ATMA that give resistance to instance KO (modId = 255)
+    MOD_SLEEPRES                  = 240, // Enhances "Resist Sleep" effect
+    MOD_POISONRES                 = 241, // Enhances "Resist Poison" effect
+    MOD_PARALYZERES               = 242, // Enhances "Resist Paralyze" effect
+    MOD_BLINDRES                  = 243, // Enhances "Resist Blind" effect
+    MOD_SILENCERES                = 244, // Enhances "Resist Silence" effect
+    MOD_VIRUSRES                  = 245, // Enhances "Resist Virus" effect
+    MOD_PETRIFYRES                = 246, // Enhances "Resist Petrify" effect
+    MOD_BINDRES                   = 247, // Enhances "Resist Bind" effect
+    MOD_CURSERES                  = 248, // Enhances "Resist Curse" effect
+    MOD_GRAVITYRES                = 249, // Enhances "Resist Gravity" effect
+    MOD_SLOWRES                   = 250, // Enhances "Resist Slow" effect
+    MOD_STUNRES                   = 251, // Enhances "Resist Stun" effect
+    MOD_CHARMRES                  = 252, // Enhances "Resist Charm" effect
+    MOD_AMNESIARES                = 253, // Enhances "Resist Amnesia" effect
+    // PLACEHOLDER                   = 254, // placeholder for future resist effect
+    MOD_DEATHRES                  = 255, // Used by gear and ATMA that give resistance to instance KO
 
-    MOD_PARALYZE                  = 0x101, // Paralyze -- percent chance to proc (modId = 257)
-    MOD_MIJIN_GAKURE              = 0x102, // Tracks whether or not you used this ability to die. (modId = 258)
-    MOD_DUAL_WIELD                = 0x103, // Percent reduction in dual wield delay. (modId = 259)
+    MOD_PARALYZE                  = 257, // Paralyze -- percent chance to proc
+    MOD_MIJIN_GAKURE              = 258, // Tracks whether or not you used this ability to die.
+    MOD_DUAL_WIELD                = 259, // Percent reduction in dual wield delay.
 
     // Warrior
-    MOD_DOUBLE_ATTACK             = 0x120, // Percent chance to proc (modId = 288)
-    MOD_WARCRY_DURATION           = 0x1E3, // Warcy duration bonus from gear
+    MOD_DOUBLE_ATTACK             = 288, // Percent chance to proc
+    MOD_WARCRY_DURATION           = 483, // Warcy duration bonus from gear
 
     // Monk
-    MOD_SUBTLE_BLOW               = 0x121, // How much TP to reduce. (modId = 289)
-    MOD_COUNTER                   = 0x123, // Percent chance to counter (modId = 291)
-    MOD_KICK_ATTACK               = 0x124, // Percent chance to kick (modId = 292)
-    MOD_PERFECT_COUNTER_ATT       = 0x1AC, // TODO: Raises weapon damage by 20 when countering while under the Perfect Counter effect. This also affects Weapon Rank (though not if fighting barehanded). (modId = 428)
-    MOD_FOOTWORK_ATT_BONUS        = 0x1AD, // TODO: Raises the attack bonus of Footwork. (Tantra Gaiters +2 raise 100/1024 to 152/1024) (modId = 429)
+    MOD_SUBTLE_BLOW               = 289, // How much TP to reduce.
+    MOD_COUNTER                   = 291, // Percent chance to counter
+    MOD_KICK_ATTACK               = 292, // Percent chance to kick
+    MOD_PERFECT_COUNTER_ATT       = 428, // TODO: Raises weapon damage by 20 when countering while under the Perfect Counter effect. This also affects Weapon Rank (though not if fighting barehanded).
+    MOD_FOOTWORK_ATT_BONUS        = 429, // TODO: Raises the attack bonus of Footwork. (Tantra Gaiters +2 raise 100/1024 to 152/1024)
 
     // White Mage
-    MOD_AFFLATUS_SOLACE           = 0x125, // Pool of HP accumulated during Afflatus Solace (modId = 293)
-    MOD_AFFLATUS_MISERY           = 0x126, // Pool of HP accumulated during Afflatus Misery (modId = 294)
-    MOD_AUSPICE_EFFECT            = 0x1E4, // Bonus to Auspice Subtle Blow Effect.
-    MOD_AOE_NA                    = 0x20C, // Set to 1 to make -na spells/erase always AoE w/ Divine Veil (modId = 524)
+    MOD_AFFLATUS_SOLACE           = 293, // Pool of HP accumulated during Afflatus Solace
+    MOD_AFFLATUS_MISERY           = 294, // Pool of HP accumulated during Afflatus Misery
+    MOD_AUSPICE_EFFECT            = 484, // Bonus to Auspice Subtle Blow Effect.
+    MOD_AOE_NA                    = 524, // Set to 1 to make -na spells/erase always AoE w/ Divine Veil
 
     // Black Mage
-    MOD_CLEAR_MIND                = 0x127, // Used in conjunction with MOD_HEALMP to increase amount between tics (modId = 295)
-    MOD_CONSERVE_MP               = 0x128, // Percent chance (modId = 296)
+    MOD_CLEAR_MIND                = 295, // Used in conjunction with MOD_HEALMP to increase amount between tics
+    MOD_CONSERVE_MP               = 296, // Percent chance
 
     // Red Mage
-    MOD_BLINK                     = 0x12B, // Tracks blink shadows (modId = 299)
-    MOD_STONESKIN                 = 0x12C, // Tracks stoneskin HP pool (modId = 300)
-    MOD_PHALANX                   = 0x12D, // Tracks direct damage reduction (modId = 301)
+    MOD_BLINK                     = 299, // Tracks blink shadows
+    MOD_STONESKIN                 = 300, // Tracks stoneskin HP pool
+    MOD_PHALANX                   = 301, // Tracks direct damage reduction
 
     // Thief
-    MOD_STEAL                     = 0x12A, // Increase/Decrease THF Steal chance (modId = 298)
-    MOD_TRIPLE_ATTACK             = 0x12E, // Percent chance (modId = 302)
-    MOD_TREASURE_HUNTER           = 0x12F, // Percent chance (modId = 303)
-    MOD_TRICK_ATK_AGI             = 0x208, // % AGI boost to Trick Attack (if gear mod, needs to be equipped on hit) (modId = 520)
+    MOD_STEAL                     = 298, // Increase/Decrease THF Steal chance
+    MOD_TRIPLE_ATTACK             = 302, // Percent chance
+    MOD_TREASURE_HUNTER           = 303, // Percent chance
+    MOD_TRICK_ATK_AGI             = 520, // % AGI boost to Trick Attack (if gear mod, needs to be equipped on hit)
 
     // Paladin
-    MOD_ABSORB_PHYSDMG_TO_MP      = 0x1AA, // Absorbs a percentage of physical damage taken to MP. (modId = 426)
-    MOD_ENMITY_REDUCTION_PHYSICAL = 0x1AB, // TODO: Reduces Enmity decrease when taking physical damage (modId = 427)
-    MOD_SHIELD_MASTERY_TP         = 0x1E5, // Shield mastery TP bonus when blocking with a shield (modId = 485)
+    MOD_ABSORB_PHYSDMG_TO_MP      = 426, // Absorbs a percentage of physical damage taken to MP.
+    MOD_ENMITY_REDUCTION_PHYSICAL = 427, // TODO: Reduces Enmity decrease when taking physical damage
+    MOD_SHIELD_MASTERY_TP         = 485, // Shield mastery TP bonus when blocking with a shield
 
     // Dark Knight
     // Nothing here yet..
 
     // Beastmaster
-    MOD_TAME                      = 0x130, // Additional percent chance to charm (modId = 304)
-    MOD_CHARM_TIME                = 0x168, // extends the charm time only, no effect of charm chance (modId = 360)
-    MOD_REWARD_HP_BONUS           = 0x16C, // Percent to add to reward HP healed. (364) (modId = 364)
-    MOD_CHARM_CHANCE              = 0x187, // extra chance to charm (light+apollo staff ect) (modId = 391)
-    MOD_FERAL_HOWL_DURATION       = 0x1F7, // +20% duration per merit when wearing augmented Monster Jackcoat +2 (modId = 503)
+    MOD_TAME                      = 304, // Additional percent chance to charm
+    MOD_CHARM_TIME                = 360, // extends the charm time only, no effect of charm chance
+    MOD_REWARD_HP_BONUS           = 364, // Percent to add to reward HP healed. (364)
+    MOD_CHARM_CHANCE              = 391, // extra chance to charm (light+apollo staff ect)
+    MOD_FERAL_HOWL_DURATION       = 503, // +20% duration per merit when wearing augmented Monster Jackcoat +2
 
     // Bard
-    MOD_MINNE_EFFECT              = 0x1B1, // (modId = 433)
-    MOD_MINUET_EFFECT             = 0x1B2, // (modId = 434)
-    MOD_PAEON_EFFECT              = 0x1B3, // (modId = 435)
-    MOD_REQUIEM_EFFECT            = 0x1B4, // (modId = 436)
-    MOD_THRENODY_EFFECT           = 0x1B5, // (modId = 437)
-    MOD_MADRIGAL_EFFECT           = 0x1B6, // (modId = 438)
-    MOD_MAMBO_EFFECT              = 0x1B7, // (modId = 439)
-    MOD_LULLABY_EFFECT            = 0x1B8, // (modId = 440)
-    MOD_ETUDE_EFFECT              = 0x1B9, // (modId = 441)
-    MOD_BALLAD_EFFECT             = 0x1BA, // (modId = 442)
-    MOD_MARCH_EFFECT              = 0x1BB, // (modId = 443)
-    MOD_FINALE_EFFECT             = 0x1BC, // (modId = 444)
-    MOD_CAROL_EFFECT              = 0x1BD, // (modId = 445)
-    MOD_MAZURKA_EFFECT            = 0x1BE, // (modId = 446)
-    MOD_ELEGY_EFFECT              = 0x1BF, // (modId = 447)
-    MOD_PRELUDE_EFFECT            = 0x1C0, // (modId = 448)
-    MOD_HYMNUS_EFFECT             = 0x1C1, // (modId = 449)
-    MOD_VIRELAI_EFFECT            = 0x1C2, // (modId = 450)
-    MOD_SCHERZO_EFFECT            = 0x1C3, // (modId = 451)
-    MOD_ALL_SONGS_EFFECT          = 0x1C4, // (modId = 452)
-    MOD_MAXIMUM_SONGS_BONUS       = 0x1C5, // (modId = 453)
-    MOD_SONG_DURATION_BONUS       = 0x1C6, // (modId = 454)
-    MOD_SONG_SPELLCASTING_TIME    = 0x1C7, // (modId = 455)
+    MOD_MINNE_EFFECT              = 433, //
+    MOD_MINUET_EFFECT             = 434, //
+    MOD_PAEON_EFFECT              = 435, //
+    MOD_REQUIEM_EFFECT            = 436, //
+    MOD_THRENODY_EFFECT           = 437, //
+    MOD_MADRIGAL_EFFECT           = 438, //
+    MOD_MAMBO_EFFECT              = 439, //
+    MOD_LULLABY_EFFECT            = 440, //
+    MOD_ETUDE_EFFECT              = 441, //
+    MOD_BALLAD_EFFECT             = 442, //
+    MOD_MARCH_EFFECT              = 443, //
+    MOD_FINALE_EFFECT             = 444, //
+    MOD_CAROL_EFFECT              = 445, //
+    MOD_MAZURKA_EFFECT            = 446, //
+    MOD_ELEGY_EFFECT              = 447, //
+    MOD_PRELUDE_EFFECT            = 448, //
+    MOD_HYMNUS_EFFECT             = 449, //
+    MOD_VIRELAI_EFFECT            = 450, //
+    MOD_SCHERZO_EFFECT            = 451, //
+    MOD_ALL_SONGS_EFFECT          = 452, //
+    MOD_MAXIMUM_SONGS_BONUS       = 453, //
+    MOD_SONG_DURATION_BONUS       = 454, //
+    MOD_SONG_SPELLCASTING_TIME    = 455, //
 
     // Ranger
-    MOD_RECYCLE                   = 0x131, // Percent chance to recycle (modId = 305)
-    MOD_SNAP_SHOT                 = 0x16D, // Percent reduction to range attack delay (modId = 365)
-    MOD_RAPID_SHOT                = 0x167, // Percent chance to proc rapid shot (modId = 359)
-    MOD_WIDESCAN                  = 0x154, // (modId = 340)
-    MOD_BARRAGE_ACC               = 0x1A4, // Barrage accuracy (modId = 420)
-    MOD_DOUBLE_SHOT_RATE          = 0x1A6, // The rate that double shot can proc. Without this, the default is 40%. (modId = 422)
-    MOD_VELOCITY_SNAPSHOT_BONUS   = 0x1A7, // Increases Snapshot whilst Velocity Shot is up. (modId = 423)
-    MOD_VELOCITY_RATT_BONUS       = 0x1A8, // Increases Ranged Attack whilst Velocity Shot is up. (modId = 424)
-    MOD_SHADOW_BIND_EXT           = 0x1A9, // Extends the time of shadowbind (modId = 425)
-    MOD_SCAVENGE_EFFECT           = 0x138, // (modId = 312)
-    MOD_SHARPSHOT                 = 0x13A, // (modId = 314)
-
+    MOD_RECYCLE                   = 305, // Percent chance to recycle
+    MOD_SNAP_SHOT                 = 365, // Percent reduction to range attack delay
+    MOD_RAPID_SHOT                = 359, // Percent chance to proc rapid shot
+    MOD_WIDESCAN                  = 340, //
+    MOD_BARRAGE_ACC               = 420, // Barrage accuracy
+    MOD_DOUBLE_SHOT_RATE          = 422, // The rate that double shot can proc. Without this, the default is 40%.
+    MOD_VELOCITY_SNAPSHOT_BONUS   = 423, // Increases Snapshot whilst Velocity Shot is up.
+    MOD_VELOCITY_RATT_BONUS       = 424, // Increases Ranged Attack whilst Velocity Shot is up.
+    MOD_SHADOW_BIND_EXT           = 425, // Extends the time of shadowbind
+    MOD_SCAVENGE_EFFECT           = 312, //
+    MOD_SHARPSHOT                 = 314, //
 
     // Samurai
-    MOD_ZANSHIN                   = 0x132, // Zanshin percent chance (modId = 306)
+    MOD_ZANSHIN                   = 306, // Zanshin percent chance
 
     // Ninja
-    MOD_UTSUSEMI                  = 0x133, // Everyone's favorite --tracks shadows. (modId = 307)
-    MOD_NINJA_TOOL                = 0x134, // Percent chance to not use a tool. (modId = 308)
-    MOD_NIN_NUKE_BONUS            = 0x20A, // magic attack bonus for NIN nukes (modId = 522)
+    MOD_UTSUSEMI                  = 307, // Everyone's favorite --tracks shadows.
+    MOD_NINJA_TOOL                = 308, // Percent chance to not use a tool.
+    MOD_NIN_NUKE_BONUS            = 522, // magic attack bonus for NIN nukes
 
     // Dragoon
-    MOD_JUMP_TP_BONUS             = 0x169, // bonus tp player receives when using jump (must be divided by 10) (modId = 361)
-    MOD_JUMP_ATT_BONUS            = 0x16A, // ATT% bonus for jump + high jump (modId = 362)
-    MOD_HIGH_JUMP_ENMITY_REDUCTION = 0x16B, // for gear that reduces more enmity from high jump (modId = 363)
+    MOD_JUMP_TP_BONUS             = 361, // bonus tp player receives when using jump (must be divided by 10)
+    MOD_JUMP_ATT_BONUS            = 362, // ATT% bonus for jump + high jump
+    MOD_HIGH_JUMP_ENMITY_REDUCTION = 363, // for gear that reduces more enmity from high jump
 
     // Summoner
-    MOD_AVATAR_PERPETUATION       = 0x173, // stores base cost of current avatar (modId = 371)
-    MOD_WEATHER_REDUCTION         = 0x174, // stores perpetuation reduction depending on weather (modId = 372)
-    MOD_DAY_REDUCTION             = 0x175, // stores perpetuation reduction depending on day (modId = 373)
-    MOD_PERPETUATION_REDUCTION    = 0x15A, // stores the MP/tick reduction from gear (modId = 346)
-    MOD_BP_DELAY                  = 0x165, // stores blood pact delay reduction (modId = 357)
+    MOD_AVATAR_PERPETUATION       = 371, // stores base cost of current avatar
+    MOD_WEATHER_REDUCTION         = 372, // stores perpetuation reduction depending on weather
+    MOD_DAY_REDUCTION             = 373, // stores perpetuation reduction depending on day
+    MOD_PERPETUATION_REDUCTION    = 346, // stores the MP/tick reduction from gear
+    MOD_BP_DELAY                  = 357, // stores blood pact delay reduction
 
     // Blue Mage
-    MOD_BLUE_POINTS               = 0x135, // Tracks extra blue points (modId = 309)
+    MOD_BLUE_POINTS               = 309, // Tracks extra blue points
 
     // Corsair
-    MOD_EXP_BONUS                 = 0x17E, // (modId = 382)
-    MOD_ROLL_RANGE                = 0x210, // Additional range for COR roll abilities. (modId = 528)
+    MOD_EXP_BONUS                 = 382, //
+    MOD_ROLL_RANGE                = 528, // Additional range for COR roll abilities.
 
-    MOD_DMG_REFLECT               = 0x13C, // Tracks totals (modId = 316)
-    MOD_ROLL_ROGUES               = 0x13D, // Tracks totals (modId = 317)
-    MOD_ROLL_GALLANTS             = 0x13E, // Tracks totals (modId = 318)
-    MOD_ROLL_CHAOS                = 0x13F, // Tracks totals (modId = 319)
-    MOD_ROLL_BEAST                = 0x140, // Tracks totals (modId = 320)
-    MOD_ROLL_CHORAL               = 0x141, // Tracks totals (modId = 321)
-    MOD_ROLL_HUNTERS              = 0x142, // Tracks totals (modId = 322)
-    MOD_ROLL_SAMURAI              = 0x143, // Tracks totals (modId = 323)
-    MOD_ROLL_NINJA                = 0x144, // Tracks totals (modId = 324)
-    MOD_ROLL_DRACHEN              = 0x145, // Tracks totals (modId = 325)
-    MOD_ROLL_EVOKERS              = 0x146, // Tracks totals (modId = 326)
-    MOD_ROLL_MAGUS                = 0x147, // Tracks totals (modId = 327)
-    MOD_ROLL_CORSAIRS             = 0x148, // Tracks totals (modId = 328)
-    MOD_ROLL_PUPPET               = 0x149, // Tracks totals (modId = 329)
-    MOD_ROLL_DANCERS              = 0x14A, // Tracks totals (modId = 330)
-    MOD_ROLL_SCHOLARS             = 0x14B, // Tracks totals (modId = 331)
-    MOD_BUST                      = 0x14C, // # of busts (modId = 332)
-    MOD_QUICK_DRAW_DMG            = 0x19B, // (modId = 411)
+    MOD_DMG_REFLECT               = 316, // Tracks totals
+    MOD_ROLL_ROGUES               = 317, // Tracks totals
+    MOD_ROLL_GALLANTS             = 318, // Tracks totals
+    MOD_ROLL_CHAOS                = 319, // Tracks totals
+    MOD_ROLL_BEAST                = 320, // Tracks totals
+    MOD_ROLL_CHORAL               = 321, // Tracks totals
+    MOD_ROLL_HUNTERS              = 322, // Tracks totals
+    MOD_ROLL_SAMURAI              = 323, // Tracks totals
+    MOD_ROLL_NINJA                = 324, // Tracks totals
+    MOD_ROLL_DRACHEN              = 325, // Tracks totals
+    MOD_ROLL_EVOKERS              = 326, // Tracks totals
+    MOD_ROLL_MAGUS                = 327, // Tracks totals
+    MOD_ROLL_CORSAIRS             = 328, // Tracks totals
+    MOD_ROLL_PUPPET               = 329, // Tracks totals
+    MOD_ROLL_DANCERS              = 330, // Tracks totals
+    MOD_ROLL_SCHOLARS             = 331, // Tracks totals
+    MOD_BUST                      = 332, // # of busts
+    MOD_QUICK_DRAW_DMG            = 411, //
 
     // Puppetmaster
-    MOD_MANEUVER_BONUS            = 0x1F8, // (modId = 504) Maneuver Stat Bonus
-    MOD_OVERLOAD_THRESH           = 0x1F9, // (modId = 505) Overload Threshold Bonus
+    MOD_MANEUVER_BONUS            = 504, // Maneuver Stat Bonus
+    MOD_OVERLOAD_THRESH           = 505, // Overload Threshold Bonus
 
     // Dancer
-    MOD_FINISHING_MOVES           = 0x14D, // Tracks # of finishing moves (modId = 333)
-    MOD_SAMBA_DURATION            = 0x1EA, // Samba duration bonus(modId = 490)
-    MOD_WALTZ_POTENTCY            = 0x1EB, // Waltz Potentcy Bonus(modId = 491)
-    MOD_CHOCO_JIG_DURATION        = 0x1EC, // Jig duration bonus (modId = 492)
-    MOD_VFLOURISH_MACC            = 0x1ED, // Violent Flourish accuracy bonus (modId = 493)
-    MOD_STEP_FINISH               = 0x1EE, // Bonus finishing moves from steps (modId = 494)
-    MOD_STEP_ACCURACY             = 0x193, // Bonus accuracy for Dancer's steps (modId = 403)
-    MOD_SPECTRAL_JIG              = 0x1EF, // Spectral Jig duration modifier (percent increase) (modId = 495)
-    MOD_WALTZ_RECAST              = 0x1F1, // (modID = 497) Waltz recast modifier (percent)
-    MOD_SAMBA_PDURATION           = 0x1F2, // (modID = 498) Samba percent duration bonus
+    MOD_FINISHING_MOVES           = 333, // Tracks # of finishing moves
+    MOD_SAMBA_DURATION            = 490, // Samba duration bonus
+    MOD_WALTZ_POTENTCY            = 491, // Waltz Potentcy Bonus
+    MOD_CHOCO_JIG_DURATION        = 492, // Jig duration bonus
+    MOD_VFLOURISH_MACC            = 493, // Violent Flourish accuracy bonus
+    MOD_STEP_FINISH               = 494, // Bonus finishing moves from steps
+    MOD_STEP_ACCURACY             = 403, // Bonus accuracy for Dancer's steps
+    MOD_SPECTRAL_JIG              = 495, // Spectral Jig duration modifier (percent increase)
+    MOD_WALTZ_RECAST              = 497, // Waltz recast modifier (percent)
+    MOD_SAMBA_PDURATION           = 498, // Samba percent duration bonus
 
     //Scholar
-    MOD_BLACK_MAGIC_COST          = 0x189, // MP cost for black magic (light/dark arts) (modId = 393)
-    MOD_WHITE_MAGIC_COST          = 0x18A, // MP cost for white magic (light/dark arts) (modId = 394)
-    MOD_BLACK_MAGIC_CAST          = 0x18B, // Cast time for black magic (light/dark arts) (modId = 395)
-    MOD_WHITE_MAGIC_CAST          = 0x18C, // Cast time for black magic (light/dark arts) (modId = 396)
-    MOD_BLACK_MAGIC_RECAST        = 0x18D, // Recast time for black magic (light/dark arts) (modId = 397)
-    MOD_WHITE_MAGIC_RECAST        = 0x18E, // Recast time for white magic (light/dark arts) (modId = 398)
-    MOD_ALACRITY_CELERITY_EFFECT  = 0x18F, // Bonus for celerity/alacrity effect (modId = 399)
-    MOD_LIGHT_ARTS_EFFECT         = 0x14E, // (modId = 334)
-    MOD_DARK_ARTS_EFFECT          = 0x14F, // (modId = 335)
-    MOD_LIGHT_ARTS_SKILL          = 0x150, // (modId = 336)
-    MOD_DARK_ARTS_SKILL           = 0x151, // (modId = 337)
-    MOD_REGEN_EFFECT              = 0x152, // (modId = 338)
-    MOD_REGEN_DURATION            = 0x153, // (modId = 339)
-    MOD_HELIX_EFFECT              = 0x1DE, // (modId = 478)
-    MOD_HELIX_DURATION            = 0x1DD, // (modId = 477)
-    MOD_STORMSURGE_EFFECT         = 0x190, // (modId = 400)
-    MOD_SUBLIMATION_BONUS         = 0x191, // (modId = 401)
-    MOD_GRIMOIRE_SPELLCASTING     = 0x1E9, // (modID = 489) "Grimoire: Reduces spellcasting time" bonus
+    MOD_BLACK_MAGIC_COST          = 393, // MP cost for black magic (light/dark arts)
+    MOD_WHITE_MAGIC_COST          = 394, // MP cost for white magic (light/dark arts)
+    MOD_BLACK_MAGIC_CAST          = 395, // Cast time for black magic (light/dark arts)
+    MOD_WHITE_MAGIC_CAST          = 396, // Cast time for black magic (light/dark arts)
+    MOD_BLACK_MAGIC_RECAST        = 397, // Recast time for black magic (light/dark arts)
+    MOD_WHITE_MAGIC_RECAST        = 398, // Recast time for white magic (light/dark arts)
+    MOD_ALACRITY_CELERITY_EFFECT  = 399, // Bonus for celerity/alacrity effect
+    MOD_LIGHT_ARTS_EFFECT         = 334, //
+    MOD_DARK_ARTS_EFFECT          = 335, //
+    MOD_LIGHT_ARTS_SKILL          = 336, //
+    MOD_DARK_ARTS_SKILL           = 337, //
+    MOD_REGEN_EFFECT              = 338, //
+    MOD_REGEN_DURATION            = 339, //
+    MOD_HELIX_EFFECT              = 478, //
+    MOD_HELIX_DURATION            = 477, //
+    MOD_STORMSURGE_EFFECT         = 400, //
+    MOD_SUBLIMATION_BONUS         = 401, //
+    MOD_GRIMOIRE_SPELLCASTING     = 489, // "Grimoire: Reduces spellcasting time" bonus
 
-    MOD_ENSPELL                   = 0x155, // stores the type of enspell active (0 if nothing) (modId = 341)
-    MOD_ENSPELL_DMG               = 0x157, // stores the base damage of the enspell before reductions (modId = 343)
-    MOD_ENSPELL_DMG_BONUS         = 0x1B0, // (modId = 432)
-    MOD_SPIKES                    = 0x156, // store the type of spike spell active (0 if nothing) (modId = 342)
-    MOD_SPIKES_DMG                = 0x158, // stores the base damage of the spikes before reductions (modId = 344)
+    MOD_ENSPELL                   = 341, // stores the type of enspell active (0 if nothing)
+    MOD_ENSPELL_DMG               = 343, // stores the base damage of the enspell before reductions
+    MOD_ENSPELL_DMG_BONUS         = 432, //
+    MOD_SPIKES                    = 342, // store the type of spike spell active (0 if nothing)
+    MOD_SPIKES_DMG                = 344, // stores the base damage of the spikes before reductions
 
-    MOD_TP_BONUS                  = 0x159, // (modId = 345)
+    MOD_TP_BONUS                  = 345, //
 
     //stores the amount of elemental affinity (elemental staves mostly)
-    MOD_FIRE_AFFINITY             = 0x15B, // Fire Affinity (modId = 347)
-    MOD_EARTH_AFFINITY            = 0x15C, // Earth Affinity (modId = 348)
-    MOD_WATER_AFFINITY            = 0x15D, // Water Affinity (modId = 349)
-    MOD_ICE_AFFINITY              = 0x15E, // Ice Affinity (modId = 350)
-    MOD_THUNDER_AFFINITY          = 0x15F, // Lightning Affinity (modId = 351)
-    MOD_WIND_AFFINITY             = 0x160, // Wind Affinity (modId = 352)
-    MOD_LIGHT_AFFINITY            = 0x161, // Light Affinity (modId = 353)
-    MOD_DARK_AFFINITY             = 0x162, // Dark Affinity (modId = 354)
+    MOD_FIRE_AFFINITY             = 347, // Fire Affinity
+    MOD_EARTH_AFFINITY            = 348, // Earth Affinity
+    MOD_WATER_AFFINITY            = 349, // Water Affinity
+    MOD_ICE_AFFINITY              = 350, // Ice Affinity
+    MOD_THUNDER_AFFINITY          = 351, // Lightning Affinity
+    MOD_WIND_AFFINITY             = 352, // Wind Affinity
+    MOD_LIGHT_AFFINITY            = 353, // Light Affinity
+    MOD_DARK_AFFINITY             = 354, // Dark Affinity
 
     // Special Modifier+
-    MOD_ADDS_WEAPONSKILL          = 0x163, // (modId = 355)
-    MOD_ADDS_WEAPONSKILL_DYN      = 0x164, // In Dynamis (modId = 356)
+    MOD_ADDS_WEAPONSKILL          = 355, //
+    MOD_ADDS_WEAPONSKILL_DYN      = 356, // In Dynamis
 
-    MOD_STEALTH                   = 0x166, // (modId = 358)
+    MOD_STEALTH                   = 358, //
 
-    MOD_MAIN_DMG_RATING           = 0x16E, // adds damage rating to main hand weapon (maneater/blau dolch etc hidden effects) (modId = 366)
-    MOD_SUB_DMG_RATING            = 0x16F, // adds damage rating to off hand weapon (modId = 367)
-    MOD_REGAIN                    = 0x170, // auto regain TP (from items) | this is multiplied by 10 e.g. 20 is 2% TP (modId = 368)
-    MOD_REGAIN_DOWN               = 0x196, // plague, reduce tp (modId = 406)
-    MOD_REFRESH                   = 0x171, // auto refresh from equipment (modId = 369)
-    MOD_REFRESH_DOWN              = 0x195, // plague, reduce mp (modId = 405)
-    MOD_REGEN                     = 0x172, // auto regen from equipment (modId = 370)
-    MOD_REGEN_DOWN                = 0x194, // poison (modId = 404)
-    MOD_CURE_POTENCY              = 0x176, // % cure potency | bonus from gear is capped at 50 (modId = 374)
-    MOD_CURE_POTENCY_RCVD         = 0x177, // % potency of received cure | healer's roll, some items have this (modId = 375)
-    MOD_RANGED_DMG_RATING         = 0x178, // adds damage rating to ranged weapon (modId = 376)
-    MOD_MAIN_DMG_RANK             = 0x179, // adds weapon rank to main weapon (modId = 377) (http://wiki.bluegartr.com/bg/Weapon_Rank)
-    MOD_SUB_DMG_RANK              = 0x17A, // adds weapon rank to sub weapon (modId = 378)
-    MOD_RANGED_DMG_RANK           = 0x17B, // adds weapon rank to ranged weapon (modId = 379)
-    MOD_DELAYP                    = 0x17C, // delay addition percent (does not affect tp gain) (modId = 380)
-    MOD_RANGED_DELAYP             = 0x17D, // ranged delay addition percent (does not affect tp gain) (modId = 381)
+    MOD_MAIN_DMG_RATING           = 366, // adds damage rating to main hand weapon (maneater/blau dolch etc hidden effects)
+    MOD_SUB_DMG_RATING            = 367, // adds damage rating to off hand weapon
+    MOD_REGAIN                    = 368, // auto regain TP (from items) | this is multiplied by 10 e.g. 20 is 2% TP
+    MOD_REGAIN_DOWN               = 406, // plague, reduce tp
+    MOD_REFRESH                   = 369, // auto refresh from equipment
+    MOD_REFRESH_DOWN              = 405, // plague, reduce mp
+    MOD_REGEN                     = 370, // auto regen from equipment
+    MOD_REGEN_DOWN                = 404, // poison
+    MOD_CURE_POTENCY              = 374, // % cure potency | bonus from gear is capped at 50
+    MOD_CURE_POTENCY_RCVD         = 375, // % potency of received cure | healer's roll, some items have this
+    MOD_RANGED_DMG_RATING         = 376, // adds damage rating to ranged weapon
+    MOD_MAIN_DMG_RANK             = 377, // adds weapon rank to main weapon http://wiki.bluegartr.com/bg/Weapon_Rank
+    MOD_SUB_DMG_RANK              = 378, // adds weapon rank to sub weapon
+    MOD_RANGED_DMG_RANK           = 379, // adds weapon rank to ranged weapon
+    MOD_DELAYP                    = 380, // delay addition percent (does not affect tp gain)
+    MOD_RANGED_DELAYP             = 381, // ranged delay addition percent (does not affect tp gain)
 
-    MOD_SHIELD_BASH               = 0x181, // (modId = 385)
-    MOD_KICK_DMG                  = 0x182, // increases kick attack damage (modId = 386)
-    MOD_WEAPON_BASH               = 0x188, // (modId = 392)
+    MOD_SHIELD_BASH               = 385, //
+    MOD_KICK_DMG                  = 386, // increases kick attack damage
+    MOD_WEAPON_BASH               = 392, //
 
-    MOD_WYVERN_BREATH             = 0x192, // (modId = 402)
-
+    MOD_WYVERN_BREATH             = 402, //
 
     /// Gear set modifiers
-    MOD_DA_DOUBLE_DAMAGE          = 0x198, // Double attack's double damage chance %. (modId = 408)
-    MOD_TA_TRIPLE_DAMAGE          = 0x199, // Triple attack's triple damage chance %. (modId = 409)
-    MOD_ZANSHIN_DOUBLE_DAMAGE     = 0x19A, // Zanshin's double damage chance %. (modId = 410)
-    MOD_RAPID_SHOT_DOUBLE_DAMAGE  = 0x1DF, // Rapid shot's double damage chance %. (modId = 479)
-    MOD_ABSORB_DMG_CHANCE         = 0x1E0, // Chance to absorb damage % (modId = 480)
-    MOD_EXTRA_DUAL_WIELD_ATTACK   = 0x1E1, // Chance to land an extra attack when dual wielding (modId = 481)
-    MOD_EXTRA_KICK_ATTACK         = 0x1E2, // Occasionally allows a second Kick Attack during an attack round without the use of Footwork.  (modId = 482)
-    MOD_SAMBA_DOUBLE_DAMAGE       = 0x19F, // Double damage chance when samba is up. (modId = 415)
-    MOD_NULL_PHYSICAL_DAMAGE      = 0x1A0, // Chance to NULL physical damage. (modId = 416)
-    MOD_QUICK_DRAW_TRIPLE_DAMAGE  = 0x1A1, // Chance to do triple damage with quick draw. (modId = 417)
-    MOD_BAR_ELEMENT_NULL_CHANCE   = 0x1A2, // Bar Elemental spells will occasionally NULLify damage of the same element. (modId = 418)
-    MOD_GRIMOIRE_INSTANT_CAST     = 0x1A3, // Spells that match your current Arts will occasionally cast instantly, without recast. (modId = 419)
-    MOD_QUAD_ATTACK               = 0x1AE, // Quadruple attack chance. (modId = 430)
+    MOD_DA_DOUBLE_DAMAGE          = 408, // Double attack's double damage chance %.
+    MOD_TA_TRIPLE_DAMAGE          = 409, // Triple attack's triple damage chance %.
+    MOD_ZANSHIN_DOUBLE_DAMAGE     = 410, // Zanshin's double damage chance %.
+    MOD_RAPID_SHOT_DOUBLE_DAMAGE  = 479, // Rapid shot's double damage chance %.
+    MOD_ABSORB_DMG_CHANCE         = 480, // Chance to absorb damage %
+    MOD_EXTRA_DUAL_WIELD_ATTACK   = 481, // Chance to land an extra attack when dual wielding
+    MOD_EXTRA_KICK_ATTACK         = 482, // Occasionally allows a second Kick Attack during an attack round without the use of Footwork.
+    MOD_SAMBA_DOUBLE_DAMAGE       = 415, // Double damage chance when samba is up.
+    MOD_NULL_PHYSICAL_DAMAGE      = 416, // Chance to NULL physical damage.
+    MOD_QUICK_DRAW_TRIPLE_DAMAGE  = 417, // Chance to do triple damage with quick draw.
+    MOD_BAR_ELEMENT_NULL_CHANCE   = 418, // Bar Elemental spells will occasionally NULLify damage of the same element.
+    MOD_GRIMOIRE_INSTANT_CAST     = 419, // Spells that match your current Arts will occasionally cast instantly, without recast.
+    MOD_QUAD_ATTACK               = 430, // Quadruple attack chance.
 
     // Reraise (Auto Reraise, used by gear)
-    MOD_RERAISE_I                 = 0x1C8, // Reraise. (modId = 456)
-    MOD_RERAISE_II                = 0x1C9, // Reraise II. (modId = 457)
-    MOD_RERAISE_III               = 0x1CA, // Reraise III. (modId = 458)
+    MOD_RERAISE_I                 = 456, // Reraise.
+    MOD_RERAISE_II                = 457, // Reraise II.
+    MOD_RERAISE_III               = 458, // Reraise III.
 
     //Elemental Absorb Chance
-    MOD_FIRE_ABSORB               = 0x1CB, // (modId = 459)
-    MOD_EARTH_ABSORB              = 0x1CC, // (modId = 460)
-    MOD_WATER_ABSORB              = 0x1CD, // (modId = 461)
-    MOD_WIND_ABSORB               = 0x1CE, // (modId = 462)
-    MOD_ICE_ABSORB                = 0x1CF, // (modId = 463)
-    MOD_LTNG_ABSORB               = 0x1D0, // (modId = 464)
-    MOD_LIGHT_ABSORB              = 0x1D1, // (modId = 465)
-    MOD_DARK_ABSORB               = 0x1D2, // (modId = 466)
+    MOD_FIRE_ABSORB               = 459, //
+    MOD_EARTH_ABSORB              = 460, //
+    MOD_WATER_ABSORB              = 461, //
+    MOD_WIND_ABSORB               = 462, //
+    MOD_ICE_ABSORB                = 463, //
+    MOD_LTNG_ABSORB               = 464, //
+    MOD_LIGHT_ABSORB              = 465, //
+    MOD_DARK_ABSORB               = 466, //
 
     //Elemental Null Chance
-    MOD_FIRE_NULL                 = 0x1D3, // (modId = 467)
-    MOD_EARTH_NULL                = 0x1D4, // (modId = 468)
-    MOD_WATER_NULL                = 0x1D5, // (modId = 469)
-    MOD_WIND_NULL                 = 0x1D6, // (modId = 470)
-    MOD_ICE_NULL                  = 0x1D7, // (modId = 471)
-    MOD_LTNG_NULL                 = 0x1D8, // (modId = 472)
-    MOD_LIGHT_NULL                = 0x1D9, // (modId = 473)
-    MOD_DARK_NULL                 = 0x1DA, // (modId = 474)
+    MOD_FIRE_NULL                 = 467, //
+    MOD_EARTH_NULL                = 468, //
+    MOD_WATER_NULL                = 469, //
+    MOD_WIND_NULL                 = 470, //
+    MOD_ICE_NULL                  = 471, //
+    MOD_LTNG_NULL                 = 472, //
+    MOD_LIGHT_NULL                = 473, //
+    MOD_DARK_NULL                 = 474, //
 
-    MOD_MAGIC_ABSORB              = 0x1DB, // (modId = 475)
-    MOD_MAGIC_NULL                = 0x1DC, // (modId = 476)
-    MOD_PHYS_ABSORB               = 0x200, // (modId = 512)
-    MOD_ABSORB_DMG_TO_MP          = 0x204, // (modId = 516)  Unlike PLD gear mod, works on all damage types (Ethereal Earring)
+    MOD_MAGIC_ABSORB              = 475, //
+    MOD_MAGIC_NULL                = 476, //
+    MOD_PHYS_ABSORB               = 512, //
+    MOD_ABSORB_DMG_TO_MP          = 516, // Unlike PLD gear mod, works on all damage types (Ethereal Earring)
 
-    MOD_ADDITIONAL_EFFECT         = 0x1AF, // (modId = 431)
-    MOD_ITEM_SPIKES_TYPE          = 0x1F3, // Type spikes an item has (modId = 499)
-    MOD_ITEM_SPIKES_DMG           = 0x1F4, // Damage of an items spikes (modId = 500)
-    MOD_ITEM_SPIKES_CHANCE        = 0x1F5, // Chance of an items spike proc (modId = 501)
+    MOD_ADDITIONAL_EFFECT         = 431, //
+    MOD_ITEM_SPIKES_TYPE          = 499, // Type spikes an item has
+    MOD_ITEM_SPIKES_DMG           = 500, // Damage of an items spikes
+    MOD_ITEM_SPIKES_CHANCE        = 501, // Chance of an items spike proc
 
-    MOD_GOV_CLEARS                = 0x1F0, // 4% bonus per Grounds of Valor Page clear (modId = 496)
+    MOD_GOV_CLEARS                = 496, // 4% bonus per Grounds of Valor Page clear
 
-    MOD_EXTRA_DMG_CHANCE          = 0x1FA, // Proc rate of MOD_OCC_DO_EXTRA_DMG. 111 would be 11.1% (modId = 506)
-    MOD_OCC_DO_EXTRA_DMG          = 0x1FB, // Multiplier for "Occasionally do x times normal damage". 250 would be 2.5 times damage. (modId = 507)
+    MOD_EXTRA_DMG_CHANCE          = 506, // Proc rate of MOD_OCC_DO_EXTRA_DMG. 111 would be 11.1%
+    MOD_OCC_DO_EXTRA_DMG          = 507, // Multiplier for "Occasionally do x times normal damage". 250 would be 2.5 times damage.
 
-    MOD_EAT_RAW_FISH              = 0x19C, // (modId = 412)
-    MOD_EAT_RAW_MEAT              = 0x19D, // (modId = 413)
+    MOD_EAT_RAW_FISH              = 412, //
+    MOD_EAT_RAW_MEAT              = 413, //
 
-    MOD_ENHANCES_CURSNA           = 0x136, // Used by gear with the "Enhances Cursna" attribute (modId = 310)
-    MOD_RETALIATION               = 0x19E, // Increases damage of Retaliation hits (modId = 414)
-    MOD_AUGMENTS_THIRD_EYE        = 0x1FC, // Adds counter to 3rd eye anticipates & if using Seigan counter rate is increased by 15% (modId = 508)
+    MOD_ENHANCES_CURSNA           = 310, // Used by gear with the "Enhances Cursna" attribute
+    MOD_RETALIATION               = 414, // Increases damage of Retaliation hits
+    MOD_AUGMENTS_THIRD_EYE        = 508, // Adds counter to 3rd eye anticipates & if using Seigan counter rate is increased by 15%
 
-    MOD_CLAMMING_IMPROVED_RESULTS = 0x1FD, // (modId = 509)
-    MOD_CLAMMING_REDUCED_INCIDENTS= 0x1FE, // (modId = 510)
+    MOD_CLAMMING_IMPROVED_RESULTS = 509, //
+    MOD_CLAMMING_REDUCED_INCIDENTS= 510, //
 
-    MOD_CHOCOBO_RIDING_TIME       = 0x1FF, // Increases chocobo riding time (modId = 511)
+    MOD_CHOCOBO_RIDING_TIME       = 511, // Increases chocobo riding time
 
-    MOD_HARVESTING_RESULT         = 0x201, // Improves harvesting results (modId = 513)
-    MOD_LOGGING_RESULT            = 0x202, // Improves logging results (modId = 514)
-    MOD_MINNING_RESULT            = 0x203, // Improves mining results (modId = 515)
+    MOD_HARVESTING_RESULT         = 513, // Improves harvesting results
+    MOD_LOGGING_RESULT            = 514, // Improves logging results
+    MOD_MINNING_RESULT            = 515, // Improves mining results
 
-    MOD_EGGHELM                   = 0x205,
+    MOD_EGGHELM                   = 517,
 
-    MOD_SHIELDBLOCKRATE           = 0x206, // Affects shield block rate, percent based (modID = 518)
-    MOD_DIA_DOT                   = 0x139, // Increases the DoT damage of Dia (modId = 313)
-    MOD_ENH_DRAIN_ASPIR           = 0x13B, // % damage boost to Drain and Aspir(modId = 315)
-    MOD_AUGMENTS_ABSORB           = 0x209, // Direct Absorb spell increase while Liberator is equipped (percentage based) (modId = 521)
-    MOD_AMMO_SWING                = 0x20B, // Extra swing rate w/ ammo (ie. Jailer weapons). Use gearsets, and does nothing for non-players. (modId = 523)
-    MOD_AUGMENTS_CONVERT          = 0x20D, // Convert HP to MP Ratio Multiplier. Value = MP multiplier rate. (modId = 525)
-    MOD_AUGMENTS_SA               = 0x20E, // Adds Critical Attack Bonus to Sneak Attack, percentage based. (modId = 526)
-    MOD_AUGMENTS_TA               = 0x20F  // Adds Critical Attack Bonus to Trick Attack, percentage based. (modId = 527)
+    MOD_SHIELDBLOCKRATE           = 518, // Affects shield block rate, percent based
+    MOD_DIA_DOT                   = 313, // Increases the DoT damage of Dia
+    MOD_ENH_DRAIN_ASPIR           = 315, // % damage boost to Drain and Aspir
+    MOD_AUGMENTS_ABSORB           = 521, // Direct Absorb spell increase while Liberator is equipped (percentage based)
+    MOD_AMMO_SWING                = 523, // Extra swing rate w/ ammo (ie. Jailer weapons). Use gearsets, and does nothing for non-players.
+    MOD_AUGMENTS_CONVERT          = 525, // Convert HP to MP Ratio Multiplier. Value = MP multiplier rate.
+    MOD_AUGMENTS_SA               = 526, // Adds Critical Attack Bonus to Sneak Attack, percentage based.
+    MOD_AUGMENTS_TA               = 527  // Adds Critical Attack Bonus to Trick Attack, percentage based.
 
-    // MOD_SPARE = 0x211, // (modId = 529)
-    // MOD_SPARE = 0x212, // (modId = 530)
+    // MOD_SPARE = 92, // stuff
+    // MOD_SPARE = 93, // stuff
+    // MOD_SPARE = 94, // stuff
+    // MOD_SPARE = 95, // stuff
+    // MOD_SPARE = 96, // stuff
+    // MOD_SPARE = 97, // stuff
+    // MOD_SPARE = 98, // stuff
+    // MOD_SPARE = 99, // stuff
+    // MOD_SPARE = 100, // stuff
+    // MOD_SPARE = 530, // stuff
 
 };
 


### PR DESCRIPTION
**Because:**
1) These are decimal everywhere else..
2) These are neither offsets nor masks, just arbitrary numbered lists..
3) Mistakes have been made repeatedly by the "base 16 challenged" folk among us..

No other changes in this commit, so nothing busted or incorrect that wasn't already.