### PR TITLE
Scripts: Pso'Xja Gargoyle door able to be picked open

### DIFF
--- a/scripts/zones/Phomiuna_Aqueducts/npcs/_ir7.lua
+++ b/scripts/zones/Phomiuna_Aqueducts/npcs/_ir7.lua
@@ -15,12 +15,15 @@ require("scripts/zones/Phomiuna_Aqueducts/TextIDs");
 
 function onTrade(player,npc,trade)
     
-    if (trade:hasItemQty(1660,1) and trade:getItemCount() == 1) then -- Bronze Key
-        player:tradeComplete();
-        npc:openDoor(15);
-    elseif (trade:hasItemQty(1022,1) and trade:getItemCount() == 1 and player:getMainJob() == 6) then -- thief's tool
-        player:tradeComplete();
-        npc:openDoor(15);
+    if (player:getXPos() >= 70 and npc:getAnimation() == 9) then -- only if they're on the locked side and gate is closed.
+        if (trade:hasItemQty(1660,1) and trade:getItemCount() == 1) then -- Bronze Key
+            player:tradeComplete();
+            npc:openDoor(15);
+        elseif ((trade:hasItemQty(1115,1) or trade:hasItemQty(1023,1) or trade:hasItemQty(1022,1)) and trade:getItemCount() == 1 and player:getMainJob() == 6) then
+            -- thief's tool/living key/skeleton key as THF main
+            player:tradeComplete();
+            npc:openDoor(15);
+        end
     end
     
 end; 
@@ -33,7 +36,7 @@ function onTrigger(player,npc)
    
     if (player:getXPos() <= -71) then
         npc:openDoor(15); -- Retail timed
-    else
+    elseif (npc:getAnimation() == 9) then -- don't want it to say the door is locked when it's wide open!
         player:messageSpecial(DOOR_LOCKED,1660);
     end
     return 1;

--- a/scripts/zones/Phomiuna_Aqueducts/npcs/_ir9.lua
+++ b/scripts/zones/Phomiuna_Aqueducts/npcs/_ir9.lua
@@ -14,15 +14,18 @@ require("scripts/zones/Phomiuna_Aqueducts/TextIDs");
 -----------------------------------
 
 function onTrade(player,npc,trade)
-    
-    if (trade:hasItemQty(1660,1) and trade:getItemCount() == 1) then -- Bronze Key
-        player:tradeComplete();
-        npc:openDoor(15);
-    elseif (trade:hasItemQty(1022,1) and trade:getItemCount() == 1 and player:getMainJob() == 6) then -- thief's tool
-        player:tradeComplete();
-        npc:openDoor(15);
+
+    if (player:getXPos() < 70 and npc:getAnimation() == 9) then
+        if (trade:hasItemQty(1660,1) and trade:getItemCount() == 1) then -- Bronze Key
+            player:tradeComplete();
+            npc:openDoor(15);
+        elseif ((trade:hasItemQty(1115,1) or trade:hasItemQty(1023,1) or trade:hasItemQty(1022,1)) and trade:getItemCount() == 1 and player:getMainJob() == 6) then
+            -- thief's tool/living key/skeleton key as THF main
+            player:tradeComplete();
+            npc:openDoor(15);
+        end
     end
-    
+
 end; 
 
 -----------------------------------
@@ -33,7 +36,7 @@ function onTrigger(player,npc)
    
     if (player:getXPos() >= 70) then
         npc:openDoor(15); -- Retail timed
-    else
+    elseif (npc:getAnimation() == 9) then
         player:messageSpecial(DOOR_LOCKED,1660);
     end
     return 1;

--- a/scripts/zones/PsoXja/TextIDs.lua
+++ b/scripts/zones/PsoXja/TextIDs.lua
@@ -8,12 +8,14 @@ ITEM_CANNOT_BE_OBTAINED = 6379; -- You cannot obtain the item <item> come back a
 NOTHING_OUT_OF_ORDINARY = 6398; -- There is nothing out of the ordinary here.
     DEVICE_IN_OPERATION = 7226; -- The device appears to be in operation...
             DOOR_LOCKED = 7229; -- The door is locked.
-     ARCH_GLOW_BLUE = 7230; -- The arch above the door is glowing blue...
-    ARCH_GLOW_GREEN = 7231; -- The arch above the door is glowing green...
+         ARCH_GLOW_BLUE = 7230; -- The arch above the door is glowing blue...
+        ARCH_GLOW_GREEN = 7231; -- The arch above the door is glowing green...
        CANNOT_OPEN_SIDE = 7234; -- The door cannot be opened from this side.
          TRAP_ACTIVATED = 7236; -- A trap connected to it has been activated!
              TRAP_FAILS = 7237; -- The trap connected to it fails to activate.
-            HOMEPOINT_SET = 7471; -- Home point set!
+   DISCOVER_DISARM_FAIL = 7238; -- <player> discovers a trap connected to the door, but fails to disarm it!
+DISCOVER_DISARM_SUCCESS = 7239; -- <player> discovers a trap connected to the door and succeeds in disarming it!
+          HOMEPOINT_SET = 7471; -- Home point set!
 
 -- Treasure Coffer/Chest Dialog
 CHEST_UNLOCKED = 7458; -- You unlock the chest!

--- a/scripts/zones/PsoXja/npcs/_090.lua
+++ b/scripts/zones/PsoXja/npcs/_090.lua
@@ -2,9 +2,7 @@
 -- Area:  Pso'Xja
 -- NPC:   _090 (Stone Gate)
 -- Notes: Spawns Gargoyle when triggered
--- @pos -330.000 14.074 -261.600 9
--- TODO: The spawned Gargoyle should spawn as claimed to the trigger target. 
--- Text Message not displaying players name before the text at all. 
+-- @pos 341.600 -1.925 -50.000 9
 -----------------------------------
 package.loaded["scripts/zones/PsoXja/TextIDs"] = nil;
 -----------------------------------
