### PR TITLE
Scripts: Remove hardcoded itemid check on Relic WSs

### DIFF
--- a/scripts/globals/weaponskills/blade_metsu.lua
+++ b/scripts/globals/weaponskills/blade_metsu.lua
@@ -35,20 +35,13 @@ function onUseWeaponSkill(player, target, wsID)
 
 
     local damage, criticalHit, tpHits, extraHits = doPhysicalWeaponskill(player, target, params);
-    if damage > 0 and (target:hasStatusEffect(EFFECT_PARALYSIS) == false) then
+    -- TODO: Whoever codes those level 85 weapons with the latent that grants this WS needs to code a check to not give the aftermath effect.
+    if (damage > 0) then
+        local amDuration = 20 * math.floor(player:getTP()/100);
+        player:addStatusEffect(EFFECT_AFTERMATH, 10, 0, amDuration, 0, 1);
         target:addStatusEffect(EFFECT_PARALYSIS, 10, 0, 60);
     end
-        if ((player:getEquipID(SLOT_MAIN) or (SLOT_SUB) == 18312) and (player:getMainJob() == JOB_NIN)) then
-        if (damage > 0) then
-            if (player:getTP() >= 100 and player:getTP() <200) then
-                player:addStatusEffect(EFFECT_AFTERMATH, 5, 0, 20, 0, 1);
-            elseif (player:getTP() >= 200 and player:getTP() <300) then
-                player:addStatusEffect(EFFECT_AFTERMATH, 5, 0, 40, 0, 1);
-            elseif (player:getTP() == 300) then
-                player:addStatusEffect(EFFECT_AFTERMATH, 5, 0, 60, 0, 1);
-            end
-        end
-    end
+
     damage = damage * WEAPON_SKILL_POWER
     return tpHits, extraHits, criticalHit, damage;
 end

--- a/scripts/globals/weaponskills/catastrophe.lua
+++ b/scripts/globals/weaponskills/catastrophe.lua
@@ -33,22 +33,16 @@ function onUseWeaponSkill(player, target, wsID)
     end
 
     local damage, criticalHit, tpHits, extraHits = doPhysicalWeaponskill(player, target, params);
+    -- TODO: Whoever codes those level 85 weapons with the latent that grants this WS needs to code a check to not give the aftermath effect.
+    if (damage > 0) then
+        local amDuration = 20 * math.floor(player:getTP()/100);
+        player:addStatusEffect(EFFECT_AFTERMATH, 100, 0, amDuration, 0, 6);
+    end
+
     damage = damage * WEAPON_SKILL_POWER
     if (target:isUndead() == false) then
         local drain = (damage * 0.4);
         player:addHP(drain);
-    end
-    
-    if ((player:getEquipID(SLOT_MAIN) == 18306) and (player:getMainJob() == JOB_DRK)) then
-        if (damage > 0) then
-            if (player:getTP() >= 100 and player:getTP() <200) then
-                player:addStatusEffect(EFFECT_AFTERMATH, 100, 0, 20, 0, 6);
-            elseif (player:getTP() >= 200 and player:getTP() <300) then
-                player:addStatusEffect(EFFECT_AFTERMATH, 100, 0, 40, 0, 6);
-            elseif (player:getTP() == 300) then
-                player:addStatusEffect(EFFECT_AFTERMATH, 100, 0, 60, 0, 6);
-            end
-        end
     end
     return tpHits, extraHits, criticalHit, damage;
 end

--- a/scripts/globals/weaponskills/coronach.lua
+++ b/scripts/globals/weaponskills/coronach.lua
@@ -29,19 +29,14 @@ function onUseWeaponSkill(player, target, wsID)
     params.canCrit = false;
     params.acc100 = 0.0; params.acc200= 0.0; params.acc300= 0.0;
     params.atkmulti = 1;
+
     local damage, tpHits, extraHits = doRangedWeaponskill(player, target, params);
