### PR TITLE
SQL/SCRIPTS: The Opo-opo and I questline 

### DIFF
--- a/scripts/zones/Kazham/npcs/Balih_Chavizaai.lua
+++ b/scripts/zones/Kazham/npcs/Balih_Chavizaai.lua
@@ -19,7 +19,11 @@ end;
 -----------------------------------
 
 function onTrigger(player,npc)
-	player:startEvent(0x0028);
+    if (player:getVar("BathedInScent") == 1) then
+        player:startEvent(0x00A0); -- scent from Blue Rafflesias
+    else
+        player:startEvent(0x0028);
+    end
 end;
 -----------------------------------
 -- onEventUpdate

--- a/scripts/zones/Kazham/npcs/Bhi_Telifahgo.lua
+++ b/scripts/zones/Kazham/npcs/Bhi_Telifahgo.lua
@@ -19,7 +19,11 @@ end;
 -----------------------------------
 
 function onTrigger(player,npc)
-	player:startEvent(0x005D);
+    if (player:getVar("BathedInScent") == 1) then
+        player:startEvent(0x00B7); -- scent from Blue Rafflesias
+    else
+        player:startEvent(0x005D);
+    end
 end;
 -----------------------------------
 -- onEventUpdate

--- a/scripts/zones/Kazham/npcs/Bhukka_Sahbeo.lua
+++ b/scripts/zones/Kazham/npcs/Bhukka_Sahbeo.lua
@@ -19,7 +19,11 @@ end;
 -----------------------------------
 
 function onTrigger(player,npc)
-	player:startEvent(0x007A);
+    if (player:getVar("BathedInScent") == 1) then
+        player:startEvent(0x00BC); -- scent from Blue Rafflesias
+    else
+        player:startEvent(0x007A);
+    end
 end;
 -----------------------------------
 -- onEventUpdate

--- a/scripts/zones/Kazham/npcs/Bubupp.lua
+++ b/scripts/zones/Kazham/npcs/Bubupp.lua
@@ -76,7 +76,7 @@ end;
 -- onEventFinish
 -----------------------------------
 
-function onEventFinish(player,csid,option,npc)
+function onEventFinish(player,csid,option)
 --printf("CSID: %u",csid);
 --printf("RESULT: %u",option);
 

--- a/scripts/zones/Kazham/npcs/Bubupp.lua
+++ b/scripts/zones/Kazham/npcs/Bubupp.lua
@@ -11,15 +11,57 @@ require("scripts/zones/Kazham/TextIDs");
 -- onTrade Action
 -----------------------------------
 
+-- item IDs
+            -- 483       Broken Mithran Fishing Rod
+            -- 22        Workbench
+            -- 1008      Ten of Coins
+            -- 1157      Sands of Silence
+            -- 1158      Wandering Bulb
+            -- 904       Giant Fish Bones
+            -- 4599      Blackened Toad
+            -- 905       Wyvern Skull
+            -- 1147      Ancient Salt
+            -- 4600      Lucky Egg
+         
 function onTrade(player,npc,trade)
-end; 
+    local OpoOpoAndIStatus = player:getQuestStatus(OUTLANDS, THE_OPO_OPO_AND_I);
+    local progress = player:getVar("OPO_OPO_PROGRESS");
+    local failed = player:getVar("OPO_OPO_FAILED");
+    local goodtrade = trade:hasItemQty(904,1);
+    local badtrade = (trade:hasItemQty(483,1) or trade:hasItemQty(22,1) or trade:hasItemQty(1008,1) or trade:hasItemQty(1157,1) or trade:hasItemQty(1158,1) or trade:hasItemQty(4599,1) or trade:hasItemQty(905,1) or trade:hasItemQty(1147,1) or trade:hasItemQty(4600,1));
+
+    if (OpoOpoAndIStatus == QUEST_ACCEPTED) then
+        if progress == 5 or failed == 6 then
+            if goodtrade then
+                player:startEvent(0x00E0);
+            elseif badtrade then
+                player:startEvent(0x00EA);
+            end
+        end
+    end
+end;
 
 -----------------------------------
 -- onTrigger Action
 -----------------------------------
 
 function onTrigger(player,npc)
-	player:startEvent(0x00CA);
+    local OpoOpoAndIStatus = player:getQuestStatus(OUTLANDS, THE_OPO_OPO_AND_I);
+    local progress = player:getVar("OPO_OPO_PROGRESS");
+    local failed = player:getVar("OPO_OPO_FAILED");
+    local retry = player:getVar("OPO_OPO_RETRY");
+    
+    if (OpoOpoAndIStatus == QUEST_ACCEPTED) then
+        if retry >= 1 then                          -- has failed on future npc so disregard previous successful trade
+            player:startEvent(0x00CA);
+        elseif (progress == 5 or failed == 6) then
+                player:startEvent(0x00D3);  -- asking for giant fish bones
+        elseif (progress >= 6 or failed >= 7) then
+            player:startEvent(0x00F7); -- happy with giant fish bones
+        end
+	else
+        player:startEvent(0x00CA);
+    end
 end;
 -----------------------------------
 -- onEventUpdate
@@ -34,9 +76,22 @@ end;
 -- onEventFinish
 -----------------------------------
 
-function onEventFinish(player,csid,option)
+function onEventFinish(player,csid,option,npc)
 --printf("CSID: %u",csid);
 --printf("RESULT: %u",option);
+
+    if (csid == 0x00E0) then    -- correct trade, onto next opo
+        if player:getVar("OPO_OPO_PROGRESS") == 5 then
+            player:tradeComplete();
+            player:setVar("OPO_OPO_PROGRESS",6);
+            player:setVar("OPO_OPO_FAILED",0);
+        else
+            player:setVar("OPO_OPO_FAILED",7);
+        end
+    elseif (csid == 0x00EA) then              -- wrong trade, restart at first opo
+        player:setVar("OPO_OPO_FAILED",1);
+        player:setVar("OPO_OPO_RETRY",6);
+    end
 end;
 
 

--- a/scripts/zones/Kazham/npcs/Cha_Tigunalhgo.lua
+++ b/scripts/zones/Kazham/npcs/Cha_Tigunalhgo.lua
@@ -19,7 +19,11 @@ end;
 -----------------------------------
 
 function onTrigger(player,npc)
-	player:startEvent(0x0064);
+    if (player:getVar("BathedInScent") == 1) then
+        player:startEvent(0x00B9); -- scent from Blue Rafflesias
+    else
+        player:startEvent(0x0064);
+    end
 end;
 -----------------------------------
 -- onEventUpdate

--- a/scripts/zones/Kazham/npcs/Cobbi_Malgharam.lua
+++ b/scripts/zones/Kazham/npcs/Cobbi_Malgharam.lua
@@ -19,7 +19,11 @@ end;
 -----------------------------------
 
 function onTrigger(player,npc)
-	player:startEvent(0x0029);
+    if (player:getVar("BathedInScent") == 1) then
+        player:startEvent(0x00A1); -- scent from Blue Rafflesias
+    else
+        player:startEvent(0x0029);
+    end
 end;
 -----------------------------------
 -- onEventUpdate

--- a/scripts/zones/Kazham/npcs/Dakha_Topsalwan.lua
+++ b/scripts/zones/Kazham/npcs/Dakha_Topsalwan.lua
@@ -25,7 +25,7 @@ function onTrigger(player,npc)
 	
 	Z = player:getZPos();
 	
-	if(Z >= -20 and Z <= -16) then
+	if (Z >= -20 and Z <= -16) then
 		player:startEvent(0x0042);
 	else
 		player:startEvent(0x0079);

--- a/scripts/zones/Kazham/npcs/Dakha_Topsalwan.lua
+++ b/scripts/zones/Kazham/npcs/Dakha_Topsalwan.lua
@@ -25,7 +25,7 @@ function onTrigger(player,npc)
 	
 	Z = player:getZPos();
 	
-	if (Z >= -20 and Z <= -16) then
+	if(Z >= -20 and Z <= -16) then
 		player:startEvent(0x0042);
 	else
 		player:startEvent(0x0079);

--- a/scripts/zones/Kazham/npcs/Dheo_Nbolo.lua
+++ b/scripts/zones/Kazham/npcs/Dheo_Nbolo.lua
@@ -19,7 +19,11 @@ end;
 -----------------------------------
 
 function onTrigger(player,npc)
-	player:startEvent(0x005B);
+    if (player:getVar("BathedInScent") == 1) then
+        player:startEvent(0x00B5); -- scent from Blue Rafflesias
+    else
+        player:startEvent(0x005B);
+    end
 end;
 -----------------------------------
 -- onEventUpdate

--- a/scripts/zones/Kazham/npcs/Gatih_Mijurabi.lua
+++ b/scripts/zones/Kazham/npcs/Gatih_Mijurabi.lua
@@ -22,7 +22,19 @@ end;
 -----------------------------------
 
 function onTrigger(player,npc)
-	player:startEvent(0x00c4);
+    if player:getVar("BathedInScent") == 1 then
+        if (player:getQuestStatus(OUTLANDS, PERSONAL_HYGIENE) == QUEST_AVAILABLE) then
+            player:startEvent(0x00BF);
+        elseif (player:getQuestStatus(OUTLANDS, PERSONAL_HYGIENE) == QUEST_ACCEPTED) then
+            player:startEvent(0x00C0);
+        else
+            player:startEvent(0x00C3);
+        end
+    elseif player:getVar("PERSONAL_HYGIENE_PROGRESS") == 1 then
+        player:startEvent(0x00C1);
+    else 
+        player:startEvent(0x00c4);
+    end
 end;
 
 -----------------------------------
@@ -38,8 +50,16 @@ end;
 -- onEventFinish
 -----------------------------------
 
-function onEventFinish(player,csid,option)
+function onEventFinish(player,csid,option)    
 	-- printf("CSID: %u",csid);
 	-- printf("RESULT: %u",option);
+    if (csid == 0x00BF) then
+        player:addQuest(OUTLANDS, PERSONAL_HYGIENE);
+    elseif (csid == 0x00C1) then
+        player:completeQuest(OUTLANDS, PERSONAL_HYGIENE);
+        player:addItem(13247)   -- Mithran Stone
+        player:messageSpecial(ITEM_OBTAINED,13247);
+        player:setVar("PERSONAL_HYGIENE_PROGRESS", 0);
+    end
 end;
 

--- a/scripts/zones/Kazham/npcs/Gatih_Mijurabi.lua
+++ b/scripts/zones/Kazham/npcs/Gatih_Mijurabi.lua
@@ -50,7 +50,7 @@ end;
 -- onEventFinish
 -----------------------------------
 
-function onEventFinish(player,csid,option)    
+function onEventFinish(player,csid,option)
 	-- printf("CSID: %u",csid);
 	-- printf("RESULT: %u",option);
     if (csid == 0x00BF) then

--- a/scripts/zones/Kazham/npcs/Ghosa_Demuhzo.lua
+++ b/scripts/zones/Kazham/npcs/Ghosa_Demuhzo.lua
@@ -19,7 +19,11 @@ end;
 -----------------------------------
 
 function onTrigger(player,npc)