@@ -17,6 +15,32 @@ require("scripts/globals/keyitems");
 -----------------------------------
 
 function onTrade(player,npc,trade)
+
+    -- thief's tool/living key/skeleton key as THF main
+    if ((trade:hasItemQty(1115,1) or trade:hasItemQty(1023,1) or trade:hasItemQty(1022,1)) and trade:getItemCount() == 1 and player:getMainJob() == 6) then
+
+        local X=player:getXPos();
+    
+        if (npc:getAnimation() == 9) then    
+            if (X <= 341) then
+                if (GetMobAction(16814081) == 0) then
+                    local Rand = math.random(1,2); -- estimated 50% success as per the wiki
+                    if (Rand == 1) then -- Spawn Gargoyle
+                        -- + 0x8000 along with the 6th param being true makes it display the player's name properly as part of the message.
+                        player:messageSpecial(DISCOVER_DISARM_FAIL + 0x8000, 0, 0, 0, 0, true);
+                        SpawnMob(16814081,120):updateClaim(player); -- Gargoyle
+                    else
+                        player:messageSpecial(DISCOVER_DISARM_SUCCESS + 0x8000, 0, 0, 0, 0, true);
+                        npc:openDoor(30);
+                    end
+                    player:tradeComplete();
+                else
+                    player:messageSpecial(DOOR_LOCKED);
+                end
+            end
+        end
+    end
+
 end;
 
 -----------------------------------
@@ -32,10 +56,10 @@ function onTrigger(player,npc)
             if (GetMobAction(16814081) == 0) then
                 local Rand = math.random(1,10);
                 if (Rand <=9) then -- Spawn Gargoyle
-                    player:messageSpecial(TRAP_ACTIVATED); 
+                    player:messageSpecial(TRAP_ACTIVATED + 0x8000, 0, 0, 0, 0, true); 
                     SpawnMob(16814081,120):updateClaim(player); -- Gargoyle
                 else
-                    player:messageSpecial(TRAP_FAILS);
+                    player:messageSpecial(TRAP_FAILS + 0x8000, 0, 0, 0, 0, true);
                     npc:openDoor(30);
                 end    
             else

--- a/scripts/zones/PsoXja/npcs/_091.lua
+++ b/scripts/zones/PsoXja/npcs/_091.lua
@@ -2,7 +2,7 @@
 -- Area:  Pso'Xja
 -- NPC:   _091 (Stone Gate)
 -- Notes: Spawns Gargoyle when triggered
--- @pos -330.000 14.074 -261.600 9
+-- @pos 350.000 -1.925 -61.600 9
 -----------------------------------
 package.loaded["scripts/zones/PsoXja/TextIDs"] = nil;
 -----------------------------------
@@ -15,6 +15,30 @@ require("scripts/globals/keyitems");
 -----------------------------------
 
 function onTrade(player,npc,trade)
+
+    if ((trade:hasItemQty(1115,1) or trade:hasItemQty(1023,1) or trade:hasItemQty(1022,1)) and trade:getItemCount() == 1 and player:getMainJob() == 6) then
+
+        local Z=player:getZPos();
+    
+        if (npc:getAnimation() == 9) then    
+            if (Z >= -61) then
+                if (GetMobAction(16814082) == 0) then
+                    local Rand = math.random(1,2); -- estimated 50% success as per the wiki
+                    if (Rand == 1) then -- Spawn Gargoyle
+                        player:messageSpecial(DISCOVER_DISARM_FAIL + 0x8000, 0, 0, 0, 0, true); 
+                        SpawnMob(16814082,120):updateClaim(player); -- Gargoyle
+                    else
+                        player:messageSpecial(DISCOVER_DISARM_SUCCESS + 0x8000, 0, 0, 0, 0, true);
+                        npc:openDoor(30);
+                    end
+                    player:tradeComplete();
+                else
+                    player:messageSpecial(DOOR_LOCKED);
+                end
+            end
+        end
+    end
+
 end;
 
 -----------------------------------
@@ -30,10 +54,10 @@ function onTrigger(player,npc)
             if (GetMobAction(16814082) == 0) then
                 local Rand = math.random(1,10);
                 if (Rand <=9) then -- Spawn Gargoyle
-                    player:messageSpecial(TRAP_ACTIVATED); 
+                    player:messageSpecial(TRAP_ACTIVATED + 0x8000, 0, 0, 0, 0, true); 
                     SpawnMob(16814082,120):updateClaim(player); -- Gargoyle
                 else
-                    player:messageSpecial(TRAP_FAILS);
+                    player:messageSpecial(TRAP_FAILS + 0x8000, 0, 0, 0, 0, true);
                     npc:openDoor(30);
                 end    
             else

--- a/scripts/zones/PsoXja/npcs/_092.lua
+++ b/scripts/zones/PsoXja/npcs/_092.lua
@@ -2,7 +2,7 @@
 -- Area:  Pso'Xja
 -- NPC:   _092 (Stone Gate)
 -- Notes: Spawns Gargoyle when triggered
--- @pos -330.000 14.074 -261.600 9
+-- @pos 338.399 -1.925 -70.000 9
 -----------------------------------
 package.loaded["scripts/zones/PsoXja/TextIDs"] = nil;
 -----------------------------------
@@ -15,6 +15,30 @@ require("scripts/globals/keyitems");
 -----------------------------------
 
 function onTrade(player,npc,trade)
