### PR TITLE
Scripts: Remove full moon check from RNG AF weapon quest.

### DIFF
--- a/scripts/zones/Jugner_Forest/npcs/qm2.lua
+++ b/scripts/zones/Jugner_Forest/npcs/qm2.lua
@@ -26,7 +26,7 @@ function onTrigger(player,npc)
    
   	local SinHunting = player:getVar("sinHunting");	-- RNG AF1 
    
-	if (SinHunting == 4 and IsMoonFull() == true) then
+	if (SinHunting == 4) then
 		player:startEvent(0x000d, 0, 1107);		
 	end
 end;


### PR DESCRIPTION
It was removed from retail a year ago. http://ffxiclopedia.wikia.com/wiki/Sin_Hunting