### PR TITLE
Scripts/SQL: Update mdt-% values from shell/mob family mods

### DIFF
--- a/scripts/globals/effects/fealty.lua
+++ b/scripts/globals/effects/fealty.lua
@@ -11,7 +11,6 @@ require("scripts/globals/status");
 -----------------------------------
 
 function onEffectGain(target,effect)
-   target:addMod(MOD_UDMGMAGIC,-100);
    target:addMod(MOD_MEVA,200);
 end;
 
@@ -27,6 +26,5 @@ end;
 -----------------------------------
 
 function onEffectLose(target,effect)
-   target:delMod(MOD_UDMGMAGIC,-100);
    target:delMod(MOD_MEVA,200);
 end;

--- a/scripts/globals/fieldsofvalor.lua
+++ b/scripts/globals/fieldsofvalor.lua
@@ -268,13 +268,13 @@ function finishFov(player, csid, option, r1, r2, r3, r4, r5, msg_offset)
             -- values taken from Shell scripts by Tenjou.
             local def = 0;
             if (player:getMainLvl() < 37) then -- before shell 2, give shell 1
-                def = 24;
+                def = 9;
             elseif (player:getMainLvl() < 57) then -- after s2, before s3
-                def = 36;
+                def = 14;
             elseif (player:getMainLvl() < 68) then -- after s3, before s4
-                def = 48;
+                def = 19;
             else -- after s4
-                def = 56;
+                def = 22;
             end
             -- Add shell
             player:addStatusEffect(EFFECT_SHELL, def, 0, 1800);

--- a/scripts/globals/items/coated_shield.lua
+++ b/scripts/globals/items/coated_shield.lua
@@ -20,7 +20,7 @@ end;
 
 function onItemUse(target)
 
-    local power = 24;
+    local power = 9;
 
     if (target:addStatusEffect(EFFECT_SHELL, power, 0, 1800)) then
         target:messageBasic(205);

--- a/scripts/globals/mobskills/Bubble_Armor.lua
+++ b/scripts/globals/mobskills/Bubble_Armor.lua
@@ -20,7 +20,7 @@ end;
 
 function onMobWeaponSkill(target, mob, skill)
     local typeEffect = EFFECT_SHELL;
-    local power = 128;
+    local power = 50;
 
 
     skill:setMsg(MobBuffMove(mob, typeEffect, power, 0, 180));

--- a/scripts/globals/mobskills/Bubble_Curtain.lua
+++ b/scripts/globals/mobskills/Bubble_Curtain.lua
@@ -20,7 +20,7 @@ end;
 
 function onMobWeaponSkill(target, mob, skill)
     local typeEffect = EFFECT_SHELL;
-    local power = 128;
+    local power = 50;
 
     skill:setMsg(MobBuffMove(mob, typeEffect, power, 0, 180));
 

--- a/scripts/globals/mobskills/Crystaline_Cocoon.lua
+++ b/scripts/globals/mobskills/Crystaline_Cocoon.lua
@@ -22,9 +22,12 @@ function onMobWeaponSkill(target, mob, skill)
 
     local typeEffect1 = EFFECT_PROTECT;
     local typeEffect2 = EFFECT_SHELL;
+    local power1 = 50;
+    local power2 = 20;
+    local duration = 300;
 
-    skill:setMsg(MobBuffMove(mob, typeEffect1, 50, 0, 60));
-    MobBuffMove(mob, typeEffect2, 50, 0, 60);
+    skill:setMsg(MobBuffMove(mob, typeEffect1, power1, 0, duration));
+    MobBuffMove(mob, typeEffect2, power2, 0, duration);
 
     return typeEffect1;
 end;

--- a/scripts/globals/mobskills/Unblessed_Armor.lua
+++ b/scripts/globals/mobskills/Unblessed_Armor.lua
@@ -20,7 +20,7 @@ end;
 
 function onMobWeaponSkill(target, mob, skill)
     local typeEffect = EFFECT_SHELL;
-    local power = 128;
+    local power = 50;
 
     skill:setMsg(MobBuffMove(mob, typeEffect, power, 0, 180));
 

--- a/scripts/globals/spells/protectra_v.lua
+++ b/scripts/globals/spells/protectra_v.lua
@@ -16,9 +16,11 @@ end;
 function onSpellCast(caster,target,spell)
     local meritBonus = caster:getMerit(MERIT_PROTECTRA_V);
     local duration = 1800;
