### PR TITLE
Fixing CBattleEntity::ATT and battleutils::GetDamageRatio to take into account main vs sub weapon

### DIFF
--- a/src/map/ai/ai_automaton_dummy.cpp
+++ b/src/map/ai/ai_automaton_dummy.cpp
@@ -206,7 +206,7 @@ void CAIAutomatonDummy::ActionAttack()
                             Action.messageID = 1;
 
                             bool isCritical = (dsprand::GetRandomNumber(100) < battleutils::GetCritHitRate(m_PPet, m_PBattleTarget, false));
-                            float DamageRatio = battleutils::GetDamageRatio(m_PPet, m_PBattleTarget, isCritical, 0);
+                            float DamageRatio = battleutils::GetDamageRatio(m_PPet, m_PBattleTarget, SLOT_MAIN, isCritical, 0);
 
                             if (isCritical)
                             {

--- a/src/map/ai/ai_mob_dummy.cpp
+++ b/src/map/ai/ai_mob_dummy.cpp
@@ -1689,7 +1689,7 @@ void CAIMobDummy::ActionAttack()
                                     }
                                     
                                     isCritical = (dsprand::GetRandomNumber(100) < battleutils::GetCritHitRate(m_PBattleTarget, m_PMob, false));
-                                    float DamageRatio = battleutils::GetDamageRatio(m_PBattleTarget, m_PMob, isCritical, 0);
+                                    float DamageRatio = battleutils::GetDamageRatio(m_PBattleTarget, m_PMob, SLOT_MAIN, isCritical, 0);
                                     damage = (int32)((m_PBattleTarget->GetMainWeaponDmg() + naturalh2hDMG + battleutils::GetFSTR(m_PBattleTarget, m_PMob, SLOT_MAIN)) * DamageRatio);
                                     Action.spikesParam = battleutils::TakePhysicalDamage(m_PBattleTarget, m_PMob, damage, false, SLOT_MAIN, 1, nullptr, true, false, true);
                                     Action.spikesMessage = 33;
@@ -1752,7 +1752,7 @@ void CAIMobDummy::ActionAttack()
                                     isCritical=true;
                                 }
 
-                                float DamageRatio = battleutils::GetDamageRatio(m_PMob, m_PBattleTarget,isCritical, 0);
+                                float DamageRatio = battleutils::GetDamageRatio(m_PMob, m_PBattleTarget, SLOT_MAIN, isCritical, 0);
 
                                 if (isCritical)
                                 {
@@ -1840,7 +1840,7 @@ void CAIMobDummy::ActionAttack()
                                     }
                                     
                                     isCritical = (dsprand::GetRandomNumber(100) < battleutils::GetCritHitRate(m_PBattleTarget, m_PMob, false));
-                                    float DamageRatio = battleutils::GetDamageRatio(m_PBattleTarget, m_PMob, isCritical, 0);
+                                    float DamageRatio = battleutils::GetDamageRatio(m_PBattleTarget, m_PMob, SLOT_MAIN, isCritical, 0);
                                     damage = (int32)((m_PBattleTarget->GetMainWeaponDmg() + naturalh2hDMG + battleutils::GetFSTR(m_PBattleTarget, m_PMob, SLOT_MAIN)) * DamageRatio);
                                     Action.spikesParam = battleutils::TakePhysicalDamage(m_PBattleTarget, m_PMob, damage, false, SLOT_MAIN, 1, nullptr, true, false, true);
                                     Action.spikesMessage = 33;

--- a/src/map/ai/ai_pet_dummy.cpp
+++ b/src/map/ai/ai_pet_dummy.cpp
@@ -808,7 +808,7 @@ void CAIPetDummy::ActionAttack()
                             Action.messageID = 1;
 
                             bool isCritical = (dsprand::GetRandomNumber(100) < battleutils::GetCritHitRate(m_PPet, m_PBattleTarget, false));
