### PR TITLE
Fix for ZM8 - Kam'lanaut Fight CS issue #2756 :

### DIFF
--- a/scripts/zones/Stellar_Fulcrum/bcnms/return_to_delkfutts_tower.lua
+++ b/scripts/zones/Stellar_Fulcrum/bcnms/return_to_delkfutts_tower.lua
@@ -56,6 +56,10 @@ function onEventFinish(player,csid,option)
             player:addMission(ZILART,ROMAEVE);
             player:setVar("ZilartStatus",0);
         end
+        -- Play last CS if not skipped.
+        if (option == 1) then
+            player:startEvent(17);
+        end
     end
     
 end;

--- a/scripts/zones/Throne_Room/Zone.lua
+++ b/scripts/zones/Throne_Room/Zone.lua
@@ -63,7 +63,7 @@ end;
 function onEventFinish(player,csid,option)    
     --printf("CSID: %u",csid);
     --printf("RESULT: %u",option);
-    if (csid == 0x06) then
+    if (csid == 0x07) then
         -- You will be transported back to the entrance of Castle Zvahl Baileys
         player:setPos(378.222,-12,-20.299,125,0xA1);
     end

--- a/scripts/zones/Throne_Room/bcnms/shadow_lord_battle.lua
+++ b/scripts/zones/Throne_Room/bcnms/shadow_lord_battle.lua
@@ -59,7 +59,7 @@ function onEventFinish(player,csid,option)
             player:setVar("MissionStatus",4);
         end
         if (option == 1) then
-            player:startEvent(0x06);
+            player:startEvent(0x07);
         else
             -- You will be transported back to the entrance of Castle Zvahl Baileys
             player:setPos(378.222,-12,-20.299,125,0xA1);

--- a/src/map/battlefield.cpp
+++ b/src/map/battlefield.cpp
@@ -36,6 +36,7 @@
 #include "status_effect_container.h"
 #include "ai/ai_container.h"
 #include "enmity_container.h"
+#include "ai/states/death_state.h"
 
 CBattlefield::CBattlefield(CBattlefieldHandler* hand, uint16 id, BATTLEFIELDTYPE type){
 	m_Type = type;
@@ -89,6 +90,10 @@ uint16 CBattlefield::getLootId(){
 
 time_point CBattlefield::getStartTime(){
 	return m_StartTime;
+}
+
+time_point CBattlefield::getWinTime(){
+	return m_WinTime;
 }
 
 time_point CBattlefield::getDeadTime(){
@@ -324,7 +329,7 @@ void CBattlefield::addEnemy(CMobEntity* PMob, uint8 condition){
 	PMob->PBCNM = this;
 	if (condition & CONDITION_WIN_REQUIREMENT)
 	{
-		MobVictoryCondition_t mobCondition = {PMob, false, false};
+		MobVictoryCondition_t mobCondition = {PMob, false};
 		m_EnemyVictoryList.push_back(mobCondition);
 	}
     // TODO: move dynamis/limbus shit to a subclass (this is just ridiculous)
@@ -342,10 +347,8 @@ void CBattlefield::addNpc(CBaseEntity* PNpc){
 bool CBattlefield::allEnemiesDefeated(){
 	bool allDefeated = true;
 	for(auto&& Condition : m_EnemyVictoryList){
-		if (Condition.MobEntity->isDead() && Condition.spawned) {
+		if (Condition.MobEntity->PAI->IsCurrentState<CDeathState>()) {
 			Condition.killed = true;
-		} else if (Condition.MobEntity->PAI->IsSpawned()){
-			Condition.spawned = true;
 		}
 
 		if(Condition.killed == false){

--- a/src/map/battlefield.h
+++ b/src/map/battlefield.h
@@ -57,7 +57,6 @@ class CBattlefieldHandler;
 typedef struct
 {
 	CMobEntity* MobEntity;	// BCNM Target
-	bool spawned;			// whether it has spawned or not
 	bool killed;			// whether it has died or not
 } MobVictoryCondition_t;
 
@@ -80,6 +79,7 @@ public:
 	uint8		getLevelCap();
 	uint16		getLootId();
     time_point		getStartTime();
+	time_point		getWinTime();
     time_point		getDeadTime();
 	uint8		getEntrance();
 
@@ -168,6 +168,7 @@ private:
 	BATTLEFIELDTYPE m_Type;
 	uint8			m_BattlefieldNumber;
 	time_point			m_StartTime;
+	time_point 			m_WinTime;
     time_point			m_AllDeadTime;											// time when every pt member has fallen
 	duration			m_TimeLimit;
 	uint32			m_LootId;

--- a/src/map/lua/lua_battlefield.cpp
+++ b/src/map/lua/lua_battlefield.cpp
@@ -92,7 +92,7 @@ inline int32 CLuaBattlefield::getBcnmID(lua_State* L)
 
 inline int32 CLuaBattlefield::getTimeInside(lua_State* L) {
     DSP_DEBUG_BREAK_IF(m_PLuaBattlefield == nullptr);
-    uint32 duration = std::chrono::duration_cast<std::chrono::seconds>(m_PLuaBattlefield->lastTick - m_PLuaBattlefield->getStartTime()).count();
+    uint32 duration = std::chrono::duration_cast<std::chrono::seconds>(m_PLuaBattlefield->getWinTime() - m_PLuaBattlefield->getStartTime()).count();
     lua_pushinteger(L, duration);
     return 1;
 }


### PR DESCRIPTION
End BCNM 7 seconds after winning.
Play CS 6 (The final cutscene) after ZM8 BCNM is won.

Tested against Mission 5-2, ZM8 and a BCNM (Under observation).