### PR TITLE
Scripts: Remove regain from Mammets (2-5); fix stun chance on Tremoro…

### DIFF
--- a/scripts/globals/mobskills/Tremorous_Tread.lua
+++ b/scripts/globals/mobskills/Tremorous_Tread.lua
@@ -23,7 +23,9 @@ function onMobWeaponSkill(target, mob, skill)
     local info = MobPhysicalMove(mob,target,skill,numhits,accmod,dmgmod,TP_NO_EFFECT);
     local dmg = MobFinalAdjustments(info.dmg,mob,skill,target,MOBSKILL_PHYSICAL,MOBPARAM_SLASH,MOBPARAM_2_SHADOW);
 
+    local typeEffect = EFFECT_STUN;
+
+    MobPhysicalStatusEffectMove(mob, target, skill, typeEffect, 1, 0, 3);
     target:delHP(dmg);
-    MobStatusEffectMove(mob, target, EFFECT_STUN, 1, 0, 3);
     return dmg;
 end;

--- a/scripts/zones/Monarch_Linn/mobs/Mammet-19_Epsilon.lua
+++ b/scripts/zones/Monarch_Linn/mobs/Mammet-19_Epsilon.lua
@@ -11,7 +11,6 @@ require("scripts/globals/status");
 
 function onMobSpawn(mob)
     mob:SetMagicCastingEnabled(false);
-    mob:addMod(MOD_REGAIN, 30);
 end;
 
 -----------------------------------


### PR DESCRIPTION
…us Tread

Mammets aren't supposed to have regain, and the stun from the mobskill is only supposed to land if it actually hits (ie. MobPhysicalStatusEffectMove).

Partial resolution of https://github.com/DarkstarProject/darkstar/issues/2518