### PR TITLE
Core/Scripts: Rework forced spawn NPC disappearance

### DIFF
--- a/scripts/globals/settings.lua
+++ b/scripts/globals/settings.lua
@@ -163,6 +163,7 @@ HOMEPOINT_TELEPORT = 0; -- Enables the homepoint teleport system
 DIG_ABUNDANCE_BONUS = 0; -- Increase chance of digging up an item (450  = item digup chance +45)
 DIG_FATIGUE = 1; -- Set to 0 to disable Dig Fatigue
 MIASMA_FILTER_COOLDOWN = 5;  -- Number of days a player can obtain a Miasma Filter KI for any of the Boneyard Gully ENMs (Minimum:1)
+FORCE_SPAWN_QM_RESET_TIME = 300; -- Number of seconds the ??? remains hidden for after the despawning of the mob it force spawns.
 
 -- LIMBUS
 BETWEEN_2COSMOCLEANSE_WAIT_TIME = 3; -- day between 2 limbus keyitem  (default 3 days)

--- a/scripts/zones/Carpenters_Landing/mobs/Mycophile.lua
+++ b/scripts/zones/Carpenters_Landing/mobs/Mycophile.lua
@@ -15,5 +15,12 @@ end;
 -----------------------------------
 
 function onMobDeath(mob,killer)
-	GetNPCByID(16785730):hideNPC(900);
+end;
+
+-----------------------------------
+-- onMobDespawn
+-----------------------------------
+
+function onMobDespawn(mob)
+    GetNPCByID(16785729):updateNPCHideTime(FORCE_SPAWN_QM_RESET_TIME);
 end;

--- a/scripts/zones/Carpenters_Landing/npcs/qm1.lua
+++ b/scripts/zones/Carpenters_Landing/npcs/qm1.lua
@@ -12,13 +12,13 @@ package.loaded["scripts/zones/Carpenters_Landing/TextIDs"] = nil;
 -----------------------------------
 
 function onTrade(player,npc,trade)
-	
-	-- Trade Sleepshroom, Woozyshroom, Danceshroom, 
-	if (GetMobAction(16785722) == 0 and trade:hasItemQty(4373,1) and trade:hasItemQty(4374,1) and trade:hasItemQty(4375,1) and trade:getItemCount() == 3) then 
-		player:tradeComplete();
-		SpawnMob(16785722,300):updateClaim(player); -- Mycophile
-	end
-
+    
+    -- Trade Sleepshroom, Woozyshroom, Danceshroom, 
+    if (GetMobAction(16785722) == 0 and trade:hasItemQty(4373,1) and trade:hasItemQty(4374,1) and trade:hasItemQty(4375,1) and trade:getItemCount() == 3) then 
+        player:tradeComplete();
+        SpawnMob(16785722,300):updateClaim(player); -- Mycophile
+        npc:setStatus(STATUS_DISAPPEAR);
+    end
 end; 
 
 

--- a/scripts/zones/Den_of_Rancor/mobs/Hakutaku.lua
+++ b/scripts/zones/Den_of_Rancor/mobs/Hakutaku.lua
@@ -15,5 +15,12 @@ end;
 -----------------------------------
 
 function onMobDeath(mob,killer)
-	GetNPCByID(17433018):hideNPC(900);
+end;
+
+-----------------------------------
+-- onMobDespawn
+-----------------------------------
+
+function onMobDespawn(mob)
+    GetNPCByID(17433015):updateNPCHideTime(FORCE_SPAWN_QM_RESET_TIME);
 end;

--- a/scripts/zones/Den_of_Rancor/npcs/qm1.lua
+++ b/scripts/zones/Den_of_Rancor/npcs/qm1.lua
@@ -14,13 +14,12 @@ require("scripts/zones/Den_of_Rancor/TextIDs");
 
 function onTrade(player,npc,trade)
 
-	-- Trade Hakutaku Eye Cluster 
-	if (GetMobAction(17433005) == 0 and trade:hasItemQty(1298,1) and trade:getItemCount() == 1) then 
-		player:tradeComplete();
-		SpawnMob(17433005,120):updateClaim(player); -- Hakutaku
-	end
-
-
+    -- Trade Hakutaku Eye Cluster 
+    if (GetMobAction(17433005) == 0 and trade:hasItemQty(1298,1) and trade:getItemCount() == 1) then 
+        player:tradeComplete();
+        SpawnMob(17433005,120):updateClaim(player); -- Hakutaku
+        npc:setStatus(STATUS_DISAPPEAR);
+    end
 end; 
 
 -----------------------------------