-	player:startEvent(0x0057);
+    if (player:getVar("BathedInScent") == 1) then
+        player:startEvent(0x00B1); -- scent from Blue Rafflesias
+    else
+        player:startEvent(0x0057);
+    end
 end;
 -----------------------------------
 -- onEventUpdate

--- a/scripts/zones/Kazham/npcs/Haih_Ahmpagako.lua
+++ b/scripts/zones/Kazham/npcs/Haih_Ahmpagako.lua
@@ -19,7 +19,11 @@ end;
 -----------------------------------
 
 function onTrigger(player,npc)
-	player:startEvent(0x003E);
+    if (player:getVar("BathedInScent") == 1) then
+        player:startEvent(0x00A2); -- scent from Blue Rafflesias
+    else
+        player:startEvent(0x003E);
+    end
 end;
 -----------------------------------
 -- onEventUpdate

--- a/scripts/zones/Kazham/npcs/Hozie_Naharaf.lua
+++ b/scripts/zones/Kazham/npcs/Hozie_Naharaf.lua
@@ -19,7 +19,11 @@ end;
 -----------------------------------
 
 function onTrigger(player,npc)
-	player:startEvent(0x0059);
+    if (player:getVar("BathedInScent") == 1) then
+        player:startEvent(0x00B3); -- scent from Blue Rafflesias
+    else
+        player:startEvent(0x0059);
+    end
 end;
 -----------------------------------
 -- onEventUpdate

--- a/scripts/zones/Kazham/npcs/Kakapp.lua
+++ b/scripts/zones/Kazham/npcs/Kakapp.lua
@@ -11,15 +11,57 @@ require("scripts/zones/Kazham/TextIDs");
 -- onTrade Action
 -----------------------------------
 
+-- item IDs
+            -- 483       Broken Mithran Fishing Rod
+            -- 22        Workbench
+            -- 1008      Ten of Coins
+            -- 1157      Sands of Silence
+            -- 1158      Wandering Bulb
+            -- 904       Giant Fish Bones
+            -- 4599      Blackened Toad
+            -- 905       Wyvern Skull
+            -- 1147      Ancient Salt
+            -- 4600      Lucky Egg
+         
 function onTrade(player,npc,trade)
-end; 
+    local OpoOpoAndIStatus = player:getQuestStatus(OUTLANDS, THE_OPO_OPO_AND_I);
+    local progress = player:getVar("OPO_OPO_PROGRESS");
+    local failed = player:getVar("OPO_OPO_FAILED");
+    local goodtrade = trade:hasItemQty(905,1);
+    local badtrade = (trade:hasItemQty(483,1) or trade:hasItemQty(22,1) or trade:hasItemQty(1008,1) or trade:hasItemQty(1157,1) or trade:hasItemQty(1158,1) or trade:hasItemQty(4599,1) or trade:hasItemQty(904,1) or trade:hasItemQty(1147,1) or trade:hasItemQty(4600,1));
+
+    if (OpoOpoAndIStatus == QUEST_ACCEPTED) then
+        if progress == 7 or failed == 8 then
+            if goodtrade then
+                player:startEvent(0x00E2);
+            elseif badtrade then
+                player:startEvent(0x00EC);
+            end
+        end
+    end
+end;
 
 -----------------------------------
 -- onTrigger Action
 -----------------------------------
 
 function onTrigger(player,npc)
-	player:startEvent(0x00CC);
+    local OpoOpoAndIStatus = player:getQuestStatus(OUTLANDS, THE_OPO_OPO_AND_I);
+    local progress = player:getVar("OPO_OPO_PROGRESS");
+    local failed = player:getVar("OPO_OPO_FAILED");
+    local retry = player:getVar("OPO_OPO_RETRY");
+    
+    if (OpoOpoAndIStatus == QUEST_ACCEPTED) then
+        if retry >= 1 then                          -- has failed on future npc so disregard previous successful trade
+            player:startEvent(0x00CC);
+        elseif (progress == 7 or failed == 8) then
+                player:startEvent(0x00D5);  -- asking for wyvern skull
+        elseif (progress >= 8 or failed >= 9) then
+            player:startEvent(0x00F9); -- happy with wyvern skull
+        end
+	else
+        player:startEvent(0x00CC);
+    end
 end;
 -----------------------------------
 -- onEventUpdate
@@ -34,9 +76,22 @@ end;
 -- onEventFinish
 -----------------------------------
 
-function onEventFinish(player,csid,option)
+function onEventFinish(player,csid,option,npc)
 --printf("CSID: %u",csid);
 --printf("RESULT: %u",option);
+
+    if (csid == 0x00E2) then    -- correct trade, onto next opo
+        if player:getVar("OPO_OPO_PROGRESS") == 7 then
+            player:tradeComplete();
+            player:setVar("OPO_OPO_PROGRESS",8);
+            player:setVar("OPO_OPO_FAILED",0);
+        else
+            player:setVar("OPO_OPO_FAILED",9);
+        end
+    elseif (csid == 0x00EC) then              -- wrong trade, restart at first opo
+        player:setVar("OPO_OPO_FAILED",1);
+        player:setVar("OPO_OPO_RETRY",8);
+    end
 end;
 
 

--- a/scripts/zones/Kazham/npcs/Kakapp.lua
+++ b/scripts/zones/Kazham/npcs/Kakapp.lua
@@ -76,7 +76,7 @@ end;
 -- onEventFinish
 -----------------------------------
 
-function onEventFinish(player,csid,option,npc)
+function onEventFinish(player,csid,option)
 --printf("CSID: %u",csid);
 --printf("RESULT: %u",option);
 

--- a/scripts/zones/Kazham/npcs/Khaffi_Salponoihz.lua
+++ b/scripts/zones/Kazham/npcs/Khaffi_Salponoihz.lua
@@ -19,7 +19,11 @@ end;
 -----------------------------------
 
 function onTrigger(player,npc)
-	player:startEvent(0x0053);
+    if (player:getVar("BathedInScent") == 1) then
+        player:startEvent(0x00B0); -- scent from Blue Rafflesias
+    else
+        player:startEvent(0x0053);
+    end
 end;
 -----------------------------------
 -- onEventUpdate

--- a/scripts/zones/Kazham/npcs/Khau_Mahiyoeloh.lua
+++ b/scripts/zones/Kazham/npcs/Khau_Mahiyoeloh.lua
@@ -19,7 +19,11 @@ end;
 -----------------------------------
 
 function onTrigger(player,npc)
-	player:startEvent(0x003C);
+    if (player:getVar("BathedInScent") == 1) then
+        player:startEvent(0x00A5); -- scent from Blue Rafflesias
+    else
+        player:startEvent(0x003C);
+    end
 end;
 -----------------------------------
 -- onEventUpdate

--- a/scripts/zones/Kazham/npcs/Kocho_Phunakcham.lua
+++ b/scripts/zones/Kazham/npcs/Kocho_Phunakcham.lua
@@ -19,7 +19,11 @@ end;
 -----------------------------------
 
 function onTrigger(player,npc)
-	player:startEvent(0x0041);
+    if (player:getVar("BathedInScent") == 1) then
+        player:startEvent(0x00AA); -- scent from Blue Rafflesias
+    else
+        player:startEvent(0x0041);
+    end
 end;
 -----------------------------------
 -- onEventUpdate

--- a/scripts/zones/Kazham/npcs/Kukupp.lua
+++ b/scripts/zones/Kazham/npcs/Kukupp.lua
@@ -6,6 +6,7 @@
 
 package.loaded["scripts/zones/Kazham/TextIDs"] = nil;
 require("scripts/zones/Kazham/TextIDs");
