### PR TITLE
Scripts: Fix Cura's future Misery support

### DIFF
--- a/scripts/globals/spells/cura.lua
+++ b/scripts/globals/spells/cura.lua
@@ -16,105 +16,113 @@ require("scripts/globals/magic");
 -----------------------------------------
 
 function onMagicCastingCheck(caster,target,spell)
-	return 0;
+    if (caster:getID() ~= target:getID()) then
+        return MSGBASIC_CANNOT_PERFORM_TARG;
+    else
+        return 0;
+    end;
 end;
 
 function onSpellCast(caster,target,spell)
-	local divisor = 0;
-	local constant = 0;
-	local basepower = 0;
-	local power = 0;
-	local basecure = 0;
-	local final = 0;
+    local divisor = 0;
+    local constant = 0;
+    local basepower = 0;
+    local power = 0;
+    local basecure = 0;
+    local final = 0;
 
-	local minCure = 10;
-	if (USE_OLD_CURE_FORMULA == true) then
-		power = getCurePowerOld(caster);
-		divisor = 1;
-		constant = -10;
-		if (power > 100) then
-				divisor = 57;
-				constant = 29.125;
-		elseif (power > 60) then
-				divisor = 2;
-				constant = 5;
-		end
-	else
-		power = getCurePower(caster);
-		if (power < 20) then
-			divisor = 4;
-			constant = 10;
-			basepower = 0;
-		elseif (power < 40) then
-			divisor =  1.3333;
-			constant = 15;
-			basepower = 20;
-		elseif (power < 125) then
-			divisor = 8.5;
-			constant = 30;
-			basepower = 40;
-		elseif (power < 200) then
-			divisor = 15;
-			constant = 40;
-			basepower = 125;
-		elseif (power < 600) then
-			divisor = 20;
-			constant = 40;
-			basepower = 200;
-		else
-			divisor = 999999;
-			constant = 65;
-			basepower = 0;
-		end
-	end
+    local minCure = 10;
+    if (USE_OLD_CURE_FORMULA == true) then
+        power = getCurePowerOld(caster);
+        divisor = 1;
+        constant = -10;
+        if (power > 100) then
+                divisor = 57;
+                constant = 29.125;
+        elseif (power > 60) then
+                divisor = 2;
+                constant = 5;
+        end
+    else
+        power = getCurePower(caster);
+        if (power < 20) then
+            divisor = 4;
+            constant = 10;
+            basepower = 0;
+        elseif (power < 40) then
+            divisor =  1.3333;
+            constant = 15;
+            basepower = 20;
+        elseif (power < 125) then
+            divisor = 8.5;
+            constant = 30;
+            basepower = 40;
+        elseif (power < 200) then
+            divisor = 15;
+            constant = 40;
+            basepower = 125;
+        elseif (power < 600) then
+            divisor = 20;
+            constant = 40;
+            basepower = 200;
+        else
+            divisor = 999999;
+            constant = 65;
+            basepower = 0;
+        end
+    end
 
