### PR TITLE
fixing PC DRG pet wyvern breath abilities

### DIFF
--- a/src/map/utils/petutils.cpp
+++ b/src/map/utils/petutils.cpp
@@ -1400,6 +1400,10 @@ namespace petutils
 		PPet->SetMJob(JOB_DRG);
 		PPet->SetMLevel(PMaster->GetMLevel());
 
+        if (PMaster->objtype == TYPE_PC) {
+            PPet->m_MobSkillList = 193; //set the mob skill list id for player dragoon wyvern pets
+        }
+
 		LoadAvatarStats(PPet); //follows PC calcs (w/o SJ)
 		PPet->m_Weapons[SLOT_MAIN]->setDelay(floor(1000.0f*(320.0f / 60.0f))); //320 delay
 		PPet->m_Weapons[SLOT_MAIN]->setDamage(1 + floor(PPet->GetMLevel()*0.9f));


### PR DESCRIPTION
I tested the fix for healing breaths for defensive-type wyvern, hybrid-type wyvern. Tested that offensive breaths are used for sub war and not used for sub whm. 

The person who is maintaining this code might think another way is cleaner, but this works. One thing that I might want to do personally is create a constant in a header for this skill list id to avoid a magic hardcoded number. 