### PR TITLE
SCRIPTS: Broke down magic resist methods into smaller ones

### DIFF
--- a/scripts/globals/magic.lua
+++ b/scripts/globals/magic.lua
@@ -319,66 +319,7 @@ end;
 -- The factor to multiply down damage (1/2 1/4 1/8 1/16) - In this format so this func can be used for enfeebs on duration.
 
 function applyResistance(player,spell,target,diff,skill,bonus)
-
-    local magicaccbonus = 0;
-    local element = spell:getElement();
-    local castersWeather = player:getWeather();
-
-    if (bonus ~= nil) then
-        magicaccbonus = magicaccbonus + bonus;
-    end
-
-    if (skill == SINGING_SKILL and player:hasStatusEffect(EFFECT_TROUBADOUR)) then
-        if (math.random(0,99) < player:getMerit(MERIT_TROUBADOUR)-25) then
-            return 1.0;
-        end
-    end
-
-    local percentBonus = 0;
-
-    if player:hasStatusEffect(EFFECT_ALTRUISM) and spell:getSpellGroup() == SPELLGROUP_WHITE then
-        magicaccbonus = magicaccbonus + player:getStatusEffect(EFFECT_ALTRUISM):getPower();
-    end
-	
-    if player:hasStatusEffect(EFFECT_FOCALIZATION) and spell:getSpellGroup() == SPELLGROUP_BLACK then
-        magicaccbonus = magicaccbonus + player:getStatusEffect(EFFECT_FOCALIZATION):getPower();
-    end
-    --difference in int/mnd
-	
-    if (diff > 10) then
-        magicaccbonus = magicaccbonus + 10 + (diff - 10)/2;
-    else
-        magicaccbonus = magicaccbonus + diff;
-    end
-	
-    --Add acc for dark seal
-    if (player:getStatusEffect(EFFECT_DARK_SEAL) ~= nil and skill == DARK_MAGIC_SKILL) then
-        magicaccbonus = magicaccbonus + 256;
-    end
-	
-    --Add acc for klimaform
-    if (player:hasStatusEffect(EFFECT_KLIMAFORM) and (castersWeather == singleWeatherStrong[element] or castersWeather == doubleWeatherStrong[element])) then
-        magicaccbonus = magicaccbonus + 15;
-    end
-
-    local skillchainTier, skillchainCount = FormMagicBurst(element, target);
-
-    --add acc for BLM AMII spells
-    if (spell:getID() == 205 or spell:getID() == 207 or spell:getID() == 209 or spell:getID() == 211 or spell:getID() == 213 or spell:getID() == 215) then
-        if (player:getMerit(blmAMIIMerit[spell:getElement()]) ~= 0) then -- no bonus if the caster has zero merit investment - don't want to give them a negative bonus
-            magicaccbonus = magicaccbonus + (player:getMerit(blmAMIIMerit[spell:getElement()]) - 1) * 5; -- bonus value granted by merit is 1; subtract 1 since unlock doesn't give an accuracy bonus
-            -- print((player:getMerit(blmAMIIMerit[spell:getElement()]) - 1) * 5)
-        end
-    end
-    
-    --add acc for skillchains
-    if (skillchainTier > 0) then
-        magicaccbonus = magicaccbonus + 25;
-    end
-
-    local p = getMagicHitRate(player, target, skill, element, percentBonus, magicaccbonus);
-
-    return getMagicResist(p);
+    return applyResistanceEffect(player, spell, target, diff, skill, bonus, nil);
 end;
 
 -- USED FOR Status Effect Enfeebs (blind, slow, para, etc.)
@@ -388,17 +329,9 @@ end;
 function applyResistanceEffect(player,spell,target,diff,skill,bonus,effect)
 
     -- If Stymie is active, as long as the mob is not immune then the effect is not resisted
-    if (player:hasStatusEffect(EFFECT_STYMIE) and target:canGainStatusEffect(effect)) then
+    if (skill == ENFEEBLING_MAGIC_SKILL and player:hasStatusEffect(EFFECT_STYMIE) and target:canGainStatusEffect(effect)) then
         player:delStatusEffect(EFFECT_STYMIE);
         return 1;
