### PR TITLE
Scripts/SQL: Qutrub weapon breaking + mobskills

### DIFF
--- a/scripts/globals/mobskills/Animating_Wail.lua
+++ b/scripts/globals/mobskills/Animating_Wail.lua
@@ -1,6 +1,12 @@
 ---------------------------------------------------
--- Animating Wail
--- Increases attack speed.
+--  Animating Wail
+--  Family: Qutrub
+--  Description: Let's out a wail that applies Haste to itself and nearby allies.
+--  Type: Enhancing
+--  Can be dispelled: Yes
+--  Utsusemi/Blink absorb: N/A
+--  Range: Self
+--  Notes:
 ---------------------------------------------------
 
 require("scripts/globals/settings");
@@ -14,7 +20,10 @@ function onMobSkillCheck(target,mob,skill)
 end;
 
 function onMobWeaponSkill(target, mob, skill)
+    local power = 153;
+    local duration = 300;
     local typeEffect = EFFECT_HASTE;
-    skill:setMsg(MobBuffMove(mob, typeEffect, 153, 0, 300));
+
+    skill:setMsg(MobBuffMove(mob, typeEffect, power, 0, duration));
     return typeEffect;
 end

--- a/scripts/globals/mobskills/Fortifying_Wail.lua
+++ b/scripts/globals/mobskills/Fortifying_Wail.lua
@@ -1,0 +1,29 @@
+---------------------------------------------------
+--  Fortifying Wail
+--  Family: Qutrub
+--  Description: Let's out a wail that applies Protect to itself and nearby allies.
+--  Type: Enhancing
+--  Can be dispelled: Yes
+--  Utsusemi/Blink absorb: N/A
+--  Range: AoE
+--  Notes:
+---------------------------------------------------
+
+require("scripts/globals/settings");
+require("scripts/globals/status");
+require("scripts/globals/monstertpmoves");
+
+---------------------------------------------------
+
+function onMobSkillCheck(target,mob,skill)
+    return 0;
+end;
+
+function onMobWeaponSkill(target, mob, skill)
+    local power = 60;
+    local duration = 300;
+    local typeEffect = EFFECT_PROTECT;
+
+    skill:setMsg(MobBuffMove(mob, typeEffect, power, 0, duration));
+    return typeEffect;
+end;

--- a/scripts/globals/mobskills/Hex_Palm.lua
+++ b/scripts/globals/mobskills/Hex_Palm.lua
@@ -1,0 +1,33 @@
+---------------------------------------------------
+--  Hex Palm
+--  Family: Qutrub
+--  Description: Steals HP from targets in front.
+--  Type: Magical
+--  Utsusemi/Blink absorb: Wipes shadows
+--  Range: Front cone
+--  Notes: Used only when wielding no weapon.
+---------------------------------------------------
+
+require("scripts/globals/settings");
+require("scripts/globals/status");
+require("scripts/globals/monstertpmoves");
+
+---------------------------------------------------
+
+function onMobSkillCheck(target,mob,skill)
+    if (mob:AnimationSub() == 1 or mob:AnimationSub() == 3) then
+        return 0;
+    else
+        return 1;
+    end
+end;
+
+function onMobWeaponSkill(target, mob, skill)
+    local dmgmod = 1.1;
+    local info = MobMagicalMove(mob,target,skill,mob:getWeaponDmg()*2,ELE_DARK,dmgmod,TP_MAB_BONUS,1);
+    local dmg = MobFinalAdjustments(info.dmg,mob,skill,target,MOBSKILL_MAGICAL,MOBPARAM_DARK,MOBPARAM_WIPE_SHADOWS);
+
+    skill:setMsg(MobPhysicalDrainMove(mob, target, skill, MOBDRAIN_HP, dmg));
+
+    return dmg;
+end;

--- a/scripts/globals/mobskills/Leaping_Cleave.lua
+++ b/scripts/globals/mobskills/Leaping_Cleave.lua
@@ -1,11 +1,11 @@
 ---------------------------------------------
 --  Leaping Cleave
---
+--  Family: Qutrub
 --  Description: Performs a jumping slash on a single target.
 --  Type: Physical
 --  Utsusemi/Blink absorb: 1 shadow
 --  Range: Melee
---  Notes: Used only when wielding their initial sword, or the dagger on their backs.
+--  Notes: Used only when wielding their initial sword.
 ---------------------------------------------
 
 require("scripts/globals/settings");