+
+    if ((trade:hasItemQty(1115,1) or trade:hasItemQty(1023,1) or trade:hasItemQty(1022,1)) and trade:getItemCount() == 1 and player:getMainJob() == 6) then
+
+        local X=player:getXPos();
+    
+        if (npc:getAnimation() == 9) then    
+            if (X >= 339) then
+                if (GetMobAction(16814083) == 0) then
+                    local Rand = math.random(1,2); -- estimated 50% success as per the wiki
+                    if (Rand == 1) then -- Spawn Gargoyle
+                        player:messageSpecial(DISCOVER_DISARM_FAIL + 0x8000, 0, 0, 0, 0, true); 
+                        SpawnMob(16814083,120):updateClaim(player); -- Gargoyle
+                    else
+                        player:messageSpecial(DISCOVER_DISARM_SUCCESS + 0x8000, 0, 0, 0, 0, true);
+                        npc:openDoor(30);
+                    end
+                    player:tradeComplete();
+                else
+                    player:messageSpecial(DOOR_LOCKED);
+                end
+            end
+        end
+    end
+
 end;
 
 -----------------------------------
@@ -30,10 +54,10 @@ function onTrigger(player,npc)
             if (GetMobAction(16814083) == 0) then
                 local Rand = math.random(1,10);
                 if (Rand <=9) then -- Spawn Gargoyle
-                    player:messageSpecial(TRAP_ACTIVATED); 
+                    player:messageSpecial(TRAP_ACTIVATED + 0x8000, 0, 0, 0, 0, true); 
                     SpawnMob(16814083,120):updateClaim(player); -- Gargoyle
                 else
-                    player:messageSpecial(TRAP_FAILS);
+                    player:messageSpecial(TRAP_FAILS + 0x8000, 0, 0, 0, 0, true);
                     npc:openDoor(30);
                 end    
             else

--- a/scripts/zones/PsoXja/npcs/_093.lua
+++ b/scripts/zones/PsoXja/npcs/_093.lua
@@ -2,7 +2,7 @@
 -- Area:  Pso'Xja
 -- NPC:   _093 (Stone Gate)
 -- Notes: Spawns Gargoyle when triggered
--- @pos -330.000 14.074 -261.600 9
+-- @pos 321.600 -1.925 -70.000 9
 -----------------------------------
 package.loaded["scripts/zones/PsoXja/TextIDs"] = nil;
 -----------------------------------
@@ -15,6 +15,30 @@ require("scripts/globals/keyitems");
 -----------------------------------
 
 function onTrade(player,npc,trade)
+
+    if ((trade:hasItemQty(1115,1) or trade:hasItemQty(1023,1) or trade:hasItemQty(1022,1)) and trade:getItemCount() == 1 and player:getMainJob() == 6) then
+
+        local X=player:getXPos();
+    
+        if (npc:getAnimation() == 9) then    
+            if (X >= 322) then
+                if (GetMobAction(16814084) == 0) then
+                    local Rand = math.random(1,2); -- estimated 50% success as per the wiki
+                    if (Rand == 1) then -- Spawn Gargoyle
+                        player:messageSpecial(DISCOVER_DISARM_FAIL + 0x8000, 0, 0, 0, 0, true); 
+                        SpawnMob(16814084,120):updateClaim(player); -- Gargoyle
+                    else
+                        player:messageSpecial(DISCOVER_DISARM_SUCCESS + 0x8000, 0, 0, 0, 0, true);
+                        npc:openDoor(30);
+                    end
+                    player:tradeComplete();
+                else
+                    player:messageSpecial(DOOR_LOCKED);
+                end
+            end
+        end
+    end
+
 end;
 
 -----------------------------------
@@ -30,10 +54,10 @@ function onTrigger(player,npc)
             if (GetMobAction(16814084) == 0) then
                 local Rand = math.random(1,10);
                 if (Rand <=9) then -- Spawn Gargoyle
-                    player:messageSpecial(TRAP_ACTIVATED); 
+                    player:messageSpecial(TRAP_ACTIVATED + 0x8000, 0, 0, 0, 0, true); 
                     SpawnMob(16814084,120):updateClaim(player); -- Gargoyle
                 else
-                    player:messageSpecial(TRAP_FAILS);
+                    player:messageSpecial(TRAP_FAILS + 0x8000, 0, 0, 0, 0, true);
                     npc:openDoor(30);
                 end    
             else

--- a/scripts/zones/PsoXja/npcs/_094.lua
+++ b/scripts/zones/PsoXja/npcs/_094.lua
@@ -15,6 +15,30 @@ require("scripts/globals/keyitems");
 -----------------------------------
 
 function onTrade(player,npc,trade)
+
+    if ((trade:hasItemQty(1115,1) or trade:hasItemQty(1023,1) or trade:hasItemQty(1022,1)) and trade:getItemCount() == 1 and player:getMainJob() == 6) then
+
+        local Z=player:getZPos();
+    
+        if (npc:getAnimation() == 9) then    
+            if (Z >= -101) then
+                if (GetMobAction(16814085) == 0) then
+                    local Rand = math.random(1,2); -- estimated 50% success as per the wiki
+                    if (Rand == 1) then -- Spawn Gargoyle
+                        player:messageSpecial(DISCOVER_DISARM_FAIL + 0x8000, 0, 0, 0, 0, true); 
+                        SpawnMob(16814085,120):updateClaim(player); -- Gargoyle
+                    else
+                        player:messageSpecial(DISCOVER_DISARM_SUCCESS + 0x8000, 0, 0, 0, 0, true);
+                        npc:openDoor(30);
+                    end
+                    player:tradeComplete();
+                else
+                    player:messageSpecial(DOOR_LOCKED);
+                end
+            end
+        end
+    end
+
 end;
 
 -----------------------------------
@@ -30,10 +54,10 @@ function onTrigger(player,npc)
             if (GetMobAction(16814085) == 0) then
                 local Rand = math.random(1,10);
                 if (Rand <=9) then -- Spawn Gargoyle
