### PR TITLE
Fix issue #2376 and other errors in land king respawn behavior.

### DIFF
--- a/scripts/globals/settings.lua
+++ b/scripts/globals/settings.lua
@@ -82,8 +82,8 @@ CHEST_MIN_ILLUSION_TIME  = 1800;  -- 30 minutes
 
 -- Sets spawn type for: Behemoth, Fafnir, Adamantoise, King Behemoth, Nidhog, Aspidochelone.
 -- Use 0 for timed spawns, 1 for force pop only, 2 for both
-LandKingSystem_NQ = 2;
-LandKingSystem_HQ = 2;
+LandKingSystem_NQ = 0;
+LandKingSystem_HQ = 0;
 
 -- DYNAMIS SETTINGS
     BETWEEN_2DYNA_WAIT_TIME = 1;        -- wait time between 2 Dynamis (in real day) min: 1 day

--- a/scripts/zones/Behemoths_Dominion/mobs/Behemoth.lua
+++ b/scripts/zones/Behemoths_Dominion/mobs/Behemoth.lua
@@ -27,26 +27,26 @@ end;
 -----------------------------------
 
 function onMobDespawn(mob)
-    local Behemoth      = mob:getID();
-    local King_Behemoth = 17297441;
-    local ToD     = GetServerVariable("[POP]King_Behemoth");
-    local kills   = GetServerVariable("[PH]King_Behemoth");
-    if (LandKingSystem_HQ == 0 or LandKingSystem_HQ == 2) then
-        if (ToD <= os.time(t) and GetMobAction(King_Behemoth) == 0) then
-            if (math.random((1),(5)) == 3 or kills > 6) then
-                DeterMob(Behemoth, true);
-                DeterMob(King_Behemoth, false);
-                UpdateNMSpawnPoint(King_Behemoth);
-                GetMobByID(King_Behemoth):setRespawnTime(math.random((75600),(86400)));
-            elseif (LandKingSystem_NQ == 0 or LandKingSystem_NQ == 2) then
-                UpdateNMSpawnPoint(Behemoth);
-                mob:setRespawnTime(math.random((75600),(86400)));
-                SetServerVariable("[PH]King_Behemoth", kills + 1);
-            end
+    local Behemoth = mob:getID();
+    local King_Behemoth = mob:getID()+1;
+    local ToD = GetServerVariable("[POP]King_Behemoth");
+    local kills = GetServerVariable("[PH]King_Behemoth");
+    local popNow = (math.random(1,5) == 3 or kills > 6);
+
+    if (LandKingSystem_HQ ~= 1 and ToD <= os.time(t) and popNow == true) then
+        -- 0 = timed spawn, 1 = force pop only, 2 = BOTH
+        if (LandKingSystem_NQ == 0) then
+            DeterMob(Behemoth, true);
         end
-    elseif (LandKingSystem_NQ == 0 or LandKingSystem_NQ == 2) then
-        UpdateNMSpawnPoint(Behemoth);
-        mob:setRespawnTime(math.random((75600),(86400)));
-        SetServerVariable("[PH]King_Behemoth", kills + 1);
+
+        DeterMob(King_Behemoth, false);
+        UpdateNMSpawnPoint(King_Behemoth);
+        GetMobByID(King_Behemoth):setRespawnTime(math.random(75600,86400));
+    else
+        if (LandKingSystem_NQ ~= 1) then
+            UpdateNMSpawnPoint(Behemoth);
+            mob:setRespawnTime(math.random(75600,86400));
+            SetServerVariable("[PH]King_Behemoth", kills + 1);
+        end
     end
 end;

--- a/scripts/zones/Behemoths_Dominion/mobs/King_Behemoth.lua
+++ b/scripts/zones/Behemoths_Dominion/mobs/King_Behemoth.lua
@@ -15,6 +15,19 @@ function onMobInitialize(mob)
     mob:setMobMod(MOBMOD_MAGIC_COOL, 60);
 end;
 
+-----------------------------------
+-- onSpellPrecast
+-----------------------------------
+
+function onSpellPrecast(mob, spell)
+    if (spell:getID() == 218) then
+        spell:setAoE(SPELLAOE_RADIAL);
+        spell:setFlag(SPELLFLAG_HIT_ALL);
+        spell:setRadius(30);
+        spell:setAnimation(280);
+        spell:setMPCost(1);
+    end
+end;
 
 -----------------------------------
 -- onMobDeath
