### PR TITLE
ADDED - Tahrongi Cacti Scripting

### DIFF
--- a/scripts/zones/Tahrongi_Canyon/TextIDs.lua
+++ b/scripts/zones/Tahrongi_Canyon/TextIDs.lua
@@ -18,11 +18,14 @@ MINING_IS_POSSIBLE_HERE = 7423; -- Mining is possible here if you have
 REPULSIVE_CREATURE_EMERGES = 7542; -- A repulsive creature emerges from the ground!
 SPROUT_DOES_NOT_NEED_WATER = 7543; -- The sprout does not need any more water now.
      SPROUT_LOOKING_BETTER = 7545; -- The sprout is looking better.
-     
+
 -- Tahrongi Cactus
             BUD_BREAKS_OFF = 7400; -- The bud breaks off. You obtain
     POISONOUS_LOOKING_BUDS = 7401; -- The flowers have poisonous-looking buds.
         CANT_TAKE_ANY_MORE = 7402; -- You can't take any more.
+
+-- Luck Rune
+NOTHING_OUT_OF_THE_ORDINARY = 6579;  -- There is nothing out of the ordinary here.
 
 -- Other Texts
 TELEPOINT_HAS_BEEN_SHATTERED = 7498; -- The telepoint has been shattered into a thousand pieces...
@@ -40,4 +43,3 @@ CONQUEST_BASE = 0;
 -- chocobo digging
 DIG_THROW_AWAY = 7239; -- You dig up ?Possible Special Code: 01??Possible Special Code: 01??Possible Special Code: 01? ?Possible Special Code: 01??Possible Special Code: 05?$?BAD CHAR: 8280??BAD CHAR: 80??BAD CHAR: 80?, but your inventory is full.
 FIND_NOTHING = 7241; -- You dig and you dig, but find nothing.
-

--- a/scripts/zones/Tahrongi_Canyon/npcs/Tahrongi_Cacti.lua
+++ b/scripts/zones/Tahrongi_Canyon/npcs/Tahrongi_Cacti.lua
@@ -1,0 +1,47 @@
+-----------------------------------
+-- Area: Tahrongi Canyon
+-- NPC:  Tahrongi Cacti
+-- Involved in Quest: Say It with Flowers
+--
+-- @pos -308.721 7.477 264.454
+-----------------------------------
+package.loaded["scripts/zones/Tahrongi_Canyon/TextIDs"] = nil;
+-----------------------------------
+
+require("scripts/globals/quests");
+require("scripts/globals/zone");
+require("scripts/zones/Tahrongi_Canyon/TextIDs");
+
+-----------------------------------
+-- onTrigger Action
+-----------------------------------
+
+function onTrigger(player,npc)
+    if (player:getQuestStatus(WINDURST,SAY_IT_WITH_FLOWERS) == QUEST_ACCEPTED) and player:getVar("FLOWER_PROGRESS") == 1) and player:hasItem(950) == false) then
+        --Meets conditions to receive a Tahrongi Cactus flower
+        if (player:getFreeSlotsCount() > 0) then
+            --Meets inventory space requirements, throws item receipt message in game
+            player:addItem(950);
+            player:messageSpecial(BUD_BREAKS_OFF,950);
+        else
+            --Inventory is full, throws error message in game
+            player:messageSpecial(CANT_TAKE_ANY_MORE);
+        end;
+        --No further scripting required as this item could also be obtained through gardening.  This trigger should simply provide the player the item if they already do not have one (no quest updates or cutscenes required)!
+    else
+        --Not on the Say It With Flowers quest
+        player:messageSpecial(POISONOUS_LOOKING_BUDS);
+    end;
+end;
+
+-----------------------------------
+-- onEventUpdate
+-----------------------------------
+function onEventUpdate(player,csid,option)
+end;
+
+-----------------------------------
+-- onEventFinish
+-----------------------------------
+function onEventFinish(player,csid,option)
+end;


### PR DESCRIPTION
- Added scripting to handle giving Tahrongi Cactus flower to players who
trigger the Tahrongi Cacti and are on the proper part of the "Say it
with Flowers" quest.
- Re-added lost textID for Luck Rune in Tahrongi Canyon

Resolved conflicts; re-submission of https://github.com/DarkstarProject/darkstar/pull/2555