### PR TITLE
Scripts: Fiery/Glacial Breath subanim check fix

### DIFF
--- a/scripts/globals/mobskills/Fiery_Breath.lua
+++ b/scripts/globals/mobskills/Fiery_Breath.lua
@@ -18,7 +18,7 @@ function onMobSkillCheck(target,mob,skill)
         return 1;
 	elseif (target:isBehind(mob, 48) == true) then
 		return 1;
-    elseif (mob:AnimationSub() ~= 0) then
+    elseif (mob:AnimationSub() == 1) then
         return 1;
 	end
 	return 0;

--- a/scripts/globals/mobskills/Glacial_Breath.lua
+++ b/scripts/globals/mobskills/Glacial_Breath.lua
@@ -18,7 +18,7 @@ function onMobSkillCheck(target,mob,skill)
         return 1;
 	elseif (target:isBehind(mob, 48) == true) then
 		return 1;
-    elseif (mob:AnimationSub() ~= 0) then
+    elseif (mob:AnimationSub() == 1) then
         return 1;
 	end
 	return 0;


### PR DESCRIPTION
Made them check for not flying instead of a specific mobsub.

Edit: This is because it starts in subanim 0, but touchdown sets subanim 2.