@@ -24,36 +37,30 @@ function onMobDeath(mob, killer)
 
     killer:addTitle(BEHEMOTH_DETHRONER);
 
-    if (math.random((1),(100)) <= 5) then -- Hardcoded "this or this item" drop rate until implemented.
+    -- Todo: move this to SQL after drop slots are a thing
+    if (math.random(1,100) <= 5) then -- Hardcoded "this or this item" drop rate until implemented.
         SetDropRate(1936,13566,1000); -- Defending Ring
         SetDropRate(1936,13415,0);
     else
         SetDropRate(1936,13566,0);
         SetDropRate(1936,13415,1000); -- Pixie Earring
     end
+
     -- Set King_Behemoth's Window Open Time
-    if (LandKingSystem_HQ == 0 or LandKingSystem_HQ == 2) then
-        local wait = 72 * 3600
+    if (LandKingSystem_HQ ~= 1) then
+        local wait = 72 * 3600;
         SetServerVariable("[POP]King_Behemoth", os.time(t) + wait); -- 3 days
-        DeterMob(mob:getID(), true);
+        if (LandKingSystem_HQ == 0) then -- Is time spawn only
+            DeterMob(mob:getID(), true);
+        end
     end
 
     -- Set Behemoth's spawnpoint and respawn time (21-24 hours)
-    if (LandKingSystem_NQ == 0 or LandKingSystem_NQ == 2) then
+    if (LandKingSystem_NQ ~= 1) then
         SetServerVariable("[PH]King_Behemoth", 0);
-        local Behemoth = 17297440;
+        local Behemoth = mob:getID()-1;
         DeterMob(Behemoth, false);
         UpdateNMSpawnPoint(Behemoth);
-        GetMobByID(Behemoth):setRespawnTime(math.random((75600),(86400)));
-    end
-end;
-
-function onSpellPrecast(mob, spell)
-    if (spell:getID() == 218) then
-        spell:setAoE(SPELLAOE_RADIAL);
-        spell:setFlag(SPELLFLAG_HIT_ALL);
-        spell:setRadius(30);
-        spell:setAnimation(280);
-        spell:setMPCost(1);
+        GetMobByID(Behemoth):setRespawnTime(math.random(75600,86400));
     end
 end;

--- a/scripts/zones/Behemoths_Dominion/npcs/qm2.lua
+++ b/scripts/zones/Behemoths_Dominion/npcs/qm2.lua
@@ -1,38 +1,39 @@
 -----------------------------------
 -- Area: Behemoth's Dominion
--- NPC:  ???
+--  NPC: qm2 (???)
+-- Spawns Behemoth or King Behemoth
 -- @pos -267 -19 74 127
 -----------------------------------
 package.loaded["scripts/zones/Behemoths_Dominion/TextIDs"] = nil;
 -----------------------------------
-
+require("scripts/zones/Behemoths_Dominion/TextIDs");
 require("scripts/globals/settings");
 require("scripts/globals/status");
-require("scripts/zones/Behemoths_Dominion/TextIDs");
 
 -----------------------------------
 -- onTrade Action
 -----------------------------------
 
 function onTrade(player,npc,trade)
+    local Behemoth = GetMobAction(17297440);
+    local KingBehemoth = GetMobAction(17297441);
 
-	local Behemoth = GetMobAction(17297440);
-	local KingBehemoth = GetMobAction(17297441);
-
-	-- Trade Savory Shank
-	if ((KingBehemoth == ACTION_NONE or KingBehemoth == ACTION_SPAWN) and trade:hasItemQty(3342,1) and trade:getItemCount() == 1) then -- Check trade, and if mob is ACTION_NONE (0) or waiting to spawn (24)
-		if (LandKingSystem_HQ == 1 or LandKingSystem_HQ == 2) then
-			player:tradeComplete();
-			SpawnMob(17297441,180):updateClaim(player);
-		end
-	-- Trade Beastly Shank
-	elseif ((Behemoth == ACTION_NONE or Behemoth == ACTION_SPAWN) and trade:hasItemQty(3341,1) and trade:getItemCount() == 1) then
-		if (LandKingSystem_NQ == 1 or LandKingSystem_NQ == 2) then
-			player:tradeComplete();
-			SpawnMob(17297440,180):updateClaim(player);
-		end
-	end
-
+    if ((KingBehemoth == ACTION_NONE or KingBehemoth == ACTION_SPAWN)
+    and (Behemoth == ACTION_NONE or Behemoth == ACTION_SPAWN)) then
+        -- Trade Beastly Shank
+        if (trade:hasItemQty(3341,1) and trade:getItemCount() == 1) then
+            if (LandKingSystem_NQ ~= 0) then
+                player:tradeComplete();
+                SpawnMob(17297440):updateClaim(player);
+            end
+        -- Trade Savory Shank
+        elseif (trade:hasItemQty(3342,1) and trade:getItemCount() == 1) then
+            if (LandKingSystem_HQ ~= 0) then
+                player:tradeComplete();
+                SpawnMob(17297441):updateClaim(player);
+            end
+        end
+    end
 
 end;
 
