### PR TITLE
bug fixes for RNG AF quest line.

### DIFF
--- a/scripts/globals/abilities/scavenge.lua
+++ b/scripts/globals/abilities/scavenge.lua
@@ -56,23 +56,20 @@ function onUseAbility(player, target, ability, action)
         else
             if (arrowsToReturn > 99) then
                 arrowsToReturn = 99;
-            end
+            end;
 
             local arrowID = math.floor(player:getLocalVar("ArrowsUsed") / 10000);
             player:addItem(arrowID, arrowsToReturn);
             
             if (arrowsToReturn == 1) then
                 action:messageID(playerID,140);
-                action:param(playerID, arrowID);
             else
                 action:messageID(playerID, 674);
                 action:additionalEffect(playerID, 1);
                 action:addEffectParam(playerID, arrowsToReturn);
-                action:param(playerID, arrowID);
             end;
+         player:setLocalVar("ArrowsUsed", 0);
+        return arrowID;
         end;
-        
-        -- Reset use count
-        player:setLocalVar("ArrowsUsed", 0);
-    end
+    end;
 end;

--- a/scripts/globals/abilities/scavenge.lua
+++ b/scripts/globals/abilities/scavenge.lua
@@ -68,7 +68,7 @@ function onUseAbility(player, target, ability, action)
                 action:additionalEffect(playerID, 1);
                 action:addEffectParam(playerID, arrowsToReturn);
             end;
-         player:setLocalVar("ArrowsUsed", 0);
+        player:setLocalVar("ArrowsUsed", 0);
         return arrowID;
         end;
     end;

--- a/scripts/globals/abilities/scavenge.lua
+++ b/scripts/globals/abilities/scavenge.lua
@@ -25,46 +25,52 @@ function onUseAbility(player, target, ability, action)
 
     -- RNG AF2 quest check
     local FireAndBrimstoneCS = player:getVar("fireAndBrimstone");
+    local oldEarring = 1113;
 