-	if (USE_OLD_CURE_FORMULA == true) then
-		basecure = getBaseCure(power,divisor,constant);
-	else
-		basecure = getBaseCure(power,divisor,constant,basepower);
-	end
-	
-	--Apply Afflatus Misery Bonus to Final Result
-	if (caster:hasStatusEffect(EFFECT_AFFLATUS_MISERY)) then
-		local misery = caster:getMod(MOD_AFFLATUS_MISERY);
-			
-		--THIS IS LARELY SEMI-EDUCATED GUESSWORK. THERE IS NOT A
-		--LOT OF CONCRETE INFO OUT THERE ON CURA THAT I COULD FIND
-			
-		--If the target max affluent misery bonus
-		--according to tests I found seems to cap out at most
-		--people about 125 misery. With that in mind, if you
-		--were hitting the Cure I cap of 65hp, then each misery
-		--point would boost your Cura by about 1hp, capping at ~175hp
-		--So with lack of available formula documentation, I'll go with that.
-			
-		--printf("BEFORE AFFLATUS MISERY BONUS: %d", basecure);
-			
-		basecure = basecure + misery;
-			
-		if (basecure > 175) then
-			basecure = 175;
-		end
-		
-		--printf("AFTER AFFLATUS MISERY BONUS: %d", basecure);
-		
-		--Afflatus Misery Mod Gets Used Up
-		caster:setMod(MOD_AFFLATUS_MISERY, 0);
-	end
-	
-	final = getCureFinal(caster,spell,basecure,minCure,false);
-	final = final + (final * (target:getMod(MOD_CURE_POTENCY_RCVD)/100));
+    if (USE_OLD_CURE_FORMULA == true) then
+        basecure = getBaseCure(power,divisor,constant);
+    else
+        basecure = getBaseCure(power,divisor,constant,basepower);
+    end
+    
+    --Apply Afflatus Misery Bonus to Final Result
+    if (caster:hasStatusEffect(EFFECT_AFFLATUS_MISERY)) then
+        if (caster:getID() == target:getID()) then -- Let's use a local var to hold the power of Misery so the boost is applied to all targets,
+            caster:setLocalVar("Misery_Power", caster:getMod(MOD_AFFLATUS_MISERY));
+        end;
+        local misery = caster:getLocalVar("Misery_Power");
+        -- print(caster:getLocalVar("Misery_Power"));
+            
+        --THIS IS LARELY SEMI-EDUCATED GUESSWORK. THERE IS NOT A
+        --LOT OF CONCRETE INFO OUT THERE ON CURA THAT I COULD FIND
+            
+        --If the target max affluent misery bonus
+        --according to tests I found seems to cap out at most
+        --people about 125 misery. With that in mind, if you
+        --were hitting the Cure I cap of 65hp, then each misery
+        --point would boost your Cura by about 1hp, capping at ~175hp
+        --So with lack of available formula documentation, I'll go with that.
+            
+        --printf("BEFORE AFFLATUS MISERY BONUS: %d", basecure);
+            
+        basecure = basecure + misery;
+            
+        if (basecure > 175) then
+            basecure = 175;
+        end
+        
+        --printf("AFTER AFFLATUS MISERY BONUS: %d", basecure);
+        
+        --Afflatus Misery Mod Gets Used Up
+        caster:setMod(MOD_AFFLATUS_MISERY, 0);
+    end
+    
+    final = getCureFinal(caster,spell,basecure,minCure,false);
+    final = final + (final * (target:getMod(MOD_CURE_POTENCY_RCVD)/100));
 
-	--Applying server mods....
-	final = final * CURE_POWER;
-	
-	target:addHP(final);
+    --Applying server mods....
+    final = final * CURE_POWER;
+    
+    target:addHP(final);
 
-	target:wakeUp();
-	
-	--Enmity for Cura is fixed, so its CE/VE is set in the SQL and not calculated with updateEnmityFromCure
-	
-	spell:setMsg(367);
-	
-	return final;
+    target:wakeUp();
+    
+    --Enmity for Cura is fixed, so its CE/VE is set in the SQL and not calculated with updateEnmityFromCure
+    
+    spell:setMsg(367);
+    
+    return final;
 end;

--- a/scripts/globals/spells/cura_ii.lua
+++ b/scripts/globals/spells/cura_ii.lua
@@ -16,105 +16,112 @@ require("scripts/globals/magic");
 -----------------------------------------
 
 function onMagicCastingCheck(caster,target,spell)
-	return 0;
+    if (caster:getID() ~= target:getID()) then
+        return MSGBASIC_CANNOT_PERFORM_TARG;
+    else
+        return 0;
+    end;
 end;
 
 function onSpellCast(caster,target,spell)
-	local divisor = 0;
-	local constant = 0;
-	local basepower = 0;
-	local power = 0;
-	local basecure = 0;
-	local final = 0;
+    local divisor = 0;
+    local constant = 0;
+    local basepower = 0;
+    local power = 0;
+    local basecure = 0;
+    local final = 0;
 