@@ -41,7 +42,7 @@ end;
 -----------------------------------
 
 function onTrigger(player,npc)
-	player:messageSpecial(IRREPRESSIBLE_MIGHT);
+    player:messageSpecial(IRREPRESSIBLE_MIGHT);
 end;
 
 -----------------------------------
@@ -49,8 +50,8 @@ end;
 -----------------------------------
 
 function onEventUpdate(player,csid,option)
---printf("CSID: %u",csid);
---printf("RESULT: %u",option);
+    -- printf("CSID: %u",csid);
+    -- printf("RESULT: %u",option);
 end;
 
 -----------------------------------
@@ -58,6 +59,6 @@ end;
 -----------------------------------
 
 function onEventFinish(player,csid,option)
---printf("CSID: %u",csid);
---printf("RESULT: %u",option);
+    -- printf("CSID: %u",csid);
+    -- printf("RESULT: %u",option);
 end;

--- a/scripts/zones/Dragons_Aery/mobs/Fafnir.lua
+++ b/scripts/zones/Dragons_Aery/mobs/Fafnir.lua
@@ -27,27 +27,26 @@ end;
 -----------------------------------
 
 function onMobDespawn(mob)
-    local Fafnir  = mob:getID();
-    local Nidhogg = 17408019;
-    local ToD     = GetServerVariable("[POP]Nidhogg");
-    local kills   = GetServerVariable("[PH]Nidhogg");
-    if (LandKingSystem_HQ == 0 or LandKingSystem_HQ == 2) then
-        if (ToD <= os.time(t) and GetMobAction(Nidhogg) == 0) then
-            if (math.random((1),(5)) == 3 or kills > 6) then
-                DeterMob(Fafnir, true);
-                DeterMob(Nidhogg, false);
-                UpdateNMSpawnPoint(Nidhogg);
-                GetMobByID(Nidhogg):setRespawnTime(math.random((75600),(86400)));
-            elseif (LandKingSystem_NQ == 0 or LandKingSystem_NQ == 2) then
-                UpdateNMSpawnPoint(Fafnir);
-                mob:setRespawnTime(math.random((75600),(86400)));
-                SetServerVariable("[PH]Nidhogg", kills + 1);
-                GetMobByID(Nidhogg):setRespawnTime(math.random((75600),(86400)));
-            end
+    local Fafnir = mob:getID();
+    local Nidhogg = mob:getID()+1;
+    local ToD = GetServerVariable("[POP]Nidhogg");
+    local kills = GetServerVariable("[PH]Nidhogg");
+    local popNow = (math.random(1,5) == 3 or kills > 6);
+
+    if (LandKingSystem_HQ ~= 1 and ToD <= os.time(t) and popNow == true) then
+        -- 0 = timed spawn, 1 = force pop only, 2 = BOTH
+        if (LandKingSystem_NQ == 0) then
+            DeterMob(Fafnir, true);
         end
-    elseif (LandKingSystem_NQ == 0 or LandKingSystem_NQ == 2) then
-        UpdateNMSpawnPoint(Fafnir);
-        mob:setRespawnTime(math.random((75600),(86400)));
-        SetServerVariable("[PH]Nidhogg", kills + 1);
+        
+        DeterMob(Nidhogg, false);
+        UpdateNMSpawnPoint(Nidhogg);
+        GetMobByID(Nidhogg):setRespawnTime(math.random(75600,86400));
+    else
+        if (LandKingSystem_NQ ~= 1) then
+            UpdateNMSpawnPoint(Fafnir);
+            mob:setRespawnTime(math.random(75600,86400));
+            SetServerVariable("[PH]Nidhogg", kills + 1);
+        end
     end
 end;

