### PR TITLE
Scripts: Setting for Dynamis entry to count by midnights

### DIFF
--- a/scripts/globals/settings.lua
+++ b/scripts/globals/settings.lua
@@ -86,6 +86,7 @@ LandKingSystem_HQ = 2;
 
 -- DYNAMIS SETTINGS
     BETWEEN_2DYNA_WAIT_TIME = 1;        -- wait time between 2 Dynamis (in real day) min: 1 day
+        DYNA_MIDNIGHT_RESET = true;     -- if true, makes the wait time count by number of server midnights instead of full 24 hour intervals
              DYNA_LEVEL_MIN = 65;       -- level min for entering in Dynamis
     TIMELESS_HOURGLASS_COST = 500000;   -- cost of the timeless hourglass for Dynamis.
      CURRENCY_EXCHANGE_RATE = 100;      -- X Tier 1 ancient currency -> 1 Tier 2, and so on.  Certain values may conflict with shop items.  Not designed to exceed 198.

--- a/scripts/zones/Dynamis-Bastok/bcnms/dynamis_bastok.lua
+++ b/scripts/zones/Dynamis-Bastok/bcnms/dynamis_bastok.lua
@@ -5,24 +5,27 @@
 
 -- After registering the BCNM via bcnmRegister(bcnmid)
 function onBcnmRegister(player,instance)
-	
-	SetServerVariable("[DynaBastok]UniqueID",player:getDynamisUniqueID(1280));
-	SetServerVariable("[DynaBastok]Boss_Trigger",0);
-	SetServerVariable("[DynaBastok]Already_Received",0);
-	
+    
+    SetServerVariable("[DynaBastok]UniqueID",player:getDynamisUniqueID(1280));
+    SetServerVariable("[DynaBastok]Boss_Trigger",0);
+    SetServerVariable("[DynaBastok]Already_Received",0);
+    
 end;
 
 -- Physically entering the BCNM via bcnmEnter(bcnmid)
 function onBcnmEnter(player,instance)
-	
-	player:setVar("DynamisID",GetServerVariable("[DynaBastok]UniqueID"));
-	local realDay = os.time();
+    
+    player:setVar("DynamisID",GetServerVariable("[DynaBastok]UniqueID"));
+    local realDay = os.time();
+    if (DYNA_MIDNIGHT_RESET == true) then
+        realDay = getMidnight() - 86400;
+    end
     local dynaWaitxDay = player:getVar("dynaWaitxDay");
 
     if ((dynaWaitxDay + (BETWEEN_2DYNA_WAIT_TIME * 24 * 60 * 60)) < realDay) then
-		player:setVar("dynaWaitxDay",realDay);
-	end
-	
+        player:setVar("dynaWaitxDay",realDay);
+    end
+    
 end;
 
 -- Leaving the Dynamis by every mean possible, given by the LeaveCode
@@ -31,10 +34,10 @@ end;
 
 function onBcnmLeave(player,instance,leavecode)
 --print("leave code "..leavecode);
-	
-	if (leavecode == 4) then
-		GetNPCByID(17539323):setStatus(2);
-		SetServerVariable("[DynaBastok]UniqueID",0);
-	end
-	
+    
+    if (leavecode == 4) then
+        GetNPCByID(17539323):setStatus(2);
+        SetServerVariable("[DynaBastok]UniqueID",0);
+    end
+    
 end;

--- a/scripts/zones/Dynamis-Beaucedine/bcnms/dynamis_beaucedine.lua
+++ b/scripts/zones/Dynamis-Beaucedine/bcnms/dynamis_beaucedine.lua
@@ -5,24 +5,26 @@
 
 -- After registering the BCNM via bcnmRegister(bcnmid)
 function onBcnmRegister(player,instance)
-	
-	SetServerVariable("[DynaBeaucedine]UniqueID",player:getDynamisUniqueID(1284));
-	SetServerVariable("[DynaBeaucedine]Already_Received",0);
-	
+    
+    SetServerVariable("[DynaBeaucedine]UniqueID",player:getDynamisUniqueID(1284));
+    SetServerVariable("[DynaBeaucedine]Already_Received",0);
+    
 end;
 
 -- Physically entering the BCNM via bcnmEnter(bcnmid)
 function onBcnmEnter(player,instance)
