### PR TITLE
SCRIPTS: Removed respawn time for certain force spawned NM crawlers

### DIFF
--- a/scripts/zones/Crawlers_Nest/mobs/Awd_Goggie.lua
+++ b/scripts/zones/Crawlers_Nest/mobs/Awd_Goggie.lua
@@ -1,6 +1,4 @@
 -----------------------------------
--- Area:
--- NPC:  Awd_Goggie
 -- Area: Crawler's Nest
 -- NPC:  Awd Goggie
 -- @pos -253.026 -1.867 253.055 197
@@ -16,10 +14,17 @@ function onMobSpawn(mob)
 end;
 
 -----------------------------------
+-- onMobDespawn
+-----------------------------------
+
+function onMobDespawn(mob)
+     GetNPCByID(17584461):setStatus(STATUS_NORMAL); -- qm7
+end;
+
+-----------------------------------
 -- onMobDeath
 -----------------------------------
 
-function onMobDeath(mob, killer)
-	killer:addTitle(BOGEYDOWNER);
-	GetNPCByID(17584461):hideNPC(900); -- qm7
+function onMobDeath(mob,killer)
+    killer:addTitle(BOGEYDOWNER);
 end;

--- a/scripts/zones/Crawlers_Nest/mobs/Drone_Crawler.lua
+++ b/scripts/zones/Crawlers_Nest/mobs/Drone_Crawler.lua
@@ -14,21 +14,20 @@ function onMobSpawn(mob)
 end;
 
 -----------------------------------
+-- onMobDespawn
+-----------------------------------
+
+function onMobDespawn(mob)
+    if (mob:getID() == 17584131) then
+        GetNPCByID(17584457):setStatus(STATUS_NORMAL); -- qm3
+    elseif (mob:getID() == 17584132) then
+        GetNPCByID(17584458):setStatus(STATUS_NORMAL); -- qm4
+    end
+end;
+
+-----------------------------------
 -- onMobDeath
 -----------------------------------
 
-
 function onMobDeath(mob,killer)
-
-	mob = mob:getID();
-
-	if (mob == 17584131) then
-		GetNPCByID(17584457):hideNPC(900); -- qm3
-	elseif (mob == 17584132) then
-		GetNPCByID(17584458):hideNPC(900);-- qm4
-	end
-
 end;
-
-
-

--- a/scripts/zones/Crawlers_Nest/mobs/Guardian_Crawler.lua
+++ b/scripts/zones/Crawlers_Nest/mobs/Guardian_Crawler.lua
@@ -14,17 +14,20 @@ function onMobSpawn(mob)
 end;
 
 -----------------------------------
+-- onMobDespawn
+-----------------------------------
+
+function onMobDespawn(mob)
+    if (mob:getID() == 17584129) then
+        GetNPCByID(17584455):setStatus(STATUS_NORMAL); -- qm1
+    elseif (mob:getID() == 17584130) then
+        GetNPCByID(17584456):setStatus(STATUS_NORMAL); -- qm2
+    end
+end;
+
+-----------------------------------
 -- onMobDeath
 -----------------------------------
 
 function onMobDeath(mob,killer)
-
-	local mob = mob:getID();
-
-	if (mob == 17584129) then
-		GetNPCByID(17584455):hideNPC(900); -- qm1
-	elseif (mob == 17584130) then
-		GetNPCByID(17584456):hideNPC(900); -- qm2
-	end
-
 end;

--- a/scripts/zones/Crawlers_Nest/mobs/Matron_Crawler.lua
+++ b/scripts/zones/Crawlers_Nest/mobs/Matron_Crawler.lua
@@ -13,9 +13,16 @@ function onMobSpawn(mob)
 end;
 
 -----------------------------------
+-- onMobDespawn
+-----------------------------------
+
+function onMobDespawn(mob)
+     GetNPCByID(17584460):setStatus(STATUS_NORMAL); -- qm6
+end;
+
+-----------------------------------
 -- onMobDeath
 -----------------------------------
 
-function onMobDeath(mob, killer)
-	GetNPCByID(17584460):hideNPC(900); -- qm6
+function onMobDeath(mob,killer)
 end;

--- a/scripts/zones/Crawlers_Nest/mobs/Queen_Crawler.lua
+++ b/scripts/zones/Crawlers_Nest/mobs/Queen_Crawler.lua
@@ -13,9 +13,16 @@ function onMobSpawn(mob)
 end;
 
 -----------------------------------
+-- onMobDespawn
+-----------------------------------
+
+function onMobDespawn(mob)
+    GetNPCByID(17584459):setStatus(STATUS_NORMAL); -- qm5
+end;
+
+-----------------------------------
 -- onMobDeath
 -----------------------------------
 
 function onMobDeath(mob,killer)
-	GetNPCByID(17584459):hideNPC(900); -- qm5
 end;