--- a/scripts/zones/Grand_Palace_of_HuXzoi/mobs/Ix_aern_mnk.lua
+++ b/scripts/zones/Grand_Palace_of_HuXzoi/mobs/Ix_aern_mnk.lua
@@ -82,4 +82,6 @@ function onMobDespawn(mob)
     -- Despawn his minions if they are alive (Qn'aern)
     DespawnMob(mob:getID()+1);
     DespawnMob(mob:getID()+2);
+    local QuestionMark = 16916819; -- The ??? that spawned this mob.
+    QuestionMark::updateNPCHideTime(FORCE_SPAWN_QM_RESET_TIME);
 end;

--- a/scripts/zones/Grand_Palace_of_HuXzoi/npcs/qm1.lua
+++ b/scripts/zones/Grand_Palace_of_HuXzoi/npcs/qm1.lua
@@ -18,7 +18,7 @@ function onTrade(player,npc,trade)
     local chance = 0; -- Rate in percent in which an item will drop.
     local validTrade = 0;
     -- Trade Organs
-	if (GetMobAction(IxAern) == 0) then
+    if (GetMobAction(IxAern) == 0) then
         if (trade:hasItemQty(1900,1) and trade:getItemCount() == 1) then -- 1 HQ Aern Organ (33%)
             chance=33;
             validTrade=1;
@@ -47,7 +47,7 @@ function onTrade(player,npc,trade)
             SpawnMob(IxAern+2,300):updateClaim(player);
         end
         
-        npc:hideNPC(900); -- 15 minute respawn timer
+        npc:setStatus(STATUS_DISAPPEAR);
          -- Change the location to G-7 or I-7
         if (math.random(0,1) ==1) then
             npc:setPos(380,0,540,0); -- G-7

--- a/scripts/zones/Halvung/mobs/Big_Bomb.lua
+++ b/scripts/zones/Halvung/mobs/Big_Bomb.lua
@@ -15,5 +15,12 @@ end;
 -----------------------------------
 
 function onMobDeath(mob,killer)
-	GetNPCByID(17031609):hideNPC(900);
+end;
+
+-----------------------------------
+-- onMobDespawn
+-----------------------------------
+
+function onMobDespawn(mob)
+    GetNPCByID(17031608):updateNPCHideTime(FORCE_SPAWN_QM_RESET_TIME);
 end;

--- a/scripts/zones/Halvung/npcs/qm1.lua
+++ b/scripts/zones/Halvung/npcs/qm1.lua
@@ -13,14 +13,13 @@ require("scripts/zones/Halvung/TextIDs");
 -----------------------------------
 
 function onTrade(player,npc,trade)
-	
-	-- Trade Smokey Flask
-	if (GetMobAction(17031401) == 0 and trade:hasItemQty(2384,1) and trade:getItemCount() == 1) then 
-		player:tradeComplete();
-		SpawnMob(17031401,900):updateClaim(player); -- Big Bomb
-	end
-
-
+    
+    -- Trade Smokey Flask
+    if (GetMobAction(17031401) == 0 and trade:hasItemQty(2384,1) and trade:getItemCount() == 1) then 
+        player:tradeComplete();
+        SpawnMob(17031401,900):updateClaim(player); -- Big Bomb
+        npc:setStatus(STATUS_DISAPPEAR);
+    end
 end; 
 
 -----------------------------------
@@ -28,7 +27,7 @@ end;
 -----------------------------------
 
 function onTrigger(player,npc)
-	player:messageSpecial(BLUE_FLAMES);
+    player:messageSpecial(BLUE_FLAMES);
 end;
 
 -----------------------------------

--- a/scripts/zones/Ifrits_Cauldron/mobs/Bomb_Queen.lua
+++ b/scripts/zones/Ifrits_Cauldron/mobs/Bomb_Queen.lua
@@ -15,5 +15,12 @@ end;
 -----------------------------------
 
 function onMobDeath(mob, killer)
-	GetNPCByID(17617180):hideNPC(900); -- 15min, qm2 in npc_list
+end;
+
+-----------------------------------
+-- onMobDespawn
+-----------------------------------
+
+function onMobDespawn(mob)
+    GetNPCByID(17617180):updateNPCHideTime(FORCE_SPAWN_QM_RESET_TIME);
 end;

--- a/scripts/zones/Ifrits_Cauldron/mobs/Magma.lua
+++ b/scripts/zones/Ifrits_Cauldron/mobs/Magma.lua
@@ -15,5 +15,12 @@ end;
 -----------------------------------
 
 function onMobDeath(mob, killer)
-	GetNPCByID(17617214):hideNPC(900); -- 15min, qm4 in npc_list
+end;
+
+-----------------------------------
+-- onMobDespawn
+-----------------------------------
+
+function onMobDespawn(mob)
+    GetNPCByID(17617214):updateNPCHideTime(FORCE_SPAWN_QM_RESET_TIME);
 end;

--- a/scripts/zones/Ifrits_Cauldron/mobs/Tarasque.lua
+++ b/scripts/zones/Ifrits_Cauldron/mobs/Tarasque.lua
@@ -16,5 +16,12 @@ end;
 -----------------------------------
 
 function onMobDeath(mob, killer)
-	GetNPCByID(17617179):hideNPC(900); -- 15min, qm1 in npc_list
+end;
+
+-----------------------------------
+-- onMobDespawn
+-----------------------------------
+
+function onMobDespawn(mob)
+    GetNPCByID(17617179):updateNPCHideTime(FORCE_SPAWN_QM_RESET_TIME);
 end;

--- a/scripts/zones/Ifrits_Cauldron/npcs/qm1.lua
+++ b/scripts/zones/Ifrits_Cauldron/npcs/qm1.lua
@@ -14,13 +14,13 @@ require("scripts/zones/Ifrits_Cauldron/TextIDs");
 -----------------------------------
 
 function onTrade(player,npc,trade)
-	
-	-- Trade a Rattling Egg to pop Tarasque
-	if(GetMobAction(17617164) == 0 and trade:hasItemQty(1189,1) and trade:getItemCount() == 1) then
-		player:tradeComplete();
-		SpawnMob(17617164,900):updateClaim(player); -- Spawn Tarasque
-	end
-	
+    
+    -- Trade a Rattling Egg to pop Tarasque
+    if(GetMobAction(17617164) == 0 and trade:hasItemQty(1189,1) and trade:getItemCount() == 1) then
+        player:tradeComplete();
+        SpawnMob(17617164,900):updateClaim(player); -- Spawn Tarasque
+        npc:setStatus(STATUS_DISAPPEAR);
+    end
 end; 
 
 -----------------------------------
@@ -28,7 +28,7 @@ end;
 -----------------------------------
 
 function onTrigger(player,npc)
-	player:messageSpecial(EGGSHELLS_LIE_SCATTERED);
+    player:messageSpecial(EGGSHELLS_LIE_SCATTERED);
 end;
 
 -----------------------------------

--- a/scripts/zones/Ifrits_Cauldron/npcs/qm2.lua
+++ b/scripts/zones/Ifrits_Cauldron/npcs/qm2.lua
@@ -14,13 +14,13 @@ require("scripts/zones/Ifrits_Cauldron/TextIDs");
 -----------------------------------
 
 function onTrade(player,npc,trade)
-	
-	-- Trade 3 pinches of Bomb Queen Ash and a Bomb Queen Core and a verification if the nm is already spawned
-	if (GetMobAction(17617158) == 0 and trade:hasItemQty(1187,3) and trade:hasItemQty(1186,1) and trade:getItemCount() == 4) then
-		player:tradeComplete();
-		SpawnMob(17617158,900):updateClaim(player); -- Spawn Bomb Queen
-	end
-	
+    
+    -- Trade 3 pinches of Bomb Queen Ash and a Bomb Queen Core and a verification if the nm is already spawned
+    if (GetMobAction(17617158) == 0 and trade:hasItemQty(1187,3) and trade:hasItemQty(1186,1) and trade:getItemCount() == 4) then
+        player:tradeComplete();
+        SpawnMob(17617158,900):updateClaim(player); -- Spawn Bomb Queen
+        npc:setStatus(STATUS_DISAPPEAR);
+    end
 end; 
 
 -----------------------------------
@@ -28,7 +28,7 @@ end;
 -----------------------------------
 
 function onTrigger(player,npc)
-	player:messageSpecial(NOTHING_OUT_OF_ORDINARY);
+    player:messageSpecial(NOTHING_OUT_OF_ORDINARY);
 end;
 
 -----------------------------------

--- a/scripts/zones/Ifrits_Cauldron/npcs/qm4.lua
+++ b/scripts/zones/Ifrits_Cauldron/npcs/qm4.lua
@@ -15,15 +15,15 @@ require("scripts/zones/Ifrits_Cauldron/TextIDs");
 -----------------------------------
 
 function onTrade(player,npc,trade)
-	
-	if (player:getCurrentMission(BASTOK) == THE_PIRATE_S_COVE and player:getVar("MissionStatus") == 2) then
-		if (GetMobAction(17616897) == 0 and GetMobAction(17616898) == 0 and trade:hasItemQty(646,1) and trade:getItemCount() == 1) then
-			player:tradeComplete();
-			SpawnMob(17616897):updateClaim(player);
-			SpawnMob(17616898):updateClaim(player);
-		end
-	end	
-	
+    
+    if (player:getCurrentMission(BASTOK) == THE_PIRATE_S_COVE and player:getVar("MissionStatus") == 2) then
+        if (GetMobAction(17616897) == 0 and GetMobAction(17616898) == 0 and trade:hasItemQty(646,1) and trade:getItemCount() == 1) then
+            player:tradeComplete();
+            SpawnMob(17616897):updateClaim(player);
+            SpawnMob(17616898):updateClaim(player);
+            npc:setStatus(STATUS_DISAPPEAR);
+        end
+    end    
 end; 
 
 -----------------------------------
@@ -31,7 +31,7 @@ end;
 -----------------------------------
 
 function onTrigger(player,npc)
-	player:messageSpecial(NOTHING_OUT_OF_ORDINARY);
+    player:messageSpecial(NOTHING_OUT_OF_ORDINARY);
 end; 
 
 -----------------------------------

--- a/scripts/zones/Korroloka_Tunnel/mobs/Morion_Worm.lua
+++ b/scripts/zones/Korroloka_Tunnel/mobs/Morion_Worm.lua
@@ -7,23 +7,27 @@
 -- onMobDeath
 -----------------------------------
 
-function onMobDeath(mob,killer)	
-
-	local npc = GetNPCByID(17486213);
-	
-	npc:hideNPC(900);
-	
-	local randpos = math.random(1,6);
-	
-	switch (randpos): caseof
-	{
-		[1] = function (x) npc:setPos(254.652,-6.039,20.878); end, 
-		[2] = function (x) npc:setPos(273.350,-7.567,95.349); end, 
-		[3] = function (x) npc:setPos(-43.004,-5.579,96.528); end, 
-		[4] = function (x) npc:setPos(-96.798,-5.679,94.728); end,  
-		[5] = function (x) npc:setPos(-373.924,-10.548,-27.850); end, 
-		[6] = function (x) npc:setPos(-376.787,-8.574,-54.842); end, 
-	}
-	
+function onMobDeath(mob,killer)    
 end;
 
+-----------------------------------
+-- onMobDespawn
+-----------------------------------
+
+function onMobDespawn(mob)
+    local npc = GetNPCByID(17486213);
+    
+    npc:updateNPCHideTime(FORCE_SPAWN_QM_RESET_TIME);
+    
+    local randpos = math.random(1,6);
+    
+    switch (randpos): caseof
+    {
+        [1] = function (x) npc:setPos(254.652,-6.039,20.878); end, 
+        [2] = function (x) npc:setPos(273.350,-7.567,95.349); end, 
+        [3] = function (x) npc:setPos(-43.004,-5.579,96.528); end, 
+        [4] = function (x) npc:setPos(-96.798,-5.679,94.728); end,  
+        [5] = function (x) npc:setPos(-373.924,-10.548,-27.850); end, 
+        [6] = function (x) npc:setPos(-376.787,-8.574,-54.842); end, 
+    }    
+end;

--- a/scripts/zones/Korroloka_Tunnel/npcs/qm1.lua
+++ b/scripts/zones/Korroloka_Tunnel/npcs/qm1.lua
@@ -21,19 +21,18 @@ end;
 
 function onTrade(player,npc,trade)
 
-	local x = npc:getXPos(); 
-	local y = npc:getYPos(); 
-	local z = npc:getZPos(); 
-	local mob = GetMobByID(17486190);
-	
-	-- Trade Darksteel ore
-	if (GetMobAction(17486190) == 0 and trade:hasItemQty(643,1) and trade:getItemCount() == 1) then 
-		player:tradeComplete();
-		SpawnMob(17486190,1800):updateClaim(player); -- Morion Worm
-		mob:setPos(x+1,y,z);
-	end
-
-
+    local x = npc:getXPos(); 
+    local y = npc:getYPos(); 
+    local z = npc:getZPos(); 
+    local mob = GetMobByID(17486190);
+    
+    -- Trade Iron ore
+    if (GetMobAction(17486190) == 0 and trade:hasItemQty(643,1) and trade:getItemCount() == 1) then 
+        player:tradeComplete();
+        SpawnMob(17486190,1800):updateClaim(player); -- Morion Worm
+        mob:setPos(x+1,y,z);
+        npc:setStatus(STATUS_DISAPPEAR);
+    end
 end; 
 
 -----------------------------------
@@ -41,5 +40,5 @@ end;
 -----------------------------------
 
 function onTrigger(player,npc)
-	player:messageSpecial(MORION_WORM_1);
+    player:messageSpecial(MORION_WORM_1);
 end;

--- a/scripts/zones/Kuftal_Tunnel/mobs/Cancer.lua
+++ b/scripts/zones/Kuftal_Tunnel/mobs/Cancer.lua
@@ -15,5 +15,12 @@ end;
 -----------------------------------
 
 function onMobDeath(mob,killer)
-	GetNPCByID(17490254):hideNPC(900); -- qm2 in npc_list
+end;
+
+-----------------------------------
+-- onMobDespawn
+-----------------------------------
+
+function onMobDespawn(mob)
+    GetNPCByID(17490254):updateNPCHideTime(FORCE_SPAWN_QM_RESET_TIME);
 end;

--- a/scripts/zones/Kuftal_Tunnel/mobs/Phantom_Worm.lua
+++ b/scripts/zones/Kuftal_Tunnel/mobs/Phantom_Worm.lua
@@ -7,17 +7,22 @@
 -- onMobDeath
 -----------------------------------
 
-function onMobDeath(mob,killer)	
+function onMobDeath(mob,killer)    
+end;
 
-	local npc = GetNPCByID(17490254);
-	
-	npc:hideNPC(900);
-	
-	local randpos = math.random(1,16);
-	
-	switch (randpos): caseof
-	{
-	[1] = function (x) npc:setPos(75.943,29.969,118.854); end, 
+-----------------------------------
+-- onMobDespawn
+-----------------------------------
+
+function onMobDespawn(mob)
+    local npc = GetNPCByID(17490253);
+    npc:updateNPCHideTime(FORCE_SPAWN_QM_RESET_TIME);
+
+    local randpos = math.random(1,16);
+
+    switch (randpos): caseof
+    {
+    [1] = function (x) npc:setPos(75.943,29.969,118.854); end, 
     [2] = function (x) npc:setPos(75.758,30.000,125.815); end,
     [3] = function (x) npc:setPos(65.222,29.364,131.645); end,
     [4] = function (x) npc:setPos(53.088,25.033,138.725); end,
@@ -33,7 +38,5 @@ function onMobDeath(mob,killer)
     [14] = function (x) npc:setPos(80.460,30.293,112.721); end,
     [15] = function (x) npc:setPos(76.929,30.050,127.630); end,
     [16] = function (x) npc:setPos(68.810,30.175,123.516); end,
-	}
-	
+    }
 end;
-

--- a/scripts/zones/Kuftal_Tunnel/mobs/Robber_Crab.lua
+++ b/scripts/zones/Kuftal_Tunnel/mobs/Robber_Crab.lua
@@ -16,14 +16,18 @@ end;
 
 function onMobDeath(mob,killer)
 
-	checkGoVregime(killer,mob,735,1);
-	checkGoVregime(killer,mob,736,1);
-	checkGoVregime(killer,mob,738,1);
+    checkGoVregime(killer,mob,735,1);
+    checkGoVregime(killer,mob,736,1);
+    checkGoVregime(killer,mob,738,1);
+end;
 
-	local mobID = mob:getID();
+-----------------------------------
+-- onMobDespawn
+-----------------------------------
 
-	if (mobID == 17490232) then -- Crab for Cancer spawn
-		GetNPCByID(17490254):hideNPC(900); -- qm2 in npc_list
-	end
-
+function onMobDespawn(mob)
+    local mobID = mob:getID();
+    if (mobID == 17490232) then -- Crab for Cancer spawn
+        GetNPCByID(17490254):updateNPCHideTime(FORCE_SPAWN_QM_RESET_TIME);
+    end
 end;

--- a/scripts/zones/Kuftal_Tunnel/npcs/qm1.lua
+++ b/scripts/zones/Kuftal_Tunnel/npcs/qm1.lua
@@ -22,19 +22,18 @@ end;
 
 function onTrade(player,npc,trade)
 
-	local x = npc:getXPos(); 
-	local y = npc:getYPos(); 
-	local z = npc:getZPos(); 
-	local mob = GetMobByID(17490233);
-	
-	-- Trade Darksteel ore
-	if (GetMobAction(17490233) == 0 and trade:hasItemQty(645,1) and trade:getItemCount() == 1) then 
-		player:tradeComplete();
-		SpawnMob(17490233,180):updateClaim(player); -- Phantom Worm
-		mob:setPos(x+1,y,z+1);
-	end
-
-
+    local x = npc:getXPos(); 
+    local y = npc:getYPos(); 
+    local z = npc:getZPos(); 
+    local mob = GetMobByID(Phantom_Worm);
+    
+    -- Trade Darksteel ore
+    if (GetMobAction(Phantom_Worm) == 0 and trade:hasItemQty(645,1) and trade:getItemCount() == 1) then 
+        player:tradeComplete();
+        SpawnMob(Phantom_Worm,180):updateClaim(player); -- Phantom Worm
+        mob:setPos(x+1,y,z+1);
+        npc:setStatus(STATUS_DISAPPEAR);
+    end
 end; 
 
 -----------------------------------

--- a/scripts/zones/Kuftal_Tunnel/npcs/qm2.lua
+++ b/scripts/zones/Kuftal_Tunnel/npcs/qm2.lua
@@ -15,18 +15,19 @@ require("scripts/globals/missions");
 -----------------------------------
 
 function onTrade(player,npc,trade)
-	
-	
-	-- Trade quus
-	if (GetMobAction(17490231) == 0 and GetMobAction(17490232) == 0 and trade:hasItemQty(4514,1) and trade:getItemCount() == 1) then 
-		player:tradeComplete(); 
-		
-		if (math.random((1),(14)) <= 13) then
-			SpawnMob(17490232,180) -- Robber Crab
-		else 
-			SpawnMob(17490231,180) -- Cancer about 7% chance to pop per trade
-		end
-	end
+    
+    
+    -- Trade quus
+    if (GetMobAction(17490231) == 0 and GetMobAction(17490232) == 0 and trade:hasItemQty(4514,1) and trade:getItemCount() == 1) then 
+        player:tradeComplete(); 
+        
+        if (math.random((1),(14)) <= 13) then
+            SpawnMob(17490232,180) -- Robber Crab
+        else 
+            SpawnMob(Cancer,180) -- Cancer about 7% chance to pop per trade
+        end
+        npc:setStatus(STATUS_DISAPPEAR);
+    end
 end; 
 
 -----------------------------------

--- a/scripts/zones/Lufaise_Meadows/mobs/Amaltheia.lua
+++ b/scripts/zones/Lufaise_Meadows/mobs/Amaltheia.lua
@@ -16,5 +16,12 @@ end;
 -----------------------------------
 
 function onMobDeath(mob,killer)
-	GetNPCByID(16875889):hideNPC(900);
+end;
+
+-----------------------------------
+-- onMobDespawn
+-----------------------------------
+
+function onMobDespawn(mob)
+    GetNPCByID(16875890):updateNPCHideTime(FORCE_SPAWN_QM_RESET_TIME);
 end;

--- a/scripts/zones/Lufaise_Meadows/mobs/Kurrea.lua
+++ b/scripts/zones/Lufaise_Meadows/mobs/Kurrea.lua
@@ -15,5 +15,12 @@ end;
 -----------------------------------
 
 function onMobDeath(mob,killer)
-	GetNPCByID(16875885):hideNPC(900);
+end;
+
+-----------------------------------
+-- onMobDespawn
+-----------------------------------
+
+function onMobDespawn(mob)
+    GetNPCByID(16875886):updateNPCHideTime(FORCE_SPAWN_QM_RESET_TIME);
 end;

--- a/scripts/zones/Lufaise_Meadows/npcs/qm1.lua
+++ b/scripts/zones/Lufaise_Meadows/npcs/qm1.lua
@@ -13,14 +13,13 @@ require("scripts/zones/Lufaise_Meadows/TextIDs");
 -----------------------------------
 
 function onTrade(player,npc,trade)
-	
-	-- Trade Relic Shield
-	if (GetMobAction(16875779) == 0 and trade:hasItemQty(15066,1) and trade:getItemCount() == 1) then 
-		player:tradeComplete();
-		SpawnMob(16875779,120):updateClaim(player); -- Amaltheia
-	end
-
-
+    
+    -- Trade Relic Shield
+    if (GetMobAction(16875779) == 0 and trade:hasItemQty(15066,1) and trade:getItemCount() == 1) then 
+        player:tradeComplete();
+        SpawnMob(16875779,120):updateClaim(player); -- Amaltheia
+        npc:setStatus(STATUS_DISAPPEAR);
+    end
 end; 
 
 -----------------------------------

--- a/scripts/zones/Lufaise_Meadows/npcs/qm2.lua
+++ b/scripts/zones/Lufaise_Meadows/npcs/qm2.lua
@@ -14,12 +14,11 @@ require("scripts/zones/Lufaise_Meadows/TextIDs");
 
 function onTrade(player,npc,trade)
 
-	if (trade:hasItemQty(5210,1) and trade:getItemCount() == 1) then -- Adamantoise Soup 
-		player:tradeComplete();
-		SpawnMob(16875778,120):updateClaim(player); -- Kurrea
-	end
-
-
+    if (trade:hasItemQty(5210,1) and trade:getItemCount() == 1) then -- Adamantoise Soup 
+        player:tradeComplete();
+        SpawnMob(16875778,120):updateClaim(player); -- Kurrea
+        npc:setStatus(STATUS_DISAPPEAR);
+    end
 end; 
 
 -----------------------------------
@@ -27,5 +26,5 @@ end;
 -----------------------------------
 
 function onTrigger(player,npc)
-	player:messageSpecial(NOTHING_OUT_OF_THE_ORDINARY);
+    player:messageSpecial(NOTHING_OUT_OF_THE_ORDINARY);
 end;

--- a/scripts/zones/Misareaux_Coast/mobs/Gration.lua
+++ b/scripts/zones/Misareaux_Coast/mobs/Gration.lua
@@ -17,7 +17,7 @@ end;
 -----------------------------------
 
 function onMobSpawn(mob)
-	mob:addStatusEffect(EFFECT_KILLER_INSTINCT,40,0,0);
+    mob:addStatusEffect(EFFECT_KILLER_INSTINCT,40,0,0);
 end;
 
 -----------------------------------
@@ -32,9 +32,16 @@ end;
 -----------------------------------
 
 function onMobDeath(mob, killer)
-	GetNPCByID(16879943):hideNPC(900);
-	local kills = killer:getVar("FOMOR_HATE");
-	if (kills > 1) then
-		killer:setVar("FOMOR_HATE",kills -2);
-	end
+    local kills = killer:getVar("FOMOR_HATE");
+    if (kills > 1) then
+        killer:setVar("FOMOR_HATE",kills -2);
+    end
+end;
+
+-----------------------------------
+-- onMobDespawn
+-----------------------------------
+
+function onMobDespawn(mob)
+    GetNPCByID(16879918):updateNPCHideTime(FORCE_SPAWN_QM_RESET_TIME);
 end;

--- a/scripts/zones/Misareaux_Coast/npcs/qm1.lua
+++ b/scripts/zones/Misareaux_Coast/npcs/qm1.lua
@@ -13,13 +13,13 @@ require("scripts/zones/Misareaux_Coast/TextIDs");
 -----------------------------------
 
 function onTrade(player,npc,trade)
-	
-	-- Trade Hickory Shield OR Picaroon's Shield
-	if (GetMobAction(16879899) == 0 and (trade:hasItemQty(12370,1) or trade:hasItemQty(12359,1)) and trade:getItemCount() == 1) then
-	  	player:tradeComplete();
-		SpawnMob(16879899,900):updateClaim(player);
+    
+    -- Trade Hickory Shield OR Picaroon's Shield
+    if (GetMobAction(16879899) == 0 and (trade:hasItemQty(12370,1) or trade:hasItemQty(12359,1)) and trade:getItemCount() == 1) then
+          player:tradeComplete();
+        SpawnMob(16879899,900):updateClaim(player);
+        npc:setStatus(STATUS_DISAPPEAR);
     end
-	
 end;
 
 -----------------------------------
@@ -27,7 +27,7 @@ end;
 -----------------------------------
 
 function onTrigger(player,npc)
-	player:messageSpecial(NOTHING_OUT_OF_ORDINARY);
+    player:messageSpecial(NOTHING_OUT_OF_ORDINARY);
 end;
 
 -----------------------------------

--- a/scripts/zones/Newton_Movalpolos/mobs/Bugbear_Matman.lua
+++ b/scripts/zones/Newton_Movalpolos/mobs/Bugbear_Matman.lua
@@ -15,5 +15,12 @@ end;
 -----------------------------------
 
 function onMobDeath(mob,killer)
-	GetNPCByID(16826573):hideNPC(900); -- Moblin Showman in NPC_List
+end;
+
+-----------------------------------
+-- onMobDespawn
+-----------------------------------
+
+function onMobDespawn(mob)
+    GetNPCByID(16826573):updateNPCHideTime(FORCE_SPAWN_QM_RESET_TIME);
 end;

--- a/scripts/zones/Newton_Movalpolos/npcs/Moblin_Showman.lua
+++ b/scripts/zones/Newton_Movalpolos/npcs/Moblin_Showman.lua
@@ -14,15 +14,14 @@ require("scripts/zones/Newton_Movalpolos/TextIDs");
 
 function onTrade(player,npc,trade)
 
-	if (GetMobAction(16826570) == 0 and trade:hasItemQty(1878,1) and trade:getItemCount() == 1) then -- Air tank 
-		player:tradeComplete();
-		player:showText(npc, SHOWMAN_ACCEPT); -- Moblin Showman's dialogue
-		SpawnMob(16826570,300):updateClaim(player); -- Bugbear Matman
-	else
-		player:showText(npc, SHOWMAN_DECLINE); -- Moblin Showman refuses your trade
-	end
-
-
+    if (GetMobAction(16826570) == 0 and trade:hasItemQty(1878,1) and trade:getItemCount() == 1) then -- Air tank 
+        player:tradeComplete();
+        player:showText(npc, SHOWMAN_ACCEPT); -- Moblin Showman's dialogue
+        SpawnMob(16826570,300):updateClaim(player); -- Bugbear Matman
+        npc:setStatus(STATUS_DISAPPEAR);
+    else
+        player:showText(npc, SHOWMAN_DECLINE); -- Moblin Showman refuses your trade
+    end
 end; 
 
 -----------------------------------
@@ -30,5 +29,5 @@ end;
 -----------------------------------
 
 function onTrigger(player,npc)
-	 player:showText(npc, SHOWMAN_TRIGGER);
+     player:showText(npc, SHOWMAN_TRIGGER);
 end;

--- a/scripts/zones/Promyvion-Vahzl/mobs/Deviator.lua
+++ b/scripts/zones/Promyvion-Vahzl/mobs/Deviator.lua
@@ -16,5 +16,12 @@ end;
 -----------------------------------
 
 function onMobDeath(mob, killer)
-	GetNPCByID(16867687):hideNPC(900); -- 15m Hide Time?, qm1
+end;
+
+-----------------------------------
+-- onMobDespawn
+-----------------------------------
+
+function onMobDespawn(mob)
+    GetNPCByID(16867687):updateNPCHideTime(FORCE_SPAWN_QM_RESET_TIME);
 end;

--- a/scripts/zones/Promyvion-Vahzl/mobs/Provoker.lua
+++ b/scripts/zones/Promyvion-Vahzl/mobs/Provoker.lua
@@ -16,5 +16,12 @@ end;
 -----------------------------------
 
 function onMobDeath(mob, killer)
-	GetNPCByID(16867689):hideNPC(900); -- 15m Hide Time?, qm3
+end;
+
+-----------------------------------
+-- onMobDespawn
+-----------------------------------
+
+function onMobDespawn(mob)
+    GetNPCByID(16867689):updateNPCHideTime(FORCE_SPAWN_QM_RESET_TIME);
 end;

--- a/scripts/zones/Promyvion-Vahzl/mobs/Wailer.lua
+++ b/scripts/zones/Promyvion-Vahzl/mobs/Wailer.lua
@@ -16,5 +16,12 @@ end;
 -----------------------------------
 
 function onMobDeath(mob, killer)
-	GetNPCByID(16867688):hideNPC(900); -- 15m Hide Time?, qm2
+end;
+
+-----------------------------------
+-- onMobDespawn
+-----------------------------------
+
+function onMobDespawn(mob)
+    GetNPCByID(16867688):updateNPCHideTime(FORCE_SPAWN_QM_RESET_TIME);
 end;

--- a/scripts/zones/Promyvion-Vahzl/npcs/qm1.lua
+++ b/scripts/zones/Promyvion-Vahzl/npcs/qm1.lua
@@ -14,12 +14,13 @@ require("scripts/zones/Promyvion-Vahzl/TextIDs");
 -----------------------------------
 
 function onTrade(player,npc,trade)
-	
-	if (trade:hasItemQty(1756,1) and trade:getItemCount() == 1) then -- Cerebrator Remnant
-		player:tradeComplete();
-		player:messageSpecial(ON_NM_SPAWN);
-		SpawnMob(16867455,180):updateClaim(player); -- Spawn Deviator
-	end
+    
+    if (trade:hasItemQty(1756,1) and trade:getItemCount() == 1) then -- Cerebrator Remnant
+        player:tradeComplete();
+        player:messageSpecial(ON_NM_SPAWN);
+        SpawnMob(16867455,180):updateClaim(player); -- Spawn Deviator
+        npc:setStatus(STATUS_DISAPPEAR);
+    end
 
 end;
 
@@ -28,5 +29,5 @@ end;
 -----------------------------------
 
 function onTrigger(player,npc)
-	player:messageSpecial(POPPED_NM_OFFSET);
+    player:messageSpecial(POPPED_NM_OFFSET);
 end;

--- a/scripts/zones/Promyvion-Vahzl/npcs/qm2.lua
+++ b/scripts/zones/Promyvion-Vahzl/npcs/qm2.lua
@@ -14,12 +14,13 @@ require("scripts/zones/Promyvion-Vahzl/TextIDs");
 -----------------------------------
 
 function onTrade(player,npc,trade)
-	
-	if (trade:hasItemQty(1757,1) and trade:getItemCount() == 1) then -- Coveter Remnant
-		player:tradeComplete();
-		player:messageSpecial(ON_NM_SPAWN);
-		SpawnMob(16867544,180):updateClaim(player); -- Spawn Wailer
-	end
+    
+    if (trade:hasItemQty(1757,1) and trade:getItemCount() == 1) then -- Coveter Remnant
+        player:tradeComplete();
+        player:messageSpecial(ON_NM_SPAWN);
+        SpawnMob(16867544,180):updateClaim(player); -- Spawn Wailer
+        npc:setStatus(STATUS_DISAPPEAR);
+    end
 
 end;
 
@@ -28,5 +29,5 @@ end;
 -----------------------------------
 
 function onTrigger(player,npc)
-	player:messageSpecial(POPPED_NM_OFFSET+1);
+    player:messageSpecial(POPPED_NM_OFFSET+1);
 end;

--- a/scripts/zones/Promyvion-Vahzl/npcs/qm3.lua
+++ b/scripts/zones/Promyvion-Vahzl/npcs/qm3.lua
@@ -14,13 +14,13 @@ require("scripts/zones/Promyvion-Vahzl/TextIDs");
 -----------------------------------
 
 function onTrade(player,npc,trade)
-	
-	if (trade:hasItemQty(1758,1) and trade:getItemCount() == 1) then -- Satiator Remnant
-		player:tradeComplete();
-		player:messageSpecial(ON_NM_SPAWN);
-		SpawnMob(16867642,180):updateClaim(player); -- Spawn Provoker
-	end
-
+    
+    if (trade:hasItemQty(1758,1) and trade:getItemCount() == 1) then -- Satiator Remnant
+        player:tradeComplete();
+        player:messageSpecial(ON_NM_SPAWN);
+        SpawnMob(16867642,180):updateClaim(player); -- Spawn Provoker
+        npc:setStatus(STATUS_DISAPPEAR);
+    end
 end;
 
 -----------------------------------
@@ -28,5 +28,5 @@ end;
 -----------------------------------
 
 function onTrigger(player,npc)
-	player:messageSpecial(POPPED_NM_OFFSET+2);
+    player:messageSpecial(POPPED_NM_OFFSET+2);
 end;

--- a/scripts/zones/PsoXja/mobs/Golden-Tongued_Culberry.lua
+++ b/scripts/zones/PsoXja/mobs/Golden-Tongued_Culberry.lua
@@ -10,8 +10,8 @@
 
 function onMobFight(mob,target)
     mob:SetAutoAttackEnabled(false);
-	mob:SetMobAbilityEnabled(false);
-	mob:setMobMod(MOBMOD_MAGIC_COOL, 6);
+    mob:SetMobAbilityEnabled(false);
+    mob:setMobMod(MOBMOD_MAGIC_COOL, 6);
 end;
 
 -----------------------------------
@@ -19,5 +19,12 @@ end;
 -----------------------------------
 
 function onMobDeath(mob, killer)
-	GetNPCByID(16814434):hideNPC(900); -- qm1
+end;
+
+-----------------------------------
+-- onMobDespawn
+-----------------------------------
+
+function onMobDespawn(mob)
+    GetNPCByID(16814434):updateNPCHideTime(FORCE_SPAWN_QM_RESET_TIME);
 end;

--- a/scripts/zones/PsoXja/npcs/qm1.lua
+++ b/scripts/zones/PsoXja/npcs/qm1.lua
@@ -14,16 +14,19 @@ require("scripts/zones/PsoXja/TextIDs");
 -----------------------------------
 
 function onTrade(player,npc,trade)
-	
-	-- Trade Odorous knife or Odorous knife +1
-	if (GetMobAction(16814432) == 0 and trade:hasItemQty(18014,1) and trade:getItemCount() == 1) then
-	  	player:tradeComplete();
-		SpawnMob(16814432,900):updateClaim(player);
-		SetDropRate(1512, 0, 13145, 500);
-	elseif (GetMobAction(16814432) == 0 and trade:hasItemQty(18016,1) and trade:getItemCount() == 1) then
-		SpawnMob(16814432,900):updateClaim(player);	
-		SetDropRate(1512, 0, 13145, 1000);
-	end	
+    
+    -- Trade Odorous knife or Odorous knife +1
+    if (GetMobAction(16814432) == 0 and trade:hasItemQty(18014,1) and trade:getItemCount() == 1) then
+          player:tradeComplete();
+        SpawnMob(16814432,900):updateClaim(player);
+        SetDropRate(1512, 0, 13145, 500);
+        npc:setStatus(STATUS_DISAPPEAR);
+    elseif (GetMobAction(16814432) == 0 and trade:hasItemQty(18016,1) and trade:getItemCount() == 1) then
+          player:tradeComplete();
+        SpawnMob(16814432,900):updateClaim(player);    
+        SetDropRate(1512, 0, 13145, 1000);
+        npc:setStatus(STATUS_DISAPPEAR);
+    end    
 end;
 
 -----------------------------------
@@ -31,7 +34,7 @@ end;
 -----------------------------------
 
 function onTrigger(player,npc)
-	player:messageSpecial(BROKEN_KNIFE);
+    player:messageSpecial(BROKEN_KNIFE);
 end;
 
 -----------------------------------

--- a/scripts/zones/Quicksand_Caves/mobs/Tribunus_VII-I.lua
+++ b/scripts/zones/Quicksand_Caves/mobs/Tribunus_VII-I.lua
@@ -1,7 +1,7 @@
------------------------------------	
+-----------------------------------    
 -- Area: Quicksand Caves
 -- MOB:  Tribunus_VII-I
------------------------------------	
+-----------------------------------    
 
 -----------------------------------
 -- onMobFight Action
@@ -15,5 +15,12 @@ end;
 -----------------------------------
 
 function onMobDeath(mob, killer)
-	GetNPCByID(17629661):hideNPC(900); -- qm2 in npc_list
+end;
+
+-----------------------------------
+-- onMobDespawn
+-----------------------------------
+
+function onMobDespawn(mob)
+    GetNPCByID(17629661):updateNPCHideTime(FORCE_SPAWN_QM_RESET_TIME);
 end;

--- a/scripts/zones/Quicksand_Caves/npcs/qm2.lua
+++ b/scripts/zones/Quicksand_Caves/npcs/qm2.lua
@@ -1,8 +1,8 @@
 -----------------------------------
---	Area: Quicksand Caves
--- 	NPC:  qm2
+--    Area: Quicksand Caves
+--     NPC:  qm2
 --  Notes: Used to spawn Tribunus VII-I
--- 	@pos -49.944 -0.891 -139.485 208
+--     @pos -49.944 -0.891 -139.485 208
 -----------------------------------
 package.loaded["scripts/zones/Quicksand_Caves/TextIDs"] = nil;
 -----------------------------------
@@ -14,13 +14,14 @@ require("scripts/zones/Quicksand_Caves/TextIDs");
 -----------------------------------
 
 function onTrade(player,npc,trade)
-	
-	-- Trade Antican Tag
-	if (GetMobAction(17629643) == 0 and trade:hasItemQty(1190,1) and trade:getItemCount() == 1) then
-	  	player:tradeComplete();
-		SpawnMob(17629643,900):updateClaim(player);
-	end
-	
+    
+    -- Trade Antican Tag
+    if (GetMobAction(17629643) == 0 and trade:hasItemQty(1190,1) and trade:getItemCount() == 1) then
+          player:tradeComplete();
+        SpawnMob(17629643,900):updateClaim(player);
+        npc:setStatus(STATUS_DISAPPEAR);
+    end
+    
 end;
 
 -----------------------------------
@@ -28,7 +29,7 @@ end;
 -----------------------------------
 
 function onTrigger(player,npc)
-	player:messageSpecial(NOTHING_OUT_OF_ORDINARY);
+    player:messageSpecial(NOTHING_OUT_OF_ORDINARY);
 end;
 
 -----------------------------------

--- a/scripts/zones/Riverne-Site_B01/mobs/Unstable_Cluster.lua
+++ b/scripts/zones/Riverne-Site_B01/mobs/Unstable_Cluster.lua
@@ -15,5 +15,12 @@ end;
 -----------------------------------
 
 function onMobDeath(mob, killer)
-	GetNPCByID(16896175):hideNPC(900); -- (qm1 in NPC_LIST)
+end;
+
+-----------------------------------
+-- onMobDespawn
+-----------------------------------
+
+function onMobDespawn(mob)
+    GetNPCByID(16896175):updateNPCHideTime(FORCE_SPAWN_QM_RESET_TIME);
 end;

--- a/scripts/zones/Riverne-Site_B01/npcs/qm1.lua
+++ b/scripts/zones/Riverne-Site_B01/npcs/qm1.lua
@@ -13,12 +13,12 @@ require("scripts/zones/Riverne-Site_B01/TextIDs");
 -----------------------------------
 
 function onTrade(player,npc,trade)
-	
-	if (GetMobAction(16896155) == 0 and trade:hasItemQty(1880,1) and trade:getItemCount() == 1) then -- Trade Clustered tar
-		player:tradeComplete();
-		SpawnMob(16896155):updateClaim(player); -- Unstable Cluster
-	end	
-	
+    
+    if (GetMobAction(16896155) == 0 and trade:hasItemQty(1880,1) and trade:getItemCount() == 1) then -- Trade Clustered tar
+        player:tradeComplete();
+        SpawnMob(16896155):updateClaim(player); -- Unstable Cluster
+        npc:setStatus(STATUS_DISAPPEAR);
+    end    
 end;
 
 -----------------------------------
@@ -26,7 +26,7 @@ end;
 -----------------------------------
 
 function onTrigger(player,npc)
-	player:messageSpecial(GROUND_GIVING_HEAT);
+    player:messageSpecial(GROUND_GIVING_HEAT);
 end;
 
 -----------------------------------

--- a/scripts/zones/RuAun_Gardens/mobs/Byakko.lua
+++ b/scripts/zones/RuAun_Gardens/mobs/Byakko.lua
@@ -22,15 +22,6 @@ function onMobSpawn(mob)
 end;
 
 -----------------------------------
--- onMobDeath
------------------------------------
-
-function onMobDeath(mob, killer)
-    killer:showText(mob,SKY_GOD_OFFSET + 12);
-    GetNPCByID(17310051):hideNPC(120);
-end;
-
------------------------------------
 -- onAdditionalEffect
 -----------------------------------
 
@@ -46,4 +37,20 @@ function onAdditionalEffect(mob, target, damage)
     dmg = finalMagicNonSpellAdjustments(mob,target,ELE_LIGHT,dmg);
 
     return SUBEFFECT_LIGHT_DAMAGE, MSGBASIC_ADD_EFFECT_DMG, dmg;
+end;
+
+-----------------------------------
+-- onMobDeath
+-----------------------------------
+
+function onMobDeath(mob, killer)
+    killer:showText(mob,SKY_GOD_OFFSET + 12);
+end;
+
+-----------------------------------
+-- onMobDespawn
+-----------------------------------
+
+function onMobDespawn(mob)
+    GetNPCByID(17310052):updateNPCHideTime(FORCE_SPAWN_QM_RESET_TIME);
 end;

--- a/scripts/zones/RuAun_Gardens/mobs/Genbu.lua
+++ b/scripts/zones/RuAun_Gardens/mobs/Genbu.lua
@@ -22,15 +22,6 @@ function onMobSpawn(mob)
 end;
 
 -----------------------------------
--- onMobDeath
------------------------------------
-
-function onMobDeath(mob, killer)
-    killer:showText(mob,SKY_GOD_OFFSET + 6);
-    GetNPCByID(17310098):hideNPC(120);
-end;
-
------------------------------------
 -- onAdditionalEffect
 -----------------------------------
 
@@ -46,4 +37,20 @@ function onAdditionalEffect(mob, target, damage)
     dmg = finalMagicNonSpellAdjustments(mob,target,ELE_WATER,dmg);
 
     return SUBEFFECT_WATER_DAMAGE, MSGBASIC_ADD_EFFECT_DMG, dmg;
+end;
+
+-----------------------------------
+-- onMobDeath
+-----------------------------------
+
+function onMobDeath(mob, killer)
+    killer:showText(mob,SKY_GOD_OFFSET + 6);
+end;
+
+-----------------------------------
+-- onMobDespawn
+-----------------------------------
+
+function onMobDespawn(mob)
+    GetNPCByID(17310099):updateNPCHideTime(FORCE_SPAWN_QM_RESET_TIME);
 end;

--- a/scripts/zones/RuAun_Gardens/mobs/Seiryu.lua
+++ b/scripts/zones/RuAun_Gardens/mobs/Seiryu.lua
@@ -22,15 +22,6 @@ function onMobSpawn(mob)
 end;
 
 -----------------------------------
--- onMobDeath
------------------------------------
-
-function onMobDeath(mob, killer)
-    killer:showText(mob,SKY_GOD_OFFSET + 10);
-    GetNPCByID(17310052):hideNPC(900);
-end;
-
------------------------------------
 -- onMonsterMagicPrepare
 -----------------------------------
 
@@ -68,4 +59,20 @@ function onAdditionalEffect(mob, target, damage)
     dmg = finalMagicNonSpellAdjustments(mob,target,ELE_WIND,dmg);
 
     return SUBEFFECT_WIND_DAMAGE, MSGBASIC_ADD_EFFECT_DMG, dmg;
+end;
+
+-----------------------------------
+-- onMobDeath
+-----------------------------------
+
+function onMobDeath(mob, killer)
+    killer:showText(mob,SKY_GOD_OFFSET + 10);
+end;
+
+-----------------------------------
+-- onMobDespawn
+-----------------------------------
+
+function onMobDespawn(mob)
+    GetNPCByID(17310053):updateNPCHideTime(FORCE_SPAWN_QM_RESET_TIME);
 end;

--- a/scripts/zones/RuAun_Gardens/mobs/Suzaku.lua
+++ b/scripts/zones/RuAun_Gardens/mobs/Suzaku.lua
@@ -22,13 +22,8 @@ function onMobSpawn(mob)
 end;
 
 -----------------------------------
--- onMobDeath
+-- onMonsterMagicPrepare Action
 -----------------------------------
-
-function onMobDeath(mob, killer)
-    killer:showText(mob,SKY_GOD_OFFSET + 8);
-    GetNPCByID(17310050):hideNPC(120);
-end;
 
 -- Return the selected spell ID.
 function onMonsterMagicPrepare(mob, target)
@@ -63,4 +58,20 @@ function onAdditionalEffect(mob, target, damage)
     dmg = finalMagicNonSpellAdjustments(mob,target,ELE_FIRE,dmg);
 
     return SUBEFFECT_FIRE_DAMAGE, MSGBASIC_ADD_EFFECT_DMG, dmg;
+end;
+
+-----------------------------------
+-- onMobDeath
+-----------------------------------
+
+function onMobDeath(mob, killer)
+    killer:showText(mob,SKY_GOD_OFFSET + 8);
+end;
+
+-----------------------------------
+-- onMobDespawn
+-----------------------------------
+
+function onMobDespawn(mob)
+    GetNPCByID(17310051):updateNPCHideTime(FORCE_SPAWN_QM_RESET_TIME);
 end;

--- a/scripts/zones/RuAun_Gardens/npcs/qm1.lua
+++ b/scripts/zones/RuAun_Gardens/npcs/qm1.lua
@@ -14,14 +14,14 @@ require("scripts/zones/RuAun_Gardens/TextIDs");
 -----------------------------------
 
 function onTrade(player,npc,trade)
-	
-	-- Trade Gem of the North and Winterstone
-	if (GetMobAction(17309980) == 0 and trade:hasItemQty(1424,1) and trade:hasItemQty(1425,1) and trade:getItemCount() == 2) then
-		player:tradeComplete();
-		SpawnMob(17309980,300):updateClaim(player); -- Spawn Genbu
-		player:showText(npc,SKY_GOD_OFFSET + 5);
-	end
-	
+    
+    -- Trade Gem of the North and Winterstone
+    if (GetMobAction(17309980) == 0 and trade:hasItemQty(1424,1) and trade:hasItemQty(1425,1) and trade:getItemCount() == 2) then
+        player:tradeComplete();
+        SpawnMob(17309980,300):updateClaim(player); -- Spawn Genbu
+        player:showText(npc,SKY_GOD_OFFSET + 5);
+        npc:setStatus(STATUS_DISAPPEAR);
+    end
 end; 
 
 -----------------------------------
@@ -29,7 +29,7 @@ end;
 -----------------------------------
 
 function onTrigger(player,npc)
-	player:messageSpecial(SKY_GOD_OFFSET);
+    player:messageSpecial(SKY_GOD_OFFSET);
 end; 
 
 -----------------------------------

--- a/scripts/zones/RuAun_Gardens/npcs/qm2.lua
+++ b/scripts/zones/RuAun_Gardens/npcs/qm2.lua
@@ -14,14 +14,14 @@ require("scripts/zones/RuAun_Gardens/TextIDs");
 -----------------------------------
 
 function onTrade(player,npc,trade)
-	
-	-- Trade Gem of the East and Springstone
-	if (GetMobAction(17309981) == 0 and trade:hasItemQty(1418,1) and trade:hasItemQty(1419,1) and trade:getItemCount() == 2) then
-		player:tradeComplete();
-		SpawnMob(17309981,300):updateClaim(player); -- Spawn Seiryu
-		player:showText(npc,SKY_GOD_OFFSET + 9);
-	end
-	
+    
+    -- Trade Gem of the East and Springstone
+    if (GetMobAction(17309981) == 0 and trade:hasItemQty(1418,1) and trade:hasItemQty(1419,1) and trade:getItemCount() == 2) then
+        player:tradeComplete();
+        SpawnMob(17309981,300):updateClaim(player); -- Spawn Seiryu
+        player:showText(npc,SKY_GOD_OFFSET + 9);
+        npc:setStatus(STATUS_DISAPPEAR);
+    end
 end; 
 
 -----------------------------------
@@ -29,7 +29,7 @@ end;
 -----------------------------------
 
 function onTrigger(player,npc)
-	player:messageSpecial(SKY_GOD_OFFSET + 1);
+    player:messageSpecial(SKY_GOD_OFFSET + 1);
 end; 
 
 -----------------------------------

--- a/scripts/zones/RuAun_Gardens/npcs/qm3.lua
+++ b/scripts/zones/RuAun_Gardens/npcs/qm3.lua
@@ -14,14 +14,14 @@ require("scripts/zones/RuAun_Gardens/TextIDs");
 -----------------------------------
 
 function onTrade(player,npc,trade)
-	
-	-- Trade Gem of the West and Autumnstone
-	if (GetMobAction(17309982) == 0 and trade:hasItemQty(1422,1) and trade:hasItemQty(1423,1) and trade:getItemCount() == 2) then
-		player:tradeComplete();
-		SpawnMob(17309982,300):updateClaim(player); -- Spawn Byakko
-		player:showText(npc,SKY_GOD_OFFSET + 11);
-	end
-	
+    
+    -- Trade Gem of the West and Autumnstone
+    if (GetMobAction(17309982) == 0 and trade:hasItemQty(1422,1) and trade:hasItemQty(1423,1) and trade:getItemCount() == 2) then
+        player:tradeComplete();
+        SpawnMob(17309982,300):updateClaim(player); -- Spawn Byakko
+        player:showText(npc,SKY_GOD_OFFSET + 11);
+        npc:setStatus(STATUS_DISAPPEAR);
+    end
 end; 
 
 -----------------------------------
@@ -29,7 +29,7 @@ end;
 -----------------------------------
 
 function onTrigger(player,npc)
-	player:messageSpecial(SKY_GOD_OFFSET + 2);
+    player:messageSpecial(SKY_GOD_OFFSET + 2);
 end; 
 
 -----------------------------------

--- a/scripts/zones/RuAun_Gardens/npcs/qm4.lua
+++ b/scripts/zones/RuAun_Gardens/npcs/qm4.lua
@@ -14,14 +14,14 @@ require("scripts/zones/RuAun_Gardens/TextIDs");
 -----------------------------------
 
 function onTrade(player,npc,trade)
-	
-	-- Trade Gem of the South and Summerstone
-	if (GetMobAction(17309983) == 0 and trade:hasItemQty(1420,1) and trade:hasItemQty(1421,1) and trade:getItemCount() == 2) then
-		player:tradeComplete();
-		SpawnMob(17309983,300):updateClaim(player); -- Spawn Suzaku
-		player:showText(npc,SKY_GOD_OFFSET + 7);
-	end
-	
+    
+    -- Trade Gem of the South and Summerstone
+    if (GetMobAction(17309983) == 0 and trade:hasItemQty(1420,1) and trade:hasItemQty(1421,1) and trade:getItemCount() == 2) then
+        player:tradeComplete();
+        SpawnMob(17309983,300):updateClaim(player); -- Spawn Suzaku
+        player:showText(npc,SKY_GOD_OFFSET + 7);
+        npc:setStatus(STATUS_DISAPPEAR);
+    end
 end; 
 
 -----------------------------------
@@ -29,7 +29,7 @@ end;
 -----------------------------------
 
 function onTrigger(player,npc)
-	player:messageSpecial(SKY_GOD_OFFSET + 3);
+    player:messageSpecial(SKY_GOD_OFFSET + 3);
 end; 
 
 -----------------------------------

--- a/scripts/zones/Temple_of_Uggalepih/mobs/Habetrot.lua
+++ b/scripts/zones/Temple_of_Uggalepih/mobs/Habetrot.lua
@@ -9,5 +9,12 @@
 -----------------------------------
 
 function onMobDeath(mob,killer)
-   GetNPCByID(17428871):hideNPC(900); -- 15min, qm8 in npc_list
+end;
+
+-----------------------------------
+-- onMobDespawn
+-----------------------------------
+
+function onMobDespawn(mob)
+    GetNPCByID(17428871):updateNPCHideTime(FORCE_SPAWN_QM_RESET_TIME);
 end;

--- a/scripts/zones/Temple_of_Uggalepih/mobs/Rumble_Crawler.lua
+++ b/scripts/zones/Temple_of_Uggalepih/mobs/Rumble_Crawler.lua
@@ -11,9 +11,15 @@ require("scripts/globals/groundsofvalor");
 
 function onMobDeath(mob,killer)
    checkGoVregime(killer,mob,791,2);
-   
-   -- Rumble Crawler that spawns in place of Habetrot
-   if(mob:getID() == 17428812) then
-       GetNPCByID(17428871):hideNPC(900); -- 15min, qm8 in npc_list
-   end
+end;
+
+-----------------------------------
+-- onMobDespawn
+-----------------------------------
+
+function onMobDespawn(mob)
+    -- Rumble Crawler that spawns in place of Habetrot
+    if(mob:getID() == 17428812) then
+        GetNPCByID(17428871):updateNPCHideTime(FORCE_SPAWN_QM_RESET_TIME);
+    end
 end;

--- a/scripts/zones/Temple_of_Uggalepih/npcs/qm8.lua
+++ b/scripts/zones/Temple_of_Uggalepih/npcs/qm8.lua
@@ -25,8 +25,8 @@ function onTrade(player,npc,trade)
         else
             SpawnMob(17428812,900):updateClaim(player); -- Spawn Rumble Crawler
         end
+        npc:setStatus(STATUS_DISAPPEAR);
     end
-
 end; 
 
 -----------------------------------
@@ -34,7 +34,7 @@ end;
 -----------------------------------
 
 function onTrigger(player,npc)
-	player:messageSpecial(BITS_OF_VEGETABLE);
+    player:messageSpecial(BITS_OF_VEGETABLE);
 end;
 
 -----------------------------------

--- a/scripts/zones/The_Garden_of_RuHmet/Zone.lua
+++ b/scripts/zones/The_Garden_of_RuHmet/Zone.lua
@@ -96,23 +96,12 @@ end;
 function onGameHour(npc, mob, player)
     
     local VanadielHour = VanadielHour();
-    local qm2 = GetNPCByID(16921028); -- Jailer of Faith
-    local qm3 = GetNPCByID(16921029); -- Ix'aern drk
+    local qm2 = GetNPCByID(16921028); -- Ix'aern drk
+    local qm3 = GetNPCByID(Jailer_of_Faith_QM); -- Jailer of Faith
     local s = math.random(6,12) -- wait time till change to next spawn pos, random 15~30 mins.
-    
-    -- Jailer of Fortitude spawn randomiser
-    if (VanadielHour % 6 == 0) then
-        local qm1 = GetNPCByID(Jailer_of_Fortitude_QM);
-        qm1:hideNPC(60);
-        
-        local qm1position = math.random(1,5);
-        qm1:setPos(Jailer_of_Fortitude_QM_POS[qm1position][1], Jailer_of_Fortitude_QM_POS[qm1position][2], Jailer_of_Fortitude_QM_POS[qm1position][3]);
-    end
-    
+
     -- Jailer of Faith spawn randomiser
     if (VanadielHour % s == 0) then
-        -- Get the ??? NPC 
-        local qm3 = GetNPCByID(Jailer_of_Faith_QM);
         -- Hide it for 60 seconds
         qm3:hideNPC(60);
         
@@ -121,7 +110,7 @@ function onGameHour(npc, mob, player)
         -- Set the new ??? place
         qm3:setPos(Jailer_of_Faith_QM_POS[qm3position][1], Jailer_of_Faith_QM_POS[qm3position][2], Jailer_of_Faith_QM_POS[qm3position][3]);
     end
-    
+
     --[[
     -- Ix'DRK spawn randomiser
     if (VanadielHour % 6 == 0) then -- Change ??? position every 6 hours Vana'diel time (~15 mins)

--- a/scripts/zones/The_Garden_of_RuHmet/mobs/Jailer_of_Faith.lua
+++ b/scripts/zones/The_Garden_of_RuHmet/mobs/Jailer_of_Faith.lua
@@ -8,10 +8,10 @@
 -----------------------------------
 
 function onMobSpawn(mob)
-	-- Give it two hour
-	mob:setMod(MOBMOD_MAIN_2HOUR, 1);
-	-- Change animation to open
-	mob:AnimationSub(2);
+    -- Give it two hour
+    mob:setMod(MOBMOD_MAIN_2HOUR, 1);
+    -- Change animation to open
+    mob:AnimationSub(2);
 end;
 
 -----------------------------------
@@ -20,28 +20,35 @@ end;
 -----------------------------------
 
 function onMobFight(mob)
-	-- Forms: 0 = Closed  1 = Closed  2 = Open 3 = Closed 
-	local randomTime = math.random(45,180);
-	local changeTime = mob:getLocalVar("changeTime");
-	
-	if (mob:getBattleTime() - changeTime > randomTime) then
-		-- Change close to open.
-		if (mob:AnimationSub() == 1) then
-			mob:AnimationSub(2);
-		else -- Change from open to close
-			mob:AnimationSub(1);
-		end
-		mob:setLocalVar("changeTime", mob:getBattleTime());
-	end
+    -- Forms: 0 = Closed  1 = Closed  2 = Open 3 = Closed 
+    local randomTime = math.random(45,180);
+    local changeTime = mob:getLocalVar("changeTime");
+    
+    if (mob:getBattleTime() - changeTime > randomTime) then
+        -- Change close to open.
+        if (mob:AnimationSub() == 1) then
+            mob:AnimationSub(2);
+        else -- Change from open to close
+            mob:AnimationSub(1);
+        end
+        mob:setLocalVar("changeTime", mob:getBattleTime());
+    end
 end;
 
 -----------------------------------
 -- onMobDeath
 -----------------------------------
 
-function onMobDeath(mob, killer, npc)
-	local qm3 = GetNPCByID(Jailer_of_Faith_QM);
-	qm3:hideNPC(900);
-	local qm3position = math.random(1,5);
-	qm3:setPos(Jailer_of_Faith_QM_POS[qm3position][1], Jailer_of_Faith_QM_POS[qm3position][2], Jailer_of_Faith_QM_POS[qm3position][3]);
+function onMobDeath(mob)
+end;
+
+-----------------------------------
+-- onMobDespawn
+-----------------------------------
+
+function onMobDespawn(mob, killer, npc)
+    local qm3 = GetNPCByID(Jailer_of_Faith_QM);
+    qm3:updateNPCHideTime(FORCE_SPAWN_QM_RESET_TIME);
+    local qm3position = math.random(1,5);
+    qm3:setPos(Jailer_of_Faith_QM_POS[qm3position][1], Jailer_of_Faith_QM_POS[qm3position][2], Jailer_of_Faith_QM_POS[qm3position][3]);
 end;

--- a/scripts/zones/The_Garden_of_RuHmet/mobs/Jailer_of_Fortitude.lua
+++ b/scripts/zones/The_Garden_of_RuHmet/mobs/Jailer_of_Fortitude.lua
@@ -13,7 +13,7 @@ require("scripts/globals/magic");
 function onMobSpawn(mob)
     -- Give it two hour
     mob:setMobMod(MOBMOD_MAIN_2HOUR, 1);
-	mob:setMobMod(MOBMOD_2HOUR_MULTI, 1);
+    mob:setMobMod(MOBMOD_2HOUR_MULTI, 1);
     -- Change animation to humanoid w/ prismatic core
     mob:AnimationSub(1);
     mob:setModelId(1169);
@@ -70,9 +70,16 @@ function onMobDeath(mob, killer, npc)
     -- Despawn the pets if alive
     DespawnMob(Kf_Ghrah_WHM);
     DespawnMob(Kf_Ghrah_BLM);
+end;
+
+-----------------------------------
+-- onMobDespawn
+-----------------------------------
+
+function onMobDespawn(mob)
     -- Set 15 mins respawn
     local qm1 = GetNPCByID(Jailer_of_Fortitude_QM);
-    qm1:hideNPC(900);
+    qm1:updateNPCHideTime(FORCE_SPAWN_QM_RESET_TIME);
 
     -- Move it to a random location
     local qm1position = math.random(1,5);

--- a/scripts/zones/The_Garden_of_RuHmet/npcs/qm1.lua
+++ b/scripts/zones/The_Garden_of_RuHmet/npcs/qm1.lua
@@ -16,20 +16,21 @@ require("scripts/zones/The_Garden_of_RuHmet/MobIDs");
 
 function onTrade(player,npc,trade)
     -- Trade 12 Ghrah M Chips
-	if (GetMobAction(Jailer_of_Fortitude) == 0 and trade:hasItemQty(1872,12) and trade:getItemCount() == 12) then
-		-- Complete the trade
-		player:tradeComplete();
-		-- Hide the NPC for 15 mins
-		GetNPCByID(Jailer_of_Fortitude_QM):hideNPC(900);
-		-- Change MobSpawn to Players @pos. 
-		GetMobByID(Jailer_of_Fortitude):setSpawn(player:getXPos(),player:getYPos(),player:getZPos()); 
-		-- Change spawn point of pets to be at the players pos as well
-		GetMobByID(Kf_Ghrah_WHM):setSpawn(player:getXPos(),player:getYPos(),player:getZPos());
-		GetMobByID(Kf_Ghrah_BLM):setSpawn(player:getXPos(),player:getYPos(),player:getZPos());
-		-- Spawn Jailer of Fortitude
-		SpawnMob(Jailer_of_Fortitude,180):updateClaim(player); 
-		SpawnMob(Kf_Ghrah_WHM,180):updateClaim(player); 
-		SpawnMob(Kf_Ghrah_BLM,180):updateClaim(player); 
+    if (GetMobAction(Jailer_of_Fortitude) == 0 and trade:hasItemQty(1872,12) and trade:getItemCount() == 12) then
+        local qm1 = GetNPCByID(Jailer_of_Fortitude_QM);
+        -- Complete the trade
+        player:tradeComplete();
+        -- Hide the NPC, will become unhidden after Jailer of Fortitude despawns
+        qm1:setStatus(STATUS_DISAPPEAR);
+        -- Change MobSpawn to ???'s @pos. 
+        GetMobByID(Jailer_of_Fortitude):setSpawn(qm1:getXPos(),qm1:getYPos(),qm1:getZPos()); 
+        -- Change spawn point of pets to be at the ???'s pos as well
+        GetMobByID(Kf_Ghrah_WHM):setSpawn(qm1:getXPos(),qm1:getYPos(),qm1:getZPos());
+        GetMobByID(Kf_Ghrah_BLM):setSpawn(qm1:getXPos(),qm1:getYPos(),qm1:getZPos());
+        -- Spawn Jailer of Fortitude
+        SpawnMob(Jailer_of_Fortitude,180):updateClaim(player); 
+        SpawnMob(Kf_Ghrah_WHM,180):updateClaim(player); 
+        SpawnMob(Kf_Ghrah_BLM,180):updateClaim(player); 
     end
 end;               
 -----------------------------------

--- a/scripts/zones/The_Garden_of_RuHmet/npcs/qm3.lua
+++ b/scripts/zones/The_Garden_of_RuHmet/npcs/qm3.lua
@@ -15,16 +15,17 @@ require("scripts/zones/The_Garden_of_RuHmet/MobIDs");
 -----------------------------------
 
 function onTrade(player,npc,trade)
-	 --Trade 1 High-Quality Euvhi Organ
-	if (GetMobAction(Jailer_of_Faith) == 0 and trade:hasItemQty(1899,1) and trade:getItemCount() == 1) then
-		player:tradeComplete();
-		-- Hide the ???
-		GetNPCByID(Jailer_of_Faith_QM):hideNPC(900);
-		-- Change MobSpawn to Players @pos.
-		GetMobByID(Jailer_of_Faith):setSpawn(player:getXPos(),player:getYPos(),player:getZPos());
-		-- Spawn Jailer of Faith
-		SpawnMob(Jailer_of_Faith,900):updateClaim(player); 
-	end
+     --Trade 1 High-Quality Euvhi Organ
+    if (GetMobAction(Jailer_of_Faith) == 0 and trade:hasItemQty(1899,1) and trade:getItemCount() == 1) then
+        local qm3 = GetNPCByID(Jailer_of_Faith_QM);
+        player:tradeComplete();
+        -- Hide the ???
+        qm3:setStatus(STATUS_DISAPPEAR);
+        -- Change MobSpawn to ???'s @pos.
+        GetMobByID(Jailer_of_Faith):setSpawn(qm3:getXPos(),qm3:getYPos(),qm3:getZPos());
+        -- Spawn Jailer of Faith
+        SpawnMob(Jailer_of_Faith,900):updateClaim(player); 
+    end
 end; 
 
 -----------------------------------

--- a/scripts/zones/The_Shrine_of_RuAvitau/mobs/Kirin.lua
+++ b/scripts/zones/The_Shrine_of_RuAvitau/mobs/Kirin.lua
@@ -87,7 +87,6 @@ function onMobDeath( mob, killer )
     -- Award title and cleanup..
     killer:addTitle( KIRIN_CAPTIVATOR );
     killer:showText( mob, KIRIN_OFFSET + 1 );
-    GetNPCByID( 17506693 ):hideNPC( 900 );
     
     -- Despawn pets..
     DespawnMob( 17506671 );
@@ -105,4 +104,5 @@ function onMobDespawn( mob )
     DespawnMob( 17506672 );
     DespawnMob( 17506673 );
     DespawnMob( 17506674 );
+    GetNPCByID( 17506693 ):updateNPCHideTime(FORCE_SPAWN_QM_RESET_TIME);
 end

--- a/scripts/zones/The_Shrine_of_RuAvitau/mobs/Olla_Grande.lua
+++ b/scripts/zones/The_Shrine_of_RuAvitau/mobs/Olla_Grande.lua
@@ -15,5 +15,12 @@ end;
 -----------------------------------
 
 function onMobDeath(mob, killer)
-	GetNPCByID(17506692):hideNPC(900);
+end;
+
+-----------------------------------
+-- onMobDespawn
+-----------------------------------
+
+function onMobDespawn(mob)
+    GetNPCByID(17506692):updateNPCHideTime(FORCE_SPAWN_QM_RESET_TIME);
 end;

--- a/scripts/zones/The_Shrine_of_RuAvitau/mobs/Olla_Media.lua
+++ b/scripts/zones/The_Shrine_of_RuAvitau/mobs/Olla_Media.lua
@@ -15,5 +15,15 @@ end;
 -----------------------------------
 
 function onMobDeath(mob, killer)
-	SpawnMob(17506669,180):updateEnmity(killer);
+    SpawnMob(mob:getID() + 1,180):updateEnmity(killer);
+end;
+
+-----------------------------------
+-- onMobDespawn
+-----------------------------------
+
+function onMobDespawn(mob)
+    if (GetMobAction(mob:getID() + 1) == 0) then -- if this Media despawns and Grande is not alive, it would be because it despawned outside of being killed.
+        GetNPCByID(17506692):updateNPCHideTime(FORCE_SPAWN_QM_RESET_TIME);
+    end
 end;

--- a/scripts/zones/The_Shrine_of_RuAvitau/mobs/Olla_Pequena.lua
+++ b/scripts/zones/The_Shrine_of_RuAvitau/mobs/Olla_Pequena.lua
@@ -15,5 +15,15 @@ end;
 -----------------------------------
 
 function onMobDeath(mob, killer)
-	SpawnMob(17506668,180):updateEnmity(killer);
+    SpawnMob(mob:getID() + 1,180):updateEnmity(killer);
+end;
+
+-----------------------------------
+-- onMobDespawn
+-----------------------------------
+
+function onMobDespawn(mob)
+    if (GetMobAction(mob:getID() + 1) == 0) then -- if this Pequena despawns and Media is not alive, it would be because it despawned outside of being killed.
+        GetNPCByID(17506692):updateNPCHideTime(FORCE_SPAWN_QM_RESET_TIME);
+    end
 end;

--- a/scripts/zones/The_Shrine_of_RuAvitau/mobs/Ullikummi.lua
+++ b/scripts/zones/The_Shrine_of_RuAvitau/mobs/Ullikummi.lua
@@ -15,5 +15,12 @@ end;
 -----------------------------------
 
 function onMobDeath(mob, killer)
-	GetNPCByID(17506694):hideNPC(900);
+end;
+
+-----------------------------------
+-- onMobDespawn
+-----------------------------------
+
+function onMobDespawn(mob)
+    GetNPCByID(17506694):updateNPCHideTime(FORCE_SPAWN_QM_RESET_TIME);
 end;

--- a/scripts/zones/The_Shrine_of_RuAvitau/npcs/qm1.lua
+++ b/scripts/zones/The_Shrine_of_RuAvitau/npcs/qm1.lua
@@ -13,13 +13,14 @@ require("scripts/zones/The_Shrine_of_RuAvitau/TextIDs");
 -----------------------------------
 
 function onTrade(player,npc,trade)
-	
-	if (GetMobAction(17506667) == 0 and GetMobAction(17506668) == 0 and GetMobAction(17506669) == 0 and 
-	trade:hasItemQty(1195,1) and trade:getItemCount() == 1) then -- Trade Ro'Maeve Water
-		player:tradeComplete();
-		SpawnMob(17506667,180):updateClaim(player);
-	end
-	
+    
+    if (GetMobAction(17506667) == 0 and GetMobAction(17506668) == 0 and GetMobAction(17506669) == 0 and 
+    trade:hasItemQty(1195,1) and trade:getItemCount() == 1) then -- Trade Ro'Maeve Water
+        player:tradeComplete();
+        SpawnMob(17506667,180):updateClaim(player);
+        npc:setStatus(STATUS_DISAPPEAR);
+    end
+    
 end;
 
 -----------------------------------
@@ -27,7 +28,7 @@ end;
 -----------------------------------
 
 function onTrigger(player,npc)
-	player:messageSpecial(SMALL_HOLE_HERE);
+    player:messageSpecial(SMALL_HOLE_HERE);
 end;
 
 -----------------------------------

--- a/scripts/zones/The_Shrine_of_RuAvitau/npcs/qm2.lua
+++ b/scripts/zones/The_Shrine_of_RuAvitau/npcs/qm2.lua
@@ -13,18 +13,16 @@ require("scripts/zones/The_Shrine_of_RuAvitau/TextIDs");
 -----------------------------------
 
 function onTrade(player,npc,trade)
-    -- Ensure Kirin is not alive..
-    if (GetMobAction( 17506670 ) == 0) then
-        -- Validate traded items are all needed seals..
-        if (trade:hasItemQty( 1404, 1 ) and trade:hasItemQty( 1405, 1 ) and trade:hasItemQty( 1406, 1 ) and trade:hasItemQty( 1407, 1 ) and trade:getItemCount() == 4) then
-            -- Complete the trade..
-            player:tradeComplete();
+    -- Validate traded items are all needed seals and ensure Kirin is not alive
+    if (GetMobAction(17506670) == 0 and trade:hasItemQty(1404, 1) and trade:hasItemQty(1405, 1) and trade:hasItemQty(1406, 1) and trade:hasItemQty(1407, 1) and trade:getItemCount() == 4) then
+        -- Complete the trade..
+        player:tradeComplete();
             
-            -- Spawn Kirin..
-            local mob = SpawnMob( 17506670, 180 );
-            player:showText( npc, KIRIN_OFFSET );
-            mob:updateClaim( player );
-        end    
+        -- Spawn Kirin..
+        local mob = SpawnMob(17506670, 180);
+        player:showText(npc, KIRIN_OFFSET);
+        mob:updateClaim(player);
+        npc:setStatus(STATUS_DISAPPEAR);
     end
 end;
 
@@ -33,7 +31,7 @@ end;
 -----------------------------------
 
 function onTrigger(player,npc)
-	player:startEvent(0x0064);
+    player:startEvent(0x0064);
 end;
 
 -----------------------------------

--- a/scripts/zones/The_Shrine_of_RuAvitau/npcs/qm3.lua
+++ b/scripts/zones/The_Shrine_of_RuAvitau/npcs/qm3.lua
@@ -13,12 +13,12 @@ require("scripts/zones/The_Shrine_of_RuAvitau/TextIDs");
 -----------------------------------
 
 function onTrade(player,npc,trade)
-	
-	if (GetMobAction(17506418) == 0 and trade:hasItemQty(2388,1) and trade:getItemCount() == 1) then -- Trade Diorite
-		player:tradeComplete();
-		SpawnMob(17506418,180):updateClaim(player);
-	end
-	
+    
+    if (GetMobAction(17506418) == 0 and trade:hasItemQty(2388,1) and trade:getItemCount() == 1) then -- Trade Diorite
+        player:tradeComplete();
+        SpawnMob(17506418,180):updateClaim(player);
+        npc:setStatus(STATUS_DISAPPEAR);
+    end
 end;
 
 -----------------------------------
@@ -26,7 +26,7 @@ end;
 -----------------------------------
 
 function onTrigger(player,npc)
-	player:messageSpecial(NOTHING_OUT_OF_ORDINARY);
+    player:messageSpecial(NOTHING_OUT_OF_ORDINARY);
 end;
 
 -----------------------------------

--- a/scripts/zones/Uleguerand_Range/mobs/Geush_Urvan.lua
+++ b/scripts/zones/Uleguerand_Range/mobs/Geush_Urvan.lua
@@ -16,5 +16,12 @@ end;
 -----------------------------------
 
 function onMobDeath(mob,killer)
-	GetNPCByID(16798095):hideNPC(900);
+end;
+
+-----------------------------------
+-- onMobDespawn
+-----------------------------------
+
+function onMobDespawn(mob)
+    GetNPCByID(16798097):updateNPCHideTime(FORCE_SPAWN_QM_RESET_TIME);
 end;

--- a/scripts/zones/Uleguerand_Range/npcs/qm1.lua
+++ b/scripts/zones/Uleguerand_Range/npcs/qm1.lua
@@ -12,13 +12,13 @@ require("scripts/zones/Uleguerand_Range/TextIDs");
 -----------------------------------
 
 function onTrade(player,npc,trade)
-	
-	-- Trade  Haunted Muleta
-	if (GetMobAction(16798078) == 0 and trade:hasItemQty(1824,1) and trade:getItemCount() == 1) then 
-		player:tradeComplete();
-		SpawnMob(16798078,1800):updateClaim(player); -- Geush Urvan
-	end
-
+    
+    -- Trade  Haunted Muleta
+    if (GetMobAction(16798078) == 0 and trade:hasItemQty(1824,1) and trade:getItemCount() == 1) then 
+        player:tradeComplete();
+        SpawnMob(16798078,1800):updateClaim(player); -- Geush Urvan
+        npc:setStatus(STATUS_DISAPPEAR);
+    end
 end; 
 
 -----------------------------------

--- a/scripts/zones/Upper_Delkfutts_Tower/mobs/Alkyoneus.lua
+++ b/scripts/zones/Upper_Delkfutts_Tower/mobs/Alkyoneus.lua
@@ -15,5 +15,12 @@ end;
 -----------------------------------
 
 function onMobDeath(mob,killer)
-	GetNPCByID(17424518):hideNPC(900); -- qm1 in npc_list
+end;
+
+-----------------------------------
+-- onMobDespawn
+-----------------------------------
+
+function onMobDespawn(mob)
+    GetNPCByID(17424518):updateNPCHideTime(FORCE_SPAWN_QM_RESET_TIME);
 end;

--- a/scripts/zones/Upper_Delkfutts_Tower/mobs/Pallas.lua
+++ b/scripts/zones/Upper_Delkfutts_Tower/mobs/Pallas.lua
@@ -15,5 +15,12 @@ end;
 -----------------------------------
 
 function onMobDeath(mob,killer)
-	GetNPCByID(17424519):hideNPC(900); -- qm2 in npc_list
+end;
+
+-----------------------------------
+-- onMobDespawn
+-----------------------------------
+
+function onMobDespawn(mob)
+    GetNPCByID(17424519):updateNPCHideTime(FORCE_SPAWN_QM_RESET_TIME);
 end;

--- a/scripts/zones/Upper_Delkfutts_Tower/npcs/qm1.lua
+++ b/scripts/zones/Upper_Delkfutts_Tower/npcs/qm1.lua
@@ -13,14 +13,13 @@ require("scripts/zones/Upper_Delkfutts_Tower/TextIDs");
 -----------------------------------
 
 function onTrade(player,npc,trade)
-	
-	-- Trade moldy buckler
-	if (GetMobAction(17424480) == 0 and trade:hasItemQty(2385,1) and trade:getItemCount() == 1) then 
-		player:tradeComplete();
-		SpawnMob(17424480,120):updateClaim(player); -- Alkyoneus
-	end
-
-
+    
+    -- Trade moldy buckler
+    if (GetMobAction(17424480) == 0 and trade:hasItemQty(2385,1) and trade:getItemCount() == 1) then 
+        player:tradeComplete();
+        SpawnMob(17424480,120):updateClaim(player); -- Alkyoneus
+        npc:setStatus(STATUS_DISAPPEAR);
+    end
 end; 
 
 -----------------------------------

--- a/scripts/zones/Upper_Delkfutts_Tower/npcs/qm2.lua
+++ b/scripts/zones/Upper_Delkfutts_Tower/npcs/qm2.lua
@@ -13,14 +13,13 @@ require("scripts/zones/Upper_Delkfutts_Tower/TextIDs");
 -----------------------------------
 
 function onTrade(player,npc,trade)
-	
-	-- Trade moldy buckler
-	if (GetMobAction(17424444) == 0 and trade:hasItemQty(2386,1) and trade:getItemCount() == 1) then 
-		player:tradeComplete();
-		SpawnMob(17424444,120):updateClaim(player); -- Pallas
-	end
-
-
+    
+    -- Trade moldy buckler
+    if (GetMobAction(17424444) == 0 and trade:hasItemQty(2386,1) and trade:getItemCount() == 1) then 
+        player:tradeComplete();
+        SpawnMob(17424444,120):updateClaim(player); -- Pallas
+        npc:setStatus(STATUS_DISAPPEAR);
+    end
 end; 
 
 -----------------------------------

--- a/scripts/zones/VeLugannon_Palace/mobs/Brigandish_Blade.lua
+++ b/scripts/zones/VeLugannon_Palace/mobs/Brigandish_Blade.lua
@@ -10,7 +10,7 @@ require("scripts/globals/status");
 -----------------------------------
 
 function onMobInitialize(mob)
-	mob:setMobMod(MOBMOD_ADD_EFFECT,mob:getShortID());
+    mob:setMobMod(MOBMOD_ADD_EFFECT,mob:getShortID());
 end;
 
 -----------------------------------
@@ -24,7 +24,6 @@ end;
 -- onMobDeath
 -----------------------------------
 function onMobDeath(mob, killer)
-	GetNPCByID(17502582):hideNPC(300);
 end;
 
 -----------------------------------
@@ -32,14 +31,21 @@ end;
 -----------------------------------
 function onAdditionalEffect(mob,target,damage)
 
-	local rand = math.random(1,10);
+    local rand = math.random(1,10);
 
-	if ((rand >= 4) or (target:hasStatusEffect(EFFECT_TERROR) == true)) then -- 30% chance to terror
-		return 0,0,0;
-	else
-		local duration = math.random(3,5);
-		target:addStatusEffect(EFFECT_TERROR,1,0,duration);
-		return SUBEFFECT_NONE,0,EFFECT_TERROR;
-	end
+    if ((rand >= 4) or (target:hasStatusEffect(EFFECT_TERROR) == true)) then -- 30% chance to terror
+        return 0,0,0;
+    else
+        local duration = math.random(3,5);
+        target:addStatusEffect(EFFECT_TERROR,1,0,duration);
+        return SUBEFFECT_NONE,0,EFFECT_TERROR;
+    end
+end;
 
+-----------------------------------
+-- onMobDespawn
+-----------------------------------
+
+function onMobDespawn(mob)
+    GetNPCByID(17502582):updateNPCHideTime(FORCE_SPAWN_QM_RESET_TIME);
 end;

--- a/scripts/zones/VeLugannon_Palace/npcs/qm2.lua
+++ b/scripts/zones/VeLugannon_Palace/npcs/qm2.lua
@@ -14,12 +14,12 @@ require("scripts/zones/VeLugannon_Palace/TextIDs");
 -----------------------------------
 
 function onTrade(player,npc,trade)
-	
-	if (GetMobAction(17502568) == 0 and trade:hasItemQty(16575,1) and trade:getItemCount() == 1) then -- Trade Curtana
-		player:tradeComplete();
-		SpawnMob(17502568,180):updateClaim(player);
-	end
-	
+    
+    if (GetMobAction(17502568) == 0 and trade:hasItemQty(16575,1) and trade:getItemCount() == 1) then -- Trade Curtana
+        player:tradeComplete();
+        SpawnMob(17502568,180):updateClaim(player);
+        npc:setStatus(STATUS_DISAPPEAR);
+    end    
 end;
 
 -----------------------------------
@@ -27,7 +27,7 @@ end;
 -----------------------------------
 
 function onTrigger(player,npc)
-	player:startEvent(0x0002);
+    player:startEvent(0x0002);
 end;
 
 -----------------------------------

--- a/scripts/zones/Xarcabard/mobs/Chaos_Elemental.lua
+++ b/scripts/zones/Xarcabard/mobs/Chaos_Elemental.lua
@@ -18,5 +18,12 @@ end;
 -----------------------------------
 
 function onMobDeath(mob, killer)
-	GetNPCByID(17236279):hideNPC(600); -- qm1
+end;
+
+-----------------------------------
+-- onMobDespawn
+-----------------------------------
+
+function onMobDespawn(mob)
+    GetNPCByID(17236279):updateNPCHideTime(FORCE_SPAWN_QM_RESET_TIME);
 end;

--- a/scripts/zones/Xarcabard/npcs/qm1.lua
+++ b/scripts/zones/Xarcabard/npcs/qm1.lua
@@ -1,7 +1,7 @@
 -----------------------------------
 -- Area: Xarcabard
 -- NPC:  qm1 (???)
--- Involved in Quests: The Three Magi (for Boreal Hound)
+-- Involved in Quests: The Three Magi
 -- @pos -331 -29 -49 112
 -----------------------------------
 package.loaded["scripts/zones/Xarcabard/TextIDs"] = nil;
@@ -15,14 +15,14 @@ require("scripts/zones/Xarcabard/TextIDs");
 -----------------------------------
 
 function onTrade(player,npc,trade)
-	
-	if (player:getQuestStatus(WINDURST,THE_THREE_MAGI) == QUEST_ACCEPTED and player:hasItem(1104) == false) then
-		if (trade:hasItemQty(613,1) and trade:getItemCount() == 1) then -- Trade Faded Crystal
-			player:tradeComplete();
-			SpawnMob(17236201,180):updateClaim(player);
-		end
-	end
-	
+    
+    if (player:getQuestStatus(WINDURST,THE_THREE_MAGI) == QUEST_ACCEPTED and player:hasItem(1104) == false) then
+        if (trade:hasItemQty(613,1) and trade:getItemCount() == 1) then -- Trade Faded Crystal
+            player:tradeComplete();
+            SpawnMob(17236201,180):updateClaim(player);
+            npc:setStatus(STATUS_DISAPPEAR);
+        end
+    end
 end;
 
 -----------------------------------
@@ -30,7 +30,7 @@ end;
 -----------------------------------
 
 function onTrigger(player,npc)
-	player:messageSpecial(NOTHING_OUT_OF_ORDINARY);
+    player:messageSpecial(NOTHING_OUT_OF_ORDINARY);
 end;
 
 -----------------------------------

--- a/src/map/lua/lua_baseentity.cpp
+++ b/src/map/lua/lua_baseentity.cpp
@@ -7544,6 +7544,20 @@ inline int32 CLuaBaseEntity::hideNPC(lua_State *L)
     return 0;
 }
 
+inline int32 CLuaBaseEntity::updateNPCHideTime(lua_State *L)
+{
+    DSP_DEBUG_BREAK_IF(m_PBaseEntity == nullptr);
+    DSP_DEBUG_BREAK_IF(m_PBaseEntity->objtype != TYPE_NPC);
+
+    if (m_PBaseEntity->status == STATUS_DISAPPEAR)
+    {
+        uint32 OpenTime = (!lua_isnil(L, 1) && lua_isnumber(L, 1)) ? (uint32)lua_tointeger(L, 1) * 1000 : 15000;
+
+        CTaskMgr::getInstance()->AddTask(new CTaskMgr::CTask("reappear_npc", gettick() + OpenTime, m_PBaseEntity, CTaskMgr::TASK_ONCE, reappear_npc));
+    }
+    return 0;
+}
+
 //==========================================================//
 
 inline int32 CLuaBaseEntity::getCurrency(lua_State *L)
@@ -10307,6 +10321,7 @@ Lunar<CLuaBaseEntity>::Register_t CLuaBaseEntity::methods[] =
     LUNAR_DECLARE_METHOD(CLuaBaseEntity,getAngle),
     LUNAR_DECLARE_METHOD(CLuaBaseEntity,showNPC),
     LUNAR_DECLARE_METHOD(CLuaBaseEntity,hideNPC),
+    LUNAR_DECLARE_METHOD(CLuaBaseEntity,updateNPCHideTime),
     LUNAR_DECLARE_METHOD(CLuaBaseEntity,getStealItem),
     LUNAR_DECLARE_METHOD(CLuaBaseEntity,itemStolen),
     LUNAR_DECLARE_METHOD(CLuaBaseEntity,getBCNMloot),

--- a/src/map/lua/lua_baseentity.h
+++ b/src/map/lua/lua_baseentity.h
@@ -408,6 +408,7 @@ public:
     int32 closeDoor(lua_State*);            // npc.closeDoor(timeToStayClosed)
     int32 showNPC(lua_State*);              // Show an NPC
     int32 hideNPC(lua_State*);              // hide an NPC
+    int32 updateNPCHideTime(lua_State*);    // Updates the length of time a NPC remains hidden, if shorter than the original hide time.
     int32 resetRecasts(lua_State*);         // Reset recasts for the caller
     int32 resetRecast(lua_State*);          // Reset one recast ID
 


### PR DESCRIPTION
I created a new lua binding that will set a hidden NPC to unhide after the specified period of time - the existing function only works on non-hidden NPCs. I've also created a variable in settings.lua that holds a default time for the force spawning NPC hiding time (defaults to five minutes).

Upon force spawning the mob, the NPC will be hidden indefinitely, until the despawn (NOT death action) of the mob it spawned - at that time, the hiding time is updated to the time specified with the new setting.

Other misc. fixes that I've done while going through the files:
-Fixed the NPCIDs various ???s
-Made the ??? for Jailer of Fortitude not move around as it's untouched - it only moves after its death.
-Unswapped the comment labels in the zone.lua file of The Garden of Ru'Hmet for the ??? of Ix'DRK and Jailer of Faith;
-Used stored ID for the ??? for Jailer of Faith because it's there and was being set twice in the same function for some reason. Same with a couple mobs.
-Changed the spawn point of Jailer of Faith/Fortitude to be at the ???'s pos rather than the player's pos.