### PR TITLE
Fix for issue #2204

### DIFF
--- a/scripts/zones/Norg/npcs/Muzaffar.lua
+++ b/scripts/zones/Norg/npcs/Muzaffar.lua
@@ -1,36 +1,37 @@
 -----------------------------------
 -- Area: Norg
--- NPC: Muzaffar
+--  NPC: Muzaffar
 -- Standard Info NPC
 -- Quests: Black Market
--- @zone 252
--- @pos 16.678, -2.044, -14.600
+-- @pos 16.678, -2.044, -14.600 252
 -----------------------------------
-
+package.loaded["scripts/zones/Norg/TextIDs"] = nil;
+-----------------------------------
 require("scripts/zones/Norg/TextIDs");
 require("scripts/globals/titles");
 require("scripts/globals/quests");
+
 -----------------------------------
 -- onTrade Action
 -----------------------------------
 
 function onTrade(player,npc,trade)
-   local count = trade:getItemCount();
-   local NorthernFurs = trade:hasItemQty(1199,4);
-   local EasternPottery = trade:hasItemQty(1200,4);
-   local SouthernMummies = trade:hasItemQty(1201,4);
-   if (player:getQuestStatus(NORG,BLACK_MARKET) == QUEST_ACCEPTED or player:getQuestStatus(NORG,BLACK_MARKET) == QUEST_COMPLETED) then
-       if (NorthernFurs == true and count == 4) then
-           player:tradeComplete();
-           player:startEvent(0x0011, 1199, 1199);
-       elseif (EasternPottery == true and count == 4) then
-           player:tradeComplete();
-           player:startEvent(0x0012, 1200, 1200);
-       elseif (SouthernMummies == true and count == 4) then
-           player:tradeComplete();
-           player:startEvent(0x0013, 1201, 1201);
-       end
-   end
+    local count = trade:getItemCount();
+    local NorthernFurs = trade:hasItemQty(1199,4);
+    local EasternPottery = trade:hasItemQty(1200,4);
+    local SouthernMummies = trade:hasItemQty(1201,4);
+    if (player:getQuestStatus(NORG,BLACK_MARKET) == QUEST_ACCEPTED or player:getQuestStatus(NORG,BLACK_MARKET) == QUEST_COMPLETED) then
+        if (NorthernFurs == true and count == 4) then
+            player:tradeComplete();
+            player:startEvent(0x0011, 1199, 1199);
+        elseif (EasternPottery == true and count == 4) then
+            player:tradeComplete();
+            player:startEvent(0x0012, 1200, 1200);
+        elseif (SouthernMummies == true and count == 4) then
+            player:tradeComplete();
+            player:startEvent(0x0013, 1201, 1201);
+        end
+    end
 end;
 
 -----------------------------------
@@ -38,11 +39,11 @@ end;
 -----------------------------------
 
 function onTrigger(player,npc)
-   if (player:getQuestStatus(NORG,BLACK_MARKET) == QUEST_ACCEPTED or player:getQuestStatus(NORG,BLACK_MARKET) == QUEST_COMPLETED) then
-       player:startEvent(0x0010);
-   else
-       player:startEvent(0x000F);
-   end
+    if (player:getQuestStatus(NORG,BLACK_MARKET) == QUEST_ACCEPTED or player:getQuestStatus(NORG,BLACK_MARKET) == QUEST_COMPLETED) then
+        player:startEvent(0x0010);
+    else
+        player:startEvent(0x000F);
+    end
 end;
 
 -----------------------------------
@@ -50,8 +51,8 @@ end;
 -----------------------------------
 
 function onEventUpdate(player,csid,option)
---printf("CSID: %u",csid);
---printf("RESULT: %u",option);
+    -- printf("CSID: %u",csid);
+    -- printf("RESULT: %u",option);
 end;
 
 -----------------------------------
@@ -59,39 +60,36 @@ end;
 -----------------------------------
 
 function onEventFinish(player,csid,option)
