### PR TITLE
Scripts: Tenzen's Path KI bug fix + Sea requirement check

### DIFF
--- a/scripts/zones/Batallia_Downs/npcs/qm4.lua
+++ b/scripts/zones/Batallia_Downs/npcs/qm4.lua
@@ -14,12 +14,13 @@ require("scripts/globals/missions");
 -----------------------------------
 
 function onTrigger(player,npc)
-	if (player:getCurrentMission(COP) == THREE_PATHS  and  player:getVar("COP_Tenzen_s_Path") == 5) then	
-	 player:startEvent(0x0000);
-	elseif (player:getCurrentMission(COP) == THREE_PATHS  and  player:getVar("COP_Tenzen_s_Path") == 6 and player:hasKeyItem(DELKFUTT_RECOGNITION_DEVICE) == false) then	
-	 player:addKeyItem(DELKFUTT_RECOGNITION_DEVICE);
-	 player:messageSpecial(KEYITEM_OBTAINED,DELKFUTT_RECOGNITION_DEVICE);
-	end
+    local missionProgress = player:getVar("COP_Tenzen_s_Path")
+    if (player:getCurrentMission(COP) == THREE_PATHS and missionProgress == 5) then    
+        player:startEvent(0x0000);
+    elseif (player:getCurrentMission(COP) == THREE_PATHS and (missionProgress == 6 or missionProgress == 7) and player:hasKeyItem(DELKFUTT_RECOGNITION_DEVICE) == false) then    
+        player:addKeyItem(DELKFUTT_RECOGNITION_DEVICE);
+        player:messageSpecial(KEYITEM_OBTAINED,DELKFUTT_RECOGNITION_DEVICE);
+    end
 
 end;
 

--- a/scripts/zones/Konschtat_Highlands/npcs/Dimensional_Portal.lua
+++ b/scripts/zones/Konschtat_Highlands/npcs/Dimensional_Portal.lua
@@ -23,7 +23,7 @@ end;
 
 function onTrigger(player,npc)
 
-	if (player:hasKeyItem(LIGHT_OF_ALTAIEU) == true) or (DIMENSIONAL_PORTAL_UNLOCK == true) then
+	if (player:getCurrentMission(COP) > THE_WARRIOR_S_PATH) or (DIMENSIONAL_PORTAL_UNLOCK == true) then
 		player:startEvent(0x0393);
 	else
 		player:messageSpecial(ALREADY_OBTAINED_TELE+1); -- Telepoint Disappeared

--- a/scripts/zones/La_Theine_Plateau/npcs/Dimensional_Portal.lua
+++ b/scripts/zones/La_Theine_Plateau/npcs/Dimensional_Portal.lua
@@ -22,7 +22,7 @@ end;
 
 function onTrigger(player,npc)
 
-	if (player:hasKeyItem(LIGHT_OF_ALTAIEU) == true) or (DIMENSIONAL_PORTAL_UNLOCK == true) then
+	if (player:getCurrentMission(COP) > THE_WARRIOR_S_PATH) or (DIMENSIONAL_PORTAL_UNLOCK == true) then
         player:startEvent(0x00CC);
 	else
 		player:messageSpecial(ALREADY_OBTAINED_TELE+1); -- Telepoint Disappeared

--- a/scripts/zones/Mhaura/npcs/Wilhelm.lua
+++ b/scripts/zones/Mhaura/npcs/Wilhelm.lua
@@ -12,26 +12,26 @@ require("scripts/globals/armor_upgrade");
 -----------------------------------
 
 function onTrade(player,npc,trade)
-local armor=0;
-  if (trade:getItemCount() == 1) then
-      for n = 1,table.getn (LIMBUSARMOR),2 do
-	      if (trade:hasItemQty( LIMBUSARMOR[n] ,1) ) then
-		      armor=LIMBUSARMOR[n+1][1];
-          end
-      end
-  end
+    local armor = 0;
+    if (trade:getItemCount() == 1) then
+        for n = 1,table.getn (LIMBUSARMOR),2 do
+            if (trade:hasItemQty( LIMBUSARMOR[n] ,1) ) then
+                armor=LIMBUSARMOR[n+1][1];
+            end
+        end
+    end
   --print("armor"..armor);
- if (armor > 0) then 
-  if (player:getFreeSlotsCount()==0 or player:hasItem(armor) ) then	 
-         player:messageSpecial(ITEM_CANNOT_BE_OBTAINED,armor); 
-  else
-       if (armor == 15241 or armor == 14489 or armor == 14906 or armor == 15577 or armor == 15662) then  -- utlima
-          player:startEvent(0x0148,armor);
-       elseif (armor == 15576 or armor == 15661 or armor == 15240 or armor == 14905 or armor == 14488) then -- omega
-          player:startEvent(0x014A,armor);
-       end
- end   
-end
+    if (armor > 0) then 
+        if (player:getFreeSlotsCount()==0 or player:hasItem(armor) ) then     
+            player:messageSpecial(ITEM_CANNOT_BE_OBTAINED,armor); 
+        else
+            if (armor == 15241 or armor == 14489 or armor == 14906 or armor == 15577 or armor == 15662) then  -- utlima
+                player:startEvent(0x0148,armor);
+            elseif (armor == 15576 or armor == 15661 or armor == 15240 or armor == 14905 or armor == 14488) then -- omega
+                player:startEvent(0x014A,armor);
+            end
+        end   
+    end
 end;
 
 -----------------------------------
@@ -39,19 +39,19 @@ end;
 -----------------------------------
 
 function onTrigger(player,npc)
-    if (player:hasKeyItem(LIGHT_OF_ALTAIEU) == true or player:getCurrentMission(COP) > THE_WARRIOR_S_PATH) then
-	 player:startEvent(0x0146);
-	else
-	player:startEvent(0x0145);
-	end
-	
---Wilhelm 	325 default
---Wilhelm 	326 demande fragment de creature
---Wilhelm 	327
---Wilhelm 	328 apres trade fragment d'ultima
---Wilhelm 	329
---Wilhelm 	330  apres trade fragment omega
---Wilhelm 	331 
+    if (player:getCurrentMission(COP) > THE_WARRIOR_S_PATH) then
+        player:startEvent(0x0146);
+    else
+       player:startEvent(0x0145);
+    end
+    
+--Wilhelm     325 default
+--Wilhelm     326 demande fragment de creature
+--Wilhelm     327
+--Wilhelm     328 apres trade fragment d'ultima
+--Wilhelm     329
+--Wilhelm     330  apres trade fragment omega
+--Wilhelm     331 
 end;
 
 -----------------------------------
@@ -59,8 +59,8 @@ end;
 -----------------------------------
 
 function onEventUpdate(player,csid,option)
-	-- printf("CSID: %u",csid);
-	-- printf("RESULT: %u",option);
+    -- printf("CSID: %u",csid);
+    -- printf("RESULT: %u",option);
 end;
 
 -----------------------------------
@@ -68,13 +68,13 @@ end;
 -----------------------------------
 
 function onEventFinish(player,csid,option)
-	-- printf("CSID: %u",csid);
-	-- printf("RESULT: %u",option);
-	 
-	 if (csid== 0x0148 or csid == 0x014A) then
-	 	 player:addItem(option);
-	     player:messageSpecial(ITEM_OBTAINED,option);
-		 player:tradeComplete();
-	 end
+    -- printf("CSID: %u",csid);
+    -- printf("RESULT: %u",option);
+     
+    if (csid== 0x0148 or csid == 0x014A) then
+        player:addItem(option);
+        player:messageSpecial(ITEM_OBTAINED,option);
+        player:tradeComplete();
+     end
 end;
 

--- a/scripts/zones/Sealions_Den/npcs/_0w0.lua
+++ b/scripts/zones/Sealions_Den/npcs/_0w0.lua
@@ -33,7 +33,7 @@ function onTrigger(player,npc)
 		player:startEvent(0x000D);
 	elseif (EventTriggerBCNM(player,npc)) then
 		return;
-	elseif (player:hasKeyItem(LIGHT_OF_ALTAIEU) == true or player:getCurrentMission(COP) > THE_WARRIOR_S_PATH) then
+	elseif (player:getCurrentMission(COP) > THE_WARRIOR_S_PATH) then
 		player:startEvent(0x000C);
 	end	
 end;

--- a/scripts/zones/Tahrongi_Canyon/npcs/Dimensional_Portal.lua
+++ b/scripts/zones/Tahrongi_Canyon/npcs/Dimensional_Portal.lua
@@ -23,7 +23,7 @@ end;
 
 function onTrigger(player,npc)
 
