### PR TITLE
Scripts/SQL/Core: Elemental Obi bonus as mods, Hachirin-no-Obi

### DIFF
--- a/scripts/globals/magic.lua
+++ b/scripts/globals/magic.lua
@@ -45,8 +45,8 @@ require("scripts/globals/utils")
     doubleWeatherStrong = {WEATHER_HEAT_WAVE, WEATHER_SAND_STORM, WEATHER_SQUALL, WEATHER_GALES, WEATHER_BLIZZARDS, WEATHER_THUNDERSTORMS, WEATHER_STELLAR_GLARE, WEATHER_DARKNESS};
     singleWeatherWeak = {WEATHER_RAIN, WEATHER_WIND, WEATHER_THUNDER, WEATHER_SNOW, WEATHER_HOT_SPELL, WEATHER_DUST_STORM, WEATHER_GLOOM, WEATHER_AURORAS};
     doubleWeatherWeak = {WEATHER_SQUALL, WEATHER_GALES, WEATHER_THUNDERSTORMS, WEATHER_BLIZZARDS, WEATHER_HEAT_WAVE, WEATHER_SAND_STORM, WEATHER_DARKNESS, WEATHER_STELLAR_GLARE};
-    elementalObi = {15435, 15438, 15440, 15437, 15436, 15439, 15441, 15442};
-    elementalObiWeak = {15440, 15437, 15439, 15436, 15435, 15438, 15442, 15441};
+    elementalObi = {MOD_FORCE_FIRE_DWBONUS, MOD_FORCE_EARTH_DWBONUS, MOD_FORCE_WATER_DWBONUS, MOD_FORCE_WIND_DWBONUS, MOD_FORCE_ICE_DWBONUS, MOD_FORCE_LIGHTNING_DWBONUS, MOD_FORCE_LIGHT_DWBONUS, MOD_FORCE_DARK_DWBONUS};
+    elementalObiWeak = {MOD_FORCE_WATER_DWBONUS, MOD_FORCE_WIND_DWBONUS, MOD_FORCE_LIGHTNING_DWBONUS, MOD_FORCE_ICE_DWBONUS, MOD_FORCE_FIRE_DWBONUS, MOD_FORCE_EARTH_DWBONUS, MOD_FORCE_DARK_DWBONUS, MOD_FORCE_LIGHT_DWBONUS};
     spellAcc = {MOD_FIREACC, MOD_EARTHACC, MOD_WATERACC, MOD_WINDACC, MOD_ICEACC, MOD_THUNDERACC, MOD_LIGHTACC, MOD_DARKACC};
     strongAffinity = {MOD_FIRE_AFFINITY, MOD_EARTH_AFFINITY, MOD_WATER_AFFINITY, MOD_WIND_AFFINITY, MOD_ICE_AFFINITY, MOD_THUNDER_AFFINITY, MOD_LIGHT_AFFINITY, MOD_DARK_AFFINITY};
     weakAffinity = {MOD_WATER_AFFINITY, MOD_WIND_AFFINITY, MOD_THUNDER_AFFINITY, MOD_ICE_AFFINITY, MOD_FIRE_AFFINITY, MOD_EARTH_AFFINITY, MOD_DARK_AFFINITY, MOD_LIGHT_AFFINITY};
@@ -231,39 +231,39 @@ function getCureFinal(caster,spell,basecure,minCure,isBlueMagic)
 
     if (castersWeather == singleWeatherStrong[ele]) then
         if (equippedMain == 18632 or equippedMain == 18633) then
-            if (math.random() < 0.33 or equippedWaist == elementalObi[ele]) then
+            if (math.random() < 0.33 or caster:getMod(elementalObi[ele]) >= 1) then
                 dayWeatherBonus = dayWeatherBonus + 0.10;
             end
         end
