### PR TITLE
Scripts: Fix faulty check on F/GoV, un-global variable

### DIFF
--- a/scripts/globals/fieldsofvalor.lua
+++ b/scripts/globals/fieldsofvalor.lua
@@ -434,7 +434,7 @@ function checkRegime(player, mob, rid, index)
         return;
     end
 
-    partyType = player:checkSoloPartyAlliance();
+    local partyType = player:checkSoloPartyAlliance();
 
     if (player:checkFovAllianceAllowed() == 1) then
         partyType = 1;
@@ -444,7 +444,7 @@ function checkRegime(player, mob, rid, index)
         -- Need to add difference because a lvl1 can xp with a level 75 at ro'maeve
         local difference = math.abs(mob:getMainLvl() - player:getMainLvl());
         
-        if ((partyType < 2 and mob:checkBaseExp() and player:checkDistance(mob) < 100 and difference <= 15) or player:checkFovDistancePenalty() == 0) then
+        if (partyType < 2 and (mob:checkBaseExp() or LOW_LEVEL_REGIME == 1) and difference <= 15 and (player:checkDistance(mob) < 100 or player:checkFovDistancePenalty() == 0)) then
             -- get the number of mobs needed/killed
             local needed = player:getVar("fov_numneeded"..index);
             local killed = player:getVar("fov_numkilled"..index);

--- a/scripts/globals/groundsofvalor.lua
+++ b/scripts/globals/groundsofvalor.lua
@@ -483,7 +483,7 @@ function checkGoVregime(player,mob,rid,index)
         -- Need to add difference because a lvl1 can XP with a level 75 at Ro'Maeve
         local difference = math.abs(mob:getMainLvl() - player:getMainLvl());
 
-        if ((mob:checkBaseExp() and player:checkDistance(mob) < 100 and difference <= 15) or player:checkFovDistancePenalty() == 0) then
+        if ((mob:checkBaseExp() or LOW_LEVEL_REGIME == 1) and difference <= 15 and (player:checkDistance(mob) < 100 or player:checkFovDistancePenalty() == 0)) then
             -- Get the number of mobs needed/killed
             local needed = player:getVar("fov_numneeded"..index);
             local killed = player:getVar("fov_numkilled"..index);


### PR DESCRIPTION
-Made the partyType variable in FoV a local one because it's not used anywhere else.
-Fixed the if statement regarding distance, as if the one config setting to ignore distance was set, it would also ignore the player/mob level difference or if the mob gave exp to the player.
-Made the setting to allow for players to have page progress on TWs actually work.