-	
-	player:setVar("DynamisID",GetServerVariable("[DynaBeaucedine]UniqueID"));
-	
-	local realDay = os.time();
+    
+    player:setVar("DynamisID",GetServerVariable("[DynaBeaucedine]UniqueID"));
+    local realDay = os.time();
+    if (DYNA_MIDNIGHT_RESET == true) then
+        realDay = getMidnight() - 86400;
+    end
     local dynaWaitxDay = player:getVar("dynaWaitxDay");
 
     if ((dynaWaitxDay + (BETWEEN_2DYNA_WAIT_TIME * 24 * 60 * 60)) < realDay) then
-		player:setVar("dynaWaitxDay",realDay);
-	end
-	
+        player:setVar("dynaWaitxDay",realDay);
+    end
+    
 end;
 
 -- Leaving the Dynamis by every mean possible, given by the LeaveCode
@@ -31,9 +33,9 @@ end;
 
 function onBcnmLeave(player,instance,leavecode)
 --print("leave code "..leavecode);
-	
-	if (leavecode == 4) then
-		SetServerVariable("[DynaBeaucedine]UniqueID",0);
-	end
-	
+    
+    if (leavecode == 4) then
+        SetServerVariable("[DynaBeaucedine]UniqueID",0);
+    end
+    
 end;

--- a/scripts/zones/Dynamis-Buburimu/bcnms/dynamis_Buburimu.lua
+++ b/scripts/zones/Dynamis-Buburimu/bcnms/dynamis_Buburimu.lua
@@ -7,25 +7,28 @@
 
 -- After registering the BCNM via bcnmRegister(bcnmid)
 function onBcnmRegister(player,instance)
-	
-	SetServerVariable("[DynaBuburimu]UniqueID",player:getDynamisUniqueID(1287));
-	SetServerVariable("[DynaBuburimu]Boss_Trigger",0);
-	SetServerVariable("[DynaBuburimu]Already_Received",0);
-	
-	
+    
+    SetServerVariable("[DynaBuburimu]UniqueID",player:getDynamisUniqueID(1287));
+    SetServerVariable("[DynaBuburimu]Boss_Trigger",0);
+    SetServerVariable("[DynaBuburimu]Already_Received",0);
+    
+    
 end;
 
 -- Physically entering the BCNM via bcnmEnter(bcnmid)
 function onBcnmEnter(player,instance)
-	
-	player:setVar("DynamisID",GetServerVariable("[DynaBuburimu]UniqueID"));
-	local realDay = os.time();
+    
+    player:setVar("DynamisID",GetServerVariable("[DynaBuburimu]UniqueID"));
+    local realDay = os.time();
+    if (DYNA_MIDNIGHT_RESET == true) then
+        realDay = getMidnight() - 86400;
+    end
     local dynaWaitxDay = player:getVar("dynaWaitxDay");
 
     if ((dynaWaitxDay + (BETWEEN_2DYNA_WAIT_TIME * 24 * 60 * 60)) < realDay) then
-		player:setVar("dynaWaitxDay",realDay);
-	end
-	
+        player:setVar("dynaWaitxDay",realDay);
+    end
+    
 end;
 
 -- Leaving the Dynamis by every mean possible, given by the LeaveCode
@@ -34,9 +37,9 @@ end;
 
 function onBcnmLeave(player,instance,leavecode)
 --print("leave code "..leavecode);
-	
-	if (leavecode == 4) then
-		SetServerVariable("[DynaBuburimu]UniqueID",0);
-	end
-	
+    
+    if (leavecode == 4) then
+        SetServerVariable("[DynaBuburimu]UniqueID",0);
+    end
+    
 end;

--- a/scripts/zones/Dynamis-Jeuno/bcnms/dynamis_jeuno.lua
+++ b/scripts/zones/Dynamis-Jeuno/bcnms/dynamis_jeuno.lua
@@ -5,24 +5,27 @@
 
 -- After registering the BCNM via bcnmRegister(bcnmid)
 function onBcnmRegister(player,instance)
-	
-	SetServerVariable("[DynaJeuno]UniqueID",player:getDynamisUniqueID(1283));
-	SetServerVariable("[DynaJeuno]Boss_Trigger",0);
-	SetServerVariable("[DynaJeuno]Already_Received",0);
-	
+    
+    SetServerVariable("[DynaJeuno]UniqueID",player:getDynamisUniqueID(1283));
+    SetServerVariable("[DynaJeuno]Boss_Trigger",0);
+    SetServerVariable("[DynaJeuno]Already_Received",0);
+    
 end;
 
 -- Physically entering the BCNM via bcnmEnter(bcnmid)
 function onBcnmEnter(player,instance)