-	if (player:hasKeyItem(LIGHT_OF_ALTAIEU) == true) or (DIMENSIONAL_PORTAL_UNLOCK == true) then
+	if (player:getCurrentMission(COP) > THE_WARRIOR_S_PATH) or (DIMENSIONAL_PORTAL_UNLOCK == true) then
 		player:startEvent(0x0393);
 	else
 		player:messageSpecial(ALREADY_OBTAINED_TELE+1); -- Telepoint Disappeared

--- a/scripts/zones/Tavnazian_Safehold/npcs/Meret.lua
+++ b/scripts/zones/Tavnazian_Safehold/npcs/Meret.lua
@@ -8,99 +8,100 @@ require("scripts/globals/keyitems");
 require("scripts/globals/quests");
 require("scripts/zones/Tavnazian_Safehold/TextIDs");
 
---Meret 	24A 586 recompense
+--Meret     24A 586 recompense
 local Sin_of_Indulgence=1915;
-local        FUTSUNO_MITAMA=17810;
-local Sin_of_Indolence=1914;	   
-local        AUREOLE=18245;
-local Sin_of_Invidiousness=1916;	   
-local        RAPHAEL_ROD=18398;
-local Sin_of_Indignation=1913;	   
-local        NINURTA_SASH=15458;
-local Sin_of_Insolence=1917;	   
-local        MARS_RING=15548;
-local Sin_of_Infatuation=1918;	   
-local        BELLONA_RING=15549;
-local Sin_of_Intemperance=1919;	   
-local        MINERVA_RING =15550;
-local Aura_of_Adulation=1911; 	   
-local        NOVIO_EARRING=14808;
-local Aura_of_Voracity=1912;	   
-local       NOVIA_EARRING =14809;
-local Vice_of_Antipathy=1901;	   
-local        MERCIFUL_CAPE=15471; 
-local Vice_of_Avarice=1902;	   
-local        ALTRUISTIC_CAPE=15472;
-local Vice_of_Aspersion=1903; 	   
-local        ASTUTE_CAPE=15473; 
-	
-  --------------------------------------  
- local    AERN_ORGAN=1786;
- local    EUVHI_ORGAN=1818;
- local    HPEMDE_ORGAN=1787;
- local    PHUABO_ORGAN=1784;
- local    XZOMIT_ORGAN=1785;
- local    YOVRA_ORGAN=1788;
- local    LUMINON_Chip=1819;
- local    LUMINIAN_Tissue=1783;
- local 	    VIRTUE_STONE_POUCH=5410;
+local FUTSUNO_MITAMA=17810;
+local Sin_of_Indolence=1914;       
+local AUREOLE=18245;
+local Sin_of_Invidiousness=1916;       
+local RAPHAEL_ROD=18398;
+local Sin_of_Indignation=1913;       
+local NINURTA_SASH=15458;
+local Sin_of_Insolence=1917;       
+local MARS_RING=15548;
+local Sin_of_Infatuation=1918;       
+local BELLONA_RING=15549;
+local Sin_of_Intemperance=1919;       
+local MINERVA_RING =15550;
+local Aura_of_Adulation=1911;        
+local NOVIO_EARRING=14808;
+local Aura_of_Voracity=1912;       
+local NOVIA_EARRING =14809;
+local Vice_of_Antipathy=1901;       
+local MERCIFUL_CAPE=15471; 
+local Vice_of_Avarice=1902;       
+local ALTRUISTIC_CAPE=15472;
+local Vice_of_Aspersion=1903;        
+local ASTUTE_CAPE=15473; 
+    
+--------------------------------------  
+local AERN_ORGAN=1786;
+local EUVHI_ORGAN=1818;
+local HPEMDE_ORGAN=1787;
+local PHUABO_ORGAN=1784;
+local XZOMIT_ORGAN=1785;
+local YOVRA_ORGAN=1788;
+local LUMINON_Chip=1819;
+local LUMINIAN_Tissue=1783;
+local VIRTUE_STONE_POUCH=5410;
 -----------------------------------
 -- onTrade Action
 -----------------------------------
 
 function onTrade(player,npc,trade)
-local reward = 0;
-local item = 0;
-local NameOfScience = player:getQuestStatus(OTHER_AREAS,IN_THE_NAME_OF_SCIENCE);
-  if (NameOfScience == QUEST_COMPLETED and trade:getItemCount()==1) then
-    if (trade:hasItemQty(Sin_of_Indulgence,1)) then
-     item = Sin_of_Indulgence; reward = FUTSUNO_MITAMA;
-    elseif (trade:hasItemQty(Sin_of_Indolence,1)) then	   
-     item = Sin_of_Indolence; reward = AUREOLE;
-    elseif (trade:hasItemQty(Sin_of_Invidiousness,1)) then  
-      item = Sin_of_Invidiousness;reward = RAPHAEL_ROD;
-    elseif (trade:hasItemQty(Sin_of_Indignation,1)) then	   
-      item = Sin_of_Indignation;reward = NINURTA_SASH;
-    elseif (trade:hasItemQty(Sin_of_Insolence,1)) then  
-      item = Sin_of_Insolence;reward = MARS_RING;
-    elseif (trade:hasItemQty(Sin_of_Infatuation,1)) then	   
-     item = Sin_of_Infatuation; reward = BELLONA_RING;
-    elseif (trade:hasItemQty(Sin_of_Intemperance,1)) then	   
-     item = Sin_of_Intemperance; reward = MINERVA_RING;
-    elseif (trade:hasItemQty(Aura_of_Adulation,1)) then	   
-      item = Aura_of_Adulation;reward = NOVIO_EARRING;
-    elseif (trade:hasItemQty(Aura_of_Voracity,1)) then  
-      item = Aura_of_Voracity;reward = NOVIA_EARRING; 
-    elseif (trade:hasItemQty(Vice_of_Antipathy,1)) then  
-      item = Vice_of_Antipathy;reward = MERCIFUL_CAPE; 
-    elseif (trade:hasItemQty(Vice_of_Avarice,1)) then	   
-      item = Vice_of_Avarice;reward = ALTRUISTIC_CAPE;
-    elseif (trade:hasItemQty(Vice_of_Aspersion,1)) then	   
-     item = Vice_of_Aspersio;reward = ASTUTE_CAPE;
-	
-  --------------------------------------  
-    elseif (trade:hasItemQty(AERN_ORGAN,1)) then
-	     item =AERN_ORGAN; reward = VIRTUE_STONE_POUCH;
-	elseif (trade:hasItemQty(EUVHI_ORGAN,1)) then
-	     item =EUVHI_ORGAN; reward = VIRTUE_STONE_POUCH;
-	elseif (trade:hasItemQty(HPEMDE_ORGAN,1)) then
-	     item =HPEMDE_ORGAN; reward = VIRTUE_STONE_POUCH;
-    elseif (trade:hasItemQty(PHUABO_ORGAN,1)) then
-	     item =PHUABO_ORGAN; reward = VIRTUE_STONE_POUCH;
-	elseif (trade:hasItemQty(XZOMIT_ORGAN,1)) then
-	     item =XZOMIT_ORGAN; reward = VIRTUE_STONE_POUCH;
-	elseif ( trade:hasItemQty(YOVRA_ORGAN,1)) then
-	     item =YOVRA_ORGAN; reward = VIRTUE_STONE_POUCH;
-    elseif (trade:hasItemQty(LUMINON_Chip,1)) then
-	     item =LUMINON_Chip; reward = VIRTUE_STONE_POUCH;
-	elseif (trade:hasItemQty(LUMINIAN_Tissue,1)) then
-         item =LUMINIAN_Tissue; reward = VIRTUE_STONE_POUCH;
+    local reward = 0;
+    local item = 0;
+    local NameOfScience = player:getQuestStatus(OTHER_AREAS,IN_THE_NAME_OF_SCIENCE);
+
+    if (NameOfScience == QUEST_COMPLETED and trade:getItemCount()==1) then
+        if (trade:hasItemQty(Sin_of_Indulgence,1)) then
+            item = Sin_of_Indulgence; reward = FUTSUNO_MITAMA;
+        elseif (trade:hasItemQty(Sin_of_Indolence,1)) then       
+            item = Sin_of_Indolence; reward = AUREOLE;
+        elseif (trade:hasItemQty(Sin_of_Invidiousness,1)) then  
+            item = Sin_of_Invidiousness;reward = RAPHAEL_ROD;
+        elseif (trade:hasItemQty(Sin_of_Indignation,1)) then       
+            item = Sin_of_Indignation;reward = NINURTA_SASH;
+        elseif (trade:hasItemQty(Sin_of_Insolence,1)) then  
+            item = Sin_of_Insolence;reward = MARS_RING;
+        elseif (trade:hasItemQty(Sin_of_Infatuation,1)) then       
+            item = Sin_of_Infatuation; reward = BELLONA_RING;
+        elseif (trade:hasItemQty(Sin_of_Intemperance,1)) then       
+            item = Sin_of_Intemperance; reward = MINERVA_RING;
+        elseif (trade:hasItemQty(Aura_of_Adulation,1)) then       
+            item = Aura_of_Adulation;reward = NOVIO_EARRING;
+        elseif (trade:hasItemQty(Aura_of_Voracity,1)) then  
+            item = Aura_of_Voracity;reward = NOVIA_EARRING; 
+        elseif (trade:hasItemQty(Vice_of_Antipathy,1)) then  
+            item = Vice_of_Antipathy;reward = MERCIFUL_CAPE; 
+        elseif (trade:hasItemQty(Vice_of_Avarice,1)) then       
+            item = Vice_of_Avarice;reward = ALTRUISTIC_CAPE;
+        elseif (trade:hasItemQty(Vice_of_Aspersion,1)) then       
+            item = Vice_of_Aspersio;reward = ASTUTE_CAPE;
+    
+  --------------virtue stones------------------------  
+        elseif (trade:hasItemQty(AERN_ORGAN,1)) then
+            item =AERN_ORGAN; reward = VIRTUE_STONE_POUCH;
+        elseif (trade:hasItemQty(EUVHI_ORGAN,1)) then
+            item =EUVHI_ORGAN; reward = VIRTUE_STONE_POUCH;
+        elseif (trade:hasItemQty(HPEMDE_ORGAN,1)) then
+            item =HPEMDE_ORGAN; reward = VIRTUE_STONE_POUCH;
+        elseif (trade:hasItemQty(PHUABO_ORGAN,1)) then
+            item =PHUABO_ORGAN; reward = VIRTUE_STONE_POUCH;
+        elseif (trade:hasItemQty(XZOMIT_ORGAN,1)) then
+            item =XZOMIT_ORGAN; reward = VIRTUE_STONE_POUCH;
+        elseif ( trade:hasItemQty(YOVRA_ORGAN,1)) then
+            item =YOVRA_ORGAN; reward = VIRTUE_STONE_POUCH;
+        elseif (trade:hasItemQty(LUMINON_Chip,1)) then
+            item =LUMINON_Chip; reward = VIRTUE_STONE_POUCH;
+        elseif (trade:hasItemQty(LUMINIAN_Tissue,1)) then
+            item =LUMINIAN_Tissue; reward = VIRTUE_STONE_POUCH;
+        end
+    
+        if (reward > 0) then
+            player:startEvent(0x024A,item,reward);
+        end
     end