--- a/scripts/zones/Dragons_Aery/mobs/Nidhogg.lua
+++ b/scripts/zones/Dragons_Aery/mobs/Nidhogg.lua
@@ -14,12 +14,18 @@ require("scripts/globals/status");
 function onMobInitialize(mob)
 end;
 
+-----------------------------------
+-- onMobFight Action
+-----------------------------------
+
 function onMobFight(mob, target)
     local battletime = mob:getBattleTime();
     local twohourTime = mob:getLocalVar("twohourTime");
+
     if (twohourTime == 0) then
         mob:setLocalVar("twohourTime",math.random(30,90));
     end
+
     if (battletime >= twohourTime) then
         mob:useMobAbility(700);
         -- technically aerial hurricane wing, but I'm using 700 for his two hour
@@ -37,19 +43,21 @@ function onMobDeath(mob, killer)
     killer:addTitle(NIDHOGG_SLAYER);
 
     -- Set Nidhogg's Window Open Time
-    if (LandKingSystem_HQ == 0 or LandKingSystem_HQ == 2) then
-        local wait = 72 * 3600
+    if (LandKingSystem_HQ ~= 1) then
+        local wait = 72 * 3600;
         SetServerVariable("[POP]Nidhogg", os.time(t) + wait); -- 3 days
-        DeterMob(mob:getID(), true);
+        if (LandKingSystem_HQ == 0) then -- Is time spawn only
+            DeterMob(mob:getID(), true);
+        end
     end
 
     -- Set Fafnir's spawnpoint and respawn time (21-24 hours)
-    if (LandKingSystem_NQ == 0 or LandKingSystem_NQ == 2) then
-        local Fafnir = 17408018;
+    if (LandKingSystem_NQ ~= 1) then
+        local Fafnir = mob:getID()-1;
         SetServerVariable("[PH]Nidhogg", 0);
         DeterMob(Fafnir, false);
         UpdateNMSpawnPoint(Fafnir);
-        GetMobByID(Fafnir):setRespawnTime(math.random((75600),(86400)));
+        GetMobByID(Fafnir):setRespawnTime(math.random(75600,86400));
     end
 
 end;

--- a/scripts/zones/Dragons_Aery/npcs/qm0.lua
+++ b/scripts/zones/Dragons_Aery/npcs/qm0.lua
@@ -1,12 +1,13 @@
 -----------------------------------
 -- Area: Dragons Aery
--- NPC:  ??? (Spawn Nidhogg)
+--  NPC: qm0 (???)
+-- Spawns Fafnir or Nidhogg
 -- @pos -81 32 2 178
 -----------------------------------
 package.loaded["scripts/zones/Dragons_Aery/TextIDs"] = nil;
 -----------------------------------
-
 require("scripts/zones/Dragons_Aery/TextIDs");
+require("scripts/globals/settings");
 require("scripts/globals/status");
 
 -----------------------------------
@@ -14,22 +15,25 @@ require("scripts/globals/status");
 -----------------------------------
 
 function onTrade(player,npc,trade)
-	local Fafnir = GetMobAction(17408018);
-	local Nidhogg = GetMobAction(17408019);
+    local Fafnir = GetMobAction(17408018);
+    local Nidhogg = GetMobAction(17408019);
 
-	-- Trade Cup of Sweet Tea
-	if ((Nidhogg == ACTION_NONE or Nidhogg == ACTION_SPAWN) and trade:hasItemQty(3340,1) and trade:getItemCount() == 1) then -- Check trade, and if mob is ACTION_NONE (0) or waiting to spawn (24)
-		if (LandKingSystem_HQ == 1 or LandKingSystem_HQ == 2) then
-			player:tradeComplete();
-			SpawnMob(17408019,180):updateClaim(player); -- onMobEngaged does not run for scripted spawns.
-		end
-	-- Trade Cup of Honey Wine
-	elseif ((Fafnir == ACTION_NONE or Fafnir == ACTION_SPAWN) and trade:hasItemQty(3339,1) and trade:getItemCount() == 1) then
-		if (LandKingSystem_NQ == 1 or LandKingSystem_NQ == 2) then
-			player:tradeComplete();
-			SpawnMob(17408018,180):updateClaim(player);
-		end
-	end
+    if ((Nidhogg == ACTION_NONE or Nidhogg == ACTION_SPAWN)
+    and (Fafnir == ACTION_NONE or Fafnir == ACTION_SPAWN)) then
+        -- Trade Cup of Honey Wine
+        if (trade:hasItemQty(3339,1) and trade:getItemCount() == 1) then
+            if (LandKingSystem_NQ ~= 0) then
+                player:tradeComplete();
+                SpawnMob(17408018):updateClaim(player);
+            end
+        -- Trade Cup of Sweet Tea
+        elseif (trade:hasItemQty(3340,1) and trade:getItemCount() == 1) then
+            if (LandKingSystem_HQ ~= 0) then
+                player:tradeComplete();
+                SpawnMob(17408019):updateClaim(player);
+            end
+        end
+    end
 
 end;
 
