### PR TITLE
Added removal of sigil and sanction to signet staff activation

### DIFF
--- a/scripts/globals/items/federation_signet_staff.lua
+++ b/scripts/globals/items/federation_signet_staff.lua
@@ -19,6 +19,12 @@ end;
 -----------------------------------------
 
 function onItemUse(target)
-    target:delStatusEffect(EFFECT_SIGNET);
-    target:addStatusEffect(EFFECT_SIGNET,0,0,18000);
+    if (player:getNation() == WINDURST)
+        if (target:getNation() == WINDURST)
+        target:delStatusEffect(EFFECT_SIGIL);
+        target:delStatusEffect(EFFECT_SANCTION);
+        target:delStatusEffect(EFFECT_SIGNET);
+        target:addStatusEffect(EFFECT_SIGNET,0,0,18000);
+        end;
+    end;
 end;

--- a/scripts/globals/items/federation_signet_staff.lua
+++ b/scripts/globals/items/federation_signet_staff.lua
@@ -19,12 +19,8 @@ end;
 -----------------------------------------
 
 function onItemUse(target)
-    if (player:getNation() == WINDURST)
-        if (target:getNation() == WINDURST)
-        target:delStatusEffect(EFFECT_SIGIL);
-        target:delStatusEffect(EFFECT_SANCTION);
-        target:delStatusEffect(EFFECT_SIGNET);
-        target:addStatusEffect(EFFECT_SIGNET,0,0,18000);
-        end;
-    end;
+    target:delStatusEffect(EFFECT_SIGIL);
+    target:delStatusEffect(EFFECT_SANCTION);
+    target:delStatusEffect(EFFECT_SIGNET);
+    target:addStatusEffect(EFFECT_SIGNET,0,0,18000);
 end;

--- a/scripts/globals/items/kingdom_signet_staff.lua
+++ b/scripts/globals/items/kingdom_signet_staff.lua
@@ -19,12 +19,8 @@ end;
 -----------------------------------------
 
 function onItemUse(target)
-    if (player:getNation() == SANDORIA)
-        if (target:getNation() == SANDORIA)
-        target:delStatusEffect(EFFECT_SIGIL);
-        target:delStatusEffect(EFFECT_SANCTION);
-        target:delStatusEffect(EFFECT_SIGNET);
-        target:addStatusEffect(EFFECT_SIGNET,0,0,18000);
-        end;
-    end;
+    target:delStatusEffect(EFFECT_SIGIL);
+    target:delStatusEffect(EFFECT_SANCTION);
+    target:delStatusEffect(EFFECT_SIGNET);
+    target:addStatusEffect(EFFECT_SIGNET,0,0,18000);
 end;

--- a/scripts/globals/items/kingdom_signet_staff.lua
+++ b/scripts/globals/items/kingdom_signet_staff.lua
@@ -19,6 +19,12 @@ end;
 -----------------------------------------
 
 function onItemUse(target)
-    target:delStatusEffect(EFFECT_SIGNET);
-    target:addStatusEffect(EFFECT_SIGNET,0,0,18000);
+    if (player:getNation() == SANDORIA)
+        if (target:getNation() == SANDORIA)
+        target:delStatusEffect(EFFECT_SIGIL);
+        target:delStatusEffect(EFFECT_SANCTION);
+        target:delStatusEffect(EFFECT_SIGNET);
+        target:addStatusEffect(EFFECT_SIGNET,0,0,18000);
+        end;
+    end;
 end;

--- a/scripts/globals/items/republic_signet_staff.lua
+++ b/scripts/globals/items/republic_signet_staff.lua
@@ -19,6 +19,12 @@ end;
 -----------------------------------------
 
 function onItemUse(target)
-    target:delStatusEffect(EFFECT_SIGNET);
-    target:addStatusEffect(EFFECT_SIGNET,0,0,18000);
+    if (player:getNation() == BASTOK)
+        if (target:getNation() == BASTOK)
+        target:delStatusEffect(EFFECT_SIGIL);
+        target:delStatusEffect(EFFECT_SANCTION);
+        target:delStatusEffect(EFFECT_SIGNET);
+        target:addStatusEffect(EFFECT_SIGNET,0,0,18000);
+        end;
+    end;
 end;

--- a/scripts/globals/items/republic_signet_staff.lua
+++ b/scripts/globals/items/republic_signet_staff.lua
@@ -19,12 +19,8 @@ end;
 -----------------------------------------
 
 function onItemUse(target)
-    if (player:getNation() == BASTOK)
-        if (target:getNation() == BASTOK)
-        target:delStatusEffect(EFFECT_SIGIL);
-        target:delStatusEffect(EFFECT_SANCTION);
-        target:delStatusEffect(EFFECT_SIGNET);
-        target:addStatusEffect(EFFECT_SIGNET,0,0,18000);
-        end;
-    end;
+    target:delStatusEffect(EFFECT_SIGIL);
+    target:delStatusEffect(EFFECT_SANCTION);
+    target:delStatusEffect(EFFECT_SIGNET);
+    target:addStatusEffect(EFFECT_SIGNET,0,0,18000);
 end;


### PR DESCRIPTION
Tested this and it works. Until I get better at the logic, I cannot completely retail the staffs, but at least they are one step closer.