-	
-	if (reward > 0) then
-	  player:startEvent(0x024A,item,reward);
-	end
-  end
 end; 
 
 -----------------------------------
@@ -108,20 +109,20 @@ end;
 -----------------------------------
 
 function onTrigger(player,npc)
-local NameOfScience = player:getQuestStatus(OTHER_AREAS,IN_THE_NAME_OF_SCIENCE);
-local rnd= math.random();
-    if (player:hasKeyItem(LIGHT_OF_ALTAIEU)) then
-	  if (NameOfScience == QUEST_COMPLETED) then
-	    if (rnd < 0.5) then
-		 player:startEvent(0x0246);
-		else
-		 player:startEvent(0x0247);
-		end
-	  else
-	  player:startEvent(0x0249);
-	  end	   
-	else
-     player:startEvent(0x0248);
+    local NameOfScience = player:getQuestStatus(OTHER_AREAS,IN_THE_NAME_OF_SCIENCE);
+    local rnd= math.random();
+    if (player:getCurrentMission(COP) > THE_WARRIOR_S_PATH) then
+        if (NameOfScience == QUEST_COMPLETED) then
+            if (rnd < 0.5) then
+                player:startEvent(0x0246);
+            else
+                player:startEvent(0x0247);
+            end
+        else
+            player:startEvent(0x0249);
+        end       
+    else
+        player:startEvent(0x0248);
     end
 end; 
 
@@ -141,16 +142,13 @@ end;
 function onEventFinish(player,csid,option)
 --printf("CSID: %u",csid);
 --printf("RESULT: %u",option);
-   if (csid == 0x024A) then
-    if (player:getFreeSlotsCount()==0 or (option ~= VIRTUE_STONE_POUCH and player:hasItem(option)==true)) then
-        player:messageSpecial(ITEM_CANNOT_BE_OBTAINED,option); 
-    else
-	 player:tradeComplete();
-     player:addItem(option);
-     player:messageSpecial(ITEM_OBTAINED,option); -- Item 
-	 end
-   end
+    if (csid == 0x024A) then
+        if (player:getFreeSlotsCount()==0 or (option ~= VIRTUE_STONE_POUCH and player:hasItem(option)==true)) then
+            player:messageSpecial(ITEM_CANNOT_BE_OBTAINED,option); 
+        else
+        player:tradeComplete();
+        player:addItem(option);
+        player:messageSpecial(ITEM_OBTAINED,option); -- Item 
+        end
+    end
 end;
-
-
-

--- a/scripts/zones/Tavnazian_Safehold/npcs/Yurim.lua
+++ b/scripts/zones/Tavnazian_Safehold/npcs/Yurim.lua
@@ -11,7 +11,7 @@ require("scripts/zones/Tavnazian_Safehold/TextIDs");
                      --reward              tradebase   tradeChip                     tradeOrgane1          tradeOrgane2            tradeOrgane3        tradeOrgane4
 --Relaxing Earring     14792; Silver Earring 13327;  Black Chip  481; Luminian Tissue x5 1783; Euvhi Organ x5  1818; 
 --Sanative Earring     14791; Silver Earring 13327;  White Chip  480; Luminian Tissue x5 1783; Euvhi Organ x5  1818; 
---Karin Obi: (Fire)    15435; Silver Obi 	 13205;  Red Chip 	 474; Phuabo Organ x7    1784; Xzomit Organ x3 1785; Luminian Tissue x3 1783;
+--Karin Obi: (Fire)    15435; Silver Obi      13205;  Red Chip      474; Phuabo Organ x7    1784; Xzomit Organ x3 1785; Luminian Tissue x3 1783;
 --Dorin Obi: (Earth)   15438; Silver Obi     13205;  Yellow Chip 476; Hpemde Organ x7    1787; Aern Organ x3   1786; Luminian Tissue x3 1783;
 --Suirin Obi: (Water)  15440; Silver Obi     13205;  Blue Chip   475; Hpemde Organ x7    1787; Phuabo Organ x3 1784; Luminian Tissue x3 1783;
 --Furin Obi: (Wind)    15437; Silver Obi     13205;  Green Chip  477; Aern Organ x7      1786; Hpemde Organ x3 1787; Luminian Tissue x3 1783;
@@ -19,14 +19,14 @@ require("scripts/zones/Tavnazian_Safehold/TextIDs");
 --Rairin Obi: (Thunder)15439; Silver Obi     13205;  Purple Chip 479; Phuabo Organ x7    1784; Hpemde Organ x3 1787; Luminian Tissue x3 1783;
 --Korin Obi: (Light)   15441; Silver Obi     13205;  White Chip  480; Xzomit Organ x7    1785; Aern Organ x3   1786; Luminian Tissue x3 1783;
 --Anrin Obi: (Dark)    15442; Silver Obi     13205;  Black Chip  481; Aern Organ x7      1786; Xzomit Organ x3 1785; Luminian Tissue x3 1783;