-    if ((player:getEquipID(SLOT_RANGED) == 18336) and (player:getMainJob() == JOB_RNG)) then
-        if (damage > 0) then
-            if (player:getTP() >= 100 and player:getTP() < 200) then
-                player:addStatusEffect(EFFECT_AFTERMATH, -20, 0, 20, 0, 11);
-            elseif (player:getTP() >= 200 and player:getTP() < 300) then
-                player:addStatusEffect(EFFECT_AFTERMATH, -20, 0, 40, 0, 11);
-            elseif (player:getTP() == 300) then
-                player:addStatusEffect(EFFECT_AFTERMATH, -20, 0, 60, 0, 11);
-            end
-        end
+    -- TODO: Whoever codes those level 85 weapons with the latent that grants this WS needs to code a check to not give the aftermath effect.
+    if (damage > 0) then
+        local amDuration = 20 * math.floor(player:getTP()/100);
+        player:addStatusEffect(EFFECT_AFTERMATH, -20, 0, amDuration, 0, 11);
     end
+
     damage = damage * WEAPON_SKILL_POWER
     return tpHits, extraHits, criticalHit, damage;
-
 end;

--- a/scripts/globals/weaponskills/final_heaven.lua
+++ b/scripts/globals/weaponskills/final_heaven.lua
@@ -38,17 +38,12 @@ function onUseWeaponSkill(player, target, wsID)
 
     --damage = damage * ftp(player:getTP(), ftp100, ftp200, ftp300);
     local damage, criticalHit, tpHits, extraHits = doPhysicalWeaponskill(player, target, params);
-    if ((player:getEquipID(SLOT_MAIN) == 18264) and (player:getMainJob() == JOB_MNK)) then
-        if (damage > 0) then
-            if (player:getTP() >= 100 and player:getTP() < 200) then
-                player:addStatusEffect(EFFECT_AFTERMATH, 45, 0, 20, 0, 1);
-            elseif (player:getTP() >= 200 and player:getTP() < 300) then
-                player:addStatusEffect(EFFECT_AFTERMATH, 45, 0, 40, 0, 1);
-            elseif (player:getTP() == 300) then
-                player:addStatusEffect(EFFECT_AFTERMATH, 45, 0, 60, 0, 1);
-            end
-        end
+    -- TODO: Whoever codes those level 85 weapons with the latent that grants this WS needs to code a check to not give the aftermath effect.
+    if (damage > 0) then
+        local amDuration = 20 * math.floor(player:getTP()/100);
+        player:addStatusEffect(EFFECT_AFTERMATH, 10, 0, amDuration, 0, 1);
     end
+
     damage = damage * WEAPON_SKILL_POWER
     return tpHits, extraHits, criticalHit, damage;
 end

--- a/scripts/globals/weaponskills/gate_of_tartarus.lua
+++ b/scripts/globals/weaponskills/gate_of_tartarus.lua
@@ -31,18 +31,17 @@ function onUseWeaponSkill(player, target, wsID)
     params.atkmulti = 1;
 
     if (USE_ADOULIN_WEAPON_SKILL_CHANGES == true) then
-        params.chr_wsc = 0.8;
+        params.int_wsc = 0.8; params.chr_wsc = 0.0;
     end
 
     local damage, criticalHit, tpHits, extraHits = doPhysicalWeaponskill(player, target, params);
-        if ((player:getEquipID(SLOT_MAIN) == 18330) and (player:getMainJob() == JOB_BLM or JOB_SMN)) then
-        if (damage > 0) then
-            if (player:getTP() == 300) then
-                player:addStatusEffect(EFFECT_AFTERMATH, 8, 0, 60, 0, 10);
-            end
-        end
+    -- TODO: Whoever codes those level 85 weapons with the latent that grants this WS needs to code a check to not give the aftermath effect.
+    if (damage > 0) then
+        local amDuration = 20 * math.floor(player:getTP()/100);
+        player:addStatusEffect(EFFECT_AFTERMATH, 8, 0, amDuration, 0, 10);
+        target:addStatusEffect(EFFECT_ATTACK_DOWN, 20, 0, 60);
     end