-	
-	player:setVar("DynamisID",GetServerVariable("[DynaJeuno]UniqueID"));
-	local realDay = os.time();
+    
+    player:setVar("DynamisID",GetServerVariable("[DynaJeuno]UniqueID"));
+    local realDay = os.time();
+    if (DYNA_MIDNIGHT_RESET == true) then
+        realDay = getMidnight() - 86400;
+    end
     local dynaWaitxDay = player:getVar("dynaWaitxDay");
 
     if ((dynaWaitxDay + (BETWEEN_2DYNA_WAIT_TIME * 24 * 60 * 60)) < realDay) then
-		player:setVar("dynaWaitxDay",realDay);
-	end
-	
+        player:setVar("dynaWaitxDay",realDay);
+    end
+    
 end;
 
 -- Leaving the Dynamis by every mean possible, given by the LeaveCode
@@ -31,10 +34,10 @@ end;
 
 function onBcnmLeave(player,instance,leavecode)
 --print("leave code "..leavecode);
-	
-	if (leavecode == 4) then
-		GetNPCByID(17547510):setStatus(2);
-		SetServerVariable("[DynaJeuno]UniqueID",0);
-	end
-	
+    
+    if (leavecode == 4) then
+        GetNPCByID(17547510):setStatus(2);
+        SetServerVariable("[DynaJeuno]UniqueID",0);
+    end
+    
 end;

--- a/scripts/zones/Dynamis-Qufim/bcnms/dynamis_Qufim.lua
+++ b/scripts/zones/Dynamis-Qufim/bcnms/dynamis_Qufim.lua
@@ -7,25 +7,28 @@
 
 -- After registering the BCNM via bcnmRegister(bcnmid)
 function onBcnmRegister(player,instance)
-	
-	SetServerVariable("[DynaQufim]UniqueID",player:getDynamisUniqueID(1288));
-	SetServerVariable("[DynaQufim]Boss_Trigger",0);
-	SetServerVariable("[DynaQufim]Already_Received",0);
-	
-	
+    
+    SetServerVariable("[DynaQufim]UniqueID",player:getDynamisUniqueID(1288));
+    SetServerVariable("[DynaQufim]Boss_Trigger",0);
+    SetServerVariable("[DynaQufim]Already_Received",0);
+    
+    
 end;
 
 -- Physically entering the BCNM via bcnmEnter(bcnmid)
 function onBcnmEnter(player,instance)
-	
-	player:setVar("DynamisID",GetServerVariable("[DynaQufim]UniqueID"));
-	local realDay = os.time();
+    
+    player:setVar("DynamisID",GetServerVariable("[DynaQufim]UniqueID"));
+    local realDay = os.time();
+    if (DYNA_MIDNIGHT_RESET == true) then
+        realDay = getMidnight() - 86400;
+    end
     local dynaWaitxDay = player:getVar("dynaWaitxDay");
 
     if ((dynaWaitxDay + (BETWEEN_2DYNA_WAIT_TIME * 24 * 60 * 60)) < realDay) then
-		player:setVar("dynaWaitxDay",realDay);
-	end
-	
+        player:setVar("dynaWaitxDay",realDay);
+    end
+    
 end;
 
 -- Leaving the Dynamis by every mean possible, given by the LeaveCode
@@ -34,9 +37,9 @@ end;
 
 function onBcnmLeave(player,instance,leavecode)
 --print("leave code "..leavecode);
-	
-	if (leavecode == 4) then
-		SetServerVariable("[DynaQufim]UniqueID",0);
-	end
-	
+    
+    if (leavecode == 4) then
+        SetServerVariable("[DynaQufim]UniqueID",0);
+    end
+    
 end;

--- a/scripts/zones/Dynamis-San_dOria/bcnms/dynamis_sandoria.lua
+++ b/scripts/zones/Dynamis-San_dOria/bcnms/dynamis_sandoria.lua
@@ -5,24 +5,27 @@
 
 -- After registering the BCNM via bcnmRegister(bcnmid)
 function onBcnmRegister(player,instance)
-	
-	SetServerVariable("[DynaSandoria]UniqueID",player:getDynamisUniqueID(1281));
-	SetServerVariable("[DynaSandoria]Boss_Trigger",0);
-	SetServerVariable("[DynaSandoria]Already_Received",0);
-	
+    
+    SetServerVariable("[DynaSandoria]UniqueID",player:getDynamisUniqueID(1281));
+    SetServerVariable("[DynaSandoria]Boss_Trigger",0);
+    SetServerVariable("[DynaSandoria]Already_Received",0);
+    
 end;
 
 -- Physically entering the BCNM via bcnmEnter(bcnmid)
 function onBcnmEnter(player,instance)