-                    player:messageSpecial(TRAP_ACTIVATED); 
+                    player:messageSpecial(TRAP_ACTIVATED + 0x8000, 0, 0, 0, 0, true); 
                     SpawnMob(16814085,120):updateClaim(player); -- Gargoyle
                 else
-                    player:messageSpecial(TRAP_FAILS);
+                    player:messageSpecial(TRAP_FAILS + 0x8000, 0, 0, 0, 0, true);
                     npc:openDoor(30);
                 end    
             else

--- a/scripts/zones/PsoXja/npcs/_095.lua
+++ b/scripts/zones/PsoXja/npcs/_095.lua
@@ -2,7 +2,7 @@
 -- Area:  Pso'Xja
 -- NPC:   _095 (Stone Gate)
 -- Notes: Spawns Gargoyle when triggered
--- @pos -330.000 14.074 -261.600 9
+-- @pos 298.399 -1.925 -110.000 9
 -----------------------------------
 package.loaded["scripts/zones/PsoXja/TextIDs"] = nil;
 -----------------------------------
@@ -15,6 +15,30 @@ require("scripts/globals/keyitems");
 -----------------------------------
 
 function onTrade(player,npc,trade)
+
+    if ((trade:hasItemQty(1115,1) or trade:hasItemQty(1023,1) or trade:hasItemQty(1022,1)) and trade:getItemCount() == 1 and player:getMainJob() == 6) then
+
+        local X=player:getXPos();
+    
+        if (npc:getAnimation() == 9) then    
+            if (X >= 299) then
+                if (GetMobAction(16814086) == 0) then
+                    local Rand = math.random(1,2); -- estimated 50% success as per the wiki
+                    if (Rand == 1) then -- Spawn Gargoyle
+                        player:messageSpecial(DISCOVER_DISARM_FAIL + 0x8000, 0, 0, 0, 0, true); 
+                        SpawnMob(16814086,120):updateClaim(player); -- Gargoyle
+                    else
+                        player:messageSpecial(DISCOVER_DISARM_SUCCESS + 0x8000, 0, 0, 0, 0, true);
+                        npc:openDoor(30);
+                    end
+                    player:tradeComplete();
+                else
+                    player:messageSpecial(DOOR_LOCKED);
+                end
+            end
+        end
+    end
+
 end;
 
 -----------------------------------
@@ -30,10 +54,10 @@ function onTrigger(player,npc)
             if (GetMobAction(16814086) == 0) then
                 local Rand = math.random(1,10);
                 if (Rand <=9) then -- Spawn Gargoyle
-                    player:messageSpecial(TRAP_ACTIVATED); 
+                    player:messageSpecial(TRAP_ACTIVATED + 0x8000, 0, 0, 0, 0, true); 
                     SpawnMob(16814086,120):updateClaim(player); -- Gargoyle
                 else
-                    player:messageSpecial(TRAP_FAILS);
+                    player:messageSpecial(TRAP_FAILS + 0x8000, 0, 0, 0, 0, true);
                     npc:openDoor(30);
                 end    
             else

--- a/scripts/zones/PsoXja/npcs/_096.lua
+++ b/scripts/zones/PsoXja/npcs/_096.lua
@@ -2,7 +2,7 @@
 -- Area:  Pso'Xja
 -- NPC:   _096 (Stone Gate)
 -- Notes: Spawns Gargoyle when triggered
--- @pos -330.000 14.074 -261.600 9
+-- @pos 290.000 -1.925 -98.399 9
 -----------------------------------
 package.loaded["scripts/zones/PsoXja/TextIDs"] = nil;
 -----------------------------------
@@ -15,6 +15,30 @@ require("scripts/globals/keyitems");
 -----------------------------------
 
 function onTrade(player,npc,trade)
+
+    if ((trade:hasItemQty(1115,1) or trade:hasItemQty(1023,1) or trade:hasItemQty(1022,1)) and trade:getItemCount() == 1 and player:getMainJob() == 6) then
+
+        local Z=player:getZPos();
+    
+        if (npc:getAnimation() == 9) then    
+            if (Z <= -99) then
+                if (GetMobAction(16814087) == 0) then
+                    local Rand = math.random(1,2); -- estimated 50% success as per the wiki
+                    if (Rand == 1) then -- Spawn Gargoyle
+                        player:messageSpecial(DISCOVER_DISARM_FAIL + 0x8000, 0, 0, 0, 0, true); 
+                        SpawnMob(16814087,120):updateClaim(player); -- Gargoyle
+                    else
+                        player:messageSpecial(DISCOVER_DISARM_SUCCESS + 0x8000, 0, 0, 0, 0, true);
+                        npc:openDoor(30);
+                    end
+                    player:tradeComplete();
+                else
+                    player:messageSpecial(DOOR_LOCKED);
+                end
+            end
+        end
+    end
+
 end;
 
 -----------------------------------
@@ -30,10 +54,10 @@ function onTrigger(player,npc)
             if (GetMobAction(16814087) == 0) then
                 local Rand = math.random(1,10);
                 if (Rand <=9) then -- Spawn Gargoyle
-                    player:messageSpecial(TRAP_ACTIVATED); 
+                    player:messageSpecial(TRAP_ACTIVATED + 0x8000, 0, 0, 0, 0, true); 
                     SpawnMob(16814087,120):updateClaim(player); -- Gargoyle
                 else
-                    player:messageSpecial(TRAP_FAILS);
+                    player:messageSpecial(TRAP_FAILS + 0x8000, 0, 0, 0, 0, true);
                     npc:openDoor(30);
                 end    
             else

--- a/scripts/zones/PsoXja/npcs/_097.lua
+++ b/scripts/zones/PsoXja/npcs/_097.lua
@@ -2,7 +2,7 @@
 -- Area:  Pso'Xja
 -- NPC:   _097 (Stone Gate)
 -- Notes: Spawns Gargoyle when triggered