-    end
-
-    local magicaccbonus = 0;
-    local element = spell:getElement();
-    local percentBonus = 0;
-
-    if (bonus ~= nil) then
-        magicaccbonus = magicaccbonus + bonus;
     end
 
     if (skill == SINGING_SKILL and player:hasStatusEffect(EFFECT_TROUBADOUR)) then
@@ -407,68 +340,22 @@ function applyResistanceEffect(player,spell,target,diff,skill,bonus,effect)
         end
     end
 
-    if player:hasStatusEffect(EFFECT_ALTRUISM) and spell:getSpellGroup() == SPELLGROUP_WHITE then
-      magicaccbonus = magicaccbonus + player:getStatusEffect(EFFECT_ALTRUISM):getPower();
-    end
-    if player:hasStatusEffect(EFFECT_FOCALIZATION) and spell:getSpellGroup() == SPELLGROUP_BLACK then
-      magicaccbonus = magicaccbonus + player:getStatusEffect(EFFECT_FOCALIZATION):getPower();
-    end
+    local element = spell:getElement();
+    local percentBonus = 0;
+    local magicaccbonus = getSpellBonusAcc(player, target, spell);
 
-    --difference in int/mnd
     if (diff > 10) then
         magicaccbonus = magicaccbonus + 10 + (diff - 10)/2;
     else
         magicaccbonus = magicaccbonus + diff;
     end
-    --add acc for ele/dark seal
-    if (player:getStatusEffect(EFFECT_DARK_SEAL) ~= nil and skill == DARK_MAGIC_SKILL) then
-        magicaccbonus = magicaccbonus + 256;
+
+    if (bonus ~= nil) then
+        magicaccbonus = magicaccbonus + bonus;
     end
 
-    local skillchainTier, skillchainCount = FormMagicBurst(element, target);
-    --add acc for skillchains
-    if (skillchainTier > 0) then
-        magicaccbonus = magicaccbonus + 25;
-    end
-
-    -- add effect resistence
-    if (effect ~= nil and effect > 0) then
-        local effectres = 0;
-        if (effect == EFFECT_SLEEP_I or effect == EFFECT_SLEEP_II) then
-            effectres = MOD_SLEEPRES;
-        elseif(effect == EFFECT_LULLABY) then
-            effectres = MOD_LULLABYRES;
-        elseif (effect == EFFECT_POISON) then
-            effectres = MOD_POISONRES;
-        elseif (effect == EFFECT_PARALYZE) then
-            effectres = MOD_PARALYZERES;
-        elseif (effect == EFFECT_BLINDNESS) then
-            effectres = MOD_BLINDRES
-        elseif (effect == EFFECT_SILENCE) then
-            effectres = MOD_SILENCERES;
-        elseif (effect == EFFECT_PLAGUE or effect == EFFECT_DISEASE) then
-            effectres = MOD_VIRUSRES;
-        elseif (effect == EFFECT_PETRIFICATION) then
-            effectres = MOD_PETRIFYRES;
-        elseif (effect == EFFECT_BIND) then
-            effectres = MOD_BINDRES;
-        elseif (effect == EFFECT_CURSE_I or effect == EFFECT_CURSE_II or effect == EFFECT_BANE) then
-            effectres = MOD_CURSERES;
-        elseif (effect == EFFECT_WEIGHT) then
-            effectres = MOD_GRAVITYRES;
-        elseif (effect == EFFECT_SLOW) then
-            effectres = MOD_SLOWRES;
-        elseif (effect == EFFECT_STUN) then
-            effectres = MOD_STUNRES;
-        elseif (effect == EFFECT_CHARM) then
-            effectres = MOD_CHARMRES;
-        elseif (effect == EFFECT_AMNESIA) then
-            effectres = MOD_AMNESIARES;
-        end
-
-        if (effectres > 0) then
-            percentBonus = percentBonus - target:getMod(effectres);
-        end
+    if(effect ~= nil) then
+        percentBonus = percentBonus - getEffectResistance(target, effect);
     end
 
     local p = getMagicHitRate(player, target, skill, element, percentBonus, magicaccbonus);