-	
-	player:setVar("DynamisID",GetServerVariable("[DynaSandoria]UniqueID"));
-	local realDay = os.time();
+    
+    player:setVar("DynamisID",GetServerVariable("[DynaSandoria]UniqueID"));
+    local realDay = os.time();
+    if (DYNA_MIDNIGHT_RESET == true) then
+        realDay = getMidnight() - 86400;
+    end
     local dynaWaitxDay = player:getVar("dynaWaitxDay");
 
     if ((dynaWaitxDay + (BETWEEN_2DYNA_WAIT_TIME * 24 * 60 * 60)) < realDay) then
-		player:setVar("dynaWaitxDay",realDay);
-	end
-	
+        player:setVar("dynaWaitxDay",realDay);
+    end
+    
 end;
 
 -- Leaving the Dynamis by every mean possible, given by the LeaveCode
@@ -31,10 +34,10 @@ end;
 
 function onBcnmLeave(player,instance,leavecode)
 --print("leave code "..leavecode);
-	
-	if (leavecode == 4) then
-		GetNPCByID(17535224):setStatus(2);
-		SetServerVariable("[DynaSandoria]UniqueID",0);
-	end
-	
+    
+    if (leavecode == 4) then
+        GetNPCByID(17535224):setStatus(2);
+        SetServerVariable("[DynaSandoria]UniqueID",0);
+    end
+    
 end;

--- a/scripts/zones/Dynamis-Tavnazia/bcnms/dynamis_Tavnazia.lua
+++ b/scripts/zones/Dynamis-Tavnazia/bcnms/dynamis_Tavnazia.lua
@@ -8,23 +8,26 @@
 -- After registering the BCNM via bcnmRegister(bcnmid)
 function onBcnmRegister(player,instance)
 
-	SetServerVariable("[DynaTavnazia]UniqueID",player:getDynamisUniqueID(1289));
-	SetServerVariable("[DynaTavnazia]Boss_Trigger",0);
-	SetServerVariable("[DynaTavnazia]Already_Received",0);
-	
+    SetServerVariable("[DynaTavnazia]UniqueID",player:getDynamisUniqueID(1289));
+    SetServerVariable("[DynaTavnazia]Boss_Trigger",0);
+    SetServerVariable("[DynaTavnazia]Already_Received",0);
+    
 end;
 
 -- Physically entering the BCNM via bcnmEnter(bcnmid)
 function onBcnmEnter(player,instance)
-	
-	player:setVar("DynamisID",GetServerVariable("[DynaTavnazia]UniqueID"));
-	local realDay = os.time();
+    
+    player:setVar("DynamisID",GetServerVariable("[DynaTavnazia]UniqueID"));
+    local realDay = os.time();
+    if (DYNA_MIDNIGHT_RESET == true) then
+        realDay = getMidnight() - 86400;
+    end
     local dynaWaitxDay = player:getVar("dynaWaitxDay");
 
     if ((dynaWaitxDay + (BETWEEN_2DYNA_WAIT_TIME * 24 * 60 * 60)) < realDay) then
-		player:setVar("dynaWaitxDay",realDay);
-	end
-	
+        player:setVar("dynaWaitxDay",realDay);
+    end
+    
 end;
 
 -- Leaving the Dynamis by every mean possible, given by the LeaveCode
@@ -34,8 +37,8 @@ end;
 function onBcnmLeave(player,instance,leavecode)
 --print("leave code "..leavecode);
 
-	if (leavecode == 4) then
-		SetServerVariable("[DynaTavnazia]UniqueID",0);
-	end
-	
+    if (leavecode == 4) then
+        SetServerVariable("[DynaTavnazia]UniqueID",0);
+    end
+    
 end;

--- a/scripts/zones/Dynamis-Valkurm/bcnms/dynamis_Valkurm.lua
+++ b/scripts/zones/Dynamis-Valkurm/bcnms/dynamis_Valkurm.lua
@@ -7,44 +7,47 @@
 
 -- After registering the BCNM via bcnmRegister(bcnmid)
 function onBcnmRegister(player,instance)