-                            float DamageRatio = battleutils::GetDamageRatio(m_PPet, m_PBattleTarget, isCritical, 0);
+                            float DamageRatio = battleutils::GetDamageRatio(m_PPet, m_PBattleTarget, SLOT_MAIN, isCritical, 0);
 
                             if (isCritical)
                             {

--- a/src/map/attack.cpp
+++ b/src/map/attack.cpp
@@ -101,7 +101,7 @@ bool CAttack::IsCritical()
 void CAttack::SetCritical(bool value)
 {
 	m_isCritical = value;
-	m_damageRatio = battleutils::GetDamageRatio(m_attacker, m_victim, m_isCritical, 0);
+	m_damageRatio = battleutils::GetDamageRatio(m_attacker, m_victim, GetWeaponSlot(), m_isCritical, 0);
 }
 
 /************************************************************************

--- a/src/map/entities/battleentity.h
+++ b/src/map/entities/battleentity.h
@@ -458,7 +458,7 @@ public:
     uint16          MND();
     uint16          CHR();
     uint16          DEF();
-    uint16          ATT();
+    uint16          ATT(uint8 attackNumber, uint8 offsetAttack);
     uint16			ACC(uint8 attackNumber, uint8 offsetAccuracy);
     uint16          EVA();
     uint16          RATT(uint8 skill, uint16 bonusSkill = 0);

--- a/src/map/lua/lua_baseentity.cpp
+++ b/src/map/lua/lua_baseentity.cpp
@@ -2067,7 +2067,7 @@ inline int32 CLuaBaseEntity::getStat(lua_State *L)
         case MOD_INT:  lua_pushinteger(L, PEntity->INT()); break;
         case MOD_MND:  lua_pushinteger(L, PEntity->MND()); break;
         case MOD_CHR:  lua_pushinteger(L, PEntity->CHR()); break;
-        case MOD_ATT:  lua_pushinteger(L, PEntity->ATT()); break;
+        case MOD_ATT:  lua_pushinteger(L, PEntity->ATT(SLOT_MAIN, 0)); break;
         case MOD_DEF:  lua_pushinteger(L, PEntity->DEF()); break;
         default: lua_pushnil(L);
     }
@@ -6694,7 +6694,7 @@ inline int32 CLuaBaseEntity::getMeleeHitDamage(lua_State *L)
 
     if (dsprand::GetRandomNumber(100) < hitrate)
     {
-        float DamageRatio = battleutils::GetDamageRatio(PAttacker, PDefender, false, 0);
+        float DamageRatio = battleutils::GetDamageRatio(PAttacker, PDefender, SLOT_MAIN, false, 0);
         int damage = (uint16)((PAttacker->GetMainWeaponDmg() + battleutils::GetFSTR(PAttacker, PDefender, SLOT_MAIN)) * DamageRatio);
         lua_pushinteger(L, damage);
         return 1;

--- a/src/map/packet_system.cpp
+++ b/src/map/packet_system.cpp
@@ -4282,10 +4282,10 @@ void SmallPacket0x0DD(map_session_data_t* session, CCharEntity* PChar, CBasicPac
         {
             PChar->pushPacket(new CMessageBasicPacket(PChar, PChar, 0, 0, MSGBASIC_CHECKPARAM_NAME));
             PChar->pushPacket(new CMessageBasicPacket(PChar, PChar, 0, 0, MSGBASIC_CHECKPARAM_ILVL));
-            PChar->pushPacket(new CMessageBasicPacket(PChar, PChar, PChar->ACC(0, 0), PChar->ATT(), MSGBASIC_CHECKPARAM_PRIMARY));
+            PChar->pushPacket(new CMessageBasicPacket(PChar, PChar, PChar->ACC(SLOT_MAIN, 0), PChar->ATT(SLOT_MAIN, 0), MSGBASIC_CHECKPARAM_PRIMARY));
             if (PChar->getEquip(SLOT_SUB) && PChar->getEquip(SLOT_SUB)->isType(ITEM_WEAPON))
             {
-                PChar->pushPacket(new CMessageBasicPacket(PChar, PChar, PChar->ACC(1, 0), PChar->ATT(), MSGBASIC_CHECKPARAM_AUXILIARY));
+                PChar->pushPacket(new CMessageBasicPacket(PChar, PChar, PChar->ACC(SLOT_SUB, 0), PChar->ATT(SLOT_SUB, 0), MSGBASIC_CHECKPARAM_AUXILIARY));
             }
             else
             {
@@ -4312,10 +4312,10 @@ void SmallPacket0x0DD(map_session_data_t* session, CCharEntity* PChar, CBasicPac
         else if (PChar->PPet && PChar->PPet->id == id)
         {
             PChar->pushPacket(new CMessageBasicPacket(PChar, PChar->PPet, 0, 0, MSGBASIC_CHECKPARAM_NAME));
-            PChar->pushPacket(new CMessageBasicPacket(PChar, PChar->PPet, PChar->PPet->ACC(0, 0), PChar->PPet->ATT(), MSGBASIC_CHECKPARAM_PRIMARY));
+            PChar->pushPacket(new CMessageBasicPacket(PChar, PChar->PPet, PChar->PPet->ACC(SLOT_MAIN, 0), PChar->PPet->ATT(SLOT_MAIN, 0), MSGBASIC_CHECKPARAM_PRIMARY));
             if (PChar->getEquip(SLOT_SUB) && PChar->getEquip(SLOT_SUB)->isType(ITEM_WEAPON))
             {
-                PChar->pushPacket(new CMessageBasicPacket(PChar, PChar->PPet, PChar->PPet->ACC(1, 0), PChar->PPet->ATT(), MSGBASIC_CHECKPARAM_AUXILIARY));
+                PChar->pushPacket(new CMessageBasicPacket(PChar, PChar->PPet, PChar->PPet->ACC(SLOT_SUB, 0), PChar->PPet->ATT(SLOT_SUB, 0), MSGBASIC_CHECKPARAM_AUXILIARY));
             }
             else
             {
@@ -4365,7 +4365,7 @@ void SmallPacket0x0DD(map_session_data_t* session, CCharEntity* PChar, CBasicPac
             {
                 uint32 baseExp = charutils::GetRealExp(PChar->GetMLevel(), PTarget->GetMLevel());
                 uint16 charAcc = PChar->ACC(SLOT_MAIN, (uint8)0);
-                uint16 charAtt = PChar->ATT();
+                uint16 charAtt = PChar->ATT(SLOT_MAIN, (uint8)0);
                 uint16 mobEva = PTarget->EVA();
                 uint16 mobDef = PTarget->DEF();
 

--- a/src/map/packets/char_stats.cpp
+++ b/src/map/packets/char_stats.cpp
@@ -59,7 +59,7 @@ CCharStatsPacket::CCharStatsPacket(CCharEntity * PChar)
 	WBUFW(data,(0x2C)) = dsp_cap(PChar->getMod(MOD_MND), -999 + PChar->stats.MND, 999 - PChar->stats.MND);
 	WBUFW(data,(0x2E)) = dsp_cap(PChar->getMod(MOD_CHR), -999 + PChar->stats.CHR, 999 - PChar->stats.CHR);
 
-    WBUFW(data,(0x30)) = PChar->ATT();
+    WBUFW(data,(0x30)) = PChar->ATT(SLOT_MAIN, 0);
 	WBUFW(data,(0x32)) = PChar->DEF();
 
 	WBUFW(data,(0x34)) = PChar->getMod(MOD_FIRERES);

--- a/src/map/utils/battleutils.cpp
+++ b/src/map/utils/battleutils.cpp
@@ -684,7 +684,7 @@ namespace battleutils
                 bool crit = battleutils::GetCritHitRate(PDefender, PAttacker, true) > dsprand::GetRandomNumber(100);
 
                 // Dmg math.
-                float DamageRatio = GetDamageRatio(PDefender, PAttacker, crit, 0);
+                float DamageRatio = GetDamageRatio(PDefender, PAttacker, SLOT_MAIN, crit, 0);
                 uint16 dmg = (uint32)((PDefender->GetMainWeaponDmg() + battleutils::GetFSTR(PDefender, PAttacker, SLOT_MAIN)) * DamageRatio);
                 dmg = attackutils::CheckForDamageMultiplier(((CCharEntity*)PDefender), PDefender->m_Weapons[SLOT_MAIN], dmg, ATTACK_NORMAL);
                 uint16 bonus = dmg * (PDefender->getMod(MOD_RETALIATION) / 100);
@@ -2265,15 +2265,15 @@ namespace battleutils
     *																		*
     ************************************************************************/
 
-    float GetDamageRatio(CBattleEntity* PAttacker, CBattleEntity* PDefender, bool isCritical, uint16 bonusAttPercent)
+    float GetDamageRatio(CBattleEntity* PAttacker, CBattleEntity* PDefender, uint8 weaponSlot, bool isCritical, uint16 bonusAttPercent)
     {
         // used to apply a % of attack bonus
         float attPercentBonus = 0;
         if (bonusAttPercent >= 1)
-            attPercentBonus = (float)(PAttacker->ATT() * bonusAttPercent / 100);
+            attPercentBonus = (float)(PAttacker->ATT(weaponSlot, 0) * bonusAttPercent / 100);
 
         //wholly possible for DEF to be near 0 with the amount of debuffs/effects now.
-        float ratio = (float)(PAttacker->ATT() + attPercentBonus) / (float)((PDefender->DEF() == 0) ? 1 : PDefender->DEF());
+        float ratio = (float)(PAttacker->ATT(weaponSlot, 0) + attPercentBonus) / (float)((PDefender->DEF() == 0) ? 1 : PDefender->DEF());
         float cRatioMax = 0;
         float cRatioMin = 0;
         float ratioCap = 2.0f;
@@ -3895,7 +3895,7 @@ namespace battleutils
                     if (PAttacker->objtype == TYPE_PC)
                         AttMultiplerPercent = PAttacker->getMod(MOD_JUMP_ATT_BONUS);
 
-                    float DamageRatio = battleutils::GetDamageRatio(PAttacker, PVictim, false, AttMultiplerPercent);
+                    float DamageRatio = battleutils::GetDamageRatio(PAttacker, PVictim, SLOT_MAIN, false, AttMultiplerPercent);
                     damageForRound = (uint16)((PAttacker->GetMainWeaponDmg() + battleutils::GetFSTR(PAttacker, PVictim, SLOT_MAIN)) * DamageRatio);
 
                     // bonus applies to jump only, not high jump

--- a/src/map/utils/battleutils.h
+++ b/src/map/utils/battleutils.h
@@ -145,7 +145,7 @@ namespace battleutils
     uint8				GetBlockRate(CBattleEntity* PAttacker, CBattleEntity* PDefender);
     uint8				GetParryRate(CBattleEntity* PAttacker, CBattleEntity* PDefender);
     uint8				GetGuardRate(CBattleEntity* PAttacker, CBattleEntity* PDefender);
-    float				GetDamageRatio(CBattleEntity* PAttacker, CBattleEntity* PDefender, bool isCritical, uint16 bonusAttPercent);
+    float				GetDamageRatio(CBattleEntity* PAttacker, CBattleEntity* PDefender, uint8 weaponSlot, bool isCritical, uint16 bonusAttPercent);
 
     int32				TakePhysicalDamage(CBattleEntity* PAttacker, CBattleEntity* PDefender, int32 damage, bool isBlocked, uint8 slot, uint16 tpMultiplier, CBattleEntity* taChar, bool giveTPtoVictim, bool giveTPtoAttacker, bool isCounter = false);
     int32				TakeWeaponskillDamage(CCharEntity* PChar, CBattleEntity* PDefender, int32 damage, uint8 slot, uint16 tpMultiplier, CBattleEntity* taChar);


### PR DESCRIPTION
Changing battleutils::GetDamageRatio to have additional argument weaponSlot in order to properly calculate the attack value.
- Made necessary follow-on changes.

Changing CBattleEntity::ATT to have additional argument attackNumber in order to properly calculate the attack value.
- Made necessary follow-on changes.

Refactor of CBattleEntity::ATT, ACC, RATT, and RACC.
- While doing the refactor, found and fixed a bug in CBattleEntity::RATT. It was using MOD_ATTP instead of MOD_RATTP for PUP pets.