-	local minCure = 60;
-	if (USE_OLD_CURE_FORMULA == true) then
-		power = getCurePowerOld(caster);
-		divisor = 1;
-		constant = 20;
-		if (power > 170) then
-				divisor = 35.6666;
-				constant = 87.62;
-		elseif (power > 110) then
-				divisor = 2;
-				constant = 47.5;
-		end
-	else
-		power = getCurePower(caster);
-		if (power < 70) then
-			divisor = 1;
-			constant = 60;
-			basepower = 40;
-		elseif (power < 125) then
-			divisor = 5.5;
-			constant = 90;
-			basepower = 70;
-		elseif (power < 200) then
-			divisor = 7.5;
-			constant = 100;
-			basepower = 125;
-		elseif (power < 400) then
-			divisor = 10;
-			constant = 110;
-			basepower = 200;
-		elseif (power < 700) then
-			divisor = 20;
-			constant = 130;
-			basepower = 400;
-		else
-			divisor = 999999;
-			constant = 145;
-			basepower = 0;
-		end
-	end
+    local minCure = 60;
+    if (USE_OLD_CURE_FORMULA == true) then
+        power = getCurePowerOld(caster);
+        divisor = 1;
+        constant = 20;
+        if (power > 170) then
+                divisor = 35.6666;
+                constant = 87.62;
+        elseif (power > 110) then
+                divisor = 2;
+                constant = 47.5;
+        end
+    else
+        power = getCurePower(caster);
+        if (power < 70) then
+            divisor = 1;
+            constant = 60;
+            basepower = 40;
+        elseif (power < 125) then
+            divisor = 5.5;
+            constant = 90;
+            basepower = 70;
+        elseif (power < 200) then
+            divisor = 7.5;
+            constant = 100;
+            basepower = 125;
+        elseif (power < 400) then
+            divisor = 10;
+            constant = 110;
+            basepower = 200;
+        elseif (power < 700) then
+            divisor = 20;
+            constant = 130;
+            basepower = 400;
+        else
+            divisor = 999999;
+            constant = 145;
+            basepower = 0;
+        end
+    end
 
-	if (USE_OLD_CURE_FORMULA == true) then
-		basecure = getBaseCure(power,divisor,constant);
-	else
-		basecure = getBaseCure(power,divisor,constant,basepower);
-	end
+    if (USE_OLD_CURE_FORMULA == true) then
+        basecure = getBaseCure(power,divisor,constant);
+    else
+        basecure = getBaseCure(power,divisor,constant,basepower);
+    end
 
-	--Apply Afflatus Misery Bonus to Final Result
-	if (caster:hasStatusEffect(EFFECT_AFFLATUS_MISERY)) then
-		local misery = caster:getMod(MOD_AFFLATUS_MISERY);
-		
-		--THIS IS LARELY SEMI-EDUCATED GUESSWORK. THERE IS NOT A
-		--LOT OF CONCRETE INFO OUT THERE ON CURA THAT I COULD FIND
-		
-		--Not very much documentation for Cura II known at all.
-		--As with Cura, the Afflatus Misery bonus can boost this spell up
-		--to roughly the level of a Curaga 3. For Cura I vs Curaga II,
-		--this is document at ~175HP, 15HP less than the cap of 190HP. So
-		--for Cura II, i'll go with 15 less than the cap of Curaga III (390): 375
-		--So with lack of available formula documentation, I'll go with that.
-		
-		--printf("BEFORE AFFLATUS MISERY BONUS: %d", basecure);
-		
-		basecure = basecure + misery;
-		
-		if (basecure > 375) then
-			basecure = 375;
-		end
-		
-		--printf("AFTER AFFLATUS MISERY BONUS: %d", basecure);
-		
-		--Afflatus Misery Mod Gets Used Up
-		caster:setMod(MOD_AFFLATUS_MISERY, 0);
-	end
-	
-	final = getCureFinal(caster,spell,basecure,minCure,false);
-	final = final + (final * (target:getMod(MOD_CURE_POTENCY_RCVD)/100));
+    --Apply Afflatus Misery Bonus to Final Result
+    if (caster:hasStatusEffect(EFFECT_AFFLATUS_MISERY)) then
+        if (caster:getID() == target:getID()) then -- Let's use a local var to hold the power of Misery so the boost is applied to all targets,
+            caster:setLocalVar("Misery_Power", caster:getMod(MOD_AFFLATUS_MISERY));
+        end;
+        local misery = caster:getLocalVar("Misery_Power");
+        
+        --THIS IS LARELY SEMI-EDUCATED GUESSWORK. THERE IS NOT A
+        --LOT OF CONCRETE INFO OUT THERE ON CURA THAT I COULD FIND
+        
+        --Not very much documentation for Cura II known at all.
+        --As with Cura, the Afflatus Misery bonus can boost this spell up
+        --to roughly the level of a Curaga 3. For Cura I vs Curaga II,
+        --this is document at ~175HP, 15HP less than the cap of 190HP. So
+        --for Cura II, i'll go with 15 less than the cap of Curaga III (390): 375
+        --So with lack of available formula documentation, I'll go with that.
+        
+        --printf("BEFORE AFFLATUS MISERY BONUS: %d", basecure);
+        
+        basecure = basecure + misery;
+        
+        if (basecure > 375) then
+            basecure = 375;
+        end
+        
+        --printf("AFTER AFFLATUS MISERY BONUS: %d", basecure);
+        
+        --Afflatus Misery Mod Gets Used Up
+        caster:setMod(MOD_AFFLATUS_MISERY, 0);
+    end
+    
+    final = getCureFinal(caster,spell,basecure,minCure,false);
+    final = final + (final * (target:getMod(MOD_CURE_POTENCY_RCVD)/100));
 