---Flame Gorget:        15495; Gorget 	     13080;  Red Chip 	 474; Phuabo Organ x10   1784; Xzomit Organ x5 1785; Yovra Organ x1     1788;
---Soil Gorget:         15498; Gorget 	     13080;  Yellow Chip 476; Xzomit Organ x10   1785; Aern Organ x5   1786; Yovra Organ x1     1788;
---Aqua Gorget:         15500; Gorget 	     13080;  Blue Chip 	 475; Aern Organ x10     1786; Hpemde Organ x5 1787; Yovra Organ x1     1788;
---Breeze Gorget:       15497; Gorget 	     13080;  Green Chip  477; Phuabo Organ x10   1784; Hpemde Organ x5 1787; Yovra Organ x1     1788;
---Snow Gorget:         15496; Gorget 	     13080;  Clear Chip  478; Phuabo Organ x10   1784; Aern Organ x5   1786; Yovra Organ x1     1788;
---Thunder Gorget:      15499; Gorget 	     13080;  Purple Chip 479; Xzomit Organ x10   1785; Hpemde Organ x5 1787; Yovra Organ x1     1788;
---Light Gorget:        15501; Gorget 	     13080;  White Chip  480; Aern Organ x7      1786; Phuabo Organ x3 1784; Hpemde Organ x3    1787; Yovra Organ x2  1788;
---Shadow Gorget:       15502; Gorget 	     13080;  Black Chip  481; Hpemde Organ x7    1787; Phuabo Organ x3 1784; Aern Organ x3      1786; Yovra Organ x2  1788;
+--Flame Gorget:        15495; Gorget          13080;  Red Chip      474; Phuabo Organ x10   1784; Xzomit Organ x5 1785; Yovra Organ x1     1788;
+--Soil Gorget:         15498; Gorget          13080;  Yellow Chip 476; Xzomit Organ x10   1785; Aern Organ x5   1786; Yovra Organ x1     1788;
+--Aqua Gorget:         15500; Gorget          13080;  Blue Chip      475; Aern Organ x10     1786; Hpemde Organ x5 1787; Yovra Organ x1     1788;
+--Breeze Gorget:       15497; Gorget          13080;  Green Chip  477; Phuabo Organ x10   1784; Hpemde Organ x5 1787; Yovra Organ x1     1788;
+--Snow Gorget:         15496; Gorget          13080;  Clear Chip  478; Phuabo Organ x10   1784; Aern Organ x5   1786; Yovra Organ x1     1788;
+--Thunder Gorget:      15499; Gorget          13080;  Purple Chip 479; Xzomit Organ x10   1785; Hpemde Organ x5 1787; Yovra Organ x1     1788;
+--Light Gorget:        15501; Gorget          13080;  White Chip  480; Aern Organ x7      1786; Phuabo Organ x3 1784; Hpemde Organ x3    1787; Yovra Organ x2  1788;
+--Shadow Gorget:       15502; Gorget          13080;  Black Chip  481; Hpemde Organ x7    1787; Phuabo Organ x3 1784; Aern Organ x3      1786; Yovra Organ x2  1788;
 local LUMINIAN_TISSUE = 1783;
 local PHUABOS_ORGAN = 1784;
 local HPEMDE_ORGAN = 1787;
@@ -63,195 +63,196 @@ local ANRIN_OBI =15442; local SHADOW_GORGET= 15502;
 local APPLE_PIE = 4413;
 
 function getNOS(itemtarget,item)
-  local returnITEM;
- if (itemtarget == RELAXING_EARRING) then 
-   returnITEM={SILVER_EARRING,BLACK_CHIP};
- elseif (itemtarget == SANATIVE_EARRING) then 
-   returnITEM={SILVER_EARRING,WHITE_CHIP};
- elseif (itemtarget == KARIN_OBI) then 
-   returnITEM={SILVER_OBI,RED_CHIP};
- elseif (itemtarget == DORIN_OBI) then 
-   returnITEM={SILVER_OBI,YELLOW_CHIP};
- elseif (itemtarget == SUIRIN_OBI) then 
-   returnITEM={SILVER_OBI,BLUE_CHIP};
- elseif (itemtarget == FURIN_OBI) then 
-   returnITEM={SILVER_OBI,GREEN_CHIP};
- elseif (itemtarget == HYORIN_OBI) then 
-   returnITEM={SILVER_OBI,CLEAR_CHIP};
- elseif (itemtarget == RAIRIN_OBI) then 
-   returnITEM={SILVER_OBI,PURPLE_CHIP}; 
- elseif (itemtarget == KORIN_OBI) then 
-   returnITEM={SILVER_OBI,WHITE_CHIP};
- elseif (itemtarget == ANRIN_OBI) then 
-   returnITEM={SILVER_OBI,BLACK_CHIP};
- elseif (itemtarget == FLAME_GORGET) then 
-   returnITEM={GORGET,RED_CHIP};
- elseif (itemtarget == SOIL_GORGET) then 
-   returnITEM={GORGET,YELLOW_CHIP};
- elseif (itemtarget == AQUA_GORGET) then 
-   returnITEM={GORGET,BLUE_CHIP};
- elseif (itemtarget == BREEZE_GORGET) then 
-   returnITEM={GORGET,GREEN_CHIP}; 
- elseif (itemtarget == SNOW_GORGET) then 
-   returnITEM={GORGET,CLEAR_CHIP};
- elseif (itemtarget == THUNDER_GORGET) then 
-   returnITEM={GORGET,PURPLE_CHIP};
- elseif (itemtarget == LIGHT_GORGET) then 
-   returnITEM={GORGET,WHITE_CHIP};
- elseif (itemtarget == SHADOW_GORGET) then 
-   returnITEM={GORGET,BLACK_CHIP};
- end
-       return returnITEM[item];
+    local returnITEM;
+    if (itemtarget == RELAXING_EARRING) then 
+        returnITEM={SILVER_EARRING,BLACK_CHIP};
+    elseif (itemtarget == SANATIVE_EARRING) then 
+        returnITEM={SILVER_EARRING,WHITE_CHIP};
+    elseif (itemtarget == KARIN_OBI) then 
+        returnITEM={SILVER_OBI,RED_CHIP};
+    elseif (itemtarget == DORIN_OBI) then 
+        returnITEM={SILVER_OBI,YELLOW_CHIP};
+    elseif (itemtarget == SUIRIN_OBI) then 
+        returnITEM={SILVER_OBI,BLUE_CHIP};
+    elseif (itemtarget == FURIN_OBI) then 
+        returnITEM={SILVER_OBI,GREEN_CHIP};
+    elseif (itemtarget == HYORIN_OBI) then 
+        returnITEM={SILVER_OBI,CLEAR_CHIP};
+    elseif (itemtarget == RAIRIN_OBI) then 
+        returnITEM={SILVER_OBI,PURPLE_CHIP}; 
+    elseif (itemtarget == KORIN_OBI) then 
+        returnITEM={SILVER_OBI,WHITE_CHIP};
+    elseif (itemtarget == ANRIN_OBI) then 
+        returnITEM={SILVER_OBI,BLACK_CHIP};
+    elseif (itemtarget == FLAME_GORGET) then 
+        returnITEM={GORGET,RED_CHIP};
+    elseif (itemtarget == SOIL_GORGET) then 
+        returnITEM={GORGET,YELLOW_CHIP};
+    elseif (itemtarget == AQUA_GORGET) then 
+        returnITEM={GORGET,BLUE_CHIP};
+    elseif (itemtarget == BREEZE_GORGET) then 
+        returnITEM={GORGET,GREEN_CHIP}; 
+    elseif (itemtarget == SNOW_GORGET) then 
+        returnITEM={GORGET,CLEAR_CHIP};
+    elseif (itemtarget == THUNDER_GORGET) then 
+        returnITEM={GORGET,PURPLE_CHIP};
+    elseif (itemtarget == LIGHT_GORGET) then 
+        returnITEM={GORGET,WHITE_CHIP};
+    elseif (itemtarget == SHADOW_GORGET) then 
+        returnITEM={GORGET,BLACK_CHIP};
+    end
+
+    return returnITEM[item];
 end;
 ----------------------------------
 -- onTrade Action
 -----------------------------------
 function onTrade(player,npc,trade)
-local NameOfScience = player:getQuestStatus(OTHER_AREAS,IN_THE_NAME_OF_SCIENCE); 
-local count = trade:getItemCount(); --nombre d'objet total
-local itemtarget = player:getVar("NAME_OF_SCIENCE_target");
-local reward = false;
+    local NameOfScience = player:getQuestStatus(OTHER_AREAS,IN_THE_NAME_OF_SCIENCE); 
+    local count = trade:getItemCount(); --nombre d'objet total
+    local itemtarget = player:getVar("NAME_OF_SCIENCE_target");
+    local reward = false;
 -- printf("count: %u",count);
 -----------------------------------------trade the chip and the base item---------------------------------------------------------------------