-        if (math.random() < 0.33 or equippedWaist == elementalObi[ele]) then
+        if (math.random() < 0.33 or caster:getMod(elementalObi[ele]) >= 1) then
             dayWeatherBonus = dayWeatherBonus + 0.10;
         end
     elseif (castersWeather == singleWeatherWeak[ele]) then
-        if (math.random() < 0.33 or equippedWaist == elementalObi[ele]) then
+        if (math.random() < 0.33 or caster:getMod(elementalObi[ele]) >= 1) then
             dayWeatherBonus = dayWeatherBonus - 0.10;
         end
     elseif (castersWeather == doubleWeatherStrong[ele]) then
         if (equippedMain == 18632 or equippedMain == 18633) then
-            if (math.random() < 0.33 or equippedWaist == elementalObi[ele]) then
+            if (math.random() < 0.33 or caster:getMod(elementalObi[ele]) >= 1) then
                 dayWeatherBonus = dayWeatherBonus + 0.10;
             end
         end
-        if (math.random() < 0.33 or equippedWaist == elementalObi[ele]) then
+        if (math.random() < 0.33 or caster:getMod(elementalObi[ele]) >= 1) then
             dayWeatherBonus = dayWeatherBonus + 0.25;
         end
     elseif (castersWeather == doubleWeatherWeak[ele]) then
-        if (math.random() < 0.33 or equippedWaist == elementalObi[ele]) then
+        if (math.random() < 0.33 or caster:getMod(elementalObi[ele]) >= 1) then
             dayWeatherBonus = dayWeatherBonus - 0.25;
         end
     end
 
     local dayElement = VanadielDayElement();
     if (dayElement == dayStrong[ele]) then
-        if (math.random() < 0.33 or equippedWaist == elementalObi[ele]) then
+        if (math.random() < 0.33 or caster:getMod(elementalObi[ele]) >= 1) then
             dayWeatherBonus = dayWeatherBonus + 0.10;
         end
     elseif (dayElement == dayWeak[ele]) then
-        if (math.random() < 0.33 or equippedWaist == elementalObi[ele]) then
+        if (math.random() < 0.33 or caster:getMod(elementalObi[ele]) >= 1) then
             dayWeatherBonus = dayWeatherBonus - 0.10;
         end
     end
@@ -1126,29 +1126,29 @@ function addBonuses(caster, spell, target, dmg, bonusmab)
     if (weather == singleWeatherStrong[ele]) then
         -- Iridescence
         if (equippedMain == 18632 or equippedMain == 18633) then
-            if (math.random() < 0.33 or equippedWaist == elementalObi[ele] or isHelixSpell(spell)) then
+            if (math.random() < 0.33 or caster:getMod(elementalObi[ele]) >= 1 or isHelixSpell(spell)) then
                 dayWeatherBonus = dayWeatherBonus + 0.10;
             end
         end
-        if (math.random() < 0.33 or equippedWaist == elementalObi[ele] or isHelixSpell(spell)) then
+        if (math.random() < 0.33 or caster:getMod(elementalObi[ele]) >= 1 or isHelixSpell(spell)) then
             dayWeatherBonus = dayWeatherBonus + 0.10;
         end
     elseif (caster:getWeather() == singleWeatherWeak[ele]) then
-        if (math.random() < 0.33 or equippedWaist == elementalObiWeak[ele] or isHelixSpell(spell)) then
+        if (math.random() < 0.33 or caster:getMod(elementalObiWeak[ele]) >= 1 or isHelixSpell(spell)) then
             dayWeatherBonus = dayWeatherBonus - 0.10;
         end
     elseif (weather == doubleWeatherStrong[ele]) then
         -- Iridescence
         if (equippedMain == 18632 or equippedMain == 18633) then
-            if (math.random() < 0.33 or equippedWaist == elementalObi[ele] or isHelixSpell(spell)) then
+            if (math.random() < 0.33 or caster:getMod(elementalObi[ele]) >= 1 or isHelixSpell(spell)) then
                 dayWeatherBonus = dayWeatherBonus + 0.10;
             end
         end
