### PR TITLE
Scripts: Animsub resets on respawn

### DIFF
--- a/scripts/zones/Attohwa_Chasm/mobs/Tiamat.lua
+++ b/scripts/zones/Attohwa_Chasm/mobs/Tiamat.lua
@@ -14,6 +14,15 @@ function onMobInitialize(mob)
 end;
 
 -----------------------------------
+-- onMobSpawn Action
+-----------------------------------
+
+function onMobSpawn(mob)
+    mob:SetMobSkillAttack(false); -- resetting so it doesn't respawn in flight mode.
+    mob:AnimationSub(0); -- subanim 0 is only used when it spawns until first flight.
+end;
+
+-----------------------------------
 -- onMobFight Action
 -----------------------------------
 

--- a/scripts/zones/Grand_Palace_of_HuXzoi/mobs/Ix_aern_mnk.lua
+++ b/scripts/zones/Grand_Palace_of_HuXzoi/mobs/Ix_aern_mnk.lua
@@ -28,6 +28,7 @@ function onMobSpawn(mob)
         SetDropRate(4398,1901,chance*10); -- Vice of Antipathy
     end
     GetNPCByID(QuestionMark):setLocalVar("[SEA]IxAern_DropRate", 0); -- Clears the var from the ???.
+    mob:AnimationSub(1); -- Reset the subanim - otherwise it will respawn with bracers on. Note that Aerns are never actually supposed to be in subanim 0.
 end;
 
 -----------------------------------

--- a/scripts/zones/Monarch_Linn/mobs/Ouryu.lua
+++ b/scripts/zones/Monarch_Linn/mobs/Ouryu.lua
@@ -11,7 +11,13 @@ require("scripts/globals/titles");
 -----------------------------------
 
 function onMobSpawn(mob)
+    mob:SetMobSkillAttack(false); -- resetting so it doesn't respawn in flight mode.
+    mob:AnimationSub(0); -- subanim 0 is only used when it spawns until first flight.
 end;
+
+-----------------------------------
+-- onMobFight Action
+-----------------------------------
 
 function onMobFight(mob,target)
 

--- a/scripts/zones/Uleguerand_Range/mobs/Jormungand.lua
+++ b/scripts/zones/Uleguerand_Range/mobs/Jormungand.lua
@@ -18,6 +18,8 @@ end;
 -----------------------------------
 
 function onMobSpawn(mob)
+    mob:SetMobSkillAttack(false); -- resetting so it doesn't respawn in flight mode.
+    mob:AnimationSub(0); -- subanim 0 is only used when it spawns until first flight.
 end;
 
 -----------------------------------


### PR DESCRIPTION
These mobs are supposed to have their animsubs reset on spawn because they'll have different ones upon death. Also, the SetMobSkillAttack thing doesn't reset on death, so it needs to be set to false or else it will use the flight mobskill attack.

Note that Aerns should be using Animsub 1 as the default because going from 0 to 2 (bracers) makes them disappear for a second, while they don't when going from 1 to 2.