-   if ((NameOfScience == QUEST_ACCEPTED or NameOfScience == QUEST_COMPLETED) and count == 2 and itemtarget == 0) then  
-       if (trade:hasItemQty(SILVER_EARRING,1)) then 
-	       if (trade:hasItemQty(BLACK_CHIP,1) and player:hasItem(RELAXING_EARRING)==false) then 
-		      player:setVar("NAME_OF_SCIENCE_target",RELAXING_EARRING); player:tradeComplete(); player:startEvent(0x020E,SILVER_EARRING,BLACK_CHIP);
-		   elseif (trade:hasItemQty(WHITE_CHIP,1) and player:hasItem(SANATIVE_EARRING)==false) then
-		      player:setVar("NAME_OF_SCIENCE_target",SANATIVE_EARRING); player:tradeComplete(); player:startEvent(0x020E,SILVER_EARRING,WHITE_CHIP);
-		   elseif (trade:hasItemQty(RED_CHIP,1) and player:hasItem(SANATIVE_EARRING)==false) then
-		      player:setVar("NAME_OF_SCIENCE_target",SANATIVE_EARRING); player:tradeComplete(); player:startEvent(0x020E,SILVER_EARRING,RED_CHIP);
-		   elseif (trade:hasItemQty(YELLOW_CHIP,1) and player:hasItem(RELAXING_EARRING)==false) then
-		      player:setVar("NAME_OF_SCIENCE_target",RELAXING_EARRING); player:tradeComplete(); player:startEvent(0x020E,SILVER_EARRING,YELLOW_CHIP);
-		   elseif (trade:hasItemQty(BLUE_CHIP,1) and player:hasItem(RELAXING_EARRING)==false) then
-		      player:setVar("NAME_OF_SCIENCE_target",RELAXING_EARRING); player:tradeComplete(); player:startEvent(0x020E,SILVER_EARRING,BLUE_CHIP);
-		   elseif (trade:hasItemQty(GREEN_CHIP,1) and player:hasItem(SANATIVE_EARRING)==false) then
-		      player:setVar("NAME_OF_SCIENCE_target",SANATIVE_EARRING); player:tradeComplete(); player:startEvent(0x020E,SILVER_EARRING,GREEN_CHIP);
-		   elseif (trade:hasItemQty(CLEAR_CHIP,1) and player:hasItem(RELAXING_EARRING)==false) then
-		      player:setVar("NAME_OF_SCIENCE_target",RELAXING_EARRING); player:tradeComplete(); player:startEvent(0x020E,SILVER_EARRING,CLEAR_CHIP);
-		   elseif (trade:hasItemQty(PURPLE_CHIP,1) and player:hasItem(SANATIVE_EARRING)==false) then
-		      player:setVar("NAME_OF_SCIENCE_target",SANATIVE_EARRING); player:tradeComplete(); player:startEvent(0x020E,SILVER_EARRING,PURPLE_CHIP);
-		   end
-       elseif (trade:hasItemQty(SILVER_OBI,1)) then	   
-	       if (trade:hasItemQty(BLACK_CHIP,1) and player:hasItem(ANRIN_OBI)==false) then
-		      player:setVar("NAME_OF_SCIENCE_target",ANRIN_OBI); player:tradeComplete(); player:startEvent(0x020E,SILVER_OBI,BLACK_CHIP);
-	       elseif (trade:hasItemQty(WHITE_CHIP,1) and player:hasItem(KORIN_OBI)==false) then
-		      player:setVar("NAME_OF_SCIENCE_target",KORIN_OBI); player:tradeComplete(); player:startEvent(0x020E,SILVER_OBI,WHITE_CHIP);
-		   elseif (trade:hasItemQty(RED_CHIP,1) and player:hasItem(KARIN_OBI)==false) then
-		      player:setVar("NAME_OF_SCIENCE_target",KARIN_OBI); player:tradeComplete(); player:startEvent(0x020E,SILVER_OBI,RED_CHIP);
-		   elseif (trade:hasItemQty(YELLOW_CHIP,1) and player:hasItem(DORIN_OBI)==false) then
-		      player:setVar("NAME_OF_SCIENCE_target",DORIN_OBI); player:tradeComplete(); player:startEvent(0x020E,SILVER_OBI,YELLOW_CHIP);
-		   elseif (trade:hasItemQty(BLUE_CHIP,1) and player:hasItem(SUIRIN_OBI)==false) then
-		      player:setVar("NAME_OF_SCIENCE_target",SUIRIN_OBI); player:tradeComplete(); player:startEvent(0x020E,SILVER_OBI,BLUE_CHIP);
-		   elseif (trade:hasItemQty(GREEN_CHIP,1) and player:hasItem(FURIN_OBI)==false) then
-		      player:setVar("NAME_OF_SCIENCE_target",FURIN_OBI); player:tradeComplete(); player:startEvent(0x020E,SILVER_OBI,GREEN_CHIP);
-		   elseif (trade:hasItemQty(CLEAR_CHIP,1) and player:hasItem(HYORIN_OBI)==false) then
-		      player:setVar("NAME_OF_SCIENCE_target",HYORIN_OBI); player:tradeComplete(); player:startEvent(0x020E,SILVER_OBI,CLEAR_CHIP);
-		   elseif (trade:hasItemQty(PURPLE_CHIP,1) and player:hasItem(RAIRIN_OBI)==false) then
-		      player:setVar("NAME_OF_SCIENCE_target",RAIRIN_OBI); player:tradeComplete(); player:startEvent(0x020E,SILVER_OBI,PURPLE_CHIP);
-		   end
-       elseif (trade:hasItemQty(GORGET,1)) then 
-	      	if (trade:hasItemQty(BLACK_CHIP,1) and player:hasItem(SHADOW_GORGET)==false) then
-		      player:setVar("NAME_OF_SCIENCE_target",SHADOW_GORGET); player:tradeComplete(); player:startEvent(0x020E,GORGET,BLACK_CHIP);
-	       elseif (trade:hasItemQty(WHITE_CHIP,1) and player:hasItem(LIGHT_GORGET)==false) then
-		      player:setVar("NAME_OF_SCIENCE_target",LIGHT_GORGET); player:tradeComplete(); player:startEvent(0x020E,GORGET,WHITE_CHIP);
-		   elseif (trade:hasItemQty(RED_CHIP,1) and player:hasItem(FLAME_GORGET)==false) then
-		      player:setVar("NAME_OF_SCIENCE_target",FLAME_GORGET); player:tradeComplete(); player:startEvent(0x020E,GORGET,RED_CHIP);
-		   elseif (trade:hasItemQty(YELLOW_CHIP,1) and player:hasItem(SOIL_GORGET)==false) then
-		      player:setVar("NAME_OF_SCIENCE_target",SOIL_GORGET); player:tradeComplete(); player:startEvent(0x020E,GORGET,YELLOW_CHIP);
-		   elseif (trade:hasItemQty(BLUE_CHIP,1) and player:hasItem(AQUA_GORGET)==false) then
-		      player:setVar("NAME_OF_SCIENCE_target",AQUA_GORGET); player:tradeComplete(); player:startEvent(0x020E,GORGET,BLUE_CHIP);
-		   elseif (trade:hasItemQty(GREEN_CHIP,1) and player:hasItem(BREEZE_GORGET)==false) then
-		      player:setVar("NAME_OF_SCIENCE_target",BREEZE_GORGET); player:tradeComplete(); player:startEvent(0x020E,GORGET,GREEN_CHIP);
-		   elseif (trade:hasItemQty(CLEAR_CHIP,1) and player:hasItem(SNOW_GORGET)==false) then
-		      player:setVar("NAME_OF_SCIENCE_target",SNOW_GORGET); player:tradeComplete(); player:startEvent(0x020E,GORGET,CLEAR_CHIP);
-		   elseif (trade:hasItemQty(PURPLE_CHIP,1) and player:hasItem(THUNDER_GORGET)==false) then
-		      player:setVar("NAME_OF_SCIENCE_target",THUNDER_GORGET); player:tradeComplete(); player:startEvent(0x020E,GORGET,PURPLE_CHIP);
-		   end  
-	   end
-----------------------------------------------------------------------------------------------------------------------------------------------	      
-  elseif ((NameOfScience == QUEST_ACCEPTED or NameOfScience == QUEST_COMPLETED) and count == 1 and itemtarget > 0 and trade:hasItemQty(APPLE_PIE,1) ) then 
-		     player:startEvent(0x0213,APPLE_PIE); player:tradeComplete();
---------------------------------------------------trade  organe-----------------------------------------------------------------------------------------------	
-  elseif ((NameOfScience == QUEST_ACCEPTED or NameOfScience == QUEST_COMPLETED) and itemtarget > 0  ) then	
-             if (itemtarget == RELAXING_EARRING and count == 10) then	 
-			  if (trade:hasItemQty(LUMINIAN_TISSUE,5)and trade:hasItemQty(EUVHI_ORGAN,5)) then
-			  reward = true;
-			  end
-             elseif (itemtarget == SANATIVE_EARRING and count == 10) then
-			  if (trade:hasItemQty(LUMINIAN_TISSUE,5)and trade:hasItemQty(EUVHI_ORGAN,5)) then
-              reward = true;			  
-			  end
-             elseif (itemtarget == KARIN_OBI and count == 13) then
-			  if (trade:hasItemQty(PHUABOS_ORGAN,7)and trade:hasItemQty(XZOMIT_ORGAN,3)and trade:hasItemQty(LUMINIAN_TISSUE,3)) then
-              reward = true;			  
-			  end
-             elseif (itemtarget == DORIN_OBI and count == 13) then
-			  if (trade:hasItemQty(HPEMDE_ORGAN,7)and trade:hasItemQty(AERN_ORGAN,3)and trade:hasItemQty(LUMINIAN_TISSUE,3)) then
-			  reward = true;
-              end			  
-             elseif (itemtarget == SUIRIN_OBI and count == 13) then
-			  if (trade:hasItemQty(HPEMDE_ORGAN,7)and trade:hasItemQty(PHUABOS_ORGAN,3)and trade:hasItemQty(LUMINIAN_TISSUE,3)) then	
-			  reward = true;
-              end			  
-             elseif (itemtarget == FURIN_OBI and count == 13) then
-			  if (trade:hasItemQty(AERN_ORGAN,7)and trade:hasItemQty(HPEMDE_ORGAN,3)and trade:hasItemQty(LUMINIAN_TISSUE,3)) then	
-			  reward = true;
-              end			  
-             elseif (itemtarget == HYORIN_OBI and count == 13) then
-			  if (trade:hasItemQty(XZOMIT_ORGAN,7)and trade:hasItemQty(PHUABOS_ORGAN,3)and trade:hasItemQty(LUMINIAN_TISSUE,3)) then
-			  reward = true;
-              end			  
-             elseif (itemtarget == RAIRIN_OBI and count == 13) then
-			  if (trade:hasItemQty(PHUABOS_ORGAN,7)and trade:hasItemQty(HPEMDE_ORGAN,3)and trade:hasItemQty(LUMINIAN_TISSUE,3)) then
-			  reward = true;
-              end			  
-             elseif (itemtarget == KORIN_OBI and count == 13) then
-			  if (trade:hasItemQty(XZOMIT_ORGAN,7)and trade:hasItemQty(AERN_ORGAN,3)and trade:hasItemQty(LUMINIAN_TISSUE,3)) then
-			  reward = true;
-              end			  
-             elseif (itemtarget == ANRIN_OBI and count == 13) then
-              if (trade:hasItemQty(AERN_ORGAN,7)and trade:hasItemQty(XZOMIT_ORGAN,3)and trade:hasItemQty(LUMINIAN_TISSUE,3)) then
-              reward = true;			  
-              end			  
-             elseif (itemtarget == SHADOW_GORGET and count == 15) then
-			  if (trade:hasItemQty(HPEMDE_ORGAN,7)and trade:hasItemQty(PHUABOS_ORGAN,3)and trade:hasItemQty(AERN_ORGAN,3)and trade:hasItemQty(YOVRA_ORGAN,2)) then	 
-              reward = true;
-              end
-             elseif (itemtarget == LIGHT_GORGET and count == 15) then
-		      if (trade:hasItemQty(AERN_ORGAN,7)and trade:hasItemQty(PHUABOS_ORGAN,3)and trade:hasItemQty(HPEMDE_ORGAN,3)and trade:hasItemQty(YOVRA_ORGAN,2)) then
-              reward = true;
-			  end
-             elseif (itemtarget == FLAME_GORGET and count == 16) then
-			  if (trade:hasItemQty(PHUABOS_ORGAN,10)and trade:hasItemQty(XZOMIT_ORGAN,5)and trade:hasItemQty(YOVRA_ORGAN,1)) then	
-			  reward = true;
-              end			  
-             elseif (itemtarget == SOIL_GORGET and count == 16) then
-			  if (trade:hasItemQty(XZOMIT_ORGAN,10)and trade:hasItemQty(AERN_ORGAN,5)and trade:hasItemQty(YOVRA_ORGAN,1)) then
-	          reward = true;		  
-              end			  
-             elseif (itemtarget == AQUA_GORGET and count == 16) then
-			  if (trade:hasItemQty(AERN_ORGAN,10)and trade:hasItemQty(HPEMDE_ORGAN,5)and trade:hasItemQty(YOVRA_ORGAN,1)) then
-			  reward = true;
-              end			  
-			 elseif (itemtarget == BREEZE_GORGET and count == 16) then
-			  if (trade:hasItemQty(PHUABOS_ORGAN,10)and trade:hasItemQty(HPEMDE_ORGAN,5)and trade:hasItemQty(YOVRA_ORGAN,1)) then	
-			  reward = true;
-              end			  
-             elseif (itemtarget == SNOW_GORGET and count == 16) then
-			  if (trade:hasItemQty(PHUABOS_ORGAN,10)and trade:hasItemQty(AERN_ORGAN,5)and trade:hasItemQty(YOVRA_ORGAN,1)) then
-              reward = true;			  
-			  end
-             elseif (itemtarget == THUNDER_GORGET and count == 16) then
-              if (trade:hasItemQty(XZOMIT_ORGAN,10)and trade:hasItemQty(HPEMDE_ORGAN,5)and trade:hasItemQty(YOVRA_ORGAN,1)) then
-              reward = true;			  
-              end			  
-             end	
-	end	   
-   --------------------------------------------------------------------------------------------------------------------
-   if (reward == true) then
-     player:startEvent(0x0211, GORGET, SILVER_EARRING, SILVER_OBI);
-   end
+    if ((NameOfScience == QUEST_ACCEPTED or NameOfScience == QUEST_COMPLETED) and count == 2 and itemtarget == 0) then  
+        if (trade:hasItemQty(SILVER_EARRING,1)) then 
+            if (trade:hasItemQty(BLACK_CHIP,1) and player:hasItem(RELAXING_EARRING)==false) then 
+                player:setVar("NAME_OF_SCIENCE_target",RELAXING_EARRING); player:tradeComplete(); player:startEvent(0x020E,SILVER_EARRING,BLACK_CHIP);
+            elseif (trade:hasItemQty(WHITE_CHIP,1) and player:hasItem(SANATIVE_EARRING)==false) then
+                player:setVar("NAME_OF_SCIENCE_target",SANATIVE_EARRING); player:tradeComplete(); player:startEvent(0x020E,SILVER_EARRING,WHITE_CHIP);
+            elseif (trade:hasItemQty(RED_CHIP,1) and player:hasItem(SANATIVE_EARRING)==false) then
+                player:setVar("NAME_OF_SCIENCE_target",SANATIVE_EARRING); player:tradeComplete(); player:startEvent(0x020E,SILVER_EARRING,RED_CHIP);
+            elseif (trade:hasItemQty(YELLOW_CHIP,1) and player:hasItem(RELAXING_EARRING)==false) then
+                player:setVar("NAME_OF_SCIENCE_target",RELAXING_EARRING); player:tradeComplete(); player:startEvent(0x020E,SILVER_EARRING,YELLOW_CHIP);
+            elseif (trade:hasItemQty(BLUE_CHIP,1) and player:hasItem(RELAXING_EARRING)==false) then
+                player:setVar("NAME_OF_SCIENCE_target",RELAXING_EARRING); player:tradeComplete(); player:startEvent(0x020E,SILVER_EARRING,BLUE_CHIP);
+            elseif (trade:hasItemQty(GREEN_CHIP,1) and player:hasItem(SANATIVE_EARRING)==false) then
+                player:setVar("NAME_OF_SCIENCE_target",SANATIVE_EARRING); player:tradeComplete(); player:startEvent(0x020E,SILVER_EARRING,GREEN_CHIP);
+            elseif (trade:hasItemQty(CLEAR_CHIP,1) and player:hasItem(RELAXING_EARRING)==false) then
+                player:setVar("NAME_OF_SCIENCE_target",RELAXING_EARRING); player:tradeComplete(); player:startEvent(0x020E,SILVER_EARRING,CLEAR_CHIP);
+            elseif (trade:hasItemQty(PURPLE_CHIP,1) and player:hasItem(SANATIVE_EARRING)==false) then
+                player:setVar("NAME_OF_SCIENCE_target",SANATIVE_EARRING); player:tradeComplete(); player:startEvent(0x020E,SILVER_EARRING,PURPLE_CHIP);
+            end
+        elseif (trade:hasItemQty(SILVER_OBI,1)) then       
+            if (trade:hasItemQty(BLACK_CHIP,1) and player:hasItem(ANRIN_OBI)==false) then
+                player:setVar("NAME_OF_SCIENCE_target",ANRIN_OBI); player:tradeComplete(); player:startEvent(0x020E,SILVER_OBI,BLACK_CHIP);
+            elseif (trade:hasItemQty(WHITE_CHIP,1) and player:hasItem(KORIN_OBI)==false) then
+                player:setVar("NAME_OF_SCIENCE_target",KORIN_OBI); player:tradeComplete(); player:startEvent(0x020E,SILVER_OBI,WHITE_CHIP);
+            elseif (trade:hasItemQty(RED_CHIP,1) and player:hasItem(KARIN_OBI)==false) then
+                player:setVar("NAME_OF_SCIENCE_target",KARIN_OBI); player:tradeComplete(); player:startEvent(0x020E,SILVER_OBI,RED_CHIP);
+            elseif (trade:hasItemQty(YELLOW_CHIP,1) and player:hasItem(DORIN_OBI)==false) then
+                player:setVar("NAME_OF_SCIENCE_target",DORIN_OBI); player:tradeComplete(); player:startEvent(0x020E,SILVER_OBI,YELLOW_CHIP);
+            elseif (trade:hasItemQty(BLUE_CHIP,1) and player:hasItem(SUIRIN_OBI)==false) then
+                player:setVar("NAME_OF_SCIENCE_target",SUIRIN_OBI); player:tradeComplete(); player:startEvent(0x020E,SILVER_OBI,BLUE_CHIP);
+            elseif (trade:hasItemQty(GREEN_CHIP,1) and player:hasItem(FURIN_OBI)==false) then
+                player:setVar("NAME_OF_SCIENCE_target",FURIN_OBI); player:tradeComplete(); player:startEvent(0x020E,SILVER_OBI,GREEN_CHIP);
+            elseif (trade:hasItemQty(CLEAR_CHIP,1) and player:hasItem(HYORIN_OBI)==false) then
+                player:setVar("NAME_OF_SCIENCE_target",HYORIN_OBI); player:tradeComplete(); player:startEvent(0x020E,SILVER_OBI,CLEAR_CHIP);
+            elseif (trade:hasItemQty(PURPLE_CHIP,1) and player:hasItem(RAIRIN_OBI)==false) then
+                player:setVar("NAME_OF_SCIENCE_target",RAIRIN_OBI); player:tradeComplete(); player:startEvent(0x020E,SILVER_OBI,PURPLE_CHIP);
+            end
+        elseif (trade:hasItemQty(GORGET,1)) then 
+            if (trade:hasItemQty(BLACK_CHIP,1) and player:hasItem(SHADOW_GORGET)==false) then
+                player:setVar("NAME_OF_SCIENCE_target",SHADOW_GORGET); player:tradeComplete(); player:startEvent(0x020E,GORGET,BLACK_CHIP);
+            elseif (trade:hasItemQty(WHITE_CHIP,1) and player:hasItem(LIGHT_GORGET)==false) then
+                player:setVar("NAME_OF_SCIENCE_target",LIGHT_GORGET); player:tradeComplete(); player:startEvent(0x020E,GORGET,WHITE_CHIP);
+            elseif (trade:hasItemQty(RED_CHIP,1) and player:hasItem(FLAME_GORGET)==false) then
+                player:setVar("NAME_OF_SCIENCE_target",FLAME_GORGET); player:tradeComplete(); player:startEvent(0x020E,GORGET,RED_CHIP);
+            elseif (trade:hasItemQty(YELLOW_CHIP,1) and player:hasItem(SOIL_GORGET)==false) then
+                player:setVar("NAME_OF_SCIENCE_target",SOIL_GORGET); player:tradeComplete(); player:startEvent(0x020E,GORGET,YELLOW_CHIP);
+            elseif (trade:hasItemQty(BLUE_CHIP,1) and player:hasItem(AQUA_GORGET)==false) then
+                player:setVar("NAME_OF_SCIENCE_target",AQUA_GORGET); player:tradeComplete(); player:startEvent(0x020E,GORGET,BLUE_CHIP);
+            elseif (trade:hasItemQty(GREEN_CHIP,1) and player:hasItem(BREEZE_GORGET)==false) then
+                player:setVar("NAME_OF_SCIENCE_target",BREEZE_GORGET); player:tradeComplete(); player:startEvent(0x020E,GORGET,GREEN_CHIP);
+            elseif (trade:hasItemQty(CLEAR_CHIP,1) and player:hasItem(SNOW_GORGET)==false) then
+                player:setVar("NAME_OF_SCIENCE_target",SNOW_GORGET); player:tradeComplete(); player:startEvent(0x020E,GORGET,CLEAR_CHIP);
+            elseif (trade:hasItemQty(PURPLE_CHIP,1) and player:hasItem(THUNDER_GORGET)==false) then
+                player:setVar("NAME_OF_SCIENCE_target",THUNDER_GORGET); player:tradeComplete(); player:startEvent(0x020E,GORGET,PURPLE_CHIP);
+            end  
+        end
+--------------------------------------------------apple pie trade-------------------------------------------------------------------------------          
+    elseif ((NameOfScience == QUEST_ACCEPTED or NameOfScience == QUEST_COMPLETED) and count == 1 and itemtarget > 0 and trade:hasItemQty(APPLE_PIE,1) ) then 
+        player:startEvent(0x0213,APPLE_PIE); player:tradeComplete();
+--------------------------------------------------trade  organe-----------------------------------------------------------------------------------------------    
+    elseif ((NameOfScience == QUEST_ACCEPTED or NameOfScience == QUEST_COMPLETED) and itemtarget > 0  ) then    
+        if (itemtarget == RELAXING_EARRING and count == 10) then     
+            if (trade:hasItemQty(LUMINIAN_TISSUE,5)and trade:hasItemQty(EUVHI_ORGAN,5)) then
+                reward = true;
+            end
+        elseif (itemtarget == SANATIVE_EARRING and count == 10) then
+            if (trade:hasItemQty(LUMINIAN_TISSUE,5)and trade:hasItemQty(EUVHI_ORGAN,5)) then
+                reward = true;              
+            end
+        elseif (itemtarget == KARIN_OBI and count == 13) then
+            if (trade:hasItemQty(PHUABOS_ORGAN,7)and trade:hasItemQty(XZOMIT_ORGAN,3)and trade:hasItemQty(LUMINIAN_TISSUE,3)) then
+                reward = true;              
+            end
+        elseif (itemtarget == DORIN_OBI and count == 13) then
+            if (trade:hasItemQty(HPEMDE_ORGAN,7)and trade:hasItemQty(AERN_ORGAN,3)and trade:hasItemQty(LUMINIAN_TISSUE,3)) then
+                reward = true;
+            end              
+        elseif (itemtarget == SUIRIN_OBI and count == 13) then
+            if (trade:hasItemQty(HPEMDE_ORGAN,7)and trade:hasItemQty(PHUABOS_ORGAN,3)and trade:hasItemQty(LUMINIAN_TISSUE,3)) then    
+                reward = true;
+            end              
+        elseif (itemtarget == FURIN_OBI and count == 13) then
+            if (trade:hasItemQty(AERN_ORGAN,7)and trade:hasItemQty(HPEMDE_ORGAN,3)and trade:hasItemQty(LUMINIAN_TISSUE,3)) then    
+                reward = true;
+            end              
+        elseif (itemtarget == HYORIN_OBI and count == 13) then
+            if (trade:hasItemQty(XZOMIT_ORGAN,7)and trade:hasItemQty(PHUABOS_ORGAN,3)and trade:hasItemQty(LUMINIAN_TISSUE,3)) then
+                reward = true;
+            end              
+        elseif (itemtarget == RAIRIN_OBI and count == 13) then
+            if (trade:hasItemQty(PHUABOS_ORGAN,7)and trade:hasItemQty(HPEMDE_ORGAN,3)and trade:hasItemQty(LUMINIAN_TISSUE,3)) then
+                reward = true;
+            end              
+        elseif (itemtarget == KORIN_OBI and count == 13) then
+            if (trade:hasItemQty(XZOMIT_ORGAN,7)and trade:hasItemQty(AERN_ORGAN,3)and trade:hasItemQty(LUMINIAN_TISSUE,3)) then
+                reward = true;
+            end              
+        elseif (itemtarget == ANRIN_OBI and count == 13) then
+            if (trade:hasItemQty(AERN_ORGAN,7)and trade:hasItemQty(XZOMIT_ORGAN,3)and trade:hasItemQty(LUMINIAN_TISSUE,3)) then
+                reward = true;              
+            end              
+        elseif (itemtarget == SHADOW_GORGET and count == 15) then
+            if (trade:hasItemQty(HPEMDE_ORGAN,7)and trade:hasItemQty(PHUABOS_ORGAN,3)and trade:hasItemQty(AERN_ORGAN,3)and trade:hasItemQty(YOVRA_ORGAN,2)) then     
+                reward = true;
+            end
+        elseif (itemtarget == LIGHT_GORGET and count == 15) then
+            if (trade:hasItemQty(AERN_ORGAN,7)and trade:hasItemQty(PHUABOS_ORGAN,3)and trade:hasItemQty(HPEMDE_ORGAN,3)and trade:hasItemQty(YOVRA_ORGAN,2)) then
+                reward = true;
+            end
+        elseif (itemtarget == FLAME_GORGET and count == 16) then
+            if (trade:hasItemQty(PHUABOS_ORGAN,10)and trade:hasItemQty(XZOMIT_ORGAN,5)and trade:hasItemQty(YOVRA_ORGAN,1)) then    
+                reward = true;
+            end              
+        elseif (itemtarget == SOIL_GORGET and count == 16) then
+            if (trade:hasItemQty(XZOMIT_ORGAN,10)and trade:hasItemQty(AERN_ORGAN,5)and trade:hasItemQty(YOVRA_ORGAN,1)) then
+                reward = true;          
+            end              
+        elseif (itemtarget == AQUA_GORGET and count == 16) then
+            if (trade:hasItemQty(AERN_ORGAN,10)and trade:hasItemQty(HPEMDE_ORGAN,5)and trade:hasItemQty(YOVRA_ORGAN,1)) then
+                reward = true;
+            end              
+        elseif (itemtarget == BREEZE_GORGET and count == 16) then
+            if (trade:hasItemQty(PHUABOS_ORGAN,10)and trade:hasItemQty(HPEMDE_ORGAN,5)and trade:hasItemQty(YOVRA_ORGAN,1)) then    
+                reward = true;
+            end              
+        elseif (itemtarget == SNOW_GORGET and count == 16) then
+            if (trade:hasItemQty(PHUABOS_ORGAN,10)and trade:hasItemQty(AERN_ORGAN,5)and trade:hasItemQty(YOVRA_ORGAN,1)) then
+                reward = true;              
+            end
+        elseif (itemtarget == THUNDER_GORGET and count == 16) then
+            if (trade:hasItemQty(XZOMIT_ORGAN,10)and trade:hasItemQty(HPEMDE_ORGAN,5)and trade:hasItemQty(YOVRA_ORGAN,1)) then
+                reward = true;              
+            end              
+        end    
+    end       
+    --------------------------------------------------------------------------------------------------------------------
+    if (reward == true) then
+        player:startEvent(0x0211, GORGET, SILVER_EARRING, SILVER_OBI);
+    end
 end; 
 
 -----------------------------------