-   --printf("CSID: %u",csid);
-   --printf("RESULT: %u",option);
-   if (csid == 0x000F and option == 1) then
-       player:addQuest(NORG,BLACK_MARKET);
-   elseif (csid == 0x0011) then
-       player:addGil(GIL_RATE*1500);
-      player:messageSpecial(GIL_OBTAINED,GIL_RATE*1500);
-       if (player:getQuestStatus(NORG,BLACK_MARKET) == QUEST_ACCEPTED) then
-           player:completeQuest(NORG,BLACK_MARKET);
-       end
-       player:addFame(NORG,40*NORG_FAME);
-       player:addTitle(BLACK_MARKETEER);
-       player:startEvent(0x0014);
-   elseif (csid == 0x0012) then
-       player:addGil(GIL_RATE*2000);
-       player:messageSpecial(GIL_OBTAINED,GIL_RATE*2000);
-       if (player:getQuestStatus(NORG,BLACK_MARKET) == QUEST_ACCEPTED) then
-           player:completeQuest(NORG,BLACK_MARKET);
-       end
-       player:addFame(NORG,50*NORG_FAME);
-       player:addTitle(BLACK_MARKETEER);
-       player:startEvent(0x0014);
-   elseif (csid == 0x0013) then
-       player:addGil(GIL_RATE*3000);
-       player:messageSpecial(GIL_OBTAINED,GIL_RATE*3000);
-       if (player:getQuestStatus(NORG,BLACK_MARKET) == QUEST_ACCEPTED) then
-           player:completeQuest(NORG,BLACK_MARKET);
-       end
-       player:addFame(NORG,80*NORG_FAME);
-       player:addTitle(BLACK_MARKETEER);
-       player:startEvent(0x0014);
-   end
+    -- printf("CSID: %u",csid);
+    -- printf("RESULT: %u",option);
+    if (csid == 0x000F and option == 1) then
+        player:addQuest(NORG,BLACK_MARKET);
+    elseif (csid == 0x0011) then
+        player:addGil(GIL_RATE*1500);
+        player:messageSpecial(GIL_OBTAINED,GIL_RATE*1500);
+        if (player:getQuestStatus(NORG,BLACK_MARKET) == QUEST_ACCEPTED) then
+            player:completeQuest(NORG,BLACK_MARKET);
+        end
+        player:addFame(NORG,40*NORG_FAME);
+        player:addTitle(BLACK_MARKETEER);
+        player:startEvent(0x0014);
+    elseif (csid == 0x0012) then
+        player:addGil(GIL_RATE*2000);
+        player:messageSpecial(GIL_OBTAINED,GIL_RATE*2000);
+        if (player:getQuestStatus(NORG,BLACK_MARKET) == QUEST_ACCEPTED) then
+            player:completeQuest(NORG,BLACK_MARKET);
+        end
+        player:addFame(NORG,50*NORG_FAME);
+        player:addTitle(BLACK_MARKETEER);
+        player:startEvent(0x0014);
+    elseif (csid == 0x0013) then
+        player:addGil(GIL_RATE*3000);
+        player:messageSpecial(GIL_OBTAINED,GIL_RATE*3000);
+        if (player:getQuestStatus(NORG,BLACK_MARKET) == QUEST_ACCEPTED) then
+            player:completeQuest(NORG,BLACK_MARKET);
+        end
+        player:addFame(NORG,80*NORG_FAME);
+        player:addTitle(BLACK_MARKETEER);
+        player:startEvent(0x0014);
+    end
 end;
-
-
-

--- a/scripts/zones/Norg/npcs/Muzaffar.lua
+++ b/scripts/zones/Norg/npcs/Muzaffar.lua
@@ -21,13 +21,13 @@ function onTrade(player,npc,trade)
     local EasternPottery = trade:hasItemQty(1200,4);
     local SouthernMummies = trade:hasItemQty(1201,4);
     if (player:getQuestStatus(NORG,BLACK_MARKET) == QUEST_ACCEPTED or player:getQuestStatus(NORG,BLACK_MARKET) == QUEST_COMPLETED) then
-        if (NorthernFurs == true and count == 4) then
+        if (NorthernFurs and count == 4) then
             player:tradeComplete();
             player:startEvent(0x0011, 1199, 1199);
-        elseif (EasternPottery == true and count == 4) then
+        elseif (EasternPottery and count == 4) then
             player:tradeComplete();
             player:startEvent(0x0012, 1200, 1200);
-        elseif (SouthernMummies == true and count == 4) then
+        elseif (SouthernMummies and count == 4) then
             player:tradeComplete();
             player:startEvent(0x0013, 1201, 1201);
         end


### PR DESCRIPTION
Explanation: the reason we null TextIDs.lua is because with every zone loading the same file name, you can wind up with null or invalid text ID from the previous zone being loaded instead the correct TextID from the zone a player is currently in.