### PR TITLE
Scripts: Add textID include to Ominous Cloud

### DIFF
--- a/scripts/zones/Southern_San_dOria/npcs/Ominous_Cloud.lua
+++ b/scripts/zones/Southern_San_dOria/npcs/Ominous_Cloud.lua
@@ -9,6 +9,8 @@
 package.loaded["scripts/zones/Southern_San_dOria/TextIDs"] = nil;
 -----------------------------------
 
+require("scripts/zones/Southern_San_dOria/TextIDs");
+
 -----------------------------------
 -- onTrade Action
 -----------------------------------

--- a/scripts/zones/Windurst_Woods/npcs/Ominous_Cloud.lua
+++ b/scripts/zones/Windurst_Woods/npcs/Ominous_Cloud.lua
@@ -10,6 +10,8 @@
 package.loaded["scripts/zones/Windurst_Woods/TextIDs"] = nil;
 -----------------------------------
 
+require("scripts/zones/Windurst_Woods/TextIDs");
+
 -----------------------------------
 -- onTrade Action
 -----------------------------------


### PR DESCRIPTION
It was being nil'd out, but it wasn't loaded. The version in Port Bastok was the only one that loaded it.