### PR TITLE
Transition from Chamber of Oracles to Return to Delkfuts tower Variables Incorrect

### DIFF
--- a/scripts/zones/Chamber_of_Oracles/npcs/Pedestal_of_Dark.lua
+++ b/scripts/zones/Chamber_of_Oracles/npcs/Pedestal_of_Dark.lua
@@ -65,7 +65,7 @@ function onEventFinish(player,csid,option)
     
     if (csid == 0x0001) then
         player:addTitle(LIGHTWEAVER);
-        player:setVar("ZilartStatus",2);
+        player:setVar("ZilartStatus",0);
         player:addKeyItem(PRISMATIC_FRAGMENT);
         player:messageSpecial(KEYITEM_OBTAINED,PRISMATIC_FRAGMENT);
         player:completeMission(ZILART,THE_CHAMBER_OF_ORACLES);

--- a/scripts/zones/Chamber_of_Oracles/npcs/Pedestal_of_Earth.lua
+++ b/scripts/zones/Chamber_of_Oracles/npcs/Pedestal_of_Earth.lua
@@ -65,7 +65,7 @@ function onEventFinish(player,csid,option)
     
     if (csid == 0x0001) then
         player:addTitle(LIGHTWEAVER);
-        player:setVar("ZilartStatus",2);
+        player:setVar("ZilartStatus",0);
         player:addKeyItem(PRISMATIC_FRAGMENT);
         player:messageSpecial(KEYITEM_OBTAINED,PRISMATIC_FRAGMENT);
         player:completeMission(ZILART,THE_CHAMBER_OF_ORACLES);

--- a/scripts/zones/Chamber_of_Oracles/npcs/Pedestal_of_Fire.lua
+++ b/scripts/zones/Chamber_of_Oracles/npcs/Pedestal_of_Fire.lua
@@ -65,7 +65,7 @@ function onEventFinish(player,csid,option)
     
     if (csid == 0x0001) then
         player:addTitle(LIGHTWEAVER);
-        player:setVar("ZilartStatus",2);
+        player:setVar("ZilartStatus",0);
         player:addKeyItem(PRISMATIC_FRAGMENT);
         player:messageSpecial(KEYITEM_OBTAINED,PRISMATIC_FRAGMENT);
         player:completeMission(ZILART,THE_CHAMBER_OF_ORACLES);

--- a/scripts/zones/Chamber_of_Oracles/npcs/Pedestal_of_Ice.lua
+++ b/scripts/zones/Chamber_of_Oracles/npcs/Pedestal_of_Ice.lua
@@ -65,7 +65,7 @@ function onEventFinish(player,csid,option)
     
     if (csid == 0x0001) then
         player:addTitle(LIGHTWEAVER);
-        player:setVar("ZilartStatus",2);
+        player:setVar("ZilartStatus",0);
         player:addKeyItem(PRISMATIC_FRAGMENT);
         player:messageSpecial(KEYITEM_OBTAINED,PRISMATIC_FRAGMENT);
         player:completeMission(ZILART,THE_CHAMBER_OF_ORACLES);

--- a/scripts/zones/Chamber_of_Oracles/npcs/Pedestal_of_Light.lua
+++ b/scripts/zones/Chamber_of_Oracles/npcs/Pedestal_of_Light.lua
@@ -65,7 +65,7 @@ function onEventFinish(player,csid,option)
     
     if (csid == 0x0001) then
         player:addTitle(LIGHTWEAVER);
-        player:setVar("ZilartStatus",2);
+        player:setVar("ZilartStatus",0);
         player:addKeyItem(PRISMATIC_FRAGMENT);
         player:messageSpecial(KEYITEM_OBTAINED,PRISMATIC_FRAGMENT);
         player:completeMission(ZILART,THE_CHAMBER_OF_ORACLES);

--- a/scripts/zones/Chamber_of_Oracles/npcs/Pedestal_of_Lightning.lua
+++ b/scripts/zones/Chamber_of_Oracles/npcs/Pedestal_of_Lightning.lua
@@ -65,7 +65,7 @@ function onEventFinish(player,csid,option)
     
     if (csid == 0x0001) then
         player:addTitle(LIGHTWEAVER);
-        player:setVar("ZilartStatus",2);
+        player:setVar("ZilartStatus",0);
         player:addKeyItem(PRISMATIC_FRAGMENT);
         player:messageSpecial(KEYITEM_OBTAINED,PRISMATIC_FRAGMENT);
         player:completeMission(ZILART,THE_CHAMBER_OF_ORACLES);

--- a/scripts/zones/Chamber_of_Oracles/npcs/Pedestal_of_Water.lua
+++ b/scripts/zones/Chamber_of_Oracles/npcs/Pedestal_of_Water.lua
@@ -65,7 +65,7 @@ function onEventFinish(player,csid,option)
     
     if (csid == 0x0001) then
         player:addTitle(LIGHTWEAVER);
-        player:setVar("ZilartStatus",2);
+        player:setVar("ZilartStatus",0);
         player:addKeyItem(PRISMATIC_FRAGMENT);
         player:messageSpecial(KEYITEM_OBTAINED,PRISMATIC_FRAGMENT);
         player:completeMission(ZILART,THE_CHAMBER_OF_ORACLES);

--- a/scripts/zones/Chamber_of_Oracles/npcs/Pedestal_of_Wind.lua
+++ b/scripts/zones/Chamber_of_Oracles/npcs/Pedestal_of_Wind.lua
@@ -65,7 +65,7 @@ function onEventFinish(player,csid,option)
     
     if (csid == 0x0001) then
         player:addTitle(LIGHTWEAVER);
-        player:setVar("ZilartStatus",2);
+        player:setVar("ZilartStatus",0);
         player:addKeyItem(PRISMATIC_FRAGMENT);
         player:messageSpecial(KEYITEM_OBTAINED,PRISMATIC_FRAGMENT);
         player:completeMission(ZILART,THE_CHAMBER_OF_ORACLES);


### PR DESCRIPTION
Changing ZM status to 2 At the end of the mission forces you to skip both the Optional CS at Aldo for the next mission as well as the ZoneIN CS in lower delkfuts tower - in Return to Delkfuts Tower.
Aldo requirement = 0 
ZoneIN CS <= 1 (which is set by ALDO or 0 at the end of the last mission)
Both Optional CS and ZoneIN CS appear to be coded correctly - No reason to skip.