### PR TITLE
Scripts: Add sanity check for switch by Sacrifical Chamber

### DIFF
--- a/scripts/zones/Den_of_Rancor/npcs/Switch.lua
+++ b/scripts/zones/Den_of_Rancor/npcs/Switch.lua
@@ -16,5 +16,7 @@ end;
 -----------------------------------
 
 function onTrigger(player,npc)
-	GetNPCByID(17433051):openDoor(); -- drop gate to Sacrificial Chamber   
+    if (player:getZPos() > 35) then
+        GetNPCByID(17433051):openDoor(); -- drop gate to Sacrificial Chamber
+    end
 end;


### PR DESCRIPTION
Though in my tests I wasn't able to interact with it from the wrong side of the gate, it's still probably a good idea for this check to exist.