### PR TITLE
SCRIPTS/LUA: Medusa Javelin Update for AV

### DIFF
--- a/scripts/globals/mobskills/Medusa_Javelin.lua
+++ b/scripts/globals/mobskills/Medusa_Javelin.lua
@@ -25,7 +25,7 @@ function onMobWeaponSkill(target, mob, skill)
     	end
 	local info = MobPhysicalMove(mob,target,skill,numhits,accmod,dmgmod,TP_NO_EFFECT);
 	local dmg = MobFinalAdjustments(info.dmg,mob,skill,target,MOBSKILL_PHYSICAL,MOBPARAM_NONE,info.hitslanded);
-	target:delHP(dmg);	
+	target:delHP(dmg);
 
 	local typeEffect = EFFECT_PETRIFICATION;
 

--- a/scripts/globals/mobskills/Medusa_Javelin.lua
+++ b/scripts/globals/mobskills/Medusa_Javelin.lua
@@ -16,16 +16,23 @@ end;
 
 function onMobWeaponSkill(target, mob, skill)
 
+	local mobID = mob:getID();
 	local numhits = 1;
 	local accmod = 1;
 	local dmgmod = 1.5;
+	if (mobID == 16912876) then 
+   	dmgmod = 10.5;
+    	end
 	local info = MobPhysicalMove(mob,target,skill,numhits,accmod,dmgmod,TP_NO_EFFECT);
 	local dmg = MobFinalAdjustments(info.dmg,mob,skill,target,MOBSKILL_PHYSICAL,MOBPARAM_NONE,info.hitslanded);
-	target:delHP(dmg);
+	target:delHP(dmg);	
 
 	local typeEffect = EFFECT_PETRIFICATION;
 
 	MobPhysicalStatusEffectMove(mob, target, skill, typeEffect, 1, 0, 60);
+
+	
+		
 
 	return dmg;
 end;


### PR DESCRIPTION
Changed to deal the correct amount of damage specifically for AV, seeing as he is the only mob in the family ID that uses medusa javelin to require this modifier thought this would be the most straightforward approach.