### PR TITLE
Refining Magic Resist Formula

### DIFF
--- a/scripts/globals/magic.lua
+++ b/scripts/globals/magic.lua
@@ -334,21 +334,21 @@ function applyResistance(player,spell,target,diff,skill,bonus)
         end
     end
 
-    local magicacc = 0;
+    local percentBonus = 0;
 
     if player:hasStatusEffect(EFFECT_ALTRUISM) and spell:getSpellGroup() == SPELLGROUP_WHITE then
-        magicacc = magicacc + player:getStatusEffect(EFFECT_ALTRUISM):getPower();
+        magicaccbonus = magicaccbonus + player:getStatusEffect(EFFECT_ALTRUISM):getPower();
     end
 	
     if player:hasStatusEffect(EFFECT_FOCALIZATION) and spell:getSpellGroup() == SPELLGROUP_BLACK then
-        magicacc = magicacc + player:getStatusEffect(EFFECT_FOCALIZATION):getPower();
+        magicaccbonus = magicaccbonus + player:getStatusEffect(EFFECT_FOCALIZATION):getPower();
     end
     --difference in int/mnd
 	
     if (diff > 10) then
-        magicacc = magicacc + 10 + (diff - 10)/2;
+        magicaccbonus = magicaccbonus + 10 + (diff - 10)/2;
     else
-        magicacc = magicacc + diff;
+        magicaccbonus = magicaccbonus + diff;
     end
 	
     --Add acc for dark seal
@@ -376,7 +376,7 @@ function applyResistance(player,spell,target,diff,skill,bonus)
         magicaccbonus = magicaccbonus + 25;
     end
 
-    local p = getMagicHitRate(player, target, skill, element, magicacc, magicaccbonus);
+    local p = getMagicHitRate(player, target, skill, element, percentBonus, magicaccbonus);
 
     return getMagicResist(p);
 end;
@@ -395,7 +395,7 @@ function applyResistanceEffect(player,spell,target,diff,skill,bonus,effect)
 
     local magicaccbonus = 0;
     local element = spell:getElement();
-    local magicacc = 0;
+    local percentBonus = 0;
 
     if (bonus ~= nil) then
         magicaccbonus = magicaccbonus + bonus;
@@ -408,17 +408,17 @@ function applyResistanceEffect(player,spell,target,diff,skill,bonus,effect)
     end
 
     if player:hasStatusEffect(EFFECT_ALTRUISM) and spell:getSpellGroup() == SPELLGROUP_WHITE then
-      magicacc = magicacc + player:getStatusEffect(EFFECT_ALTRUISM):getPower();
+      magicaccbonus = magicaccbonus + player:getStatusEffect(EFFECT_ALTRUISM):getPower();
     end
     if player:hasStatusEffect(EFFECT_FOCALIZATION) and spell:getSpellGroup() == SPELLGROUP_BLACK then
-      magicacc = magicacc + player:getStatusEffect(EFFECT_FOCALIZATION):getPower();
+      magicaccbonus = magicaccbonus + player:getStatusEffect(EFFECT_FOCALIZATION):getPower();
     end
 
     --difference in int/mnd
     if (diff > 10) then
-        magicacc = magicacc + 10 + (diff - 10)/2;
+        magicaccbonus = magicaccbonus + 10 + (diff - 10)/2;
     else
-        magicacc = magicacc + diff;
+        magicaccbonus = magicaccbonus + diff;
     end
     --add acc for ele/dark seal
     if (player:getStatusEffect(EFFECT_DARK_SEAL) ~= nil and skill == DARK_MAGIC_SKILL) then
@@ -465,7 +465,7 @@ function applyResistanceEffect(player,spell,target,diff,skill,bonus,effect)
         end
 
         if (effectres > 0) then
-            magicacc = magicacc - target:getMod(effectres);
+            percentBonus = percentBonus - target:getMod(effectres);
         end
 
         if(effect == EFFECT_LULLABY) then
@@ -473,7 +473,7 @@ function applyResistanceEffect(player,spell,target,diff,skill,bonus,effect)
         end
     end
 
-    local p = getMagicHitRate(player, target, skill, element, magicacc, magicaccbonus);
+    local p = getMagicHitRate(player, target, skill, element, percentBonus, magicaccbonus);
 
     return getMagicResist(p);
 end;
@@ -494,7 +494,7 @@ function applyResistanceAddEffect(player,target,element,bonus)
     return getMagicResist(p);
 end;
 
-function getMagicHitRate(caster, target, skillType, element, fullBonus, minorBonus)
+function getMagicHitRate(caster, target, skillType, element, percentBonus, bonusAcc)
     -- resist everything if magic shield is active
     if (target:hasStatusEffect(EFFECT_MAGIC_SHIELD, 0)) then
         return 0;