--- @pos -330.000 14.074 -261.600 9
+-- @pos 290.000 -1.925 -81.600 9
 -----------------------------------
 package.loaded["scripts/zones/PsoXja/TextIDs"] = nil;
 -----------------------------------
@@ -15,6 +15,30 @@ require("scripts/globals/keyitems");
 -----------------------------------
 
 function onTrade(player,npc,trade)
+
+    if ((trade:hasItemQty(1115,1) or trade:hasItemQty(1023,1) or trade:hasItemQty(1022,1)) and trade:getItemCount() == 1 and player:getMainJob() == 6) then
+
+        local Z=player:getZPos();
+    
+        if (npc:getAnimation() == 9) then    
+            if (Z <= -82) then
+                if (GetMobAction(16814088) == 0) then
+                    local Rand = math.random(1,2); -- estimated 50% success as per the wiki
+                    if (Rand == 1) then -- Spawn Gargoyle
+                        player:messageSpecial(DISCOVER_DISARM_FAIL + 0x8000, 0, 0, 0, 0, true); 
+                        SpawnMob(16814088,120):updateClaim(player); -- Gargoyle
+                    else
+                        player:messageSpecial(DISCOVER_DISARM_SUCCESS + 0x8000, 0, 0, 0, 0, true);
+                        npc:openDoor(30);
+                    end
+                    player:tradeComplete();
+                else
+                    player:messageSpecial(DOOR_LOCKED);
+                end
+            end
+        end
+    end
+
 end;
 
 -----------------------------------
@@ -30,10 +54,10 @@ function onTrigger(player,npc)
             if (GetMobAction(16814088) == 0) then
                 local Rand = math.random(1,10);
                 if (Rand <=9) then -- Spawn Gargoyle
-                    player:messageSpecial(TRAP_ACTIVATED); 
+                    player:messageSpecial(TRAP_ACTIVATED + 0x8000, 0, 0, 0, 0, true); 
                     SpawnMob(16814088,120):updateClaim(player); -- Gargoyle
                 else
-                    player:messageSpecial(TRAP_FAILS);
+                    player:messageSpecial(TRAP_FAILS + 0x8000, 0, 0, 0, 0, true);
                     npc:openDoor(30);
                 end    
             else

--- a/scripts/zones/PsoXja/npcs/_098.lua
+++ b/scripts/zones/PsoXja/npcs/_098.lua
@@ -2,7 +2,7 @@
 -- Area:  Pso'Xja
 -- NPC:   _098 (Stone Gate)
 -- Notes: Spawns Gargoyle when triggered
--- @pos -330.000 14.074 -261.600 9
+-- @pos 258.399 -1.925 -70.000 9
 -----------------------------------
 package.loaded["scripts/zones/PsoXja/TextIDs"] = nil;
 -----------------------------------
@@ -15,6 +15,30 @@ require("scripts/globals/keyitems");
 -----------------------------------
 
 function onTrade(player,npc,trade)
+
+    if ((trade:hasItemQty(1115,1) or trade:hasItemQty(1023,1) or trade:hasItemQty(1022,1)) and trade:getItemCount() == 1 and player:getMainJob() == 6) then
+
+        local X=player:getXPos();
+    
+        if (npc:getAnimation() == 9) then    
+            if (X >= 259) then
+                if (GetMobAction(16814089) == 0) then
+                    local Rand = math.random(1,2); -- estimated 50% success as per the wiki
+                    if (Rand == 1) then -- Spawn Gargoyle
+                        player:messageSpecial(DISCOVER_DISARM_FAIL + 0x8000, 0, 0, 0, 0, true); 
+                        SpawnMob(16814089,120):updateClaim(player); -- Gargoyle
+                    else
+                        player:messageSpecial(DISCOVER_DISARM_SUCCESS + 0x8000, 0, 0, 0, 0, true);
+                        npc:openDoor(30);
+                    end
+                    player:tradeComplete();
+                else
+                    player:messageSpecial(DOOR_LOCKED);
+                end
+            end
+        end
+    end
+
 end;
 
 -----------------------------------
@@ -30,10 +54,10 @@ function onTrigger(player,npc)
             if (GetMobAction(16814089) == 0) then
                 local Rand = math.random(1,10);
                 if (Rand <=9) then -- Spawn Gargoyle
-                    player:messageSpecial(TRAP_ACTIVATED); 
+                    player:messageSpecial(TRAP_ACTIVATED + 0x8000, 0, 0, 0, 0, true); 
                     SpawnMob(16814089,120):updateClaim(player); -- Gargoyle
                 else
-                    player:messageSpecial(TRAP_FAILS);
+                    player:messageSpecial(TRAP_FAILS + 0x8000, 0, 0, 0, 0, true);
                     npc:openDoor(30);
                 end    
             else

--- a/scripts/zones/PsoXja/npcs/_099.lua
+++ b/scripts/zones/PsoXja/npcs/_099.lua
@@ -2,7 +2,7 @@
 -- Area:  Pso'Xja
 -- NPC:   _099 (Stone Gate)
 -- Notes: Spawns Gargoyle when triggered
--- @pos -330.000 14.074 -261.600 9
+-- @pos 250.000 -1.925 -58.399 9
 -----------------------------------
 package.loaded["scripts/zones/PsoXja/TextIDs"] = nil;
 -----------------------------------
@@ -15,6 +15,30 @@ require("scripts/globals/keyitems");
 -----------------------------------
 
 function onTrade(player,npc,trade)