-        if (math.random() < 0.33 or equippedWaist == elementalObi[ele] or isHelixSpell(spell)) then
+        if (math.random() < 0.33 or caster:getMod(elementalObi[ele]) >= 1 or isHelixSpell(spell)) then
             dayWeatherBonus = dayWeatherBonus + 0.25;
         end
     elseif (weather == doubleWeatherWeak[ele]) then
-        if (math.random() < 0.33 or equippedWaist == elementalObiWeak[ele] or isHelixSpell(spell)) then
+        if (math.random() < 0.33 or caster:getMod(elementalObiWeak[ele]) >= 1 or isHelixSpell(spell)) then
             dayWeatherBonus = dayWeatherBonus - 0.25;
         end
     end
@@ -1159,12 +1159,12 @@ function addBonuses(caster, spell, target, dmg, bonusmab)
         if (equippedLegs == 15120 or equippedLegs == 15583) then
             dayWeatherBonus = dayWeatherBonus + 0.05;
         end
-        if (math.random() < 0.33 or equippedWaist == elementalObi[ele] or isHelixSpell(spell)) then
+        if (math.random() < 0.33 or caster:getMod(elementalObi[ele]) >= 1 or isHelixSpell(spell)) then
             dayWeatherBonus = dayWeatherBonus + 0.10;
         end
     elseif (dayElement == dayWeak[ele]) then
-        if (math.random() < 0.33 or equippedWaist == elementalObiWeak[ele] or isHelixSpell(spell)) then
-            dayWeatherBonus = dayWeatherBonus + 0.10;
+        if (math.random() < 0.33 or caster:getMod(elementalObiWeak[ele]) >= 1 or isHelixSpell(spell)) then
+            dayWeatherBonus = dayWeatherBonus - 0.10;
         end
     end
 
@@ -1241,29 +1241,29 @@ function addBonusesAbility(caster, ele, target, dmg, params)
     if (weather == singleWeatherStrong[ele]) then
         -- Iridescence
         if (equippedMain == 18632 or equippedMain == 18633) then
-            if (math.random() < 0.33 or equippedWaist == elementalObi[ele] ) then
+            if (math.random() < 0.33 or caster:getMod(elementalObi[ele]) >= 1) then
                 dayWeatherBonus = dayWeatherBonus + 0.10;
             end
         end
-        if (math.random() < 0.33 or equippedWaist == elementalObi[ele] ) then
+        if (math.random() < 0.33 or caster:getMod(elementalObi[ele]) >= 1) then
             dayWeatherBonus = dayWeatherBonus + 0.10;
         end
     elseif (caster:getWeather() == singleWeatherWeak[ele]) then
-        if (math.random() < 0.33 or equippedWaist == elementalObiWeak[ele] ) then
+        if (math.random() < 0.33 or caster:getMod(elementalObiWeak[ele]) >= 1) then
             dayWeatherBonus = dayWeatherBonus - 0.10;
         end
     elseif (weather == doubleWeatherStrong[ele]) then
         -- Iridescence
         if (equippedMain == 18632 or equippedMain == 18633) then
-            if (math.random() < 0.33 or equippedWaist == elementalObi[ele] ) then
+            if (math.random() < 0.33 or caster:getMod(elementalObi[ele]) >= 1) then
                 dayWeatherBonus = dayWeatherBonus + 0.10;
             end
         end
-        if (math.random() < 0.33 or equippedWaist == elementalObi[ele] ) then
+        if (math.random() < 0.33 or caster:getMod(elementalObi[ele]) >= 1) then
             dayWeatherBonus = dayWeatherBonus + 0.25;
         end
     elseif (weather == doubleWeatherWeak[ele]) then