-    --Base Power is actually 175, but you have to have at least 1 merit and they're each +5
     
-    local power = 170 + meritBonus;
+    local power = 175 + meritBonus;
+    if (meritBonus > 0) then -- certain mobs can cast this spell, so don't apply the -5 for having 0 merits.
+        power = power + meritBonus - 5;
+    end
     --printf("Protectra V Power: %d", power);
     
     duration = calculateDurationForLvl(duration, 75, target:getMainLvl());

--- a/scripts/globals/spells/shell.lua
+++ b/scripts/globals/spells/shell.lua
@@ -14,7 +14,7 @@ function onMagicCastingCheck(caster,target,spell)
 end;
 
 function onSpellCast(caster,target,spell)
-    local power = 24;
+    local power = 9;
     local duration = 1800;
 
     duration = calculateDurationForLvl(duration, 18, target:getMainLvl());

--- a/scripts/globals/spells/shell_ii.lua
+++ b/scripts/globals/spells/shell_ii.lua
@@ -14,7 +14,7 @@ function onMagicCastingCheck(caster,target,spell)
 end;
 
 function onSpellCast(caster,target,spell)
-    local power = 36;
+    local power = 14;
     local duration = 1800;
 
     duration = calculateDurationForLvl(duration, 37, target:getMainLvl());

--- a/scripts/globals/spells/shell_iii.lua
+++ b/scripts/globals/spells/shell_iii.lua
@@ -14,7 +14,7 @@ function onMagicCastingCheck(caster,target,spell)
 end;
 
 function onSpellCast(caster,target,spell)
-    local power = 48;
+    local power = 19;
     local duration = 1800;
 
     duration = calculateDurationForLvl(duration, 57, target:getMainLvl());

--- a/scripts/globals/spells/shell_iv.lua
+++ b/scripts/globals/spells/shell_iv.lua
@@ -14,7 +14,7 @@ function onMagicCastingCheck(caster,target,spell)
 end;
 
 function onSpellCast(caster,target,spell)
-    local power = 56;
+    local power = 22;
     local duration = 1800;
 
     duration = calculateDurationForLvl(duration, 68, target:getMainLvl());

--- a/scripts/globals/spells/shell_v.lua
+++ b/scripts/globals/spells/shell_v.lua
@@ -13,7 +13,7 @@ function onMagicCastingCheck(caster,target,spell)
 end;
 
 function onSpellCast(caster,target,spell)
-    local power = 62;
+    local power = 24;
     local duration = 1800;
 
     local typeEffect = EFFECT_SHELL;

--- a/scripts/globals/spells/shellra.lua
+++ b/scripts/globals/spells/shellra.lua
@@ -14,7 +14,7 @@ function onMagicCastingCheck(caster,target,spell)
 end;
 
 function onSpellCast(caster,target,spell)
-    local power = 24;
+    local power = 9;
     local duration = 1800;
 
     duration = calculateDurationForLvl(duration, 18, target:getMainLvl());

--- a/scripts/globals/spells/shellra_ii.lua
+++ b/scripts/globals/spells/shellra_ii.lua
@@ -14,7 +14,7 @@ function onMagicCastingCheck(caster,target,spell)
 end;
 
 function onSpellCast(caster,target,spell)
-    local power = 36;
+    local power = 14;
     local duration = 1800;
 
     duration = calculateDurationForLvl(duration, 37, target:getMainLvl());

--- a/scripts/globals/spells/shellra_iii.lua
+++ b/scripts/globals/spells/shellra_iii.lua
@@ -14,7 +14,7 @@ function onMagicCastingCheck(caster,target,spell)
 end;
 
 function onSpellCast(caster,target,spell)
-    local power = 48;
+    local power = 19;
     local duration = 1800;
 
     duration = calculateDurationForLvl(duration, 57, target:getMainLvl());

--- a/scripts/globals/spells/shellra_iv.lua
+++ b/scripts/globals/spells/shellra_iv.lua
@@ -14,7 +14,7 @@ function onMagicCastingCheck(caster,target,spell)
 end;
 
 function onSpellCast(caster,target,spell)
-    local power = 56;
+    local power = 22;
     local duration = 1800;
 
     duration = calculateDurationForLvl(duration, 68, target:getMainLvl());