+
+    if ((trade:hasItemQty(1115,1) or trade:hasItemQty(1023,1) or trade:hasItemQty(1022,1)) and trade:getItemCount() == 1 and player:getMainJob() == 6) then
+
+        local Z=player:getZPos();
+    
+        if (npc:getAnimation() == 9) then    
+            if (Z <= -59) then
+                if (GetMobAction(16814090) == 0) then
+                    local Rand = math.random(1,2); -- estimated 50% success as per the wiki
+                    if (Rand == 1) then -- Spawn Gargoyle
+                        player:messageSpecial(DISCOVER_DISARM_FAIL + 0x8000, 0, 0, 0, 0, true); 
+                        SpawnMob(16814090,120):updateClaim(player); -- Gargoyle
+                    else
+                        player:messageSpecial(DISCOVER_DISARM_SUCCESS + 0x8000, 0, 0, 0, 0, true);
+                        npc:openDoor(30);
+                    end
+                    player:tradeComplete();
+                else
+                    player:messageSpecial(DOOR_LOCKED);
+                end
+            end
+        end
+    end
+
 end;
 
 -----------------------------------
@@ -30,10 +54,10 @@ function onTrigger(player,npc)
             if (GetMobAction(16814090) == 0) then
                 local Rand = math.random(1,10);
                 if (Rand <=9) then -- Spawn Gargoyle
-                    player:messageSpecial(TRAP_ACTIVATED); 
+                    player:messageSpecial(TRAP_ACTIVATED + 0x8000, 0, 0, 0, 0, true); 
                     SpawnMob(16814090,120):updateClaim(player); -- Gargoyle
                 else
-                    player:messageSpecial(TRAP_FAILS); -- 10% Chance the door will simply open without Gargoyle pop
+                    player:messageSpecial(TRAP_FAILS + 0x8000, 0, 0, 0, 0, true); -- 10% Chance the door will simply open without Gargoyle pop
                     npc:openDoor(30);
                 end    
             else

--- a/scripts/zones/PsoXja/npcs/_09a.lua
+++ b/scripts/zones/PsoXja/npcs/_09a.lua
@@ -2,7 +2,7 @@
 -- Area:  Pso'Xja
 -- NPC:   _09a (Stone Gate)
 -- Notes: Spawns Gargoyle when triggered
--- @pos -330.000 14.074 -261.600 9
+-- @pos 261.600 -1.925 -50.000 9
 -----------------------------------
 package.loaded["scripts/zones/PsoXja/TextIDs"] = nil;
 -----------------------------------
@@ -15,6 +15,30 @@ require("scripts/globals/keyitems");
 -----------------------------------
 
 function onTrade(player,npc,trade)
+
+    if ((trade:hasItemQty(1115,1) or trade:hasItemQty(1023,1) or trade:hasItemQty(1022,1)) and trade:getItemCount() == 1 and player:getMainJob() == 6) then
+
+        local X=player:getXPos();
+    
+        if (npc:getAnimation() == 9) then    
+            if (X <= 261) then
+                if (GetMobAction(16814091) == 0) then
+                    local Rand = math.random(1,2); -- estimated 50% success as per the wiki
+                    if (Rand == 1) then -- Spawn Gargoyle
+                        player:messageSpecial(DISCOVER_DISARM_FAIL + 0x8000, 0, 0, 0, 0, true); 
+                        SpawnMob(16814091,120):updateClaim(player); -- Gargoyle
+                    else
+                        player:messageSpecial(DISCOVER_DISARM_SUCCESS + 0x8000, 0, 0, 0, 0, true);
+                        npc:openDoor(30);
+                    end
+                    player:tradeComplete();
+                else
+                    player:messageSpecial(DOOR_LOCKED);
+                end
+            end
+        end
+    end
+
 end;
 
 -----------------------------------
@@ -30,10 +54,10 @@ function onTrigger(player,npc)
             if (GetMobAction(16814091) == 0) then
                 local Rand = math.random(1,10);
                 if (Rand <=9) then -- Spawn Gargoyle
-                    player:messageSpecial(TRAP_ACTIVATED); 
+                    player:messageSpecial(TRAP_ACTIVATED + 0x8000, 0, 0, 0, 0, true); 
                     SpawnMob(16814091,120):updateClaim(player); -- Gargoyle
                 else
-                    player:messageSpecial(TRAP_FAILS);
+                    player:messageSpecial(TRAP_FAILS + 0x8000, 0, 0, 0, 0, true);
                     npc:openDoor(30);
                 end    
             else

--- a/scripts/zones/PsoXja/npcs/_09b.lua
+++ b/scripts/zones/PsoXja/npcs/_09b.lua
@@ -2,7 +2,7 @@
 -- Area:  Pso'Xja
 -- NPC:   _09b (Stone Gate)
 -- Notes: Spawns Gargoyle when triggered
--- @pos -330.000 14.074 -261.600 9
+-- @pos 278.399 -1.925 -50.000 9
 -----------------------------------
 package.loaded["scripts/zones/PsoXja/TextIDs"] = nil;
 -----------------------------------
@@ -15,6 +15,30 @@ require("scripts/globals/keyitems");
 -----------------------------------
 
 function onTrade(player,npc,trade)
+
+    if ((trade:hasItemQty(1115,1) or trade:hasItemQty(1023,1) or trade:hasItemQty(1022,1)) and trade:getItemCount() == 1 and player:getMainJob() == 6) then
+
+        local X=player:getXPos();
+    
+        if (npc:getAnimation() == 9) then    
+            if (X <= 278) then
+                if (GetMobAction(16814092) == 0) then
+                    local Rand = math.random(1,2); -- estimated 50% success as per the wiki
+                    if (Rand == 1) then -- Spawn Gargoyle
+                        player:messageSpecial(DISCOVER_DISARM_FAIL + 0x8000, 0, 0, 0, 0, true); 
+                        SpawnMob(16814092,120):updateClaim(player); -- Gargoyle
+                    else
+                        player:messageSpecial(DISCOVER_DISARM_SUCCESS + 0x8000, 0, 0, 0, 0, true);
+                        npc:openDoor(30);
+                    end
+                    player:tradeComplete();
+                else
+                    player:messageSpecial(DOOR_LOCKED);
+                end
+            end
+        end
+    end
+
 end;
 
 -----------------------------------
