### PR TITLE
ZNM should no longer steal pop items or despawn immediately after party wipe.

### DIFF
--- a/scripts/zones/Aht_Urhgan_Whitegate/npcs/Ryo.lua
+++ b/scripts/zones/Aht_Urhgan_Whitegate/npcs/Ryo.lua
@@ -1,14 +1,13 @@
 -----------------------------------
 -- Area: Aht Urhgan Whitegate
--- NPC:  Ryo
--- Type: ZNM
+--  NPC: Ryo
+-- Type: ZNM assistant
 -- @pos -127.086 0.999 22.693 50
 -----------------------------------
 package.loaded["scripts/zones/Aht_Urhgan_Whitegate/TextIDs"] = nil;
 -----------------------------------
-
-require("scripts/globals/besieged");
 require("scripts/zones/Aht_Urhgan_Whitegate/TextIDs");
+require("scripts/globals/besieged");
 
 -----------------------------------
 -- onTrade Action
@@ -22,7 +21,7 @@ end;
 -----------------------------------
 
 function onTrigger(player,npc)
-	player:startEvent(0x0391);
+    player:startEvent(0x0391);
 end;
 
 -----------------------------------
@@ -30,15 +29,13 @@ end;
 -----------------------------------
 
 function onEventUpdate(player,csid,option)
---printf("updateCSID: %u",csid);
---printf("updateRESULT: %u",option);
-	
-	if (option == 300) then
-		player:updateEvent(player:getCurrency("zeni_point"),0);
-	else
-		player:updateEvent(0,0);
-	end
-	
+    -- printf("updateCSID: %u",csid);
+    -- printf("updateRESULT: %u",option);
+    if (option == 300) then
+        player:updateEvent(player:getCurrency("zeni_point"),0);
+    else
+        player:updateEvent(0,0);
+    end
 end;
 
 -----------------------------------
@@ -46,6 +43,6 @@ end;
 -----------------------------------
 
 function onEventFinish(player,csid,option)
-	-- printf("finishCSID: %u",csid);
-	-- printf("finishRESULT: %u",option);
+    -- printf("finishCSID: %u",csid);
+    -- printf("finishRESULT: %u",option);
 end;

--- a/scripts/zones/Alzadaal_Undersea_Ruins/npcs/qm1.lua
+++ b/scripts/zones/Alzadaal_Undersea_Ruins/npcs/qm1.lua
@@ -1,24 +1,25 @@
 -----------------------------------
 -- Area: Alzadaal Undersea Ruins
--- NPC:  ??? (Spawn Ob(ZNM T1))
+--  NPC: ??? (Spawn Ob(ZNM T1))
 -- @pos 542 0 -129 72
 -----------------------------------
 package.loaded["scripts/zones/Alzadaal_Undersea_Ruins/TextIDs"] = nil;
 -----------------------------------
-
 require("scripts/zones/Alzadaal_Undersea_Ruins/TextIDs");
+require("scripts/globals/status");
 
 -----------------------------------
 -- onTrade Action
 -----------------------------------
 
 function onTrade(player,npc,trade)
-	
-	if (trade:hasItemQty(2592,1) and trade:getItemCount() == 1) then -- Trade Coq Lubricant
-		player:tradeComplete();
-		SpawnMob(17072171,180):updateClaim(player);
-	end
-	
+    local mobID = 17072171;
+    if (trade:hasItemQty(2592,1) and trade:getItemCount() == 1) then -- Trade Coq Lubricant
+        if (GetMobAction(mobID) == ACTION_NONE) then
+            player:tradeComplete();
+            SpawnMob(mobID):updateClaim(player);
+        end
+    end
 end;
 
 -----------------------------------
@@ -26,7 +27,7 @@ end;
 -----------------------------------
 
 function onTrigger(player,npc)
-	player:messageSpecial(NOTHING_HAPPENS);
+    player:messageSpecial(NOTHING_HAPPENS);
 end;
 
 -----------------------------------
@@ -34,8 +35,8 @@ end;
 -----------------------------------
 
 function onEventUpdate(player,csid,option)
--- printf("CSID: %u",csid);
--- printf("RESULT: %u",option);
+    -- printf("CSID: %u",csid);
+    -- printf("RESULT: %u",option);
 end;
 
 -----------------------------------
@@ -43,6 +44,6 @@ end;
 -----------------------------------
 
 function onEventFinish(player,csid,option)
--- printf("CSID: %u",csid);
--- printf("RESULT: %u",option);
+    -- printf("CSID: %u",csid);
+    -- printf("RESULT: %u",option);
 end;

--- a/scripts/zones/Alzadaal_Undersea_Ruins/npcs/qm2.lua
+++ b/scripts/zones/Alzadaal_Undersea_Ruins/npcs/qm2.lua
@@ -1,24 +1,25 @@
 -----------------------------------
 -- Area: Alzadaal Undersea Ruins
--- NPC:  ??? (Spawn Cheese Hoarder Gigiroon(ZNM T1))
+--  NPC: ??? (Spawn Cheese Hoarder Gigiroon(ZNM T1))
 -- @pos -184 -8 24 72
 -----------------------------------
 package.loaded["scripts/zones/Alzadaal_Undersea_Ruins/TextIDs"] = nil;
 -----------------------------------
-
 require("scripts/zones/Alzadaal_Undersea_Ruins/TextIDs");
+require("scripts/globals/status");
 
 -----------------------------------
 -- onTrade Action
 -----------------------------------
 
 function onTrade(player,npc,trade)
-	
-	if (trade:hasItemQty(2582,1) and trade:getItemCount() == 1) then -- Trade Rodent Cheese
-		player:tradeComplete();
-		SpawnMob(17072172,180):updateClaim(player);
-	end
-	
+    local mobID = 17072172;
+    if (trade:hasItemQty(2582,1) and trade:getItemCount() == 1) then -- Trade Rodent Cheese
+        if (GetMobAction(mobID) == ACTION_NONE) then
+            player:tradeComplete();
+            SpawnMob(mobID):updateClaim(player);
+        end
+    end
 end;
 
 -----------------------------------
@@ -26,7 +27,7 @@ end;
 -----------------------------------
 
 function onTrigger(player,npc)
-	player:messageSpecial(NOTHING_HAPPENS);
+    player:messageSpecial(NOTHING_HAPPENS);
 end;
 
 -----------------------------------
@@ -34,8 +35,8 @@ end;
 -----------------------------------
 
 function onEventUpdate(player,csid,option)
--- printf("CSID: %u",csid);
--- printf("RESULT: %u",option);
+    -- printf("CSID: %u",csid);
+    -- printf("RESULT: %u",option);
 end;
 
 -----------------------------------
@@ -43,6 +44,6 @@ end;
 -----------------------------------
 
 function onEventFinish(player,csid,option)
--- printf("CSID: %u",csid);
--- printf("RESULT: %u",option);
+    -- printf("CSID: %u",csid);
+    -- printf("RESULT: %u",option);
 end;

--- a/scripts/zones/Alzadaal_Undersea_Ruins/npcs/qm3.lua
+++ b/scripts/zones/Alzadaal_Undersea_Ruins/npcs/qm3.lua
@@ -1,24 +1,25 @@
 -----------------------------------
 -- Area: Alzadaal Undersea Ruins
--- NPC:  ??? (Spawn Armed Gears(ZNM T3))
+--  NPC: ??? (Spawn Armed Gears(ZNM T3))
 -- @pos -42 -4 -169 72
 -----------------------------------
 package.loaded["scripts/zones/Alzadaal_Undersea_Ruins/TextIDs"] = nil;
 -----------------------------------
-
 require("scripts/zones/Alzadaal_Undersea_Ruins/TextIDs");
+require("scripts/globals/status");
 
 -----------------------------------
 -- onTrade Action
 -----------------------------------
 
 function onTrade(player,npc,trade)
-	
-	if (trade:hasItemQty(2574,1) and trade:getItemCount() == 1) then -- Trade Ferrite
-		player:tradeComplete();
-		SpawnMob(17072178,180):updateClaim(player);
-	end
-	
+    local mobID = 17072178;
+    if (trade:hasItemQty(2574,1) and trade:getItemCount() == 1) then -- Trade Ferrite
+        if (GetMobAction(mobID) == ACTION_NONE) then
+            player:tradeComplete();
+            SpawnMob(mobID):updateClaim(player);
+        end
+    end
 end;
 
 -----------------------------------
@@ -26,7 +27,7 @@ end;
 -----------------------------------
 
 function onTrigger(player,npc)
-	player:messageSpecial(NOTHING_HAPPENS);
+    player:messageSpecial(NOTHING_HAPPENS);
 end;
 
 -----------------------------------
@@ -34,8 +35,8 @@ end;
 -----------------------------------
 
 function onEventUpdate(player,csid,option)
--- printf("CSID: %u",csid);
--- printf("RESULT: %u",option);
+    -- printf("CSID: %u",csid);
+    -- printf("RESULT: %u",option);
 end;
 
 -----------------------------------
@@ -43,6 +44,6 @@ end;
 -----------------------------------
 
 function onEventFinish(player,csid,option)
