### PR TITLE
Stop Windurst mission 1-3 from infinitely repeating itself

### DIFF
--- a/scripts/zones/Windurst_Waters/Zone.lua
+++ b/scripts/zones/Windurst_Waters/Zone.lua
@@ -5,12 +5,11 @@
 -----------------------------------
 package.loaded["scripts/zones/Windurst_Waters/TextIDs"] = nil;
 -----------------------------------
-
-require("scripts/globals/events/harvest_festivals");
-require("scripts/globals/zone");
-require("scripts/globals/settings");
-require("scripts/globals/missions");
 require("scripts/zones/Windurst_Waters/TextIDs");
+require("scripts/globals/events/harvest_festivals");
+require("scripts/globals/missions");
+require("scripts/globals/settings");
+require("scripts/globals/zone");
 
 -----------------------------------
 -- onInitialize
@@ -29,27 +28,29 @@ end;
 
 function onZoneIn(player,prevZone)
     local cs = -1;
+
     -- FIRST LOGIN (START CS)
     if (player:getPlaytime(false) == 0) then
         if (OPENING_CUTSCENE_ENABLE == 1) then
-            cs = 0x213;
+            cs = 531;
         end
         player:setPos(-40,-5,80,64);
         player:setHomePoint();
     end
+
     -- MOG HOUSE EXIT
     if (player:getXPos() == 0 and player:getYPos() == 0 and player:getZPos() == 0) then
         position = math.random(1,5) + 157;
         player:setPos(position,-5,-62,192);
         if (player:getMainJob() ~= player:getVar("PlayerMainJob")) then
-            cs = 0x7534;
+            cs = 30004;
         end
         player:setVar("PlayerMainJob",0);
     end
 
     if (player:getCurrentMission(COP) == THE_ROAD_FORKS and player:getVar("MEMORIES_OF_A_MAIDEN_Status") == 1) then -- COP MEMORIES_OF_A_MAIDEN--3-3B: Windurst Route
         player:setVar("MEMORIES_OF_A_MAIDEN_Status",2);
-        cs = 0x0367;
+        cs = 871;
     end
 
     return cs;
@@ -101,14 +102,14 @@ end;
 function onEventFinish(player,csid,option)
     -- printf("CSID: %u",csid);
     -- printf("RESULT: %u",option);
-    if (csid == 0x213) then
-        player:messageSpecial(ITEM_OBTAINED,0x218);
-    elseif (csid == 0x7534 and option == 0) then
+    if (csid == 531) then
+        player:messageSpecial(ITEM_OBTAINED, 536);
+    elseif (csid == 30004 and option == 0) then
         player:setHomePoint();
         player:messageSpecial(HOMEPOINT_SET);
-    elseif (csid == 0x0092) then -- Returned from Giddeus, Windurst 1-3
-        player:setVar("MissionStatus",3);
-        player:setVar("ghoo_talk",0);
-        player:setVar("laa_talk",0);
+    elseif (csid == 146) then -- Returned from Giddeus, Windurst 1-3
+        player:setVar("MissionStatus", 3);
+        player:setVar("ghoo_talk", 0);
+        player:setVar("laa_talk", 0);
     end
 end;

--- a/scripts/zones/Windurst_Waters/npcs/Leepe-Hoppe.lua
+++ b/scripts/zones/Windurst_Waters/npcs/Leepe-Hoppe.lua
@@ -19,28 +19,27 @@ require("scripts/zones/Windurst_Waters/TextIDs");
 function onTrigger(player,npc)
     local moonlitPath = player:getQuestStatus(WINDURST,THE_MOONLIT_PATH)
     local realday = tonumber(os.date("%j")); -- %M for next minute, %j for next day
+    local MissionStatus = player:getVar("MissionStatus");
 
-    -- Check if we are on Windurst Mission 1-3
-    if (player:getCurrentMission(WINDURST) == THE_PRICE_OF_PEACE) then
-        MissionStatus = player:getVar("MissionStatus");
-
+    -- Check if we are on Windurst Mission 1-3 and haven't already delivered both offerings.
+    if (player:getCurrentMission(WINDURST) == THE_PRICE_OF_PEACE and MissionStatus < 3) then
         if (player:hasKeyItem(FOOD_OFFERINGS) == false and player:hasKeyItem(DRINK_OFFERINGS) == false) then