-        if (math.random() < 0.33 or equippedWaist == elementalObiWeak[ele] ) then
+        if (math.random() < 0.33 or caster:getMod(elementalObiWeak[ele]) >= 1) then
             dayWeatherBonus = dayWeatherBonus - 0.25;
         end
     end
@@ -1274,12 +1274,12 @@ function addBonusesAbility(caster, ele, target, dmg, params)
         if (equippedLegs == 15120 or equippedLegs == 15583) then
             dayWeatherBonus = dayWeatherBonus + 0.05;
         end
-        if (math.random() < 0.33 or equippedWaist == elementalObi[ele] ) then
+        if (math.random() < 0.33 or caster:getMod(elementalObi[ele]) >= 1) then
             dayWeatherBonus = dayWeatherBonus + 0.10;
         end
     elseif (dayElement == dayWeak[ele]) then
-        if (math.random() < 0.33 or equippedWaist == elementalObiWeak[ele] ) then
-            dayWeatherBonus = dayWeatherBonus + 0.10;
+        if (math.random() < 0.33 or caster:getMod(elementalObiWeak[ele]) >= 1) then
+            dayWeatherBonus = dayWeatherBonus - 0.10;
         end
     end
 

--- a/scripts/globals/status.lua
+++ b/scripts/globals/status.lua
@@ -1223,14 +1223,25 @@ MOD_LOGGING_RESULT      = 514 -- Improves logging results
 MOD_MINNING_RESULT      = 515 -- Improves mining results
 MOD_EGGHELM             = 517 -- Egg Helm (Chocobo Digging)
 
-MOD_SHIELDBLOCKRATE = 518 -- Affects shield block rate, percent based
-MOD_SCAVENGE_EFFECT = 312 --
-MOD_DIA_DOT         = 313 -- Increases the DoT damage of Dia
-MOD_SHARPSHOT       = 314 -- Sharpshot accuracy bonus
-MOD_ENH_DRAIN_ASPIR = 315 -- % damage boost to Drain and Aspir
-MOD_TRICK_ATK_AGI   = 520 -- % AGI boost to Trick Attack (if gear mod, needs to be equipped on hit)
-MOD_NIN_NUKE_BONUS  = 522 -- magic attack bonus for NIN nukes
-MOD_AMMO_SWING      = 523 -- Extra swing rate w/ ammo (ie. Jailer weapons). Use gearsets, and does nothing for non-players.
+MOD_SHIELDBLOCKRATE           = 518 -- Affects shield block rate, percent based
+MOD_SCAVENGE_EFFECT           = 312 --
+MOD_DIA_DOT                   = 313 -- Increases the DoT damage of Dia
+MOD_SHARPSHOT                 = 314 -- Sharpshot accuracy bonus
+MOD_ENH_DRAIN_ASPIR           = 315 -- % damage boost to Drain and Aspir
+MOD_TRICK_ATK_AGI             = 520 -- % AGI boost to Trick Attack (if gear mod, needs to be equipped on hit)
+MOD_NIN_NUKE_BONUS            = 522 -- magic attack bonus for NIN nukes
+MOD_AMMO_SWING                = 523 -- Extra swing rate w/ ammo (ie. Jailer weapons). Use gearsets, and does nothing for non-players.
+MOD_ROLL_RANGE                = 528 -- Additional range for COR roll abilities.
+MOD_ENHANCES_REFRESH          = 529 -- "Enhances Refresh" adds +1 per modifier to spell's tick result.
+MOD_NO_SPELL_MP_DEPLETION     = 530 -- % to not deplete MP on spellcast.
+MOD_FORCE_FIRE_DWBONUS        = 531 -- Set to 1 to force fire day/weather spell bonus/penalty. Do not have it total more than 1.
+MOD_FORCE_EARTH_DWBONUS       = 532 -- Set to 1 to force earth day/weather spell bonus/penalty. Do not have it total more than 1.
+MOD_FORCE_WATER_DWBONUS       = 533 -- Set to 1 to force water day/weather spell bonus/penalty. Do not have it total more than 1.
+MOD_FORCE_WIND_DWBONUS        = 534 -- Set to 1 to force wind day/weather spell bonus/penalty. Do not have it total more than 1.
+MOD_FORCE_ICE_DWBONUS         = 535 -- Set to 1 to force ice day/weather spell bonus/penalty. Do not have it total more than 1.
+MOD_FORCE_LIGHTNING_DWBONUS   = 536 -- Set to 1 to force lightning day/weather spell bonus/penalty. Do not have it total more than 1.
+MOD_FORCE_LIGHT_DWBONUS       = 537 -- Set to 1 to force light day/weather spell bonus/penalty. Do not have it total more than 1.
+MOD_FORCE_DARK_DWBONUS        = 538 -- Set to 1 to force dark day/weather spell bonus/penalty. Do not have it total more than 1.
 
 -- Mythic Weapon Mods
 MOD_AUGMENTS_ABSORB    = 521 -- Direct Absorb spell increase while Liberator is equipped (percentage based)