+
     damage = damage * WEAPON_SKILL_POWER
     return tpHits, extraHits, criticalHit, damage;
-
 end

--- a/scripts/globals/weaponskills/geirskogul.lua
+++ b/scripts/globals/weaponskills/geirskogul.lua
@@ -32,17 +32,12 @@ function onUseWeaponSkill(player, target, wsID)
     end
 
     local damage, criticalHit, tpHits, extraHits = doPhysicalWeaponskill(player, target, params);
-    if ((player:getEquipID(SLOT_MAIN) == 18300) and (player:getMainJob() == JOB_DRG)) then
-        if (damage > 0) then
-            if (player:getTP() >= 100 and player:getTP() < 200) then
-                player:addStatusEffect(EFFECT_AFTERMATH, 6, 0, 20, 0, 7);
-            elseif (player:getTP() >= 200 and player:getTP() < 300) then
-                player:addStatusEffect(EFFECT_AFTERMATH, 6, 0, 40, 0, 7);
-            elseif (player:getTP() == 300) then
-                player:addStatusEffect(EFFECT_AFTERMATH, 6, 0, 60, 0, 7);
-            end
-        end
+    -- TODO: Whoever codes those level 85 weapons with the latent that grants this WS needs to code a check to not give the aftermath effect.
+    if (damage > 0) then
+        local amDuration = 20 * math.floor(player:getTP()/100);
+        player:addStatusEffect(EFFECT_AFTERMATH, 6, 0, amDuration, 0, 7);
     end
+
     damage = damage * WEAPON_SKILL_POWER
     return tpHits, extraHits, criticalHit, damage;
 end

--- a/scripts/globals/weaponskills/knights_of_round.lua
+++ b/scripts/globals/weaponskills/knights_of_round.lua
@@ -34,18 +34,12 @@ function onUseWeaponSkill(player, target, wsID)
     end
 
     local damage, criticalHit, tpHits, extraHits = doPhysicalWeaponskill(player, target, params);
-    if ((player:getEquipID(SLOT_MAIN) == 18276) and (player:getMainJob() == JOB_RDM or JOB_PLD)) then
-        if (damage > 0) then
-            if (player:getTP() >= 100 and player:getTP() < 200) then
-                player:addStatusEffect(EFFECT_AFTERMATH, 10, 0, 20, 0, 3);
-            elseif (player:getTP() >= 200 and player:getTP() < 300) then
-                player:addStatusEffect(EFFECT_AFTERMATH, 10, 0, 40, 0, 3);
-            elseif (player:getTP() == 300) then
-                player:addStatusEffect(EFFECT_AFTERMATH, 10, 0, 60, 0, 3);
-            end
-        end
+    -- TODO: Whoever codes those level 85 weapons with the latent that grants this WS needs to code a check to not give the aftermath effect.
+    if (damage > 0) then
+        local amDuration = 20 * math.floor(player:getTP()/100);
+        player:addStatusEffect(EFFECT_AFTERMATH, 10, 0, amDuration, 0, 3);
     end
+
     damage = damage * WEAPON_SKILL_POWER
     return tpHits, extraHits, criticalHit, damage;
-
-end
+end;

--- a/scripts/globals/weaponskills/mercy_stroke.lua
+++ b/scripts/globals/weaponskills/mercy_stroke.lua
@@ -33,18 +33,12 @@ function onUseWeaponSkill(player, target, wsID)
     end
 
     local damage, criticalHit, tpHits, extraHits = doPhysicalWeaponskill(player, target, params);
