### PR TITLE
Prevent some server variables related to the old Land Kings from incrementing multiple items on a single kill.

### DIFF
--- a/scripts/zones/Behemoths_Dominion/mobs/Behemoth.lua
+++ b/scripts/zones/Behemoths_Dominion/mobs/Behemoth.lua
@@ -8,11 +8,10 @@ require("scripts/globals/titles");
 require("scripts/globals/status");
 
 -----------------------------------
--- onMobInitialize Action
+-- onMobInitialize
 -----------------------------------
 
 function onMobInitialize(mob)
-
 end;
 
 -----------------------------------
@@ -20,9 +19,14 @@ end;
 -----------------------------------
 
 function onMobDeath(mob, killer)
-
     killer:addTitle(BEHEMOTHS_BANE);
+end;
 
+-----------------------------------
+-- onMobDespawn
+-----------------------------------
+
+function onMobDespawn(mob)
     local Behemoth      = mob:getID();
     local King_Behemoth = 17297441;
     local ToD     = GetServerVariable("[POP]King_Behemoth");

--- a/scripts/zones/Dragons_Aery/mobs/Fafnir.lua
+++ b/scripts/zones/Dragons_Aery/mobs/Fafnir.lua
@@ -8,21 +8,25 @@ require("scripts/globals/titles");
 require("scripts/globals/status");
 
 -----------------------------------
--- onMobInitialize Action
+-- onMobInitialize
 -----------------------------------
 
 function onMobInitialize(mob)
 end;
-
 
 -----------------------------------
 -- onMobDeath
 -----------------------------------
 
 function onMobDeath(mob, killer)
-
     killer:addTitle(FAFNIR_SLAYER);
+end;
 
+-----------------------------------
+-- onMobDespawn
+-----------------------------------
+
+function onMobDespawn(mob)
     local Fafnir  = mob:getID();
     local Nidhogg = 17408019;
     local ToD     = GetServerVariable("[POP]Nidhogg");

--- a/scripts/zones/Jugner_Forest/mobs/Knight_Crab.lua
+++ b/scripts/zones/Jugner_Forest/mobs/Knight_Crab.lua
@@ -10,20 +10,25 @@ require("scripts/globals/titles");
 -----------------------------------
 
 function onMobSpawn(mob)
-	SetServerVariable("[POP]King_Arthro",0);
+    SetServerVariable("[POP]King_Arthro",0);
 end;
 
 -----------------------------------
 -- onMobDeath
 -----------------------------------
 
-function onMobDeath(mob)
+function onMobDeath(mob, killer)
+end;
 
-	SetServerVariable("[POP]King_Arthro",GetServerVariable("[POP]King_Arthro") + 1);
+-----------------------------------
+-- onMobDespawn
+-----------------------------------
 
-	if (GetServerVariable("[POP]King_Arthro") == 10) then
-		SetServerVariable("[POP]King_Arthro",0);
-		SpawnMob(17203216,600); -- Pop King Arthro !
-	end
+function onMobDespawn(mob)
+    SetServerVariable("[POP]King_Arthro",GetServerVariable("[POP]King_Arthro") + 1);
 
+    if (GetServerVariable("[POP]King_Arthro") == 10) then
+        SetServerVariable("[POP]King_Arthro",0);
+        SpawnMob(17203216,600); -- Pop King Arthro !
+    end
 end;

--- a/scripts/zones/Valley_of_Sorrows/mobs/Adamantoise.lua
+++ b/scripts/zones/Valley_of_Sorrows/mobs/Adamantoise.lua
@@ -8,7 +8,7 @@ require("scripts/globals/titles");
 require("scripts/globals/status");
 
 -----------------------------------
--- onMobInitialize Action
+-- onMobInitialize
 -----------------------------------
 
 function onMobInitialize(mob)
@@ -20,7 +20,13 @@ end;
 
 function onMobDeath(mob, killer)
     killer:addTitle(TORTOISE_TORTURER);
+end;
 
+-----------------------------------
+-- onMobDespawn
+-----------------------------------
+
+function onMobDespawn(mob)
     local Adamantoise  = mob:getID();
     local Aspidochelone = 17301538;
     local ToD     = GetServerVariable("[POP]Aspidochelone");


### PR DESCRIPTION
Today @Hozu mentioned to me that the were increment per-party member because of the nature of onMobDeath.

Since these never despawn except after being killed, and onMobDespawn will run after onMobDeath has finished, this should be a safe change. The only way for it to increment more than intended here would require abuse of GM commands.