### PR TITLE
SCRIPTS: Corrects a quest blocking DRG AF2 and fixes S.O.B. quests

### DIFF
--- a/scripts/zones/Castle_Oztroja/npcs/_47d.lua
+++ b/scripts/zones/Castle_Oztroja/npcs/_47d.lua
@@ -13,6 +13,10 @@ require("scripts/zones/Castle_Oztroja/TextIDs");
 -----------------------------------
 
 function onTrigger(player,npc)
+	if(player:hasKeyItem(OLD_RING) == false) then
+		player:addKeyItem(OLD_RING);
+		player:messageSpecial(KEYITEM_OBTAINED,OLD_RING);
+	end
 	if (npc:getAnimation() == 9) then
 		npc:openDoor();
 	end	

--- a/scripts/zones/West_Ronfaure/npcs/Esca.lua
+++ b/scripts/zones/West_Ronfaure/npcs/Esca.lua
@@ -48,16 +48,16 @@ function onTrigger(player,npc)
 	local Quotas_Status = player:getVar("ChasingQuotas_Progress");
 	
 	-- "The Pickpocket" Quest Dialog
-	if (thePickpocket == 1 and player:getVar("thePickpocketGiltGlasses") == 1)  then
+	if (Quotas_Status == 4) then
+		player:startEvent(137); -- My earring!  I stole the last dragoon's armor.  Chosen option does not matter.
+	elseif (Quotas_Status == 5) then
+		player:startEvent(138); -- Reminder for finding the armor.
+	elseif (thePickpocket == 1 and player:getVar("thePickpocketGiltGlasses") == 1)  then
 		player:startEvent(0x0080);
 	elseif (thePickpocket == 1) then
 		player:startEvent(0x0078);
 	elseif (thePickpocket == 2) then
 		player:startEvent(0x007b);
-	elseif (Quotas_Status == 4) then
-		player:startEvent(137); -- My earring!  I stole the last dragoon's armor.  Chosen option does not matter.
-	elseif (Quotas_Status == 5) then
-		player:startEvent(138); -- Reminder for finding the armor.
 	else
 		player:startEvent(0x0077);
 	end;

--- a/scripts/zones/Windurst_Waters/npcs/Chamama.lua
+++ b/scripts/zones/Windurst_Waters/npcs/Chamama.lua
@@ -146,8 +146,8 @@ function onEventFinish(player,csid,option)
 		player:setVar("ThePromise",1);
 	elseif (csid == 0x031f) then
 		player:tradeComplete();
-		player:addKeyItem(FAKE_MOUSTACHE);
-		player:messageSpecial(KEYITEM_OBTAINED,FAKE_MOUSTACHE);
+		player:addKeyItem(INVISIBLE_MAN_STICKER);
+		player:messageSpecial(KEYITEM_OBTAINED,INVISIBLE_MAN_STICKER);
 	elseif (csid == 0x028e and option == 1) then  -- IN A PICKLE + RARAB TAIL: Quest Begin
 		player:addQuest(WINDURST,IN_A_PICKLE);
 	elseif (csid == 0x0293) then  -- IN A PICKLE: Quest Turn In (1st Time)


### PR DESCRIPTION
Esca changes text depending on whether you have finished The Pickpocket, this was blocking the checks for DRG AF2 quest.

Implemented a way to obtain Old Ring KI for quest Onion Rings, corrected wrong KI being given during The Promise