### PR TITLE
Scripts: Kaustra/Embrava adjustments

### DIFF
--- a/scripts/globals/spells/embrava.lua
+++ b/scripts/globals/spells/embrava.lua
@@ -25,8 +25,9 @@ function onSpellCast(caster,target,spell)
     local regen = math.floor(skill / 7) + 1;
     local refresh = math.floor(skill / 100) + 1;
     local haste = math.floor(skill/(500/256));
+    local duration = 90;
     
-    target:addStatusEffect(EFFECT_EMBRAVA,regen,0,180,0,refresh,haste);
+    target:addStatusEffect(EFFECT_EMBRAVA,regen,0,duration,0,refresh,haste);
         
     return EFFECT_EMBRAVA;
 end;

--- a/scripts/globals/spells/kaustra.lua
+++ b/scripts/globals/spells/kaustra.lua
@@ -27,12 +27,16 @@ function onSpellCast(caster,target,spell)
     if (skill > 500) then
         skill = 500;
     end
+    if (dINT > 300) then
+        dINT = 300;
+    end
 
     local duration = 3 * (1 + (skill / 11));
     local base = math.floor((math.floor(0.67 * caster:getMainLvl())/10)*(37 + math.floor(0.67*dINT)))
     local resist = applyResistance(caster,spell,target,dINT,DARK_MAGIC_SKILL,0);
     local dmg = base * resist;
     duration = duration * resist;
+    dmg = addBonuses(caster, spell, target, dmg);
     dmg = adjustForTarget(target,dmg,spell:getElement());
     dmg = finalMagicAdjustments(caster,target,spell,dmg);
 


### PR DESCRIPTION
-Corrected the duration of Embrava to 90s from 180s.
-Added the addBonuses calculation to Kaustra as it's supposed to be affected by magic attack/defense bonus, elemental affinity, weather, etc. Also added the dINT cap of 300. https://www.bg-wiki.com/bg/Kaustra