--- a/scripts/zones/Crawlers_Nest/npcs/qm1.lua
+++ b/scripts/zones/Crawlers_Nest/npcs/qm1.lua
@@ -13,15 +13,16 @@ require("scripts/zones/Crawlers_Nest/TextIDs");
 -----------------------------------
 
 function onTrade(player,npc,trade)
-	-- Trade Rolanberry
-	if (GetMobAction(17584130) == 0 and trade:hasItemQty(4365,1) and trade:getItemCount() == 1) then  
-		player:tradeComplete();
-		if (math.random(1,100)<=38) then
-			SpawnMob(17584129,120):updateClaim(player); -- Guardian Crawler
-		else 
-			player:messageSpecial(NOTHING_SEEMS_TO_HAPPEN);				
-		end
-	end
+    -- Trade Rolanberry
+    if (GetMobAction(17584130) == 0 and trade:hasItemQty(4365,1) and trade:getItemCount() == 1) then  
+        player:tradeComplete();
+        if (math.random(1,100)<=38) then
+            SpawnMob(17584129,120):updateClaim(player); -- Guardian Crawler
+            npc:setStatus(STATUS_DISAPPEAR) -- hide ???
+        else
+            player:messageSpecial(NOTHING_SEEMS_TO_HAPPEN);				
+        end
+    end
 end; 
 
 -----------------------------------

--- a/scripts/zones/Crawlers_Nest/npcs/qm2.lua
+++ b/scripts/zones/Crawlers_Nest/npcs/qm2.lua
@@ -13,15 +13,16 @@ require("scripts/zones/Crawlers_Nest/TextIDs");
 -----------------------------------
 
 function onTrade(player,npc,trade)
-	-- Trade Rolanberry
-	if (GetMobAction(17584130) == 0 and trade:hasItemQty(4365,1) and trade:getItemCount() == 1) then   
-		player:tradeComplete();
-		if (math.random(1,100)<=38) then
-			SpawnMob(17584130,120):updateClaim(player); -- Guardian Crawler
-		else 
-			player:messageSpecial(NOTHING_SEEMS_TO_HAPPEN);				
-		end
-	end
+    -- Trade Rolanberry
+    if (GetMobAction(17584130) == 0 and trade:hasItemQty(4365,1) and trade:getItemCount() == 1) then   
+        player:tradeComplete();
+        if (math.random(1,100)<=38) then
+            SpawnMob(17584130,120):updateClaim(player); -- Guardian Crawler
+            npc:setStatus(STATUS_DISAPPEAR) -- hide ???
+        else 
+            player:messageSpecial(NOTHING_SEEMS_TO_HAPPEN);				
+        end
+    end
 end; 
 
 -----------------------------------

--- a/scripts/zones/Crawlers_Nest/npcs/qm3.lua
+++ b/scripts/zones/Crawlers_Nest/npcs/qm3.lua
@@ -13,15 +13,16 @@ require("scripts/zones/Crawlers_Nest/TextIDs");
 -----------------------------------
 
 function onTrade(player,npc,trade)
-	-- Trade Rolanberry 881
-	if (GetMobAction(17584132) == 0 and trade:hasItemQty(4529,1) and trade:getItemCount() == 1) then 
-		player:tradeComplete();
-		if (math.random(1,100)<=50) then
-			SpawnMob(17584131,120):updateClaim(player); -- Drone Crawler
-		else 
-			player:messageSpecial(NOTHING_SEEMS_TO_HAPPEN);				
-		end
-	end
+    -- Trade Rolanberry 881
+    if (GetMobAction(17584132) == 0 and trade:hasItemQty(4529,1) and trade:getItemCount() == 1) then 
+        player:tradeComplete();
+        if (math.random(1,100)<=50) then
+            SpawnMob(17584131,120):updateClaim(player); -- Drone Crawler
+            npc:setStatus(STATUS_DISAPPEAR) -- hide ???
+        else 
+            player:messageSpecial(NOTHING_SEEMS_TO_HAPPEN);				
+        end
+    end
 end; 
 
 -----------------------------------

--- a/scripts/zones/Crawlers_Nest/npcs/qm4.lua
+++ b/scripts/zones/Crawlers_Nest/npcs/qm4.lua
@@ -13,15 +13,16 @@ require("scripts/zones/Crawlers_Nest/TextIDs");
 -----------------------------------
 
 function onTrade(player,npc,trade)
-	-- Trade Rolanberry 881
-	if (GetMobAction(17584132) == 0 and trade:hasItemQty(4529,1) and trade:getItemCount() == 1) then 
-		player:tradeComplete();
-		if (math.random(1,100)<=50) then
-			SpawnMob(17584132,120):updateClaim(player); -- Drone Crawler
-		else 
-			player:messageSpecial(NOTHING_SEEMS_TO_HAPPEN);				
-		end
-	end
+    -- Trade Rolanberry 881
+    if (GetMobAction(17584132) == 0 and trade:hasItemQty(4529,1) and trade:getItemCount() == 1) then 
+        player:tradeComplete();
+        if (math.random(1,100)<=50) then
+            SpawnMob(17584132,120):updateClaim(player); -- Drone Crawler
+            npc:setStatus(STATUS_DISAPPEAR) -- hide ???
+        else 
+            player:messageSpecial(NOTHING_SEEMS_TO_HAPPEN);				
+        end
+    end
 end; 
 
 -----------------------------------