+require("scripts/globals/pathfind");
 
 local path = {
 43.067505, -11.000000, -177.214966,
@@ -78,16 +79,59 @@ end;
 -- onTrade Action
 -----------------------------------
 
+-- item IDs
+            -- 483       Broken Mithran Fishing Rod
+            -- 22        Workbench
+            -- 1008      Ten of Coins
+            -- 1157      Sands of Silence
+            -- 1158      Wandering Bulb
+            -- 904       Giant Fish Bones
+            -- 4599      Blackened Toad
+            -- 905       Wyvern Skull
+            -- 1147      Ancient Salt
+            -- 4600      Lucky Egg
+         
 function onTrade(player,npc,trade)
-end; 
+    local OpoOpoAndIStatus = player:getQuestStatus(OUTLANDS, THE_OPO_OPO_AND_I);
+    local progress = player:getVar("OPO_OPO_PROGRESS");
+    local failed = player:getVar("OPO_OPO_FAILED");
+    local goodtrade = trade:hasItemQty(22,1);
+    local badtrade = (trade:hasItemQty(483,1) or trade:hasItemQty(1008,1) or trade:hasItemQty(1157,1) or trade:hasItemQty(1158,1) or trade:hasItemQty(904,1) or trade:hasItemQty(4599,1) or trade:hasItemQty(905,1) or trade:hasItemQty(1147,1) or trade:hasItemQty(4600,1));
+
+    if (OpoOpoAndIStatus == QUEST_ACCEPTED) then
+        if progress == 1 or failed == 2 then
+            if goodtrade then
+                player:startEvent(0x00DC);
+            elseif badtrade then
+                player:startEvent(0x00E6);
+            end
+        end
+    end
+end;
 
 -----------------------------------
 -- onTrigger Action
 -----------------------------------
 
 function onTrigger(player,npc)
-	player:startEvent(0x00C6);
-	npc:wait(-1);
+    local OpoOpoAndIStatus = player:getQuestStatus(OUTLANDS, THE_OPO_OPO_AND_I);
+    local progress = player:getVar("OPO_OPO_PROGRESS");
+    local failed = player:getVar("OPO_OPO_FAILED");
+    local retry = player:getVar("OPO_OPO_RETRY");
+    
+    if (OpoOpoAndIStatus == QUEST_ACCEPTED) then
+        if retry >= 1 then                          -- has failed on future npc so disregard previous successful trade
+            player:startEvent(0x00C6);
+            npc:wait(-1);
+        elseif (progress == 1 or failed == 2) then
+                player:startEvent(0x00D0);  -- asking for workbench
+        elseif (progress >= 2 or failed >= 3) then
+            player:startEvent(0x00F3); -- happy with workbench
+        end
+	else
+        player:startEvent(0x00C6);
+        npc:wait(-1);
+    end
 end;
 -----------------------------------
 -- onEventUpdate
@@ -105,7 +149,21 @@ end;
 function onEventFinish(player,csid,option,npc)
 --printf("CSID: %u",csid);
 --printf("RESULT: %u",option);
-    npc:wait(0);
+
+    if (csid == 0x00DC) then    -- correct trade, onto next opo
+        if player:getVar("OPO_OPO_PROGRESS") == 1 then
+            player:tradeComplete();
+            player:setVar("OPO_OPO_PROGRESS",2);
+            player:setVar("OPO_OPO_FAILED",0);
+        else
+            player:setVar("OPO_OPO_FAILED",3);
+        end
+    elseif (csid == 0x00E6) then              -- wrong trade, restart at first opo
+        player:setVar("OPO_OPO_FAILED",1);
+        player:setVar("OPO_OPO_RETRY",2);
+    else
+        npc:wait(0);
+    end
 end;
 
 

--- a/scripts/zones/Kazham/npcs/Kukupp.lua
+++ b/scripts/zones/Kazham/npcs/Kukupp.lua
@@ -146,7 +146,7 @@ end;
 -- onEventFinish
 -----------------------------------
 
-function onEventFinish(player,csid,option,npc)
+function onEventFinish(player,csid,option)
 --printf("CSID: %u",csid);
 --printf("RESULT: %u",option);
 

--- a/scripts/zones/Kazham/npcs/Kukupp.lua
+++ b/scripts/zones/Kazham/npcs/Kukupp.lua
@@ -146,7 +146,7 @@ end;
 -- onEventFinish
 -----------------------------------
 
-function onEventFinish(player,csid,option)
+function onEventFinish(player,csid,option,npc)
 --printf("CSID: %u",csid);
 --printf("RESULT: %u",option);
 

--- a/scripts/zones/Kazham/npcs/Kyun_Magopiteh.lua
+++ b/scripts/zones/Kazham/npcs/Kyun_Magopiteh.lua
@@ -19,7 +19,11 @@ end;
 -----------------------------------
 
 function onTrigger(player,npc)
-	player:startEvent(0x0056);
+    if (player:getVar("BathedInScent") == 1) then
+        player:startEvent(0x00AE); -- scent from Blue Rafflesias
+    else
+        player:startEvent(0x0056);
+    end
 end;
 -----------------------------------
 -- onEventUpdate

--- a/scripts/zones/Kazham/npcs/Lalapp.lua
+++ b/scripts/zones/Kazham/npcs/Lalapp.lua
@@ -28,16 +28,59 @@ end;
 -- onTrade Action
 -----------------------------------
 
+-- item IDs
+            -- 483       Broken Mithran Fishing Rod
+            -- 22        Workbench
+            -- 1008      Ten of Coins
+            -- 1157      Sands of Silence
+            -- 1158      Wandering Bulb
+            -- 904       Giant Fish Bones
+            -- 4599      Blackened Toad
+            -- 905       Wyvern Skull
+            -- 1147      Ancient Salt
+            -- 4600      Lucky Egg
+         
 function onTrade(player,npc,trade)
-end; 
+    local OpoOpoAndIStatus = player:getQuestStatus(OUTLANDS, THE_OPO_OPO_AND_I);
+    local progress = player:getVar("OPO_OPO_PROGRESS");
+    local failed = player:getVar("OPO_OPO_FAILED");
+    local goodtrade = trade:hasItemQty(1147,1);
+    local badtrade = (trade:hasItemQty(483,1) or trade:hasItemQty(22,1) or trade:hasItemQty(1157,1) or trade:hasItemQty(1158,1) or trade:hasItemQty(904,1) or trade:hasItemQty(1008,1) or trade:hasItemQty(905,1) or trade:hasItemQty(4599,1) or trade:hasItemQty(4600,1));
+
+    if (OpoOpoAndIStatus == QUEST_ACCEPTED) then
+        if progress == 8 or failed == 9 then
+            if goodtrade then
+                player:startEvent(0x00E3);
+            elseif badtrade then
+                player:startEvent(0x00ED);
+            end
+        end
+    end
+end;
 
 -----------------------------------
 -- onTrigger Action
 -----------------------------------
 
 function onTrigger(player,npc)
-	player:startEvent(0x00CD);
-	npc:wait(-1);
+    local OpoOpoAndIStatus = player:getQuestStatus(OUTLANDS, THE_OPO_OPO_AND_I);
+    local progress = player:getVar("OPO_OPO_PROGRESS");
+    local failed = player:getVar("OPO_OPO_FAILED");
+    local retry = player:getVar("OPO_OPO_RETRY");
+    
+    if (OpoOpoAndIStatus == QUEST_ACCEPTED) then
+        if retry >= 1 then                          -- has failed on future npc so disregard previous successful trade
+            player:startEvent(0x00CD);
+            npc:wait(-1);
+        elseif (progress == 8 or failed == 9) then
+                player:startEvent(0x00D6);  -- asking for ancient salt
+        elseif (progress >= 9 or failed >= 10) then
+            player:startEvent(0x00FA); -- happy with ancient salt
+        end
+	else
+        player:startEvent(0x00CD);
+        npc:wait(-1);
+    end
 end;
 -----------------------------------
 -- onEventUpdate
@@ -56,8 +99,20 @@ function onEventFinish(player,csid,option,npc)
 --printf("CSID: %u",csid);
 --printf("RESULT: %u",option);
 
-	npc:wait(0);
-
+    if (csid == 0x00E3) then    -- correct trade, onto next opo
+        if player:getVar("OPO_OPO_PROGRESS") == 8 then
+            player:tradeComplete();
+            player:setVar("OPO_OPO_PROGRESS",9);
+            player:setVar("OPO_OPO_FAILED",0);
+        else
+            player:setVar("OPO_OPO_FAILED",10);
+        end
+    elseif (csid == 0x00ED) then              -- wrong trade, restart at first opo
+        player:setVar("OPO_OPO_FAILED",1);
+        player:setVar("OPO_OPO_RETRY",9);
+    else
+        npc:wait(0);
+    end
 end;
 
 

--- a/scripts/zones/Kazham/npcs/Lalapp.lua
+++ b/scripts/zones/Kazham/npcs/Lalapp.lua
@@ -95,7 +95,7 @@ end;
 -- onEventFinish
 -----------------------------------
 
-function onEventFinish(player,csid,option,npc)
+function onEventFinish(player,csid,option)
 --printf("CSID: %u",csid);
 --printf("RESULT: %u",option);
 

--- a/scripts/zones/Kazham/npcs/Lalapp.lua
+++ b/scripts/zones/Kazham/npcs/Lalapp.lua
@@ -95,7 +95,7 @@ end;
 -- onEventFinish
 -----------------------------------
 
-function onEventFinish(player,csid,option)
+function onEventFinish(player,csid,option,npc)
 --printf("CSID: %u",csid);
 --printf("RESULT: %u",option);
 

--- a/scripts/zones/Kazham/npcs/Lulupp.lua
+++ b/scripts/zones/Kazham/npcs/Lulupp.lua
@@ -1,14 +1,14 @@
------------------------------------
+     -----------------------------------
 --  Area: Kazham
 --   NPC: Lulupp
 --  Type: Standard NPC
 -- @zone: 250
 --  @pos -26.567 -3.5 -3.544
---
--- Auto-Script: Requires Verification (Verified by Brawndo)
 -----------------------------------
 package.loaded["scripts/zones/Kazham/TextIDs"] = nil;
 -----------------------------------
+require("scripts/globals/pathfind");
+
 local path = {
 -27.457125, -3.043032, -22.057966,
 -27.373426, -2.772481, -20.974442,
@@ -44,7 +44,34 @@ end;
 -- onTrade Action
 -----------------------------------
 
+ -- item IDs
+            -- 483       Broken Mithran Fishing Rod
+            -- 22        Workbench
+            -- 1008      Ten of Coins
+            -- 1157      Sands of Silence
+            -- 1158      Wandering Bulb
+            -- 904       Giant Fish Bones
+            -- 4599      Blackened Toad
+            -- 905       Wyvern Skull
+            -- 1147      Ancient Salt
+            -- 4600      Lucky Egg
+         
 function onTrade(player,npc,trade)
+    local OpoOpoAndIStatus = player:getQuestStatus(OUTLANDS, THE_OPO_OPO_AND_I);
+    local progress = player:getVar("OPO_OPO_PROGRESS");
+    local failed = player:getVar("OPO_OPO_FAILED");
+    local goodtrade = trade:hasItemQty(483,1);
+    local badtrade = (trade:hasItemQty(22,1) or trade:hasItemQty(1008,1) or trade:hasItemQty(1157,1) or trade:hasItemQty(1158,1) or trade:hasItemQty(904,1) or trade:hasItemQty(4599,1) or trade:hasItemQty(905,1) or trade:hasItemQty(1147,1) or trade:hasItemQty(4600,1));
+
+    if (OpoOpoAndIStatus == QUEST_ACCEPTED) then
+        if progress == 0 or failed == 1 then
+            if goodtrade then                   -- first or second time trading correctly
+                player:startEvent(0x00DB);
+            elseif badtrade then
+                player:startEvent(0x00E5);
+            end
+        end     
+    end
 end;
 
 -----------------------------------
@@ -52,8 +79,44 @@ end;
 -----------------------------------
 
 function onTrigger(player,npc)
-	player:startEvent(0x00c5);
-	npc:wait(-1);
+    local OpoOpoAndIStatus = player:getQuestStatus(OUTLANDS, THE_OPO_OPO_AND_I);
+    local progress = player:getVar("OPO_OPO_PROGRESS");
+    local failed = player:getVar("OPO_OPO_FAILED");
+    local retry = player:getVar("OPO_OPO_RETRY");
+    
+    if (player:getVar("BathedInScent") == 1 and OpoOpoAndIStatus == QUEST_AVAILABLE) then
+        player:startEvent(0x00D9, 0, 483)  -- 483 broken mithran fishing rod
+        npc:wait(-1);
+	elseif (OpoOpoAndIStatus == QUEST_ACCEPTED) then
+        if retry == 1 then  
+            player:startEvent(0x00EF); -- gave 1st NPC wrong item instead of "Broken Mithran Fishing Rod"
+        elseif retry == 2 then
+            player:startEvent(0x00EF, 0, 0, 1); -- gave 2nd NPC wrong item instead of "Workbench"
+        elseif retry == 3 then
+            player:startEvent(0x00EF, 0, 0, 2); -- gave 3rd NPC wrong item instead of "Ten of Coins"
+        elseif retry == 4 then
+            player:startEvent(0x00EF, 0, 0, 3); -- gave 4th NPC wrong item instead of "Sands of silence"
+        elseif retry == 5 then
+            player:startEvent(0x00EF, 0, 0, 4); -- gave 5th NPC wrong item instead of "Wandering Bulb"
+        elseif retry == 6 then
+            player:startEvent(0x00EF, 0, 0, 5); -- gave 6th NPC wrong item instead of "Giant Fish Bones"
+        elseif retry == 7 then
+            player:startEvent(0x00EF, 0, 0, 6); -- gave 7th NPC wrong item instead of "Blackened Toad"
+        elseif retry == 8 then
+            player:startEvent(0x00EF, 0, 0, 7); -- gave 8th NPC wrong item instead of "Wyvern Skull"
+        elseif retry == 9 then
+            player:startEvent(0x00EF, 0, 0, 8); -- gave 9th NPC wrong item instead of "Ancient Salt"
+        elseif retry == 10 then
+            player:startEvent(0x00EF, 0, 0, 9); -- gave 10th NPC wrong item instead of "Lucky Egg" ... uwot
+        elseif (progress == 0 or failed == 1) then
+            player:startEvent(0x00CF);  -- asking for rod with Opoppo
+        elseif (progress >= 1 or failed >= 2) then
+            player:startEvent(0x00F2); -- happy with rod
+        end
+    else
+        player:startEvent(0x00c5);  -- not sure why but this cs has no text
+        npc:wait(-1);
+    end
 end;
 
 -----------------------------------
@@ -72,6 +135,24 @@ end;
 function onEventFinish(player,csid,option,npc)
 	-- printf("CSID: %u",csid);
 	-- printf("RESULT: %u",option);
-	npc:wait(0);
+    if (csid == 0x00D9 and option == 1)  then                   -- Opo Opo and I quest start CS
+        player:addQuest(OUTLANDS, THE_OPO_OPO_AND_I);
+    elseif (csid == 0x00DB) then
+        if (player:getVar("OPO_OPO_PROGRESS") == 0) then 
+            player:tradeComplete();
+            player:setVar("OPO_OPO_PROGRESS",1);
+        else
+            player:setVar("OPO_OPO_FAILED",2);
+        end
+    elseif (csid == 0x00E5) then                                -- Traded wrong item, saving current progress to not take item up to this point
+        player:setVar("OPO_OPO_RETRY",1);
+    elseif (csid == 0x00EF and option == 1) then                -- Traded wrong to another NPC, give a clue
+        player:setVar("OPO_OPO_RETRY",0);
+        player:setVar("OPO_OPO_FAILED",1);
+    else
+        npc:wait(0);
+    end
 end;
+
+
 

--- a/scripts/zones/Kazham/npcs/Lulupp.lua
+++ b/scripts/zones/Kazham/npcs/Lulupp.lua
@@ -1,4 +1,4 @@
-     -----------------------------------
+-----------------------------------
 --  Area: Kazham
 --   NPC: Lulupp
 --  Type: Standard NPC
@@ -6,7 +6,6 @@
 --  @pos -26.567 -3.5 -3.544
 -----------------------------------
 package.loaded["scripts/zones/Kazham/TextIDs"] = nil;
------------------------------------
 require("scripts/globals/pathfind");
 
 local path = {

--- a/scripts/zones/Kazham/npcs/Lulupp.lua
+++ b/scripts/zones/Kazham/npcs/Lulupp.lua
@@ -132,7 +132,7 @@ end;
 -- onEventFinish
 -----------------------------------
 
-function onEventFinish(player,csid,option)
+function onEventFinish(player,csid,option,npc)
 	-- printf("CSID: %u",csid);
 	-- printf("RESULT: %u",option);
     if (csid == 0x00D9 and option == 1)  then                   -- Opo Opo and I quest start CS

--- a/scripts/zones/Kazham/npcs/Lulupp.lua
+++ b/scripts/zones/Kazham/npcs/Lulupp.lua
@@ -132,7 +132,7 @@ end;
 -- onEventFinish
 -----------------------------------
 
-function onEventFinish(player,csid,option,npc)
+function onEventFinish(player,csid,option)
 	-- printf("CSID: %u",csid);
 	-- printf("RESULT: %u",option);
     if (csid == 0x00D9 and option == 1)  then                   -- Opo Opo and I quest start CS

--- a/scripts/zones/Kazham/npcs/Magriffon.lua
+++ b/scripts/zones/Kazham/npcs/Magriffon.lua
@@ -9,6 +9,7 @@ package.loaded["scripts/zones/Kazham/TextIDs"] = nil;
 require("scripts/globals/settings");
 require("scripts/globals/quests");
 require("scripts/globals/titles");
+require("scripts/globals/keyitems");
 require("scripts/zones/Kazham/TextIDs");
 
 
@@ -21,6 +22,10 @@ function onTrade(player,npc,trade)
         if (trade:getGil() >= player:getVar("MAGRIFFON_GIL_REQUEST")) then
             player:startEvent(0x0092);
         end
+    elseif (player:getQuestStatus(OUTLANDS, EVEN_MORE_GULLIBLES_TRAVELS) == QUEST_ACCEPTED and player:getVar("EVEN_MORE_GULLIBLES_PROGRESS") == 0) then
+        if (trade:getGil() >= 35000) then
+            player:startEvent(0x0096, 0, 256);
+        end
     end
 end;
 
@@ -30,6 +35,7 @@ end;
 
 function onTrigger(player,npc)
     local gulliblesTravelsStatus = player:getQuestStatus(OUTLANDS, GULLIBLES_TRAVELS);
+    local evenmoreTravelsStatus = player:getQuestStatus(OUTLANDS, EVEN_MORE_GULLIBLES_TRAVELS);
 
     if (gulliblesTravelsStatus == QUEST_ACCEPTED) then
         local magriffonGilRequest = player:getVar("MAGRIFFON_GIL_REQUEST");
@@ -38,11 +44,23 @@ function onTrigger(player,npc)
         local gil = math.random(10, 30) * 1000;
         player:setVar("MAGRIFFON_GIL_REQUEST", gil);
         player:startEvent(0x0090, 0, gil);
+    elseif (evenmoreTravelsStatus == QUEST_ACCEPTED and player:getVar("EVEN_MORE_GULLIBLES_PROGRESS") == 0) then
+        player:startEvent(0x0095, 0, 256, 0, 0, 0, 35000);
+    elseif (evenmoreTravelsStatus == QUEST_ACCEPTED and player:getVar("EVEN_MORE_GULLIBLES_PROGRESS") == 1) then
+        player:startEvent(0x0097);
+    elseif (evenmoreTravelsStatus == QUEST_ACCEPTED and player:getVar("EVEN_MORE_GULLIBLES_PROGRESS") == 2) then
+        player:startEvent(0x0098, 0, 1144, 256);
     elseif (gulliblesTravelsStatus == QUEST_COMPLETED) then
-        player:startEvent(0x0093);
+        if (evenmoreTravelsStatus == QUEST_AVAILABLE and player:getFameLevel(KAZHAM) >= 7 and player:needToZone() == false) then
+        player:startEvent(0x0094, 0, 256, 0, 0, 35000);
+        else
+            player:startEvent(0x0093);
+        end
+
     else
         player:startEvent(0x008F);
     end
+    
 end;
 -----------------------------------
 -- onEventUpdate
@@ -58,14 +76,28 @@ end;
 -----------------------------------
 
 function onEventFinish(player,csid,option)
-    if (csid == 0x0090 and option == 1)  then                 -- Gullible's Travels: First CS
+    if (csid == 0x0090 and option == 1)  then                     -- Gullible's Travels: First CS
         player:addQuest(OUTLANDS, GULLIBLES_TRAVELS);
-    elseif (csid == 0x0092) then                              -- Gullible's Travels: Final CS
+    elseif (csid == 0x0092) then                                  -- Gullible's Travels: Final CS
         player:confirmTrade();
         player:delGil(player:getVar("MAGRIFFON_GIL_REQUEST"));
         player:setVar("MAGRIFFON_GIL_REQUEST", 0);
         player:addFame(KAZHAM, WIN_FAME*30);
-        player:setTitle(285);                                -- Global Variable not working for this quest
+        player:setTitle(285);                                     -- Global Variable not working for this quest
         player:completeQuest(OUTLANDS, GULLIBLES_TRAVELS);
+        player:needToZone(true);
+    elseif (csid == 0x0094 and option == 1) then                  -- Even More Guillible's Travels First CS
+        player:addQuest(OUTLANDS, EVEN_MORE_GULLIBLES_TRAVELS);
+    elseif (csid == 0x0096) then                                  -- Even More Guillible's Travels Second CS
+        player:confirmTrade();
+        player:delGil(35000);
+        player:setVar("EVEN_MORE_GULLIBLES_PROGRESS", 1);
+        player:setTitle(286);
+        player:addKeyItem(256);
+        player:messageSpecial(KEYITEM_OBTAINED,TREASURE_MAP);
+    elseif (csid == 0x0098) then
+        player:setVar("EVEN_MORE_GULLIBLES_PROGRESS", 0);
+        player:addFame(KAZHAM, WIN_FAME*30);
+        player:completeQuest(OUTLANDS, EVEN_MORE_GULLIBLES_TRAVELS);
     end
 end;

--- a/scripts/zones/Kazham/npcs/Mijeh_Sholpoilo.lua
+++ b/scripts/zones/Kazham/npcs/Mijeh_Sholpoilo.lua
@@ -19,7 +19,11 @@ end;
 -----------------------------------
 
 function onTrigger(player,npc)
-	player:startEvent(0x003F);
+    if (player:getVar("BathedInScent") == 1) then
+        player:startEvent(0x00A8); -- scent from Blue Rafflesias
+    else
+        player:startEvent(0x003F);
+    end
 end;
 -----------------------------------
 -- onEventUpdate

--- a/scripts/zones/Kazham/npcs/Mitti_Haplihza.lua
+++ b/scripts/zones/Kazham/npcs/Mitti_Haplihza.lua
@@ -19,7 +19,11 @@ end;
 -----------------------------------
 
 function onTrigger(player,npc)
-	player:startEvent(0x005E);
+    if (player:getVar("BathedInScent") == 1) then
+        player:startEvent(0x00B8); -- scent from Blue Rafflesias
+    else
+        player:startEvent(0x005E);
+    end
 end;
 -----------------------------------
 -- onEventUpdate

--- a/scripts/zones/Kazham/npcs/Mumupp.lua
+++ b/scripts/zones/Kazham/npcs/Mumupp.lua
@@ -111,7 +111,7 @@ end;
 -- onEventFinish
 -----------------------------------
 
-function onEventFinish(player,csid,option,npc)
+function onEventFinish(player,csid,option)
 --printf("CSID: %u",csid);
 --printf("RESULT: %u",option);
 

--- a/scripts/zones/Kazham/npcs/Mumupp.lua
+++ b/scripts/zones/Kazham/npcs/Mumupp.lua
@@ -111,7 +111,7 @@ end;
 -- onEventFinish
 -----------------------------------
 
-function onEventFinish(player,csid,option)
+function onEventFinish(player,csid,option,npc)
 --printf("CSID: %u",csid);
 --printf("RESULT: %u",option);
 

--- a/scripts/zones/Kazham/npcs/Nenepp.lua
+++ b/scripts/zones/Kazham/npcs/Nenepp.lua
@@ -6,20 +6,81 @@
 
 package.loaded["scripts/zones/Kazham/TextIDs"] = nil;
 require("scripts/zones/Kazham/TextIDs");
+require("scripts/globals/pathfind");
+
+local path = {
+29.014000, -11.00000, -183.884000,
+31.023000, -11.00000, -183.538000,
+33.091000, -11.00000, -183.738000
+};
+
+function onSpawn(npc)
+    npc:initNpcAi();
+	npc:setPos(pathfind.first(path));
+	onPath(npc);
+end;
+
+function onPath(npc)
+	pathfind.patrol(npc, path);
+end;
 
 -----------------------------------
 -- onTrade Action
 -----------------------------------
 
+-- item IDs
+            -- 483       Broken Mithran Fishing Rod
+            -- 22        Workbench
+            -- 1008      Ten of Coins
+            -- 1157      Sands of Silence
+            -- 1158      Wandering Bulb
+            -- 904       Giant Fish Bones
+            -- 4599      Blackened Toad
+            -- 905       Wyvern Skull
+            -- 1147      Ancient Salt
+            -- 4600      Lucky Egg
+         
 function onTrade(player,npc,trade)
-end; 
+    local OpoOpoAndIStatus = player:getQuestStatus(OUTLANDS, THE_OPO_OPO_AND_I);
+    local progress = player:getVar("OPO_OPO_PROGRESS");
+    local failed = player:getVar("OPO_OPO_FAILED");
+    local goodtrade = trade:hasItemQty(4600,1);
+    local badtrade = (trade:hasItemQty(483,1) or trade:hasItemQty(22,1) or trade:hasItemQty(1157,1) or trade:hasItemQty(1158,1) or trade:hasItemQty(904,1) or trade:hasItemQty(1008,1) or trade:hasItemQty(905,1) or trade:hasItemQty(4599,1) or trade:hasItemQty(1147,1));
+
+    if (OpoOpoAndIStatus == QUEST_ACCEPTED) then
+        if progress == 9 or failed == 10 then
+            if goodtrade then
+                player:startEvent(0x00F1);
+            elseif badtrade then
+                player:startEvent(0x00EE);
+            end
+        end
+    end
+end;
 
 -----------------------------------
 -- onTrigger Action
 -----------------------------------
 
 function onTrigger(player,npc)
-	player:startEvent(0x00CE);
+    local OpoOpoAndIStatus = player:getQuestStatus(OUTLANDS, THE_OPO_OPO_AND_I);
+    local progress = player:getVar("OPO_OPO_PROGRESS");
+    local failed = player:getVar("OPO_OPO_FAILED");
+    local retry = player:getVar("OPO_OPO_RETRY");
+    
+    if (OpoOpoAndIStatus == QUEST_ACCEPTED) then
+        if retry >= 1 then                          -- has failed on future npc so disregard previous successful trade
+            player:startEvent(0x00CE);
+            npc:wait(-1);
+        elseif (progress == 9 or failed == 10) then
+                player:startEvent(0x00D4);  -- asking for lucky egg
+        elseif (progress >= 10 or failed >= 11) then
+            player:startEvent(0x00FA); -- happy with lucky egg
+        end
+	else
+        player:startEvent(0x00CE);
+        npc:wait(-1);
+    end
 end;
 -----------------------------------
 -- onEventUpdate
@@ -34,9 +95,33 @@ end;
 -- onEventFinish
 -----------------------------------
 
-function onEventFinish(player,csid,option)
+function onEventFinish(player,csid,option,npc)
 --printf("CSID: %u",csid);
 --printf("RESULT: %u",option);
+
+    if (csid == 0x00F1) then    -- correct trade, finished quest and receive opo opo crown and 3 pamamas
+        local FreeSlots = player:getFreeSlotsCount();
+        if (FreeSlots >= 4) then
+            player:tradeComplete();
+            player:addFame(KAZHAM, WIN_FAME*75);
+            player:completeQuest(OUTLANDS, THE_OPO_OPO_AND_I);
+            player:addItem(13870);   -- opo opo crown
+            player:messageSpecial(ITEM_OBTAINED,13870);
+            player:addItem(4468,3);  -- 3 pamamas
+            player:messageSpecial(ITEM_OBTAINED,4468,3);
+            player:setVar("OPO_OPO_PROGRESS",0);
+            player:setVar("OPO_OPO_FAILED", 0);
+            player:setVar("OPO_OPO_RETRY", 0);
+            player:setTitle(257);
+        else
+            player:messageSpecial(ITEM_CANNOT_BE_OBTAINED);
+        end
+    elseif (csid == 0x00EE) then              -- wrong trade, restart at first opo
+        player:setVar("OPO_OPO_FAILED",1);
+        player:setVar("OPO_OPO_RETRY",10);
+    else
+        npc:wait(0);
+    end
 end;
 
 

--- a/scripts/zones/Kazham/npcs/Nenepp.lua
+++ b/scripts/zones/Kazham/npcs/Nenepp.lua
@@ -95,7 +95,7 @@ end;
 -- onEventFinish
 -----------------------------------
 
-function onEventFinish(player,csid,option,npc)
+function onEventFinish(player,csid,option)
 --printf("CSID: %u",csid);
 --printf("RESULT: %u",option);
 

--- a/scripts/zones/Kazham/npcs/Nenepp.lua
+++ b/scripts/zones/Kazham/npcs/Nenepp.lua
@@ -95,7 +95,7 @@ end;
 -- onEventFinish
 -----------------------------------
 
-function onEventFinish(player,csid,option)
+function onEventFinish(player,csid,option,npc)
 --printf("CSID: %u",csid);
 --printf("RESULT: %u",option);
 

--- a/scripts/zones/Kazham/npcs/Nti_Badolsoma.lua
+++ b/scripts/zones/Kazham/npcs/Nti_Badolsoma.lua
@@ -19,7 +19,11 @@ end;
 -----------------------------------
 
 function onTrigger(player,npc)
-	player:startEvent(0x0058);
+    if (player:getVar("BathedInScent") == 1) then
+        player:startEvent(0x00B2); -- scent from Blue Rafflesias
+    else
+        player:startEvent(0x0058);
+    end
 end;
 -----------------------------------
 -- onEventUpdate

--- a/scripts/zones/Kazham/npcs/Pofhu_Tendelicon.lua
+++ b/scripts/zones/Kazham/npcs/Pofhu_Tendelicon.lua
@@ -19,7 +19,11 @@ end;
 -----------------------------------
 
 function onTrigger(player,npc)
-	player:startEvent(0x0040);
+    if (player:getVar("BathedInScent") == 1) then
+        player:startEvent(0x00A9); -- scent from Blue Rafflesias
+    else
+        player:startEvent(0x0040);
+    end
 end;
 -----------------------------------
 -- onEventUpdate

--- a/scripts/zones/Kazham/npcs/Popopp.lua
+++ b/scripts/zones/Kazham/npcs/Popopp.lua
@@ -76,7 +76,7 @@ end;
 -- onEventFinish
 -----------------------------------
 
-function onEventFinish(player,csid,option,npc)
+function onEventFinish(player,csid,option)
 --printf("CSID: %u",csid);
 --printf("RESULT: %u",option);
 

--- a/scripts/zones/Kazham/npcs/Popopp.lua
+++ b/scripts/zones/Kazham/npcs/Popopp.lua
@@ -11,15 +11,57 @@ require("scripts/zones/Kazham/TextIDs");
 -- onTrade Action
 -----------------------------------
 
+-- item IDs
+            -- 483       Broken Mithran Fishing Rod
+            -- 22        Workbench
+            -- 1008      Ten of Coins
+            -- 1157      Sands of Silence
+            -- 1158      Wandering Bulb
+            -- 904       Giant Fish Bones
+            -- 4599      Blackened Toad
+            -- 905       Wyvern Skull
+            -- 1147      Ancient Salt
+            -- 4600      Lucky Egg
+         
 function onTrade(player,npc,trade)
-end; 
+    local OpoOpoAndIStatus = player:getQuestStatus(OUTLANDS, THE_OPO_OPO_AND_I);
+    local progress = player:getVar("OPO_OPO_PROGRESS");
+    local failed = player:getVar("OPO_OPO_FAILED");
+    local goodtrade = trade:hasItemQty(1158,1);
+    local badtrade = (trade:hasItemQty(483,1) or trade:hasItemQty(22,1) or trade:hasItemQty(1008,1) or trade:hasItemQty(1157,1) or trade:hasItemQty(904,1) or trade:hasItemQty(4599,1) or trade:hasItemQty(905,1) or trade:hasItemQty(1147,1) or trade:hasItemQty(4600,1));
+
+    if (OpoOpoAndIStatus == QUEST_ACCEPTED) then
+        if progress == 4 or failed == 5 then
+            if goodtrade then
+                player:startEvent(0x00DF);
+            elseif badtrade then
+                player:startEvent(0x00E9);
+            end
+        end
+    end
+end;
 
 -----------------------------------
 -- onTrigger Action
 -----------------------------------
 
 function onTrigger(player,npc)
-	player:startEvent(0x00C9);
+    local OpoOpoAndIStatus = player:getQuestStatus(OUTLANDS, THE_OPO_OPO_AND_I);
+    local progress = player:getVar("OPO_OPO_PROGRESS");
+    local failed = player:getVar("OPO_OPO_FAILED");
+    local retry = player:getVar("OPO_OPO_RETRY");
+    
+    if (OpoOpoAndIStatus == QUEST_ACCEPTED) then
+        if retry >= 1 then                          -- has failed on future npc so disregard previous successful trade
+            player:startEvent(0x00C9);
+        elseif (progress == 4 or failed == 5) then
+                player:startEvent(0x00D2);  -- asking for wandering bulb
+        elseif (progress >= 5 or failed >= 6) then
+            player:startEvent(0x00F6); -- happy with wandering bulb
+        end
+	else
+        player:startEvent(0x00C9);
+    end
 end;
 -----------------------------------
 -- onEventUpdate
@@ -34,9 +76,22 @@ end;
 -- onEventFinish
 -----------------------------------
 
-function onEventFinish(player,csid,option)
+function onEventFinish(player,csid,option,npc)
 --printf("CSID: %u",csid);
 --printf("RESULT: %u",option);
+
+    if (csid == 0x00DF) then    -- correct trade, onto next opo
+        if player:getVar("OPO_OPO_PROGRESS") == 4 then
+            player:tradeComplete();
+            player:setVar("OPO_OPO_PROGRESS",5);
+            player:setVar("OPO_OPO_FAILED",0);
+        else
+            player:setVar("OPO_OPO_FAILED",6);
+        end
+    elseif (csid == 0x00E9) then              -- wrong trade, restart at first opo
+        player:setVar("OPO_OPO_FAILED",1);
+        player:setVar("OPO_OPO_RETRY",5);
+    end
 end;
 
 

--- a/scripts/zones/Kazham/npcs/Qhio_Plittibhi.lua
+++ b/scripts/zones/Kazham/npcs/Qhio_Plittibhi.lua
@@ -19,7 +19,11 @@ end;
 -----------------------------------
 
 function onTrigger(player,npc)
-	player:startEvent(0x009A);
+    if (player:getVar("BathedInScent") == 1) then
+        player:startEvent(0x00BD); -- scent from Blue Rafflesias
+    else
+        player:startEvent(0x009A);
+    end
 end;
 -----------------------------------
 -- onEventUpdate

--- a/scripts/zones/Kazham/npcs/Roropp.lua
+++ b/scripts/zones/Kazham/npcs/Roropp.lua
@@ -6,7 +6,6 @@
 
 package.loaded["scripts/zones/Kazham/TextIDs"] = nil;
 require("scripts/zones/Kazham/TextIDs");
-
 require("scripts/globals/pathfind");
 
 local path = {
@@ -164,16 +163,59 @@ end;
 -- onTrade Action
 -----------------------------------
 
+-- item IDs
+            -- 483       Broken Mithran Fishing Rod
+            -- 22        Workbench
+            -- 1008      Ten of Coins
+            -- 1157      Sands of Silence
+            -- 1158      Wandering Bulb
+            -- 904       Giant Fish Bones
+            -- 4599      Blackened Toad
+            -- 905       Wyvern Skull
+            -- 1147      Ancient Salt
+            -- 4600      Lucky Egg
+         
 function onTrade(player,npc,trade)
-end; 
+    local OpoOpoAndIStatus = player:getQuestStatus(OUTLANDS, THE_OPO_OPO_AND_I);
+    local progress = player:getVar("OPO_OPO_PROGRESS");
+    local failed = player:getVar("OPO_OPO_FAILED");
+    local goodtrade = trade:hasItemQty(1157,1);
+    local badtrade = (trade:hasItemQty(483,1) or trade:hasItemQty(22,1) or trade:hasItemQty(1008,1) or trade:hasItemQty(1158,1) or trade:hasItemQty(904,1) or trade:hasItemQty(4599,1) or trade:hasItemQty(905,1) or trade:hasItemQty(1147,1) or trade:hasItemQty(4600,1));
+
+    if (OpoOpoAndIStatus == QUEST_ACCEPTED) then
+        if progress == 3 or failed == 4 then
+            if goodtrade then
+                player:startEvent(0x00DE);
+            elseif badtrade then
+                player:startEvent(0x00E8);
+            end
+        end
+    end
+end;
 
 -----------------------------------
 -- onTrigger Action
 -----------------------------------
 
 function onTrigger(player,npc)
-	player:startEvent(0x00C8);
-	npc:wait(-1);
+    local OpoOpoAndIStatus = player:getQuestStatus(OUTLANDS, THE_OPO_OPO_AND_I);
+    local progress = player:getVar("OPO_OPO_PROGRESS");
+    local failed = player:getVar("OPO_OPO_FAILED");
+    local retry = player:getVar("OPO_OPO_RETRY");
+    
+    if (OpoOpoAndIStatus == QUEST_ACCEPTED) then
+        if retry >= 1 then                          -- has failed on future npc so disregard previous successful trade
+            player:startEvent(0x00C8);
+            npc:wait(-1);
+        elseif (progress == 3 or failed == 4) then
+                player:startEvent(0x00D2);  -- asking for sands of silence
+        elseif (progress >= 4 or failed >= 5) then
+            player:startEvent(0x00F5); -- happy with sands of silence
+        end
+	else
+        player:startEvent(0x00C8);
+        npc:wait(-1);
+    end
 end;
 -----------------------------------
 -- onEventUpdate
@@ -191,7 +233,21 @@ end;
 function onEventFinish(player,csid,option,npc)
 --printf("CSID: %u",csid);
 --printf("RESULT: %u",option);
-    npc:wait(0);
+
+    if (csid == 0x00DE) then    -- correct trade, onto next opo
+        if player:getVar("OPO_OPO_PROGRESS") == 3 then
+            player:tradeComplete();
+            player:setVar("OPO_OPO_PROGRESS",4);
+            player:setVar("OPO_OPO_FAILED",0);
+        else
+            player:setVar("OPO_OPO_FAILED",5);
+        end
+    elseif (csid == 0x00E8) then              -- wrong trade, restart at first opo
+        player:setVar("OPO_OPO_FAILED",1);
+        player:setVar("OPO_OPO_RETRY",4);
+    else
+        npc:wait(0);
+    end
 end;
 
 

--- a/scripts/zones/Kazham/npcs/Roropp.lua
+++ b/scripts/zones/Kazham/npcs/Roropp.lua
@@ -230,7 +230,7 @@ end;
 -- onEventFinish
 -----------------------------------
 
-function onEventFinish(player,csid,option,npc)
+function onEventFinish(player,csid,option)
 --printf("CSID: %u",csid);
 --printf("RESULT: %u",option);
 

--- a/scripts/zones/Kazham/npcs/Roropp.lua
+++ b/scripts/zones/Kazham/npcs/Roropp.lua
@@ -230,7 +230,7 @@ end;
 -- onEventFinish
 -----------------------------------
 
-function onEventFinish(player,csid,option)
+function onEventFinish(player,csid,option,npc)
 --printf("CSID: %u",csid);
 --printf("RESULT: %u",option);
 

--- a/scripts/zones/Kazham/npcs/Tatapp.lua
+++ b/scripts/zones/Kazham/npcs/Tatapp.lua
@@ -318,7 +318,7 @@ end;
 -- onEventFinish
 -----------------------------------
 
-function onEventFinish(player,csid,option,npc)
+function onEventFinish(player,csid,option)
 --printf("CSID: %u",csid);
 --printf("RESULT: %u",option);
 

--- a/scripts/zones/Kazham/npcs/Tatapp.lua
+++ b/scripts/zones/Kazham/npcs/Tatapp.lua
@@ -318,7 +318,7 @@ end;
 -- onEventFinish
 -----------------------------------
 
-function onEventFinish(player,csid,option)
+function onEventFinish(player,csid,option,npc)
 --printf("CSID: %u",csid);
 --printf("RESULT: %u",option);
 

--- a/scripts/zones/Kazham/npcs/Thali_Mhobrum.lua
+++ b/scripts/zones/Kazham/npcs/Thali_Mhobrum.lua
@@ -42,8 +42,13 @@ end;
 -----------------------------------
 
 function onTrigger(player,npc)
+    if (player:getVar("BathedInScent") == 1) then
+        player:startEvent(0x00A3); -- scent from Blue Rafflesias
+        npc:wait(-1);
+	else
 	player:startEvent(0x00BE);
 	npc:wait(-1);
+    end
 end;
 -----------------------------------
 -- onEventUpdate

--- a/scripts/zones/Kazham/npcs/Toeh_Leddenbah.lua
+++ b/scripts/zones/Kazham/npcs/Toeh_Leddenbah.lua
@@ -19,7 +19,11 @@ end;
 -----------------------------------
 
 function onTrigger(player,npc)
-	player:startEvent(0x0055);
+    if (player:getVar("BathedInScent") == 1) then
+        player:startEvent(0x00AD); -- scent from Blue Rafflesias
+    else
+        player:startEvent(0x0055);
+    end
 end;
 -----------------------------------
 -- onEventUpdate

--- a/scripts/zones/Kazham/npcs/Tsahbi_Ifalombo.lua
+++ b/scripts/zones/Kazham/npcs/Tsahbi_Ifalombo.lua
@@ -19,7 +19,11 @@ end;
 -----------------------------------
 
 function onTrigger(player,npc)
-	player:startEvent(0x005A);
+    if (player:getVar("BathedInScent") == 1) then
+        player:startEvent(0x00B4); -- scent from Blue Rafflesias
+	else
+        player:startEvent(0x005A);
+    end
 end;
 -----------------------------------
 -- onEventUpdate

--- a/scripts/zones/Kazham/npcs/Tsui_Golalapahn.lua
+++ b/scripts/zones/Kazham/npcs/Tsui_Golalapahn.lua
@@ -19,7 +19,11 @@ end;
 -----------------------------------
 
 function onTrigger(player,npc)
-	player:startEvent(0x003D);
+    if (player:getVar("BathedInScent") == 1) then
+        player:startEvent(0x00A6); -- scent from Blue Rafflesias
+    else
+        player:startEvent(0x003D);
+    end
 end;
 -----------------------------------
 -- onEventUpdate

--- a/scripts/zones/Kazham/npcs/Vah_Keshura.lua
+++ b/scripts/zones/Kazham/npcs/Vah_Keshura.lua
@@ -19,7 +19,11 @@ end;
 -----------------------------------
 
 function onTrigger(player,npc)
-	player:startEvent(0x007C);
+    if (player:getVar("BathedInScent") == 1) then
+        player:startEvent(0x00BB); -- scent from Blue Rafflesias
+    else
+        player:startEvent(0x007C);
+    end    
 end;
 -----------------------------------
 -- onEventUpdate

--- a/scripts/zones/Korroloka_Tunnel/TextIDs.lua
+++ b/scripts/zones/Korroloka_Tunnel/TextIDs.lua
@@ -5,18 +5,21 @@ ITEM_CANNOT_BE_OBTAINED = 6379; -- You cannot obtain the item <item> come back a
           ITEM_OBTAINED = 6383; -- Obtained: <item>.
            GIL_OBTAINED = 6384; -- Obtained <number> gil.
        KEYITEM_OBTAINED = 6386; -- Obtained key item: <keyitem>.
- FISHING_MESSAGE_OFFSET = 7040; -- You can't fish here.
+ FISHING_MESSAGE_OFFSET = 7038; -- You can't fish here.
 
 -- Mining
-MINING_IS_POSSIBLE_HERE = 7294; -- Mining is possible here if you have
+MINING_IS_POSSIBLE_HERE = 7292; -- Mining is possible here if you have
 
 -- Quest dialog
 NOTHING_OUT_OF_ORDINARY = 6397; -- There is nothing out of the ordinary here.
     SENSE_OF_BOREBODING = 6398; -- You are suddenly overcome with a sense of foreboding...
 
 -- Other
-MORION_WORM_1 = 7315; -- It appears to be a hole made by some kind of animal. Fragments of iron ore are scattered around the area...
+      MORION_WORM_1 = 7313; -- It appears to be a hole made by some kind of animal. Fragments of iron ore are scattered around the area...
+     ENTERED_SPRING = 7308; -- The water in this spring is pleasant and tepid. This looks like a nice place to warm yourself up.
+  LEFT_SPRING_EARLY = 7309; -- You are not warm enough yet. You will need to spend more time than that in the spring to get your body heated up.
+  LEFT_SPRING_CLEAN = 7310; -- Your whole body is piping hot, and the smell of the Rafflesia pollen is gone!
 
 -- conquest Base
-CONQUEST_BASE = 7135; -- Tallying conquest results...
+CONQUEST_BASE = 7133; -- Tallying conquest results...
 

--- a/scripts/zones/Korroloka_Tunnel/TextIDs.lua
+++ b/scripts/zones/Korroloka_Tunnel/TextIDs.lua
@@ -5,21 +5,21 @@ ITEM_CANNOT_BE_OBTAINED = 6379; -- You cannot obtain the item <item> come back a
           ITEM_OBTAINED = 6383; -- Obtained: <item>.
            GIL_OBTAINED = 6384; -- Obtained <number> gil.
        KEYITEM_OBTAINED = 6386; -- Obtained key item: <keyitem>.
- FISHING_MESSAGE_OFFSET = 7038; -- You can't fish here.
+ FISHING_MESSAGE_OFFSET = 7040; -- You can't fish here.
 
 -- Mining
-MINING_IS_POSSIBLE_HERE = 7292; -- Mining is possible here if you have
+MINING_IS_POSSIBLE_HERE = 7294; -- Mining is possible here if you have
 
 -- Quest dialog
 NOTHING_OUT_OF_ORDINARY = 6397; -- There is nothing out of the ordinary here.
     SENSE_OF_BOREBODING = 6398; -- You are suddenly overcome with a sense of foreboding...
 
 -- Other
-      MORION_WORM_1 = 7313; -- It appears to be a hole made by some kind of animal. Fragments of iron ore are scattered around the area...
-     ENTERED_SPRING = 7308; -- The water in this spring is pleasant and tepid. This looks like a nice place to warm yourself up.
-  LEFT_SPRING_EARLY = 7309; -- You are not warm enough yet. You will need to spend more time than that in the spring to get your body heated up.
-  LEFT_SPRING_CLEAN = 7310; -- Your whole body is piping hot, and the smell of the Rafflesia pollen is gone!
+      MORION_WORM_1 = 7315; -- It appears to be a hole made by some kind of animal. Fragments of iron ore are scattered around the area...
+     ENTERED_SPRING = 7310; -- The water in this spring is pleasant and tepid. This looks like a nice place to warm yourself up.
+  LEFT_SPRING_EARLY = 7311; -- You are not warm enough yet. You will need to spend more time than that in the spring to get your body heated up.
+  LEFT_SPRING_CLEAN = 7312; -- Your whole body is piping hot, and the smell of the Rafflesia pollen is gone!
 
 -- conquest Base
-CONQUEST_BASE = 7133; -- Tallying conquest results...
+CONQUEST_BASE = 7135; -- Tallying conquest results...
 

--- a/scripts/zones/Korroloka_Tunnel/Zone.lua
+++ b/scripts/zones/Korroloka_Tunnel/Zone.lua
@@ -18,6 +18,12 @@ function onInitialize(zone)
     local tomes = {17486258,17486259,17486260,17486261};
 
     SetGroundsTome(tomes);
+    
+    -- Waterfalls (RegionID, X, Radius, Z)
+	zone:registerRegion(1,   -87, 4, -105, 0,0,0); -- Left pool
+	zone:registerRegion(2, 	-101, 7, -114, 0,0,0); -- Center Pool
+	zone:registerRegion(3, 	-112, 3, -103, 0,0,0); -- Right Pool
+    
 end;
 
 -----------------------------------
@@ -49,6 +55,55 @@ end;
 -----------------------------------
 
 function onRegionEnter(player,region)
+    local pooltime = (os.time() - player:getVar("POOL_TIME"));
+    
+    if player:getVar("BathedInScent") == 1 then  -- pollen scent from touching all 3 Blue Rafflesias in Yuhtunga
+        switch (region:GetRegionID()): caseof
+        {
+            [1] = function (x)  -- Left Pool
+                player:messageSpecial(ENTERED_SPRING);
+                player:setVar("POOL_TIME", os.time());
+            end,
+            [2] = function (x)  -- Center Pool
+                player:messageSpecial(ENTERED_SPRING);
+                player:setVar("POOL_TIME", os.time());
+            end,
+            [3] = function (x)  -- Right pool
+                player:messageSpecial(ENTERED_SPRING);
+                player:setVar("POOL_TIME", os.time());
+            end,
+        }
+    end
+end;
+    
+
+
+-----------------------------------		
+-- OnRegionLeave		
+-----------------------------------		
+
+function onRegionLeave(player,region)
+
+	local RegionID = region:GetRegionID();
+	local pooltime = (os.time() - player:getVar("POOL_TIME"));
+    
+	if(RegionID <= 3 and player:getVar("BathedInScent") == 1) then
+        if pooltime >= 300 then
+            if (player:getQuestStatus(OUTLANDS, PERSONAL_HYGIENE) == QUEST_ACCEPTED) then
+                player:messageSpecial(LEFT_SPRING_CLEAN);
+                player:setVar("POOL_TIME", 0);
+                player:setVar("BathedInScent", 0);
+                player:setVar("PERSONAL_HYGIENE_PROGRESS", 1);
+            else
+                player:messageSpecial(LEFT_SPRING_CLEAN);
+                player:setVar("POOL_TIME", 0);
+                player:setVar("BathedInScent", 0);
+            end
+        else
+            player:messageSpecial(LEFT_SPRING_EARLY);
+            player:setVar("POOL_TIME", 0);
+        end
+    end
 end;
 
 -----------------------------------

--- a/scripts/zones/Yuhtunga_Jungle/TextIDs.lua
+++ b/scripts/zones/Yuhtunga_Jungle/TextIDs.lua
@@ -5,34 +5,34 @@ ITEM_CANNOT_BE_OBTAINED = 6379; -- You cannot obtain the item <item>. Come back 
           ITEM_OBTAINED = 6383; -- Obtained: <item>.
            GIL_OBTAINED = 6384; -- Obtained <number> gil.
        KEYITEM_OBTAINED = 6386; -- Obtained key item: <keyitem>.
-        BEASTMEN_BANNER = 7119; -- There is a beastmen's banner.
- FISHING_MESSAGE_OFFSET = 7539; -- You can't fish here.
+        BEASTMEN_BANNER = 7121; -- There is a beastmen's banner.
+ FISHING_MESSAGE_OFFSET = 7541; -- You can't fish here.
 
 -- Conquest
-CONQUEST = 7206; -- You've earned conquest points!
+CONQUEST = 7208; -- You've earned conquest points!
 
 -- Logging
-   LOGGING_IS_POSSIBLE_HERE = 7681; -- Logging is possible here if you have
-HARVESTING_IS_POSSIBLE_HERE = 7688; -- Harvesting is possible here if you have
+   LOGGING_IS_POSSIBLE_HERE = 7683; -- Logging is possible here if you have
+HARVESTING_IS_POSSIBLE_HERE = 7690; -- Harvesting is possible here if you have
 
 -- ZM4 Dialog
-    CANNOT_REMOVE_FRAG = 7660; -- It is an oddly shaped stone monument. A shining stone is embedded in it, but cannot be removed...
- ALREADY_OBTAINED_FRAG = 7661; -- You have already obtained this monument's
-ALREADY_HAVE_ALL_FRAGS = 7662; -- You have obtained all of the fragments. You must hurry to the ruins of the ancient shrine!
-       FOUND_ALL_FRAGS = 7663; -- You now have all 8 fragments of light!
-       ZILART_MONUMENT = 7664; -- It is an ancient Zilart monument.
+    CANNOT_REMOVE_FRAG = 7662; -- It is an oddly shaped stone monument. A shining stone is embedded in it, but cannot be removed...
+ ALREADY_OBTAINED_FRAG = 7663; -- You have already obtained this monument's
+ALREADY_HAVE_ALL_FRAGS = 7664; -- You have obtained all of the fragments. You must hurry to the ruins of the ancient shrine!
+       FOUND_ALL_FRAGS = 7665; -- You now have all 8 fragments of light!
+       ZILART_MONUMENT = 7666; -- It is an ancient Zilart monument.
 
 -- Rafflesia Scent
-FLOWER_BLOOMING = 7640; -- A large flower is blooming.
-FOUND_NOTHING_IN_FLOWER = 7643; -- You find nothing inside the flower.
-FEEL_DIZZY = 7644; -- You feel slightly dizzy. You must have breathed in too much of the pollen.
+FLOWER_BLOOMING = 7642; -- A large flower is blooming.
+FOUND_NOTHING_IN_FLOWER = 7645; -- You find nothing inside the flower.
+FEEL_DIZZY = 7646; -- You feel slightly dizzy. You must have breathed in too much of the pollen.
 -- Other
 NOTHING_HAPPENS = 119; -- Nothing happens...
 
 -- conquest Base
-CONQUEST_BASE = 7038; -- Tallying conquest results...
+CONQUEST_BASE = 7040; -- Tallying conquest results...
 
 -- chocobo digging
-DIG_THROW_AWAY = 7552; -- You dig up ?Possible Special Code: 01??Possible Special Code: 01??Possible Special Code: 01? ?Possible Special Code: 01??Possible Special Code: 05?$?BAD CHAR: 8280??BAD CHAR: 80??BAD CHAR: 80?, but your inventory is full.
-FIND_NOTHING = 7554; -- You dig and you dig, but find nothing.
+DIG_THROW_AWAY = 7554; -- You dig up ?Possible Special Code: 01??Possible Special Code: 01??Possible Special Code: 01? ?Possible Special Code: 01??Possible Special Code: 05?$?BAD CHAR: 8280??BAD CHAR: 80??BAD CHAR: 80?, but your inventory is full.
+FIND_NOTHING = 7556; -- You dig and you dig, but find nothing.
 

--- a/scripts/zones/Yuhtunga_Jungle/TextIDs.lua
+++ b/scripts/zones/Yuhtunga_Jungle/TextIDs.lua
@@ -5,30 +5,34 @@ ITEM_CANNOT_BE_OBTAINED = 6379; -- You cannot obtain the item <item>. Come back 
           ITEM_OBTAINED = 6383; -- Obtained: <item>.
            GIL_OBTAINED = 6384; -- Obtained <number> gil.
        KEYITEM_OBTAINED = 6386; -- Obtained key item: <keyitem>.
-        BEASTMEN_BANNER = 7121; -- There is a beastmen's banner.
- FISHING_MESSAGE_OFFSET = 7541; -- You can't fish here.
+        BEASTMEN_BANNER = 7119; -- There is a beastmen's banner.
+ FISHING_MESSAGE_OFFSET = 7539; -- You can't fish here.
 
 -- Conquest
-CONQUEST = 7208; -- You've earned conquest points!
+CONQUEST = 7206; -- You've earned conquest points!
 
 -- Logging
-   LOGGING_IS_POSSIBLE_HERE = 7683; -- Logging is possible here if you have
-HARVESTING_IS_POSSIBLE_HERE = 7690; -- Harvesting is possible here if you have
+   LOGGING_IS_POSSIBLE_HERE = 7681; -- Logging is possible here if you have
+HARVESTING_IS_POSSIBLE_HERE = 7688; -- Harvesting is possible here if you have
 
 -- ZM4 Dialog
-    CANNOT_REMOVE_FRAG = 7662; -- It is an oddly shaped stone monument. A shining stone is embedded in it, but cannot be removed...
- ALREADY_OBTAINED_FRAG = 7663; -- You have already obtained this monument's
-ALREADY_HAVE_ALL_FRAGS = 7664; -- You have obtained all of the fragments. You must hurry to the ruins of the ancient shrine!
-       FOUND_ALL_FRAGS = 7665; -- You now have all 8 fragments of light!
-       ZILART_MONUMENT = 7666; -- It is an ancient Zilart monument.
+    CANNOT_REMOVE_FRAG = 7660; -- It is an oddly shaped stone monument. A shining stone is embedded in it, but cannot be removed...
+ ALREADY_OBTAINED_FRAG = 7661; -- You have already obtained this monument's
+ALREADY_HAVE_ALL_FRAGS = 7662; -- You have obtained all of the fragments. You must hurry to the ruins of the ancient shrine!
+       FOUND_ALL_FRAGS = 7663; -- You now have all 8 fragments of light!
+       ZILART_MONUMENT = 7664; -- It is an ancient Zilart monument.
 
+-- Rafflesia Scent
+FLOWER_BLOOMING = 7640; -- A large flower is blooming.
+FOUND_NOTHING_IN_FLOWER = 7643; -- You find nothing inside the flower.
+FEEL_DIZZY = 7644; -- You feel slightly dizzy. You must have breathed in too much of the pollen.
 -- Other
 NOTHING_HAPPENS = 119; -- Nothing happens...
 
 -- conquest Base
-CONQUEST_BASE = 7040; -- Tallying conquest results...
+CONQUEST_BASE = 7038; -- Tallying conquest results...
 
 -- chocobo digging
-DIG_THROW_AWAY = 7554; -- You dig up ?Possible Special Code: 01??Possible Special Code: 01??Possible Special Code: 01? ?Possible Special Code: 01??Possible Special Code: 05?$?BAD CHAR: 8280??BAD CHAR: 80??BAD CHAR: 80?, but your inventory is full.
-FIND_NOTHING = 7556; -- You dig and you dig, but find nothing.
+DIG_THROW_AWAY = 7552; -- You dig up ?Possible Special Code: 01??Possible Special Code: 01??Possible Special Code: 01? ?Possible Special Code: 01??Possible Special Code: 05?$?BAD CHAR: 8280??BAD CHAR: 80??BAD CHAR: 80?, but your inventory is full.
+FIND_NOTHING = 7554; -- You dig and you dig, but find nothing.
 

--- a/scripts/zones/Yuhtunga_Jungle/npcs/br1.lua
+++ b/scripts/zones/Yuhtunga_Jungle/npcs/br1.lua
@@ -1,0 +1,73 @@
+-----------------------------------
+-- Area: Yuhtunga Jungle
+-- NPC: Blue Rafflesia
+-- Used in quest Even More Gullible Travels
+-- @pos -468.876 -1 220.247 170
+-----------------------------------
+package.loaded["scripts/zones/Yuhtunga_Jungle/TextIDs"] = nil;
+-----------------------------------
+
+require("scripts/zones/Yuhtunga_Jungle/TextIDs");
+
+-----------------------------------
+-- onTrade Action
+-----------------------------------
+
+function onTrade(player,npc,trade)
+end; 
+
+-----------------------------------
+-- onTrigger Action
+-----------------------------------
+
+function onTrigger(player,npc)
+    local evenmoreTravelsStatus = player:getQuestStatus(OUTLANDS, EVEN_MORE_GULLIBLES_TRAVELS)
+    local scentDay = player:getVar("RafflesiaScentDay");
+    local currentDay = VanadielDayOfTheYear();
+    local scentReady = ((scentDay < currentDay) or (scentDay > currentDay and player:getVar("RafflesiaScentYear") < VanadielYear()));
+    
+    if (evenmoreTravelsStatus == QUEST_ACCEPTED and player:getVar("EVEN_MORE_GULLIBLES_PROGRESS") == 1 and player:getVar("FirstBlueRafflesiaCS") == 0) then
+        player:startEvent(0x0015);
+    elseif (evenmoreTravelsStatus == QUEST_COMPLETED and scentReady == true and player:getVar("BathedInScent") == 0 and player:getVar("FirstBlueRafflesiaCS") == 0) then
+        player:startEvent(0x0015);
+    else
+        player:messageSpecial(FLOWER_BLOOMING);
+    end
+end;
+
+-----------------------------------
+-- onEventUpdate
+-----------------------------------
+
+function onEventUpdate(player,csid,option)
+--printf("CSID: %u",csid);
+--printf("OPTION: %u",option);
+end;
+
+-----------------------------------
+-- onEventFinish
+-----------------------------------
+
+function onEventFinish(player,csid,option)
+--printf("CSID: %u",csid);
+--printf("OPTION: %u",option);
+
+-- Set BathedInScent to 1 if they touched all 3 Rafflesia for EVEN_MORE_GULLIBLES_TRAVELS which opens the quest The Opo-Opo and I
+    if (csid == 0x0015 and option == 1) then
+        if (player:getVar("SecondBlueRafflesiaCS") == 1 and player:getVar("ThirdBlueRafflesiaCS") == 1) then
+            player:setVar("SecondBlueRafflesiaCS", 0);
+            player:setVar("ThirdBlueRafflesiaCS", 0);
+            player:setVar("BathedInScent", 1);
+            player:setVar("RafflesiaScentDay",VanadielDayOfTheYear());
+            player:setVar("RafflesiaScentYear",VanadielYear());
+            player:setVar("EVEN_MORE_GULLIBLES_PROGRESS", 2);
+            player:addItem(1144);        -- Rafflesia Nectar
+            player:messageSpecial(ITEM_OBTAINED,1144);
+            player:messageSpecial(FEEL_DIZZY); -- You feel slightly dizzy. You must have breathed in too much of the pollen.
+        else
+            player:setVar("FirstBlueRafflesiaCS", 1);
+            player:addItem(1144);        -- Rafflesia Nectar
+            player:messageSpecial(ITEM_OBTAINED,1144);
+        end
+    end
+end;

--- a/scripts/zones/Yuhtunga_Jungle/npcs/br2.lua
+++ b/scripts/zones/Yuhtunga_Jungle/npcs/br2.lua
@@ -1,0 +1,73 @@
+-----------------------------------
+-- Area: Yuhtunga Jungle
+-- NPC: Blue Rafflesia
+-- Used in quest Even More Gullible Travels
+-- @pos -468.876 -1 220.247 170
+-----------------------------------
+package.loaded["scripts/zones/Yuhtunga_Jungle/TextIDs"] = nil;
+-----------------------------------
+
+require("scripts/zones/Yuhtunga_Jungle/TextIDs");
+
+-----------------------------------
+-- onTrade Action
+-----------------------------------
+
+function onTrade(player,npc,trade)
+end; 
+
+-----------------------------------
+-- onTrigger Action
+-----------------------------------
+
+function onTrigger(player,npc)
+    local evenmoreTravelsStatus = player:getQuestStatus(OUTLANDS, EVEN_MORE_GULLIBLES_TRAVELS)
+    local scentDay = player:getVar("RafflesiaScentDay");
+    local currentDay = VanadielDayOfTheYear();
+    local scentReady = ((scentDay < currentDay) or (scentDay > currentDay and player:getVar("RafflesiaScentYear") < VanadielYear()));
+    
+    if (evenmoreTravelsStatus == QUEST_ACCEPTED and player:getVar("EVEN_MORE_GULLIBLES_PROGRESS") == 1 and player:getVar("SecondBlueRafflesiaCS") == 0) then
+        player:startEvent(0x0016);
+    elseif (evenmoreTravelsStatus == QUEST_COMPLETED and scentReady == true and player:getVar("BathedInScent") == 0 and player:getVar("SecondBlueRafflesiaCS") == 0) then
+        player:startEvent(0x0016);
+    else
+        player:messageSpecial(FLOWER_BLOOMING);
+    end
+end;
+
+-----------------------------------
+-- onEventUpdate
+-----------------------------------
+
+function onEventUpdate(player,csid,option)
+--printf("CSID: %u",csid);
+--printf("OPTION: %u",option);
+end;
+
+-----------------------------------
+-- onEventFinish
+-----------------------------------
+
+function onEventFinish(player,csid,option)
+--printf("CSID: %u",csid);
+--printf("OPTION: %u",option);
+
+-- Set BathedInScent to 1 if they touched all 3 Rafflesia for EVEN_MORE_GULLIBLES_TRAVELS which opens the quest The Opo-Opo and I
+    if (csid == 0x0016 and option == 1) then
+        if (player:getVar("FirstBlueRafflesiaCS") == 1 and player:getVar("ThirdBlueRafflesiaCS") == 1) then
+            player:setVar("FirstBlueRafflesiaCS", 0);
+            player:setVar("ThirdBlueRafflesiaCS", 0);
+            player:setVar("BathedInScent", 1);
+            player:setVar("RafflesiaScentDay",VanadielDayOfTheYear());
+            player:setVar("RafflesiaScentYear",VanadielYear());
+            player:setVar("EVEN_MORE_GULLIBLES_PROGRESS", 2);
+            player:addItem(1144);        -- Rafflesia Nectar
+            player:messageSpecial(ITEM_OBTAINED,1144);
+            player:messageSpecial(FEEL_DIZZY); -- You feel slightly dizzy. You must have breathed in too much of the pollen.
+        else
+            player:setVar("SecondBlueRafflesiaCS", 1);
+            player:addItem(1144);        -- Rafflesia Nectar
+            player:messageSpecial(ITEM_OBTAINED,1144);
+        end
+    end
+end;

--- a/scripts/zones/Yuhtunga_Jungle/npcs/br3.lua
+++ b/scripts/zones/Yuhtunga_Jungle/npcs/br3.lua
@@ -1,0 +1,73 @@
+-----------------------------------
+-- Area: Yuhtunga Jungle
+-- NPC: Blue Rafflesia
+-- Used in quest Even More Gullible Travels
+-- @pos -468.876 -1 220.247 170
+-----------------------------------
+package.loaded["scripts/zones/Yuhtunga_Jungle/TextIDs"] = nil;
+-----------------------------------
+
+require("scripts/zones/Yuhtunga_Jungle/TextIDs");
+
+-----------------------------------
+-- onTrade Action
+-----------------------------------
+
+function onTrade(player,npc,trade)
+end; 
+
+-----------------------------------
+-- onTrigger Action
+-----------------------------------
+
+function onTrigger(player,npc)
+    local evenmoreTravelsStatus = player:getQuestStatus(OUTLANDS, EVEN_MORE_GULLIBLES_TRAVELS)
+    local scentDay = player:getVar("RafflesiaScentDay");
+    local currentDay = VanadielDayOfTheYear();
+    local scentReady = ((scentDay < currentDay) or (scentDay > currentDay and player:getVar("RafflesiaScentYear") < VanadielYear()));
+    
+    if (evenmoreTravelsStatus == QUEST_ACCEPTED and player:getVar("EVEN_MORE_GULLIBLES_PROGRESS") == 1 and player:getVar("ThirdBlueRafflesiaCS") == 0) then
+        player:startEvent(0x0017);
+    elseif (evenmoreTravelsStatus == QUEST_COMPLETED and scentReady == true and player:getVar("BathedInScent") == 0 and player:getVar("ThirdBlueRafflesiaCS") == 0) then
+        player:startEvent(0x0017);
+    else
+        player:messageSpecial(FLOWER_BLOOMING);
+    end
+end;
+
+-----------------------------------
+-- onEventUpdate
+-----------------------------------
+
+function onEventUpdate(player,csid,option)
+--printf("CSID: %u",csid);
+--printf("OPTION: %u",option);
+end;
+
+-----------------------------------
+-- onEventFinish
+-----------------------------------
+
+function onEventFinish(player,csid,option)
+--printf("CSID: %u",csid);
+--printf("OPTION: %u",option);
+
+-- Set BathedInScent to 1 if they touched all 3 Rafflesia for EVEN_MORE_GULLIBLES_TRAVELS which opens the quest The Opo-Opo and I
+    if (csid == 0x0017 and option == 1) then
+        if (player:getVar("FirstBlueRafflesiaCS") == 1 and player:getVar("SecondBlueRafflesiaCS") == 1) then
+            player:setVar("FirstBlueRafflesiaCS", 0);
+            player:setVar("SecondBlueRafflesiaCS", 0);
+            player:setVar("BathedInScent", 1);
+            player:setVar("RafflesiaScentDay",VanadielDayOfTheYear());
+            player:setVar("RafflesiaScentYear",VanadielYear());
+            player:setVar("EVEN_MORE_GULLIBLES_PROGRESS", 2);
+            player:addItem(1144);        -- Rafflesia Nectar
+            player:messageSpecial(ITEM_OBTAINED,1144);
+            player:messageSpecial(FEEL_DIZZY); -- You feel slightly dizzy. You must have breathed in too much of the pollen.
+        else
+            player:setVar("ThirdBlueRafflesiaCS", 1);
+            player:addItem(1144);        -- Rafflesia Nectar
+            player:messageSpecial(ITEM_OBTAINED,1144);
+        end
+    end
+end;


### PR DESCRIPTION
3 quests added; Even More Gullibles Travels, The Opo-opo and I, and Personal Hygiene. The first quest Gullibles Travels already exists.


Everything is per wiki (even weird trades for The Opo-opo and I, where they wont take the item the 2nd time around if you failed once).  The Rafflesia scent received from Even More Gullibles Travels is erased via Personal Hygiene. The scent can be reacquired every 24hours, in case you erased it before you flagged The Opo-opo and I.