### PR TITLE
The Sandworm Lua's

### DIFF
--- a/scripts/globals/mobskills/Aeolian_Void.lua
+++ b/scripts/globals/mobskills/Aeolian_Void.lua
@@ -1,0 +1,36 @@
+---------------------------------------------
+--  Aeolian Void
+--
+--  Description: AoE Blind and Silence. Goes through shadows.
+--
+---------------------------------------------
+require("scripts/globals/settings");
+require("scripts/globals/status");
+require("scripts/globals/monstertpmoves");
+
+---------------------------------------------
+function onMobSkillCheck(target,mob,skill)
+	return 0;
+end;
+
+function onMobWeaponSkill(target, mob, skill)
+	local typeEffect = EFFECT_BLINDNESS;
+	local power = 15;
+	local duration = 120;
+
+	MobStatusEffectMove(mob, target, typeEffect, power, 0, duration);
+
+	local dmgmod = 1;
+	local info = MobMagicalMove(mob,target,skill,mob:getWeaponDmg()*5,ELE_DARK,dmgmod,TP_NO_EFFECT);
+	local dmg = MobFinalAdjustments(info.dmg,mob,skill,target,MOBSKILL_MAGICAL,MOBPARAM_DARK,MOBPARAM_IGNORE_SHADOWS);
+	target:delHP(dmg);
+	
+	   
+	local typeEffect = EFFECT_SILENCE;
+
+    skill:setMsg(MobStatusEffectMove(mob, target, typeEffect, 1, 0, 60));
+
+    return typeEffect,dmg;
+	
+	
+end;

--- a/scripts/globals/mobskills/Bubble_Shower.lua
+++ b/scripts/globals/mobskills/Bubble_Shower.lua
@@ -1,6 +1,6 @@
 ---------------------------------------------------
 -- Bubble Shower
--- Deals Water damage in an area of effect. Additional effect: STR Down
+-- Deals Water damage in an area of effect. Additional effect: Spawns Adds on King Arthro Fight
 ---------------------------------------------------
 
 require("scripts/globals/settings");
@@ -9,7 +9,25 @@ require("scripts/globals/monstertpmoves");
 
 ---------------------------------------------------
 