-    if ((player:getEquipID(SLOT_MAIN) == 18270) and (player:getMainJob() == JOB_RDM or JOB_THF or JOB_BRD)) then
-        if (damage > 0) then
-            if (player:getTP() >= 100 and player:getTP() < 200) then
-                player:addStatusEffect(EFFECT_AFTERMATH, 5, 0, 20, 0, 2);
-            elseif (player:getTP() >= 200 and player:getTP() < 300) then
-                player:addStatusEffect(EFFECT_AFTERMATH, 5, 0, 40, 0, 2);
-            elseif (player:getTP() == 300) then
-                player:addStatusEffect(EFFECT_AFTERMATH, 5, 0, 60, 0, 2);
-            end
-        end
+    -- TODO: Whoever codes those level 85 weapons with the latent that grants this WS needs to code a check to not give the aftermath effect.
+    if (damage > 0) then
+        local amDuration = 20 * math.floor(player:getTP()/100);
+        player:addStatusEffect(EFFECT_AFTERMATH, 5, 0, amDuration, 0, 2);
     end
+
     damage = damage * WEAPON_SKILL_POWER
     return tpHits, extraHits, criticalHit, damage;
-
 end

--- a/scripts/globals/weaponskills/metatron_torment.lua
+++ b/scripts/globals/weaponskills/metatron_torment.lua
@@ -38,21 +38,13 @@ function onUseWeaponSkill(player, target, wsID)
     end
 
     local damage, criticalHit, tpHits, extraHits = doPhysicalWeaponskill(player, target, params);
-    if damage > 0 and (target:hasStatusEffect(EFFECT_DEFENSE_DOWN) == false) then
-        target:addStatusEffect(EFFECT_DEFENSE_DOWN, 18.5, 0, 120);
+    -- TODO: Whoever codes those level 85 weapons with the latent that grants this WS needs to code a check to not give the aftermath effect.
+    if (damage > 0) then
+        local amDuration = 20 * math.floor(player:getTP()/100);
+        player:addStatusEffect(EFFECT_AFTERMATH, -21, 0, amDuration, 0, 5);
+        target:addStatusEffect(EFFECT_DEFENSE_DOWN, 19, 0, 120);
     end
-    if ((player:getEquipID(SLOT_MAIN) == 18294) and (player:getMainJob() == JOB_WAR)) then
-        if (damage > 0) then
-            if (player:getTP() >= 100 and player:getTP() < 200) then
-                player:addStatusEffect(EFFECT_AFTERMATH, -21, 0, 20, 0, 5);
-            elseif (player:getTP() >= 200 and player:getTP() < 300) then
-                player:addStatusEffect(EFFECT_AFTERMATH, -21, 0, 40, 0, 5);
-            elseif (player:getTP() == 300) then
-                player:addStatusEffect(EFFECT_AFTERMATH, -21, 0, 60, 0, 5);
-            end
-        end
-    end
+
     damage = damage * WEAPON_SKILL_POWER
     return tpHits, extraHits, criticalHit, damage;
-
 end

--- a/scripts/globals/weaponskills/namas_arrow.lua
+++ b/scripts/globals/weaponskills/namas_arrow.lua
@@ -29,18 +29,12 @@ function onUseWeaponSkill(player, target, wsID)
     params.atkmulti = 1;
 
     local damage, tpHits, extraHits = doRangedWeaponskill(player, target, params);
-        if ((player:getEquipID(SLOT_RANGED) == 18348) and (player:getMainJob() == JOB_RNG or JOB_SAM)) then
-        if (damage > 0) then
-            if (player:getTP() >= 100 and player:getTP() < 200) then
-                player:addStatusEffect(EFFECT_AFTERMATH, 20, 0, 20, 0, 12);
-            elseif (player:getTP() >= 200 and player:getTP() < 300) then
-                player:addStatusEffect(EFFECT_AFTERMATH, 20, 0, 40, 0, 12);
-            elseif (player:getTP() == 300) then
-                player:addStatusEffect(EFFECT_AFTERMATH, 20, 0, 60, 0, 12);
-            end
-        end
+    -- TODO: Whoever codes those level 85 weapons with the latent that grants this WS needs to code a check to not give the aftermath effect.
+    if (damage > 0) then
+        local amDuration = 20 * math.floor(player:getTP()/100);
+        player:addStatusEffect(EFFECT_AFTERMATH, 20, 0, amDuration, 0, 12);
     end