-	
-	SetServerVariable("[DynaValkurm]UniqueID",player:getDynamisUniqueID(1286));
-	SetServerVariable("[DynaValkurm]Boss_Trigger",0);
-	SetServerVariable("[DynaValkurm]Already_Received",0);
-	
-	    local RNDpositionTable=TimerStatueRandomPos;
-		local X=0;
-		local Y=0;
-		local Z=0;
+    
+    SetServerVariable("[DynaValkurm]UniqueID",player:getDynamisUniqueID(1286));
+    SetServerVariable("[DynaValkurm]Boss_Trigger",0);
+    SetServerVariable("[DynaValkurm]Already_Received",0);
+    
+        local RNDpositionTable=TimerStatueRandomPos;
+        local X=0;
+        local Y=0;
+        local Z=0;
         local statueID = {16937287,16937262,16937237,16937212};
-	--spawn random timer statue
-	    local statueRND = math.random(1,4);
-		local SpawnStatueID= statueID[statueRND];
-		--printf("timer_statue_ID = %u",SpawnStatueID); 
-        local F={2,4,6,8};	     
-		--printf("position_type = %u",statueRND); 	
-		X=RNDpositionTable[F[statueRND]][1];
-		--printf("X = %u",X); 
-		Y=RNDpositionTable[F[statueRND]][2];
-		--printf("Y = %u",Y); 
-		Z=RNDpositionTable[F[statueRND]][3];
+    --spawn random timer statue
+        local statueRND = math.random(1,4);
+        local SpawnStatueID= statueID[statueRND];
+        --printf("timer_statue_ID = %u",SpawnStatueID); 
+        local F={2,4,6,8};         
+        --printf("position_type = %u",statueRND);     
+        X=RNDpositionTable[F[statueRND]][1];
+        --printf("X = %u",X); 
+        Y=RNDpositionTable[F[statueRND]][2];
+        --printf("Y = %u",Y); 
+        Z=RNDpositionTable[F[statueRND]][3];
         --printf("Z = %u",Z); 
-					SpawnMob(SpawnStatueID);
-					 GetMobByID(SpawnStatueID):setPos(X,Y,Z);
-					GetMobByID(SpawnStatueID):setSpawn(X,Y,Z);	
+                    SpawnMob(SpawnStatueID);
+                     GetMobByID(SpawnStatueID):setPos(X,Y,Z);
+                    GetMobByID(SpawnStatueID):setSpawn(X,Y,Z);    
 end;
 
 -- Physically entering the BCNM via bcnmEnter(bcnmid)
 function onBcnmEnter(player,instance)
-	
-	player:setVar("DynamisID",GetServerVariable("[DynaValkurm]UniqueID"));
-	local realDay = os.time();
+    
+    player:setVar("DynamisID",GetServerVariable("[DynaValkurm]UniqueID"));
+    local realDay = os.time();
+    if (DYNA_MIDNIGHT_RESET == true) then
+        realDay = getMidnight() - 86400;
+    end
     local dynaWaitxDay = player:getVar("dynaWaitxDay");
 
     if ((dynaWaitxDay + (BETWEEN_2DYNA_WAIT_TIME * 24 * 60 * 60)) < realDay) then
-		player:setVar("dynaWaitxDay",realDay);
-	end
-	
+        player:setVar("dynaWaitxDay",realDay);
+    end
+    
 end;
 
 -- Leaving the Dynamis by every mean possible, given by the LeaveCode
@@ -53,9 +56,9 @@ end;
 
 function onBcnmLeave(player,instance,leavecode)
 --print("leave code "..leavecode);
-	
-	if (leavecode == 4) then
-		SetServerVariable("[DynaValkurm]UniqueID",0);
-	end
-	
+    
+    if (leavecode == 4) then
+        SetServerVariable("[DynaValkurm]UniqueID",0);
+    end
+    
 end;

--- a/scripts/zones/Dynamis-Windurst/bcnms/dynamis_windurst.lua
+++ b/scripts/zones/Dynamis-Windurst/bcnms/dynamis_windurst.lua
@@ -5,24 +5,27 @@
 
 -- After registering the BCNM via bcnmRegister(bcnmid)
 function onBcnmRegister(player,instance)