-function onMobSkillCheck(target,mob,skill)
+function onMobSkillCheck(target,mob,skill,zone)
+	mob = mob:getID();
+	if (mob == 17129519) then
+	local mobids = {17129520,   -- King Arthro's Knights
+		17129521,
+		17129522,
+		17129523,
+		17129524,
+		17129525,
+		17129526,
+		17129527,
+		17129528,
+		17129529,
+		17129530,
+		17129531}
+	local mob = mobids[math.random(1, #mobids)];
+	SpawnMob(mob);
+	end;
+	
 	return 0;
 end;
 

--- a/scripts/globals/mobskills/Doomvoid.lua
+++ b/scripts/globals/mobskills/Doomvoid.lua
@@ -1,0 +1,72 @@
+---------------------------------------------
+--  Doomvoid
+--
+--  Description: Teleports all alliance members within 25' distance of itself into another zone to fight
+-- 	a high level, shaworeign version, HNM for 60 mins.
+--  
+---------------------------------------------
+require("scripts/globals/settings");
+require("scripts/globals/status");
+require("scripts/globals/monstertpmoves");
+
+---------------------------------------------
+function onMobSkillCheck(target,mob,skill)
+	if (mob:getHPP() > 35) then
+        return 1;
+    end
+    return 0;
+end;
+	
+
+function onMobWeaponSkill(target, mob, skill,killer,ally,zone)
+	
+	
+	local zone = target:getZoneID();
+	local random = 0;
+	random = math.random(10);
+		
+	
+	if (mob:getLocalVar"KingArthroFight" == 1) then
+		SpawnMob(17129519);
+		target:setPos(-19.938, -8.750, -320.105, 65, 86);
+		
+		end
+		
+	if (mob:getLocalVar"LambtonWormFight" == 1) then
+		SpawnMob(17129532);
+		target:setPos(-241.068, 0, -402.123, 60, 86);
+		
+		end
+		
+	if (mob:getLocalVar"SerketFight" == 1) then
+		SpawnMob(17305666);
+		target:setPos(102.365,-0.206,-295.594, 60, 129);
+		end
+		
+	if (mob:getLocalVar"LambtonWormFight" == 2) then
+		SpawnMob(17305667);
+		target:setPos(-323.390, 0, -419.010, 60, 129);
+		end
+		
+		
+	if (mob:getLocalVar"GuivreFight" == 1) then
+		SpawnMob(17158202);
+		target:setPos(-20.541, 0, 249.768, 60, 93);
+		
+		end
+		
+	if (mob:getLocalVar"LambtonWormFight" == 3) then
+		SpawnMob(17158202);
+		target:setPos(347.866, 0, -460.499, 100, 93);
+		end
+		
+	
+		if (mob:getID() == 17129532 or  mob:getID() == 17158203 or mob:getID() == 17305667) then
+		MobBuffMove(mob, EFFECT_MAGIC_SHIELD, 5, 0, 30);
+		MobBuffMove(mob,EFFECT_PHYSICAL_SHIELD,5,0,30);
+		mob:setMsg(MSG_BUFF);
+		
+	
+		end
+		
+end;

--- a/scripts/globals/mobskills/Slaverous_Gale.lua
+++ b/scripts/globals/mobskills/Slaverous_Gale.lua
@@ -1,0 +1,25 @@
+---------------------------------------------
+--  Slaverous Gale
+--
+--  Description: AoE ability which drains *all* buffs and debuffs, transferring them to Sandworm (except sigil). 
+--  also causes BST pets to become uncharmed and jug pets to despawn. Does not seem to absorb Stoneskin.
+--
+---------------------------------------------
+require("scripts/globals/settings");
+require("scripts/globals/status");
+require("scripts/globals/monstertpmoves");
+
+---------------------------------------------
+function onMobSkillCheck(target,mob,skill)
+	return 0;
+end;
+
+function onMobWeaponSkill(target, mob, skill)
+	local typeEffect = EFFECT_PLAGUE;
+    skill:setMsg(MobStatusEffectMove(mob, target, typeEffect, 5, 0, 60));
+
+    local typeEffect = EFFECT_SLOW;
+    skill:setMsg(MobStatusEffectMove(mob, target, typeEffect, 128, 0, 120));
+
+	return typeEffect;
+end;

--- a/scripts/zones/Batallia_Downs_[S]/mobs/Sandworm.lua
+++ b/scripts/zones/Batallia_Downs_[S]/mobs/Sandworm.lua
@@ -5,13 +5,42 @@
 -----------------------------------
 
 require("scripts/globals/titles");
+-----------------------------------
+-- onMobInitialize
+-----------------------------------
 
 -----------------------------------
 -- onMobSpawn Action
 -----------------------------------
 
 function onMobSpawn(mob)
+		
+		DespawnMob(17138041); 
+		DespawnMob(17150317); 
+		DespawnMob(17109357); 
+		DespawnMob(17166720); 
+		DespawnMob(17178901); 
+		DespawnMob(17174888); 
+		
+		local random = 0;
+		random = math.random(10);
+		
+		if (random <=7) then
+		mob:setLocalVar("KingArthroFight",1);
+		end
+		if (random >=8) then
+		mob:setLocalVar("LambtonWormFight",1);
+		end
+	
 end;
+-----------------------------------
+-- onMobWeaponSkill
+-----------------------------------
+function onMobWeaponSkill(target, mob, skill)
+     if (mob:getHP() < ((mob:getMaxHP() / 10) * 2.5)) then
+	mob:useMobAbility(1936);
+	end
+end
 
 -----------------------------------
 -- onMobDeath
@@ -19,4 +48,13 @@ end;
 
 function onMobDeath(mob, killer)
 	killer:addTitle(SANDWORM_WRANGLER);
+	mob:setRespawnTime(math.random(75600,86400));
+
+end;
+-----------------------------------
+-- onMobDespawn
+-----------------------------------
+
+function onMobDespawn(mob)
+
 end;

--- a/scripts/zones/East_Ronfaure_[S]/Zone.lua
+++ b/scripts/zones/East_Ronfaure_[S]/Zone.lua
@@ -17,13 +17,13 @@ require("scripts/globals/missions");
 function onInitialize(zone)
 
 	local mobids = {17109357,
-					17138041,
-					17166720,
-					17178901,
-					17121693,
-					17150317,
-					17174888}
-	local mob = mobids[math.random(1, #mobids)];
+			17138041,
+			17166720,
+			17178901,
+			17121693,
+			17150317,
+			17174888}
+	local mob = mobids[math.random(2, #mobids)];
 	SpawnMob(mob);
 
 end;

--- a/scripts/zones/East_Ronfaure_[S]/Zone.lua
+++ b/scripts/zones/East_Ronfaure_[S]/Zone.lua
@@ -16,15 +16,15 @@ require("scripts/globals/missions");
 
 function onInitialize(zone)
 
-	local mobids = {17109357,
-			17138041,
-			17166720,
-			17178901,
-			17121693,
-			17150317,
-			17174888}
-	local mob = mobids[math.random(2, #mobids)];
-	SpawnMob(mob);
+local mobids = {17109357,
+	17138041,
+	17166720,
+	17178901,
+	17121693,
+	17150317,
+	17174888}
+local mob = mobids[math.random(2, #mobids)];
+SpawnMob(mob);
 
 end;
 

--- a/scripts/zones/East_Ronfaure_[S]/Zone.lua
+++ b/scripts/zones/East_Ronfaure_[S]/Zone.lua
@@ -72,4 +72,4 @@ function onEventFinish(player,csid,option)
         player:completeMission(WOTG, WHILE_THE_CAT_IS_AWAY);
         player:addMission(WOTG, A_TIMESWEPT_BUTTERFLY);
     end
-end;    
+end;

--- a/scripts/zones/East_Ronfaure_[S]/mobs/Sandworm.lua
+++ b/scripts/zones/East_Ronfaure_[S]/mobs/Sandworm.lua
@@ -5,18 +5,68 @@
 -----------------------------------
 
 require("scripts/globals/titles");
+-----------------------------------
+-- onMobInitialize
+-----------------------------------
 
+function onMobInitialize(mob)	
+	
+	
+end;
 -----------------------------------
 -- onMobSpawn Action
 -----------------------------------
 
-function onMobSpawn(mob)
+function onMobSpawn(mob,player)
+		
+	DespawnMob(17138041); 
+	DespawnMob(17166720);
+	DespawnMob(17178901);
+	DespawnMob(17121693);
+	DespawnMob(17150317);
+	DespawnMob(17174888);		
+		
+		local random = 0;
+		random = math.random(10);
+		
+		if (random <=7) then
+		mob:setLocalVar("KingArthroFight",1);
+		end
+		if (random >=8) then
+		mob:setLocalVar("LambtonWormFight",1);
+		end
+	
 end;
+-----------------------------------
+-- onMobFight Action
+-----------------------------------
+
+function onMobFight(mob, target)
+	
+
+end;
+-----------------------------------
+-- onMobWeaponSkill
+-----------------------------------
+function onMobWeaponSkill(target, mob, skill)
+     if (mob:getHP() < ((mob:getMaxHP() / 10) * 2.5)) then
+	mob:useMobAbility(1936);
+	end
+end
 
 -----------------------------------
 -- onMobDeath
 -----------------------------------
 
-function onMobDeath(mob, killer)
+function onMobDeath(mob,killer)
 	killer:addTitle(SANDWORM_WRANGLER);
+	mob:setRespawnTime(math.random(75600,86400));
+	
+end;
+-----------------------------------
+-- onMobDespawn
+-----------------------------------
+
+function onMobDespawn(mob)
+		
 end;

--- a/scripts/zones/Everbloom_Hollow/Zone.lua
+++ b/scripts/zones/Everbloom_Hollow/Zone.lua
@@ -12,18 +12,38 @@ require("scripts/zones/Everbloom_Hollow/TextIDs");
 --  onInitialize
 -----------------------------------
 
-function onInitialize(zone)
+function onInitialize(zone,mob)
+	local mobids = {17129520, -- King Arthro's  Knights
+					17129521,
+					17129522,
+					17129523,
+					17129524,
+					17129525,
+					17129526,
+					17129527,
+					17129528,
+					17129529,
+					17129530,
+					17129531}
+	local mob = mobids[math.random(12, #mobids)];
+	DespawnMob(mob);
+	
 end;
 
 -----------------------------------
 -- onZoneIn
 -----------------------------------
 
-function onZoneIn(player,prevZone)
-cs = -1;
-
-return cs;
+function onZoneIn(player,prevZone,zone)
+	
+	cs = -1;
+	if (prevZone == 81 or prevZone == 84)then
+	GetMobByID(17109357):setHP(0);
+	GetMobByID(17121693):setHP(0);
+	end
+	return cs;
 end;
+
 
 -----------------------------------
 -- onRegionEnter          
@@ -49,6 +69,7 @@ function onEventFinish(player,csid,option)
 --printf("CSID: %u",csid);
 --printf("RESULT: %u",option);
 end;
+
 
 
 

--- a/scripts/zones/Everbloom_Hollow/mobs/King_Arthro.lua
+++ b/scripts/zones/Everbloom_Hollow/mobs/King_Arthro.lua
@@ -1,0 +1,55 @@
+-----------------------------------
+-- Area: BCNM
+-- NPC:  King Arthro
+-----------------------------------
+
+require("scripts/globals/titles");
+
+-----------------------------------
+-- onMobSpawn Action
+-----------------------------------
+
+function onMobSpawn(mob)
+end;
+-----------------------------------
+-- onMobFight
+-----------------------------------
+function onMobFight(mob, target)
+
+end;
+    
+        
+-----------------------------------
+-- onMonsterMagicPrepare
+-----------------------------------
+
+function onMonsterMagicPrepare(mob, target)
+    
+	-- Instant cast on spells - Waterga IV, Poisonga II, Drown, and Enwater
+	local rnd = math.random();
+	
+	if (rnd < 0.2) then
+		return 202; -- Waterga IV
+	elseif (rnd < 0.6) then
+		return 226; -- Poisonga II
+	elseif (rnd < 0.8) then
+		return 240; -- Drown
+	else
+		return 105; -- Enwater
+	end
+    
+end;
+
+-----------------------------------
+-- onMobSkill
+-----------------------------------
+function onMobSkill(target)
+
+end;
+-----------------------------------
+-- onMobDeath
+-----------------------------------
+
+function onMobDeath(mob, killer)
+	killer:addItem(4181);
+end;

--- a/scripts/zones/Everbloom_Hollow/mobs/Knight_Crab.lua
+++ b/scripts/zones/Everbloom_Hollow/mobs/Knight_Crab.lua
@@ -1,0 +1,56 @@
+-----------------------------------
+-- Area: Everbloom Hollow
+-- NPC:  Knight Crab
+-----------------------------------
+
+require("scripts/globals/titles");
+
+-----------------------------------
+-- onMobSpawn Action
+-----------------------------------
+
+function onMobSpawn(mob,target)
+	
+end;
+-----------------------------------
+-- onMonsterMagicPrepare
+-----------------------------------
+function onMonsterMagicPrepare(mob,target)
+	local rnd = math.random();
+	
+	if (rnd < 0.6) then
+		return 4;
+		
+	end
+	
+
+end;
+
+-----------------------------------
+-- onSpellPrecast
+-----------------------------------
+
+function onSpellPrecast(mob, spell)
+	 if (spell:getID() == 4) then
+        spell:setAoE(SPELLAOE_RADIAL);
+        spell:setFlag(SPELLFLAG_HIT_ALL);
+        spell:setRadius(30);
+        spell:setAnimation(172);
+        spell:setMPCost(1);
+    end
+end;
+
+-----------------------------------
+-- onMobDeath
+-----------------------------------
+
+function onMobDeath(mob, killer)
+end;
+
+-----------------------------------
+-- onMobDespawn
+-----------------------------------
+
+function onMobDespawn(mob)
+    
+end;

--- a/scripts/zones/Everbloom_Hollow/mobs/Lambton_Worm.lua
+++ b/scripts/zones/Everbloom_Hollow/mobs/Lambton_Worm.lua
@@ -18,4 +18,5 @@ end;
 
 function onMobDeath(mob, killer)
 	killer:addTitle(LAMBTON_WORM_DESEGMENTER);
+	killer:addItem(4181);
 end;

--- a/scripts/zones/Ghoyus_Reverie/Zone.lua
+++ b/scripts/zones/Ghoyus_Reverie/Zone.lua
@@ -21,7 +21,11 @@ end;
 
 function onZoneIn(player,prevZone)
 cs = -1;
-
+	if (prevZone == 95 or prevZone == 97 or prevZone == 98) then
+		GetMobByID(17166720):setHP(0);
+		GetMobByID(17174888):setHP(0);
+		GetMobByID(17178901):setHP(0);
+	end
 return cs;
 end;
 

--- a/scripts/zones/Ghoyus_Reverie/mobs/Lambton_Worm.lua
+++ b/scripts/zones/Ghoyus_Reverie/mobs/Lambton_Worm.lua
@@ -18,4 +18,5 @@ end;
 
 function onMobDeath(mob, killer)
 	killer:addTitle(LAMBTON_WORM_DESEGMENTER);
+	killer:addItem(4181);
 end;

--- a/scripts/zones/Ghoyus_Reverie/mobs/Serket.lua
+++ b/scripts/zones/Ghoyus_Reverie/mobs/Serket.lua
@@ -1,0 +1,22 @@
+-----------------------------------
+-- Area: BCNM
+-- NPC:  Serket
+-----------------------------------
+
+require("scripts/globals/titles");
+
+-----------------------------------
+-- onMobSpawn Action
+-----------------------------------
+
+function onMobSpawn(mob)
+end;
+
+-----------------------------------
+-- onMobDeath
+-----------------------------------
+
+function onMobDeath(mob, killer,player)
+
+	killer:addItem(4181);
+end;

--- a/scripts/zones/Meriphataud_Mountains_[S]/mobs/Sandworm.lua
+++ b/scripts/zones/Meriphataud_Mountains_[S]/mobs/Sandworm.lua
@@ -46,7 +46,7 @@ end
 function onMobDeath(mob, killer)
 	killer:addTitle(SANDWORM_WRANGLER);
 -- mob:setRespawnTime(math.random(75600,86400));
-	mob:setRespawnTime(math.random(64,128));
+	mob:setRespawnTime(math.random(75600,86400));
 end;
 -----------------------------------
 -- onMobDespawn

--- a/scripts/zones/Meriphataud_Mountains_[S]/mobs/Sandworm.lua
+++ b/scripts/zones/Meriphataud_Mountains_[S]/mobs/Sandworm.lua
@@ -1,17 +1,43 @@
 -----------------------------------
--- Area: Crystal War Areas
+-- Area: Meriphataud_Mountains_S
 -- NPC:  Sandworm
 -- Note:  Title Given if Sandworm does not Doomvoid
 -----------------------------------
 
 require("scripts/globals/titles");
+-----------------------------------
+-- onMobInitialize
+-----------------------------------
 
 -----------------------------------
 -- onMobSpawn Action
 -----------------------------------
 
 function onMobSpawn(mob)
+		DespawnMob(17138041); 
+		DespawnMob(17150317); 
+		DespawnMob(17109357); 
+		DespawnMob(17166720); 
+		DespawnMob(17178901); 
+		DespawnMob(17121693); 
+		local random = 0;
+		random = math.random(10);
+		
+		if (random<=7) then
+		mob:setLocalVar("SerketFight",1);
+		end
+		if (random >=8) then
+		mob:setLocalVar("LambtonWormFight",2);
+		end
 end;
+-----------------------------------
+-- onMobWeaponSkill
+-----------------------------------
+function onMobWeaponSkill(target, mob, skill)
+     if (mob:getHP() < ((mob:getMaxHP() / 10) * 2.5)) then
+	mob:useMobAbility(1936);
+	end
+end
 
 -----------------------------------
 -- onMobDeath
@@ -19,4 +45,13 @@ end;
 
 function onMobDeath(mob, killer)
 	killer:addTitle(SANDWORM_WRANGLER);
+-- mob:setRespawnTime(math.random(75600,86400));
+	mob:setRespawnTime(math.random(64,128));
+end;
+-----------------------------------
+-- onMobDespawn
+-----------------------------------
+
+function onMobDespawn(mob)
+
 end;

--- a/scripts/zones/North_Gustaberg_[S]/mobs/Sandworm.lua
+++ b/scripts/zones/North_Gustaberg_[S]/mobs/Sandworm.lua
@@ -48,7 +48,7 @@ end
 
 function onMobDeath(mob, killer)
 	killer:addTitle(SANDWORM_WRANGLER);
-	mob:setRespawnTime(math.random(64,128));
+	mob:setRespawnTime(math.random(75600,86400));
 
 end;
 -----------------------------------

--- a/scripts/zones/North_Gustaberg_[S]/mobs/Sandworm.lua
+++ b/scripts/zones/North_Gustaberg_[S]/mobs/Sandworm.lua
@@ -1,17 +1,46 @@
 -----------------------------------
--- Area: Crystal War Areas
+-- Area: North_Gustaberg_S
 -- NPC:  Sandworm
 -- Note:  Title Given if Sandworm does not Doomvoid
 -----------------------------------
 
 require("scripts/globals/titles");
+-----------------------------------
+-- onMobInitialize
+-----------------------------------
+
 
 -----------------------------------
 -- onMobSpawn Action
 -----------------------------------
 
 function onMobSpawn(mob)
+	
+		DespawnMob(17150317); 
+		DespawnMob(17109357); 
+		DespawnMob(17166720); 
+		DespawnMob(17178901); 
+		DespawnMob(17121693); 
+		DespawnMob(17174888); 	
+		local random = 0;
+		random = math.random(10);
+		
+		if (random<=7) then
+		mob:setLocalVar("GuivreFight",1);
+		end
+		if (random >=8) then
+		mob:setLocalVar("LambtonWormFight",3);
+		end
+	
 end;
+-----------------------------------
+-- onMobWeaponSkill
+-----------------------------------
+function onMobWeaponSkill(target, mob, skill)
+     if (mob:getHP() < ((mob:getMaxHP() / 10) * 2.5)) then
+	mob:useMobAbility(1936);
+	end
+end
 
 -----------------------------------
 -- onMobDeath
@@ -19,4 +48,13 @@ end;
 
 function onMobDeath(mob, killer)
 	killer:addTitle(SANDWORM_WRANGLER);
+	mob:setRespawnTime(math.random(64,128));
+
+end;
+-----------------------------------
+-- onMobDespawn
+-----------------------------------
+
+function onMobDespawn(mob)
+
 end;

--- a/scripts/zones/Rolanberry_Fields_[S]/mobs/Sandworm.lua
+++ b/scripts/zones/Rolanberry_Fields_[S]/mobs/Sandworm.lua
@@ -1,17 +1,44 @@
 -----------------------------------
--- Area: Crystal War Areas
+-- Area: Rolanberry_Fields
 -- NPC:  Sandworm
 -- Note:  Title Given if Sandworm does not Doomvoid
 -----------------------------------
 
 require("scripts/globals/titles");
+-----------------------------------
+-- onMobInitialize
+-----------------------------------
 
 -----------------------------------
 -- onMobSpawn Action
 -----------------------------------
 
 function onMobSpawn(mob)
+			
+		DespawnMob(17109357); 
+		DespawnMob(17138041); 
+		DespawnMob(17166720); 
+		DespawnMob(17178901); 
+		DespawnMob(17121693); 
+		DespawnMob(17174888); 	
+		local random = 0;
+		random = math.random(10);
+		
+		if (random<=7) then
+		mob:setLocalVar("GuivreFight",1);
+		end
+		if (random >=8) then
+		mob:setLocalVar("LambtonWormFight",3);
+		end
 end;
+-----------------------------------
+-- onMobWeaponSkill
+-----------------------------------
+function onMobWeaponSkill(target, mob, skill)
+     if (mob:getHP() < ((mob:getMaxHP() / 10) * 2.5)) then
+	mob:useMobAbility(1936);
+	end
+end
 
 -----------------------------------
 -- onMobDeath
@@ -19,4 +46,13 @@ end;
 
 function onMobDeath(mob, killer)
 	killer:addTitle(SANDWORM_WRANGLER);
+-- mob:setRespawnTime(math.random(75600,86400));
+		mob:setRespawnTime(math.random(75600,86400));
+end;
+-----------------------------------
+-- onMobDespawn
+-----------------------------------
+
+function onMobDespawn(mob)
+
 end;

--- a/scripts/zones/Ruhotz_Silvermines/Zone.lua
+++ b/scripts/zones/Ruhotz_Silvermines/Zone.lua
@@ -20,9 +20,14 @@ end;
 -----------------------------------
 
 function onZoneIn(player,prevZone)
-cs = -1;
+	
+	cs = -1;
 
-return cs;
+	if (prevZone == 88 or prevZone == 91) then
+	GetMobByID(17150317):setHP(0);
+	GetMobByID(17138041):setHP(0);
+	end
+	return cs;
 end;
 
 -----------------------------------
@@ -49,6 +54,7 @@ function onEventFinish(player,csid,option)
 --printf("CSID: %u",csid);
 --printf("RESULT: %u",option);
 end;
+
 
 
 

--- a/scripts/zones/Ruhotz_Silvermines/mobs/Guivre.lua
+++ b/scripts/zones/Ruhotz_Silvermines/mobs/Guivre.lua
@@ -1,0 +1,59 @@
+-----------------------------------
+-- Area: BCNM
+-- NPC:  Guivre
+-----------------------------------
+
+require("scripts/globals/titles");
+
+	local path = 
+	{
+	-79, 0 , 382,
+	-99, 0 , 372,
+	-100,0,354,
+	-103,0,345,
+	-101,0,328,
+	-99,0,308,
+	-89,0,300,
+	-66,0,300,
+	-60,0,310,
+	-59.6,0,328,
+	-54,0,338,
+	-59.5,0,347,
+	-60,0,355,
+	-59,0,368,
+	-70.7,0,379, 
+	};
+
+function onMobSpawn(mob)
+	onMobRoam(mob);
+	mob:speed(90);
+	
+end;
+
+function onPath(mob)
+	pathfind.patrol(mob, path);
+	
+end;
+
+function onMobRoam(mob)
+	-- move to start position if not moving
+	if (mob:isFollowingPath() == false) then
+		mob:pathThrough(pathfind.first(path));
+		
+	end
+	
+end;
+-----------------------------------
+-- onMobFight
+-----------------------------------
+function onMobFight(mob,killer)
+	
+	
+
+end;
+
+function onMobDeath(mob,killer)	
+killer:addItem(4181);
+   
+
+end;

--- a/scripts/zones/Ruhotz_Silvermines/mobs/Lambton_Worm.lua
+++ b/scripts/zones/Ruhotz_Silvermines/mobs/Lambton_Worm.lua
@@ -18,4 +18,5 @@ end;
 
 function onMobDeath(mob, killer)
 	killer:addTitle(LAMBTON_WORM_DESEGMENTER);
+	killer:addItem(4181);
 end;

--- a/scripts/zones/Sauromugue_Champaign_[S]/mobs/Sandworm.lua
+++ b/scripts/zones/Sauromugue_Champaign_[S]/mobs/Sandworm.lua
@@ -1,5 +1,5 @@
 -----------------------------------
--- Area: Crystal War Areas
+-- Area: Sauromuge_Champaign S
 -- NPC:  Sandworm
 -- Note:  Title Given if Sandworm does not Doomvoid
 -----------------------------------
@@ -7,11 +7,40 @@
 require("scripts/globals/titles");
 
 -----------------------------------
+-- onMobInitialize
+-----------------------------------
+
+-----------------------------------
 -- onMobSpawn Action
 -----------------------------------
 
 function onMobSpawn(mob)
+	
+		DespawnMob(17166720); 
+		DespawnMob(17121693); 
+		DespawnMob(17138041); 
+		DespawnMob(17150317); 
+		DespawnMob(17109357); 
+		DespawnMob(17174888); 
+		local random = 0;
+		random = math.random(10);
+		
+		if (random<=7) then
+		mob:setLocalVar("SerketFight",1);
+		end
+		if (random >=8) then
+		mob:setLocalVar("LambtonWormFight",2);
+		end
 end;
+-----------------------------------
+-- onMobWeaponSkill
+-----------------------------------
+function onMobWeaponSkill(target, mob, skill)
+     if (mob:getHP() < ((mob:getMaxHP() / 10) * 2.5)) then
+	mob:useMobAbility(1936);
+	end
+end
+
 
 -----------------------------------
 -- onMobDeath
@@ -19,4 +48,13 @@ end;
 
 function onMobDeath(mob, killer)
 	killer:addTitle(SANDWORM_WRANGLER);
+-- mob:setRespawnTime(math.random(75600,86400));
+	mob:setRespawnTime(math.random(75600,86400));
+end;
+-----------------------------------
+-- onMobDespawn
+-----------------------------------
+
+function onMobDespawn(mob)
+
 end;

--- a/scripts/zones/West_Sarutabaruta_[S]/mobs/Sandworm.lua
+++ b/scripts/zones/West_Sarutabaruta_[S]/mobs/Sandworm.lua
@@ -1,17 +1,44 @@
 -----------------------------------
--- Area: Crystal War Areas
+-- Area: West_Sarutabaruta
 -- NPC:  Sandworm
 -- Note:  Title Given if Sandworm does not Doomvoid
 -----------------------------------
 
 require("scripts/globals/titles");
+-----------------------------------
+-- onMobInitialize
+-----------------------------------
 
 -----------------------------------
 -- onMobSpawn Action
 -----------------------------------
 
 function onMobSpawn(mob)
+		
+		DespawnMob(17121693); 
+		DespawnMob(17138041); 
+		DespawnMob(17150317); 
+		DespawnMob(17109357); 
+		DespawnMob(17178901); 
+		DespawnMob(17174888); 
+		local random = 0;
+		random = math.random(10);
+		
+		if (random<=7) then
+		mob:setLocalVar("SerketFight",1);
+		end
+		if (random >=8) then
+		mob:setLocalVar("LambtonWormFight",2);
+		end
 end;
+-----------------------------------
+-- onMobWeaponSkill
+-----------------------------------
+function onMobWeaponSkill(target, mob, skill)
+     if (mob:getHP() < ((mob:getMaxHP() / 10) * 2.5)) then
+	mob:useMobAbility(1936);
+	end
+end
 
 -----------------------------------
 -- onMobDeath
@@ -19,4 +46,13 @@ end;
 
 function onMobDeath(mob, killer)
 	killer:addTitle(SANDWORM_WRANGLER);
+-- mob:setRespawnTime(math.random(75600,86400));
+	mob:setRespawnTime(math.random(75600,86400));
+end;
+-----------------------------------
+-- onMobDespawn
+-----------------------------------
+
+function onMobDespawn(mob)
+		
 end;

--- a/src/map/ai/helpers/pathfind.cpp
+++ b/src/map/ai/helpers/pathfind.cpp
@@ -330,7 +330,7 @@ bool CPathFind::FindPath(position_t* start, position_t* end)
 
     if (m_pathLength <= 0)
     {
-        ShowError("CPathFind::FindPath Entity (%d) could not find path", m_PTarget->id);
+        ShowError("CPathFind::FindPath Entity (%d) could not find path\n", m_PTarget->id);
         return false;
     }
 


### PR DESCRIPTION
The Sandworm and Lambton LUA's and the zones and the bcnm zones/mobs + updated bubble shower which spawns knight arthros knights. Doomvoid was the major add to make it all work. Everything's been tested and troubleshooted to get to this point. The math.random for sandworm spawn is supposed to be a 2, not a 1. Making it a 1 confuses it and glitches it out and spawns a worm in the same location every time which for some reason takes 0 damage when you atk it with melee. Making that 1 a 2 in the math.random fixed it's confusion and with the other code combined it fixes all possibility of there being more than 1 sandworm up at a time. Spawntype 128 is required. Also notice the doomvoid zone is now predetermined on spawn via Var. When the math.random was decided on use of doomvoid it would split the party and reroll the math random for every person in the party. This has been fixed via the random var on spawn. 