### PR TITLE
Scripts: Fix mob version of Thunderspark.

### DIFF
--- a/scripts/globals/mobskills/thunderspark.lua
+++ b/scripts/globals/mobskills/thunderspark.lua
@@ -1,18 +1,24 @@
+---------------------------------------------------
+-- Thunderspark
+-- Ramuh deals lightning damage and paralyzes enemies within area of effect.
+---------------------------------------------------
 require("scripts/globals/settings");
 require("scripts/globals/status");
 require("scripts/globals/monstertpmoves");
 ---------------------------------------------
 function onMobSkillCheck(target,mob,skill)
-	return 0;
+    return 0;
 end;
 
 function onMobWeaponSkill(target, mob, skill)
-	local dmgmod = 1;
-	local accmod = 1;
-	local info = MobMagicalMove(mob,target,skill,mob:getWeaponDmg()*3,ELE_LIGHTNING,dmgmod,TP_NO_EFFECT);
-	local dmg = MobFinalAdjustments(info.dmg,mob,skill,target,MOBSKILL_MAGICAL,MOBPARAM_WATER,MOBPARAM_IGNORE_SHADOWS);
+    local typeEffect = EFFECT_PARALYSIS;
+    MobStatusEffectMove(mob, target, EFFECT_PARALYZE, 30, 0, 60);
 
-    MobStatusEffectMove(mob, target, skill, EFFECT_PARALYZE, 30, 0, 60);
-	target:delHP(dmg);
-	return dmg;
+    local dmgmod = 1;
+    local accmod = 1;
+    local info = MobMagicalMove(mob,target,skill,mob:getWeaponDmg()*3,ELE_LIGHTNING,dmgmod,TP_NO_EFFECT);
+    local dmg = MobFinalAdjustments(info.dmg,mob,skill,target,MOBSKILL_MAGICAL,MOBPARAM_WATER,MOBPARAM_IGNORE_SHADOWS);
+
+    target:delHP(dmg);
+    return dmg;
 end;


### PR DESCRIPTION
MobStatusEffectMove had an extra parameter, which was triggering the breakpoint when it tried to pass the skill into the status effect part.