--- printf("CSID: %u",csid);
--- printf("RESULT: %u",option);
+    -- printf("CSID: %u",csid);
+    -- printf("RESULT: %u",option);
 end;

--- a/scripts/zones/Alzadaal_Undersea_Ruins/npcs/qm4.lua
+++ b/scripts/zones/Alzadaal_Undersea_Ruins/npcs/qm4.lua
@@ -1,24 +1,25 @@
 -----------------------------------
 -- Area: Alzadaal Undersea Ruins
--- NPC:  ??? (Spawn Wulgaru(ZNM T2))
+--  NPC: ??? (Spawn Wulgaru(ZNM T2))
 -- @pos -22 -4 204 72
 -----------------------------------
 package.loaded["scripts/zones/Alzadaal_Undersea_Ruins/TextIDs"] = nil;
 -----------------------------------
-
 require("scripts/zones/Alzadaal_Undersea_Ruins/TextIDs");
+require("scripts/globals/status");
 
 -----------------------------------
 -- onTrade Action
 -----------------------------------
 
 function onTrade(player,npc,trade)
-	
-	if (trade:hasItemQty(2597,1) and trade:getItemCount() == 1) then -- Trade Opalus Gem
-		player:tradeComplete();
-		SpawnMob(17072179,180):updateClaim(player);
-	end
-	
+    local mobID = 17072179;
+    if (trade:hasItemQty(2597,1) and trade:getItemCount() == 1) then -- Trade Opalus Gem
+        if (GetMobAction(mobID) == ACTION_NONE) then
+            player:tradeComplete();
+            SpawnMob(mobID):updateClaim(player);
+        end
+    end
 end;
 
 -----------------------------------
@@ -26,7 +27,7 @@ end;
 -----------------------------------
 
 function onTrigger(player,npc)
-	player:messageSpecial(NOTHING_HAPPENS);
+    player:messageSpecial(NOTHING_HAPPENS);
 end;
 
 -----------------------------------
@@ -34,8 +35,8 @@ end;
 -----------------------------------
 
 function onEventUpdate(player,csid,option)
--- printf("CSID: %u",csid);
--- printf("RESULT: %u",option);
+    -- printf("CSID: %u",csid);
+    -- printf("RESULT: %u",option);
 end;
 
 -----------------------------------
@@ -43,6 +44,6 @@ end;
 -----------------------------------
 
 function onEventFinish(player,csid,option)
--- printf("CSID: %u",csid);
--- printf("RESULT: %u",option);
+    -- printf("CSID: %u",csid);
+    -- printf("RESULT: %u",option);
 end;

--- a/scripts/zones/Arrapago_Reef/npcs/qm1.lua
+++ b/scripts/zones/Arrapago_Reef/npcs/qm1.lua
@@ -1,24 +1,25 @@
 -----------------------------------
 -- Area: Arrapago Reef
