### PR TITLE
Scripts: Implement that stupid door before the central elevator in th…

### DIFF
--- a/scripts/zones/The_Garden_of_RuHmet/TextIDs.lua
+++ b/scripts/zones/The_Garden_of_RuHmet/TextIDs.lua
@@ -5,13 +5,14 @@ ITEM_CANNOT_BE_OBTAINED = 6379; -- You cannot obtain the item <item> come back a
           ITEM_OBTAINED = 6384; -- Obtained: <item>
            GIL_OBTAINED = 6385; -- Obtained <number> gil
        KEYITEM_OBTAINED = 6387; -- Obtained key item: <keyitem>
-            HOMEPOINT_SET = 7753; -- Home point set!
+          HOMEPOINT_SET = 7753; -- Home point set!
             
 -- Other
 NO_NEED_INVESTIGATE = 7608; -- There is no need to investigate further.
    UNKNOWN_PRESENCE = 7745; -- You sense some unknown presence...
        NONE_HOSTILE = 7746; -- You sense some unknown presence, but it does not seem hostile.
     SHEER_ANIMOSITY = 7748; -- Player Name is enveloped in sheer animosity!
+      PORTAL_SEALED = 7637; -- The portal is firmly sealed by a mysterious energy.
 
 -- conquest Base
 CONQUEST_BASE = 7429; -- Tallying conquest results...

--- a/scripts/zones/The_Garden_of_RuHmet/npcs/_0zy.lua
+++ b/scripts/zones/The_Garden_of_RuHmet/npcs/_0zy.lua
@@ -16,14 +16,21 @@ end;
 -----------------------------------
 
 function onTrigger(player,npc)
-	
-	if (player:getZPos() <= 359) then
-		player:startEvent(0x008c);
-	else
-		player:startEvent(0x008d);
-	end
-	
-	return 1;
+     -- the door breaks during the CS in Al'Taieu after receiving the Dawn mission, which sets the var to 1. Also checking for The Last Verse mission for whenever that gets implemented.
+    if ((player:getCurrentMission(COP) == DAWN and player:getVar("PromathiaStatus") > 0) or player:getCurrentMission(COP) > DAWN) then
+        if (player:getZPos() <= 360) then
+            player:startEvent(0x008c);
+        else
+            player:startEvent(0x008d);
+        end
+    else
+        if (player:getZPos() <= 360) then
+            player:messageSpecial(PORTAL_SEALED);
+        else
+            player:startEvent(0x008b);
+        end
+    end
+    return 1;
 end;
 
 -----------------------------------


### PR DESCRIPTION
…e Garden of Ru'Hmet.

If you haven't viewed the cutscene in Al'Taieu after receiving the Dawn mission, the door isn't broken. Before that, the door is locked from the south side, and is a one-way passage from the north side, though the home point on the north side kind of makes that moot now.

Also, I changed the Z pos value that's checked because one could get really close on the south side and trigger the wrong event. Now it's not possible to trigger the wrong event from either side.