+
     damage = damage * WEAPON_SKILL_POWER
     return tpHits, extraHits, criticalHit, damage;
-
 end;

--- a/scripts/globals/weaponskills/onslaught.lua
+++ b/scripts/globals/weaponskills/onslaught.lua
@@ -34,26 +34,13 @@ function onUseWeaponSkill(player, target, wsID)
     end
 
     local damage, criticalHit, tpHits, extraHits = doPhysicalWeaponskill(player, target, params);
+    -- TODO: Whoever codes those level 85 weapons with the latent that grants this WS needs to code a check to not give the aftermath effect.
+    if (damage > 0) then
+        local amDuration = 20 * math.floor(player:getTP()/100);
+        player:addStatusEffect(EFFECT_AFTERMATH, 10, 0, amDuration, 0, 4);
+        target:addStatusEffect(EFFECT_ACCURACY_DOWN, 20, 0, 60);
+    end
 
-    if damage > 0 then
-        local tp = player:getTP();
-        local duration = (tp/100 * 20);
-        if (target:hasStatusEffect(EFFECT_ACCURACY_DOWN) == false) then
-            target:addStatusEffect(EFFECT_ACCURACY_DOWN, 20, 0, duration);
-        end
-    end
-    if ((player:getEquipID(SLOT_MAIN) == 18288) and (player:getMainJob() == JOB_BST)) then
-        if (damage > 0) then
-            if (player:getTP() >= 100 and player:getTP() < 200) then
-                player:addStatusEffect(EFFECT_AFTERMATH, 10, 0, 20, 0, 4);
-            elseif (player:getTP() >= 200 and player:getTP() < 300) then
-                player:addStatusEffect(EFFECT_AFTERMATH, 10, 0, 40, 0, 4);
-            elseif (player:getTP() == 300) then
-                player:addStatusEffect(EFFECT_AFTERMATH, 10, 0, 60, 0, 4);
-            end
-        end
-    end
     damage = damage * WEAPON_SKILL_POWER
     return tpHits, extraHits, criticalHit, damage;
-
 end

--- a/scripts/globals/weaponskills/randgrith.lua
+++ b/scripts/globals/weaponskills/randgrith.lua
@@ -30,23 +30,15 @@ function onUseWeaponSkill(player, target, wsID)
     params.canCrit = false;
     params.acc100 = 0.0; params.acc200= 0.0; params.acc300= 0.0;
     params.atkmulti = 1;
-    local damage, criticalHit, tpHits, extraHits = doPhysicalWeaponskill(player, target, params);
 
-    if damage > 0 and (target:hasStatusEffect(EFFECT_WEIGHT) == false) then
-        target:addStatusEffect(EFFECT_WEIGHT, 50, 0, 60);
+    local damage, criticalHit, tpHits, extraHits = doPhysicalWeaponskill(player, target, params);
+    -- TODO: Whoever codes those level 85 weapons with the latent that grants this WS needs to code a check to not give the aftermath effect.
+    if (damage > 0) then
+        local amDuration = 20 * math.floor(player:getTP()/100);
+        player:addStatusEffect(EFFECT_AFTERMATH, 20, 0, amDuration, 0, 9);
+        target:addStatusEffect(EFFECT_EVASION_DOWN, 32, 0, 60);
     end
-        if ((player:getEquipID(SLOT_MAIN) == 18324) and (player:getMainJob() == JOB_WHM)) then
-        if (damage > 0) then
-            if (player:getTP() >= 100 and player:getTP() < 200) then
-                player:addStatusEffect(EFFECT_AFTERMATH, 20, 0, 20, 0, 9);
-            elseif (player:getTP() >= 200 and player:getTP() < 300) then
-                player:addStatusEffect(EFFECT_AFTERMATH, 20, 0, 40, 0, 9);
-            elseif (player:getTP() == 300) then
-                player:addStatusEffect(EFFECT_AFTERMATH, 20, 0, 60, 0, 9);
-            end
-        end
-    end
+
     damage = damage * WEAPON_SKILL_POWER
     return tpHits, extraHits, criticalHit, damage;