@@ -38,7 +42,7 @@ end;
 -----------------------------------
 
 function onTrigger(player,npc)
-	player:messageSpecial(NOTHING_OUT_OF_ORDINARY);
+    player:messageSpecial(NOTHING_OUT_OF_ORDINARY);
 end;
 
 -----------------------------------
@@ -46,8 +50,8 @@ end;
 -----------------------------------
 
 function onEventUpdate(player,csid,option)
---printf("CSID: %u",csid);
---printf("RESULT: %u",option);
+    -- printf("CSID: %u",csid);
+    -- printf("RESULT: %u",option);
 end;
 
 -----------------------------------
@@ -55,6 +59,6 @@ end;
 -----------------------------------
 
 function onEventFinish(player,csid,option)
---printf("CSID: %u",csid);
---printf("RESULT: %u",option);
+    -- printf("CSID: %u",csid);
+    -- printf("RESULT: %u",option);
 end;

--- a/scripts/zones/Valley_of_Sorrows/mobs/Adamantoise.lua
+++ b/scripts/zones/Valley_of_Sorrows/mobs/Adamantoise.lua
@@ -27,26 +27,26 @@ end;
 -----------------------------------
 
 function onMobDespawn(mob)
-    local Adamantoise  = mob:getID();
-    local Aspidochelone = 17301538;
-    local ToD     = GetServerVariable("[POP]Aspidochelone");
-    local kills   = GetServerVariable("[PH]Aspidochelone");
-    if (LandKingSystem_HQ == 0 or LandKingSystem_HQ == 2) then
-        if (ToD <= os.time(t) and GetMobAction(Aspidochelone) == 0) then
-            if (math.random((1),(5)) == 3 or kills > 6) then
-                DeterMob(Adamantoise, true);
-                DeterMob(Aspidochelone, false);
-                UpdateNMSpawnPoint(Aspidochelone);
-                GetMobByID(Aspidochelone):setRespawnTime(math.random((75600),(86400)));
-            elseif (LandKingSystem_NQ == 0 or LandKingSystem_NQ == 2) then
-                UpdateNMSpawnPoint(Adamantoise);
-                mob:setRespawnTime(math.random((75600),(86400)));
-                SetServerVariable("[PH]Aspidochelone", kills + 1);
-            end
+    local Adamantoise = mob:getID();
+    local Aspidochelone = mob:getID()+1;
+    local ToD = GetServerVariable("[POP]Aspidochelone");
+    local kills = GetServerVariable("[PH]Aspidochelone");
+    local popNow = (math.random(1,5) == 3 or kills > 6);
+
+    if (LandKingSystem_HQ ~= 1 and ToD <= os.time(t) and popNow == true) then
+        -- 0 = timed spawn, 1 = force pop only, 2 = BOTH
+        if (LandKingSystem_NQ == 0) then
+            DeterMob(Adamantoise, true);
         end
-    elseif (LandKingSystem_NQ == 0 or LandKingSystem_NQ == 2) then
-        UpdateNMSpawnPoint(Adamantoise);
-        mob:setRespawnTime(math.random((75600),(86400)));
-        SetServerVariable("[PH]Aspidochelone", kills + 1);
+
+        DeterMob(Aspidochelone, false);
+        UpdateNMSpawnPoint(Aspidochelone);
+        GetMobByID(Aspidochelone):setRespawnTime(math.random(75600,86400));
+    else
+        if (LandKingSystem_NQ ~= 1) then
+            UpdateNMSpawnPoint(Adamantoise);
+            mob:setRespawnTime(math.random(75600,86400));
+            SetServerVariable("[PH]Aspidochelone", kills + 1);
+        end
     end
 end;