-    if (player:getZoneID() == 151 and FireAndBrimstoneCS == 5 and -- zone + quest match
+    if (player:getZoneID() == 151 and FireAndBrimstoneCS == 5 and-- zone + quest match
+        player:hasItem(oldEarring) == false and -- make sure player doesn't already have the earring
         player:getYPos() > -43 and player:getYPos() < -38 and -- Y match
         player:getXPos() > -85 and player:getXPos() < -73 and -- X match
         player:getZPos() > -85 and player:getZPos() < -75 and -- Z match
         math.random(100) < 50) then
 
+        local ITEM_CANNOT_BE_OBTAINED = 6564;
+        local ITEM_OBTAINED = 6569;
+
         if (player:getFreeSlotsCount() == 0) then
-            player:messageSpecial(ITEM_CANNOT_BE_OBTAINED,1113);
+            player:messageSpecial(ITEM_CANNOT_BE_OBTAINED, oldEarring);
+            return;
         else
-            player:addItem(1113);
-            player:messageSpecial(ITEM_OBTAINED,1113);
-        end
+            player:addItem(oldEarring);
+            player:messageSpecial(ITEM_OBTAINED, oldEarring);
+        end;
 
     else
 
     local bonuses = (player:getMod(MOD_SCAVENGE_EFFECT)  + player:getMerit(MERIT_SCAVENGE_EFFECT) ) / 100;
     local arrowsToReturn = math.floor(math.floor(player:getLocalVar("ArrowsUsed")  % 10000) * (player:getMainLvl() / 200 + bonuses));
-    
+    local playerID = target:getID();
+
         if (arrowsToReturn == 0) then
-            action:setMessageID(139);
+            action:messageID(playerID,139);
         else
             if (arrowsToReturn > 99) then
                 arrowsToReturn = 99;
             end
+
+            local arrowID = math.floor(player:getLocalVar("ArrowsUsed") / 10000);
+            player:addItem(arrowID, arrowsToReturn);
             
-            local arrowID = math.floor(player:getLocalVar("ArrowsUsed")  / 10000);
-            
-            player:addItem(arrowID, arrowsToReturn);        
-    
             if (arrowsToReturn == 1) then
-                action:setParam(arrowID);
-                action:setMessageID(140);
-            else 
-                action:setParam(arrowID);
-                action:setMessageID(674);
-                action:setAdditionalEffect(1);
-                action:setAddEffectParam(arrowsToReturn);
-            end
-        end
+                action:messageID(playerID,140);
+                action:param(playerID, arrowID);
+            else
+                action:messageID(playerID, 674);
+                action:additionalEffect(playerID, 1);
+                action:addEffectParam(playerID, arrowsToReturn);
+                action:param(playerID, arrowID);
+            end;
+        end;
         
         -- Reset use count
         player:setLocalVar("ArrowsUsed", 0);

--- a/scripts/zones/Jugner_Forest/npcs/qm2.lua
+++ b/scripts/zones/Jugner_Forest/npcs/qm2.lua
@@ -24,10 +24,10 @@ end;
 
 function onTrigger(player,npc)
    
-      local SinHunting = player:getVar("sinHunting");    -- RNG AF1 
-   
+      local SinHunting = player:getVar("sinHunting");-- RNG AF1 
+
     if (SinHunting == 4) then
-        player:startEvent(0x000d, 0, 1107);        
+        player:startEvent(0x000d, 0, 1107);
     end
 end;
 

--- a/scripts/zones/Sauromugue_Champaign/mobs/Old_Sabertooth.lua
+++ b/scripts/zones/Sauromugue_Champaign/mobs/Old_Sabertooth.lua
@@ -20,7 +20,7 @@ end;
 -- onMobDeath
 -----------------------------------
 
-function onMobDeath(mob, killer)
+function onMobDeath(mob,killer,ally)
 
     if (killer == nil) then
     

--- a/scripts/zones/Sauromugue_Champaign/mobs/Old_Sabertooth.lua
+++ b/scripts/zones/Sauromugue_Champaign/mobs/Old_Sabertooth.lua
@@ -22,25 +22,18 @@ end;
 
 function onMobDeath(mob, killer)
 
-    local players = mob:getZone():getPlayers();
+    if (killer == nil) then
     
-    for i, player in pairs(players) do
+        local players = mob:getZone():getPlayers();
+        for i, player in pairs(players) do
 
-        --check to see if the player has accepted this quest.
-        if (player:getQuestStatus(WINDURST,THE_FANGED_ONE) == QUEST_ACCEPTED) then
+            if (player:getQuestStatus(WINDURST,THE_FANGED_ONE) == QUEST_ACCEPTED) then
 
-        --check to see if the player's x,y,z coordinates are near enough to the cave where the RNG quest mob dies.
-        --point 1: 690, -15, -338
-        --point 2: 654, -9, -383
-        --these are outside the playable space but used to form a box around the cave where this quest takes place
-            local playerX = player:getXPos();
-            --local playerY = player:getYPos(); we shouldn't really care about the y axis for this
-            local playerZ = player:getZPos();
+            local playerDistance = player:checkDistance(mob);
+                if (playerDistance < 32) then
 
-            if (playerX < 690 and playerX > 654 and
-                playerZ < -338 and playerZ > -383) then
-
-                player:setVar("TheFangedOneCS", 2);
+                    player:setVar("TheFangedOneCS", 2);
+                end;
             end;
         end;
     end;

--- a/scripts/zones/Sauromugue_Champaign/mobs/Old_Sabertooth.lua
+++ b/scripts/zones/Sauromugue_Champaign/mobs/Old_Sabertooth.lua
@@ -1,6 +1,6 @@
 -----------------------------------
 -- Area: Sauromuge Champaign
---  MOB: Old Sabertooth
+-- NPC:  Old Sabertooth
 -- Involved in Quest: The Fanged One
 -- @pos 676 -10 -366 120
 -----------------------------------
@@ -13,12 +13,35 @@ require("scripts/globals/status");
 -----------------------------------
 
 function onMobSpawn(mob)
+
 end;
 
 -----------------------------------
 -- onMobDeath
 -----------------------------------
 
-function onMobDeath(mob, killer, ally)
-    ally:setVar("TheFangedOne_Died",0);
+function onMobDeath(mob, killer)
+
+    local players = mob:getZone():getPlayers();
+    
+    for i, player in pairs(players) do
+
+        --check to see if the player has accepted this quest.
+        if (player:getQuestStatus(WINDURST,THE_FANGED_ONE) == QUEST_ACCEPTED) then
+
+        --check to see if the player's x,y,z coordinates are near enough to the cave where the RNG quest mob dies.
+        --point 1: 690, -15, -338
+        --point 2: 654, -9, -383
+        --these are outside the playable space but used to form a box around the cave where this quest takes place
+            local playerX = player:getXPos();
+            --local playerY = player:getYPos(); we shouldn't really care about the y axis for this
+            local playerZ = player:getZPos();
+
+            if (playerX < 690 and playerX > 654 and
+                playerZ < -338 and playerZ > -383) then
+
+                player:setVar("TheFangedOneCS", 2);
+            end;
+        end;
+    end;
 end;

--- a/scripts/zones/Sauromugue_Champaign/npcs/Tiger_Bones.lua
+++ b/scripts/zones/Sauromugue_Champaign/npcs/Tiger_Bones.lua
@@ -26,20 +26,26 @@ end;
 function onTrigger(player,npc)
 
     if (player:getQuestStatus(WINDURST,THE_FANGED_ONE) == QUEST_ACCEPTED) then
-        deadTiger = player:getVar("TheFangedOne_Died");
 
-        if (deadTiger == 1 and player:hasKeyItem(OLD_TIGERS_FANG) == false) then
+        local oldTiger = 17268808;
+        local tigerAction = GetMobAction(oldTiger);
+        local fangedOneCS = player:getVar("TheFangedOneCS");
+
+        if (player:hasKeyItem(OLD_TIGERS_FANG) == false and
+            fangedOneCS == 2) then
+
             player:addKeyItem(OLD_TIGERS_FANG);
             player:messageSpecial(KEYITEM_OBTAINED, OLD_TIGERS_FANG);
-        elseif (deadTiger == 0) then
-            if (GetMobAction(17268808) == 0) then
-                SpawnMob(17268808):addStatusEffect(EFFECT_POISON,40,10,210);
-                player:messageSpecial(OLD_SABERTOOTH_DIALOG_I);
-                player:setVar("TheFangedOne_Died",1);
-            end
-        end
-    end
-    
+            player:setVar("TheFangedOneCS", 0);
+
+        elseif (tigerAction == ACTION_NONE and fangedOneCS == 1) then
+
+            SpawnMob(oldTiger):addStatusEffect(EFFECT_POISON,40,10,210);
+            player:messageSpecial(OLD_SABERTOOTH_DIALOG_I);
+        else
+            player:messageSpecial(NOTHING_HAPPENS);
+        end;
+end;
 end;
 
 -----------------------------------

--- a/scripts/zones/Windurst_Woods/npcs/Perih_Vashai.lua
+++ b/scripts/zones/Windurst_Woods/npcs/Perih_Vashai.lua
@@ -17,15 +17,18 @@ require("scripts/globals/missions");
 -----------------------------------
 -- onTrade Action
 -----------------------------------
+local twinstoneEarring = 13360;
+local oldEarring = 1113;
 
 function onTrade(player,npc,trade)
 
-    if (trade:hasItemQty(1113,1) and trade:getItemCount() == 1) then -- Trade old earring (complete Rng AF2 quest)    
+    if (trade:hasItemQty(oldEarring,1) and trade:getItemCount() == 1) then -- Trade old earring (complete Rng AF2 quest)
         local FireAndBrimstoneCS = player:getVar("fireAndBrimstone");
+
         if (FireAndBrimstoneCS == 5) then
-            player:startEvent(0x0219, 0, 13360);
+            player:startEvent(0x0219, 0, twinstoneEarring);
         end
-    end    
+    end
 
 end;
 
@@ -36,23 +39,23 @@ end;
 function onTrigger(player,npc)
 
     local TheFangedOne = player:getQuestStatus(WINDURST,THE_FANGED_ONE); -- RNG flag quest
-    
-    local SinHunting = player:getQuestStatus(WINDURST,SIN_HUNTING);    -- RNG AF1
+
+    local SinHunting = player:getQuestStatus(WINDURST,SIN_HUNTING);-- RNG AF1
     local SinHuntingCS = player:getVar("sinHunting");
-    
-    local FireAndBrimstone = player:getQuestStatus(WINDURST,FIRE_AND_BRIMSTONE);    -- RNG AF2    
-    local FireAndBrimstoneCS = player:getVar("fireAndBrimstone");    
-    
-    local UnbridledPassion = player:getQuestStatus(WINDURST,UNBRIDLED_PASSION);    -- RNG AF3    
-    local UnbridledPassionCS = player:getVar("unbridledPassion");        
-    
+
+    local FireAndBrimstone = player:getQuestStatus(WINDURST,FIRE_AND_BRIMSTONE);-- RNG AF2
+    local FireAndBrimstoneCS = player:getVar("fireAndBrimstone");
+
+    local UnbridledPassion = player:getQuestStatus(WINDURST,UNBRIDLED_PASSION);-- RNG AF3
+    local UnbridledPassionCS = player:getVar("unbridledPassion");
+
     local LvL = player:getMainLvl();
     local Job = player:getMainJob();
-    
-    -- COP mission
+
+-- COP mission
     if (player:getCurrentMission(COP) == THREE_PATHS and player:getVar("COP_Louverance_s_Path") == 1) then
-            player:startEvent(0x02AE);        
-    -- the fanged one        
+            player:startEvent(0x02AE);	
+    -- the fanged one	
     elseif (TheFangedOne ~= QUEST_COMPLETED) then
         if (TheFangedOne == QUEST_AVAILABLE and player:getMainLvl() >= ADVANCED_JOB_LEVEL) then
             player:startEvent(0x015f);
@@ -63,40 +66,40 @@ function onTrigger(player,npc)
         elseif (player:getVar("TheFangedOne_Event") == 1) then
             player:startEvent(0x0166);
         end
-    
+
     -- sin hunting
     elseif (SinHunting == QUEST_AVAILABLE and Job == 11 and LvL >= 40 and SinHuntingCS == 0) then
-        player:startEvent(0x020b);    -- start RNG AF1
+        player:startEvent(0x020b);	-- start RNG AF1
     elseif (SinHuntingCS > 0 and SinHuntingCS < 5) then
-        player:startEvent(0x020c);    -- during quest RNG AF1        
+        player:startEvent(0x020c);-- during quest RNG AF1
     elseif (SinHuntingCS == 5) then
-        player:startEvent(0x020f);    -- complete quest RNG AF1
-        
-    -- fire and brimstone    
+        player:startEvent(0x020f);-- complete quest RNG AF1
+
+    -- fire and brimstone
     elseif (SinHunting == QUEST_COMPLETED and Job == 11 and FireAndBrimstone == QUEST_AVAILABLE and FireAndBrimstoneCS == 0) then
-        player:startEvent(0x0213);    -- start RNG AF2
+        player:startEvent(0x0213);-- start RNG AF2
     elseif (FireAndBrimstoneCS > 0 and FireAndBrimstoneCS < 4) then
-        player:startEvent(0x0214);    -- during RNG AF2        
+        player:startEvent(0x0214);-- during RNG AF2
     elseif (FireAndBrimstoneCS == 4) then
-        player:startEvent(0x0217,0,13360,1113);    -- second part RNG AF2            
+        player:startEvent(0x0217,0,twinstoneEarring,oldEarring);	-- second part RNG AF2
     elseif (FireAndBrimstoneCS == 5) then
-        player:startEvent(0x0218);    -- during second part RNG AF2
-        
+        player:startEvent(0x0218,0,twinstoneEarring,oldEarring);	-- during second part RNG AF2
+
     -- Unbridled Passion
     elseif (FireAndBrimstone == QUEST_COMPLETED and Job == 11 and UnbridledPassion == QUEST_AVAILABLE and UnbridledPassion == 0) then
-        player:startEvent(0x021d, 0, 13360);    -- start RNG AF3
+        player:startEvent(0x021d, 0, twinstoneEarring);-- start RNG AF3
     elseif (UnbridledPassionCS > 0 and UnbridledPassionCS < 3) then
-        player:startEvent(0x021e);    -- during RNG AF3    
+        player:startEvent(0x021e);-- during RNG AF3
     elseif (UnbridledPassionCS >= 3 and UnbridledPassionCS < 7) then
-        player:startEvent(0x021e);    -- during RNG AF3            
+        player:startEvent(0x021e);-- during RNG AF3
     elseif (UnbridledPassionCS == 7) then
-        player:startEvent(0x0222, 0, 14099); -- complete RNG AF3        
-        
+        player:startEvent(0x0222, 0, 14099); -- complete RNG AF3
+
     -- standard dialog
     else
         player:startEvent(0x0152);
     end
-    
+
 end;
 
 -----------------------------------
@@ -118,11 +121,12 @@ function onEventFinish(player,csid,option)
 
     if (csid == 0x015f) then
         player:addQuest(WINDURST,THE_FANGED_ONE);
+        player:setVar("TheFangedOneCS", 1);
     elseif (csid == 0x0165 or csid == 0x0166) then
         if (player:getFreeSlotsCount(0) >= 1 and player:hasItem(13117) == false) then
             player:delKeyItem(OLD_TIGERS_FANG);
             player:setVar("TheFangedOne_Event",0);
-            player:setVar("TheFangedOne_Died",0);
+            player:setVar("TheFangedOneCS",0);
             player:addTitle(THE_FANGED_ONE);
             player:addItem(13117);
             player:messageSpecial(ITEM_OBTAINED,13117);
@@ -134,36 +138,36 @@ function onEventFinish(player,csid,option)
             player:messageSpecial(ITEM_CANNOT_BE_OBTAINED,13117);
             player:setVar("TheFangedOne_Event",1);
         end
-    elseif (csid == 0x020b) then    -- start quest RNG AF1
+    elseif (csid == 0x020b) then	-- start quest RNG AF1
         player:addQuest(WINDURST,SIN_HUNTING);
         player:addKeyItem(CHIEFTAINNESS_TWINSTONE_EARRING);
-        player:messageSpecial(KEYITEM_OBTAINED,CHIEFTAINNESS_TWINSTONE_EARRING);    
+        player:messageSpecial(KEYITEM_OBTAINED,CHIEFTAINNESS_TWINSTONE_EARRING);
         player:setVar("sinHunting",1);
     elseif (csid == 0x020f) then -- complete quest RNG AF1
-        if (player:getFreeSlotsCount() == 0) then 
+        if (player:getFreeSlotsCount() == 0) then
             player:messageSpecial(ITEM_CANNOT_BE_OBTAINED,17188);
-        else 
+        else
             player:addItem(17188);
             player:messageSpecial(ITEM_OBTAINED,17188);
             player:completeQuest(WINDURST,SIN_HUNTING);
-            player:delKeyItem(CHIEFTAINNESS_TWINSTONE_EARRING);        
-            player:delKeyItem(PERCHONDS_ENVELOPE);                
-            player:setVar("sinHunting",0);    
+            player:delKeyItem(CHIEFTAINNESS_TWINSTONE_EARRING);
+            player:delKeyItem(PERCHONDS_ENVELOPE);
+            player:setVar("sinHunting",0);	
         end
     elseif (csid == 0x0213) then -- start RNG AF2
         player:addQuest(WINDURST,FIRE_AND_BRIMSTONE);
         player:setVar("fireAndBrimstone",1);
     elseif (csid == 0x0217) then -- start second part RNG AF2
-        player:setVar("fireAndBrimstone",5);            
+        player:setVar("fireAndBrimstone",5);
     elseif (csid == 0x0219) then -- complete quest RNG AF2
         if (player:getFreeSlotsCount() == 0) then 
             player:messageSpecial(ITEM_CANNOT_BE_OBTAINED,12518);
-        else     
+        else
             player:tradeComplete();
             player:addItem(12518);
             player:messageSpecial(ITEM_OBTAINED,12518);
-            player:completeQuest(WINDURST,FIRE_AND_BRIMSTONE);        
-            player:setVar("fireAndBrimstone",0);    
+            player:completeQuest(WINDURST,FIRE_AND_BRIMSTONE);
+            player:setVar("fireAndBrimstone",0);	
         end
     elseif (csid == 0x021d) then -- start RNG AF3
         player:addQuest(WINDURST,UNBRIDLED_PASSION);
@@ -171,15 +175,15 @@ function onEventFinish(player,csid,option)
     elseif (csid == 0x0222) then -- complete quest RNG AF3
         if (player:getFreeSlotsCount() == 0) then 
             player:messageSpecial(ITEM_CANNOT_BE_OBTAINED,14099);
-        else     
+        else
             player:addItem(14099);
             player:messageSpecial(ITEM_OBTAINED,14099);
-            player:completeQuest(WINDURST,UNBRIDLED_PASSION);    
-            player:delKeyItem(KOHS_LETTER);                
-            player:setVar("unbridledPassion",0);    
-        end    
-    elseif (csid == 0x02AE) then 
-        player:setVar("COP_Louverance_s_Path",2);    
+            player:completeQuest(WINDURST,UNBRIDLED_PASSION);	
+            player:delKeyItem(KOHS_LETTER);
+            player:setVar("unbridledPassion",0);
+        end
+    elseif (csid == 0x02AE) then
+        player:setVar("COP_Louverance_s_Path",2);
     end
 
 end;

--- a/scripts/zones/Xarcabard/npcs/qm6.lua
+++ b/scripts/zones/Xarcabard/npcs/qm6.lua
@@ -23,13 +23,13 @@ end;
 -----------------------------------
 
 function onTrigger(player,npc)
-    
-    local UnbridledPassionCS = player:getVar("unbridledPassion");    
+
+    local UnbridledPassionCS = player:getVar("unbridledPassion");	
 
     if (UnbridledPassionCS == 5) then
         player:startEvent(0x0006, 0, 13360);
     elseif (UnbridledPassionCS == 6) then
-        player:startEvent(0x0007);    
+        player:startEvent(0x0007);
     end
 end;
 
@@ -53,13 +53,13 @@ function onEventFinish(player,csid,option)
     if (csid == 0x0006) then
         player:setVar("unbridledPassion",6);
     elseif (csid == 0x0007) then
-        if (player:getFreeSlotsCount() == 0) then 
-            player:messageSpecial(ITEM_CANNOT_BE_OBTAINED,17323);
-        else 
-            player:addItem(17323,99);
-            player:messageSpecial(ITEM_OBTAINED,17323);
-            player:setVar("unbridledPassion",7);            
-        end    
-    end
-
+        local iceArrow = 17323;
+        if (player:getFreeSlotsCount() == 0) then
+            player:messageSpecial(ITEM_CANNOT_BE_OBTAINED, iceArrow);
+        else
+            player:addItem(iceArrow, 99);
+            player:messageSpecial(ITEM_OBTAINED, iceArrow);
+            player:setVar("unbridledPassion", 7);
+        end;
+    end;
 end;

--- a/scripts/zones/Xarcabard/npcs/qm7.lua
+++ b/scripts/zones/Xarcabard/npcs/qm7.lua
@@ -21,15 +21,17 @@ end;
 -----------------------------------
 -- onTrigger Action
 -----------------------------------
+local koenigsTiger = 17236205;
 
 function onTrigger(player,npc)
-    
-    local UnbridledPassionCS = player:getVar("unbridledPassion");    
 
-    if (UnbridledPassionCS == 4) then
+    local UnbridledPassionCS = player:getVar("unbridledPassion");	
+    local tigerAction = GetMobAction(koenigsTiger);
+
+    if (UnbridledPassionCS == 4 and tigerAction == 0) then -- prevent repeated playback while the tiger is already up and fighting
         player:startEvent(0x0008);
     end
-    
+
 end;
 
 -----------------------------------
@@ -50,7 +52,7 @@ function onEventFinish(player,csid,option)
 --printf("RESULT: %u",option);
 
     if (csid == 0x0008) then
-        SpawnMob(17236205,240):updateClaim(player);
+        SpawnMob(koenigsTiger,240):updateClaim(player);
     end
 
 end;


### PR DESCRIPTION
Small fixes to the RNG AF quest line;

Fixed cases where items weren't showing up in the chat log properly during events.
Fixed cases where events could fire or repeat before requirements were met.
Changed the 'Old Sabertooth' encounter so players on the correct quest step can only advance if they are in the cave with the mob when it dies.
Fixed the Scavenge script to report results properly to chat log. note: action:param() doesn't seem to behave the way the script originally assumed.