@@ -502,10 +502,9 @@ function getMagicHitRate(caster, target, skillType, element, fullBonus, minorBon
 
     local magicacc = 0;
     local magiceva = 0;
-    local p = 0;
 
-    if (minorBonus == nil) then
-        minorBonus = 0;
+    if (bonusAcc == nil) then
+        bonusAcc = 0;
     end
 
     -- Get the base acc (just skill + skill mod (79 + skillID = ModID) + magic acc mod)
@@ -515,8 +514,6 @@ function getMagicHitRate(caster, target, skillType, element, fullBonus, minorBon
         magicacc = magicacc + caster:getSkillLevel(skillType) + caster:getMod(79 + skillType);
     end
 
-    magicacc = magicacc + fullBonus;
-
     local resMod = 0; -- Some spells may possibly be non elemental, but have status effects.
     if (element > ELE_NONE) then
         resMod = target:getMod(resistMod[element]);
@@ -525,49 +522,35 @@ function getMagicHitRate(caster, target, skillType, element, fullBonus, minorBon
     if (element > ELE_NONE) then
         -- Add acc for staves
         local affinityBonus = AffinityBonus(caster, element);
-        minorBonus = minorBonus + (affinityBonus-1) * 200;
+        bonusAcc = bonusAcc + (affinityBonus-1) * 200;
     end
 
     --add acc for RDM group 1 merits
     if (element > 0 and element <= 6) then
-        minorBonus = minorBonus + caster:getMerit(rdmMerit[element]);
+        bonusAcc = bonusAcc + caster:getMerit(rdmMerit[element]);
     end
 
     -- BLU mag acc merits - nuke acc is handled in bluemagic.lua
     if (skill == BLUE_SKILL) then
-        minorBonus = minorBonus + caster:getMerit(MERIT_MAGICAL_ACCURACY);
+        bonusAcc = bonusAcc + caster:getMerit(MERIT_MAGICAL_ACCURACY);
     end
 
     -- Base magic evasion (base magic evasion plus resistances(players), plus elemental defense(mobs)
     local magiceva = target:getMod(MOD_MEVA) + resMod;
 
-    --get the difference of acc and eva, scale with level (3.33 at 10 to 0.44 at 75)
-    local multiplier = 0;
-    if caster:getMainLvl() < 40 then
-        multiplier = 100 / 120;
-    else
-        multiplier = 100 / (caster:getMainLvl() * 3);
-    end;
-    p = (magicacc * multiplier) - (magiceva * 0.45);
-    --add magicacc bonus
-    p = p + (minorBonus / 2);
+    magicacc = magicacc + bonusAcc;
 
-    --double any acc over 50 if it's over 50
-    if (p > 5) then
-        p = 5 + (p - 5) * 2;
-    end
+    return calculateMagicHitRate(magicacc, magiceva, percentBonus, caster:getMainLvl(), target:getMainLvl());
+end
 
-    --add a flat bonus that won't get doubled in the previous step
-    p = p + 45;
-
+function calculateMagicHitRate(magicacc, magiceva, percentBonus, casterLvl, targetLvl)
+    local p = 0;
     --add a scaling bonus or penalty based on difference of targets level from caster
-    local leveldiff = caster:getMainLvl() - target:getMainLvl();
-    if (leveldiff < 0) then
-        p = p - (25 * ( (caster:getMainLvl()) / 75 )) + leveldiff;
-    else
-        p = p + (25 * ( (caster:getMainLvl()) / 75 )) + leveldiff;
-    end
-    -- printf("acc: %f, eva: %f, bonus: %f, element: %u, leveldiff: %f", magicacc, magiceva, minorBonus, element, leveldiff);
+    local levelDiff = utils.clamp(casterLvl - targetLvl, -5, 5);
+
+    p = 50 - 0.5 * (magiceva - magicacc) + levelDiff * 2 + percentBonus;
+
+    -- printf("P: %f, acc: %f, eva: %f, bonus: %f, leveldiff: %f", p, magicacc, magiceva, percentBonus, levelDiff);
 
     return utils.clamp(p, 5, 95);
 end
@@ -705,6 +688,55 @@ function getSkillLvl(rank,level)
 
     return skill;
 
+ end;
+
+ function getBase(rank, level)
+     if(level > 50) then
+         if(rank == 1) then
+             return 153+(level-50)*5.0;
+         end
+         if(rank == 2) then
+             return 147+(level-50)*4.9;
+         end
+         if(rank == 3) then
+             return 136+(level-50)*4.8;
+         end
+         if(rank == 4) then
+             return 126+(level-50)*4.7;
+         end
+         if(rank == 5) then
+             return 116+(level-50)*4.5;
+         end
+         if(rank == 6) then
+             return 106+(level-50)*4.4;
+         end
+         if(rank == 7) then
+             return 96+(level-50)*4.3;
+         end
+     end
+
+     if(rank == 1) then
+         return 6+(level-1)*3.0;
+     end
+     if(rank == 2) then
+         return 5+(level-1)*2.9;
+     end
+     if(rank == 3) then
+         return 5+(level-1)*2.8;
+     end
+     if(rank == 4) then
+         return 4+(level-1)*2.7;
+     end
+     if(rank == 5) then
+         return 4+(level-1)*2.5;
+     end
+     if(rank == 6) then
+         return 3+(level-1)*2.4;
+     end
+     if(rank == 7) then
+         return 3+(level-1)*2.3;
+     end
+    return 0;
  end;
 
 function handleAfflatusMisery(caster, spell, dmg)
@@ -1344,3 +1376,49 @@ function calculateBarspellPower(caster,enhanceSkill)
 
     return power;
 end
+
+-- Output magic hit rate for all levels
+function outputMagicHitRateInfo()
+    for casterLvl = 1, 75 do
+
+        printf("");
+        printf("-------- CasterLvl: %d", casterLvl);
+
+        for lvlMod = -5, 20 do
+
+            local targetLvl = casterLvl + lvlMod;
+
+            if(targetLvl >= 0) then
+                -- assume BLM spell, A+
+                local magicAcc = getSkillLvl(1, casterLvl);
+                -- assume default monster magic eva, D
+                local magicEvaRank = 7;
+
+                if(targetLvl > 50) then
+                    magicEvaRank = 4;
+                elseif(targetLvl > 35) then
+                    magicEvaRank = 5;
+                elseif(targetLvl > 25) then
+                    magicEvaRank = 6;
+                end
+
+                local magicEva = getBase(magicEvaRank, targetLvl);
+
+                local dINT = (lvlMod + 1) * -1;
+
+                if (dINT > 10) then
+                    magicAcc = magicAcc + 10 + (dINT - 10)/2;
+                else
+                    magicAcc = magicAcc + dINT;
+                end
+
+                local magicHitRate = calculateMagicHitRate(magicAcc, magicEva, 0, casterLvl, targetLvl);
+
+                printf("Lvl: %d vs %d, %d%%, MA: %d, ME: %d", casterLvl, targetLvl, magicHitRate, magicAcc, magicEva);
+            end
+
+        end
+    end
+end;
+
+-- outputMagicHitRateInfo();

--- a/scripts/globals/utils.lua
+++ b/scripts/globals/utils.lua
@@ -100,3 +100,4 @@ function utils.thirdeye(target)
 
     return false;
 end;
+

--- a/src/map/utils/mobutils.cpp
+++ b/src/map/utils/mobutils.cpp
@@ -613,15 +613,23 @@ void CalculateStats(CMobEntity * PMob)
     PMob->addModifier(MOD_ATT, GetBase(PMob,PMob->attRank));
     PMob->addModifier(MOD_ACC, GetBase(PMob,PMob->accRank));
 
-    SKILLTYPE mEvasionRating = SKILL_ELE;
+    uint8 mEvaRank = 7;
 
-    if(mLvl > 83)
+    if(mLvl > 50)
     {
-        mEvasionRating = SKILL_SWD;
+        mEvaRank = 4;
+    }
+    else if(mLvl > 35)
+    {
+        mEvaRank = 5;
+    }
+    else if(mLvl > 25)
+    {
+        mEvaRank = 6;
     }
 
     //natural magic evasion
-    PMob->addModifier(MOD_MEVA, battleutils::GetMaxSkill(mEvasionRating, JOB_RDM, mLvl > 99 ? 99 : mLvl));
+    PMob->addModifier(MOD_MEVA, GetBase(PMob, mEvaRank));
 
     if((PMob->m_Type & MOBTYPE_NOTORIOUS) && mJob == JOB_WHM && mLvl >= 25)
     {


### PR DESCRIPTION
The magic resist formula really sucks, and is not even close to retail, so lets make this a team effort to improve it. I have gone ahead and wrote a simple function that outputs magic hit rate per level as we currently have it.

When you run dsgame, you'll see something like this:
```
[15/Sep] [21:09:39][LUA Script] -------- CasterLvl: 61
[15/Sep] [21:09:39][LUA Script] Lvl: 61 vs 56, 95%, MA: 211, ME: 153
[15/Sep] [21:09:39][LUA Script] Lvl: 61 vs 57, 95%, MA: 210, ME: 157
[15/Sep] [21:09:39][LUA Script] Lvl: 61 vs 58, 95%, MA: 209, ME: 162
[15/Sep] [21:09:39][LUA Script] Lvl: 61 vs 59, 95%, MA: 208, ME: 166
[15/Sep] [21:09:39][LUA Script] Lvl: 61 vs 60, 95%, MA: 207, ME: 171
```

Let's discuss how we can improve the formula hopefully with some research to back it up.

We should first agree on a baseline, what should the magic hit rate be for these mobs? Assuming general stats with maxed skills.

Lvl 10 vs lvl 5 mob?
Lvl 10 vs lvl 6 mob?
Lvl 10 vs lvl 7 mob?
Lvl 10 vs lvl 8 mob?
Lvl 10 vs lvl 9 mob?
Lvl 10 vs lvl 10 mob?
Lvl 10 vs lvl 11 mob?
Lvl 10 vs lvl 12 mob?
Lvl 10 vs lvl 13 mob?
Lvl 10 vs lvl 14 mob?
Lvl 10 vs lvl 15 mob?