@@ -30,10 +54,10 @@ function onTrigger(player,npc)
             if (GetMobAction(16814092) == 0) then
                 local Rand = math.random(1,10);
                 if (Rand <=9) then -- Spawn Gargoyle
-                    player:messageSpecial(TRAP_ACTIVATED); 
+                    player:messageSpecial(TRAP_ACTIVATED + 0x8000, 0, 0, 0, 0, true); 
                     SpawnMob(16814092,120):updateClaim(player); -- Gargoyle
                 else
-                    player:messageSpecial(TRAP_FAILS);
+                    player:messageSpecial(TRAP_FAILS + 0x8000, 0, 0, 0, 0, true);
                     npc:openDoor(30);
                 end    
             else

--- a/scripts/zones/PsoXja/npcs/_09c.lua
+++ b/scripts/zones/PsoXja/npcs/_09c.lua
@@ -2,7 +2,7 @@
 -- Area:  Pso'Xja
 -- NPC:   _09c (Stone Gate)
 -- Notes: Spawns Gargoyle when triggered
--- @pos -330.000 14.074 -261.600 9
+-- @pos 290.000 -1.925 -18.400 9
 -----------------------------------
 package.loaded["scripts/zones/PsoXja/TextIDs"] = nil;
 -----------------------------------
@@ -15,6 +15,30 @@ require("scripts/globals/keyitems");
 -----------------------------------
 
 function onTrade(player,npc,trade)
+
+    if ((trade:hasItemQty(1115,1) or trade:hasItemQty(1023,1) or trade:hasItemQty(1022,1)) and trade:getItemCount() == 1 and player:getMainJob() == 6) then
+
+        local Z=player:getZPos();
+    
+        if (npc:getAnimation() == 9) then    
+            if (Z <= -19) then
+                if (GetMobAction(16814093) == 0) then
+                    local Rand = math.random(1,2); -- estimated 50% success as per the wiki
+                    if (Rand == 1) then -- Spawn Gargoyle
+                        player:messageSpecial(DISCOVER_DISARM_FAIL + 0x8000, 0, 0, 0, 0, true); 
+                        SpawnMob(16814093,120):updateClaim(player); -- Gargoyle
+                    else
+                        player:messageSpecial(DISCOVER_DISARM_SUCCESS + 0x8000, 0, 0, 0, 0, true);
+                        npc:openDoor(30);
+                    end
+                    player:tradeComplete();
+                else
+                    player:messageSpecial(DOOR_LOCKED);
+                end
+            end
+        end
+    end
+
 end;
 
 -----------------------------------
@@ -30,10 +54,10 @@ function onTrigger(player,npc)
             if (GetMobAction(16814093) == 0) then
                 local Rand = math.random(1,10);
                 if (Rand <=9) then -- Spawn Gargoyle
-                    player:messageSpecial(TRAP_ACTIVATED); 
+                    player:messageSpecial(TRAP_ACTIVATED + 0x8000, 0, 0, 0, 0, true); 
                     SpawnMob(16814093,120):updateClaim(player); -- Gargoyle
                 else
-                    player:messageSpecial(TRAP_FAILS);
+                    player:messageSpecial(TRAP_FAILS + 0x8000, 0, 0, 0, 0, true);
                     npc:openDoor(30);
                 end    
             else

--- a/scripts/zones/PsoXja/npcs/_09d.lua
+++ b/scripts/zones/PsoXja/npcs/_09d.lua
@@ -2,7 +2,7 @@
 -- Area:  Pso'Xja
 -- NPC:   _09d (Stone Gate)
 -- Notes: Spawns Gargoyle when triggered
--- @pos -330.000 14.074 -261.600 9
+-- @pos 301.600 -1.925 -10.000 9
 -----------------------------------
 package.loaded["scripts/zones/PsoXja/TextIDs"] = nil;
 -----------------------------------
@@ -15,6 +15,30 @@ require("scripts/globals/keyitems");
 -----------------------------------
 
 function onTrade(player,npc,trade)
+
+    if ((trade:hasItemQty(1115,1) or trade:hasItemQty(1023,1) or trade:hasItemQty(1022,1)) and trade:getItemCount() == 1 and player:getMainJob() == 6) then
+
+        local X=player:getXPos();
+    
+        if (npc:getAnimation() == 9) then    
+            if (X <= 301) then
+                if (GetMobAction(16814094) == 0) then
+                    local Rand = math.random(1,2); -- estimated 50% success as per the wiki
+                    if (Rand == 1) then -- Spawn Gargoyle
+                        player:messageSpecial(DISCOVER_DISARM_FAIL + 0x8000, 0, 0, 0, 0, true); 
+                        SpawnMob(16814094,120):updateClaim(player); -- Gargoyle
+                    else
+                        player:messageSpecial(DISCOVER_DISARM_SUCCESS + 0x8000, 0, 0, 0, 0, true);
+                        npc:openDoor(30);
+                    end
+                    player:tradeComplete();
+                else
+                    player:messageSpecial(DOOR_LOCKED);
+                end
+            end
+        end
+    end
+
 end;
 
 -----------------------------------
@@ -30,10 +54,10 @@ function onTrigger(player,npc)
             if (GetMobAction(16814094) == 0) then
                 local Rand = math.random(1,10);
                 if (Rand <=9) then -- Spawn Gargoyle
-                    player:messageSpecial(TRAP_ACTIVATED); 
+                    player:messageSpecial(TRAP_ACTIVATED + 0x8000, 0, 0, 0, 0, true); 
                     SpawnMob(16814094,120):updateClaim(player); -- Gargoyle
                 else