--- a/scripts/zones/Crawlers_Nest/npcs/qm5.lua
+++ b/scripts/zones/Crawlers_Nest/npcs/qm5.lua
@@ -13,15 +13,16 @@ require("scripts/zones/Crawlers_Nest/TextIDs");
 -----------------------------------
 
 function onTrade(player,npc,trade)
-	-- Trade Rolanberry 874
-	if (GetMobAction(17584133) == 0 and trade:hasItemQty(4530,1) and trade:getItemCount() == 1) then 
-		player:tradeComplete();
-		if (math.random(1,100)<=50) then
-			SpawnMob(17584133,120):updateClaim(player); -- Queen Crawler
-		else 
-			player:messageSpecial(NOTHING_SEEMS_TO_HAPPEN);				
-		end
-	end
+    -- Trade Rolanberry 874
+    if (GetMobAction(17584133) == 0 and trade:hasItemQty(4530,1) and trade:getItemCount() == 1) then 
+        player:tradeComplete();
+        if (math.random(1,100)<=50) then
+            SpawnMob(17584133,120):updateClaim(player); -- Queen Crawler
+            npc:setStatus(STATUS_DISAPPEAR) -- hide ???
+        else 
+            player:messageSpecial(NOTHING_SEEMS_TO_HAPPEN);				
+        end
+    end
 end; 
 
 -----------------------------------

--- a/scripts/zones/Crawlers_Nest/npcs/qm6.lua
+++ b/scripts/zones/Crawlers_Nest/npcs/qm6.lua
@@ -13,15 +13,16 @@ require("scripts/zones/Crawlers_Nest/TextIDs");
 -----------------------------------
 
 function onTrade(player,npc,trade)
-	-- Trade Rolanberry 874
-	if (GetMobAction(17584134) == 0 and trade:hasItemQty(4530,1) and trade:getItemCount() == 1) then 
-		player:tradeComplete();
-		if (math.random(1,100)<=34) then
-			SpawnMob(17584134,120):updateClaim(player); -- Matron Crawler
-		else 
-			player:messageSpecial(NOTHING_SEEMS_TO_HAPPEN);				
-		end
-	end
+    -- Trade Rolanberry 874
+    if (GetMobAction(17584134) == 0 and trade:hasItemQty(4530,1) and trade:getItemCount() == 1) then 
+        player:tradeComplete();
+        if (math.random(1,100)<=34) then
+            SpawnMob(17584134,120):updateClaim(player); -- Matron Crawler
+            npc:setStatus(STATUS_DISAPPEAR) -- hide ???
+        else 
+            player:messageSpecial(NOTHING_SEEMS_TO_HAPPEN);				
+        end
+    end
 end; 
 
 -----------------------------------

--- a/scripts/zones/Crawlers_Nest/npcs/qm7.lua
+++ b/scripts/zones/Crawlers_Nest/npcs/qm7.lua
@@ -13,15 +13,16 @@ require("scripts/zones/Crawlers_Nest/TextIDs");
 -----------------------------------
 
 function onTrade(player,npc,trade)
-	-- Trade Rolanberry 864
-	if (GetMobAction(17584135) == 0 and trade:hasItemQty(4531,1) and trade:getItemCount() == 1) then 
-		player:tradeComplete();
-		if (math.random(1,100)<=71) then
-			SpawnMob(17584135,120):updateClaim(player); -- Awd Goggie
-		else 
-			player:messageSpecial(NOTHING_SEEMS_TO_HAPPEN);				
-		end
-	end
+    -- Trade Rolanberry 864
+    if (GetMobAction(17584135) == 0 and trade:hasItemQty(4531,1) and trade:getItemCount() == 1) then 
+        player:tradeComplete();
+        if (math.random(1,100)<=73) then
+            SpawnMob(17584135,120):updateClaim(player); -- Awd Goggie
+            npc:setStatus(STATUS_DISAPPEAR) -- hide ???
+        else 
+            player:messageSpecial(NOTHING_SEEMS_TO_HAPPEN);				
+        end
+    end
 end; 
 
 -----------------------------------


### PR DESCRIPTION
Guardian Crawler, Drone Crawler, Queen Crawler, Matron Crawler, and Awd Goggie. According to retail, these ???s have no 15 min respawn; they disappear when the NM is successfully popped, and reappear after its death, able to be force popped immediately afterward. A player can continue to pop these as long as they have enough of the required rolanberries to do so.