### PR TITLE
changed the ForgeYourDestiny_timer to a correct value of 10800

### DIFF
--- a/scripts/zones/Norg/npcs/Jaucribaix.lua
+++ b/scripts/zones/Norg/npcs/Jaucribaix.lua
@@ -154,7 +154,7 @@ function onEventFinish(player,csid,option)
 		player:addQuest(OUTLANDS,FORGE_YOUR_DESTINY);
 	elseif (csid == 0x001b) then
 		player:tradeComplete();
-		player:setVar("ForgeYourDestiny_timer", os.time() + 10368); --Add 3 game days
+		player:setVar("ForgeYourDestiny_timer", os.time() + 10800); --Add 3 game days
 	elseif (csid == 0x001d) then
 		player:tradeComplete();
 		player:addTitle(BUSHIDO_BLADE);


### PR DESCRIPTION
changed the ForgeYourDestiny_timer to a correct value of 10800 witch is 3 hrs / 3 in-game days, instead of the 10368 witch is 2.885 hrs /2.885 in-game days.