-                    player:messageSpecial(TRAP_FAILS);
+                    player:messageSpecial(TRAP_FAILS + 0x8000, 0, 0, 0, 0, true);
                     npc:openDoor(30);
                 end    
             else

--- a/scripts/zones/PsoXja/npcs/_09e.lua
+++ b/scripts/zones/PsoXja/npcs/_09e.lua
@@ -2,7 +2,7 @@
 -- Area:  Pso'Xja
 -- NPC:   _09e (Stone Gate)
 -- Notes: Spawns Gargoyle when triggered
--- @pos -330.000 14.074 -261.600 9
+-- @pos 310.000 -1.925 -21.599 9
 -----------------------------------
 package.loaded["scripts/zones/PsoXja/TextIDs"] = nil;
 -----------------------------------
@@ -15,6 +15,30 @@ require("scripts/globals/keyitems");
 -----------------------------------
 
 function onTrade(player,npc,trade)
+
+    if ((trade:hasItemQty(1115,1) or trade:hasItemQty(1023,1) or trade:hasItemQty(1022,1)) and trade:getItemCount() == 1 and player:getMainJob() == 6) then
+
+        local Z=player:getZPos();
+    
+        if (npc:getAnimation() == 9) then    
+            if (Z >= -21) then
+                if (GetMobAction(16814095) == 0) then
+                    local Rand = math.random(1,2); -- estimated 50% success as per the wiki
+                    if (Rand == 1) then -- Spawn Gargoyle
+                        player:messageSpecial(DISCOVER_DISARM_FAIL + 0x8000, 0, 0, 0, 0, true); 
+                        SpawnMob(16814095,120):updateClaim(player); -- Gargoyle
+                    else
+                        player:messageSpecial(DISCOVER_DISARM_SUCCESS + 0x8000, 0, 0, 0, 0, true);
+                        npc:openDoor(30);
+                    end
+                    player:tradeComplete();
+                else
+                    player:messageSpecial(DOOR_LOCKED);
+                end
+            end
+        end
+    end
+
 end;
 
 -----------------------------------
@@ -30,10 +54,10 @@ function onTrigger(player,npc)
             if (GetMobAction(16814095) == 0) then
                 local Rand = math.random(1,10);
                 if (Rand <=9) then -- Spawn Gargoyle
-                    player:messageSpecial(TRAP_ACTIVATED); 
+                    player:messageSpecial(TRAP_ACTIVATED + 0x8000, 0, 0, 0, 0, true); 
                     SpawnMob(16814095,120):updateClaim(player); -- Gargoyle
                 else
-                    player:messageSpecial(TRAP_FAILS);
+                    player:messageSpecial(TRAP_FAILS + 0x8000, 0, 0, 0, 0, true);
                     npc:openDoor(30);
                 end    
             else

--- a/scripts/zones/PsoXja/npcs/_09f.lua
+++ b/scripts/zones/PsoXja/npcs/_09f.lua
@@ -2,7 +2,7 @@
 -- Area:  Pso'Xja
 -- NPC:   _09f (Stone Gate)
 -- Notes: Spawns Gargoyle when triggered
--- @pos -330.000 14.074 -261.600 9
+-- @pos 310.000 -1.925 -38.400 9
 -----------------------------------
 package.loaded["scripts/zones/PsoXja/TextIDs"] = nil;
 -----------------------------------
@@ -15,6 +15,30 @@ require("scripts/globals/keyitems");
 -----------------------------------
 
 function onTrade(player,npc,trade)
+
+    if ((trade:hasItemQty(1115,1) or trade:hasItemQty(1023,1) or trade:hasItemQty(1022,1)) and trade:getItemCount() == 1 and player:getMainJob() == 6) then
+
+        local Z=player:getZPos();
+    
+        if (npc:getAnimation() == 9) then    
+            if (Z >= -38) then
+                if (GetMobAction(16814096) == 0) then
+                    local Rand = math.random(1,2); -- estimated 50% success as per the wiki
+                    if (Rand == 1) then -- Spawn Gargoyle
+                        player:messageSpecial(DISCOVER_DISARM_FAIL + 0x8000, 0, 0, 0, 0, true); 
+                        SpawnMob(16814096,120):updateClaim(player); -- Gargoyle
+                    else
+                        player:messageSpecial(DISCOVER_DISARM_SUCCESS + 0x8000, 0, 0, 0, 0, true);
+                        npc:openDoor(30);
+                    end
+                    player:tradeComplete();
+                else
+                    player:messageSpecial(DOOR_LOCKED);
+                end
+            end
+        end
+    end
+
 end;
 
 -----------------------------------
@@ -30,10 +54,10 @@ function onTrigger(player,npc)
             if (GetMobAction(16814096) == 0) then
                 local Rand = math.random(1,10);
                 if (Rand <=9) then -- Spawn Gargoyle
-                    player:messageSpecial(TRAP_ACTIVATED); 
+                    player:messageSpecial(TRAP_ACTIVATED + 0x8000, 0, 0, 0, 0, true); 
                     SpawnMob(16814096,120):updateClaim(player); -- Gargoyle
                 else
-                    player:messageSpecial(TRAP_FAILS);
+                    player:messageSpecial(TRAP_FAILS + 0x8000, 0, 0, 0, 0, true);
                     npc:openDoor(30);
                 end    
             else


### PR DESCRIPTION
-Made the doors able to be picked open by a THF main with Thief's Tools/Living Key/Skeleton Key. Using wiki estimated success rate of 50%.
-Fix the message displayed for each message (now includes the player name, thanks @teschnei)
-Corrected the positions of the 16 Pso'Xja doors in the header.
-Added sanity checks to the locked gates in Phomiuna Aqueducts (only consumes key if gate is closed and player is on the locked side). Now able to be picked open with Living Key and Skeleton Key in addition to Thief's Tools.