@@ -486,7 +373,6 @@ end;
 --Applies resistance for additional effects
 function applyResistanceAddEffect(player,target,element,bonus)
 
-    -- Add a base 75 magic acc
     local p = getMagicHitRate(player, target, 0, element, 75, bonus);
 
     return getMagicResist(p);
@@ -498,7 +384,6 @@ function getMagicHitRate(caster, target, skillType, element, percentBonus, bonus
         return 0;
     end
 
-    local magicacc = 0;
     local magiceva = 0;
 
     if (bonusAcc == nil) then
@@ -513,24 +398,12 @@ function getMagicHitRate(caster, target, skillType, element, percentBonus, bonus
     end
 
     local resMod = 0; -- Some spells may possibly be non elemental, but have status effects.
-    if (element > ELE_NONE) then
+    if (element ~= ELE_NONE) then
         resMod = target:getMod(resistMod[element]);
-    end
 
-    if (element > ELE_NONE) then
         -- Add acc for staves
         local affinityBonus = AffinityBonus(caster, element);
         bonusAcc = bonusAcc + (affinityBonus-1) * 200;
-    end
-
-    --add acc for RDM group 1 merits
-    if (element > 0 and element <= 6) then
-        bonusAcc = bonusAcc + caster:getMerit(rdmMerit[element]);
-    end
-
-    -- BLU mag acc merits - nuke acc is handled in bluemagic.lua
-    if (skill == BLUE_SKILL) then
-        bonusAcc = bonusAcc + caster:getMerit(MERIT_MAGICAL_ACCURACY);
     end
 
     -- Base magic evasion (base magic evasion plus resistances(players), plus elemental defense(mobs)
@@ -548,7 +421,7 @@ function calculateMagicHitRate(magicacc, magiceva, percentBonus, casterLvl, targ
 
     p = 50 - 0.5 * (magiceva - magicacc) + levelDiff * 2 + percentBonus;
 
-    -- printf("P: %f, macc: %f, meva: %f, bonus: %d%%, leveldiff: %d%%", p, magicacc, magiceva, percentBonus, levelDiff);
+    -- printf("P: %f, macc: %f, meva: %f, bonus: %d%%, leveldiff: %d", p, magicacc, magiceva, percentBonus, levelDiff);
 
     return utils.clamp(p, 5, 95);
 end
@@ -591,6 +464,105 @@ function getMagicResist(magicHitRate)
 
     return resist;
 end
+
+-- Returns the amount of resistance the
+-- target has to the given effect (stun, sleep, etc..)
+function getEffectResistance(target, effect)
+    local effectres = 0;
+    if (effect == EFFECT_SLEEP_I or effect == EFFECT_SLEEP_II) then
+        effectres = MOD_SLEEPRES;
+    elseif(effect == EFFECT_LULLABY) then
+        effectres = MOD_LULLABYRES;
+    elseif (effect == EFFECT_POISON) then
+        effectres = MOD_POISONRES;
+    elseif (effect == EFFECT_PARALYZE) then
+        effectres = MOD_PARALYZERES;
+    elseif (effect == EFFECT_BLINDNESS) then
+        effectres = MOD_BLINDRES
+    elseif (effect == EFFECT_SILENCE) then
+        effectres = MOD_SILENCERES;
+    elseif (effect == EFFECT_PLAGUE or effect == EFFECT_DISEASE) then
+        effectres = MOD_VIRUSRES;
+    elseif (effect == EFFECT_PETRIFICATION) then
+        effectres = MOD_PETRIFYRES;
+    elseif (effect == EFFECT_BIND) then
+        effectres = MOD_BINDRES;
+    elseif (effect == EFFECT_CURSE_I or effect == EFFECT_CURSE_II or effect == EFFECT_BANE) then
+        effectres = MOD_CURSERES;
+    elseif (effect == EFFECT_WEIGHT) then
+        effectres = MOD_GRAVITYRES;
+    elseif (effect == EFFECT_SLOW) then
+        effectres = MOD_SLOWRES;
+    elseif (effect == EFFECT_STUN) then
+        effectres = MOD_STUNRES;
+    elseif (effect == EFFECT_CHARM) then
+        effectres = MOD_CHARMRES;
+    elseif (effect == EFFECT_AMNESIA) then
+        effectres = MOD_AMNESIARES;
+    end
+
+    if (effectres ~= 0) then
+        return target:getMod(effectres);
+    end
+
+    return 0;
+end;
+
+-- Returns the bonus magic accuracy for any spell
+function getSpellBonusAcc(caster, target, spell)
+    local magicAccBonus = 0;
+    local spellId = spell:getID();
+    local element = spell:getElement();
+    local castersWeather = caster:getWeather();
+    local skill = spell:getSkillType();
+    local spellGroup = spell:getSpellGroup();
+
+    if caster:hasStatusEffect(EFFECT_ALTRUISM) and spellGroup == SPELLGROUP_WHITE then
+      magicAccBonus = magicAccBonus + caster:getStatusEffect(EFFECT_ALTRUISM):getPower();
+    end
+
+    if caster:hasStatusEffect(EFFECT_FOCALIZATION) and spellGroup == SPELLGROUP_BLACK then
+      magicAccBonus = magicAccBonus + caster:getStatusEffect(EFFECT_FOCALIZATION):getPower();
+    end
+
+    local skillchainTier, skillchainCount = FormMagicBurst(element, target);
+
+    --add acc for BLM AMII spells
+    if (spellId == 205 or spellId == 207 or spellId == 209 or spellId == 211 or spellId == 213 or spellId == 215) then
+        -- no bonus if the caster has zero merit investment - don't want to give them a negative bonus
+        if (caster:getMerit(blmAMIIMerit[element]) ~= 0) then
+            -- bonus value granted by merit is 1; subtract 1 since unlock doesn't give an accuracy bonus
+            magicAccBonus = magicAccBonus + (caster:getMerit(blmAMIIMerit[element]) - 1) * 5;
+        end
+    end
+
+    --add acc for skillchains
+    if (skillchainTier > 0) then
+        magicAccBonus = magicAccBonus + 25;
+    end
+
+    --Add acc for klimaform
+    if (caster:hasStatusEffect(EFFECT_KLIMAFORM) and (castersWeather == singleWeatherStrong[element] or castersWeather == doubleWeatherStrong[element])) then
+        magicAccBonus = magicAccBonus + 15;
+    end
+
+    --Add acc for dark seal
+    if (skill == DARK_MAGIC_SKILL and caster:hasStatusEffect(EFFECT_DARK_SEAL)) then
+        magicAccBonus = magicAccBonus + 256;
+    end
+
+    --add acc for RDM group 1 merits
+    if (element > 0 and element <= 6) then
+        magicAccBonus = magicAccBonus + caster:getMerit(rdmMerit[element]);
+    end
+
+    -- BLU mag acc merits - nuke acc is handled in bluemagic.lua
+    if (skill == BLUE_SKILL) then
+        magicAccBonus = magicAccBonus + caster:getMerit(MERIT_MAGICAL_ACCURACY);
+    end
+
+    return magicAccBonus;
+end;
 
 -----------------------------------
 --     SKILL LEVEL CALCULATOR

--- a/scripts/globals/monstertpmoves.lua
+++ b/scripts/globals/monstertpmoves.lua
@@ -328,7 +328,6 @@ end
 --effect = EFFECT_WHATEVER if enfeeble
 --statmod = the stat to account for resist (INT,MND,etc) e.g. MOD_INT
 --This determines how much the monsters ability resists on the player.
---TODO: update all mob moves to use the new function
 function applyPlayerResistance(mob,effect,target,diff,bonus,element)
     resist = 1.0;
     magicaccbonus = 0;


### PR DESCRIPTION
This consolidates both resist functions into one. `applyResist` and `applyResistEffect`. Also creates some new helper functions: `getEffectResistance`, `getSpellBonusAcc`.

I'm thinking about putting all these magic spells under a namespace `magic`. Would keep things clear of which file they are defined in.