### PR TITLE
Aht Urhgan Mission 6: Easterly Winds

### DIFF
--- a/scripts/zones/RuLude_Gardens/Zone.lua
+++ b/scripts/zones/RuLude_Gardens/Zone.lua
@@ -134,8 +134,6 @@ function onEventFinish(player,csid,option)
         if (option ==1) then
             if (player:getFreeSlotsCount() == 0) then 
                 player:messageSpecial(ITEM_CANNOT_BE_OBTAINED,2184);
-                player:completeMission(TOAU,EASTERLY_WINDS);
-                player:addMission(TOAU,WESTERLY_WINDS);
             else
                 player:addItem(2184,10);
                 player:messageSpecial(ITEM_OBTAINED,2184);


### PR DESCRIPTION
No reason to check for free slots if you aren't going to let them make another attempt at getting the item, So the assumption is you want them to be able to get the item in which case you would NOT end the mission on a failed attempt to get the item.  

If this is wrong, then you can remove the get free slots and put the mission ending back in regardless.