@@ -260,32 +261,30 @@ end;
 
 function onTrigger(player,npc)
 
-local NameOfScience = player:getQuestStatus(OTHER_AREAS,IN_THE_NAME_OF_SCIENCE);
-local itemtarget = player:getVar("NAME_OF_SCIENCE_target");
-local rnd= math.random();
+    local NameOfScience = player:getQuestStatus(OTHER_AREAS,IN_THE_NAME_OF_SCIENCE);
+    local itemtarget = player:getVar("NAME_OF_SCIENCE_target");
+    local rnd= math.random();
 
-    if (player:hasKeyItem(LIGHT_OF_ALTAIEU)) then   --have SEA acces
-	     if ( NameOfScience == QUEST_AVAILABLE) then		 
-	          player:startEvent(0x020C,13205,13327,13080);
-		      player:addQuest(OTHER_AREAS,IN_THE_NAME_OF_SCIENCE);
-		 elseif (NameOfScience == QUEST_ACCEPTED or NameOfScience ==QUEST_COMPLETED  and itemtarget == 0) then		 
-		      player:startEvent(0x020D,13205,13327,13080);
-		 elseif (NameOfScience == QUEST_ACCEPTED or NameOfScience ==QUEST_COMPLETED and itemtarget > 0) then	  		  
-			 if (rnd < 0.3) then
-			    player:startEvent(0x0214,getNOS(itemtarget,1),getNOS(itemtarget,2));
-			  else
-			     player:startEvent(0x0210,getNOS(itemtarget,1),getNOS(itemtarget,2));
-			  end
-	     end		 
-	else 
-	    if (rnd < 0.5) then
-         player:startEvent(0x020F); --no quest
-	    else
-	     player:startEvent(0x0207); --no quest
-	    end
-	end
-	
-
+    if (player:getCurrentMission(COP) > THE_WARRIOR_S_PATH) then   --have SEA acces
+        if (NameOfScience == QUEST_AVAILABLE) then         
+            player:startEvent(0x020C,13205,13327,13080);
+            player:addQuest(OTHER_AREAS,IN_THE_NAME_OF_SCIENCE);
+        elseif (NameOfScience == QUEST_ACCEPTED or NameOfScience ==QUEST_COMPLETED  and itemtarget == 0) then         
+            player:startEvent(0x020D,13205,13327,13080);
+        elseif (NameOfScience == QUEST_ACCEPTED or NameOfScience ==QUEST_COMPLETED and itemtarget > 0) then                
+            if (rnd < 0.3) then
+                player:startEvent(0x0214,getNOS(itemtarget,1),getNOS(itemtarget,2));
+            else
+                player:startEvent(0x0210,getNOS(itemtarget,1),getNOS(itemtarget,2));
+            end
+        end         
+    else 
+        if (rnd < 0.5) then
+            player:startEvent(0x020F); --no quest
+        else
+            player:startEvent(0x0207); --no quest
+        end
+    end
 end; 
 
 -----------------------------------