@@ -15,15 +15,19 @@ require("scripts/globals/monstertpmoves");
 ---------------------------------------------
 
 function onMobSkillCheck(target,mob,skill)
-	return 0;
+    if (mob:AnimationSub() == 0) then
+        return 0;
+    else
+        return 1;
+    end
 end;
 
 function onMobWeaponSkill(target, mob, skill)
-	local numhits = 1;
-	local accmod = 3;
-	local dmgmod = 4;
-	local info = MobPhysicalMove(mob,target,skill,numhits,accmod,dmgmod,TP_NO_EFFECT);
-	local dmg = MobFinalAdjustments(info.dmg,mob,skill,target,MOBSKILL_PHYSICAL,MOBPARAM_SLASH,info.hitslanded);
-	target:delHP(dmg);
-	return dmg;
+    local numhits = 1;
+    local accmod = 3;
+    local dmgmod = 4;
+    local info = MobPhysicalMove(mob,target,skill,numhits,accmod,dmgmod,TP_NO_EFFECT);
+    local dmg = MobFinalAdjustments(info.dmg,mob,skill,target,MOBSKILL_PHYSICAL,MOBPARAM_SLASH,info.hitslanded);
+    target:delHP(dmg);
+    return dmg;
 end;

--- a/scripts/globals/mobskills/Mangle.lua
+++ b/scripts/globals/mobskills/Mangle.lua
@@ -1,27 +1,33 @@
 ---------------------------------------------
 --  Mangle
---
+--  Family: Qutrub
 --  Description: Deals damage in a threefold attack to targets in a fan-shaped area of effect.
 --  Type: Physical
 --  Utsusemi/Blink absorb: 3 shadows
 --  Range: Front cone
 --  Notes: Used only when wielding their initial sword, or the dagger on their backs.
 ---------------------------------------------
+
 require("scripts/globals/settings");
 require("scripts/globals/status");
 require("scripts/globals/monstertpmoves");
 
 ---------------------------------------------
+
 function onMobSkillCheck(target,mob,skill)
-	return 0;
+    if (mob:AnimationSub() == 0 or mob:AnimationSub() == 2) then
+        return 0;
+    else
+        return 1;
+    end
 end;
 
 function onMobWeaponSkill(target, mob, skill)
-	local numhits = 3;
-	local accmod = 1;
-	local dmgmod = .8;
-	local info = MobPhysicalMove(mob,target,skill,numhits,accmod,dmgmod,TP_NO_EFFECT);
-	local dmg = MobFinalAdjustments(info.dmg,mob,skill,target,MOBSKILL_PHYSICAL,MOBPARAM_SLASH,info.hitslanded);
-	target:delHP(dmg);
-	return dmg;
+    local numhits = 3;
+    local accmod = 1;
+    local dmgmod = .8;
+    local info = MobPhysicalMove(mob,target,skill,numhits,accmod,dmgmod,TP_NO_EFFECT);
+    local dmg = MobFinalAdjustments(info.dmg,mob,skill,target,MOBSKILL_PHYSICAL,MOBPARAM_SLASH,info.hitslanded);
+    target:delHP(dmg);
+    return dmg;
 end;

--- a/scripts/globals/mobskills/Spinal_Cleave.lua
+++ b/scripts/globals/mobskills/Spinal_Cleave.lua
@@ -1,5 +1,33 @@
 ---------------------------------------------
--- Spinal_Cleave
---
---
+--  Spinal Cleave
+--  Family: Qutrub
+--  Description: Performs a jumping slash on a single target.
+--  Type: Physical
+--  Utsusemi/Blink absorb: 1 shadow
+--  Range: Melee
+--  Notes: Used only when wielding no weapon, and only when the second weapon is not broken.
 ---------------------------------------------
+
+require("scripts/globals/settings");
+require("scripts/globals/status");
+require("scripts/globals/monstertpmoves");
+
+---------------------------------------------
+
+function onMobSkillCheck(target,mob,skill)
+    if (mob:AnimationSub() == 1) then
+        return 0;
+    else
+        return 1;
+    end
+end;
+
+function onMobWeaponSkill(target, mob, skill)
+    local numhits = 1;
+    local accmod = 3;
+    local dmgmod = 3;
+    local info = MobPhysicalMove(mob,target,skill,numhits,accmod,dmgmod,TP_NO_EFFECT);
+    local dmg = MobFinalAdjustments(info.dmg,mob,skill,target,MOBSKILL_PHYSICAL,MOBPARAM_SLASH,info.hitslanded);
+    target:delHP(dmg);
+    return dmg;
+end;

