### PR TITLE
Scripts: Correct Floodlight check, removed unused vars.

### DIFF
--- a/scripts/globals/mobskills/Floodlight.lua
+++ b/scripts/globals/mobskills/Floodlight.lua
@@ -5,6 +5,7 @@
 --  Type: Magical
 --
 ---------------------------------------------------
+
 require("scripts/globals/settings");
 require("scripts/globals/status");
 require("scripts/globals/monstertpmoves");
@@ -12,18 +13,12 @@ require("scripts/globals/monstertpmoves");
 ---------------------------------------------------
 
 function onMobSkillCheck(target,mob,skill)
-    -- skillList  54 = Omega
-    -- skillList 727 = Proto-Omega
-    -- skillList 728 = Ultima
-    -- skillList 729 = Proto-Ultima
-    local skillList = mob:getMobMod(MOBMOD_SKILL_LIST);
-    local mobhp = mob:getHPP();
+    local currentForm = mob:getLocalVar("form"); -- Proto-Omega's script sets this.
 
-    if (skillList == 727 and mobhp > 30 and mobhp < 70  ) then -- omega first bipedform
+    if (mob:AnimationSub() == 2 and currentForm == 1) then -- omega first bipedform
         return 0;
-    else
-        return 1;
     end
+    return 1;
 end;
 
 function onMobWeaponSkill(target, mob, skill)

--- a/scripts/globals/mobskills/Guided_Missile_II.lua
+++ b/scripts/globals/mobskills/Guided_Missile_II.lua
@@ -14,8 +14,7 @@ require("scripts/globals/monstertpmoves");
 ---------------------------------------------------
 
 function onMobSkillCheck(target,mob,skill)
-    local mobhp = mob:getHPP();
-    local currentForm = mob:getLocalVar("form")
+    local currentForm = mob:getLocalVar("form");
 
     if (mob:AnimationSub() == 2 and currentForm == 1) then -- proto-omega first bipedform
         return 0;

--- a/scripts/globals/mobskills/Stun_Cannon.lua
+++ b/scripts/globals/mobskills/Stun_Cannon.lua
@@ -14,8 +14,7 @@ require("scripts/globals/monstertpmoves");
 ---------------------------------------------------
 
 function onMobSkillCheck(target,mob,skill)
-    local mobhp = mob:getHPP();
-    local currentForm = mob:getLocalVar("form")
+    local currentForm = mob:getLocalVar("form");
 
     if (mob:AnimationSub() == 2 and currentForm == 1) then -- proto-omega bipedform
         return 0;


### PR DESCRIPTION
You know, there are other mobskills that can also only be used during phase 2 while standing, like Guided Missile II. Why didn't I just copy the check over from that earlier?

Also removed variables that were being set but not used.