@@ -1238,8 +1249,6 @@ MOD_AOE_NA             = 524 -- Set to 1 to make -na spells/erase always AoE w/ 
 MOD_AUGMENTS_CONVERT   = 525 -- Convert HP to MP Ratio Multiplier. Value = MP multiplier rate.
 MOD_AUGMENTS_SA        = 526 -- Adds Critical Attack Bonus to Sneak Attack, percentage based.
 MOD_AUGMENTS_TA        = 527 -- Adds Critical Attack Bonus to Trick Attack, percentage based.
-MOD_ROLL_RANGE         = 528 -- Additional range for COR roll abilities.
-MOD_ENHANCES_REFRESH   = 529 -- "Enhances Refresh" adds +1 per modifier to spell's tick result.
 
 -- The entire mod list is in desperate need of kind of some organizing.
 -- The spares take care of finding the next ID to use so long as we don't forget to list IDs that have been freed up by refactoring.
@@ -1253,8 +1262,8 @@ MOD_ENHANCES_REFRESH   = 529 -- "Enhances Refresh" adds +1 per modifier to spell
 -- MOD_SPARE = 98, -- stuff
 -- MOD_SPARE = 99, -- stuff
 -- MOD_SPARE = 100, -- stuff
--- MOD_SPARE = 530, -- stuff
--- MOD_SPARE = 531, -- stuff
+-- MOD_SPARE = 539, -- stuff
+-- MOD_SPARE = 540, -- stuff
 
 ------------------------------------
 -- Merit Definitions

