### PR TITLE
Scripts: Fix NPC for Windurst 7-2

### DIFF
--- a/scripts/zones/Kazham/npcs/Romaa_Mihgo.lua
+++ b/scripts/zones/Kazham/npcs/Romaa_Mihgo.lua
@@ -23,9 +23,9 @@ end;
 
 function onTrigger(player,npc)
 
-	if (player:getCurrentMission(WINDURST) == AWAKENING_OF_THE_GODS and player:getVar("MissionStatus") == 3) then
+	if (player:getCurrentMission(WINDURST) == AWAKENING_OF_THE_GODS and player:getVar("MissionStatus") == 2) then
 		player:startEvent(0x010A);
-	elseif (player:getCurrentMission(WINDURST) == AWAKENING_OF_THE_GODS and player:getVar("MissionStatus") == 4) then
+	elseif (player:getCurrentMission(WINDURST) == AWAKENING_OF_THE_GODS and player:getVar("MissionStatus") == 3) then
 		player:startEvent(0x010B);
 	else
 		player:startEvent(0x0107);
@@ -51,7 +51,7 @@ function onEventFinish(player,csid,option)
 	-- printf("RESULT: %u",option);
 	
 	if (csid == 0x010A) then
-		player:setVar("MissionStatus",4);
+		player:setVar("MissionStatus",3);
 	end
 	
 end;


### PR DESCRIPTION
The previous NPC in the mission, Kerutoto sets the missionStatus var to 2. Currently, players who start the mission are unable to complete the mission because it's checking for the var to be something it can't be set to without GM help.

https://github.com/DarkstarProject/darkstar/blob/master/scripts/zones/Windurst_Waters/npcs/Kerutoto.lua#L260

That's the only instance of the previous NPC setting the missionStatus var while...

https://github.com/DarkstarProject/darkstar/blob/master/scripts/zones/Windurst_Waters/npcs/Kerutoto.lua#L68

That is the event is played. At the end, it's set to 2, and then there's another event that merely changes the text.

Edit: Forgot to mention, the next NPC checks for it being 3, then sets it to 4 already. That is to say, someone took a perfectly working NPC and broke it for some reason.