--- a/scripts/zones/Valley_of_Sorrows/mobs/Aspidochelone.lua
+++ b/scripts/zones/Valley_of_Sorrows/mobs/Aspidochelone.lua
@@ -23,19 +23,21 @@ function onMobDeath(mob, killer)
     killer:addTitle(ASPIDOCHELONE_SINKER);
 
     -- Set Aspidochelone's Window Open Time
-    if (LandKingSystem_HQ == 0 or LandKingSystem_HQ == 2) then
-        local wait = 72 * 3600
+    if (LandKingSystem_HQ ~= 1) then
+        local wait = 72 * 3600;
         SetServerVariable("[POP]Aspidochelone", os.time(t) + wait); -- 3 days
-        DeterMob(mob:getID(), true);
+        if (LandKingSystem_HQ == 0) then -- Is time spawn only
+            DeterMob(mob:getID(), true);
+        end
     end
 
     -- Set Adamantoise's spawnpoint and respawn time (21-24 hours)
-    if (LandKingSystem_NQ == 0 or LandKingSystem_NQ == 2) then
-        Adamantoise = 17301537;
+    if (LandKingSystem_NQ ~= 1) then
+        Adamantoise = mob:getID()-1;
         SetServerVariable("[PH]Aspidochelone", 0);
         DeterMob(Adamantoise, false);
         UpdateNMSpawnPoint(Adamantoise);
-        GetMobByID(Adamantoise):setRespawnTime(math.random((75600),(86400)));
+        GetMobByID(Adamantoise):setRespawnTime(math.random(75600,86400));
     end
 
 end;

--- a/scripts/zones/Valley_of_Sorrows/npcs/qm1.lua
+++ b/scripts/zones/Valley_of_Sorrows/npcs/qm1.lua
@@ -1,13 +1,13 @@
 -----------------------------------
 -- Area: Valley of Sorrows
--- NPC:  qm1 (???)
--- Note: Used to spawn Adamantoise and Aspidochelone
+--  NPC: qm1 (???)
+-- Spawns Adamantoise or Aspidochelone
 -- @pos 0 0 -37 59
 -----------------------------------
 package.loaded["scripts/zones/Valley_of_Sorrows/TextIDs"] = nil;
 -----------------------------------
-
 require("scripts/zones/Valley_of_Sorrows/TextIDs");
+require("scripts/globals/settings");
 require("scripts/globals/status");
 
 -----------------------------------
@@ -15,21 +15,26 @@ require("scripts/globals/status");
 -----------------------------------
 
 function onTrade(player,npc,trade)
-	local Adamantoise = GetMobAction(17301537);
-	local Aspidochelone = GetMobAction(17301538);
-	-- Trade Clump of Red Pondweed
-	if ((Aspidochelone == ACTION_NONE or Aspidochelone == ACTION_SPAWN) and trade:hasItemQty(3344,1) and trade:getItemCount() == 1) then -- Check trade, and if mob is ACTION_NONE (0) or waiting to spawn (24)
-		if (LandKingSystem_HQ == 1 or LandKingSystem_HQ == 2) then
-			player:tradeComplete();
-			SpawnMob(17301538,180):updateClaim(player);
-		end
-		-- Trade Clump of Blue Pondweed
-	elseif ((Adamantoise == ACTION_NONE or Adamantoise == ACTION_SPAWN) and trade:hasItemQty(3343,1) and trade:getItemCount() == 1) then
-		if (LandKingSystem_NQ == 1 or LandKingSystem_NQ == 2) then
-			player:tradeComplete();
-			SpawnMob(17301537,180):updateClaim(player);
-		end
-	end
+    local Adamantoise = GetMobAction(17301537);
+    local Aspidochelone = GetMobAction(17301538);
+
+    if ((Aspidochelone == ACTION_NONE or Aspidochelone == ACTION_SPAWN)
+    and (Adamantoise == ACTION_NONE or Adamantoise == ACTION_SPAWN)) then
+        -- Trade Clump of Blue Pondweed
+        if (trade:hasItemQty(3343,1) and trade:getItemCount() == 1) then
+            if (LandKingSystem_NQ ~= 0) then
+                player:tradeComplete();
+                SpawnMob(17301537):updateClaim(player);
+            end
+        -- Trade Clump of Red Pondweed
+        elseif (trade:hasItemQty(3344,1) and trade:getItemCount() == 1) then
+            if (LandKingSystem_HQ ~= 0) then
+                player:tradeComplete();
+                SpawnMob(17301538):updateClaim(player);
+            end
+        end
+    end
+
 end;
 
 -----------------------------------