-	--Applying server mods....
-	final = final * CURE_POWER;
+    --Applying server mods....
+    final = final * CURE_POWER;
 
-	target:addHP(final);
+    target:addHP(final);
 
-	target:wakeUp();
-	
-	--Enmity for Cura is fixed, so its CE/VE is set in the SQL and not calculated with updateEnmityFromCure
-	
-	spell:setMsg(367);
-	
-	return final;
+    target:wakeUp();
+    
+    --Enmity for Cura is fixed, so its CE/VE is set in the SQL and not calculated with updateEnmityFromCure
+    
+    spell:setMsg(367);
+    
+    return final;
 end;

--- a/scripts/globals/spells/cura_iii.lua
+++ b/scripts/globals/spells/cura_iii.lua
@@ -16,105 +16,112 @@ require("scripts/globals/magic");
 -----------------------------------------
 
 function onMagicCastingCheck(caster,target,spell)
-	return 0;
+    if (caster:getID() ~= target:getID()) then
+        return MSGBASIC_CANNOT_PERFORM_TARG;
+    else
+        return 0;
+    end;
 end;
 
 function onSpellCast(caster,target,spell)
-	local divisor = 0;
-	local constant = 0;
-	local basepower = 0;
-	local power = 0;
-	local basecure = 0;
-	local final = 0;
+    local divisor = 0;
+    local constant = 0;
+    local basepower = 0;
+    local power = 0;
+    local basecure = 0;
+    local final = 0;
 
-	local minCure = 130;
-	if (USE_OLD_CURE_FORMULA == true) then
-		power = getCurePowerOld(caster);
-		rate = 1;
-		constant = 70;
-		if (power > 300) then
-				rate = 15.6666;
-				constant = 180.43;
-		elseif (power > 180) then
-				rate = 2;
-				constant = 115;
-		end
-	else
-		power = getCurePower(caster);
-		if (power < 125) then
-			divisor = 2.2
-			constant = 130;
-			basepower = 70;
-		elseif (power < 200) then
-			divisor =  75/65;
-			constant = 155;
-			basepower = 125;
-		elseif (power < 300) then
-			divisor = 2.5;
-			constant = 220;
-			basepower = 200;
-		elseif (power < 700) then
-			divisor = 5;
-			constant = 260;
-			basepower = 300;
-		else
-			divisor = 999999;
-			constant = 340;
-			basepower = 0;
-		end
-	end
+    local minCure = 130;
+    if (USE_OLD_CURE_FORMULA == true) then
+        power = getCurePowerOld(caster);
+        rate = 1;
+        constant = 70;
+        if (power > 300) then
+                rate = 15.6666;
+                constant = 180.43;
+        elseif (power > 180) then
+                rate = 2;
+                constant = 115;
+        end
+    else
+        power = getCurePower(caster);
+        if (power < 125) then
+            divisor = 2.2
+            constant = 130;
+            basepower = 70;
+        elseif (power < 200) then
+            divisor =  75/65;
+            constant = 155;
+            basepower = 125;
+        elseif (power < 300) then
+            divisor = 2.5;
+            constant = 220;
+            basepower = 200;
+        elseif (power < 700) then
+            divisor = 5;
+            constant = 260;
+            basepower = 300;
+        else
+            divisor = 999999;
+            constant = 340;
+            basepower = 0;
+        end
+    end
 
