### PR TITLE
Fixed InnoDB deprecated command

### DIFF
--- a/sql/accounts_parties.sql
+++ b/sql/accounts_parties.sql
@@ -31,7 +31,7 @@ CREATE TABLE `accounts_parties` (
   PRIMARY KEY (`charid`),
   FOREIGN KEY (`charid`) REFERENCES accounts_sessions(`charid`)
     ON DELETE CASCADE
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 ROW_FORMAT=FIXED;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --

--- a/sql/accounts_sessions.sql
+++ b/sql/accounts_sessions.sql
@@ -41,4 +41,4 @@ CREATE TABLE IF NOT EXISTS `accounts_sessions` (
   `client_port` smallint(5) unsigned NOT NULL DEFAULT '0',
   PRIMARY KEY (`charid`),
   UNIQUE KEY `accid` (`accid`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 ROW_FORMAT=FIXED;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;


### PR DESCRIPTION
I was receiving an error saying a command I was trying to use was deprecated when importing the .sql files to a new DB. After some playing around I discovered that removing the ROW_FORMAT=FIXED option fixed the issue.