@@ -37,7 +42,7 @@ end;
 -----------------------------------
 
 function onTrigger(player,npc)
-	player:messageSpecial(NOTHING_OUT_OF_ORDINARY);
+    player:messageSpecial(NOTHING_OUT_OF_ORDINARY);
 end;
 
 -----------------------------------
@@ -45,8 +50,8 @@ end;
 -----------------------------------
 
 function onEventUpdate(player,csid,option)
---printf("CSID: %u",csid);
---printf("RESULT: %u",option);
+    -- printf("CSID: %u",csid);
+    -- printf("RESULT: %u",option);
 end;
 
 -----------------------------------
@@ -54,6 +59,6 @@ end;
 -----------------------------------
 
 function onEventFinish(player,csid,option)
---printf("CSID: %u",csid);
---printf("RESULT: %u",option);
+    -- printf("CSID: %u",csid);
+    -- printf("RESULT: %u",option);
 end;

--- a/scripts/zones/Valley_of_Sorrows/npcs/qm2.lua
+++ b/scripts/zones/Valley_of_Sorrows/npcs/qm2.lua
@@ -1,12 +1,11 @@
 -----------------------------------
 -- Area: Valley of Sorrows
--- NPC:  qm2 (???)
+--  NPC: qm2 (???)
 -- Note: Used to rank 9.1 San d'oria
 -- @pos 91 -3 -16 128
 -----------------------------------
 package.loaded["scripts/zones/Valley_of_Sorrows/TextIDs"] = nil;
 -----------------------------------
-
 require("scripts/zones/Valley_of_Sorrows/TextIDs");
 require("scripts/globals/status");
 require("scripts/globals/keyitems");
@@ -15,36 +14,38 @@ require("scripts/globals/missions");
 -----------------------------------
 -- onTrade Action
 -----------------------------------
+
 function onTrade(player,npc,trade)
---printf("CSID: %u",csid);
---printf("RESULT: %u",option);
 end;
 
 -----------------------------------
 -- onTrigger Action
 -----------------------------------
+
 function onTrigger(player,npc)
-	if (player:getCurrentMission(SANDORIA) == BREAKING_BARRIERS and player:getVar("MissionStatus") == 1) then
-		player:addKeyItem(FIGURE_OF_TITAN);
-		player:messageSpecial(KEYITEM_OBTAINED,FIGURE_OF_TITAN);
-		player:setVar("MissionStatus",2);
-	else
-		player:messageSpecial(NOTHING_OUT_OF_ORDINARY);
-	end
+    if (player:getCurrentMission(SANDORIA) == BREAKING_BARRIERS and player:getVar("MissionStatus") == 1) then
+        player:addKeyItem(FIGURE_OF_TITAN);
+        player:messageSpecial(KEYITEM_OBTAINED,FIGURE_OF_TITAN);
+        player:setVar("MissionStatus",2);
+    else
+        player:messageSpecial(NOTHING_OUT_OF_ORDINARY);
+    end
 end;
 
 -----------------------------------
 -- onEventUpdate
 -----------------------------------
+
 function onEventUpdate(player,csid,option)
---printf("CSID: %u",csid);
---printf("RESULT: %u",option);
+    -- printf("CSID: %u",csid);
+    -- printf("RESULT: %u",option);
 end;
 
 -----------------------------------
 -- onEventFinish
 -----------------------------------
+
 function onEventFinish(player,csid,option)
---printf("CSID: %u",csid);
---printf("RESULT: %u",option);
+    -- printf("CSID: %u",csid);
+    -- printf("RESULT: %u",option);
 end;


### PR DESCRIPTION
The diff report is gonna look like hell even with whitespace changes hidden because I just straight up rewrote and replaced some files (and made some consistency changes while I was at it - one line ending type onry).

I tested that correct mobs were set `Deter(id, true)` when set to timed pops, and made sure the force popping works correct after my changes. If the 2 settings don't match its normal that you'll occasionally see both NQ and HQ pops up at once under some circumstances. I've changed the default so that on an unmodified clone of the repository this does not happen unless deliberately set by the server operator.