### PR TITLE
Scripts/SQL: Fix the spawning of TEs in Dynamis - Xarcabard

### DIFF
--- a/scripts/zones/Dynamis-Xarcabard/bcnms/dynamis_xarcabard.lua
+++ b/scripts/zones/Dynamis-Xarcabard/bcnms/dynamis_xarcabard.lua
@@ -7,6 +7,8 @@
 function onBcnmRegister(player,instance)
     
     SetServerVariable("[DynaXarcabard]UniqueID",player:getDynamisUniqueID(1285));
+    SetServerVariable("[DynaXarcabard]TE43_Trigger",0);
+    SetServerVariable("[DynaXarcabard]TE60_Trigger",0);
     SetServerVariable("[DynaXarcabard]TE150_Trigger",0);
     SetServerVariable("[DynaXarcabard]Boss_Trigger",0);
     

--- a/scripts/zones/Dynamis-Xarcabard/mobs/Vanguard_Eye.lua
+++ b/scripts/zones/Dynamis-Xarcabard/mobs/Vanguard_Eye.lua
@@ -19,7 +19,7 @@ end;
 -----------------------------------
 
 function onMobSpawn(mob)
-	mob:setMobMod(MOBMOD_SUPERLINK, mob:getShortID());
+    mob:setMobMod(MOBMOD_SUPERLINK, mob:getShortID());
 end;
 
 -----------------------------------
@@ -35,27 +35,47 @@ end;
 -----------------------------------
 
 function onMobDeath(mob,killer)
-	
-	local mobID = mob:getID();
-	
-	-- 035 039: spawn 043 when defeated
-	if (mobID == 17326536) then
-		SpawnMob(17326553);
-	-- 058: spawn 60 when defeated
-	elseif (mobID == 17326661 and GetMobAction(17326668) == 0 and GetMobAction(17326673) == 0 or 
-		   mobID == 17326668 and GetMobAction(17326661) == 0 and GetMobAction(17326673) == 0 or 
-		   mobID == 17326673 and GetMobAction(17326661) == 0 and GetMobAction(17326668) == 0) then
-		SpawnMob(17326706);
-	-- 114: spawn 112 when defeated
-	elseif (mobID == 17326790) then
-		SpawnMob(17326086);
-	-- 144-149: spawn 150 when defeated
-	elseif (mobID >= 17330913 and mobID <= 17330918) then
-		SetServerVariable("[DynaXarcabard]TE150_Trigger",GetServerVariable("[DynaXarcabard]TE150_Trigger") + (mobID - 17330912) ^ 2);
-	end
-	
-	if (GetServerVariable("[DynaXarcabard]TE150_Trigger") == 63) then
-		SpawnMob(17330919); -- 150
-	end
-	
+    
+    local mobID = mob:getID();
+    
+    -- 035 039: spawn 043 when defeated
+    if (mobID == 17330718) then
+        local southTE = GetServerVariable("[DynaXarcabard]TE43_Trigger");
+        if (bit.band(southTE, bit.lshift(1,0)) ~= 1) then
+            SetServerVariable("[DynaXarcabard]TE43_Trigger",bit.bor(southTE, bit.lshift(1,0)))
+        end
+    elseif (mobID == 17330756)  then
+        local southTE = GetServerVariable("[DynaXarcabard]TE43_Trigger");
+        if (bit.band(southTE, bit.lshift(1,1)) ~= 1) then
+            SetServerVariable("[DynaXarcabard]TE43_Trigger",bit.bor(southTE, bit.lshift(1,1)))
+        end
+    -- 058: spawn 60 when defeated
+    elseif (mobID >= 17330827 and mobID <= 17330829) then
+        local northTE = GetServerVariable("[DynaXarcabard]TE60_Trigger");
+        if (bit.band(northTE, bit.lshift(1, (mobID - 17330827))) ~= 1) then
+            SetServerVariable("[DynaXarcabard]TE60_Trigger",bit.bor(northTE, bit.lshift(1, (mobID - 17330827))))
+        end
+    -- 114: spawn 112 when defeated
+    elseif (mobID == 17326790) then
+        SpawnMob(17326086);
+    -- 144-149: spawn 150 when defeated
+    elseif (mobID >= 17330913 and mobID <= 17330918) then
+        local wallTE = GetServerVariable("[DynaXarcabard]TE150_Trigger");
+        if (bit.band(wallTE, bit.lshift(1, (mobID - 17330913))) ~= 1) then
+            SetServerVariable("[DynaXarcabard]TE150_Trigger",bit.bor(wallTE, bit.lshift(1, (mobID - 17330913))))
+        end
+    end
+    
+    if (GetServerVariable("[DynaXarcabard]TE150_Trigger") == 63) then
+        SpawnMob(17330919); -- 150
+        SetServerVariable("[DynaXarcabard]TE150_Trigger", 0) -- don't want it to be able to spawn again!
+    end
+    if (GetServerVariable("[DynaXarcabard]TE60_Trigger") == 7) then
+        SpawnMob(17330830); -- 60
+        SetServerVariable("[DynaXarcabard]TE60_Trigger", 0)
+    end
+    if (GetServerVariable("[DynaXarcabard]TE43_Trigger") == 3) then
+        SpawnMob(17330814); -- 43
+        SetServerVariable("[DynaXarcabard]TE43_Trigger", 0)
+    end
 end;


### PR DESCRIPTION
The checks were being thrown out of whack because of onMobDeath running for every player in the group, so I borrowed code from the Maat's Cap check to fix it. Each trigger mob will set a specific bit on the appropriate variable if it's not already set, and when the variable has reached the correct value (ie. all triggers are dead), the TE will spawn and variable is cleared.

I also corrected the mob group of two TEs, as they were spawning as eyes instead of statues.