-            player:startEvent(0x008c);
-        elseif (MissionStatus >= 1 and MissionStatus < 3) then
-            player:startEvent(0x008e); -- Keep displaying the instructions
+            player:startEvent(140);
+        elseif (MissionStatus >= 1) then
+            player:startEvent(142); -- Keep displaying the instructions
         end
     -- Check if we are on Windurst Mission 7-2
     elseif (player:getCurrentMission(WINDURST) == AWAKENING_OF_THE_GODS and player:getVar("MissionStatus") == 0) then
-        player:startEvent(0x02DE);
+        player:startEvent(734);
     elseif (player:getCurrentMission(WINDURST) == AWAKENING_OF_THE_GODS and player:getVar("MissionStatus") == 1) then
-        player:startEvent(0x02DF);
+        player:startEvent(735);
     elseif (player:getCurrentMission(WINDURST) == AWAKENING_OF_THE_GODS and player:getVar("MissionStatus") == 2) then
-        player:startEvent(0x02E3);
+        player:startEvent(739);
     elseif (player:getCurrentMission(WINDURST) == AWAKENING_OF_THE_GODS and player:getVar("MissionStatus") == 5 and player:hasKeyItem(BOOK_OF_THE_GODS)) then
-        player:startEvent(0x02E6);
+        player:startEvent(742);
     ---------------------------
     elseif (player:getQuestStatus(WINDURST,FOOD_FOR_THOUGHT) == QUEST_ACCEPTED) then
-        player:startEvent(0x0137);
+        player:startEvent(311);
 
     -- The Moonlit Path and Other Fenrir Stuff!
     elseif (moonlitPath == QUEST_AVAILABLE and
@@ -49,12 +48,12 @@ function onTrigger(player,npc)
         player:getFameLevel(BASTOK) >= 6 and
         player:getFameLevel(NORG) >= 4) then -- Fenrir flag event
 
-        player:startEvent(0x034a,0,1125);
+        player:startEvent(842,0,1125);
     elseif (moonlitPath == QUEST_ACCEPTED) then
         if (player:hasKeyItem(MOON_BAUBLE)) then -- Default text after acquiring moon bauble and before fighting Fenrir
-            player:startEvent(0x034d,0,1125,334);
+            player:startEvent(845,0,1125,334);
         elseif (player:hasKeyItem(WHISPER_OF_THE_MOON)) then -- First turn-in
-            player:startEvent(0x034e,0,13399,1208,1125,0,18165,13572);
+            player:startEvent(846,0,13399,1208,1125,0,18165,13572);
         elseif (player:hasKeyItem(WHISPER_OF_FLAMES) and
             player:hasKeyItem(WHISPER_OF_TREMORS) and
             player:hasKeyItem(WHISPER_OF_TIDES) and
@@ -63,13 +62,13 @@ function onTrigger(player,npc)
             player:hasKeyItem(WHISPER_OF_STORMS)) then
 
             -- Collected the whispers
-            player:startEvent(0x034c,0,1125,334);
+            player:startEvent(844,0,1125,334);
         else -- Talked to after flag without the whispers
-            player:startEvent(0x034b,0,1125);
+            player:startEvent(843,0,1125);
         end
     elseif (moonlitPath == QUEST_COMPLETED) then
         if (player:hasKeyItem(MOON_BAUBLE)) then -- Default text after acquiring moon bauble and before fighting Fenrir
-            player:startEvent(0x034d,0,1125,334);
+            player:startEvent(845,0,1125,334);
         elseif (player:hasKeyItem(WHISPER_OF_THE_MOON)) then -- Repeat turn-in
             local availRewards = 0
             if (player:hasItem(18165)) then availRewards = availRewards + 1; end -- Fenrir's Stone
@@ -79,14 +78,14 @@ function onTrigger(player,npc)
             if (player:hasItem(1208)) then availRewards = availRewards + 16; end -- Ancient's Key
             if (player:hasSpell(297)) then availRewards = availRewards + 64; end -- Pact
 
-            player:startEvent(0x0352,0,13399,1208,1125,availRewards,18165,13572);
+            player:startEvent(850,0,13399,1208,1125,availRewards,18165,13572);
         elseif (realday ~= player:getVar("MoonlitPath_date")) then --24 hours have passed, flag a new fight