--- a/sql/item_armor.sql
+++ b/sql/item_armor.sql
@@ -10827,6 +10827,7 @@ INSERT INTO `item_armor` VALUES (28405,'ej_necklace_+1',99,0,5188164,0,0,0,512,0
 INSERT INTO `item_armor` VALUES (28406,'nuna_gorget',99,0,1758748,0,0,0,512,0);
 INSERT INTO `item_armor` VALUES (28407,'nuna_gorget_+1',99,0,1758748,0,0,0,512,0);
 INSERT INTO `item_armor` VALUES (28418,'incarnation_sash',99,0,153204,0,0,0,1024,0);
+INSERT INTO `item_armor` VALUES (28419,'hachirin-no-obi',71,0,4194303,0,0,0,1024,0);
 INSERT INTO `item_armor` VALUES (28440,'windbuffet_belt_+1',99,0,4194303,0,0,0,1024,0);
 INSERT INTO `item_armor` VALUES (28442,'olseni_belt',99,0,4194303,0,0,0,1024,0);
 INSERT INTO `item_armor` VALUES (28443,'yamabuki-no-obi',99,0,3851870,0,0,0,1024,0);

--- a/sql/item_basic.sql
+++ b/sql/item_basic.sql
@@ -16772,6 +16772,7 @@ INSERT INTO `item_basic` VALUES (28405,0,'ej_necklace_+1','ej_necklace_+1',1,208
 INSERT INTO `item_basic` VALUES (28406,0,'nuna_gorget','nuna_gorget',1,2080,0,1,0);
 INSERT INTO `item_basic` VALUES (28407,0,'nuna_gorget_+1','nuna_gorget_+1',1,2080,0,1,0);
 INSERT INTO `item_basic` VALUES (28418,0,'incarnation_sash','incarnation_sash',1,63552,0,1,0);
+INSERT INTO `item_basic` VALUES (28419,0,'hachirin-no-obi','hachirin-no-obi',1,55312,0,1,0);
 INSERT INTO `item_basic` VALUES (28440,0,'windbuffet_belt_+1','windbuffet_belt_+1',1,34816,99,0,0);
 INSERT INTO `item_basic` VALUES (28442,0,'olseni_belt','olseni_belt',1,63552,0,1,0);
 INSERT INTO `item_basic` VALUES (28443,0,'yamabuki-no-obi','yamabuki-no-obi',1,63568,0,1,0);

--- a/sql/item_mods.sql
+++ b/sql/item_mods.sql
@@ -15761,13 +15761,21 @@ INSERT INTO `item_mods` VALUES (15434,1,3);
 INSERT INTO `item_mods` VALUES (15434,8,3);
 INSERT INTO `item_mods` VALUES (15434,23,5);
 INSERT INTO `item_mods` VALUES (15435,1,7);
+INSERT INTO `item_mods` VALUES (15435,531,1); -- fire obi
 INSERT INTO `item_mods` VALUES (15436,1,7);
+INSERT INTO `item_mods` VALUES (15436,535,1); -- ice obi
 INSERT INTO `item_mods` VALUES (15437,1,7);
+INSERT INTO `item_mods` VALUES (15437,534,1); -- wind obi
 INSERT INTO `item_mods` VALUES (15438,1,7);
+INSERT INTO `item_mods` VALUES (15438,532,1); -- earth obi
 INSERT INTO `item_mods` VALUES (15439,1,7);
+INSERT INTO `item_mods` VALUES (15439,536,1); -- thunder obi
 INSERT INTO `item_mods` VALUES (15440,1,7);
+INSERT INTO `item_mods` VALUES (15440,533,1); -- water obi
 INSERT INTO `item_mods` VALUES (15441,1,7);
+INSERT INTO `item_mods` VALUES (15441,537,1); -- light obi
 INSERT INTO `item_mods` VALUES (15442,1,7);
+INSERT INTO `item_mods` VALUES (15442,538,1); -- dark obi
 INSERT INTO `item_mods` VALUES (15443,2,20);
 INSERT INTO `item_mods` VALUES (15443,5,20);
 INSERT INTO `item_mods` VALUES (15455,27,1);
@@ -35112,6 +35120,16 @@ INSERT INTO `item_mods` VALUES (28404,68,15);
 INSERT INTO `item_mods` VALUES (28405,25,16);
 INSERT INTO `item_mods` VALUES (28405,26,16);
 INSERT INTO `item_mods` VALUES (28405,68,16);
+INSERT INTO `item_mods` VALUES (28419,1,7);
+INSERT INTO `item_mods` VALUES (28419,530,1); -- hachirin-no-obi no MP cost %
+INSERT INTO `item_mods` VALUES (28419,531,1); -- start day/weather bonus forcing
+INSERT INTO `item_mods` VALUES (28419,532,1);
+INSERT INTO `item_mods` VALUES (28419,533,1);
+INSERT INTO `item_mods` VALUES (28419,534,1);
+INSERT INTO `item_mods` VALUES (28419,535,1);
+INSERT INTO `item_mods` VALUES (28419,536,1);
+INSERT INTO `item_mods` VALUES (28419,537,1);
+INSERT INTO `item_mods` VALUES (28419,538,1); -- end day/weather bonus forcing
 INSERT INTO `item_mods` VALUES (28440,1,9);
 INSERT INTO `item_mods` VALUES (28440,25,2);
 INSERT INTO `item_mods` VALUES (28440,302,2);

--- a/src/map/ai/states/magic_state.cpp
+++ b/src/map/ai/states/magic_state.cpp
@@ -327,6 +327,10 @@ int16 CMagicState::CalculateMPCost(CSpell* PSpell)
             cost += base * (m_PEntity->getMod(MOD_WHITE_MAGIC_COST)/100.0f);
         }
     }
