### PR TITLE
Fix crash

### DIFF
--- a/src/map/entities/mobentity.cpp
+++ b/src/map/entities/mobentity.cpp
@@ -27,6 +27,7 @@
 #include <string.h>
 
 #include "mobentity.h"
+#include "../utils/battleutils.h"
 
 CMobEntity::CMobEntity()
 {
@@ -348,13 +349,14 @@ void CMobEntity::ChangeMJob(uint16 job)
 
 uint8 CMobEntity::TPUseChance()
 {
-    if (!PBattleAI->GetMobAbilityEnabled())
+    auto& MobSkillList = battleutils::GetMobSkillList(getMobMod(MOBMOD_SKILL_LIST));
+
+    if (health.tp < 1000 || MobSkillList.empty() == true || !PBattleAI->GetMobAbilityEnabled())
     {
         return 0;
     }
-    if(health.tp < 1000) return 0;
 
-    if(health.tp == 3000 || (GetHPP() <= 25 && health.tp >= 1000))
+    if (health.tp == 3000 || (GetHPP() <= 25 && health.tp >= 1000))
     {
         return 100;
     }


### PR DESCRIPTION
Fixes a crash triggered when mob has nothing to do but spam alternate ACTION_ATTACK and ACTION_MOBABILITY_START...They cycle so quickly that other things break.

I caused this in ceb079ae714f71fa8d3fd78b1033aceffa02fbec but it was not revealed during testing. I was testing on elemental, which occasionally break up their melee by casting. I triggered this crash during normal gameplay by silencing an elemental that had full TP..Made a fix after seeing a crash dump that had:
```
 	DSGame-server.exe!CAIMobDummy::ActionAttack() Line 1313	C++
 	DSGame-server.exe!CAIMobDummy::TransitionBack(bool skipWait) Line 2592	C++
 	DSGame-server.exe!CAIMobDummy::ActionAbilityStart() Line 722	C++
 	DSGame-server.exe!CAIMobDummy::ActionAttack() Line 1431	C++
 	DSGame-server.exe!CAIMobDummy::TransitionBack(bool skipWait) Line 2592	C++
```
Repeated for about 5 thousand lines in my call stack..