-            player:startEvent(0x0350,0,1125,334);
+            player:startEvent(848,0,1125,334);
         else
-            player:startEvent(0x034f,0,1125); -- Yes, this will indefinitely replace his standard dialogue!
+            player:startEvent(847,0,1125); -- Yes, this will indefinitely replace his standard dialogue!
         end
     else
-        player:startEvent(0x0159); -- Standard Dialogue?
+        player:startEvent(345); -- Standard Dialogue?
     end
 end;
 
@@ -106,8 +105,9 @@ end;
 function onEventFinish(player,csid,option)
     -- printf("CSID: %u",csid);
     -- printf("RESULT: %u",option);
+    local reward = 0
 
-    if (csid == 0x008c) then
+    if (csid == 140) then
         player:setVar("MissionStatus",1);
         player:setVar("ohbiru_dohbiru_talk",0);
         player:addKeyItem(FOOD_OFFERINGS);
@@ -116,9 +116,9 @@ function onEventFinish(player,csid,option)
         player:messageSpecial(KEYITEM_OBTAINED,DRINK_OFFERINGS);
 
     -- Moonlit Path and Other Fenrir Stuff
-    elseif (csid == 0x034a and option == 2) then
+    elseif (csid == 842 and option == 2) then
         player:addQuest(WINDURST,THE_MOONLIT_PATH);
-    elseif (csid == 0x034c) then
+    elseif (csid == 844) then
         player:addKeyItem(MOON_BAUBLE);
         player:messageSpecial(KEYITEM_OBTAINED,MOON_BAUBLE);
         player:delKeyItem(WHISPER_OF_FLAMES);
@@ -133,14 +133,12 @@ function onEventFinish(player,csid,option)
         player:delQuest(OUTLANDS,TRIAL_BY_WIND);
         player:delQuest(SANDORIA,TRIAL_BY_ICE);
         player:delQuest(OTHER_AREAS,TRIAL_BY_LIGHTNING);
-    elseif (csid == 0x034e) then -- Turn-in event
+    elseif (csid == 846) then -- Turn-in event
         player:addTitle(HEIR_OF_THE_NEW_MOON);
         player:delKeyItem(WHISPER_OF_THE_MOON);
         player:setVar("MoonlitPath_date", os.date("%j")); -- %M for next minute, %j for next day
         player:addFame(WINDURST,30);
         player:completeQuest(WINDURST,THE_MOONLIT_PATH);
-
-        reward = 0
 
         if (option == 1) then reward = 18165; -- Fenrir's Stone
         elseif (option == 2) then reward = 13572; -- Fenrir's Cape
@@ -165,13 +163,11 @@ function onEventFinish(player,csid,option)
             player:addKeyItem(DARK_MANA_ORB);
             player:messageSpecial(KEYITEM_OBTAINED,DARK_MANA_ORB);
         end
-    elseif (csid == 0x0352) then -- Repeat turn-in event
+    elseif (csid == 850) then -- Repeat turn-in event
         player:addTitle(HEIR_OF_THE_NEW_MOON);
         player:delKeyItem(WHISPER_OF_THE_MOON);
         player:setVar("MoonlitPath_date", os.date("%j")); -- %M for next minute, %j for next day
         player:addFame(WINDURST,30);
-
-        reward = 0
 
         if (option == 1) then reward = 18165; -- Fenrir's Stone
         elseif (option == 2) then reward = 13572; -- Fenrir's Cape
@@ -196,12 +192,12 @@ function onEventFinish(player,csid,option)
             player:addKeyItem(DARK_MANA_ORB);
             player:messageSpecial(KEYITEM_OBTAINED,DARK_MANA_ORB);
         end
-    elseif (csid == 0x0350) then
+    elseif (csid == 848) then
         player:addKeyItem(MOON_BAUBLE);
         player:messageSpecial(KEYITEM_OBTAINED,MOON_BAUBLE);
-    elseif (csid == 0x02DE) then
+    elseif (csid == 734) then
         player:setVar("MissionStatus",1);
-    elseif (csid == 0x02E6) then
+    elseif (csid == 742) then
         finishMissionTimeline(player,3,csid,option);
     end
 


### PR DESCRIPTION
If you happen to click the NPC "Leepe-Hoppe" before going back to the gate guard, he starts the whole thing over again.