-	if (USE_OLD_CURE_FORMULA == true) then
-		basecure = getBaseCure(power,divisor,constant);
-	else
-		basecure = getBaseCure(power,divisor,constant,basepower);
-	end
-	
-	--Apply Afflatus Misery Bonus to the Result
-	if (caster:hasStatusEffect(EFFECT_AFFLATUS_MISERY)) then
-		local misery = caster:getMod(MOD_AFFLATUS_MISERY);
-		
-		--THIS IS LARELY SEMI-EDUCATED GUESSWORK. THERE IS NOT A
-		--LOT OF CONCRETE INFO OUT THERE ON CURA THAT I COULD FIND
-		
-		--Not very much documentation for Cura II known at all.
-		--As with Cura, the Afflatus Misery bonus can boost this spell up
-		--to roughly the level of a Curaga 4. For Cura II vs Curaga III,
-		--this is document at ~375HP, 15HP less than the cap of 390HP. So
-		--for Cura II, i'll go with 15 less than the cap of Curaga IV (690): 675
-		--So with lack of available formula documentation, I'll go with that.
-		
-		--printf("BEFORE AFFLATUS MISERY BONUS: %d", basecure);
-		
-		basecure = basecure + misery;
-		
-		if (basecure > 675) then
-			basecure = 675;
-		end
-		
-		--printf("AFTER AFFLATUS MISERY BONUS: %d", basecure);
-		
-		--Afflatus Misery Mod Gets Used Up
-		caster:setMod(MOD_AFFLATUS_MISERY, 0);
-	end
-	
-	final = getCureFinal(caster,spell,basecure,minCure,false);
-	final = final + (final * (target:getMod(MOD_CURE_POTENCY_RCVD)/100));
+    if (USE_OLD_CURE_FORMULA == true) then
+        basecure = getBaseCure(power,divisor,constant);
+    else
+        basecure = getBaseCure(power,divisor,constant,basepower);
+    end
+    
+    --Apply Afflatus Misery Bonus to the Result
+    if (caster:hasStatusEffect(EFFECT_AFFLATUS_MISERY)) then
+        if (caster:getID() == target:getID()) then -- Let's use a local var to hold the power of Misery so the boost is applied to all targets,
+            caster:setLocalVar("Misery_Power", caster:getMod(MOD_AFFLATUS_MISERY));
+        end;
+        local misery = caster:getLocalVar("Misery_Power");
+        
+        --THIS IS LARELY SEMI-EDUCATED GUESSWORK. THERE IS NOT A
+        --LOT OF CONCRETE INFO OUT THERE ON CURA THAT I COULD FIND
+        
+        --Not very much documentation for Cura II known at all.
+        --As with Cura, the Afflatus Misery bonus can boost this spell up
+        --to roughly the level of a Curaga 4. For Cura II vs Curaga III,
+        --this is document at ~375HP, 15HP less than the cap of 390HP. So
+        --for Cura II, i'll go with 15 less than the cap of Curaga IV (690): 675
+        --So with lack of available formula documentation, I'll go with that.
+        
+        --printf("BEFORE AFFLATUS MISERY BONUS: %d", basecure);
+        
+        basecure = basecure + misery;
+        
+        if (basecure > 675) then
+            basecure = 675;
+        end
+        
+        --printf("AFTER AFFLATUS MISERY BONUS: %d", basecure);
+        
+        --Afflatus Misery Mod Gets Used Up
+        caster:setMod(MOD_AFFLATUS_MISERY, 0);
+    end
+    
+    final = getCureFinal(caster,spell,basecure,minCure,false);
+    final = final + (final * (target:getMod(MOD_CURE_POTENCY_RCVD)/100));
 
-	--Applying server mods....
-	final = final * CURE_POWER;
+    --Applying server mods....
+    final = final * CURE_POWER;
 
-	local diff = (target:getMaxHP() - target:getHP());
-	if (final > diff) then
-		final = diff;
-	end
-	target:addHP(final);
+    local diff = (target:getMaxHP() - target:getHP());
+    if (final > diff) then
+        final = diff;
+    end
+    target:addHP(final);
 
-	target:wakeUp();
+    target:wakeUp();
 
-	--Enmity for Cura III is fixed, so its CE/VE is set in the SQL and not calculated with updateEnmityFromCure
-	
-	spell:setMsg(367);
+    --Enmity for Cura III is fixed, so its CE/VE is set in the SQL and not calculated with updateEnmityFromCure
+    
+    spell:setMsg(367);
 
-	return final;
+    return final;
 end;


### PR DESCRIPTION
-Made the spells store the power of the Misery mod as a local var upon casting if the caster's ID == the target's ID. This enables all who are affected by the spell to get the boosted heal.
-Made the spell only able to be cast on the caster.

Please note, that since the Misery mod itself is not fully implemented (doesn't store the damage from the last hit), the boost won't actually be applied - I tested by manually setting the mod power.