### PR TITLE
Removed code that resets monster TP to zero when a monster has no skills to use

### DIFF
--- a/src/map/ai/ai_mob_dummy.cpp
+++ b/src/map/ai/ai_mob_dummy.cpp
@@ -715,20 +715,10 @@ void CAIMobDummy::ActionAbilityStart()
 
     std::vector<CMobSkill*> MobSkills = battleutils::GetMobSkillsByFamily(m_PMob->getMobMod(MOBMOD_SKILLS));
 
-    if (m_PMob->m_EcoSystem == SYSTEM_ELEMENTAL)
-    {
-        // elementals have no tp moves
-        m_PMob->health.tp = 0;
-        TransitionBack(true);
-        return;
-    }
-
     // не у всех монстов прописаны способности, так что выходим из процедуры, если способность не найдена
     // We don't have any skills we can use, so let's go back to attacking
     if (MobSkills.size() == 0)
     {
-        ShowWarning("CAIMobDummy::ActionAbilityStart No TP moves found for family (%d)\n", m_PMob->m_Family);
-        m_PMob->health.tp = 0;
         TransitionBack(true);
         return;
     }
@@ -854,7 +844,6 @@ void CAIMobDummy::ActionAbilityStart()
     if (!valid)
     {
         // couldn't find anything so go back to attack
-        m_PMob->health.tp = 0;
         TransitionBack(true);
         return;
     }


### PR DESCRIPTION
@teschnei I went ahead and removed the message too. Discovered that a few elemental type mobs from newer content the project does have implemented yet actually have a few TP moves, so checking the ecosystem had to go, and I didn't wanna see that message in log every time somebody fought an elemental nor go hunt down every script-less elemental first.