-	
-	SetServerVariable("[DynaWindurst]UniqueID",player:getDynamisUniqueID(1282));
-	SetServerVariable("[DynaWindurst]Boss_Trigger",0);
-	SetServerVariable("[DynaWindurst]Already_Received",0);
-	
+    
+    SetServerVariable("[DynaWindurst]UniqueID",player:getDynamisUniqueID(1282));
+    SetServerVariable("[DynaWindurst]Boss_Trigger",0);
+    SetServerVariable("[DynaWindurst]Already_Received",0);
+    
 end;
 
 -- Physically entering the BCNM via bcnmEnter(bcnmid)
 function onBcnmEnter(player,instance)
-	
-	player:setVar("DynamisID",GetServerVariable("[DynaWindurst]UniqueID"));
-	local realDay = os.time();
+    
+    player:setVar("DynamisID",GetServerVariable("[DynaWindurst]UniqueID"));
+    local realDay = os.time();
+    if (DYNA_MIDNIGHT_RESET == true) then
+        realDay = getMidnight() - 86400;
+    end
     local dynaWaitxDay = player:getVar("dynaWaitxDay");
 
     if ((dynaWaitxDay + (BETWEEN_2DYNA_WAIT_TIME * 24 * 60 * 60)) < realDay) then
-		player:setVar("dynaWaitxDay",realDay);
-	end
-	
+        player:setVar("dynaWaitxDay",realDay);
+    end
+    
 end;
 
 -- Leaving the Dynamis by every mean possible, given by the LeaveCode
@@ -32,9 +35,9 @@ end;
 function onBcnmLeave(player,instance,leavecode)
 --print("leave code "..leavecode);
 
-	if (leavecode == 4) then
-		GetNPCByID(17543480):setStatus(2);
-		SetServerVariable("[DynaWindurst]UniqueID",0);
-	end
-	
+    if (leavecode == 4) then
+        GetNPCByID(17543480):setStatus(2);
+        SetServerVariable("[DynaWindurst]UniqueID",0);
+    end
+    
 end;

--- a/scripts/zones/Dynamis-Xarcabard/bcnms/dynamis_xarcabard.lua
+++ b/scripts/zones/Dynamis-Xarcabard/bcnms/dynamis_xarcabard.lua
@@ -5,24 +5,27 @@
 
 -- After registering the BCNM via bcnmRegister(bcnmid)
 function onBcnmRegister(player,instance)
-	
-	SetServerVariable("[DynaXarcabard]UniqueID",player:getDynamisUniqueID(1285));
-	SetServerVariable("[DynaXarcabard]TE150_Trigger",0);
-	SetServerVariable("[DynaXarcabard]Boss_Trigger",0);
-	
+    
+    SetServerVariable("[DynaXarcabard]UniqueID",player:getDynamisUniqueID(1285));
+    SetServerVariable("[DynaXarcabard]TE150_Trigger",0);
+    SetServerVariable("[DynaXarcabard]Boss_Trigger",0);
+    
 end;
 
 -- Physically entering the BCNM via bcnmEnter(bcnmid)
 function onBcnmEnter(player,instance)
-	
-	player:setVar("DynamisID",GetServerVariable("[DynaXarcabard]UniqueID"));
-	local realDay = os.time();
+    
+    player:setVar("DynamisID",GetServerVariable("[DynaXarcabard]UniqueID"));
+    local realDay = os.time();
+    if (DYNA_MIDNIGHT_RESET == true) then
+        realDay = getMidnight() - 86400;
+    end
     local dynaWaitxDay = player:getVar("dynaWaitxDay");
 
     if ((dynaWaitxDay + (BETWEEN_2DYNA_WAIT_TIME * 24 * 60 * 60)) < realDay) then
-		player:setVar("dynaWaitxDay",realDay);
-	end
-	
+        player:setVar("dynaWaitxDay",realDay);
+    end
+    
 end;
 
 -- Leaving the Dynamis by every mean possible, given by the LeaveCode
@@ -31,10 +34,10 @@ end;
 
 function onBcnmLeave(player,instance,leavecode)
 --print("leave code "..leavecode);
-	
-	if (leavecode == 4) then
-		GetNPCByID(17330778):setStatus(2);
-		SetServerVariable("[DynaXarcabard]UniqueID",0);
-	end
-	
+    
+    if (leavecode == 4) then
+        GetNPCByID(17330778):setStatus(2);
+        SetServerVariable("[DynaXarcabard]UniqueID",0);
+    end
+    
 end;


### PR DESCRIPTION
If the setting is enabled, the entry time is simply set to the previous server midnight instead of current time. This will allow for the next entry time to be the number of midnights equal to the setting for days for next entry (ie. if it's set to 3 days for next entry, it will go by 3 server midnights instead of a full 72 hours).