--- a/scripts/globals/mobskills/Unblest_Jambiya.lua
+++ b/scripts/globals/mobskills/Unblest_Jambiya.lua
@@ -1,0 +1,33 @@
+---------------------------------------------------
+--  Unblest Jambiya
+--  Family: Qutrub
+--  Description: Steals HP from targets in an area of effect.
+--  Type: Magical
+--  Utsusemi/Blink absorb: Wipes shadows
+--  Range: AoE 15'
+--  Notes: Used only by certain NM's when their primary sword isn't broken.
+---------------------------------------------------
+
+require("scripts/globals/settings");
+require("scripts/globals/status");
+require("scripts/globals/monstertpmoves");
+
+---------------------------------------------------
+
+function onMobSkillCheck(target,mob,skill)
+    if (mob:AnimationSub() == 0) then
+        return 0;
+    else
+        return 1;
+    end
+end;
+
+function onMobWeaponSkill(target, mob, skill)
+    local dmgmod = 1.3;
+    local info = MobMagicalMove(mob,target,skill,mob:getWeaponDmg()*3,ELE_DARK,dmgmod,TP_MAB_BONUS,1);
+    local dmg = MobFinalAdjustments(info.dmg,mob,skill,target,MOBSKILL_MAGICAL,MOBPARAM_DARK,MOBPARAM_WIPE_SHADOWS);
+
+    skill:setMsg(MobPhysicalDrainMove(mob, target, skill, MOBDRAIN_HP, dmg));
+
+    return dmg;
+end;

--- a/scripts/zones/Arrapago_Reef/mobs/Lamia_Idolater.lua
+++ b/scripts/zones/Arrapago_Reef/mobs/Lamia_Idolater.lua
@@ -1,0 +1,61 @@
+-----------------------------------
+-- Area: Arrapago Reef
+--  NPC: Lamia Idolator
+-----------------------------------
+
+require("scripts/globals/status");
+    
+-----------------------------------
+-- onMobInitialize Action
+-----------------------------------
+
+function onMobInitialize(mob)
+end;
+
+-----------------------------------
+-- onMobSpawn Action
+-----------------------------------
+
+function onMobSpawn(mob)
+end;
+
+-----------------------------------
+-- onMobFight
+-----------------------------------
+
+function onMobFight(mob, target)
+    local swapTimer = mob:getLocalVar("swapTime");
+    
+    if (os.time() > swapTimer) then
+        if (mob:AnimationSub() == 1) then -- swap from fists to second weapon
+            mob:AnimationSub(2);
+            mob:setLocalVar("swapTime", os.time() + 60)
+        elseif (mob:AnimationSub() == 2) then -- swap from second weapon to fists
+            mob:AnimationSub(1);
+            mob:setLocalVar("swapTime", os.time() + 60)
+        end
+    end
+end;
+
+-----------------------------------
+-- onCriticalHit
+-----------------------------------
+
+function onCriticalHit(mob)   
+ 
+    if (math.random(100) < 10) then  -- 10% change to break the weapon on crit   
+        if (mob:AnimationSub() == 0) then -- first weapon
+            mob:AnimationSub(1);
+            mob:setLocalVar("swapTime", os.time() + 60) -- start the timer for swapping between fists and the second weapon
+        elseif (mob:AnimationSub() == 2) then -- second weapon
+            mob:AnimationSub(3);
+        end
+    end
+end;
+
+-----------------------------------
+-- onMobDeath
+-----------------------------------
+
+function onMobDeath(mob, killer)
+end;