-
 end

--- a/scripts/globals/weaponskills/scourge.lua
+++ b/scripts/globals/weaponskills/scourge.lua
@@ -33,17 +33,12 @@ function onUseWeaponSkill(player, target, wsID)
     end
 
     local damage, criticalHit, tpHits, extraHits = doPhysicalWeaponskill(player, target, params);
-    if ((player:getEquipID(SLOT_MAIN) == 18282) and (player:getMainJob() == JOB_WAR or JOB_PLD or JOB_DRK)) then
-        if (damage > 0) then
-            if (player:getTP() >= 100 and player:getTP() < 200) then
-                player:addStatusEffect(EFFECT_AFTERMATH, 5, 0, 20, 0, 2);
-            elseif (player:getTP() >= 200 and player:getTP() < 300) then
-                player:addStatusEffect(EFFECT_AFTERMATH, 5, 0, 40, 0, 2);
-            elseif (player:getTP() == 300) then
-                player:addStatusEffect(EFFECT_AFTERMATH, 5, 0, 60, 0, 2);
-            end
-        end
+    -- TODO: Whoever codes those level 85 weapons with the latent that grants this WS needs to code a check to not give the aftermath effect.
+    if (damage > 0) then
+        local amDuration = 20 * math.floor(player:getTP()/100);
+        player:addStatusEffect(EFFECT_AFTERMATH, 5, 0, amDuration, 0, 2);
     end
+
     damage = damage * WEAPON_SKILL_POWER
     return tpHits, extraHits, criticalHit, damage;
 end

--- a/scripts/globals/weaponskills/tachi_kaiten.lua
+++ b/scripts/globals/weaponskills/tachi_kaiten.lua
@@ -37,19 +37,12 @@ function onUseWeaponSkill(player, target, wsID)
     end
 
     local damage, criticalHit, tpHits, extraHits = doPhysicalWeaponskill(player, target, params);
-
-        if ((player:getEquipID(SLOT_MAIN) == 18318) and (player:getMainJob() == JOB_SAM)) then
-        if (damage > 0) then
-            if (player:getTP() >= 100 and player:getTP() <200) then
-                player:addStatusEffect(EFFECT_AFTERMATH, 7, 0, 20, 0, 8);
-            elseif (player:getTP() >= 200 and player:getTP() <300) then
-                player:addStatusEffect(EFFECT_AFTERMATH, 7, 0, 40, 0, 8);
-            elseif (player:getTP() == 300) then
-                player:addStatusEffect(EFFECT_AFTERMATH, 7, 0, 60, 0, 8);
-            end
-        end
+    -- TODO: Whoever codes those level 85 weapons with the latent that grants this WS needs to code a check to not give the aftermath effect.
+    if (damage > 0) then
+        local amDuration = 20 * math.floor(player:getTP()/100);
+        player:addStatusEffect(EFFECT_AFTERMATH, 7, 0, amDuration, 0, 8);
     end
+
     damage = damage * WEAPON_SKILL_POWER
     return tpHits, extraHits, criticalHit, damage;
-
 end


### PR DESCRIPTION
Since the only way to get access to them is to have a completed relic/stage 4 weapon in Dynamis, there's no point in having a check for Aftermath. Whoever decides to add those level 85 latent weapons will have to add a specific check that that point in time.

Other fixes include:
-Refinement of Aftermath application (removed the if/elseif trees)
-Corrected the effect inflicted to the enemy from Randgrith (from weight to evasion down)
-Corrected the Subtle Blow values for Final Heaven and Blade: Metsu Aftermath.