+    if (dsprand::GetRandomNumber(100) < (m_PEntity->getMod(MOD_NO_SPELL_MP_DEPLETION)))
+    {
+        cost = 0;
+    }
     return dsp_cap(cost, 0, 9999);
 }
 

--- a/src/map/modifier.h
+++ b/src/map/modifier.h
@@ -571,6 +571,15 @@ enum MODIFIER
     MOD_AUGMENTS_SA               = 526, // Adds Critical Attack Bonus to Sneak Attack, percentage based.
     MOD_AUGMENTS_TA               = 527, // Adds Critical Attack Bonus to Trick Attack, percentage based.
     MOD_ENHANCES_REFRESH          = 529, // "Enhances Refresh" adds +1 per modifier to spell's tick result.
+    MOD_NO_SPELL_MP_DEPLETION     = 530, // % to not deplete MP on spellcast.
+    MOD_FORCE_FIRE_DWBONUS        = 531, // Set to 1 to force fire day/weather spell bonus/penalty. Do not have it total more than 1.
+    MOD_FORCE_EARTH_DWBONUS       = 532, // Set to 1 to force earth day/weather spell bonus/penalty. Do not have it total more than 1.
+    MOD_FORCE_WATER_DWBONUS       = 533, // Set to 1 to force water day/weather spell bonus/penalty. Do not have it total more than 1.
+    MOD_FORCE_WIND_DWBONUS        = 534, // Set to 1 to force wind day/weather spell bonus/penalty. Do not have it total more than 1.
+    MOD_FORCE_ICE_DWBONUS         = 535, // Set to 1 to force ice day/weather spell bonus/penalty. Do not have it total more than 1.
+    MOD_FORCE_LIGHTNING_DWBONUS   = 536, // Set to 1 to force lightning day/weather spell bonus/penalty. Do not have it total more than 1.
+    MOD_FORCE_LIGHT_DWBONUS       = 537, // Set to 1 to force light day/weather spell bonus/penalty. Do not have it total more than 1.
+    MOD_FORCE_DARK_DWBONUS        = 538, // Set to 1 to force dark day/weather spell bonus/penalty. Do not have it total more than 1.
 
     // MOD_SPARE = 92, // stuff
     // MOD_SPARE = 93, // stuff
@@ -581,8 +590,8 @@ enum MODIFIER
     // MOD_SPARE = 98, // stuff
     // MOD_SPARE = 99, // stuff
     // MOD_SPARE = 100, // stuff
-    // MOD_SPARE = 530, // stuff
-    // MOD_SPARE = 531, // stuff
+    // MOD_SPARE = 539, // stuff
+    // MOD_SPARE = 540, // stuff
 
 };
 


### PR DESCRIPTION
I changed the hardcoded IDs used to check for elemental obis as mods. This made it easier to implement the Hachirin-no-Obi, as well as cleaning up hardcoding.

Added Hachirin-no-Obi as an item and equipable item, as well as adding all of the new obi mods to it. The old obis received the one appropriate mod they should have.

Added a modifier for no MP depleted on cast as a % chance to activate, and gave it to the Hachirin-no-Obi (1%).

Fixed the bug where spells that were weak to the current day were getting a damage boost instead of penalty.