### PR TITLE
Scripts: Implement Ninjutsu skill damage bonus for NIN nukes

### DIFF
--- a/scripts/globals/magic.lua
+++ b/scripts/globals/magic.lua
@@ -1119,6 +1119,18 @@ function doNuke(V,M,caster,spell,target,hasMultipleTargetReduction,resistBonus,s
     --get the resisted damage
     dmg = dmg*resist;
     if (skill == NINJUTSU_SKILL) then
+        if (caster:getMainJob() == JOB_NIN) then -- NIN main gets a bonus to their ninjutsu nukes
+            local ninSkillBonus = 100;
+            if (spell:getID() % 3 == 2) then -- ichi nuke spell ids are 320, 323, 326, 329, 332, and 335
+                ninSkillBonus = 100 + math.floor((caster:getSkillLevel(SKILL_NIN) - 50)/2); -- getSkillLevel includes bonuses from merits and modifiers (ie. gear)
+            elseif (spell:getID() % 3 == 0) then -- ni nuke spell ids are 1 more than their corresponding ichi spell
+                ninSkillBonus = 100 + math.floor((caster:getSkillLevel(SKILL_NIN) - 125)/2);
+            else -- san nuke spell, also has ids 1 more than their corresponding ni spell
+                ninSkillBonus = 100 + math.floor((caster:getSkillLevel(SKILL_NIN) - 275)/2);
+            end
+            ninSkillBonus = utils.clamp(ninSkillBonus, 100, 200); -- bonus caps at +100%, and does not go negative
+            dmg = dmg * ninSkillBonus/100;
+        end
         -- boost with Futae
         if (caster:hasStatusEffect(EFFECT_FUTAE)) then
             dmg = math.floor(dmg * 1.50);

--- a/scripts/globals/spells/doton_ichi.lua
+++ b/scripts/globals/spells/doton_ichi.lua
@@ -24,7 +24,7 @@ function onSpellCast(caster,target,spell)
         bonusMab = bonusMab + caster:getStatusEffect(EFFECT_INNIN):getPower();
     end
 
-    local dmg = doNinjutsuNuke(28,1,caster,spell,target,false,bonusAcc,bonusMab);
+    local dmg = doNinjutsuNuke(28,0.5,caster,spell,target,false,bonusAcc,bonusMab);
     handleNinjutsuDebuff(caster,target,spell,30,duration,MOD_WINDRES);
 
     return dmg;

--- a/scripts/globals/spells/doton_ni.lua
+++ b/scripts/globals/spells/doton_ni.lua
@@ -24,7 +24,7 @@ function onSpellCast(caster,target,spell)
         bonusMab = bonusMab + caster:getStatusEffect(EFFECT_INNIN):getPower();
     end
 
-    local dmg = doNinjutsuNuke(68,1,caster,spell,target,false,bonusAcc,bonusMab);
+    local dmg = doNinjutsuNuke(69,1,caster,spell,target,false,bonusAcc,bonusMab);
     handleNinjutsuDebuff(caster,target,spell,30,duration,MOD_WINDRES);
 
     return dmg;

--- a/scripts/globals/spells/doton_san.lua
+++ b/scripts/globals/spells/doton_san.lua
@@ -28,7 +28,7 @@ function onSpellCast(caster,target,spell)
         bonusMab = bonusMab + caster:getStatusEffect(EFFECT_INNIN):getPower();
     end
 
-    local dmg = doNinjutsuNuke(134,1,caster,spell,target,false,bonusAcc,bonusMab);
+    local dmg = doNinjutsuNuke(134,1.5,caster,spell,target,false,bonusAcc,bonusMab);
     handleNinjutsuDebuff(caster,target,spell,30,duration,MOD_WINDRES);
 
     return dmg;

--- a/scripts/globals/spells/huton_ichi.lua
+++ b/scripts/globals/spells/huton_ichi.lua
@@ -24,7 +24,7 @@ function onSpellCast(caster,target,spell)
         bonusMab = bonusMab + caster:getStatusEffect(EFFECT_INNIN):getPower();
     end
 
-    local dmg = doNinjutsuNuke(28,1,caster,spell,target,false,bonusAcc,bonusMab);
+    local dmg = doNinjutsuNuke(28,0.5,caster,spell,target,false,bonusAcc,bonusMab);
     handleNinjutsuDebuff(caster,target,spell,30,duration,MOD_ICERES);
 
     return dmg;

--- a/scripts/globals/spells/huton_ni.lua
+++ b/scripts/globals/spells/huton_ni.lua
@@ -24,7 +24,7 @@ function onSpellCast(caster,target,spell)
         bonusMab = bonusMab + caster:getStatusEffect(EFFECT_INNIN):getPower();
     end
 
-    local dmg = doNinjutsuNuke(68,1,caster,spell,target,false,bonusAcc,bonusMab);
+    local dmg = doNinjutsuNuke(69,1,caster,spell,target,false,bonusAcc,bonusMab);
     handleNinjutsuDebuff(caster,target,spell,30,duration,MOD_ICERES);
 
     return dmg;

--- a/scripts/globals/spells/huton_san.lua
+++ b/scripts/globals/spells/huton_san.lua
@@ -28,7 +28,7 @@ function onSpellCast(caster,target,spell)
         bonusMab = bonusMab + caster:getStatusEffect(EFFECT_INNIN):getPower();
     end
 
-    local dmg = doNinjutsuNuke(134,1,caster,spell,target,false,bonusAcc,bonusMab);
+    local dmg = doNinjutsuNuke(134,1.5,caster,spell,target,false,bonusAcc,bonusMab);
     handleNinjutsuDebuff(caster,target,spell,30,duration,MOD_ICERES);
 
     return dmg;

--- a/scripts/globals/spells/hyoton_ichi.lua
+++ b/scripts/globals/spells/hyoton_ichi.lua
@@ -24,7 +24,7 @@ function onSpellCast(caster,target,spell)
         bonusMab = bonusMab + caster:getStatusEffect(EFFECT_INNIN):getPower();
     end
 
-    local dmg = doNinjutsuNuke(28,1,caster,spell,target,false,bonusAcc,bonusMab);
+    local dmg = doNinjutsuNuke(28,0.5,caster,spell,target,false,bonusAcc,bonusMab);
     handleNinjutsuDebuff(caster,target,spell,30,duration,MOD_FIRERES);
 
     return dmg;

--- a/scripts/globals/spells/hyoton_ni.lua
+++ b/scripts/globals/spells/hyoton_ni.lua
@@ -24,7 +24,7 @@ function onSpellCast(caster,target,spell)
         bonusMab = bonusMab + caster:getStatusEffect(EFFECT_INNIN):getPower();
     end
 
-    local dmg = doNinjutsuNuke(68,1,caster,spell,target,false,bonusAcc,bonusMab);
+    local dmg = doNinjutsuNuke(69,1,caster,spell,target,false,bonusAcc,bonusMab);
     handleNinjutsuDebuff(caster,target,spell,30,duration,MOD_FIRERES);
 
     return dmg;

--- a/scripts/globals/spells/hyoton_san.lua
+++ b/scripts/globals/spells/hyoton_san.lua
@@ -28,7 +28,7 @@ function onSpellCast(caster,target,spell)
         bonusMab = bonusMab + caster:getStatusEffect(EFFECT_INNIN):getPower();
     end
 
-    local dmg = doNinjutsuNuke(134,1,caster,spell,target,false,bonusAcc,bonusMab);
+    local dmg = doNinjutsuNuke(134,1.5,caster,spell,target,false,bonusAcc,bonusMab);
     handleNinjutsuDebuff(caster,target,spell,30,duration,MOD_FIRERES);
 
     return dmg;

--- a/scripts/globals/spells/katon_ichi.lua
+++ b/scripts/globals/spells/katon_ichi.lua
@@ -24,7 +24,7 @@ function onSpellCast(caster,target,spell)
         bonusMab = bonusMab + caster:getStatusEffect(EFFECT_INNIN):getPower();
     end
 
-    local dmg = doNinjutsuNuke(28,1,caster,spell,target,false,bonusAcc,bonusMab);
+    local dmg = doNinjutsuNuke(28,0.5,caster,spell,target,false,bonusAcc,bonusMab);
     handleNinjutsuDebuff(caster,target,spell,30,duration,MOD_WATERRES);
 
     return dmg;

--- a/scripts/globals/spells/katon_ni.lua
+++ b/scripts/globals/spells/katon_ni.lua
@@ -24,7 +24,7 @@ function onSpellCast(caster,target,spell)
         bonusMab = bonusMab + caster:getStatusEffect(EFFECT_INNIN):getPower();
     end
 
-    local dmg = doNinjutsuNuke(68,1,caster,spell,target,false,bonusAcc,bonusMab);
+    local dmg = doNinjutsuNuke(69,1,caster,spell,target,false,bonusAcc,bonusMab);
     handleNinjutsuDebuff(caster,target,spell,30,duration,MOD_WATERRES);
 
     return dmg;

--- a/scripts/globals/spells/katon_san.lua
+++ b/scripts/globals/spells/katon_san.lua
@@ -28,7 +28,7 @@ function onSpellCast(caster,target,spell)
         bonusMab = bonusMab + caster:getStatusEffect(EFFECT_INNIN):getPower();
     end
 
-    local dmg = doNinjutsuNuke(134,1,caster,spell,target,false,bonusAcc,bonusMab);
+    local dmg = doNinjutsuNuke(134,1.5,caster,spell,target,false,bonusAcc,bonusMab);
     handleNinjutsuDebuff(caster,target,spell,30,duration,MOD_WATERRES);
 
     return dmg;

--- a/scripts/globals/spells/raiton_ichi.lua
+++ b/scripts/globals/spells/raiton_ichi.lua
@@ -24,7 +24,7 @@ function onSpellCast(caster,target,spell)
         bonusMab = bonusMab + caster:getStatusEffect(EFFECT_INNIN):getPower();
     end
 
-    local dmg = doNinjutsuNuke(28,1,caster,spell,target,false,bonusAcc,bonusMab);
+    local dmg = doNinjutsuNuke(28,0.5,caster,spell,target,false,bonusAcc,bonusMab);
     handleNinjutsuDebuff(caster,target,spell,30,duration,MOD_EARTHRES);
 
     return dmg;

--- a/scripts/globals/spells/raiton_ni.lua
+++ b/scripts/globals/spells/raiton_ni.lua
@@ -24,7 +24,7 @@ function onSpellCast(caster,target,spell)
         bonusMab = bonusMab + caster:getStatusEffect(EFFECT_INNIN):getPower();
     end
 
-    local dmg = doNinjutsuNuke(68,1,caster,spell,target,false,bonusAcc,bonusMab);
+    local dmg = doNinjutsuNuke(69,1,caster,spell,target,false,bonusAcc,bonusMab);
     handleNinjutsuDebuff(caster,target,spell,30,duration,MOD_EARTHRES);
 
     return dmg;

--- a/scripts/globals/spells/raiton_san.lua
+++ b/scripts/globals/spells/raiton_san.lua
@@ -28,7 +28,7 @@ function onSpellCast(caster,target,spell)
         bonusMab = bonusMab + caster:getStatusEffect(EFFECT_INNIN):getPower();
     end
 
-    local dmg = doNinjutsuNuke(134,1,caster,spell,target,false,bonusAcc,bonusMab);
+    local dmg = doNinjutsuNuke(134,1.5,caster,spell,target,false,bonusAcc,bonusMab);
     handleNinjutsuDebuff(caster,target,spell,30,duration,MOD_EARTHRES);
 
     return dmg;

--- a/scripts/globals/spells/suiton_ichi.lua
+++ b/scripts/globals/spells/suiton_ichi.lua
@@ -24,7 +24,7 @@ function onSpellCast(caster,target,spell)
         bonusMab = bonusMab + caster:getStatusEffect(EFFECT_INNIN):getPower();
     end
 
-    local dmg = doNinjutsuNuke(28,1,caster,spell,target,false,bonusAcc,bonusMab);
+    local dmg = doNinjutsuNuke(28,0.5,caster,spell,target,false,bonusAcc,bonusMab);
     handleNinjutsuDebuff(caster,target,spell,30,duration,MOD_THUNDERRES);
 
     return dmg;

--- a/scripts/globals/spells/suiton_ni.lua
+++ b/scripts/globals/spells/suiton_ni.lua
@@ -24,7 +24,7 @@ function onSpellCast(caster,target,spell)
         bonusMab = bonusMab + caster:getStatusEffect(EFFECT_INNIN):getPower();
     end
 
-    local dmg = doNinjutsuNuke(68,1,caster,spell,target,false,bonusAcc,bonusMab);
+    local dmg = doNinjutsuNuke(69,1,caster,spell,target,false,bonusAcc,bonusMab);
     handleNinjutsuDebuff(caster,target,spell,30,duration,MOD_THUNDERRES);
 
     return dmg;

--- a/scripts/globals/spells/suiton_san.lua
+++ b/scripts/globals/spells/suiton_san.lua
@@ -28,7 +28,7 @@ function onSpellCast(caster,target,spell)
         bonusMab = bonusMab + caster:getStatusEffect(EFFECT_INNIN):getPower();
     end
 
-    local dmg = doNinjutsuNuke(134,1,caster,spell,target,false,bonusAcc,bonusMab);
+    local dmg = doNinjutsuNuke(134,1.5,caster,spell,target,false,bonusAcc,bonusMab);
     handleNinjutsuDebuff(caster,target,spell,30,duration,MOD_THUNDERRES);
 
     return dmg;


### PR DESCRIPTION
-General idea is (skill - constant)/2 where constant depends on the tier of the spell can provide a bonus, up to +100% base damage.
-Corrected the M values on Ichi and San tier nukes, V values on Ni tier nukes.

https://www.bg-wiki.com/bg/Category:Ninjutsu#Elemental_Ninjutsu