### PR TITLE
Scripts: Make mobs despawn on teleport effect

### DIFF
--- a/scripts/commands/despawnmob.lua
+++ b/scripts/commands/despawnmob.lua
@@ -16,7 +16,7 @@ function onTrigger(player, mobId)
         player:PrintToPlayer(targ .. " despawned.");
     elseif (mobId ~= nil and (mobId ~= nil or tonumber(mobId) ~= nil or tonumber(mobId) ~= 0)) then
         DespawnMob(mobId);
-        player:PrintToPlayer(mobID .. " despawned.");
+        player:PrintToPlayer(mobId .. " despawned.");
     else
         player:PrintToPlayer("No target specified.");
     end;

--- a/scripts/globals/effects/teleport.lua
+++ b/scripts/globals/effects/teleport.lua
@@ -26,8 +26,10 @@ end;
 -----------------------------------
 
 function onEffectLose(target,effect)
-   local Teleport = effect:getPower();
-    if (Teleport == TELEPORT_DEM) then
+    local Teleport = effect:getPower();
+    if (target:isMob()) then
+        DespawnMob(target:getID())
+    elseif (Teleport == TELEPORT_DEM) then
         toDem(target);
     elseif (Teleport == TELEPORT_HOLLA) then
         toHolla(target);


### PR DESCRIPTION
For future handling of the handful of mobs that cast warp (ie. animated weapons, at least in old school, do they still do it on retail?). Player warps work fine.

Also corrected a minor typo in the despawnmob command.