--- NPC:  ??? (Spawn Lil'Apkallu(ZNM T1))
+--  NPC: ??? (Spawn Lil'Apkallu(ZNM T1))
 -- @pos 488 -1 166 54
 -----------------------------------
 package.loaded["scripts/zones/Arrapago_Reef/TextIDs"] = nil;
 -----------------------------------
-
 require("scripts/zones/Arrapago_Reef/TextIDs");
+require("scripts/globals/status");
 
 -----------------------------------
 -- onTrade Action
 -----------------------------------
 
 function onTrade(player,npc,trade)
-	
-	if (trade:hasItemQty(2601,1) and trade:getItemCount() == 1) then -- Trade Greenling
-		player:tradeComplete();
-		SpawnMob(16998871,180):updateClaim(player);
-	end
-	
+    local mobID = 16998871;
+    if (trade:hasItemQty(2601,1) and trade:getItemCount() == 1) then -- Trade Greenling
+        if (GetMobAction(mobID) == ACTION_NONE) then
+            player:tradeComplete();
+            SpawnMob(mobID):updateClaim(player);
+        end
+    end
 end;
 
 -----------------------------------
@@ -26,7 +27,7 @@ end;
 -----------------------------------
 
 function onTrigger(player,npc)
-	player:messageSpecial(NOTHING_HAPPENS);
+    player:messageSpecial(NOTHING_HAPPENS);
 end;
 
 -----------------------------------
@@ -34,8 +35,8 @@ end;
 -----------------------------------
 
 function onEventUpdate(player,csid,option)
--- printf("CSID: %u",csid);
--- printf("RESULT: %u",option);
+    -- printf("CSID: %u",csid);
+    -- printf("RESULT: %u",option);
 end;
 
 -----------------------------------
@@ -43,6 +44,6 @@ end;
 -----------------------------------
 
 function onEventFinish(player,csid,option)
--- printf("CSID: %u",csid);
--- printf("RESULT: %u",option);
+    -- printf("CSID: %u",csid);
+    -- printf("RESULT: %u",option);
 end;

--- a/scripts/zones/Arrapago_Reef/npcs/qm2.lua
+++ b/scripts/zones/Arrapago_Reef/npcs/qm2.lua
@@ -1,24 +1,25 @@
 -----------------------------------
 -- Area: Arrapago Reef
--- NPC:  ??? (Spawn Velionis(ZNM T1))
+--  NPC: ??? (Spawn Velionis(ZNM T1))
 -- @pos 311 -3 27 54
 -----------------------------------
 package.loaded["scripts/zones/Arrapago_Reef/TextIDs"] = nil;
 -----------------------------------
-
 require("scripts/zones/Arrapago_Reef/TextIDs");
+require("scripts/globals/status");
 
 -----------------------------------
 -- onTrade Action
 -----------------------------------
 
 function onTrade(player,npc,trade)
-	
-	if (trade:hasItemQty(2600,1) and trade:getItemCount() == 1) then -- Trade Golden Teeth
-		player:tradeComplete();
-		SpawnMob(16998872,180):updateClaim(player);
-	end
-	
+    local mobID = 16998872;
+    if (trade:hasItemQty(2600,1) and trade:getItemCount() == 1) then -- Trade Golden Teeth
+        if (GetMobAction(mobID) == ACTION_NONE) then
+            player:tradeComplete();
+            SpawnMob(mobID):updateClaim(player);
+        end
+    end
 end;
 
 -----------------------------------
@@ -26,7 +27,7 @@ end;
 -----------------------------------
 
 function onTrigger(player,npc)
-	player:messageSpecial(NOTHING_HAPPENS);
+    player:messageSpecial(NOTHING_HAPPENS);
 end;
 
 -----------------------------------
@@ -34,8 +35,8 @@ end;
 -----------------------------------
 
 function onEventUpdate(player,csid,option)
--- printf("CSID: %u",csid);
--- printf("RESULT: %u",option);
+    -- printf("CSID: %u",csid);
+    -- printf("RESULT: %u",option);
 end;
 
 -----------------------------------
@@ -43,6 +44,6 @@ end;
 -----------------------------------
 
 function onEventFinish(player,csid,option)
--- printf("CSID: %u",csid);
--- printf("RESULT: %u",option);
+    -- printf("CSID: %u",csid);
+    -- printf("RESULT: %u",option);
 end;

--- a/scripts/zones/Arrapago_Reef/npcs/qm3.lua
+++ b/scripts/zones/Arrapago_Reef/npcs/qm3.lua
@@ -1,24 +1,25 @@
 -----------------------------------
 -- Area: Arrapago Reef
--- NPC:  ??? (Spawn Zareehkl the Jubilant(ZNM T2))
+--  NPC: ??? (Spawn Zareehkl the Jubilant(ZNM T2))
 -- @pos 176 -4 182 54
 -----------------------------------
 package.loaded["scripts/zones/Arrapago_Reef/TextIDs"] = nil;
 -----------------------------------
-
 require("scripts/zones/Arrapago_Reef/TextIDs");
+require("scripts/globals/status");
 
 -----------------------------------
 -- onTrade Action
 -----------------------------------
 
 function onTrade(player,npc,trade)
-	
-	if (trade:hasItemQty(2598,1) and trade:getItemCount() == 1) then -- Trade Merow No 11 Molting
-		player:tradeComplete();
-		SpawnMob(16998873,180):updateClaim(player);
-	end
-	
+    local mobID = 16998873;
+    if (trade:hasItemQty(2598,1) and trade:getItemCount() == 1) then -- Trade Merow No 11 Molting
+        if (GetMobAction(mobID) == ACTION_NONE) then
+            player:tradeComplete();
+            SpawnMob(mobID):updateClaim(player);
+        end
+    end
 end;
 
 -----------------------------------
@@ -26,7 +27,7 @@ end;
 -----------------------------------
 
 function onTrigger(player,npc)
-	player:messageSpecial(NOTHING_HAPPENS);
+    player:messageSpecial(NOTHING_HAPPENS);
 end;
 
 -----------------------------------
@@ -34,8 +35,8 @@ end;
 -----------------------------------
 
 function onEventUpdate(player,csid,option)
--- printf("CSID: %u",csid);
--- printf("RESULT: %u",option);
+    -- printf("CSID: %u",csid);
+    -- printf("RESULT: %u",option);
 end;
 
 -----------------------------------
@@ -43,6 +44,6 @@ end;
 -----------------------------------
 
 function onEventFinish(player,csid,option)
--- printf("CSID: %u",csid);
--- printf("RESULT: %u",option);
+    -- printf("CSID: %u",csid);
+    -- printf("RESULT: %u",option);
 end;

--- a/scripts/zones/Arrapago_Reef/npcs/qm4.lua
+++ b/scripts/zones/Arrapago_Reef/npcs/qm4.lua
@@ -1,24 +1,25 @@
 -----------------------------------
 -- Area: Arrapago Reef
--- NPC:  ??? (Spawn Nuhn(ZNM T3))
--- @pos -451 -7 389 54 
+--  NPC: ??? (Spawn Nuhn(ZNM T3))
+-- @pos -451 -7 389 54
 -----------------------------------
 package.loaded["scripts/zones/Arrapago_Reef/TextIDs"] = nil;
 -----------------------------------
-
 require("scripts/zones/Arrapago_Reef/TextIDs");
+require("scripts/globals/status");
 
 -----------------------------------
 -- onTrade Action
 -----------------------------------
 
 function onTrade(player,npc,trade)
-	
-	if (trade:hasItemQty(2596,1) and trade:getItemCount() == 1) then -- Trade Rose Scampi
-		player:tradeComplete();
-		SpawnMob(16998874,180):updateClaim(player);
-	end
-	
+    local mobID = 16998874;
+    if (trade:hasItemQty(2596,1) and trade:getItemCount() == 1) then -- Trade Rose Scampi
+        if (GetMobAction(mobID) == ACTION_NONE) then
+            player:tradeComplete();
+            SpawnMob(mobID):updateClaim(player);
+        end
+    end
 end;
 
 -----------------------------------
@@ -26,7 +27,7 @@ end;
 -----------------------------------
 
 function onTrigger(player,npc)
-	player:messageSpecial(NOTHING_HAPPENS);
+    player:messageSpecial(NOTHING_HAPPENS);
 end;
 
 -----------------------------------
@@ -34,8 +35,8 @@ end;
 -----------------------------------
 
 function onEventUpdate(player,csid,option)
--- printf("CSID: %u",csid);
--- printf("RESULT: %u",option);
+    -- printf("CSID: %u",csid);
+    -- printf("RESULT: %u",option);
 end;
 
 -----------------------------------
@@ -43,6 +44,6 @@ end;
 -----------------------------------
 
 function onEventFinish(player,csid,option)
--- printf("CSID: %u",csid);
--- printf("RESULT: %u",option);
+    -- printf("CSID: %u",csid);
+    -- printf("RESULT: %u",option);
 end;

--- a/scripts/zones/Aydeewa_Subterrane/npcs/qm1.lua
+++ b/scripts/zones/Aydeewa_Subterrane/npcs/qm1.lua
@@ -1,25 +1,25 @@
 -----------------------------------
 -- Area: Aydeewa Subterrane
--- NPC:  ??? (Spawn Nosferatu(ZNM T3))
+--  NPC: ??? (Spawn Nosferatu(ZNM T3))
 -- @pos -199 8 -62 68
 -----------------------------------
 package.loaded["scripts/zones/Aydeewa_Subterrane/TextIDs"] = nil;
 -----------------------------------
-
 require("scripts/zones/Aydeewa_Subterrane/TextIDs");
+require("scripts/globals/status");
 
 -----------------------------------
 -- onTrade Action
 -----------------------------------
 
 function onTrade(player,npc,trade)
-
+    local mobID = 17056157;
     if (trade:hasItemQty(2584,1) and trade:getItemCount() == 1) then -- Trade Pure Blood
-        player:tradeComplete();
-        SpawnMob(17056157,180):updateClaim(player);
+        if (GetMobAction(mobID) == ACTION_NONE) then
+            player:tradeComplete();
+            SpawnMob(mobID):updateClaim(player);
+        end
     end
-
-end;
 
 -----------------------------------
 -- onTrigger Action

--- a/scripts/zones/Aydeewa_Subterrane/npcs/qm3.lua
+++ b/scripts/zones/Aydeewa_Subterrane/npcs/qm3.lua
@@ -1,24 +1,23 @@
 -----------------------------------
 -- Area: Aydeewa Subterrane
--- NPC:  ??? (Spawn Chigre(ZNM T1))
+--  NPC: ??? (Spawn Chigre(ZNM T1))
 -- @pos -217 35 12 68
 -----------------------------------
 package.loaded["scripts/zones/Aydeewa_Subterrane/TextIDs"] = nil;
 -----------------------------------
-
 require("scripts/zones/Aydeewa_Subterrane/TextIDs");
+require("scripts/globals/status");
 
 -----------------------------------
 -- onTrade Action
 -----------------------------------
 
 function onTrade(player,npc,trade)
-
+    local mobID = 17056186;
     if (trade:hasItemQty(2602,1) and trade:getItemCount() == 1) then -- Trade Spoilt Blood
         player:tradeComplete();
-        SpawnMob(17056186,180):updateClaim(player);
+        SpawnMob(mobID):updateClaim(player);
     end
-
 end;
 
 -----------------------------------

--- a/scripts/zones/Bhaflau_Thickets/npcs/qm1.lua
+++ b/scripts/zones/Bhaflau_Thickets/npcs/qm1.lua
@@ -1,24 +1,25 @@
 -----------------------------------
 -- Area: Bhaflau Thickets
--- NPC:  ??? (Spawn Lividroot Amooshah(ZNM T2))
+--  NPC: ??? (Spawn Lividroot Amooshah(ZNM T2))
 -- @pos 334 -10 184 52
 -----------------------------------
 package.loaded["scripts/zones/Bhaflau_Thickets/TextIDs"] = nil;
 -----------------------------------
-
 require("scripts/zones/Bhaflau_Thickets/TextIDs");
+require("scripts/globals/status");
 
 -----------------------------------
 -- onTrade Action
 -----------------------------------
 
 function onTrade(player,npc,trade)
-	
-	if (trade:hasItemQty(2578,1) and trade:getItemCount() == 1) then -- Trade Oily Blood
-		player:tradeComplete();
-		SpawnMob(16990473,180):updateClaim(player);
-	end
-	
+    local mobID = 16990473;
+    if (trade:hasItemQty(2578,1) and trade:getItemCount() == 1) then -- Trade Oily Blood
+        if (GetMobAction(mobID) == ACTION_NONE) then
+            player:tradeComplete();
+            SpawnMob(mobID):updateClaim(player);
+        end
+    end
 end;
 
 -----------------------------------
@@ -26,7 +27,7 @@ end;
 -----------------------------------
 
 function onTrigger(player,npc)
-	player:messageSpecial(NOTHING_HAPPENS);
+    player:messageSpecial(NOTHING_HAPPENS);
 end;
 
 -----------------------------------
@@ -34,8 +35,8 @@ end;
 -----------------------------------
 
 function onEventUpdate(player,csid,option)
--- printf("CSID: %u",csid);
--- printf("RESULT: %u",option);
+    -- printf("CSID: %u",csid);
+    -- printf("RESULT: %u",option);
 end;
 
 -----------------------------------
@@ -43,6 +44,6 @@ end;
 -----------------------------------
 
 function onEventFinish(player,csid,option)
--- printf("CSID: %u",csid);
--- printf("RESULT: %u",option);
+    -- printf("CSID: %u",csid);
+    -- printf("RESULT: %u",option);
 end;

--- a/scripts/zones/Bhaflau_Thickets/npcs/qm2.lua
+++ b/scripts/zones/Bhaflau_Thickets/npcs/qm2.lua
@@ -1,24 +1,25 @@
 -----------------------------------
 -- Area: Bhaflau Thickets
--- NPC:  ??? (Spawn Dea(ZNM T3))
+--  NPC: ??? (Spawn Dea(ZNM T3))
 -- @pos -34 -32 481 52
 -----------------------------------
 package.loaded["scripts/zones/Bhaflau_Thickets/TextIDs"] = nil;
 -----------------------------------
-
 require("scripts/zones/Bhaflau_Thickets/TextIDs");
+require("scripts/globals/status");
 
 -----------------------------------
 -- onTrade Action
 -----------------------------------
 
 function onTrade(player,npc,trade)
-	
-	if (trade:hasItemQty(2576,1) and trade:getItemCount() == 1) then -- Trade Olzhiryan Cactus
-		player:tradeComplete();
-		SpawnMob(16990474,180):updateClaim(player);
-	end
-	
+    local mobID = 16990474;
+    if (trade:hasItemQty(2576,1) and trade:getItemCount() == 1) then -- Trade Olzhiryan Cactus
+        if (GetMobAction(mobID) == ACTION_NONE) then
+            player:tradeComplete();
+            SpawnMob(mobID):updateClaim(player);
+        end
+    end
 end;
 
 -----------------------------------
@@ -26,7 +27,7 @@ end;
 -----------------------------------
 
 function onTrigger(player,npc)
-	player:messageSpecial(NOTHING_HAPPENS);
+    player:messageSpecial(NOTHING_HAPPENS);
 end;
 
 -----------------------------------
@@ -34,8 +35,8 @@ end;
 -----------------------------------
 
 function onEventUpdate(player,csid,option)
--- printf("CSID: %u",csid);
--- printf("RESULT: %u",option);
+    -- printf("CSID: %u",csid);
+    -- printf("RESULT: %u",option);
 end;
 
 -----------------------------------
@@ -43,6 +44,6 @@ end;
 -----------------------------------
 
 function onEventFinish(player,csid,option)
--- printf("CSID: %u",csid);
--- printf("RESULT: %u",option);
+    -- printf("CSID: %u",csid);
+    -- printf("RESULT: %u",option);
 end;

--- a/scripts/zones/Caedarva_Mire/npcs/qm1.lua
+++ b/scripts/zones/Caedarva_Mire/npcs/qm1.lua
@@ -1,24 +1,25 @@
 -----------------------------------
 -- Area: Caedarva Mire
--- NPC:  ??? (Spawn Verdelet(ZNM T2))
+--  NPC: ??? (Spawn Verdelet(ZNM T2))
 -- @pos 417 -19 -69 79
 -----------------------------------
 package.loaded["scripts/zones/Caedarva_Mire/TextIDs"] = nil;
 -----------------------------------
-
 require("scripts/zones/Caedarva_Mire/TextIDs");
+require("scripts/globals/status");
 
 -----------------------------------
 -- onTrade Action
 -----------------------------------
 
 function onTrade(player,npc,trade)
-	
-	if (trade:hasItemQty(2599,1) and trade:getItemCount() == 1) then -- Trade Mint Drop
-		player:tradeComplete();
-		SpawnMob(17101202,180):updateClaim(player);
-	end
-	
+    local mobID = 17101202;
+    if (trade:hasItemQty(2599,1) and trade:getItemCount() == 1) then -- Trade Mint Drop
+        if (GetMobAction(mobID) == ACTION_NONE) then
+            player:tradeComplete();
+            SpawnMob(mobID):updateClaim(player);
+        end
+    end
 end;
 
 -----------------------------------
@@ -26,7 +27,7 @@ end;
 -----------------------------------
 
 function onTrigger(player,npc)
-	player:messageSpecial(NOTHING_HAPPENS);
+    player:messageSpecial(NOTHING_HAPPENS);
 end;
 
 -----------------------------------
@@ -34,8 +35,8 @@ end;
 -----------------------------------
 
 function onEventUpdate(player,csid,option)
--- printf("CSID: %u",csid);
--- printf("RESULT: %u",option);
+    -- printf("CSID: %u",csid);
+    -- printf("RESULT: %u",option);
 end;
 
 -----------------------------------
@@ -43,6 +44,6 @@ end;
 -----------------------------------
 
 function onEventFinish(player,csid,option)
--- printf("CSID: %u",csid);
--- printf("RESULT: %u",option);
+    -- printf("CSID: %u",csid);
+    -- printf("RESULT: %u",option);
 end;

--- a/scripts/zones/Caedarva_Mire/npcs/qm2.lua
+++ b/scripts/zones/Caedarva_Mire/npcs/qm2.lua
@@ -1,24 +1,25 @@
 -----------------------------------
 -- Area: Caedarva Mire
--- NPC:  ??? (Spawn Experimental Lamia(ZNM T3))
+--  NPC: ??? (Spawn Experimental Lamia(ZNM T3))
 -- @pos -773 -11 322 79
 -----------------------------------
 package.loaded["scripts/zones/Caedarva_Mire/TextIDs"] = nil;
 -----------------------------------
-
 require("scripts/zones/Caedarva_Mire/TextIDs");
+require("scripts/globals/status");
 
 -----------------------------------
 -- onTrade Action
 -----------------------------------
 
 function onTrade(player,npc,trade)
-	
-	if (trade:hasItemQty(2595,1) and trade:getItemCount() == 1) then -- Trade Myrrh
-		player:tradeComplete();
-		SpawnMob(17101205,180):updateClaim(player);
-	end
-	
+    local mobID = 17101205;
+    if (trade:hasItemQty(2595,1) and trade:getItemCount() == 1) then -- Trade Myrrh
+        if (GetMobAction(mobID) == ACTION_NONE) then
+            player:tradeComplete();
+            SpawnMob(mobID):updateClaim(player);
+        end
+    end
 end;
 
 -----------------------------------
@@ -26,7 +27,7 @@ end;
 -----------------------------------
 
 function onTrigger(player,npc)
-	player:messageSpecial(NOTHING_HAPPENS);
+    player:messageSpecial(NOTHING_HAPPENS);
 end;
 
 -----------------------------------
@@ -34,8 +35,8 @@ end;
 -----------------------------------
 
 function onEventUpdate(player,csid,option)
--- printf("CSID: %u",csid);
--- printf("RESULT: %u",option);
+    -- printf("CSID: %u",csid);
+    -- printf("RESULT: %u",option);
 end;
 
 -----------------------------------
@@ -43,6 +44,6 @@ end;
 -----------------------------------
 
 function onEventFinish(player,csid,option)
--- printf("CSID: %u",csid);
--- printf("RESULT: %u",option);
+    -- printf("CSID: %u",csid);
+    -- printf("RESULT: %u",option);
 end;

--- a/scripts/zones/Caedarva_Mire/npcs/qm3.lua
+++ b/scripts/zones/Caedarva_Mire/npcs/qm3.lua
@@ -1,24 +1,25 @@
 -----------------------------------
 -- Area: Caedarva Mire
--- NPC:  ??? (Spawn Mahjlaef the Paintorn(ZNM T3))
+--  NPC: ??? (Spawn Mahjlaef the Paintorn(ZNM T3))
 -- @pos 695 -7 527 79
 -----------------------------------
 package.loaded["scripts/zones/Caedarva_Mire/TextIDs"] = nil;
 -----------------------------------
-
 require("scripts/zones/Caedarva_Mire/TextIDs");
+require("scripts/globals/status");
 
 -----------------------------------
 -- onTrade Action
 -----------------------------------
 
 function onTrade(player,npc,trade)
-	
-	if (trade:hasItemQty(2594,1) and trade:getItemCount() == 1) then -- Trade Exorcism Treatise
-		player:tradeComplete();
-		SpawnMob(17101204,180):updateClaim(player);
-	end
-	
+    local mobID = 17101204;
+    if (trade:hasItemQty(2594,1) and trade:getItemCount() == 1) then -- Trade Exorcism Treatise
+        if (GetMobAction(mobID) == ACTION_NONE) then
+            player:tradeComplete();
+            SpawnMob(mobID):updateClaim(player);
+        end
+    end
 end;
 
 -----------------------------------
@@ -26,7 +27,7 @@ end;
 -----------------------------------
 
 function onTrigger(player,npc)
-	player:messageSpecial(NOTHING_HAPPENS);
+    player:messageSpecial(NOTHING_HAPPENS);
 end;
 
 -----------------------------------
@@ -34,8 +35,8 @@ end;
 -----------------------------------
 
 function onEventUpdate(player,csid,option)
--- printf("CSID: %u",csid);
--- printf("RESULT: %u",option);
+    -- printf("CSID: %u",csid);
+    -- printf("RESULT: %u",option);
 end;
 
 -----------------------------------
@@ -43,6 +44,6 @@ end;
 -----------------------------------
 
 function onEventFinish(player,csid,option)
--- printf("CSID: %u",csid);
--- printf("RESULT: %u",option);
+    -- printf("CSID: %u",csid);
+    -- printf("RESULT: %u",option);
 end;

--- a/scripts/zones/Caedarva_Mire/npcs/qm4.lua
+++ b/scripts/zones/Caedarva_Mire/npcs/qm4.lua
@@ -1,24 +1,25 @@
 -----------------------------------
 -- Area: Caedarva Mire
--- NPC:  ??? (Spawn Tyger(ZNM T4))
+--  NPC: ??? (Spawn Tyger(ZNM T4))
 -- @pos -766 -12 632 79
 -----------------------------------
 package.loaded["scripts/zones/Caedarva_Mire/TextIDs"] = nil;
 -----------------------------------
-
 require("scripts/zones/Caedarva_Mire/TextIDs");
+require("scripts/globals/status");
 
 -----------------------------------
 -- onTrade Action
 -----------------------------------
 
 function onTrade(player,npc,trade)
-	
-	if (trade:hasItemQty(2593,1) and trade:getItemCount() == 1) then -- Trade Singed Buffalo
-		player:tradeComplete();
-		SpawnMob(17101203,180):updateClaim(player);
-	end
-	
+    local mobID = 17101203;
+    if (trade:hasItemQty(2593,1) and trade:getItemCount() == 1) then -- Trade Singed Buffalo
+        if (GetMobAction(mobID) == ACTION_NONE) then
+            player:tradeComplete();
+            SpawnMob(mobID):updateClaim(player);
+        end
+    end
 end;
 
 -----------------------------------
@@ -26,7 +27,7 @@ end;
 -----------------------------------
 
 function onTrigger(player,npc)
-	player:messageSpecial(NOTHING_HAPPENS);
+    player:messageSpecial(NOTHING_HAPPENS);
 end;
 
 -----------------------------------
@@ -34,8 +35,8 @@ end;
 -----------------------------------
 
 function onEventUpdate(player,csid,option)
--- printf("CSID: %u",csid);
--- printf("RESULT: %u",option);
+    -- printf("CSID: %u",csid);
+    -- printf("RESULT: %u",option);
 end;
 
 -----------------------------------
@@ -43,6 +44,6 @@ end;
 -----------------------------------
 
 function onEventFinish(player,csid,option)
--- printf("CSID: %u",csid);
--- printf("RESULT: %u",option);
+    -- printf("CSID: %u",csid);
+    -- printf("RESULT: %u",option);
 end;

--- a/scripts/zones/Halvung/npcs/qm2.lua
+++ b/scripts/zones/Halvung/npcs/qm2.lua
@@ -1,24 +1,25 @@
 -----------------------------------
 -- Area: Halvung
--- NPC:  ??? (Spawn Dextrose(ZNM T2))
+--  NPC: ??? (Spawn Dextrose(ZNM T2))
 -- @pos -144 11 464 62
 -----------------------------------
 package.loaded["scripts/zones/Halvung/TextIDs"] = nil;
 -----------------------------------
-
 require("scripts/zones/Halvung/TextIDs");
+require("scripts/globals/status");
 
 -----------------------------------
 -- onTrade Action
 -----------------------------------
 
 function onTrade(player,npc,trade)
-	
-	if (trade:hasItemQty(2589,1) and trade:getItemCount() == 1) then -- Trade Granulated Sugar
-		player:tradeComplete();
-		SpawnMob(17031598,180):updateClaim(player);
-	end
-	
+    local mobID = 17031598;
+    if (trade:hasItemQty(2589,1) and trade:getItemCount() == 1) then -- Trade Granulated Sugar
+        if (GetMobAction(mobID) == ACTION_NONE) then
+            player:tradeComplete();
+            SpawnMob(mobID):updateClaim(player);
+        end
+    end
 end;
 
 -----------------------------------
@@ -26,7 +27,7 @@ end;
 -----------------------------------
 
 function onTrigger(player,npc)
-	player:messageSpecial(NOTHING_HAPPENS);
+    player:messageSpecial(NOTHING_HAPPENS);
 end;
 
 -----------------------------------
@@ -34,8 +35,8 @@ end;
 -----------------------------------
 
 function onEventUpdate(player,csid,option)
--- printf("CSID: %u",csid);
--- printf("RESULT: %u",option);
+    -- printf("CSID: %u",csid);
+    -- printf("RESULT: %u",option);
 end;
 
 -----------------------------------
@@ -43,6 +44,6 @@ end;
 -----------------------------------
 
 function onEventFinish(player,csid,option)
--- printf("CSID: %u",csid);
--- printf("RESULT: %u",option);
+    -- printf("CSID: %u",csid);
+    -- printf("RESULT: %u",option);
 end;

--- a/scripts/zones/Halvung/npcs/qm3.lua
+++ b/scripts/zones/Halvung/npcs/qm3.lua
@@ -1,24 +1,25 @@
 -----------------------------------
 -- Area: Halvung
--- NPC:  ??? (Spawn Reacton(ZNM T2))
+--  NPC: ??? (Spawn Reacton(ZNM T2))
 -- @pos 18 -9 213 62
 -----------------------------------
 package.loaded["scripts/zones/Halvung/TextIDs"] = nil;
 -----------------------------------
-
 require("scripts/zones/Halvung/TextIDs");
+require("scripts/globals/status");
 
 -----------------------------------
 -- onTrade Action
 -----------------------------------
 
 function onTrade(player,npc,trade)
-	
-	if (trade:hasItemQty(2588,1) and trade:getItemCount() == 1) then -- Trade Bone Charcoal
-		player:tradeComplete();
-		SpawnMob(17031599,180):updateClaim(player);
-	end
-	
+    local mobID = 17031599;
+    if (trade:hasItemQty(2588,1) and trade:getItemCount() == 1) then -- Trade Bone Charcoal
+        if (GetMobAction(mobID) == ACTION_NONE) then
+            player:tradeComplete();
+            SpawnMob(mobID):updateClaim(player);
+        end
+    end
 end;
 
 -----------------------------------
@@ -26,7 +27,7 @@ end;
 -----------------------------------
 
 function onTrigger(player,npc)
-	player:messageSpecial(NOTHING_HAPPENS);
+    player:messageSpecial(NOTHING_HAPPENS);
 end;
 
 -----------------------------------
@@ -34,8 +35,8 @@ end;
 -----------------------------------
 
 function onEventUpdate(player,csid,option)
--- printf("CSID: %u",csid);
--- printf("RESULT: %u",option);
+    -- printf("CSID: %u",csid);
+    -- printf("RESULT: %u",option);
 end;
 
 -----------------------------------
@@ -43,6 +44,6 @@ end;
 -----------------------------------
 
 function onEventFinish(player,csid,option)
--- printf("CSID: %u",csid);
--- printf("RESULT: %u",option);
+    -- printf("CSID: %u",csid);
+    -- printf("RESULT: %u",option);
 end;

--- a/scripts/zones/Halvung/npcs/qm4.lua
+++ b/scripts/zones/Halvung/npcs/qm4.lua
@@ -1,24 +1,25 @@
 -----------------------------------
 -- Area: Halvung
--- NPC:  ??? (Spawn Achamoth(ZNM T3))
+--  NPC: ??? (Spawn Achamoth(ZNM T3))
 -- @pos -34 10 336 62
 -----------------------------------
 package.loaded["scripts/zones/Halvung/TextIDs"] = nil;
 -----------------------------------
-
 require("scripts/zones/Halvung/TextIDs");
+require("scripts/globals/status");
 
 -----------------------------------
 -- onTrade Action
 -----------------------------------
 
 function onTrade(player,npc,trade)
-	
-	if (trade:hasItemQty(2586,1) and trade:getItemCount() == 1) then -- Trade Rock Juice
-		player:tradeComplete();
-		SpawnMob(17031600,180):updateClaim(player);
-	end
-	
+    local mobID = 17031600;
+    if (trade:hasItemQty(2586,1) and trade:getItemCount() == 1) then -- Trade Rock Juice
+        if (GetMobAction(mobID) == ACTION_NONE) then\n
+            player:tradeComplete();
+            SpawnMob(mobID):updateClaim(player);
+        end
+    end
 end;
 
 -----------------------------------
@@ -26,7 +27,7 @@ end;
 -----------------------------------
 
 function onTrigger(player,npc)
-	player:messageSpecial(NOTHING_HAPPENS);
+    player:messageSpecial(NOTHING_HAPPENS);
 end;
 
 -----------------------------------
@@ -34,8 +35,8 @@ end;
 -----------------------------------
 
 function onEventUpdate(player,csid,option)
--- printf("CSID: %u",csid);
--- printf("RESULT: %u",option);
+    -- printf("CSID: %u",csid);
+    -- printf("RESULT: %u",option);
 end;
 
 -----------------------------------
@@ -43,6 +44,6 @@ end;
 -----------------------------------
 
 function onEventFinish(player,csid,option)
--- printf("CSID: %u",csid);
--- printf("RESULT: %u",option);
+    -- printf("CSID: %u",csid);
+    -- printf("RESULT: %u",option);
 end;

--- a/scripts/zones/Mamook/npcs/qm1.lua
+++ b/scripts/zones/Mamook/npcs/qm1.lua
@@ -1,24 +1,25 @@
 -----------------------------------
 -- Area: Mamook
--- NPC:  ??? (Spawn Chamrosh(ZNM T1))
+--  NPC: ??? (Spawn Chamrosh(ZNM T1))
 -- @pos 206 14 -285 65
 -----------------------------------
 package.loaded["scripts/zones/Mamook/TextIDs"] = nil;
 -----------------------------------
-
 require("scripts/zones/Mamook/TextIDs");
+require("scripts/globals/status");
 
 -----------------------------------
 -- onTrade Action
 -----------------------------------
 
 function onTrade(player,npc,trade)
-	
-	if (trade:hasItemQty(2581,1) and trade:getItemCount() == 1) then -- Trade Floral Nectar
-		player:tradeComplete();
-		SpawnMob(17043887,180):updateClaim(player);
-	end
-	
+    local mobID = 17043887;
+    if (trade:hasItemQty(2581,1) and trade:getItemCount() == 1) then -- Trade Floral Nectar
+        if (GetMobAction(mobID) == ACTION_NONE) then
+            player:tradeComplete();
+            SpawnMob(mobID):updateClaim(player);
+        end
+    end
 end;
 
 -----------------------------------
@@ -26,7 +27,7 @@ end;
 -----------------------------------
 
 function onTrigger(player,npc)
-	player:messageSpecial(NOTHING_HAPPENS);
+    player:messageSpecial(NOTHING_HAPPENS);
 end;
 
 -----------------------------------
@@ -34,8 +35,8 @@ end;
 -----------------------------------
 
 function onEventUpdate(player,csid,option)
--- printf("CSID: %u",csid);
--- printf("RESULT: %u",option);
+    -- printf("CSID: %u",csid);
+    -- printf("RESULT: %u",option);
 end;
 
 -----------------------------------
@@ -43,6 +44,6 @@ end;
 -----------------------------------
 
 function onEventFinish(player,csid,option)
--- printf("CSID: %u",csid);
--- printf("RESULT: %u",option);
+    -- printf("CSID: %u",csid);
+    -- printf("RESULT: %u",option);
 end;

--- a/scripts/zones/Mamook/npcs/qm2.lua
+++ b/scripts/zones/Mamook/npcs/qm2.lua
@@ -1,24 +1,25 @@
 -----------------------------------
 -- Area: Mamook
--- NPC:  ??? (Spawn Iriri Samariri(ZNM T2))
--- @pos -118 7 -80 65 
+--  NPC: ??? (Spawn Iriri Samariri(ZNM T2))
+-- @pos -118 7 -80 65
 -----------------------------------
 package.loaded["scripts/zones/Mamook/TextIDs"] = nil;
 -----------------------------------
-
 require("scripts/zones/Mamook/TextIDs");
+require("scripts/globals/status");
 
 -----------------------------------
 -- onTrade Action
 -----------------------------------
 
 function onTrade(player,npc,trade)
-	
-	if (trade:hasItemQty(2579,1) and trade:getItemCount() == 1) then -- Trade Samariri Corpsehair
-		player:tradeComplete();
-		SpawnMob(17043888,180):updateClaim(player);
-	end
-	
+    local mobID = 17043888;
+    if (trade:hasItemQty(2579,1) and trade:getItemCount() == 1) then -- Trade Samariri Corpsehair
+        if (GetMobAction(mobID) == ACTION_NONE) then
+            player:tradeComplete();
+            SpawnMob(mobID):updateClaim(player);
+        end
+    end
 end;
 
 -----------------------------------
@@ -26,7 +27,7 @@ end;
 -----------------------------------
 
 function onTrigger(player,npc)
-	player:messageSpecial(NOTHING_HAPPENS);
+    player:messageSpecial(NOTHING_HAPPENS);
 end;
 
 -----------------------------------
@@ -34,8 +35,8 @@ end;
 -----------------------------------
 
 function onEventUpdate(player,csid,option)
--- printf("CSID: %u",csid);
--- printf("RESULT: %u",option);
+    -- printf("CSID: %u",csid);
+    -- printf("RESULT: %u",option);
 end;
 
 -----------------------------------
@@ -43,6 +44,6 @@ end;
 -----------------------------------
 
 function onEventFinish(player,csid,option)
--- printf("CSID: %u",csid);
--- printf("RESULT: %u",option);
+    -- printf("CSID: %u",csid);
+    -- printf("RESULT: %u",option);
 end;

--- a/scripts/zones/Mount_Zhayolm/npcs/qm1.lua
+++ b/scripts/zones/Mount_Zhayolm/npcs/qm1.lua
@@ -1,24 +1,25 @@
 -----------------------------------
 -- Area: Mount Zhayolm
--- NPC:  ??? (Spawn Brass Borer(ZNM T1))
+--  NPC: ??? (Spawn Brass Borer(ZNM T1))
 -- @pos 399 -27 120 61
 -----------------------------------
 package.loaded["scripts/zones/Mount_Zhayolm/TextIDs"] = nil;
 -----------------------------------
-
 require("scripts/zones/Mount_Zhayolm/TextIDs");
+require("scripts/globals/status");
 
 -----------------------------------
 -- onTrade Action
 -----------------------------------
 
 function onTrade(player,npc,trade)
-	
-	if (trade:hasItemQty(2590,1) and trade:getItemCount() == 1) then -- Trade Shadeleaves
-		player:tradeComplete();
-		SpawnMob(17027471,180):updateClaim(player);
-	end
-	
+    local mobID = 17027471;
+    if (trade:hasItemQty(2590,1) and trade:getItemCount() == 1) then -- Trade Shadeleaves
+        if (GetMobAction(mobID) == ACTION_NONE) then
+            player:tradeComplete();
+            SpawnMob(mobID):updateClaim(player);
+        end
+    end
 end;
 
 -----------------------------------
@@ -26,7 +27,7 @@ end;
 -----------------------------------
 
 function onTrigger(player,npc)
-	player:messageSpecial(NOTHING_HAPPENS);
+    player:messageSpecial(NOTHING_HAPPENS);
 end;
 
 -----------------------------------
@@ -34,8 +35,8 @@ end;
 -----------------------------------
 
 function onEventUpdate(player,csid,option)
--- printf("CSID: %u",csid);
--- printf("RESULT: %u",option);
+    -- printf("CSID: %u",csid);
+    -- printf("RESULT: %u",option);
 end;
 
 -----------------------------------
@@ -43,6 +44,6 @@ end;
 -----------------------------------
 
 function onEventFinish(player,csid,option)
--- printf("CSID: %u",csid);
--- printf("RESULT: %u",option);
+    -- printf("CSID: %u",csid);
+    -- printf("RESULT: %u",option);
 end;

--- a/scripts/zones/Mount_Zhayolm/npcs/qm2.lua
+++ b/scripts/zones/Mount_Zhayolm/npcs/qm2.lua
@@ -1,24 +1,25 @@
 -----------------------------------
 -- Area: Mount Zhayolm
--- NPC:  ??? (Spawn Claret(ZNM T1))
+--  NPC: ??? (Spawn Claret(ZNM T1))
 -- @pos 497 -9 52 61
 -----------------------------------
 package.loaded["scripts/zones/Mount_Zhayolm/TextIDs"] = nil;
 -----------------------------------
-
 require("scripts/zones/Mount_Zhayolm/TextIDs");
+require("scripts/globals/status");
 
 -----------------------------------
 -- onTrade Action
 -----------------------------------
 
 function onTrade(player,npc,trade)
-	
-	if (trade:hasItemQty(2591,1) and trade:getItemCount() == 1) then -- Trade Pectin
-		player:tradeComplete();
-		SpawnMob(17027472,180):updateClaim(player);
-	end
-	
+    local mobID = 17027472;
+    if (trade:hasItemQty(2591,1) and trade:getItemCount() == 1) then -- Trade Pectin
+        if (GetMobAction(mobID) == ACTION_NONE) then
+            player:tradeComplete();
+            SpawnMob(mobID):updateClaim(player);
+        end
+    end
 end;
 
 -----------------------------------
@@ -26,7 +27,7 @@ end;
 -----------------------------------
 
 function onTrigger(player,npc)
-	player:messageSpecial(NOTHING_HAPPENS);
+    player:messageSpecial(NOTHING_HAPPENS);
 end;
 
 -----------------------------------
@@ -34,8 +35,8 @@ end;
 -----------------------------------
 
 function onEventUpdate(player,csid,option)
--- printf("CSID: %u",csid);
--- printf("RESULT: %u",option);
+    -- printf("CSID: %u",csid);
+    -- printf("RESULT: %u",option);
 end;
 
 -----------------------------------
@@ -43,6 +44,6 @@ end;
 -----------------------------------
 
 function onEventFinish(player,csid,option)
--- printf("CSID: %u",csid);
--- printf("RESULT: %u",option);
+    -- printf("CSID: %u",csid);
+    -- printf("RESULT: %u",option);
 end;

--- a/scripts/zones/Mount_Zhayolm/npcs/qm3.lua
+++ b/scripts/zones/Mount_Zhayolm/npcs/qm3.lua
@@ -1,24 +1,25 @@
 -----------------------------------
 -- Area: Mount Zhayolm
--- NPC:  ??? (Spawn Anantaboga(ZNM T2))
+--  NPC: ??? (Spawn Anantaboga(ZNM T2))
 -- @pos -368 -13 366 61
 -----------------------------------
 package.loaded["scripts/zones/Mount_Zhayolm/TextIDs"] = nil;
 -----------------------------------
-
 require("scripts/zones/Mount_Zhayolm/TextIDs");
+require("scripts/globals/status");
 
 -----------------------------------
 -- onTrade Action
 -----------------------------------
 
 function onTrade(player,npc,trade)
-	
-	if (trade:hasItemQty(2587,1) and trade:getItemCount() == 1) then -- Trade Raw Buffalo
-		player:tradeComplete();
-		SpawnMob(17027473,180):updateClaim(player);
-	end
-	
+    local mobID = 17027473;
+    if (trade:hasItemQty(2587,1) and trade:getItemCount() == 1) then -- Trade Raw Buffalo
+        if (GetMobAction(mobID) == ACTION_NONE) then
+            player:tradeComplete();
+            SpawnMob(mobID):updateClaim(player);
+        end
+    end
 end;
 
 -----------------------------------
@@ -26,7 +27,7 @@ end;
 -----------------------------------
 
 function onTrigger(player,npc)
-	player:messageSpecial(NOTHING_HAPPENS);
+    player:messageSpecial(NOTHING_HAPPENS);
 end;
 
 -----------------------------------
@@ -34,8 +35,8 @@ end;
 -----------------------------------
 
 function onEventUpdate(player,csid,option)
--- printf("CSID: %u",csid);
--- printf("RESULT: %u",option);
+    -- printf("CSID: %u",csid);
+    -- printf("RESULT: %u",option);
 end;
 
 -----------------------------------
@@ -43,6 +44,6 @@ end;
 -----------------------------------
 
 function onEventFinish(player,csid,option)
--- printf("CSID: %u",csid);
--- printf("RESULT: %u",option);
+    -- printf("CSID: %u",csid);
+    -- printf("RESULT: %u",option);
 end;

--- a/scripts/zones/Mount_Zhayolm/npcs/qm4.lua
+++ b/scripts/zones/Mount_Zhayolm/npcs/qm4.lua
@@ -1,24 +1,25 @@
 -----------------------------------
 -- Area: Mount Zhayolm
--- NPC:  ??? (Spawn Khromasoul Bhurborlor(ZNM T3))
+--  NPC: ??? (Spawn Khromasoul Bhurborlor(ZNM T3))
 -- @pos 88 -22 70 61
 -----------------------------------
 package.loaded["scripts/zones/Mount_Zhayolm/TextIDs"] = nil;
 -----------------------------------
-
 require("scripts/zones/Mount_Zhayolm/TextIDs");
+require("scripts/globals/status");
 
 -----------------------------------
 -- onTrade Action
 -----------------------------------
 
 function onTrade(player,npc,trade)
-	
-	if (trade:hasItemQty(2585,1) and trade:getItemCount() == 1) then -- Trade Vinegar Pie
-		player:tradeComplete();
-		SpawnMob(17027474,180):updateClaim(player);
-	end
-	
+    local mobID = 17027474;
+    if (trade:hasItemQty(2585,1) and trade:getItemCount() == 1) then -- Trade Vinegar Pie
+        if (GetMobAction(mobID) == ACTION_NONE) then
+            player:tradeComplete();
+            SpawnMob(mobID):updateClaim(player);
+        end
+    end
 end;
 
 -----------------------------------
@@ -26,7 +27,7 @@ end;
 -----------------------------------
 
 function onTrigger(player,npc)
-	player:messageSpecial(NOTHING_HAPPENS);
+    player:messageSpecial(NOTHING_HAPPENS);
 end;
 
 -----------------------------------
@@ -34,8 +35,8 @@ end;
 -----------------------------------
 
 function onEventUpdate(player,csid,option)
--- printf("CSID: %u",csid);
--- printf("RESULT: %u",option);
+    -- printf("CSID: %u",csid);
+    -- printf("RESULT: %u",option);
 end;
 
 -----------------------------------
@@ -43,6 +44,6 @@ end;
 -----------------------------------
 
 function onEventFinish(player,csid,option)
--- printf("CSID: %u",csid);
--- printf("RESULT: %u",option);
+    -- printf("CSID: %u",csid);
+    -- printf("RESULT: %u",option);
 end;

--- a/scripts/zones/Mount_Zhayolm/npcs/qm5.lua
+++ b/scripts/zones/Mount_Zhayolm/npcs/qm5.lua
@@ -1,24 +1,25 @@
 -----------------------------------
 -- Area: Mount Zhayolm
--- NPC:  ??? (Spawn Sarameya(ZNM T4))
+--  NPC: ??? (Spawn Sarameya(ZNM T4))
 -- @pos 322 -14 -581 61
 -----------------------------------
 package.loaded["scripts/zones/Mount_Zhayolm/TextIDs"] = nil;
 -----------------------------------
-
 require("scripts/zones/Mount_Zhayolm/TextIDs");
+require("scripts/globals/status");
 
 -----------------------------------
 -- onTrade Action
 -----------------------------------
 
 function onTrade(player,npc,trade)
-	
-	if (trade:hasItemQty(2583,1) and trade:getItemCount() == 1) then -- Trade Buffalo Corpse
-		player:tradeComplete();
-		SpawnMob(17027485,180):updateClaim(player);
-	end
-	
+    local mobID = 17027485;
+    if (trade:hasItemQty(2583,1) and trade:getItemCount() == 1) then -- Trade Buffalo Corpse
+        if (GetMobAction(mobID) == ACTION_NONE) then
+            player:tradeComplete();
+            SpawnMob(mobID):updateClaim(player);
+        end
+    end
 end;
 
 -----------------------------------
@@ -26,7 +27,7 @@ end;
 -----------------------------------
 
 function onTrigger(player,npc)
-	player:messageSpecial(NOTHING_HAPPENS);
+    player:messageSpecial(NOTHING_HAPPENS);
 end;
 
 -----------------------------------
@@ -34,8 +35,8 @@ end;
 -----------------------------------
 
 function onEventUpdate(player,csid,option)
--- printf("CSID: %u",csid);
--- printf("RESULT: %u",option);
+    -- printf("CSID: %u",csid);
+    -- printf("RESULT: %u",option);
 end;
 
 -----------------------------------
@@ -43,6 +44,6 @@ end;
 -----------------------------------
 
 function onEventFinish(player,csid,option)
--- printf("CSID: %u",csid);
--- printf("RESULT: %u",option);
+    -- printf("CSID: %u",csid);
+    -- printf("RESULT: %u",option);
 end;

--- a/scripts/zones/Wajaom_Woodlands/npcs/qm1.lua
+++ b/scripts/zones/Wajaom_Woodlands/npcs/qm1.lua
@@ -1,24 +1,25 @@
 -----------------------------------
 -- Area: Wajaom Woodlands
--- NPC:  ??? (Spawn Vulpangue(ZNM T1))
+--  NPC: ??? (Spawn Vulpangue(ZNM T1))
 -- @pos -697 -7 -123 51
 -----------------------------------
 package.loaded["scripts/zones/Wajaom_Woodlands/TextIDs"] = nil;
 -----------------------------------
-
 require("scripts/zones/Wajaom_Woodlands/TextIDs");
+require("scripts/globals/status");
 
 -----------------------------------
 -- onTrade Action
 -----------------------------------
 
 function onTrade(player,npc,trade)
-	
-	if (trade:hasItemQty(2580,1) and trade:getItemCount() == 1) then -- Trade Hellcage Butterfly
-		player:tradeComplete();
-		SpawnMob(16986428,180):updateClaim(player);
-	end
-	
+    local mobID = 16986428;
+    if (trade:hasItemQty(2580,1) and trade:getItemCount() == 1) then -- Trade Hellcage Butterfly
+        if (GetMobAction(mobID) == ACTION_NONE) then
+            player:tradeComplete();
+            SpawnMob(mobID):updateClaim(player);
+        end
+    end
 end;
 
 -----------------------------------
@@ -26,7 +27,7 @@ end;
 -----------------------------------
 
 function onTrigger(player,npc)
-	player:messageSpecial(NOTHING_HAPPENS);
+    player:messageSpecial(NOTHING_HAPPENS);
 end;
 
 -----------------------------------
@@ -34,8 +35,8 @@ end;
 -----------------------------------
 
 function onEventUpdate(player,csid,option)
--- printf("CSID: %u",csid);
--- printf("RESULT: %u",option);
+    -- printf("CSID: %u",csid);
+    -- printf("RESULT: %u",option);
 end;
 
 -----------------------------------
@@ -43,6 +44,6 @@ end;
 -----------------------------------
 
 function onEventFinish(player,csid,option)
--- printf("CSID: %u",csid);
--- printf("RESULT: %u",option);
+    -- printf("CSID: %u",csid);
+    -- printf("RESULT: %u",option);
 end;

--- a/scripts/zones/Wajaom_Woodlands/npcs/qm2.lua
+++ b/scripts/zones/Wajaom_Woodlands/npcs/qm2.lua
@@ -1,24 +1,25 @@
 -----------------------------------
 -- Area: Wajaom Woodlands
--- NPC:  ??? (Spawn Iriz Ima(ZNM T2))
+--  NPC: ??? (Spawn Iriz Ima(ZNM T2))
 -- @pos 253 -23 116 51
 -----------------------------------
 package.loaded["scripts/zones/Wajaom_Woodlands/TextIDs"] = nil;
 -----------------------------------
-
 require("scripts/zones/Wajaom_Woodlands/TextIDs");
+require("scripts/globals/status");
 
 -----------------------------------
 -- onTrade Action
 -----------------------------------
 
 function onTrade(player,npc,trade)
-	
-	if (trade:hasItemQty(2577,1) and trade:getItemCount() == 1) then -- Trade Senorita Pamamas
-		player:tradeComplete();
-		SpawnMob(16986429,180):updateClaim(player);
-	end
-	
+    local mobID = 16986429;
+    if (trade:hasItemQty(2577,1) and trade:getItemCount() == 1) then -- Trade Senorita Pamamas
+        if (GetMobAction(mobID) == ACTION_NONE) then
+            player:tradeComplete();
+            SpawnMob(mobID):updateClaim(player);
+        end
+    end
 end;
 
 -----------------------------------
@@ -26,7 +27,7 @@ end;
 -----------------------------------
 
 function onTrigger(player,npc)
-	player:messageSpecial(NOTHING_HAPPENS);
+    player:messageSpecial(NOTHING_HAPPENS);
 end;
 
 -----------------------------------
@@ -34,8 +35,8 @@ end;
 -----------------------------------
 
 function onEventUpdate(player,csid,option)
--- printf("CSID: %u",csid);
--- printf("RESULT: %u",option);
+    -- printf("CSID: %u",csid);
+    -- printf("RESULT: %u",option);
 end;
 
 -----------------------------------
@@ -43,6 +44,6 @@ end;
 -----------------------------------
 
 function onEventFinish(player,csid,option)
--- printf("CSID: %u",csid);
--- printf("RESULT: %u",option);
+    -- printf("CSID: %u",csid);
+    -- printf("RESULT: %u",option);
 end;

--- a/scripts/zones/Wajaom_Woodlands/npcs/qm3.lua
+++ b/scripts/zones/Wajaom_Woodlands/npcs/qm3.lua
@@ -1,24 +1,25 @@
 -----------------------------------
 -- Area: Wajaom Woodlands
--- NPC:  ??? (Spawn Gotoh Zha the Redolent(ZNM T3))
+--  NPC: ??? (Spawn Gotoh Zha the Redolent(ZNM T3))
 -- @pos -337 -31 676 51
 -----------------------------------
 package.loaded["scripts/zones/Wajaom_Woodlands/TextIDs"] = nil;
 -----------------------------------
-
 require("scripts/zones/Wajaom_Woodlands/TextIDs");
+require("scripts/globals/status");
 
 -----------------------------------
 -- onTrade Action
 -----------------------------------
 
 function onTrade(player,npc,trade)
-	
-	if (trade:hasItemQty(2575,1) and trade:getItemCount() == 1) then -- Trade Sheep Botfly
-		player:tradeComplete();
-		SpawnMob(16986430,180):updateClaim(player);
-	end
-	
+    local mobID = 16986430;
+    if (trade:hasItemQty(2575,1) and trade:getItemCount() == 1) then -- Trade Sheep Botfly
+        if (GetMobAction(mobID) == ACTION_NONE) then
+            player:tradeComplete();
+            SpawnMob(mobID):updateClaim(player);
+        end
+    end
 end;
 
 -----------------------------------
@@ -26,7 +27,7 @@ end;
 -----------------------------------
 
 function onTrigger(player,npc)
-	player:messageSpecial(NOTHING_HAPPENS);
+    player:messageSpecial(NOTHING_HAPPENS);
 end;
 
 -----------------------------------
@@ -34,8 +35,8 @@ end;
 -----------------------------------
 
 function onEventUpdate(player,csid,option)
--- printf("CSID: %u",csid);
--- printf("RESULT: %u",option);
+    -- printf("CSID: %u",csid);
+    -- printf("RESULT: %u",option);
 end;
 
 -----------------------------------
@@ -43,6 +44,6 @@ end;
 -----------------------------------
 
 function onEventFinish(player,csid,option)
--- printf("CSID: %u",csid);
--- printf("RESULT: %u",option);
+    -- printf("CSID: %u",csid);
+    -- printf("RESULT: %u",option);
 end;

--- a/scripts/zones/Wajaom_Woodlands/npcs/qm4.lua
+++ b/scripts/zones/Wajaom_Woodlands/npcs/qm4.lua
@@ -1,24 +1,25 @@
 -----------------------------------
 -- Area: Wajaom Woodlands
--- NPC:  ??? (Spawn Tinnin(ZNM T4))
+--  NPC: ??? (Spawn Tinnin(ZNM T4))
 -- @pos 278 0 -703 51
 -----------------------------------
 package.loaded["scripts/zones/Wajaom_Woodlands/TextIDs"] = nil;
 -----------------------------------
-
 require("scripts/zones/Wajaom_Woodlands/TextIDs");
+require("scripts/globals/status");
 
 -----------------------------------
 -- onTrade Action
 -----------------------------------
 
 function onTrade(player,npc,trade)
-	
-	if (trade:hasItemQty(2573,1) and trade:getItemCount() == 1) then -- Trade Monkey wine
-		player:tradeComplete();
-		SpawnMob(16986431,180):updateClaim(player);
-	end
-	
+    local mobID = 16986431;
+    if (trade:hasItemQty(2573,1) and trade:getItemCount() == 1) then -- Trade Monkey wine
+        if (GetMobAction(mobID) == ACTION_NONE) then
+            player:tradeComplete();
+            SpawnMob(mobID):updateClaim(player);
+        end
+    end
 end;
 
 -----------------------------------
@@ -26,7 +27,7 @@ end;
 -----------------------------------
 
 function onTrigger(player,npc)
-	player:messageSpecial(NOTHING_HAPPENS);
+    player:messageSpecial(NOTHING_HAPPENS);
 end;
 
 -----------------------------------
@@ -34,8 +35,8 @@ end;
 -----------------------------------
 
 function onEventUpdate(player,csid,option)
--- printf("CSID: %u",csid);
--- printf("RESULT: %u",option);
+    -- printf("CSID: %u",csid);
+    -- printf("RESULT: %u",option);
 end;
 
 -----------------------------------
@@ -43,6 +44,6 @@ end;
 -----------------------------------
 
 function onEventFinish(player,csid,option)
--- printf("CSID: %u",csid);
--- printf("RESULT: %u",option);
+    -- printf("CSID: %u",csid);
+    -- printf("RESULT: %u",option);
 end;

--- a/sql/mob_spawn_mods.sql
+++ b/sql/mob_spawn_mods.sql
@@ -241,6 +241,37 @@ INSERT INTO `mob_spawn_mods` VALUES (17428811,2,5625,1);
 
 INSERT INTO `mob_spawn_mods` VALUES (16986431,16,1,1); -- Tinnin 2hour
 
+-- Timers for mobs that depop when idle+unclaimed
+INSERT INTO `mob_spawn_mods` VALUES (16986428,55,180,1);
+INSERT INTO `mob_spawn_mods` VALUES (16986429,55,180,1);
+INSERT INTO `mob_spawn_mods` VALUES (16986430,55,180,1);
+INSERT INTO `mob_spawn_mods` VALUES (16986431,55,180,1);
+INSERT INTO `mob_spawn_mods` VALUES (16998871,55,180,1);
+INSERT INTO `mob_spawn_mods` VALUES (16998872,55,180,1);
+INSERT INTO `mob_spawn_mods` VALUES (16998873,55,180,1);
+INSERT INTO `mob_spawn_mods` VALUES (16998874,55,180,1);
+INSERT INTO `mob_spawn_mods` VALUES (16990473,55,180,1);
+INSERT INTO `mob_spawn_mods` VALUES (16990474,55,180,1);
+INSERT INTO `mob_spawn_mods` VALUES (17027471,55,180,1);
+INSERT INTO `mob_spawn_mods` VALUES (17027472,55,180,1);
+INSERT INTO `mob_spawn_mods` VALUES (17027473,55,180,1);
+INSERT INTO `mob_spawn_mods` VALUES (17027474,55,180,1);
+INSERT INTO `mob_spawn_mods` VALUES (17027485,55,180,1);
+INSERT INTO `mob_spawn_mods` VALUES (17031598,55,180,1);
+INSERT INTO `mob_spawn_mods` VALUES (17031599,55,180,1);
+INSERT INTO `mob_spawn_mods` VALUES (17031600,55,180,1);
+INSERT INTO `mob_spawn_mods` VALUES (17043887,55,180,1);
+INSERT INTO `mob_spawn_mods` VALUES (17043888,55,180,1);
+INSERT INTO `mob_spawn_mods` VALUES (17056157,55,180,1);
+INSERT INTO `mob_spawn_mods` VALUES (17056186,55,180,1);
+INSERT INTO `mob_spawn_mods` VALUES (17072171,55,180,1);
+INSERT INTO `mob_spawn_mods` VALUES (17072172,55,180,1);
+INSERT INTO `mob_spawn_mods` VALUES (17072178,55,180,1);
+INSERT INTO `mob_spawn_mods` VALUES (17072179,55,180,1);
+INSERT INTO `mob_spawn_mods` VALUES (17101202,55,180,1);
+INSERT INTO `mob_spawn_mods` VALUES (17101203,55,180,1);
+INSERT INTO `mob_spawn_mods` VALUES (17101204,55,180,1);
+INSERT INTO `mob_spawn_mods` VALUES (17101205,55,180,1);
 
 /*!40000 ALTER TABLE `mob_spawn_mods` ENABLE KEYS */;
 UNLOCK TABLES;


### PR DESCRIPTION
Original script author(s) did not make sure mob wasn't already up before deleting pop item and were using the wrong thing to try and make mob depop after party wipe.