### PR TITLE
Scripts/SQL: Snake Eye force 11 chance update

### DIFF
--- a/scripts/globals/abilities/snake_eye.lua
+++ b/scripts/globals/abilities/snake_eye.lua
@@ -22,7 +22,7 @@ end;
 -----------------------------------
 
 function onUseAbility(player,target,ability)
-    player:addStatusEffect(EFFECT_SNAKE_EYE,(player:getMerit(MERIT_SNAKE_EYE) - 5),0,60);
+    player:addStatusEffect(EFFECT_SNAKE_EYE,(player:getMerit(MERIT_SNAKE_EYE) - 10),0,60);
 
     return EFFECT_SNAKE_EYE;
 end;

--- a/sql/merits.sql
+++ b/sql/merits.sql
@@ -266,7 +266,7 @@ INSERT INTO `merits` VALUES ('3008', 'convergence', '5', '5', '32768', '7', '46'
 INSERT INTO `merits` VALUES ('3010', 'diffusion', '5', '5', '32768', '7', '46');
 INSERT INTO `merits` VALUES ('3012', 'enchainment', '5', '10', '32768', '7', '46');
 INSERT INTO `merits` VALUES ('3014', 'assimilation', '5', '1', '32768', '7', '46');
-INSERT INTO `merits` VALUES ('3072', 'snake_eye', '5', '5', '65536', '7', '47');
+INSERT INTO `merits` VALUES ('3072', 'snake_eye', '5', '10', '65536', '7', '47');
 INSERT INTO `merits` VALUES ('3074', 'fold', '5', '10', '65536', '7', '47');
 INSERT INTO `merits` VALUES ('3076', 'winning_streak', '5', '20', '65536', '7', '47');
 INSERT INTO `merits` VALUES ('3078', 'loaded_deck', '5', '10', '65536', '7', '47');


### PR DESCRIPTION
Client says each merit past the first gives a 10% chance to hit 11 if roll is 5 or higher.