--- a/scripts/zones/Arrapago_Reef/mobs/Qutrub.lua
+++ b/scripts/zones/Arrapago_Reef/mobs/Qutrub.lua
@@ -1,0 +1,61 @@
+-----------------------------------
+-- Area: Arrapago Reef
+--  NPC: Qutrub
+-----------------------------------
+
+require("scripts/globals/status");
+    
+-----------------------------------
+-- onMobInitialize Action
+-----------------------------------
+
+function onMobInitialize(mob)
+end;
+
+-----------------------------------
+-- onMobSpawn Action
+-----------------------------------
+
+function onMobSpawn(mob)
+end;
+
+-----------------------------------
+-- onMobFight
+-----------------------------------
+
+function onMobFight(mob, target)
+    local swapTimer = mob:getLocalVar("swapTime");
+    
+    if (os.time() > swapTimer) then
+        if (mob:AnimationSub() == 1) then -- swap from fists to second weapon
+            mob:AnimationSub(2);
+            mob:setLocalVar("swapTime", os.time() + 60)
+        elseif (mob:AnimationSub() == 2) then -- swap from second weapon to fists
+            mob:AnimationSub(1);
+            mob:setLocalVar("swapTime", os.time() + 60)
+        end
+    end
+end;
+
+-----------------------------------
+-- onCriticalHit
+-----------------------------------
+
+function onCriticalHit(mob)   
+ 
+    if (math.random(100) < 10) then  -- 10% change to break the weapon on crit   
+        if (mob:AnimationSub() == 0) then -- first weapon
+            mob:AnimationSub(1);
+            mob:setLocalVar("swapTime", os.time() + 60) -- start the timer for swapping between fists and the second weapon
+        elseif (mob:AnimationSub() == 2) then -- second weapon
+            mob:AnimationSub(3);
+        end
+    end
+end;
+
+-----------------------------------
+-- onMobDeath
+-----------------------------------
+
+function onMobDeath(mob, killer)
+end;

--- a/scripts/zones/Arrapago_Reef/mobs/Zareehkl_the_Jubilant.lua
+++ b/scripts/zones/Arrapago_Reef/mobs/Zareehkl_the_Jubilant.lua
@@ -1,0 +1,61 @@
+-----------------------------------
+-- Area: Arrapago Reef
+--  NPC: Zareehkl the Jubilant
+-----------------------------------
+
+require("scripts/globals/status");
+    
+-----------------------------------
+-- onMobInitialize Action
+-----------------------------------
+
+function onMobInitialize(mob)
+end;
+
+-----------------------------------
+-- onMobSpawn Action
+-----------------------------------
+
+function onMobSpawn(mob)
+end;
+
+-----------------------------------
+-- onMobFight
+-----------------------------------
+
+function onMobFight(mob, target)
+    local swapTimer = mob:getLocalVar("swapTime");
+    
+    if (os.time() > swapTimer) then
+        if (mob:AnimationSub() == 1) then -- swap from fists to second weapon
+            mob:AnimationSub(2);
+            mob:setLocalVar("swapTime", os.time() + 60)
+        elseif (mob:AnimationSub() == 2) then -- swap from second weapon to fists
+            mob:AnimationSub(1);
+            mob:setLocalVar("swapTime", os.time() + 60)
+        end
+    end
+end;
+
+-----------------------------------
+-- onCriticalHit
+-----------------------------------
+
+function onCriticalHit(mob)   
+ 
+    if (math.random(100) < 5) then  -- Wiki seems to imply that this thing's weapon is harder to break...
+        if (mob:AnimationSub() == 0) then -- first weapon
+            mob:AnimationSub(1);
+            mob:setLocalVar("swapTime", os.time() + 60) -- start the timer for swapping between fists and the second weapon
+        elseif (mob:AnimationSub() == 2) then -- second weapon
+            mob:AnimationSub(3);
+        end
+    end
+end;
+
+-----------------------------------
+-- onMobDeath
+-----------------------------------
+
+function onMobDeath(mob, killer)
+end;

--- a/scripts/zones/Caedarva_Mire/mobs/Aynu-Kaysey.lua
+++ b/scripts/zones/Caedarva_Mire/mobs/Aynu-Kaysey.lua
@@ -11,6 +11,40 @@ function onMobSpawn(mob)
 end;
 
 -----------------------------------
+-- onMobFight
+-----------------------------------
+
+function onMobFight(mob, target)
+    local swapTimer = mob:getLocalVar("swapTime");
+    
+    if (os.time() > swapTimer) then
+        if (mob:AnimationSub() == 1) then -- swap from fists to second weapon
+            mob:AnimationSub(2);
+            mob:setLocalVar("swapTime", os.time() + 60)
+        elseif (mob:AnimationSub() == 2) then -- swap from second weapon to fists
+            mob:AnimationSub(1);
+            mob:setLocalVar("swapTime", os.time() + 60)
+        end
+    end
+end;
+
+-----------------------------------
+-- onCriticalHit
+-----------------------------------
+
+function onCriticalHit(mob)   
+ 
+    if (math.random(100) < 10) then  -- 10% change to break the weapon on crit   
+        if (mob:AnimationSub() == 0) then -- first weapon
+            mob:AnimationSub(1);
+            mob:setLocalVar("swapTime", os.time() + 60) -- start the timer for swapping between fists and the second weapon
+        elseif (mob:AnimationSub() == 2) then -- second weapon
+            mob:AnimationSub(3);
+        end
+    end
+end;
+
+-----------------------------------
 -- onMobDeath
 -----------------------------------
 