@@ -304,19 +303,16 @@ end;
 function onEventFinish(player,csid,option)
 --printf("CSID: %u",csid);
 --printf("RESULT: %u",option);
-  if (csid == 0x0211) then
-  local itemtarget = player:getVar("NAME_OF_SCIENCE_target");
-    if (player:getFreeSlotsCount()==0) then
-     player:messageSpecial(ITEM_CANNOT_BE_OBTAINED,itemtarget);
-    else
-	 player:tradeComplete();
-	 player:completeQuest(OTHER_AREAS,IN_THE_NAME_OF_SCIENCE);
-     player:addItem(itemtarget);
-     player:messageSpecial(ITEM_OBTAINED,itemtarget); -- Item
-     player:setVar("NAME_OF_SCIENCE_target",0);
-	end
-  end
+    if (csid == 0x0211) then
+        local itemtarget = player:getVar("NAME_OF_SCIENCE_target");
+        if (player:getFreeSlotsCount()==0) then
+            player:messageSpecial(ITEM_CANNOT_BE_OBTAINED,itemtarget);
+        else
+            player:tradeComplete();
+            player:completeQuest(OTHER_AREAS,IN_THE_NAME_OF_SCIENCE);
+            player:addItem(itemtarget);
+            player:messageSpecial(ITEM_OBTAINED,itemtarget); -- Item
+            player:setVar("NAME_OF_SCIENCE_target",0);
+        end
+    end
 end;
-
-
-


### PR DESCRIPTION
-Made the ??? in Batallia Downs check for the progress before and after the defeat of the Disaster Idol. This is because you don't have to defeat it again if you forgot to get the KI. Currently, if you defeat the NM, you are stuck unable to get the KI.
-Changed the requirements to use various Sea stuff from KI Light of Al Taieu to CoP current mission is past The Warrior's Path. The KI is not Sea access, as you are supposed to lose it at some point, and only one race is to get it back. However, I'm not sure when the loss is supposed to happen, so I left that out.