### PR TITLE
Lua script errors

### DIFF
--- a/scripts/zones/Aydeewa_Subterrane/npcs/qm1.lua
+++ b/scripts/zones/Aydeewa_Subterrane/npcs/qm1.lua
@@ -20,6 +20,7 @@ function onTrade(player,npc,trade)
             SpawnMob(mobID):updateClaim(player);
         end
     end
+end;
 
 -----------------------------------
 -- onTrigger Action

--- a/scripts/zones/Halvung/npcs/qm4.lua
+++ b/scripts/zones/Halvung/npcs/qm4.lua
@@ -15,7 +15,7 @@ require("scripts/globals/status");
 function onTrade(player,npc,trade)
     local mobID = 17031600;
     if (trade:hasItemQty(2586,1) and trade:getItemCount() == 1) then -- Trade Rock Juice
-        if (GetMobAction(mobID) == ACTION_NONE) then\n
+        if (GetMobAction(mobID) == ACTION_NONE) then
             player:tradeComplete();
             SpawnMob(mobID):updateClaim(player);
         end


### PR DESCRIPTION
Fixed some lua script errors that show up when starting the game server.

```bash
[2015-Oct-16 13:07:50][Error] luautils::onSpawn: scripts/zones/Halvung/npcs/qm4.lua:18: unexpected symbol near '\'
[2015-Oct-16 13:07:50][Error] luautils::onSpawn: scripts/zones/Aydeewa_Subterrane/npcs/qm1.lua:48: 'end' expected (to close 'function' at line 15) near '<eof>'
```