--- a/scripts/globals/spells/shellra_v.lua
+++ b/scripts/globals/spells/shellra_v.lua
@@ -16,9 +16,12 @@ end;
 function onSpellCast(caster,target,spell)
     local meritBonus = caster:getMerit(MERIT_SHELLRA_V);
     local duration = 1800;
-    
-    --Base Power is actually 62, but you will always have atleast 1 merit
-    local power = 60 + meritBonus;
+
+    local power = 62;
+    if (meritBonus > 0) then -- certain mobs can cast this spell, so don't apply the -2 for having 0 merits.
+        power = power + meritBonus - 2;
+    end
+    power = power * 100/256; -- doing it this way because otherwise the merit power would have to be 0.78125.
     --printf("Shellra V Power: %d", power);
     
     duration = calculateDurationForLvl(duration, 75, target:getMainLvl());

--- a/scripts/zones/Riverne-Site_B01/mobs/Bahamut.lua
+++ b/scripts/zones/Riverne-Site_B01/mobs/Bahamut.lua
@@ -19,7 +19,7 @@ function onMobSpawn(mob)
     mob:addStatusEffect(EFFECT_PHALANX,35,0,180);
     mob:addStatusEffect(EFFECT_STONESKIN,350,0,300);
     mob:addStatusEffect(EFFECT_PROTECT,175,0,1800);
-    mob:addStatusEffect(EFFECT_SHELL,62,0,1800);
+    mob:addStatusEffect(EFFECT_SHELL,24,0,1800);
 end;
 
 -----------------------------------

--- a/sql/mob_family_mods.sql
+++ b/sql/mob_family_mods.sql
@@ -136,18 +136,18 @@ INSERT INTO `mob_family_mods` VALUES (394,4,30,1);
 INSERT INTO `mob_family_mods` VALUES (236,4,30,1);
 
 -- Adjust magic damage taken
-INSERT INTO `mob_family_mods` VALUES (4,389,-64,0);
-INSERT INTO `mob_family_mods` VALUES (112,389,64,0);
-INSERT INTO `mob_family_mods` VALUES (61,389,-64,0);
-INSERT INTO `mob_family_mods` VALUES (74,389,-64,0);
-INSERT INTO `mob_family_mods` VALUES (358,389,-64,0);
-INSERT INTO `mob_family_mods` VALUES (169,389,-64,0);
-INSERT INTO `mob_family_mods` VALUES (110,389,-32,0);
-INSERT INTO `mob_family_mods` VALUES (122,389,-32,0);
-INSERT INTO `mob_family_mods` VALUES (123,389,-32,0);
-INSERT INTO `mob_family_mods` VALUES (124,389,-32,0);
-INSERT INTO `mob_family_mods` VALUES (175,389,-128,0);
-INSERT INTO `mob_family_mods` VALUES (171,389,-32,0);
+INSERT INTO `mob_family_mods` VALUES (4,389,-25,0);
+INSERT INTO `mob_family_mods` VALUES (112,389,25,0);
+INSERT INTO `mob_family_mods` VALUES (61,389,-25,0);
+INSERT INTO `mob_family_mods` VALUES (74,389,-25,0);
+INSERT INTO `mob_family_mods` VALUES (358,389,-25,0);
+INSERT INTO `mob_family_mods` VALUES (169,389,-25,0);
+INSERT INTO `mob_family_mods` VALUES (110,389,-13,0);
+INSERT INTO `mob_family_mods` VALUES (122,389,-13,0);
+INSERT INTO `mob_family_mods` VALUES (123,389,-13,0);
+INSERT INTO `mob_family_mods` VALUES (124,389,-13,0);
+INSERT INTO `mob_family_mods` VALUES (175,389,-50,0);
+INSERT INTO `mob_family_mods` VALUES (171,389,-13,0);
 
 -- Demons and fomors are somewhat resistant to lullaby
 INSERT INTO `mob_family_mods` VALUES (358,254,25,0);


### PR DESCRIPTION
Since they were forgotten when xdt-% was refactored to all be out of /100 (yay for accuracy loss! If anything, it should all have been out of /256 imo). Also removed the flat damage reduction from Fealty though it's still wrong - should reduce the accuracy of any enfeebling effect, but not just the ones DSP has resistances for, and also certain non-elemental damage. Currently it's just magic eva +200. Added a check for Protectra/Shellra V for having no merits, for mobs who have the spell.