### PR TITLE
Core: Hasso/Seigan (re)cast penalty

### DIFF
--- a/scripts/globals/effects/hasso.lua
+++ b/scripts/globals/effects/hasso.lua
@@ -14,7 +14,6 @@ function onEffectGain(target,effect)
 	target:addMod(MOD_STR,effect:getPower());
 	target:addMod(MOD_HASTE_ABILITY,102);
 	target:addMod(MOD_ACC,10);
-	target:addMod(MOD_FASTCAST,-50);
 end;
 
 -----------------------------------
@@ -32,5 +31,4 @@ function onEffectLose(target,effect)
 	target:delMod(MOD_STR,effect:getPower());
 	target:delMod(MOD_HASTE_ABILITY,102);
 	target:delMod(MOD_ACC,10);
-	target:delMod(MOD_FASTCAST,-50);
 end;

--- a/scripts/globals/effects/seigan.lua
+++ b/scripts/globals/effects/seigan.lua
@@ -12,7 +12,6 @@ require("scripts/globals/status");
 
 function onEffectGain(target,effect)
 	target:addMod(MOD_COUNTER,(target:getMod(MOD_ZANSHIN)/4));
-	target:addMod(MOD_FASTCAST,-50);
 end;
 
 -----------------------------------
@@ -28,5 +27,4 @@ end;
 
 function onEffectLose(target,effect)
 	target:delMod(MOD_COUNTER,(target:getMod(MOD_ZANSHIN)/4));
-	target:delMod(MOD_FASTCAST,-50);
 end;

--- a/src/map/ai/states/magic_state.cpp
+++ b/src/map/ai/states/magic_state.cpp
@@ -176,6 +176,11 @@ uint32 CMagicState::CalculateCastTime(CSpell* PSpell)
     uint32 base = PSpell->getCastTime();
     uint32 cast = base;
 
+    if (m_PEntity->StatusEffectContainer->HasStatusEffect(EFFECT_HASSO) || m_PEntity->StatusEffectContainer->HasStatusEffect(EFFECT_SEIGAN))
+    {
+        cast = cast * 1.5f;
+    }
+
     if (PSpell->getSpellGroup() == SPELLGROUP_BLACK)
     {
         if (m_PEntity->StatusEffectContainer->HasStatusEffect(EFFECT_ALACRITY))
@@ -357,6 +362,10 @@ uint32 CMagicState::CalculateRecastTime(CSpell* PSpell)
     if (m_PEntity->StatusEffectContainer->HasStatusEffect(EFFECT_COMPOSURE))
     {
         recast *= 1.25;
+    }
+    if (m_PEntity->StatusEffectContainer->HasStatusEffect(EFFECT_HASSO) || m_PEntity->StatusEffectContainer->HasStatusEffect(EFFECT_SEIGAN))
+    {
+        recast *= 1.5;
     }
 
     if (PSpell->getSpellGroup() == SPELLGROUP_BLACK)


### PR DESCRIPTION
Implemented the 1.5x (re)cast time for any spell while under the effect of either ability. Removed the negative fastcast mod on the two effects because that was improper. Fixes #1833, though the additional part of Utsusemi and Third Eye being mutually exclusive remains broken.