### PR TITLE
Scripts: Correct weather check for Qu'Hau spring

### DIFF
--- a/scripts/zones/RoMaeve/npcs/Qu_Hau_Spring.lua
+++ b/scripts/zones/RoMaeve/npcs/Qu_Hau_Spring.lua
@@ -18,7 +18,7 @@ function onTrade(player,npc,trade)
     local DMRepeat = player:getQuestStatus(OUTLANDS,DIVINE_MIGHT_REPEAT);
     local Hour = VanadielHour();
 
-    if (player:getWeather() == 0 and Hour >= 0 and Hour <= 3 and IsMoonFull() == true) then
+    if (player:getWeather() == 1 and Hour >= 0 and Hour <= 2 and IsMoonFull() == true) then -- Yes, sunshine weather, as Ro'Maeve can't have clear. Misconception on the wiki.
         if (DMfirst == QUEST_ACCEPTED or DMRepeat == QUEST_ACCEPTED) then -- allow for Ark Pentasphere on both first and repeat quests
             if (trade:hasItemQty(1408,1) and trade:hasItemQty(917,1) and trade:getItemCount() == 2) then
                 player:startEvent(7,917,1408); -- Ark Pentasphere Trade


### PR DESCRIPTION
After taking a look in zone_weather.sql, I noticed that Ro'Maeve can't have clear weather, at all. I'm assuming the data is correct, particularly because the image on the wiki shows the filled spring and the reflection of the sky is partly cloudy, which is what happens during the sunshine weather.

Also I did bad math in my previous fix to this spring and gave it an extra game hour, so I'm bring it back down.