--- a/scripts/zones/Caedarva_Mire/mobs/Lamia_Idolater.lua
+++ b/scripts/zones/Caedarva_Mire/mobs/Lamia_Idolater.lua
@@ -1,0 +1,61 @@
+-----------------------------------
+-- Area: Arrapago Reef
+--  NPC: Lamia Idolator
+-----------------------------------
+
+require("scripts/globals/status");
+    
+-----------------------------------
+-- onMobInitialize Action
+-----------------------------------
+
+function onMobInitialize(mob)
+end;
+
+-----------------------------------
+-- onMobSpawn Action
+-----------------------------------
+
+function onMobSpawn(mob)
+end;
+
+-----------------------------------
+-- onMobFight
+-----------------------------------
+
+function onMobFight(mob, target)
+    local swapTimer = mob:getLocalVar("swapTime");
+    
+    if (os.time() > swapTimer) then
+        if (mob:AnimationSub() == 1) then -- swap from fists to second weapon
+            mob:AnimationSub(2);
+            mob:setLocalVar("swapTime", os.time() + 60)
+        elseif (mob:AnimationSub() == 2) then -- swap from second weapon to fists
+            mob:AnimationSub(1);
+            mob:setLocalVar("swapTime", os.time() + 60)
+        end
+    end
+end;
+
+-----------------------------------
+-- onCriticalHit
+-----------------------------------
+
+function onCriticalHit(mob)   
+ 
+    if (math.random(100) < 10) then  -- 10% change to break the weapon on crit   
+        if (mob:AnimationSub() == 0) then -- first weapon
+            mob:AnimationSub(1);
+            mob:setLocalVar("swapTime", os.time() + 60) -- start the timer for swapping between fists and the second weapon
+        elseif (mob:AnimationSub() == 2) then -- second weapon
+            mob:AnimationSub(3);
+        end
+    end
+end;
+
+-----------------------------------
+-- onMobDeath
+-----------------------------------
+
+function onMobDeath(mob, killer)
+end;

--- a/sql/mob_skill_lists.sql
+++ b/sql/mob_skill_lists.sql
@@ -1579,23 +1579,23 @@ INSERT INTO `mob_skill_lists` VALUES ('',198,1462);
 INSERT INTO `mob_skill_lists` VALUES ('',203,1522);
 INSERT INTO `mob_skill_lists` VALUES ('',203,1523);
 INSERT INTO `mob_skill_lists` VALUES ('',203,1524);
--- INSERT INTO `mob_skill_lists` VALUES ('',203,1525);
--- INSERT INTO `mob_skill_lists` VALUES ('',203,1526);
--- INSERT INTO `mob_skill_lists` VALUES ('',203,1527);
+INSERT INTO `mob_skill_lists` VALUES ('',203,1525);
+INSERT INTO `mob_skill_lists` VALUES ('',203,1526);
+INSERT INTO `mob_skill_lists` VALUES ('',203,1527);
 
 INSERT INTO `mob_skill_lists` VALUES ('',204,1522);
 INSERT INTO `mob_skill_lists` VALUES ('',204,1523);
 INSERT INTO `mob_skill_lists` VALUES ('',204,1524);
--- INSERT INTO `mob_skill_lists` VALUES ('',204,1525);
--- INSERT INTO `mob_skill_lists` VALUES ('',204,1526);
--- INSERT INTO `mob_skill_lists` VALUES ('',204,1527);
+INSERT INTO `mob_skill_lists` VALUES ('',204,1525);
+INSERT INTO `mob_skill_lists` VALUES ('',204,1526);
+INSERT INTO `mob_skill_lists` VALUES ('',204,1527);
 
 INSERT INTO `mob_skill_lists` VALUES ('',205,1522);
 INSERT INTO `mob_skill_lists` VALUES ('',205,1523);
 INSERT INTO `mob_skill_lists` VALUES ('',205,1524);
