### PR TITLE
Scripts: Add back the status effect to Promyvion Brume

### DIFF
--- a/scripts/globals/mobskills/Promyvion_Brume.lua
+++ b/scripts/globals/mobskills/Promyvion_Brume.lua
@@ -17,6 +17,7 @@ function onMobSkillCheck(target,mob,skill)
 end;
 
 function onMobWeaponSkill(target, mob, skill)
+    local typeEffect = EFFECT_POISON;
     MobStatusEffectMove(mob, target, typeEffect, 5, 3, 180);
 
     local dmgmod = 1;


### PR DESCRIPTION
typeEffect was undefined so it crashes. The line that defined it was accidentally removed in the last commit that changed this file.