### PR TITLE
Attempting Mission 5-2 BCNM (Shadow Lord) freezes char in CS.

### DIFF
--- a/src/map/battlefield.cpp
+++ b/src/map/battlefield.cpp
@@ -36,6 +36,7 @@
 #include "status_effect_container.h"
 #include "ai/ai_container.h"
 #include "enmity_container.h"
+#include "ai/states/death_state.h"
 
 CBattlefield::CBattlefield(CBattlefieldHandler* hand, uint16 id, BATTLEFIELDTYPE type){
 	m_Type = type;
@@ -342,7 +343,7 @@ void CBattlefield::addNpc(CBaseEntity* PNpc){
 bool CBattlefield::allEnemiesDefeated(){
 	bool allDefeated = true;
 	for(auto&& Condition : m_EnemyVictoryList){
-        if (Condition.MobEntity->isDead()){
+        if (Condition.MobEntity->PAI->IsCurrentState<CDeathState>()){
             Condition.killed = true;
 		}
 		if(Condition.killed == false){


### PR DESCRIPTION
Fixed BCNM winning prematurely at very start.  This makes the server start another CS while client enters BCNM.  Clients says it can't start a cutscene while one is in progress, and client stays stuck until logout.

Caused by BCNM having victory condition set on mobs that spawns later on in the BCNM Fight.  The winning condition would return true because isDead on these mobs are all true (hp ==0, and status disapear).

Adding a flag to mob entity to prevent winning until those mobs did spawn.

Fixes Mission 5-2.