--- INSERT INTO `mob_skill_lists` VALUES ('',205,1525);
--- INSERT INTO `mob_skill_lists` VALUES ('',205,1526);
--- INSERT INTO `mob_skill_lists` VALUES ('',205,1527);
+INSERT INTO `mob_skill_lists` VALUES ('',205,1525);
+INSERT INTO `mob_skill_lists` VALUES ('',205,1526);
+INSERT INTO `mob_skill_lists` VALUES ('',205,1527);
 
 -- INSERT INTO `mob_skill_lists` VALUES ('',1528,?);
 -- INSERT INTO `mob_skill_lists` VALUES ('',2634,?);
@@ -2907,10 +2907,10 @@ INSERT INTO `mob_skill_lists` VALUES ('',302,1818);
 INSERT INTO `mob_skill_lists` VALUES ('',303,1522);
 INSERT INTO `mob_skill_lists` VALUES ('',303,1523);
 INSERT INTO `mob_skill_lists` VALUES ('',303,1524);
--- INSERT INTO `mob_skill_lists` VALUES ('',303,1525);
--- INSERT INTO `mob_skill_lists` VALUES ('',303,1526);
--- INSERT INTO `mob_skill_lists` VALUES ('',303,1527);
--- INSERT INTO `mob_skill_lists` VALUES ('',303,1528);
+INSERT INTO `mob_skill_lists` VALUES ('',303,1525);
+INSERT INTO `mob_skill_lists` VALUES ('',303,1526);
+INSERT INTO `mob_skill_lists` VALUES ('',303,1527);
+INSERT INTO `mob_skill_lists` VALUES ('',303,1528);
 
 -- Armed Gears (304)
 -- INSERT INTO `mob_skill_lists` VALUES ('',304,1791);

--- a/sql/mob_skills.sql
+++ b/sql/mob_skills.sql
@@ -1570,10 +1570,10 @@ INSERT INTO `mob_skills` VALUES (1515,1258,'Tail_Slap',4,10.0,2000,1500,4,0,0,3)
 INSERT INTO `mob_skills` VALUES (1522,1205,'Spinal_Cleave',0,7.0,2000,1500,4,0,0,0);
 INSERT INTO `mob_skills` VALUES (1523,1206,'Mangle',4,16.0,2000,1500,4,0,0,0);
 INSERT INTO `mob_skills` VALUES (1524,1207,'Leaping_Cleave',0,7.0,2000,1500,4,0,0,0);
--- INSERT INTO `mob_skills` VALUES (1525,1525,'Hex_Palm',0,7.0,2000,1500,4,0,0,0);
--- INSERT INTO `mob_skills` VALUES (1526,1526,'Animating_Wail',0,7.0,2000,1500,4,0,0,0);
--- INSERT INTO `mob_skills` VALUES (1527,1527,'Fortifying_Wail',0,7.0,2000,1500,4,0,0,0);
--- INSERT INTO `mob_skills` VALUES (1528,1528,'Unblest_Jambiya',0,7.0,2000,1500,4,0,0,0);
+INSERT INTO `mob_skills` VALUES (1525,1208,'Hex_Palm',4,7.0,2000,1500,4,0,0,0);
+INSERT INTO `mob_skills` VALUES (1526,1209,'Animating_Wail',1,15.0,2000,1500,1,0,0,0);
+INSERT INTO `mob_skills` VALUES (1527,1210,'Fortifying_Wail',1,15.0,2000,1500,1,0,0,0);
+INSERT INTO `mob_skills` VALUES (1528,1211,'Unblest_Jambiya',1,15.0,2000,1500,4,0,0,0);
 INSERT INTO `mob_skills` VALUES (1529,1223,'Lava_Spit',1,10.0,2000,1500,4,0,0,0);
 INSERT INTO `mob_skills` VALUES (1530,1224,'Sulfurous_Breath',0,7.0,2000,1500,4,0,0,0);
 INSERT INTO `mob_skills` VALUES (1531,1225,'Scorching_Lash',1,20.0,2000,1500,4,0,0,0);


### PR DESCRIPTION
-Implemented the ability to break Qutrub weapons. On a critical hit, there's a chance to break the first weapon. From that point onwards, it swaps between fists and second weapon once a minute. The second weapon can be broken when it's being wielded as well.
-Scripted Fortifying Wail, Hex Palm, and Unblest Jambiya. Added animsub checks to each of the mobskills as appropriate.
-Corrected the animations of Animating Wail and the formerly unimplemented mobskills, as well as the AoE type/range.