### PR TITLE
Scripts: Remove player:getTP() from weaponskills

### DIFF
--- a/scripts/globals/weaponskills/armor_break.lua
+++ b/scripts/globals/weaponskills/armor_break.lua
@@ -36,7 +36,6 @@ function onUseWeaponSkill(player, target, wsID, tp, primary)
 
         local damage, criticalHit, tpHits, extraHits = doPhysicalWeaponskill(player, target, wsID, params, tp, primary);
     if (damage > 0) then
-        local tp = player:getTP();
         local duration = (tp/100 * 70) + 60;
         if (target:hasStatusEffect(EFFECT_DEFENSE_DOWN) == false) then
             target:addStatusEffect(EFFECT_DEFENSE_DOWN, 25, 0, duration);

--- a/scripts/globals/weaponskills/ascetics_fury.lua
+++ b/scripts/globals/weaponskills/ascetics_fury.lua
@@ -38,53 +38,53 @@ function onUseWeaponSkill(player, target, wsID, tp, primary)
 
 -- AFTERMATH LEVEL 1
 
-        if ((player:getTP() >= 100) and (player:getTP() <= 110)) then
+        if ((tp >= 100) and (tp <= 110)) then
             player:addStatusEffect(EFFECT_AFTERMATH_LV1, 10, 0, 180, 0, 1);
-        elseif ((player:getTP() >= 111) and (player:getTP() <= 120)) then
+        elseif ((tp >= 111) and (tp <= 120)) then
             player:addStatusEffect(EFFECT_AFTERMATH_LV1, 11, 0, 180, 0, 1);
-        elseif ((player:getTP() >= 121) and (player:getTP() <= 130)) then
+        elseif ((tp >= 121) and (tp <= 130)) then
             player:addStatusEffect(EFFECT_AFTERMATH_LV1, 12, 0, 180, 0, 1);
-        elseif ((player:getTP() >= 131) and (player:getTP() <= 140)) then
+        elseif ((tp >= 131) and (tp <= 140)) then
             player:addStatusEffect(EFFECT_AFTERMATH_LV1, 13, 0, 180, 0, 1);
-        elseif ((player:getTP() >= 141) and (player:getTP() <= 150)) then
+        elseif ((tp >= 141) and (tp <= 150)) then
             player:addStatusEffect(EFFECT_AFTERMATH_LV1, 14, 0, 180, 0, 1);
-        elseif ((player:getTP() >= 151) and (player:getTP() <= 160)) then
+        elseif ((tp >= 151) and (tp <= 160)) then
             player:addStatusEffect(EFFECT_AFTERMATH_LV1, 15, 0, 180, 0, 1);
-        elseif ((player:getTP() >= 161) and (player:getTP() <= 170)) then
+        elseif ((tp >= 161) and (tp <= 170)) then
             player:addStatusEffect(EFFECT_AFTERMATH_LV1, 16, 0, 180, 0, 1);
-        elseif ((player:getTP() >= 171) and (player:getTP() <= 180)) then
+        elseif ((tp >= 171) and (tp <= 180)) then
             player:addStatusEffect(EFFECT_AFTERMATH_LV1, 17, 0, 180, 0, 1);
-        elseif ((player:getTP() >= 181) and (player:getTP() <= 190)) then
+        elseif ((tp >= 181) and (tp <= 190)) then
             player:addStatusEffect(EFFECT_AFTERMATH_LV1, 18, 0, 180, 0, 1);
-        elseif ((player:getTP() >= 191) and (player:getTP() <= 199)) then
+        elseif ((tp >= 191) and (tp <= 199)) then
             player:addStatusEffect(EFFECT_AFTERMATH_LV1, 19, 0, 180, 0, 1);
 
 -- AFTERMATH LEVEL 2
 
-        elseif ((player:getTP() >= 200) and (player:getTP() <= 210)) then
+        elseif ((tp >= 200) and (tp <= 210)) then
             player:addStatusEffect(EFFECT_AFTERMATH_LV2, 24, 0, 180, 0, 1);
-        elseif ((player:getTP() >= 211) and (player:getTP() <= 219)) then
+        elseif ((tp >= 211) and (tp <= 219)) then
             player:addStatusEffect(EFFECT_AFTERMATH_LV2, 28, 0, 180, 0, 1);
-        elseif ((player:getTP() >= 221) and (player:getTP() <= 229)) then
+        elseif ((tp >= 221) and (tp <= 229)) then
             player:addStatusEffect(EFFECT_AFTERMATH_LV2, 32, 0, 180, 0, 1);
-        elseif ((player:getTP() >= 231) and (player:getTP() <= 239)) then
+        elseif ((tp >= 231) and (tp <= 239)) then
             player:addStatusEffect(EFFECT_AFTERMATH_LV2, 36, 0, 180, 0, 1);
-        elseif ((player:getTP() >= 241) and (player:getTP() <= 249)) then
+        elseif ((tp >= 241) and (tp <= 249)) then
             player:addStatusEffect(EFFECT_AFTERMATH_LV2, 40, 0, 180, 0, 1);
-        elseif ((player:getTP() >= 251) and (player:getTP() <= 259)) then
+        elseif ((tp >= 251) and (tp <= 259)) then
             player:addStatusEffect(EFFECT_AFTERMATH_LV2, 44, 0, 180, 0, 1);
-        elseif ((player:getTP() >= 261) and (player:getTP() <= 269)) then
+        elseif ((tp >= 261) and (tp <= 269)) then
             player:addStatusEffect(EFFECT_AFTERMATH_LV2, 48, 0, 180, 0, 1);
-        elseif ((player:getTP() >= 271) and (player:getTP() <= 279)) then
+        elseif ((tp >= 271) and (tp <= 279)) then
             player:addStatusEffect(EFFECT_AFTERMATH_LV2, 52, 0, 180, 0, 1);
-        elseif ((player:getTP() >= 281) and (player:getTP() <= 289)) then
+        elseif ((tp >= 281) and (tp <= 289)) then
             player:addStatusEffect(EFFECT_AFTERMATH_LV2, 56, 0, 180, 0, 1);
-        elseif ((player:getTP() >= 291) and (player:getTP() <= 299)) then
+        elseif ((tp >= 291) and (tp <= 299)) then
             player:addStatusEffect(EFFECT_AFTERMATH_LV2, 59, 0, 180, 0, 1);
 
 -- AFTERMATH LEVEL 3
 
-        elseif ((player:getTP() == 300)) then
+        elseif ((tp == 300)) then
             player:addStatusEffect(EFFECT_AFTERMATH_LV3, 45, 0, 120, 0, 1);
             end
         end

--- a/scripts/globals/weaponskills/atonement.lua
+++ b/scripts/globals/weaponskills/atonement.lua
@@ -38,53 +38,53 @@ function onUseWeaponSkill(player, target, wsID, tp, primary)
 
 -- AFTERMATH LEVEL 1
 
-        if ((player:getTP() >= 100) and (player:getTP() <= 110)) then
+        if ((tp >= 100) and (tp <= 110)) then
             player:addStatusEffect(EFFECT_AFTERMATH_LV1, 10, 0, 180, 0, 1);
-        elseif ((player:getTP() >= 111) and (player:getTP() <= 120)) then
+        elseif ((tp >= 111) and (tp <= 120)) then
             player:addStatusEffect(EFFECT_AFTERMATH_LV1, 11, 0, 180, 0, 1);
-        elseif ((player:getTP() >= 121) and (player:getTP() <= 130)) then
+        elseif ((tp >= 121) and (tp <= 130)) then
             player:addStatusEffect(EFFECT_AFTERMATH_LV1, 12, 0, 180, 0, 1);
-        elseif ((player:getTP() >= 131) and (player:getTP() <= 140)) then
+        elseif ((tp >= 131) and (tp <= 140)) then
             player:addStatusEffect(EFFECT_AFTERMATH_LV1, 13, 0, 180, 0, 1);
-        elseif ((player:getTP() >= 141) and (player:getTP() <= 150)) then
+        elseif ((tp >= 141) and (tp <= 150)) then
             player:addStatusEffect(EFFECT_AFTERMATH_LV1, 14, 0, 180, 0, 1);
-        elseif ((player:getTP() >= 151) and (player:getTP() <= 160)) then
+        elseif ((tp >= 151) and (tp <= 160)) then
             player:addStatusEffect(EFFECT_AFTERMATH_LV1, 15, 0, 180, 0, 1);
-        elseif ((player:getTP() >= 161) and (player:getTP() <= 170)) then
+        elseif ((tp >= 161) and (tp <= 170)) then
             player:addStatusEffect(EFFECT_AFTERMATH_LV1, 16, 0, 180, 0, 1);
-        elseif ((player:getTP() >= 171) and (player:getTP() <= 180)) then
+        elseif ((tp >= 171) and (tp <= 180)) then
             player:addStatusEffect(EFFECT_AFTERMATH_LV1, 17, 0, 180, 0, 1);
-        elseif ((player:getTP() >= 181) and (player:getTP() <= 190)) then
+        elseif ((tp >= 181) and (tp <= 190)) then
             player:addStatusEffect(EFFECT_AFTERMATH_LV1, 18, 0, 180, 0, 1);
-        elseif ((player:getTP() >= 191) and (player:getTP() <= 199)) then
+        elseif ((tp >= 191) and (tp <= 199)) then
             player:addStatusEffect(EFFECT_AFTERMATH_LV1, 19, 0, 180, 0, 1);
 
 -- AFTERMATH LEVEL 2
 
-        elseif ((player:getTP() >= 200) and (player:getTP() <= 210)) then
+        elseif ((tp >= 200) and (tp <= 210)) then
             player:addStatusEffect(EFFECT_AFTERMATH_LV2, 24, 0, 180, 0, 1);
-        elseif ((player:getTP() >= 211) and (player:getTP() <= 219)) then
+        elseif ((tp >= 211) and (tp <= 219)) then
             player:addStatusEffect(EFFECT_AFTERMATH_LV2, 28, 0, 180, 0, 1);
-        elseif ((player:getTP() >= 221) and (player:getTP() <= 229)) then
+        elseif ((tp >= 221) and (tp <= 229)) then
             player:addStatusEffect(EFFECT_AFTERMATH_LV2, 32, 0, 180, 0, 1);
-        elseif ((player:getTP() >= 231) and (player:getTP() <= 239)) then
+        elseif ((tp >= 231) and (tp <= 239)) then
             player:addStatusEffect(EFFECT_AFTERMATH_LV2, 36, 0, 180, 0, 1);
-        elseif ((player:getTP() >= 241) and (player:getTP() <= 249)) then
+        elseif ((tp >= 241) and (tp <= 249)) then
             player:addStatusEffect(EFFECT_AFTERMATH_LV2, 40, 0, 180, 0, 1);
-        elseif ((player:getTP() >= 251) and (player:getTP() <= 259)) then
+        elseif ((tp >= 251) and (tp <= 259)) then
             player:addStatusEffect(EFFECT_AFTERMATH_LV2, 44, 0, 180, 0, 1);
-        elseif ((player:getTP() >= 261) and (player:getTP() <= 269)) then
+        elseif ((tp >= 261) and (tp <= 269)) then
             player:addStatusEffect(EFFECT_AFTERMATH_LV2, 48, 0, 180, 0, 1);
-        elseif ((player:getTP() >= 271) and (player:getTP() <= 279)) then
+        elseif ((tp >= 271) and (tp <= 279)) then
             player:addStatusEffect(EFFECT_AFTERMATH_LV2, 52, 0, 180, 0, 1);
-        elseif ((player:getTP() >= 281) and (player:getTP() <= 289)) then
+        elseif ((tp >= 281) and (tp <= 289)) then
             player:addStatusEffect(EFFECT_AFTERMATH_LV2, 56, 0, 180, 0, 1);
-        elseif ((player:getTP() >= 291) and (player:getTP() <= 299)) then
+        elseif ((tp >= 291) and (tp <= 299)) then
             player:addStatusEffect(EFFECT_AFTERMATH_LV2, 59, 0, 180, 0, 1);
 
 -- AFTERMATH LEVEL 3
 
-        elseif ((player:getTP() == 300)) then
+        elseif ((tp == 300)) then
             player:addStatusEffect(EFFECT_AFTERMATH_LV3, 45, 0, 120, 0, 1);
             end
         end

--- a/scripts/globals/weaponskills/blade_kamu.lua
+++ b/scripts/globals/weaponskills/blade_kamu.lua
@@ -35,7 +35,6 @@ function onUseWeaponSkill(player, target, wsID, tp, primary)
 
     local damage, criticalHit, tpHits, extraHits = doPhysicalWeaponskill(player, target, wsID, params, tp, primary);
     if (damage > 0) then
-        local tp = player:getTP();
         local duration = (tp/100 * 45) + 30;
         if (target:hasStatusEffect(EFFECT_ACCURACY_DOWN) == false) then
             target:addStatusEffect(EFFECT_ACCURACY_DOWN, 10, 0, duration);
@@ -48,56 +47,56 @@ function onUseWeaponSkill(player, target, wsID, tp, primary)
 
 --        AFTERMATH LV1
 
-        if ((player:getTP() >= 100) and (player:getTP() <= 110)) then
+        if ((tp >= 100) and (tp <= 110)) then
             player:addStatusEffect(EFFECT_AFTERMATH_LV1, 10, 0, 180, 0, 1);
-    elseif ((player:getTP() >= 111) and (player:getTP() <= 120)) then
+    elseif ((tp >= 111) and (tp <= 120)) then
             player:addStatusEffect(EFFECT_AFTERMATH_LV1, 11, 0, 180, 0, 1);
-    elseif ((player:getTP() >= 121) and (player:getTP() <= 130)) then
+    elseif ((tp >= 121) and (tp <= 130)) then
             player:addStatusEffect(EFFECT_AFTERMATH_LV1, 12, 0, 180, 0, 1);
-    elseif ((player:getTP() >= 131) and (player:getTP() <= 140)) then
+    elseif ((tp >= 131) and (tp <= 140)) then
             player:addStatusEffect(EFFECT_AFTERMATH_LV1, 13, 0, 180, 0, 1);
-    elseif ((player:getTP() >= 141) and (player:getTP() <= 150)) then
+    elseif ((tp >= 141) and (tp <= 150)) then
             player:addStatusEffect(EFFECT_AFTERMATH_LV1, 14, 0, 180, 0, 1);
-    elseif ((player:getTP() >= 151) and (player:getTP() <= 160)) then
+    elseif ((tp >= 151) and (tp <= 160)) then
             player:addStatusEffect(EFFECT_AFTERMATH_LV1, 15, 0, 180, 0, 1);
-    elseif ((player:getTP() >= 161) and (player:getTP() <= 170)) then
+    elseif ((tp >= 161) and (tp <= 170)) then
             player:addStatusEffect(EFFECT_AFTERMATH_LV1, 16, 0, 180, 0, 1);
-    elseif ((player:getTP() >= 171) and (player:getTP() <= 180)) then
+    elseif ((tp >= 171) and (tp <= 180)) then
             player:addStatusEffect(EFFECT_AFTERMATH_LV1, 17, 0, 180, 0, 1);
-    elseif ((player:getTP() >= 181) and (player:getTP() <= 190)) then
+    elseif ((tp >= 181) and (tp <= 190)) then
             player:addStatusEffect(EFFECT_AFTERMATH_LV1, 18, 0, 180, 0, 1);
-    elseif ((player:getTP() >= 191) and (player:getTP() <= 199)) then
+    elseif ((tp >= 191) and (tp <= 199)) then
             player:addStatusEffect(EFFECT_AFTERMATH_LV1, 19, 0, 180, 0, 1);
 
 
 
 --        AFTERMATH LV2
 
-    elseif ((player:getTP() >= 200) and (player:getTP() <= 210)) then
+    elseif ((tp >= 200) and (tp <= 210)) then
             player:addStatusEffect(EFFECT_AFTERMATH_LV2, 24, 0, 180, 0, 1);
-    elseif ((player:getTP() >= 211) and (player:getTP() <= 219)) then
+    elseif ((tp >= 211) and (tp <= 219)) then
             player:addStatusEffect(EFFECT_AFTERMATH_LV2, 28, 0, 180, 0, 1);
-    elseif ((player:getTP() >= 221) and (player:getTP() <= 229)) then
+    elseif ((tp >= 221) and (tp <= 229)) then
             player:addStatusEffect(EFFECT_AFTERMATH_LV2, 32, 0, 180, 0, 1);
-    elseif ((player:getTP() >= 231) and (player:getTP() <= 239)) then
+    elseif ((tp >= 231) and (tp <= 239)) then
             player:addStatusEffect(EFFECT_AFTERMATH_LV2, 36, 0, 180, 0, 1);
-    elseif ((player:getTP() >= 241) and (player:getTP() <= 249)) then
+    elseif ((tp >= 241) and (tp <= 249)) then
             player:addStatusEffect(EFFECT_AFTERMATH_LV2, 40, 0, 180, 0, 1);
-    elseif ((player:getTP() >= 251) and (player:getTP() <= 259)) then
+    elseif ((tp >= 251) and (tp <= 259)) then
             player:addStatusEffect(EFFECT_AFTERMATH_LV2, 44, 0, 180, 0, 1);
-    elseif ((player:getTP() >= 261) and (player:getTP() <= 269)) then
+    elseif ((tp >= 261) and (tp <= 269)) then
             player:addStatusEffect(EFFECT_AFTERMATH_LV2, 48, 0, 180, 0, 1);
-    elseif ((player:getTP() >= 271) and (player:getTP() <= 279)) then
+    elseif ((tp >= 271) and (tp <= 279)) then
             player:addStatusEffect(EFFECT_AFTERMATH_LV2, 52, 0, 180, 0, 1);
-    elseif ((player:getTP() >= 281) and (player:getTP() <= 289)) then
+    elseif ((tp >= 281) and (tp <= 289)) then
             player:addStatusEffect(EFFECT_AFTERMATH_LV2, 56, 0, 180, 0, 1);
-    elseif ((player:getTP() >= 291) and (player:getTP() <= 299)) then
+    elseif ((tp >= 291) and (tp <= 299)) then
             player:addStatusEffect(EFFECT_AFTERMATH_LV2, 59, 0, 180, 0, 1);
 
 
 --        AFTERMATH LV3
 
-        elseif ((player:getTP() == 300)) then
+        elseif ((tp == 300)) then
             player:addStatusEffect(EFFECT_AFTERMATH_LV3, 45, 0, 120, 0, 1);
 
             end

--- a/scripts/globals/weaponskills/blade_metsu.lua
+++ b/scripts/globals/weaponskills/blade_metsu.lua
@@ -37,7 +37,7 @@ function onUseWeaponSkill(player, target, wsID, tp, primary)
     local damage, criticalHit, tpHits, extraHits = doPhysicalWeaponskill(player, target, wsID, params, tp, primary);
     -- TODO: Whoever codes those level 85 weapons with the latent that grants this WS needs to code a check to not give the aftermath effect.
     if (damage > 0) then
-        local amDuration = 20 * math.floor(player:getTP()/100);
+        local amDuration = 20 * math.floor(tp/100);
         player:addStatusEffect(EFFECT_AFTERMATH, 10, 0, amDuration, 0, 1);
         target:addStatusEffect(EFFECT_PARALYSIS, 10, 0, 60);
     end

--- a/scripts/globals/weaponskills/blade_retsu.lua
+++ b/scripts/globals/weaponskills/blade_retsu.lua
@@ -34,7 +34,6 @@ function onUseWeaponSkill(player, target, wsID, tp, primary)
 
     local damage, criticalHit, tpHits, extraHits = doPhysicalWeaponskill(player, target, wsID, params, tp, primary);
     if (damage > 0) then
-        local tp = player:getTP();
         local duration = (tp/100 * 30);
         if (target:hasStatusEffect(EFFECT_PARALYSIS) == false) then
             -- paralyze proc based on lvl difference

--- a/scripts/globals/weaponskills/blade_yu.lua
+++ b/scripts/globals/weaponskills/blade_yu.lua
@@ -33,7 +33,6 @@ function onUseWeaponSkill(player, target, wsID, tp, primary)
     local damage, tpHits, extraHits = doMagicWeaponskill(player, target, wsID, params, tp, primary);
 
     if (damage > 0) then
-        local tp = player:getTP();
         local duration = (tp/100 * 15) + 75;
         if (target:hasStatusEffect(EFFECT_POISON) == false) then
             target:addStatusEffect(EFFECT_POISON, 10, 0, duration);

--- a/scripts/globals/weaponskills/brainshaker.lua
+++ b/scripts/globals/weaponskills/brainshaker.lua
@@ -34,7 +34,6 @@ function onUseWeaponSkill(player, target, wsID, tp, primary)
     local damage, criticalHit, tpHits, extraHits = doPhysicalWeaponskill(player, target, wsID, params, tp, primary);
 
     if (damage > 0) then
-        local tp = player:getTP();
         local duration = (tp/50);
         if (target:hasStatusEffect(EFFECT_STUN) == false) then
             target:addStatusEffect(EFFECT_STUN, 1, 0, duration);

--- a/scripts/globals/weaponskills/catastrophe.lua
+++ b/scripts/globals/weaponskills/catastrophe.lua
@@ -35,7 +35,7 @@ function onUseWeaponSkill(player, target, wsID, tp, primary)
     local damage, criticalHit, tpHits, extraHits = doPhysicalWeaponskill(player, target, wsID, params, tp, primary);
     -- TODO: Whoever codes those level 85 weapons with the latent that grants this WS needs to code a check to not give the aftermath effect.
     if (damage > 0) then
-        local amDuration = 20 * math.floor(player:getTP()/100);
+        local amDuration = 20 * math.floor(tp/100);
         player:addStatusEffect(EFFECT_AFTERMATH, 100, 0, amDuration, 0, 6);
     end
 

--- a/scripts/globals/weaponskills/coronach.lua
+++ b/scripts/globals/weaponskills/coronach.lua
@@ -36,7 +36,7 @@ function onUseWeaponSkill(player, target, wsID, tp, primary)
     local damage, criticalHit, tpHits, extraHits = doRangedWeaponskill(player, target, wsID, params, tp, primary);
     -- TODO: Whoever codes those level 85 weapons with the latent that grants this WS needs to code a check to not give the aftermath effect.
     if (damage > 0) then
-        local amDuration = 20 * math.floor(player:getTP()/100);
+        local amDuration = 20 * math.floor(tp/100);
         player:addStatusEffect(EFFECT_AFTERMATH, -20, 0, amDuration, 0, 11);
     end
 

--- a/scripts/globals/weaponskills/dagan.lua
+++ b/scripts/globals/weaponskills/dagan.lua
@@ -14,8 +14,8 @@ require("scripts/globals/weaponskills");
 ---------------------------------------
 
 function onUseWeaponSkill(player, target, wsID, tp, primary)
-    local ftphp = fTP(player:getTP(),0.22,0.34,0.52);
-    local ftpmp = fTP(player:getTP(),0.15,0.25,0.35);
+    local ftphp = fTP(tp,0.22,0.34,0.52);
+    local ftpmp = fTP(tp,0.15,0.25,0.35);
     player:addHP(ftphp*player:getMaxHP());
     return 0,0,false,(ftpmp*player:getMaxMP());
 end

--- a/scripts/globals/weaponskills/death_blossom.lua
+++ b/scripts/globals/weaponskills/death_blossom.lua
@@ -37,7 +37,6 @@ function onUseWeaponSkill(player, target, wsID, tp, primary)
 
     local damage, criticalHit, tpHits, extraHits = doPhysicalWeaponskill(player, target, wsID, params, tp, primary);
     if (damage > 0) then
-        local tp = player:getTP();
         local duration = (tp/100 * 20) - 5;
         if (target:hasStatusEffect(EFFECT_MAGIC_EVASION_DOWN) == false) then
             target:addStatusEffect(EFFECT_MAGIC_EVASION_DOWN, 10, 0, duration);
@@ -50,56 +49,56 @@ function onUseWeaponSkill(player, target, wsID, tp, primary)
 
 --        AFTERMATH LV1
 
-        if ((player:getTP() >= 100) and (player:getTP() <= 110)) then
+        if ((tp >= 100) and (tp <= 110)) then
             player:addStatusEffect(EFFECT_AFTERMATH_LV1, 10, 0, 180, 0, 2);
-    elseif ((player:getTP() >= 111) and (player:getTP() <= 120)) then
+    elseif ((tp >= 111) and (tp <= 120)) then
             player:addStatusEffect(EFFECT_AFTERMATH_LV1, 11, 0, 180, 0, 2);
-    elseif ((player:getTP() >= 121) and (player:getTP() <= 130)) then
+    elseif ((tp >= 121) and (tp <= 130)) then
             player:addStatusEffect(EFFECT_AFTERMATH_LV1, 12, 0, 180, 0, 2);
-    elseif ((player:getTP() >= 131) and (player:getTP() <= 140)) then
+    elseif ((tp >= 131) and (tp <= 140)) then
             player:addStatusEffect(EFFECT_AFTERMATH_LV1, 13, 0, 180, 0, 2);
-    elseif ((player:getTP() >= 141) and (player:getTP() <= 150)) then
+    elseif ((tp >= 141) and (tp <= 150)) then
             player:addStatusEffect(EFFECT_AFTERMATH_LV1, 14, 0, 180, 0, 2);
-    elseif ((player:getTP() >= 151) and (player:getTP() <= 160)) then
+    elseif ((tp >= 151) and (tp <= 160)) then
             player:addStatusEffect(EFFECT_AFTERMATH_LV1, 15, 0, 180, 0, 2);
-    elseif ((player:getTP() >= 161) and (player:getTP() <= 170)) then
+    elseif ((tp >= 161) and (tp <= 170)) then
             player:addStatusEffect(EFFECT_AFTERMATH_LV1, 16, 0, 180, 0, 2);
-    elseif ((player:getTP() >= 171) and (player:getTP() <= 180)) then
+    elseif ((tp >= 171) and (tp <= 180)) then
             player:addStatusEffect(EFFECT_AFTERMATH_LV1, 17, 0, 180, 0, 2);
-    elseif ((player:getTP() >= 181) and (player:getTP() <= 190)) then
+    elseif ((tp >= 181) and (tp <= 190)) then
             player:addStatusEffect(EFFECT_AFTERMATH_LV1, 18, 0, 180, 0, 2);
-    elseif ((player:getTP() >= 191) and (player:getTP() <= 199)) then
+    elseif ((tp >= 191) and (tp <= 199)) then
             player:addStatusEffect(EFFECT_AFTERMATH_LV1, 19, 0, 180, 0, 2);
 
 
 
 --        AFTERMATH LV2
 
-    elseif ((player:getTP() >= 200) and (player:getTP() <= 210)) then
+    elseif ((tp >= 200) and (tp <= 210)) then
             player:addStatusEffect(EFFECT_AFTERMATH_LV2, 24, 0, 180, 0, 3);
-    elseif ((player:getTP() >= 211) and (player:getTP() <= 219)) then
+    elseif ((tp >= 211) and (tp <= 219)) then
             player:addStatusEffect(EFFECT_AFTERMATH_LV2, 28, 0, 180, 0, 3);
-    elseif ((player:getTP() >= 221) and (player:getTP() <= 229)) then
+    elseif ((tp >= 221) and (tp <= 229)) then
             player:addStatusEffect(EFFECT_AFTERMATH_LV2, 32, 0, 180, 0, 3);
-    elseif ((player:getTP() >= 231) and (player:getTP() <= 239)) then
+    elseif ((tp >= 231) and (tp <= 239)) then
             player:addStatusEffect(EFFECT_AFTERMATH_LV2, 36, 0, 180, 0, 3);
-    elseif ((player:getTP() >= 241) and (player:getTP() <= 249)) then
+    elseif ((tp >= 241) and (tp <= 249)) then
             player:addStatusEffect(EFFECT_AFTERMATH_LV2, 40, 0, 180, 0, 3);
-    elseif ((player:getTP() >= 251) and (player:getTP() <= 259)) then
+    elseif ((tp >= 251) and (tp <= 259)) then
             player:addStatusEffect(EFFECT_AFTERMATH_LV2, 44, 0, 180, 0, 3);
-    elseif ((player:getTP() >= 261) and (player:getTP() <= 269)) then
+    elseif ((tp >= 261) and (tp <= 269)) then
             player:addStatusEffect(EFFECT_AFTERMATH_LV2, 48, 0, 180, 0, 3);
-    elseif ((player:getTP() >= 271) and (player:getTP() <= 279)) then
+    elseif ((tp >= 271) and (tp <= 279)) then
             player:addStatusEffect(EFFECT_AFTERMATH_LV2, 52, 0, 180, 0, 3);
-    elseif ((player:getTP() >= 281) and (player:getTP() <= 289)) then
+    elseif ((tp >= 281) and (tp <= 289)) then
             player:addStatusEffect(EFFECT_AFTERMATH_LV2, 56, 0, 180, 0, 3);
-    elseif ((player:getTP() >= 291) and (player:getTP() <= 299)) then
+    elseif ((tp >= 291) and (tp <= 299)) then
             player:addStatusEffect(EFFECT_AFTERMATH_LV2, 59, 0, 180, 0, 3);
 
 
 --        AFTERMATH LV3
 
-        elseif ((player:getTP() == 300)) then
+        elseif ((tp == 300)) then
             player:addStatusEffect(EFFECT_AFTERMATH_LV3, 45, 0, 120, 0, 1);
 
             end

--- a/scripts/globals/weaponskills/drakesbane.lua
+++ b/scripts/globals/weaponskills/drakesbane.lua
@@ -39,56 +39,56 @@ function onUseWeaponSkill(player, target, wsID, tp, primary)
 
 --        AFTERMATH LV1
 
-        if ((player:getTP() >= 100) and (player:getTP() <= 110)) then
+        if ((tp >= 100) and (tp <= 110)) then
             player:addStatusEffect(EFFECT_AFTERMATH_LV1, 10, 0, 180, 0, 1);
-    elseif ((player:getTP() >= 111) and (player:getTP() <= 120)) then
+    elseif ((tp >= 111) and (tp <= 120)) then
             player:addStatusEffect(EFFECT_AFTERMATH_LV1, 11, 0, 180, 0, 1);
-    elseif ((player:getTP() >= 121) and (player:getTP() <= 130)) then
+    elseif ((tp >= 121) and (tp <= 130)) then
             player:addStatusEffect(EFFECT_AFTERMATH_LV1, 12, 0, 180, 0, 1);
-    elseif ((player:getTP() >= 131) and (player:getTP() <= 140)) then
+    elseif ((tp >= 131) and (tp <= 140)) then
             player:addStatusEffect(EFFECT_AFTERMATH_LV1, 13, 0, 180, 0, 1);
-    elseif ((player:getTP() >= 141) and (player:getTP() <= 150)) then
+    elseif ((tp >= 141) and (tp <= 150)) then
             player:addStatusEffect(EFFECT_AFTERMATH_LV1, 14, 0, 180, 0, 1);
-    elseif ((player:getTP() >= 151) and (player:getTP() <= 160)) then
+    elseif ((tp >= 151) and (tp <= 160)) then
             player:addStatusEffect(EFFECT_AFTERMATH_LV1, 15, 0, 180, 0, 1);
-    elseif ((player:getTP() >= 161) and (player:getTP() <= 170)) then
+    elseif ((tp >= 161) and (tp <= 170)) then
             player:addStatusEffect(EFFECT_AFTERMATH_LV1, 16, 0, 180, 0, 1);
-    elseif ((player:getTP() >= 171) and (player:getTP() <= 180)) then
+    elseif ((tp >= 171) and (tp <= 180)) then
             player:addStatusEffect(EFFECT_AFTERMATH_LV1, 17, 0, 180, 0, 1);
-    elseif ((player:getTP() >= 181) and (player:getTP() <= 190)) then
+    elseif ((tp >= 181) and (tp <= 190)) then
             player:addStatusEffect(EFFECT_AFTERMATH_LV1, 18, 0, 180, 0, 1);
-    elseif ((player:getTP() >= 191) and (player:getTP() <= 199)) then
+    elseif ((tp >= 191) and (tp <= 199)) then
             player:addStatusEffect(EFFECT_AFTERMATH_LV1, 19, 0, 180, 0, 1);
 
 
 
 --        AFTERMATH LV2
 
-    elseif ((player:getTP() >= 200) and (player:getTP() <= 210)) then
+    elseif ((tp >= 200) and (tp <= 210)) then
             player:addStatusEffect(EFFECT_AFTERMATH_LV2, 24, 0, 180, 0, 1);
-    elseif ((player:getTP() >= 211) and (player:getTP() <= 219)) then
+    elseif ((tp >= 211) and (tp <= 219)) then
             player:addStatusEffect(EFFECT_AFTERMATH_LV2, 28, 0, 180, 0, 1);
-    elseif ((player:getTP() >= 221) and (player:getTP() <= 229)) then
+    elseif ((tp >= 221) and (tp <= 229)) then
             player:addStatusEffect(EFFECT_AFTERMATH_LV2, 32, 0, 180, 0, 1);
-    elseif ((player:getTP() >= 231) and (player:getTP() <= 239)) then
+    elseif ((tp >= 231) and (tp <= 239)) then
             player:addStatusEffect(EFFECT_AFTERMATH_LV2, 36, 0, 180, 0, 1);
-    elseif ((player:getTP() >= 241) and (player:getTP() <= 249)) then
+    elseif ((tp >= 241) and (tp <= 249)) then
             player:addStatusEffect(EFFECT_AFTERMATH_LV2, 40, 0, 180, 0, 1);
-    elseif ((player:getTP() >= 251) and (player:getTP() <= 259)) then
+    elseif ((tp >= 251) and (tp <= 259)) then
             player:addStatusEffect(EFFECT_AFTERMATH_LV2, 44, 0, 180, 0, 1);
-    elseif ((player:getTP() >= 261) and (player:getTP() <= 269)) then
+    elseif ((tp >= 261) and (tp <= 269)) then
             player:addStatusEffect(EFFECT_AFTERMATH_LV2, 48, 0, 180, 0, 1);
-    elseif ((player:getTP() >= 271) and (player:getTP() <= 279)) then
+    elseif ((tp >= 271) and (tp <= 279)) then
             player:addStatusEffect(EFFECT_AFTERMATH_LV2, 52, 0, 180, 0, 1);
-    elseif ((player:getTP() >= 281) and (player:getTP() <= 289)) then
+    elseif ((tp >= 281) and (tp <= 289)) then
             player:addStatusEffect(EFFECT_AFTERMATH_LV2, 56, 0, 180, 0, 1);
-    elseif ((player:getTP() >= 291) and (player:getTP() <= 299)) then
+    elseif ((tp >= 291) and (tp <= 299)) then
             player:addStatusEffect(EFFECT_AFTERMATH_LV2, 59, 0, 180, 0, 1);
 
 
 --        AFTERMATH LV3
 
-        elseif ((player:getTP() == 300)) then
+        elseif ((tp == 300)) then
             player:addStatusEffect(EFFECT_AFTERMATH_LV3, 45, 0, 120, 0, 1);
 
             end

--- a/scripts/globals/weaponskills/exenterator.lua
+++ b/scripts/globals/weaponskills/exenterator.lua
@@ -36,7 +36,6 @@ function onUseWeaponSkill(player, target, wsID, tp, primary)
     local damage, criticalHit, tpHits, extraHits = doPhysicalWeaponskill(player, target, wsID, params, tp, primary);
 
     if (damage > 0) then
-        local tp = player:getTP();
         local duration=(tp/100*30)+90;
         if (target:hasStatusEffect(EFFECT_ACCURACY_DOWN) == false) then
             target:addStatusEffect(EFFECT_ACCURACY_DOWN, 20, 0,duration);

--- a/scripts/globals/weaponskills/expiacion.lua
+++ b/scripts/globals/weaponskills/expiacion.lua
@@ -38,53 +38,53 @@ function onUseWeaponSkill(player, target, wsID, tp, primary)
 
 -- AFTERMATH LEVEL 1
 
-        if ((player:getTP() >= 100) and (player:getTP() <= 110)) then
+        if ((tp >= 100) and (tp <= 110)) then
             player:addStatusEffect(EFFECT_AFTERMATH_LV1, 10, 0, 180, 0, 1);
-        elseif ((player:getTP() >= 111) and (player:getTP() <= 120)) then
+        elseif ((tp >= 111) and (tp <= 120)) then
             player:addStatusEffect(EFFECT_AFTERMATH_LV1, 11, 0, 180, 0, 1);
-        elseif ((player:getTP() >= 121) and (player:getTP() <= 130)) then
+        elseif ((tp >= 121) and (tp <= 130)) then
             player:addStatusEffect(EFFECT_AFTERMATH_LV1, 12, 0, 180, 0, 1);
-        elseif ((player:getTP() >= 131) and (player:getTP() <= 140)) then
+        elseif ((tp >= 131) and (tp <= 140)) then
             player:addStatusEffect(EFFECT_AFTERMATH_LV1, 13, 0, 180, 0, 1);
-        elseif ((player:getTP() >= 141) and (player:getTP() <= 150)) then
+        elseif ((tp >= 141) and (tp <= 150)) then
             player:addStatusEffect(EFFECT_AFTERMATH_LV1, 14, 0, 180, 0, 1);
-        elseif ((player:getTP() >= 151) and (player:getTP() <= 160)) then
+        elseif ((tp >= 151) and (tp <= 160)) then
             player:addStatusEffect(EFFECT_AFTERMATH_LV1, 15, 0, 180, 0, 1);
-        elseif ((player:getTP() >= 161) and (player:getTP() <= 170)) then
+        elseif ((tp >= 161) and (tp <= 170)) then
             player:addStatusEffect(EFFECT_AFTERMATH_LV1, 16, 0, 180, 0, 1);
-        elseif ((player:getTP() >= 171) and (player:getTP() <= 180)) then
+        elseif ((tp >= 171) and (tp <= 180)) then
             player:addStatusEffect(EFFECT_AFTERMATH_LV1, 17, 0, 180, 0, 1);
-        elseif ((player:getTP() >= 181) and (player:getTP() <= 190)) then
+        elseif ((tp >= 181) and (tp <= 190)) then
             player:addStatusEffect(EFFECT_AFTERMATH_LV1, 18, 0, 180, 0, 1);
-        elseif ((player:getTP() >= 191) and (player:getTP() <= 199)) then
+        elseif ((tp >= 191) and (tp <= 199)) then
             player:addStatusEffect(EFFECT_AFTERMATH_LV1, 19, 0, 180, 0, 1);
 
 -- AFTERMATH LEVEL 2
 
-        elseif ((player:getTP() >= 200) and (player:getTP() <= 210)) then
+        elseif ((tp >= 200) and (tp <= 210)) then
             player:addStatusEffect(EFFECT_AFTERMATH_LV2, 24, 0, 180, 0, 1);
-        elseif ((player:getTP() >= 211) and (player:getTP() <= 219)) then
+        elseif ((tp >= 211) and (tp <= 219)) then
             player:addStatusEffect(EFFECT_AFTERMATH_LV2, 28, 0, 180, 0, 1);
-        elseif ((player:getTP() >= 221) and (player:getTP() <= 229)) then
+        elseif ((tp >= 221) and (tp <= 229)) then
             player:addStatusEffect(EFFECT_AFTERMATH_LV2, 32, 0, 180, 0, 1);
-        elseif ((player:getTP() >= 231) and (player:getTP() <= 239)) then
+        elseif ((tp >= 231) and (tp <= 239)) then
             player:addStatusEffect(EFFECT_AFTERMATH_LV2, 36, 0, 180, 0, 1);
-        elseif ((player:getTP() >= 241) and (player:getTP() <= 249)) then
+        elseif ((tp >= 241) and (tp <= 249)) then
             player:addStatusEffect(EFFECT_AFTERMATH_LV2, 40, 0, 180, 0, 1);
-        elseif ((player:getTP() >= 251) and (player:getTP() <= 259)) then
+        elseif ((tp >= 251) and (tp <= 259)) then
             player:addStatusEffect(EFFECT_AFTERMATH_LV2, 44, 0, 180, 0, 1);
-        elseif ((player:getTP() >= 261) and (player:getTP() <= 269)) then
+        elseif ((tp >= 261) and (tp <= 269)) then
             player:addStatusEffect(EFFECT_AFTERMATH_LV2, 48, 0, 180, 0, 1);
-        elseif ((player:getTP() >= 271) and (player:getTP() <= 279)) then
+        elseif ((tp >= 271) and (tp <= 279)) then
             player:addStatusEffect(EFFECT_AFTERMATH_LV2, 52, 0, 180, 0, 1);
-        elseif ((player:getTP() >= 281) and (player:getTP() <= 289)) then
+        elseif ((tp >= 281) and (tp <= 289)) then
             player:addStatusEffect(EFFECT_AFTERMATH_LV2, 56, 0, 180, 0, 1);
-        elseif ((player:getTP() >= 291) and (player:getTP() <= 299)) then
+        elseif ((tp >= 291) and (tp <= 299)) then
             player:addStatusEffect(EFFECT_AFTERMATH_LV2, 59, 0, 180, 0, 1);
 
 -- AFTERMATH LEVEL 3
 
-        elseif ((player:getTP() == 300)) then
+        elseif ((tp == 300)) then
             player:addStatusEffect(EFFECT_AFTERMATH_LV3, 45, 0, 120, 0, 1);
             end
         end

--- a/scripts/globals/weaponskills/final_heaven.lua
+++ b/scripts/globals/weaponskills/final_heaven.lua
@@ -36,11 +36,11 @@ function onUseWeaponSkill(player, target, wsID, tp, primary)
         params.vit_wsc = 0.8;
     end
 
-    -- damage = damage * ftp(player:getTP(), ftp100, ftp200, ftp300);
+    -- damage = damage * ftp(tp, ftp100, ftp200, ftp300);
     local damage, criticalHit, tpHits, extraHits = doPhysicalWeaponskill(player, target, wsID, params, tp, primary);
     -- TODO: Whoever codes those level 85 weapons with the latent that grants this WS needs to code a check to not give the aftermath effect.
     if (damage > 0) then
-        local amDuration = 20 * math.floor(player:getTP()/100);
+        local amDuration = 20 * math.floor(tp/100);
         player:addStatusEffect(EFFECT_AFTERMATH, 10, 0, amDuration, 0, 1);
     end
 

--- a/scripts/globals/weaponskills/flat_blade.lua
+++ b/scripts/globals/weaponskills/flat_blade.lua
@@ -33,7 +33,7 @@ function onUseWeaponSkill(player, target, wsID, tp, primary)
 
     local damage, criticalHit, tpHits, extraHits = doPhysicalWeaponskill(player, target, wsID, params, tp, primary);
 
-    local chance = player:getTP()-100 > math.random()*150;
+    local chance = tp-100 > math.random()*150;
     if (damage > 0 and target:hasStatusEffect(EFFECT_STUN) == false and chance) then
         target:addStatusEffect(EFFECT_STUN, 1, 0, 4);
     end

--- a/scripts/globals/weaponskills/full_break.lua
+++ b/scripts/globals/weaponskills/full_break.lua
@@ -33,7 +33,6 @@ function onUseWeaponSkill(player, target, wsID, tp, primary)
     local damage, criticalHit, tpHits, extraHits = doPhysicalWeaponskill(player, target, wsID, params, tp, primary);
 
     if (damage > 0) then
-        local tp = player:getTP();
         local duration = (tp/100 * 30) + 60;
         if (target:hasStatusEffect(EFFECT_DEFENSE_DOWN) == false) then
             target:addStatusEffect(EFFECT_DEFENSE_DOWN, 12.5, 0, duration);

--- a/scripts/globals/weaponskills/garland_of_bliss.lua
+++ b/scripts/globals/weaponskills/garland_of_bliss.lua
@@ -34,7 +34,6 @@ function onUseWeaponSkill(player, target, wsID, tp, primary)
 
     local damage, criticalHit, tpHits, extraHits = doMagicWeaponskill(player, target, wsID, params, tp, primary);
     if (damage > 0) then
-        local tp = player:getTP();
         local duration = (tp/100 * 30) + 30;
         if (target:hasStatusEffect(EFFECT_DEFENSE_DOWN) == false) then
             target:addStatusEffect(EFFECT_DEFENSE_DOWN, 12.5, 0, duration);
@@ -47,56 +46,56 @@ function onUseWeaponSkill(player, target, wsID, tp, primary)
 
 --        AFTERMATH LV1
 
-        if ((player:getTP() >= 100) and (player:getTP() <= 110)) then
+        if ((tp >= 100) and (tp <= 110)) then
             player:addStatusEffect(EFFECT_AFTERMATH_LV1, 10, 0, 180, 0, 1);
-    elseif ((player:getTP() >= 111) and (player:getTP() <= 120)) then
+    elseif ((tp >= 111) and (tp <= 120)) then
             player:addStatusEffect(EFFECT_AFTERMATH_LV1, 11, 0, 180, 0, 1);
-    elseif ((player:getTP() >= 121) and (player:getTP() <= 130)) then
+    elseif ((tp >= 121) and (tp <= 130)) then
             player:addStatusEffect(EFFECT_AFTERMATH_LV1, 12, 0, 180, 0, 1);
-    elseif ((player:getTP() >= 131) and (player:getTP() <= 140)) then
+    elseif ((tp >= 131) and (tp <= 140)) then
             player:addStatusEffect(EFFECT_AFTERMATH_LV1, 13, 0, 180, 0, 1);
-    elseif ((player:getTP() >= 141) and (player:getTP() <= 150)) then
+    elseif ((tp >= 141) and (tp <= 150)) then
             player:addStatusEffect(EFFECT_AFTERMATH_LV1, 14, 0, 180, 0, 1);
-    elseif ((player:getTP() >= 151) and (player:getTP() <= 160)) then
+    elseif ((tp >= 151) and (tp <= 160)) then
             player:addStatusEffect(EFFECT_AFTERMATH_LV1, 15, 0, 180, 0, 1);
-    elseif ((player:getTP() >= 161) and (player:getTP() <= 170)) then
+    elseif ((tp >= 161) and (tp <= 170)) then
             player:addStatusEffect(EFFECT_AFTERMATH_LV1, 16, 0, 180, 0, 1);
-    elseif ((player:getTP() >= 171) and (player:getTP() <= 180)) then
+    elseif ((tp >= 171) and (tp <= 180)) then
             player:addStatusEffect(EFFECT_AFTERMATH_LV1, 17, 0, 180, 0, 1);
-    elseif ((player:getTP() >= 181) and (player:getTP() <= 190)) then
+    elseif ((tp >= 181) and (tp <= 190)) then
             player:addStatusEffect(EFFECT_AFTERMATH_LV1, 18, 0, 180, 0, 1);
-    elseif ((player:getTP() >= 191) and (player:getTP() <= 199)) then
+    elseif ((tp >= 191) and (tp <= 199)) then
             player:addStatusEffect(EFFECT_AFTERMATH_LV1, 19, 0, 180, 0, 1);
 
 
 
 --        AFTERMATH LV2
 
-    elseif ((player:getTP() >= 200) and (player:getTP() <= 210)) then
+    elseif ((tp >= 200) and (tp <= 210)) then
             player:addStatusEffect(EFFECT_AFTERMATH_LV2, 24, 0, 180, 0, 1);
-    elseif ((player:getTP() >= 211) and (player:getTP() <= 219)) then
+    elseif ((tp >= 211) and (tp <= 219)) then
             player:addStatusEffect(EFFECT_AFTERMATH_LV2, 28, 0, 180, 0, 1);
-    elseif ((player:getTP() >= 221) and (player:getTP() <= 229)) then
+    elseif ((tp >= 221) and (tp <= 229)) then
             player:addStatusEffect(EFFECT_AFTERMATH_LV2, 32, 0, 180, 0, 1);
-    elseif ((player:getTP() >= 231) and (player:getTP() <= 239)) then
+    elseif ((tp >= 231) and (tp <= 239)) then
             player:addStatusEffect(EFFECT_AFTERMATH_LV2, 36, 0, 180, 0, 1);
-    elseif ((player:getTP() >= 241) and (player:getTP() <= 249)) then
+    elseif ((tp >= 241) and (tp <= 249)) then
             player:addStatusEffect(EFFECT_AFTERMATH_LV2, 40, 0, 180, 0, 1);
-    elseif ((player:getTP() >= 251) and (player:getTP() <= 259)) then
+    elseif ((tp >= 251) and (tp <= 259)) then
             player:addStatusEffect(EFFECT_AFTERMATH_LV2, 44, 0, 180, 0, 1);
-    elseif ((player:getTP() >= 261) and (player:getTP() <= 269)) then
+    elseif ((tp >= 261) and (tp <= 269)) then
             player:addStatusEffect(EFFECT_AFTERMATH_LV2, 48, 0, 180, 0, 1);
-    elseif ((player:getTP() >= 271) and (player:getTP() <= 279)) then
+    elseif ((tp >= 271) and (tp <= 279)) then
             player:addStatusEffect(EFFECT_AFTERMATH_LV2, 52, 0, 180, 0, 1);
-    elseif ((player:getTP() >= 281) and (player:getTP() <= 289)) then
+    elseif ((tp >= 281) and (tp <= 289)) then
             player:addStatusEffect(EFFECT_AFTERMATH_LV2, 56, 0, 180, 0, 1);
-    elseif ((player:getTP() >= 291) and (player:getTP() <= 299)) then
+    elseif ((tp >= 291) and (tp <= 299)) then
             player:addStatusEffect(EFFECT_AFTERMATH_LV2, 59, 0, 180, 0, 1);
 
 
 --        AFTERMATH LV3
 
-        elseif ((player:getTP() == 300)) then
+        elseif ((tp == 300)) then
             player:addStatusEffect(EFFECT_AFTERMATH_LV3, 45, 0, 120, 0, 1);
 
             end

--- a/scripts/globals/weaponskills/gate_of_tartarus.lua
+++ b/scripts/globals/weaponskills/gate_of_tartarus.lua
@@ -36,7 +36,7 @@ function onUseWeaponSkill(player, target, wsID, tp, primary)
     local damage, criticalHit, tpHits, extraHits = doPhysicalWeaponskill(player, target, wsID, params, tp, primary);
     -- TODO: Whoever codes those level 85 weapons with the latent that grants this WS needs to code a check to not give the aftermath effect.
     if (damage > 0) then
-        local amDuration = 20 * math.floor(player:getTP()/100);
+        local amDuration = 20 * math.floor(tp/100);
         player:addStatusEffect(EFFECT_AFTERMATH, 8, 0, amDuration, 0, 10);
         target:addStatusEffect(EFFECT_ATTACK_DOWN, 20, 0, 60);
     end

--- a/scripts/globals/weaponskills/geirskogul.lua
+++ b/scripts/globals/weaponskills/geirskogul.lua
@@ -34,7 +34,7 @@ function onUseWeaponSkill(player, target, wsID, tp, primary)
     local damage, criticalHit, tpHits, extraHits = doPhysicalWeaponskill(player, target, wsID, params, tp, primary);
     -- TODO: Whoever codes those level 85 weapons with the latent that grants this WS needs to code a check to not give the aftermath effect.
     if (damage > 0) then
-        local amDuration = 20 * math.floor(player:getTP()/100);
+        local amDuration = 20 * math.floor(tp/100);
         player:addStatusEffect(EFFECT_AFTERMATH, 6, 0, amDuration, 0, 7);
     end
 

--- a/scripts/globals/weaponskills/glory_slash.lua
+++ b/scripts/globals/weaponskills/glory_slash.lua
@@ -29,7 +29,6 @@ function onUseWeaponSkill(player, target, wsID, tp, primary)
     params.atkmulti = 1;
 
     if (damage > 0) then
-        local tp = player:getTP();
         local duration = (tp/50);
         if (target:hasStatusEffect(EFFECT_STUN) == false) then
             target:addStatusEffect(EFFECT_STUN, 1, 0, duration);

--- a/scripts/globals/weaponskills/guillotine.lua
+++ b/scripts/globals/weaponskills/guillotine.lua
@@ -33,7 +33,6 @@ function onUseWeaponSkill(player, target, wsID, tp, primary)
     local damage, criticalHit, tpHits, extraHits = doPhysicalWeaponskill(player, target, wsID, params, tp, primary);
 
     if (damage > 0) then
-        local tp = player:getTP();
         local duration = (tp/100 * 30) + 30;
         if (target:hasStatusEffect(EFFECT_SILENCE) == false) then
             target:addStatusEffect(EFFECT_SILENCE, 1, 0, duration);

--- a/scripts/globals/weaponskills/herculean_slash.lua
+++ b/scripts/globals/weaponskills/herculean_slash.lua
@@ -33,7 +33,6 @@ function onUseWeaponSkill(player, target, wsID, tp, primary)
     local damage, criticalHit, tpHits, extraHits = doMagicWeaponskill(player, target, wsID, params, tp, primary);
 
     if (damage > 0) then
-        local tp = player:getTP();
         local duration = (tp/100 * 60)
         if (target:hasStatusEffect(EFFECT_PARALYSIS) == false) then
             target:addStatusEffect(EFFECT_PARALYSIS, 30, 0, duration);

--- a/scripts/globals/weaponskills/infernal_scythe.lua
+++ b/scripts/globals/weaponskills/infernal_scythe.lua
@@ -32,7 +32,6 @@ function onUseWeaponSkill(player, target, wsID, tp, primary)
     local damage, criticalHit, tpHits, extraHits = doMagicWeaponskill(player, target, wsID, params, tp, primary);
 
     if (damage > 0) then
-        local tp = player:getTP();
         local duration = (tp/100 * 180)
         if (target:hasStatusEffect(EFFECT_ATTACK_DOWN) == false) then
             target:addStatusEffect(EFFECT_ATTACK_DOWN, 25, 0, duration);

--- a/scripts/globals/weaponskills/insurgency.lua
+++ b/scripts/globals/weaponskills/insurgency.lua
@@ -39,56 +39,56 @@ function onUseWeaponSkill(player, target, wsID, tp, primary)
 
 --        AFTERMATH LV1
 
-        if ((player:getTP() >= 100) and (player:getTP() <= 110)) then
+        if ((tp >= 100) and (tp <= 110)) then
             player:addStatusEffect(EFFECT_AFTERMATH_LV1, 10, 0, 180, 0, 1);
-    elseif ((player:getTP() >= 111) and (player:getTP() <= 120)) then
+    elseif ((tp >= 111) and (tp <= 120)) then
             player:addStatusEffect(EFFECT_AFTERMATH_LV1, 11, 0, 180, 0, 1);
-    elseif ((player:getTP() >= 121) and (player:getTP() <= 130)) then
+    elseif ((tp >= 121) and (tp <= 130)) then
             player:addStatusEffect(EFFECT_AFTERMATH_LV1, 12, 0, 180, 0, 1);
-    elseif ((player:getTP() >= 131) and (player:getTP() <= 140)) then
+    elseif ((tp >= 131) and (tp <= 140)) then
             player:addStatusEffect(EFFECT_AFTERMATH_LV1, 13, 0, 180, 0, 1);
-    elseif ((player:getTP() >= 141) and (player:getTP() <= 150)) then
+    elseif ((tp >= 141) and (tp <= 150)) then
             player:addStatusEffect(EFFECT_AFTERMATH_LV1, 14, 0, 180, 0, 1);
-    elseif ((player:getTP() >= 151) and (player:getTP() <= 160)) then
+    elseif ((tp >= 151) and (tp <= 160)) then
             player:addStatusEffect(EFFECT_AFTERMATH_LV1, 15, 0, 180, 0, 1);
-    elseif ((player:getTP() >= 161) and (player:getTP() <= 170)) then
+    elseif ((tp >= 161) and (tp <= 170)) then
             player:addStatusEffect(EFFECT_AFTERMATH_LV1, 16, 0, 180, 0, 1);
-    elseif ((player:getTP() >= 171) and (player:getTP() <= 180)) then
+    elseif ((tp >= 171) and (tp <= 180)) then
             player:addStatusEffect(EFFECT_AFTERMATH_LV1, 17, 0, 180, 0, 1);
-    elseif ((player:getTP() >= 181) and (player:getTP() <= 190)) then
+    elseif ((tp >= 181) and (tp <= 190)) then
             player:addStatusEffect(EFFECT_AFTERMATH_LV1, 18, 0, 180, 0, 1);
-    elseif ((player:getTP() >= 191) and (player:getTP() <= 199)) then
+    elseif ((tp >= 191) and (tp <= 199)) then
             player:addStatusEffect(EFFECT_AFTERMATH_LV1, 19, 0, 180, 0, 1);
 
 
 
 --        AFTERMATH LV2
 
-    elseif ((player:getTP() >= 200) and (player:getTP() <= 210)) then
+    elseif ((tp >= 200) and (tp <= 210)) then
             player:addStatusEffect(EFFECT_AFTERMATH_LV2, 24, 0, 180, 0, 1);
-    elseif ((player:getTP() >= 211) and (player:getTP() <= 219)) then
+    elseif ((tp >= 211) and (tp <= 219)) then
             player:addStatusEffect(EFFECT_AFTERMATH_LV2, 28, 0, 180, 0, 1);
-    elseif ((player:getTP() >= 221) and (player:getTP() <= 229)) then
+    elseif ((tp >= 221) and (tp <= 229)) then
             player:addStatusEffect(EFFECT_AFTERMATH_LV2, 32, 0, 180, 0, 1);
-    elseif ((player:getTP() >= 231) and (player:getTP() <= 239)) then
+    elseif ((tp >= 231) and (tp <= 239)) then
             player:addStatusEffect(EFFECT_AFTERMATH_LV2, 36, 0, 180, 0, 1);
-    elseif ((player:getTP() >= 241) and (player:getTP() <= 249)) then
+    elseif ((tp >= 241) and (tp <= 249)) then
             player:addStatusEffect(EFFECT_AFTERMATH_LV2, 40, 0, 180, 0, 1);
-    elseif ((player:getTP() >= 251) and (player:getTP() <= 259)) then
+    elseif ((tp >= 251) and (tp <= 259)) then
             player:addStatusEffect(EFFECT_AFTERMATH_LV2, 44, 0, 180, 0, 1);
-    elseif ((player:getTP() >= 261) and (player:getTP() <= 269)) then
+    elseif ((tp >= 261) and (tp <= 269)) then
             player:addStatusEffect(EFFECT_AFTERMATH_LV2, 48, 0, 180, 0, 1);
-    elseif ((player:getTP() >= 271) and (player:getTP() <= 279)) then
+    elseif ((tp >= 271) and (tp <= 279)) then
             player:addStatusEffect(EFFECT_AFTERMATH_LV2, 52, 0, 180, 0, 1);
-    elseif ((player:getTP() >= 281) and (player:getTP() <= 289)) then
+    elseif ((tp >= 281) and (tp <= 289)) then
             player:addStatusEffect(EFFECT_AFTERMATH_LV2, 56, 0, 180, 0, 1);
-    elseif ((player:getTP() >= 291) and (player:getTP() <= 299)) then
+    elseif ((tp >= 291) and (tp <= 299)) then
             player:addStatusEffect(EFFECT_AFTERMATH_LV2, 59, 0, 180, 0, 1);
 
 
 --        AFTERMATH LV3
 
-        elseif ((player:getTP() == 300)) then
+        elseif ((tp == 300)) then
             player:addStatusEffect(EFFECT_AFTERMATH_LV3, 45, 0, 120, 0, 1);
 
             end

--- a/scripts/globals/weaponskills/kings_justice.lua
+++ b/scripts/globals/weaponskills/kings_justice.lua
@@ -39,53 +39,53 @@ function onUseWeaponSkill(player, target, wsID, tp, primary)
 
 -- AFTERMATH LEVEL 1
 
-        if ((player:getTP() >= 100) and (player:getTP() <= 110)) then
+        if ((tp >= 100) and (tp <= 110)) then
             player:addStatusEffect(EFFECT_AFTERMATH_LV1, 10, 0, 180, 0, 1);
-        elseif ((player:getTP() >= 111) and (player:getTP() <= 120)) then
+        elseif ((tp >= 111) and (tp <= 120)) then
             player:addStatusEffect(EFFECT_AFTERMATH_LV1, 11, 0, 180, 0, 1);
-        elseif ((player:getTP() >= 121) and (player:getTP() <= 130)) then
+        elseif ((tp >= 121) and (tp <= 130)) then
             player:addStatusEffect(EFFECT_AFTERMATH_LV1, 12, 0, 180, 0, 1);
-        elseif ((player:getTP() >= 131) and (player:getTP() <= 140)) then
+        elseif ((tp >= 131) and (tp <= 140)) then
             player:addStatusEffect(EFFECT_AFTERMATH_LV1, 13, 0, 180, 0, 1);
-        elseif ((player:getTP() >= 141) and (player:getTP() <= 150)) then
+        elseif ((tp >= 141) and (tp <= 150)) then
             player:addStatusEffect(EFFECT_AFTERMATH_LV1, 14, 0, 180, 0, 1);
-        elseif ((player:getTP() >= 151) and (player:getTP() <= 160)) then
+        elseif ((tp >= 151) and (tp <= 160)) then
             player:addStatusEffect(EFFECT_AFTERMATH_LV1, 15, 0, 180, 0, 1);
-        elseif ((player:getTP() >= 161) and (player:getTP() <= 170)) then
+        elseif ((tp >= 161) and (tp <= 170)) then
             player:addStatusEffect(EFFECT_AFTERMATH_LV1, 16, 0, 180, 0, 1);
-        elseif ((player:getTP() >= 171) and (player:getTP() <= 180)) then
+        elseif ((tp >= 171) and (tp <= 180)) then
             player:addStatusEffect(EFFECT_AFTERMATH_LV1, 17, 0, 180, 0, 1);
-        elseif ((player:getTP() >= 181) and (player:getTP() <= 190)) then
+        elseif ((tp >= 181) and (tp <= 190)) then
             player:addStatusEffect(EFFECT_AFTERMATH_LV1, 18, 0, 180, 0, 1);
-        elseif ((player:getTP() >= 191) and (player:getTP() <= 199)) then
+        elseif ((tp >= 191) and (tp <= 199)) then
             player:addStatusEffect(EFFECT_AFTERMATH_LV1, 19, 0, 180, 0, 1);
 
 -- AFTERMATH LEVEL 2
 
-        elseif ((player:getTP() >= 200) and (player:getTP() <= 210)) then
+        elseif ((tp >= 200) and (tp <= 210)) then
             player:addStatusEffect(EFFECT_AFTERMATH_LV2, 24, 0, 180, 0, 1);
-        elseif ((player:getTP() >= 211) and (player:getTP() <= 219)) then
+        elseif ((tp >= 211) and (tp <= 219)) then
             player:addStatusEffect(EFFECT_AFTERMATH_LV2, 28, 0, 180, 0, 1);
-        elseif ((player:getTP() >= 221) and (player:getTP() <= 229)) then
+        elseif ((tp >= 221) and (tp <= 229)) then
             player:addStatusEffect(EFFECT_AFTERMATH_LV2, 32, 0, 180, 0, 1);
-        elseif ((player:getTP() >= 231) and (player:getTP() <= 239)) then
+        elseif ((tp >= 231) and (tp <= 239)) then
             player:addStatusEffect(EFFECT_AFTERMATH_LV2, 36, 0, 180, 0, 1);
-        elseif ((player:getTP() >= 241) and (player:getTP() <= 249)) then
+        elseif ((tp >= 241) and (tp <= 249)) then
             player:addStatusEffect(EFFECT_AFTERMATH_LV2, 40, 0, 180, 0, 1);
-        elseif ((player:getTP() >= 251) and (player:getTP() <= 259)) then
+        elseif ((tp >= 251) and (tp <= 259)) then
             player:addStatusEffect(EFFECT_AFTERMATH_LV2, 44, 0, 180, 0, 1);
-        elseif ((player:getTP() >= 261) and (player:getTP() <= 269)) then
+        elseif ((tp >= 261) and (tp <= 269)) then
             player:addStatusEffect(EFFECT_AFTERMATH_LV2, 48, 0, 180, 0, 1);
-        elseif ((player:getTP() >= 271) and (player:getTP() <= 279)) then
+        elseif ((tp >= 271) and (tp <= 279)) then
             player:addStatusEffect(EFFECT_AFTERMATH_LV2, 52, 0, 180, 0, 1);
-        elseif ((player:getTP() >= 281) and (player:getTP() <= 289)) then
+        elseif ((tp >= 281) and (tp <= 289)) then
             player:addStatusEffect(EFFECT_AFTERMATH_LV2, 56, 0, 180, 0, 1);
-        elseif ((player:getTP() >= 291) and (player:getTP() <= 299)) then
+        elseif ((tp >= 291) and (tp <= 299)) then
             player:addStatusEffect(EFFECT_AFTERMATH_LV2, 59, 0, 180, 0, 1);
 
 -- AFTERMATH LEVEL 3
 
-        elseif ((player:getTP() == 300)) then
+        elseif ((tp == 300)) then
             player:addStatusEffect(EFFECT_AFTERMATH_LV3, 45, 0, 120, 0, 1);
             end
         end

--- a/scripts/globals/weaponskills/knights_of_round.lua
+++ b/scripts/globals/weaponskills/knights_of_round.lua
@@ -36,7 +36,7 @@ function onUseWeaponSkill(player, target, wsID, tp, primary)
     local damage, criticalHit, tpHits, extraHits = doPhysicalWeaponskill(player, target, wsID, params, tp, primary);
     -- TODO: Whoever codes those level 85 weapons with the latent that grants this WS needs to code a check to not give the aftermath effect.
     if (damage > 0) then
-        local amDuration = 20 * math.floor(player:getTP()/100);
+        local amDuration = 20 * math.floor(tp/100);
         player:addStatusEffect(EFFECT_AFTERMATH, 10, 0, amDuration, 0, 3);
     end
 

--- a/scripts/globals/weaponskills/leaden_salute.lua
+++ b/scripts/globals/weaponskills/leaden_salute.lua
@@ -38,53 +38,53 @@ function onUseWeaponSkill(player, target, wsID, tp, primary)
 
 -- AFTERMATH LEVEL 1
 
-        if ((player:getTP() >= 100) and (player:getTP() <= 110)) then
+        if ((tp >= 100) and (tp <= 110)) then
             player:addStatusEffect(EFFECT_AFTERMATH_LV1, 10, 0, 180, 0, 3);
-        elseif ((player:getTP() >= 111) and (player:getTP() <= 120)) then
+        elseif ((tp >= 111) and (tp <= 120)) then
             player:addStatusEffect(EFFECT_AFTERMATH_LV1, 11, 0, 180, 0, 3);
-        elseif ((player:getTP() >= 121) and (player:getTP() <= 130)) then
+        elseif ((tp >= 121) and (tp <= 130)) then
             player:addStatusEffect(EFFECT_AFTERMATH_LV1, 12, 0, 180, 0, 3);
-        elseif ((player:getTP() >= 131) and (player:getTP() <= 140)) then
+        elseif ((tp >= 131) and (tp <= 140)) then
             player:addStatusEffect(EFFECT_AFTERMATH_LV1, 13, 0, 180, 0, 3);
-        elseif ((player:getTP() >= 141) and (player:getTP() <= 150)) then
+        elseif ((tp >= 141) and (tp <= 150)) then
             player:addStatusEffect(EFFECT_AFTERMATH_LV1, 14, 0, 180, 0, 3);
-        elseif ((player:getTP() >= 151) and (player:getTP() <= 160)) then
+        elseif ((tp >= 151) and (tp <= 160)) then
             player:addStatusEffect(EFFECT_AFTERMATH_LV1, 15, 0, 180, 0, 3);
-        elseif ((player:getTP() >= 161) and (player:getTP() <= 170)) then
+        elseif ((tp >= 161) and (tp <= 170)) then
             player:addStatusEffect(EFFECT_AFTERMATH_LV1, 16, 0, 180, 0, 3);
-        elseif ((player:getTP() >= 171) and (player:getTP() <= 180)) then
+        elseif ((tp >= 171) and (tp <= 180)) then
             player:addStatusEffect(EFFECT_AFTERMATH_LV1, 17, 0, 180, 0, 3);
-        elseif ((player:getTP() >= 181) and (player:getTP() <= 190)) then
+        elseif ((tp >= 181) and (tp <= 190)) then
             player:addStatusEffect(EFFECT_AFTERMATH_LV1, 18, 0, 180, 0, 3);
-        elseif ((player:getTP() >= 191) and (player:getTP() <= 199)) then
+        elseif ((tp >= 191) and (tp <= 199)) then
             player:addStatusEffect(EFFECT_AFTERMATH_LV1, 19, 0, 180, 0, 3);
 
 -- AFTERMATH LEVEL 2
 
-        elseif ((player:getTP() >= 200) and (player:getTP() <= 210)) then
+        elseif ((tp >= 200) and (tp <= 210)) then
             player:addStatusEffect(EFFECT_AFTERMATH_LV2, 24, 0, 180, 0, 4);
-        elseif ((player:getTP() >= 211) and (player:getTP() <= 219)) then
+        elseif ((tp >= 211) and (tp <= 219)) then
             player:addStatusEffect(EFFECT_AFTERMATH_LV2, 28, 0, 180, 0, 4);
-        elseif ((player:getTP() >= 221) and (player:getTP() <= 229)) then
+        elseif ((tp >= 221) and (tp <= 229)) then
             player:addStatusEffect(EFFECT_AFTERMATH_LV2, 32, 0, 180, 0, 4);
-        elseif ((player:getTP() >= 231) and (player:getTP() <= 239)) then
+        elseif ((tp >= 231) and (tp <= 239)) then
             player:addStatusEffect(EFFECT_AFTERMATH_LV2, 36, 0, 180, 0, 4);
-        elseif ((player:getTP() >= 241) and (player:getTP() <= 249)) then
+        elseif ((tp >= 241) and (tp <= 249)) then
             player:addStatusEffect(EFFECT_AFTERMATH_LV2, 40, 0, 180, 0, 4);
-        elseif ((player:getTP() >= 251) and (player:getTP() <= 259)) then
+        elseif ((tp >= 251) and (tp <= 259)) then
             player:addStatusEffect(EFFECT_AFTERMATH_LV2, 44, 0, 180, 0, 4);
-        elseif ((player:getTP() >= 261) and (player:getTP() <= 269)) then
+        elseif ((tp >= 261) and (tp <= 269)) then
             player:addStatusEffect(EFFECT_AFTERMATH_LV2, 48, 0, 180, 0, 4);
-        elseif ((player:getTP() >= 271) and (player:getTP() <= 279)) then
+        elseif ((tp >= 271) and (tp <= 279)) then
             player:addStatusEffect(EFFECT_AFTERMATH_LV2, 52, 0, 180, 0, 4);
-        elseif ((player:getTP() >= 281) and (player:getTP() <= 289)) then
+        elseif ((tp >= 281) and (tp <= 289)) then
             player:addStatusEffect(EFFECT_AFTERMATH_LV2, 56, 0, 180, 0, 4);
-        elseif ((player:getTP() >= 291) and (player:getTP() <= 299)) then
+        elseif ((tp >= 291) and (tp <= 299)) then
             player:addStatusEffect(EFFECT_AFTERMATH_LV2, 59, 0, 180, 0, 4);
 
 -- AFTERMATH LEVEL 3
 
-        elseif ((player:getTP() == 300)) then
+        elseif ((tp == 300)) then
             player:addStatusEffect(EFFECT_AFTERMATH_LV3, 45, 0, 120, 0, 2);
             end
         end

--- a/scripts/globals/weaponskills/leg_sweep.lua
+++ b/scripts/globals/weaponskills/leg_sweep.lua
@@ -33,7 +33,7 @@ function onUseWeaponSkill(player, target, wsID, tp, primary)
 
     local damage, criticalHit, tpHits, extraHits = doPhysicalWeaponskill(player, target, wsID, params, tp, primary);
 
-    local chance = player:getTP()-100 > math.random()*150;
+    local chance = tp-100 > math.random()*150;
     if (damage > 0 and chance) then
         if (target:hasStatusEffect(EFFECT_STUN) == false) then
             target:addStatusEffect(EFFECT_STUN, 1, 0, 4);

--- a/scripts/globals/weaponskills/mandalic_stab.lua
+++ b/scripts/globals/weaponskills/mandalic_stab.lua
@@ -41,56 +41,56 @@ function onUseWeaponSkill(player, target, wsID, tp, primary)
 
 --        AFTERMATH LV1
 
-        if ((player:getTP() >= 100) and (player:getTP() <= 110)) then
+        if ((tp >= 100) and (tp <= 110)) then
             player:addStatusEffect(EFFECT_AFTERMATH_LV1, 10, 0, 180, 0, 1);
-    elseif ((player:getTP() >= 111) and (player:getTP() <= 120)) then
+    elseif ((tp >= 111) and (tp <= 120)) then
             player:addStatusEffect(EFFECT_AFTERMATH_LV1, 11, 0, 180, 0, 1);
-    elseif ((player:getTP() >= 121) and (player:getTP() <= 130)) then
+    elseif ((tp >= 121) and (tp <= 130)) then
             player:addStatusEffect(EFFECT_AFTERMATH_LV1, 12, 0, 180, 0, 1);
-    elseif ((player:getTP() >= 131) and (player:getTP() <= 140)) then
+    elseif ((tp >= 131) and (tp <= 140)) then
             player:addStatusEffect(EFFECT_AFTERMATH_LV1, 13, 0, 180, 0, 1);
-    elseif ((player:getTP() >= 141) and (player:getTP() <= 150)) then
+    elseif ((tp >= 141) and (tp <= 150)) then
             player:addStatusEffect(EFFECT_AFTERMATH_LV1, 14, 0, 180, 0, 1);
-    elseif ((player:getTP() >= 151) and (player:getTP() <= 160)) then
+    elseif ((tp >= 151) and (tp <= 160)) then
             player:addStatusEffect(EFFECT_AFTERMATH_LV1, 15, 0, 180, 0, 1);
-    elseif ((player:getTP() >= 161) and (player:getTP() <= 170)) then
+    elseif ((tp >= 161) and (tp <= 170)) then
             player:addStatusEffect(EFFECT_AFTERMATH_LV1, 16, 0, 180, 0, 1);
-    elseif ((player:getTP() >= 171) and (player:getTP() <= 180)) then
+    elseif ((tp >= 171) and (tp <= 180)) then
             player:addStatusEffect(EFFECT_AFTERMATH_LV1, 17, 0, 180, 0, 1);
-    elseif ((player:getTP() >= 181) and (player:getTP() <= 190)) then
+    elseif ((tp >= 181) and (tp <= 190)) then
             player:addStatusEffect(EFFECT_AFTERMATH_LV1, 18, 0, 180, 0, 1);
-    elseif ((player:getTP() >= 191) and (player:getTP() <= 199)) then
+    elseif ((tp >= 191) and (tp <= 199)) then
             player:addStatusEffect(EFFECT_AFTERMATH_LV1, 19, 0, 180, 0, 1);
 
 
 
 --        AFTERMATH LV2
 
-    elseif ((player:getTP() >= 200) and (player:getTP() <= 210)) then
+    elseif ((tp >= 200) and (tp <= 210)) then
             player:addStatusEffect(EFFECT_AFTERMATH_LV2, 24, 0, 180, 0, 1);
-    elseif ((player:getTP() >= 211) and (player:getTP() <= 219)) then
+    elseif ((tp >= 211) and (tp <= 219)) then
             player:addStatusEffect(EFFECT_AFTERMATH_LV2, 28, 0, 180, 0, 1);
-    elseif ((player:getTP() >= 221) and (player:getTP() <= 229)) then
+    elseif ((tp >= 221) and (tp <= 229)) then
             player:addStatusEffect(EFFECT_AFTERMATH_LV2, 32, 0, 180, 0, 1);
-    elseif ((player:getTP() >= 231) and (player:getTP() <= 239)) then
+    elseif ((tp >= 231) and (tp <= 239)) then
             player:addStatusEffect(EFFECT_AFTERMATH_LV2, 36, 0, 180, 0, 1);
-    elseif ((player:getTP() >= 241) and (player:getTP() <= 249)) then
+    elseif ((tp >= 241) and (tp <= 249)) then
             player:addStatusEffect(EFFECT_AFTERMATH_LV2, 40, 0, 180, 0, 1);
-    elseif ((player:getTP() >= 251) and (player:getTP() <= 259)) then
+    elseif ((tp >= 251) and (tp <= 259)) then
             player:addStatusEffect(EFFECT_AFTERMATH_LV2, 44, 0, 180, 0, 1);
-    elseif ((player:getTP() >= 261) and (player:getTP() <= 269)) then
+    elseif ((tp >= 261) and (tp <= 269)) then
             player:addStatusEffect(EFFECT_AFTERMATH_LV2, 48, 0, 180, 0, 1);
-    elseif ((player:getTP() >= 271) and (player:getTP() <= 279)) then
+    elseif ((tp >= 271) and (tp <= 279)) then
             player:addStatusEffect(EFFECT_AFTERMATH_LV2, 52, 0, 180, 0, 1);
-    elseif ((player:getTP() >= 281) and (player:getTP() <= 289)) then
+    elseif ((tp >= 281) and (tp <= 289)) then
             player:addStatusEffect(EFFECT_AFTERMATH_LV2, 56, 0, 180, 0, 1);
-    elseif ((player:getTP() >= 291) and (player:getTP() <= 299)) then
+    elseif ((tp >= 291) and (tp <= 299)) then
             player:addStatusEffect(EFFECT_AFTERMATH_LV2, 59, 0, 180, 0, 1);
 
 
 --        AFTERMATH LV3
 
-        elseif ((player:getTP() == 300)) then
+        elseif ((tp == 300)) then
             player:addStatusEffect(EFFECT_AFTERMATH_LV3, 45, 0, 120, 0, 1);
 
             end

--- a/scripts/globals/weaponskills/mercy_stroke.lua
+++ b/scripts/globals/weaponskills/mercy_stroke.lua
@@ -35,7 +35,7 @@ function onUseWeaponSkill(player, target, wsID, tp, primary)
     local damage, criticalHit, tpHits, extraHits = doPhysicalWeaponskill(player, target, wsID, params, tp, primary);
     -- TODO: Whoever codes those level 85 weapons with the latent that grants this WS needs to code a check to not give the aftermath effect.
     if (damage > 0) then
-        local amDuration = 20 * math.floor(player:getTP()/100);
+        local amDuration = 20 * math.floor(tp/100);
         player:addStatusEffect(EFFECT_AFTERMATH, 5, 0, amDuration, 0, 2);
     end
 

--- a/scripts/globals/weaponskills/metatron_torment.lua
+++ b/scripts/globals/weaponskills/metatron_torment.lua
@@ -40,7 +40,7 @@ function onUseWeaponSkill(player, target, wsID, tp, primary)
     local damage, criticalHit, tpHits, extraHits = doPhysicalWeaponskill(player, target, wsID, params, tp, primary);
     -- TODO: Whoever codes those level 85 weapons with the latent that grants this WS needs to code a check to not give the aftermath effect.
     if (damage > 0) then
-        local amDuration = 20 * math.floor(player:getTP()/100);
+        local amDuration = 20 * math.floor(tp/100);
         player:addStatusEffect(EFFECT_AFTERMATH, -21, 0, amDuration, 0, 5);
         target:addStatusEffect(EFFECT_DEFENSE_DOWN, 19, 0, 120);
     end

--- a/scripts/globals/weaponskills/moonlight.lua
+++ b/scripts/globals/weaponskills/moonlight.lua
@@ -8,7 +8,7 @@ require("scripts/globals/weaponskills");
 function onUseWeaponSkill(player, target, wsID, tp, primary)
     local lvl = player:getSkillLevel(11); -- get club skill
     local damage = (lvl/9) - 1;
-    local damagemod = damage * ((50+(player:getTP()*0.5))/100);
+    local damagemod = damage * ((50+(tp*0.5))/100);
     damagemod = damagemod * WEAPON_SKILL_POWER
     return 1, 0, false, damagemod;
 end

--- a/scripts/globals/weaponskills/mordant_rime.lua
+++ b/scripts/globals/weaponskills/mordant_rime.lua
@@ -34,7 +34,7 @@ function onUseWeaponSkill(player, target, wsID, tp, primary)
         params.chr_wsc = 0.7;
     end
 
-    local chance = player:getTP()-100 > math.random()*150;
+    local chance = tp-100 > math.random()*150;
     if (damage > 0 and chance) and (target:hasStatusEffect(EFFECT_WEIGHT) == false) then
         target:addStatusEffect(EFFECT_WEIGHT, 50, 0, 60);
     end
@@ -44,56 +44,56 @@ function onUseWeaponSkill(player, target, wsID, tp, primary)
 
 --        AFTERMATH LV1
 
-        if ((player:getTP() >= 100) and (player:getTP() <= 110)) then
+        if ((tp >= 100) and (tp <= 110)) then
             player:addStatusEffect(EFFECT_AFTERMATH_LV1, 10, 0, 180, 0, 2);
-    elseif ((player:getTP() >= 111) and (player:getTP() <= 120)) then
+    elseif ((tp >= 111) and (tp <= 120)) then
             player:addStatusEffect(EFFECT_AFTERMATH_LV1, 11, 0, 180, 0, 2);
-    elseif ((player:getTP() >= 121) and (player:getTP() <= 130)) then
+    elseif ((tp >= 121) and (tp <= 130)) then
             player:addStatusEffect(EFFECT_AFTERMATH_LV1, 12, 0, 180, 0, 2);
-    elseif ((player:getTP() >= 131) and (player:getTP() <= 140)) then
+    elseif ((tp >= 131) and (tp <= 140)) then
             player:addStatusEffect(EFFECT_AFTERMATH_LV1, 13, 0, 180, 0, 2);
-    elseif ((player:getTP() >= 141) and (player:getTP() <= 150)) then
+    elseif ((tp >= 141) and (tp <= 150)) then
             player:addStatusEffect(EFFECT_AFTERMATH_LV1, 14, 0, 180, 0, 2);
-    elseif ((player:getTP() >= 151) and (player:getTP() <= 160)) then
+    elseif ((tp >= 151) and (tp <= 160)) then
             player:addStatusEffect(EFFECT_AFTERMATH_LV1, 15, 0, 180, 0, 2);
-    elseif ((player:getTP() >= 161) and (player:getTP() <= 170)) then
+    elseif ((tp >= 161) and (tp <= 170)) then
             player:addStatusEffect(EFFECT_AFTERMATH_LV1, 16, 0, 180, 0, 2);
-    elseif ((player:getTP() >= 171) and (player:getTP() <= 180)) then
+    elseif ((tp >= 171) and (tp <= 180)) then
             player:addStatusEffect(EFFECT_AFTERMATH_LV1, 17, 0, 180, 0, 2);
-    elseif ((player:getTP() >= 181) and (player:getTP() <= 190)) then
+    elseif ((tp >= 181) and (tp <= 190)) then
             player:addStatusEffect(EFFECT_AFTERMATH_LV1, 18, 0, 180, 0, 2);
-    elseif ((player:getTP() >= 191) and (player:getTP() <= 199)) then
+    elseif ((tp >= 191) and (tp <= 199)) then
             player:addStatusEffect(EFFECT_AFTERMATH_LV1, 19, 0, 180, 0, 2);
 
 
 
 --        AFTERMATH LV2
 
-    elseif ((player:getTP() >= 200) and (player:getTP() <= 210)) then
+    elseif ((tp >= 200) and (tp <= 210)) then
             player:addStatusEffect(EFFECT_AFTERMATH_LV2, 24, 0, 180, 0, 2);
-    elseif ((player:getTP() >= 211) and (player:getTP() <= 219)) then
+    elseif ((tp >= 211) and (tp <= 219)) then
             player:addStatusEffect(EFFECT_AFTERMATH_LV2, 28, 0, 180, 0, 2);
-    elseif ((player:getTP() >= 221) and (player:getTP() <= 229)) then
+    elseif ((tp >= 221) and (tp <= 229)) then
             player:addStatusEffect(EFFECT_AFTERMATH_LV2, 32, 0, 180, 0, 2);
-    elseif ((player:getTP() >= 231) and (player:getTP() <= 239)) then
+    elseif ((tp >= 231) and (tp <= 239)) then
             player:addStatusEffect(EFFECT_AFTERMATH_LV2, 36, 0, 180, 0, 2);
-    elseif ((player:getTP() >= 241) and (player:getTP() <= 249)) then
+    elseif ((tp >= 241) and (tp <= 249)) then
             player:addStatusEffect(EFFECT_AFTERMATH_LV2, 40, 0, 180, 0, 2);
-    elseif ((player:getTP() >= 251) and (player:getTP() <= 259)) then
+    elseif ((tp >= 251) and (tp <= 259)) then
             player:addStatusEffect(EFFECT_AFTERMATH_LV2, 44, 0, 180, 0, 2);
-    elseif ((player:getTP() >= 261) and (player:getTP() <= 269)) then
+    elseif ((tp >= 261) and (tp <= 269)) then
             player:addStatusEffect(EFFECT_AFTERMATH_LV2, 48, 0, 180, 0, 2);
-    elseif ((player:getTP() >= 271) and (player:getTP() <= 279)) then
+    elseif ((tp >= 271) and (tp <= 279)) then
             player:addStatusEffect(EFFECT_AFTERMATH_LV2, 52, 0, 180, 0, 2);
-    elseif ((player:getTP() >= 281) and (player:getTP() <= 289)) then
+    elseif ((tp >= 281) and (tp <= 289)) then
             player:addStatusEffect(EFFECT_AFTERMATH_LV2, 56, 0, 180, 0, 2);
-    elseif ((player:getTP() >= 291) and (player:getTP() <= 299)) then
+    elseif ((tp >= 291) and (tp <= 299)) then
             player:addStatusEffect(EFFECT_AFTERMATH_LV2, 59, 0, 180, 0, 2);
 
 
 --        AFTERMATH LV3
 
-        elseif ((player:getTP() == 300)) then
+        elseif ((tp == 300)) then
             player:addStatusEffect(EFFECT_AFTERMATH_LV3, 45, 0, 120, 0, 1);
 
             end

--- a/scripts/globals/weaponskills/myrkr.lua
+++ b/scripts/globals/weaponskills/myrkr.lua
@@ -6,6 +6,6 @@ require("scripts/globals/settings");
 require("scripts/globals/weaponskills");
 
 function onUseWeaponSkill(player, target, wsID, tp, primary)
-    local ftpmp = fTP(player:getTP(),0.2,0.4,0.6);
+    local ftpmp = fTP(tp,0.2,0.4,0.6);
     return 1, 0, false, (ftpmp*player:getMaxMP());
 end

--- a/scripts/globals/weaponskills/mystic_boon.lua
+++ b/scripts/globals/weaponskills/mystic_boon.lua
@@ -38,51 +38,51 @@ function onUseWeaponSkill(player, target, wsID, tp, primary)
     if ((player:getEquipID(SLOT_MAIN) == 18993) and (player:getMainJob() == JOB_WHM)) then
         if (damage > 0) then
             -- AFTERMATH LV1
-            if ((player:getTP() >= 100) and (player:getTP() <= 110)) then
+            if ((tp >= 100) and (tp <= 110)) then
                     player:addStatusEffect(EFFECT_AFTERMATH_LV1, 10, 0, 180, 0, 2);
-            elseif ((player:getTP() >= 111) and (player:getTP() <= 120)) then
+            elseif ((tp >= 111) and (tp <= 120)) then
                     player:addStatusEffect(EFFECT_AFTERMATH_LV1, 11, 0, 180, 0, 2);
-            elseif ((player:getTP() >= 121) and (player:getTP() <= 130)) then
+            elseif ((tp >= 121) and (tp <= 130)) then
                     player:addStatusEffect(EFFECT_AFTERMATH_LV1, 12, 0, 180, 0, 2);
-            elseif ((player:getTP() >= 131) and (player:getTP() <= 140)) then
+            elseif ((tp >= 131) and (tp <= 140)) then
                     player:addStatusEffect(EFFECT_AFTERMATH_LV1, 13, 0, 180, 0, 2);
-            elseif ((player:getTP() >= 141) and (player:getTP() <= 150)) then
+            elseif ((tp >= 141) and (tp <= 150)) then
                     player:addStatusEffect(EFFECT_AFTERMATH_LV1, 14, 0, 180, 0, 2);
-            elseif ((player:getTP() >= 151) and (player:getTP() <= 160)) then
+            elseif ((tp >= 151) and (tp <= 160)) then
                     player:addStatusEffect(EFFECT_AFTERMATH_LV1, 15, 0, 180, 0, 2);
-            elseif ((player:getTP() >= 161) and (player:getTP() <= 170)) then
+            elseif ((tp >= 161) and (tp <= 170)) then
                     player:addStatusEffect(EFFECT_AFTERMATH_LV1, 16, 0, 180, 0, 2);
-            elseif ((player:getTP() >= 171) and (player:getTP() <= 180)) then
+            elseif ((tp >= 171) and (tp <= 180)) then
                     player:addStatusEffect(EFFECT_AFTERMATH_LV1, 17, 0, 180, 0, 2);
-            elseif ((player:getTP() >= 181) and (player:getTP() <= 190)) then
+            elseif ((tp >= 181) and (tp <= 190)) then
                     player:addStatusEffect(EFFECT_AFTERMATH_LV1, 18, 0, 180, 0, 2);
-            elseif ((player:getTP() >= 191) and (player:getTP() <= 199)) then
+            elseif ((tp >= 191) and (tp <= 199)) then
                     player:addStatusEffect(EFFECT_AFTERMATH_LV1, 19, 0, 180, 0, 2);
 
             -- AFTERMATH LV2
-            elseif ((player:getTP() >= 200) and (player:getTP() <= 210)) then
+            elseif ((tp >= 200) and (tp <= 210)) then
                     player:addStatusEffect(EFFECT_AFTERMATH_LV2, 24, 0, 180, 0, 2);
-            elseif ((player:getTP() >= 211) and (player:getTP() <= 219)) then
+            elseif ((tp >= 211) and (tp <= 219)) then
                     player:addStatusEffect(EFFECT_AFTERMATH_LV2, 28, 0, 180, 0, 2);
-            elseif ((player:getTP() >= 221) and (player:getTP() <= 229)) then
+            elseif ((tp >= 221) and (tp <= 229)) then
                     player:addStatusEffect(EFFECT_AFTERMATH_LV2, 32, 0, 180, 0, 2);
-            elseif ((player:getTP() >= 231) and (player:getTP() <= 239)) then
+            elseif ((tp >= 231) and (tp <= 239)) then
                     player:addStatusEffect(EFFECT_AFTERMATH_LV2, 36, 0, 180, 0, 2);
-            elseif ((player:getTP() >= 241) and (player:getTP() <= 249)) then
+            elseif ((tp >= 241) and (tp <= 249)) then
                     player:addStatusEffect(EFFECT_AFTERMATH_LV2, 40, 0, 180, 0, 2);
-            elseif ((player:getTP() >= 251) and (player:getTP() <= 259)) then
+            elseif ((tp >= 251) and (tp <= 259)) then
                     player:addStatusEffect(EFFECT_AFTERMATH_LV2, 44, 0, 180, 0, 2);
-            elseif ((player:getTP() >= 261) and (player:getTP() <= 269)) then
+            elseif ((tp >= 261) and (tp <= 269)) then
                     player:addStatusEffect(EFFECT_AFTERMATH_LV2, 48, 0, 180, 0, 2);
-            elseif ((player:getTP() >= 271) and (player:getTP() <= 279)) then
+            elseif ((tp >= 271) and (tp <= 279)) then
                     player:addStatusEffect(EFFECT_AFTERMATH_LV2, 52, 0, 180, 0, 2);
-            elseif ((player:getTP() >= 281) and (player:getTP() <= 289)) then
+            elseif ((tp >= 281) and (tp <= 289)) then
                     player:addStatusEffect(EFFECT_AFTERMATH_LV2, 56, 0, 180, 0, 2);
-            elseif ((player:getTP() >= 291) and (player:getTP() <= 299)) then
+            elseif ((tp >= 291) and (tp <= 299)) then
                     player:addStatusEffect(EFFECT_AFTERMATH_LV2, 59, 0, 180, 0, 2);
 
             -- AFTERMATH LV3
-            elseif ((player:getTP() == 300)) then
+            elseif ((tp == 300)) then
                 player:addStatusEffect(EFFECT_AFTERMATH_LV3, 45, 0, 120, 0, 1);
             end
         end

--- a/scripts/globals/weaponskills/namas_arrow.lua
+++ b/scripts/globals/weaponskills/namas_arrow.lua
@@ -33,7 +33,7 @@ function onUseWeaponSkill(player, target, wsID, tp, primary)
     local damage, criticalHit, tpHits, extraHits = doRangedWeaponskill(player, target, wsID, params, tp, primary);
     -- TODO: Whoever codes those level 85 weapons with the latent that grants this WS needs to code a check to not give the aftermath effect.
     if (damage > 0) then
-        local amDuration = 20 * math.floor(player:getTP()/100);
+        local amDuration = 20 * math.floor(tp/100);
         player:addStatusEffect(EFFECT_AFTERMATH, 20, 0, amDuration, 0, 12);
     end
 

--- a/scripts/globals/weaponskills/nightmare_scythe.lua
+++ b/scripts/globals/weaponskills/nightmare_scythe.lua
@@ -34,7 +34,6 @@ function onUseWeaponSkill(player, target, wsID, tp, primary)
     local damage, criticalHit, tpHits, extraHits = doPhysicalWeaponskill(player, target, wsID, params, tp, primary);
 
     if (damage > 0) then
-        local tp = player:getTP();
         local duration = (tp/100 * 60);
         if (target:hasStatusEffect(EFFECT_BLINDNESS) == false) then
             target:addStatusEffect(EFFECT_BLINDNESS, 15, 0, duration);

--- a/scripts/globals/weaponskills/numbing_shot.lua
+++ b/scripts/globals/weaponskills/numbing_shot.lua
@@ -33,7 +33,6 @@ function onUseWeaponSkill(player, target, wsID, tp, primary)
     local damage, criticalHit, tpHits, extraHits = doRangedWeaponskill(player, target, wsID, params, tp, primary);
 
     if (damage > 0) then
-        local tp = player:getTP();
         local duration = (tp/100 * 60)
         if (target:hasStatusEffect(EFFECT_PARALYSIS) == false) then
             target:addStatusEffect(EFFECT_PARALYSIS, 30, 0, duration);

--- a/scripts/globals/weaponskills/omniscience.lua
+++ b/scripts/globals/weaponskills/omniscience.lua
@@ -34,7 +34,6 @@ function onUseWeaponSkill(player, target, wsID, tp, primary)
     local damage, criticalHit, tpHits, extraHits = doMagicWeaponskill(player, target, wsID, params, tp, primary);
 
     if (damage > 0) then
-        local tp = player:getTP();
         local duration = (tp/100 * 60);
         if (target:hasStatusEffect(EFFECT_MAGIC_ATK_DOWN) == false) then
             target:addStatusEffect(EFFECT_MAGIC_ATK_DOWN, 10, 0, duration);
@@ -44,51 +43,51 @@ function onUseWeaponSkill(player, target, wsID, tp, primary)
     if ((player:getEquipID(SLOT_MAIN) == 18990) and (player:getMainJob() == JOB_SCH)) then
         if (damage > 0) then
             -- AFTERMATH LV1
-            if ((player:getTP() >= 100) and (player:getTP() <= 110)) then
+            if ((tp >= 100) and (tp <= 110)) then
                     player:addStatusEffect(EFFECT_AFTERMATH_LV1, 10, 0, 180, 0, 2);
-            elseif ((player:getTP() >= 111) and (player:getTP() <= 120)) then
+            elseif ((tp >= 111) and (tp <= 120)) then
                     player:addStatusEffect(EFFECT_AFTERMATH_LV1, 11, 0, 180, 0, 2);
-            elseif ((player:getTP() >= 121) and (player:getTP() <= 130)) then
+            elseif ((tp >= 121) and (tp <= 130)) then
                     player:addStatusEffect(EFFECT_AFTERMATH_LV1, 12, 0, 180, 0, 2);
-            elseif ((player:getTP() >= 131) and (player:getTP() <= 140)) then
+            elseif ((tp >= 131) and (tp <= 140)) then
                     player:addStatusEffect(EFFECT_AFTERMATH_LV1, 13, 0, 180, 0, 2);
-            elseif ((player:getTP() >= 141) and (player:getTP() <= 150)) then
+            elseif ((tp >= 141) and (tp <= 150)) then
                     player:addStatusEffect(EFFECT_AFTERMATH_LV1, 14, 0, 180, 0, 2);
-            elseif ((player:getTP() >= 151) and (player:getTP() <= 160)) then
+            elseif ((tp >= 151) and (tp <= 160)) then
                     player:addStatusEffect(EFFECT_AFTERMATH_LV1, 15, 0, 180, 0, 2);
-            elseif ((player:getTP() >= 161) and (player:getTP() <= 170)) then
+            elseif ((tp >= 161) and (tp <= 170)) then
                     player:addStatusEffect(EFFECT_AFTERMATH_LV1, 16, 0, 180, 0, 2);
-            elseif ((player:getTP() >= 171) and (player:getTP() <= 180)) then
+            elseif ((tp >= 171) and (tp <= 180)) then
                     player:addStatusEffect(EFFECT_AFTERMATH_LV1, 17, 0, 180, 0, 2);
-            elseif ((player:getTP() >= 181) and (player:getTP() <= 190)) then
+            elseif ((tp >= 181) and (tp <= 190)) then
                     player:addStatusEffect(EFFECT_AFTERMATH_LV1, 18, 0, 180, 0, 2);
-            elseif ((player:getTP() >= 191) and (player:getTP() <= 199)) then
+            elseif ((tp >= 191) and (tp <= 199)) then
                     player:addStatusEffect(EFFECT_AFTERMATH_LV1, 19, 0, 180, 0, 2);
 
             -- AFTERMATH LV2
-            elseif ((player:getTP() >= 200) and (player:getTP() <= 210)) then
+            elseif ((tp >= 200) and (tp <= 210)) then
                     player:addStatusEffect(EFFECT_AFTERMATH_LV2, 24, 0, 180, 0, 3);
-            elseif ((player:getTP() >= 211) and (player:getTP() <= 219)) then
+            elseif ((tp >= 211) and (tp <= 219)) then
                     player:addStatusEffect(EFFECT_AFTERMATH_LV2, 28, 0, 180, 0, 3);
-            elseif ((player:getTP() >= 221) and (player:getTP() <= 229)) then
+            elseif ((tp >= 221) and (tp <= 229)) then
                     player:addStatusEffect(EFFECT_AFTERMATH_LV2, 32, 0, 180, 0, 3);
-            elseif ((player:getTP() >= 231) and (player:getTP() <= 239)) then
+            elseif ((tp >= 231) and (tp <= 239)) then
                     player:addStatusEffect(EFFECT_AFTERMATH_LV2, 36, 0, 180, 0, 3);
-            elseif ((player:getTP() >= 241) and (player:getTP() <= 249)) then
+            elseif ((tp >= 241) and (tp <= 249)) then
                     player:addStatusEffect(EFFECT_AFTERMATH_LV2, 40, 0, 180, 0, 3);
-            elseif ((player:getTP() >= 251) and (player:getTP() <= 259)) then
+            elseif ((tp >= 251) and (tp <= 259)) then
                     player:addStatusEffect(EFFECT_AFTERMATH_LV2, 44, 0, 180, 0, 3);
-            elseif ((player:getTP() >= 261) and (player:getTP() <= 269)) then
+            elseif ((tp >= 261) and (tp <= 269)) then
                     player:addStatusEffect(EFFECT_AFTERMATH_LV2, 48, 0, 180, 0, 3);
-            elseif ((player:getTP() >= 271) and (player:getTP() <= 279)) then
+            elseif ((tp >= 271) and (tp <= 279)) then
                     player:addStatusEffect(EFFECT_AFTERMATH_LV2, 52, 0, 180, 0, 3);
-            elseif ((player:getTP() >= 281) and (player:getTP() <= 289)) then
+            elseif ((tp >= 281) and (tp <= 289)) then
                     player:addStatusEffect(EFFECT_AFTERMATH_LV2, 56, 0, 180, 0, 3);
-            elseif ((player:getTP() >= 291) and (player:getTP() <= 299)) then
+            elseif ((tp >= 291) and (tp <= 299)) then
                     player:addStatusEffect(EFFECT_AFTERMATH_LV2, 59, 0, 180, 0, 3);
 
             -- AFTERMATH LV3
-            elseif ((player:getTP() == 300)) then
+            elseif ((tp == 300)) then
                 player:addStatusEffect(EFFECT_AFTERMATH_LV3, 45, 0, 120, 0, 1);
 
             end

--- a/scripts/globals/weaponskills/onslaught.lua
+++ b/scripts/globals/weaponskills/onslaught.lua
@@ -36,7 +36,7 @@ function onUseWeaponSkill(player, target, wsID, tp, primary)
     local damage, criticalHit, tpHits, extraHits = doPhysicalWeaponskill(player, target, wsID, params, tp, primary);
     -- TODO: Whoever codes those level 85 weapons with the latent that grants this WS needs to code a check to not give the aftermath effect.
     if (damage > 0) then
-        local amDuration = 20 * math.floor(player:getTP()/100);
+        local amDuration = 20 * math.floor(tp/100);
         player:addStatusEffect(EFFECT_AFTERMATH, 10, 0, amDuration, 0, 4);
         target:addStatusEffect(EFFECT_ACCURACY_DOWN, 20, 0, 60);
     end

--- a/scripts/globals/weaponskills/primal_rend.lua
+++ b/scripts/globals/weaponskills/primal_rend.lua
@@ -38,51 +38,51 @@ function onUseWeaponSkill(player, target, wsID, tp, primary)
         if (damage > 0) then
 
             -- AFTERMATH LV1
-            if ((player:getTP() >= 100) and (player:getTP() <= 110)) then
+            if ((tp >= 100) and (tp <= 110)) then
                     player:addStatusEffect(EFFECT_AFTERMATH_LV1, 10, 0, 180, 0, 1);
-            elseif ((player:getTP() >= 111) and (player:getTP() <= 120)) then
+            elseif ((tp >= 111) and (tp <= 120)) then
                     player:addStatusEffect(EFFECT_AFTERMATH_LV1, 11, 0, 180, 0, 1);
-            elseif ((player:getTP() >= 121) and (player:getTP() <= 130)) then
+            elseif ((tp >= 121) and (tp <= 130)) then
                     player:addStatusEffect(EFFECT_AFTERMATH_LV1, 12, 0, 180, 0, 1);
-            elseif ((player:getTP() >= 131) and (player:getTP() <= 140)) then
+            elseif ((tp >= 131) and (tp <= 140)) then
                     player:addStatusEffect(EFFECT_AFTERMATH_LV1, 13, 0, 180, 0, 1);
-            elseif ((player:getTP() >= 141) and (player:getTP() <= 150)) then
+            elseif ((tp >= 141) and (tp <= 150)) then
                     player:addStatusEffect(EFFECT_AFTERMATH_LV1, 14, 0, 180, 0, 1);
-            elseif ((player:getTP() >= 151) and (player:getTP() <= 160)) then
+            elseif ((tp >= 151) and (tp <= 160)) then
                     player:addStatusEffect(EFFECT_AFTERMATH_LV1, 15, 0, 180, 0, 1);
-            elseif ((player:getTP() >= 161) and (player:getTP() <= 170)) then
+            elseif ((tp >= 161) and (tp <= 170)) then
                     player:addStatusEffect(EFFECT_AFTERMATH_LV1, 16, 0, 180, 0, 1);
-            elseif ((player:getTP() >= 171) and (player:getTP() <= 180)) then
+            elseif ((tp >= 171) and (tp <= 180)) then
                     player:addStatusEffect(EFFECT_AFTERMATH_LV1, 17, 0, 180, 0, 1);
-            elseif ((player:getTP() >= 181) and (player:getTP() <= 190)) then
+            elseif ((tp >= 181) and (tp <= 190)) then
                     player:addStatusEffect(EFFECT_AFTERMATH_LV1, 18, 0, 180, 0, 1);
-            elseif ((player:getTP() >= 191) and (player:getTP() <= 199)) then
+            elseif ((tp >= 191) and (tp <= 199)) then
                     player:addStatusEffect(EFFECT_AFTERMATH_LV1, 19, 0, 180, 0, 1);
 
             -- AFTERMATH LV2
-            elseif ((player:getTP() >= 200) and (player:getTP() <= 210)) then
+            elseif ((tp >= 200) and (tp <= 210)) then
                     player:addStatusEffect(EFFECT_AFTERMATH_LV2, 24, 0, 180, 0, 1);
-            elseif ((player:getTP() >= 211) and (player:getTP() <= 219)) then
+            elseif ((tp >= 211) and (tp <= 219)) then
                     player:addStatusEffect(EFFECT_AFTERMATH_LV2, 28, 0, 180, 0, 1);
-            elseif ((player:getTP() >= 221) and (player:getTP() <= 229)) then
+            elseif ((tp >= 221) and (tp <= 229)) then
                     player:addStatusEffect(EFFECT_AFTERMATH_LV2, 32, 0, 180, 0, 1);
-            elseif ((player:getTP() >= 231) and (player:getTP() <= 239)) then
+            elseif ((tp >= 231) and (tp <= 239)) then
                     player:addStatusEffect(EFFECT_AFTERMATH_LV2, 36, 0, 180, 0, 1);
-            elseif ((player:getTP() >= 241) and (player:getTP() <= 249)) then
+            elseif ((tp >= 241) and (tp <= 249)) then
                     player:addStatusEffect(EFFECT_AFTERMATH_LV2, 40, 0, 180, 0, 1);
-            elseif ((player:getTP() >= 251) and (player:getTP() <= 259)) then
+            elseif ((tp >= 251) and (tp <= 259)) then
                     player:addStatusEffect(EFFECT_AFTERMATH_LV2, 44, 0, 180, 0, 1);
-            elseif ((player:getTP() >= 261) and (player:getTP() <= 269)) then
+            elseif ((tp >= 261) and (tp <= 269)) then
                     player:addStatusEffect(EFFECT_AFTERMATH_LV2, 48, 0, 180, 0, 1);
-            elseif ((player:getTP() >= 271) and (player:getTP() <= 279)) then
+            elseif ((tp >= 271) and (tp <= 279)) then
                     player:addStatusEffect(EFFECT_AFTERMATH_LV2, 52, 0, 180, 0, 1);
-            elseif ((player:getTP() >= 281) and (player:getTP() <= 289)) then
+            elseif ((tp >= 281) and (tp <= 289)) then
                     player:addStatusEffect(EFFECT_AFTERMATH_LV2, 56, 0, 180, 0, 1);
-            elseif ((player:getTP() >= 291) and (player:getTP() <= 299)) then
+            elseif ((tp >= 291) and (tp <= 299)) then
                     player:addStatusEffect(EFFECT_AFTERMATH_LV2, 59, 0, 180, 0, 1);
 
             -- AFTERMATH LV3
-            elseif ((player:getTP() == 300)) then
+            elseif ((tp == 300)) then
                 player:addStatusEffect(EFFECT_AFTERMATH_LV3, 45, 0, 120, 0, 1);
             end
         end

--- a/scripts/globals/weaponskills/pyrrhic_kleos.lua
+++ b/scripts/globals/weaponskills/pyrrhic_kleos.lua
@@ -36,7 +36,6 @@ function onUseWeaponSkill(player, target, wsID, tp, primary)
     local damage, criticalHit, tpHits, extraHits = doPhysicalWeaponskill(player, target, wsID, params, tp, primary);
 
     if (damage > 0) then
-        local tp = player:getTP();
         local duration = (tp/100 * 60);
         if (target:hasStatusEffect(EFFECT_EVASION_DOWN) == false) then
             target:addStatusEffect(EFFECT_EVASION_DOWN, 10, 0, duration);
@@ -49,56 +48,56 @@ function onUseWeaponSkill(player, target, wsID, tp, primary)
 
 --        AFTERMATH LV1
 
-        if ((player:getTP() >= 100) and (player:getTP() <= 110)) then
+        if ((tp >= 100) and (tp <= 110)) then
             player:addStatusEffect(EFFECT_AFTERMATH_LV1, 10, 0, 180, 0, 1);
-    elseif ((player:getTP() >= 111) and (player:getTP() <= 120)) then
+    elseif ((tp >= 111) and (tp <= 120)) then
             player:addStatusEffect(EFFECT_AFTERMATH_LV1, 11, 0, 180, 0, 1);
-    elseif ((player:getTP() >= 121) and (player:getTP() <= 130)) then
+    elseif ((tp >= 121) and (tp <= 130)) then
             player:addStatusEffect(EFFECT_AFTERMATH_LV1, 12, 0, 180, 0, 1);
-    elseif ((player:getTP() >= 131) and (player:getTP() <= 140)) then
+    elseif ((tp >= 131) and (tp <= 140)) then
             player:addStatusEffect(EFFECT_AFTERMATH_LV1, 13, 0, 180, 0, 1);
-    elseif ((player:getTP() >= 141) and (player:getTP() <= 150)) then
+    elseif ((tp >= 141) and (tp <= 150)) then
             player:addStatusEffect(EFFECT_AFTERMATH_LV1, 14, 0, 180, 0, 1);
-    elseif ((player:getTP() >= 151) and (player:getTP() <= 160)) then
+    elseif ((tp >= 151) and (tp <= 160)) then
             player:addStatusEffect(EFFECT_AFTERMATH_LV1, 15, 0, 180, 0, 1);
-    elseif ((player:getTP() >= 161) and (player:getTP() <= 170)) then
+    elseif ((tp >= 161) and (tp <= 170)) then
             player:addStatusEffect(EFFECT_AFTERMATH_LV1, 16, 0, 180, 0, 1);
-    elseif ((player:getTP() >= 171) and (player:getTP() <= 180)) then
+    elseif ((tp >= 171) and (tp <= 180)) then
             player:addStatusEffect(EFFECT_AFTERMATH_LV1, 17, 0, 180, 0, 1);
-    elseif ((player:getTP() >= 181) and (player:getTP() <= 190)) then
+    elseif ((tp >= 181) and (tp <= 190)) then
             player:addStatusEffect(EFFECT_AFTERMATH_LV1, 18, 0, 180, 0, 1);
-    elseif ((player:getTP() >= 191) and (player:getTP() <= 199)) then
+    elseif ((tp >= 191) and (tp <= 199)) then
             player:addStatusEffect(EFFECT_AFTERMATH_LV1, 19, 0, 180, 0, 1);
 
 
 
 --        AFTERMATH LV2
 
-    elseif ((player:getTP() >= 200) and (player:getTP() <= 210)) then
+    elseif ((tp >= 200) and (tp <= 210)) then
             player:addStatusEffect(EFFECT_AFTERMATH_LV2, 24, 0, 180, 0, 1);
-    elseif ((player:getTP() >= 211) and (player:getTP() <= 219)) then
+    elseif ((tp >= 211) and (tp <= 219)) then
             player:addStatusEffect(EFFECT_AFTERMATH_LV2, 28, 0, 180, 0, 1);
-    elseif ((player:getTP() >= 221) and (player:getTP() <= 229)) then
+    elseif ((tp >= 221) and (tp <= 229)) then
             player:addStatusEffect(EFFECT_AFTERMATH_LV2, 32, 0, 180, 0, 1);
-    elseif ((player:getTP() >= 231) and (player:getTP() <= 239)) then
+    elseif ((tp >= 231) and (tp <= 239)) then
             player:addStatusEffect(EFFECT_AFTERMATH_LV2, 36, 0, 180, 0, 1);
-    elseif ((player:getTP() >= 241) and (player:getTP() <= 249)) then
+    elseif ((tp >= 241) and (tp <= 249)) then
             player:addStatusEffect(EFFECT_AFTERMATH_LV2, 40, 0, 180, 0, 1);
-    elseif ((player:getTP() >= 251) and (player:getTP() <= 259)) then
+    elseif ((tp >= 251) and (tp <= 259)) then
             player:addStatusEffect(EFFECT_AFTERMATH_LV2, 44, 0, 180, 0, 1);
-    elseif ((player:getTP() >= 261) and (player:getTP() <= 269)) then
+    elseif ((tp >= 261) and (tp <= 269)) then
             player:addStatusEffect(EFFECT_AFTERMATH_LV2, 48, 0, 180, 0, 1);
-    elseif ((player:getTP() >= 271) and (player:getTP() <= 279)) then
+    elseif ((tp >= 271) and (tp <= 279)) then
             player:addStatusEffect(EFFECT_AFTERMATH_LV2, 52, 0, 180, 0, 1);
-    elseif ((player:getTP() >= 281) and (player:getTP() <= 289)) then
+    elseif ((tp >= 281) and (tp <= 289)) then
             player:addStatusEffect(EFFECT_AFTERMATH_LV2, 56, 0, 180, 0, 1);
-    elseif ((player:getTP() >= 291) and (player:getTP() <= 299)) then
+    elseif ((tp >= 291) and (tp <= 299)) then
             player:addStatusEffect(EFFECT_AFTERMATH_LV2, 59, 0, 180, 0, 1);
 
 
 --        AFTERMATH LV3
 
-        elseif ((player:getTP() == 300)) then
+        elseif ((tp == 300)) then
             player:addStatusEffect(EFFECT_AFTERMATH_LV3, 45, 0, 120, 0, 1);
 
             end

--- a/scripts/globals/weaponskills/randgrith.lua
+++ b/scripts/globals/weaponskills/randgrith.lua
@@ -34,7 +34,7 @@ function onUseWeaponSkill(player, target, wsID, tp, primary)
     local damage, criticalHit, tpHits, extraHits = doPhysicalWeaponskill(player, target, wsID, params, tp, primary);
     -- TODO: Whoever codes those level 85 weapons with the latent that grants this WS needs to code a check to not give the aftermath effect.
     if (damage > 0) then
-        local amDuration = 20 * math.floor(player:getTP()/100);
+        local amDuration = 20 * math.floor(tp/100);
         player:addStatusEffect(EFFECT_AFTERMATH, 20, 0, amDuration, 0, 9);
         target:addStatusEffect(EFFECT_EVASION_DOWN, 32, 0, 60);
     end

--- a/scripts/globals/weaponskills/requiescat.lua
+++ b/scripts/globals/weaponskills/requiescat.lua
@@ -22,7 +22,7 @@ function onUseWeaponSkill(player, target, wsID, tp, primary)
     params.crit100 = 0.0; params.crit200 = 0.0; params.crit300 = 0.0;
     params.canCrit = false;
     params.acc100 = 0.0; params.acc200= 0.0; params.acc300= 0.0;
-    params.atkmulti = 0.7 + player:getTP()/1000;
+    params.atkmulti = 0.7 + tp/1000;
 
     if (USE_ADOULIN_WEAPON_SKILL_CHANGES == true) then
         params.mnd_wsc = 0.7 + (player:getMerit(MERIT_REQUIESCAT) / 100);

--- a/scripts/globals/weaponskills/sanguine_blade.lua
+++ b/scripts/globals/weaponskills/sanguine_blade.lua
@@ -20,7 +20,7 @@ require("scripts/globals/weaponskills");
 -----------------------------------
 
 function onUseWeaponSkill(player, target, wsID, tp, primary)
-    local tp = player:getTP();
+
     local drain = 0;
 
     if (tp >= 100 and tp <=199) then

--- a/scripts/globals/weaponskills/scourge.lua
+++ b/scripts/globals/weaponskills/scourge.lua
@@ -35,7 +35,7 @@ function onUseWeaponSkill(player, target, wsID, tp, primary)
     local damage, criticalHit, tpHits, extraHits = doPhysicalWeaponskill(player, target, wsID, params, tp, primary);
     -- TODO: Whoever codes those level 85 weapons with the latent that grants this WS needs to code a check to not give the aftermath effect.
     if (damage > 0) then
-        local amDuration = 20 * math.floor(player:getTP()/100);
+        local amDuration = 20 * math.floor(tp/100);
         player:addStatusEffect(EFFECT_AFTERMATH, 5, 0, amDuration, 0, 2);
     end
 

--- a/scripts/globals/weaponskills/shadowstitch.lua
+++ b/scripts/globals/weaponskills/shadowstitch.lua
@@ -34,7 +34,6 @@ function onUseWeaponSkill(player, target, wsID, tp, primary)
     local damage, criticalHit, tpHits, extraHits = doPhysicalWeaponskill(player, target, wsID, params, tp, primary);
 
     if (damage > 0) then
-        local tp = player:getTP();
         local duration = (tp/100 * 5) + 5;
         if (target:hasStatusEffect(EFFECT_BIND) == false) then
             target:addStatusEffect(EFFECT_BIND, 1, 0, duration);

--- a/scripts/globals/weaponskills/shell_crusher.lua
+++ b/scripts/globals/weaponskills/shell_crusher.lua
@@ -35,7 +35,6 @@ function onUseWeaponSkill(player, target, wsID, tp, primary)
     local damage, criticalHit, tpHits, extraHits = doPhysicalWeaponskill(player, target, wsID, params, tp, primary);
 
     if (damage > 0) then
-        local tp = player:getTP();
         local duration = (tp/100 * 60) + 120;
         if (target:hasStatusEffect(EFFECT_DEFENSE_DOWN) == false) then
             target:addStatusEffect(EFFECT_DEFENSE_DOWN, 25, 0, duration);

--- a/scripts/globals/weaponskills/shield_break.lua
+++ b/scripts/globals/weaponskills/shield_break.lua
@@ -37,7 +37,6 @@ function onUseWeaponSkill(player, target, wsID, tp, primary)
     local damage, criticalHit, tpHits, extraHits = doPhysicalWeaponskill(player, target, wsID, params, tp, primary);
 
     if (damage > 0) then
-        local tp = player:getTP();
         local duration = (tp/100 * 60) + 120;
         if (target:hasStatusEffect(EFFECT_EVASION_DOWN) == false) then
             target:addStatusEffect(EFFECT_EVASION_DOWN, 40, 0, duration);

--- a/scripts/globals/weaponskills/shijin_spiral.lua
+++ b/scripts/globals/weaponskills/shijin_spiral.lua
@@ -33,7 +33,6 @@ function onUseWeaponSkill(player, target, wsID, tp, primary)
     end
 
     if (damage > 0) then
-        local tp = player:getTP();
         local duration = (tp/100) + 4;
         if (target:hasStatusEffect(EFFECT_PLAGUE) == false) then
             target:addStatusEffect(EFFECT_PLAGUE, 5, 0, duration);

--- a/scripts/globals/weaponskills/shockwave.lua
+++ b/scripts/globals/weaponskills/shockwave.lua
@@ -28,7 +28,6 @@ function onUseWeaponSkill(player, target, wsID, tp, primary)
     local damage, criticalHit, tpHits, extraHits = doPhysicalWeaponskill(player, target, wsID, params, tp, primary);
 
     if (damage > 0 and target:hasStatusEffect(EFFECT_SLEEP_I) == false) then
-        local tp = player:getTP();
         local duration = (tp/100 * 60);
         target:addStatusEffect(EFFECT_SLEEP_I, 1, 0, duration);
     end

--- a/scripts/globals/weaponskills/shoulder_tackle.lua
+++ b/scripts/globals/weaponskills/shoulder_tackle.lua
@@ -33,7 +33,6 @@ function onUseWeaponSkill(player, target, wsID, tp, primary)
     end
 
     if (damage > 0) then
-        local tp = player:getTP();
         local duration = (tp/50);
         if (target:hasStatusEffect(EFFECT_STUN) == false) then
             target:addStatusEffect(EFFECT_STUN, 1, 0, duration);

--- a/scripts/globals/weaponskills/smash_axe.lua
+++ b/scripts/globals/weaponskills/smash_axe.lua
@@ -34,7 +34,6 @@ function onUseWeaponSkill(player, target, wsID, tp, primary)
     local damage, criticalHit, tpHits, extraHits = doPhysicalWeaponskill(player, target, wsID, params, tp, primary);
 
     if (damage > 0) then
-        local tp = player:getTP();
         local duration = (tp/50);
         if (target:hasStatusEffect(EFFECT_STUN) == false) then
             target:addStatusEffect(EFFECT_STUN, 1, 0, duration);

--- a/scripts/globals/weaponskills/starlight.lua
+++ b/scripts/globals/weaponskills/starlight.lua
@@ -8,7 +8,7 @@ require("scripts/globals/weaponskills");
 function onUseWeaponSkill(player, target, wsID, tp, primary)
     local lvl = player:getSkillLevel(11); -- get club skill
     local damage = (lvl-10)/9;
-    local damagemod = damage * (player:getTP()/100);
+    local damagemod = damage * (tp/100);
     damagemod = damagemod * WEAPON_SKILL_POWER
     return 1, 0, false, damagemod;
 end

--- a/scripts/globals/weaponskills/stringing_pummel.lua
+++ b/scripts/globals/weaponskills/stringing_pummel.lua
@@ -37,53 +37,53 @@ function onUseWeaponSkill(player, target, wsID, tp, primary)
 
 -- AFTERMATH LEVEL 1
 
-        if ((player:getTP() >= 100) and (player:getTP() <= 110)) then
+        if ((tp >= 100) and (tp <= 110)) then
             player:addStatusEffect(EFFECT_AFTERMATH_LV1, 10, 0, 180, 0, 1);
-        elseif ((player:getTP() >= 111) and (player:getTP() <= 120)) then
+        elseif ((tp >= 111) and (tp <= 120)) then
             player:addStatusEffect(EFFECT_AFTERMATH_LV1, 11, 0, 180, 0, 1);
-        elseif ((player:getTP() >= 121) and (player:getTP() <= 130)) then
+        elseif ((tp >= 121) and (tp <= 130)) then
             player:addStatusEffect(EFFECT_AFTERMATH_LV1, 12, 0, 180, 0, 1);
-        elseif ((player:getTP() >= 131) and (player:getTP() <= 140)) then
+        elseif ((tp >= 131) and (tp <= 140)) then
             player:addStatusEffect(EFFECT_AFTERMATH_LV1, 13, 0, 180, 0, 1);
-        elseif ((player:getTP() >= 141) and (player:getTP() <= 150)) then
+        elseif ((tp >= 141) and (tp <= 150)) then
             player:addStatusEffect(EFFECT_AFTERMATH_LV1, 14, 0, 180, 0, 1);
-        elseif ((player:getTP() >= 151) and (player:getTP() <= 160)) then
+        elseif ((tp >= 151) and (tp <= 160)) then
             player:addStatusEffect(EFFECT_AFTERMATH_LV1, 15, 0, 180, 0, 1);
-        elseif ((player:getTP() >= 161) and (player:getTP() <= 170)) then
+        elseif ((tp >= 161) and (tp <= 170)) then
             player:addStatusEffect(EFFECT_AFTERMATH_LV1, 16, 0, 180, 0, 1);
-        elseif ((player:getTP() >= 171) and (player:getTP() <= 180)) then
+        elseif ((tp >= 171) and (tp <= 180)) then
             player:addStatusEffect(EFFECT_AFTERMATH_LV1, 17, 0, 180, 0, 1);
-        elseif ((player:getTP() >= 181) and (player:getTP() <= 190)) then
+        elseif ((tp >= 181) and (tp <= 190)) then
             player:addStatusEffect(EFFECT_AFTERMATH_LV1, 18, 0, 180, 0, 1);
-        elseif ((player:getTP() >= 191) and (player:getTP() <= 199)) then
+        elseif ((tp >= 191) and (tp <= 199)) then
             player:addStatusEffect(EFFECT_AFTERMATH_LV1, 19, 0, 180, 0, 1);
 
 -- AFTERMATH LEVEL 2
 
-        elseif ((player:getTP() >= 200) and (player:getTP() <= 210)) then
+        elseif ((tp >= 200) and (tp <= 210)) then
             player:addStatusEffect(EFFECT_AFTERMATH_LV2, 24, 0, 180, 0, 1);
-        elseif ((player:getTP() >= 211) and (player:getTP() <= 219)) then
+        elseif ((tp >= 211) and (tp <= 219)) then
             player:addStatusEffect(EFFECT_AFTERMATH_LV2, 28, 0, 180, 0, 1);
-        elseif ((player:getTP() >= 221) and (player:getTP() <= 229)) then
+        elseif ((tp >= 221) and (tp <= 229)) then
             player:addStatusEffect(EFFECT_AFTERMATH_LV2, 32, 0, 180, 0, 1);
-        elseif ((player:getTP() >= 231) and (player:getTP() <= 239)) then
+        elseif ((tp >= 231) and (tp <= 239)) then
             player:addStatusEffect(EFFECT_AFTERMATH_LV2, 36, 0, 180, 0, 1);
-        elseif ((player:getTP() >= 241) and (player:getTP() <= 249)) then
+        elseif ((tp >= 241) and (tp <= 249)) then
             player:addStatusEffect(EFFECT_AFTERMATH_LV2, 40, 0, 180, 0, 1);
-        elseif ((player:getTP() >= 251) and (player:getTP() <= 259)) then
+        elseif ((tp >= 251) and (tp <= 259)) then
             player:addStatusEffect(EFFECT_AFTERMATH_LV2, 44, 0, 180, 0, 1);
-        elseif ((player:getTP() >= 261) and (player:getTP() <= 269)) then
+        elseif ((tp >= 261) and (tp <= 269)) then
             player:addStatusEffect(EFFECT_AFTERMATH_LV2, 48, 0, 180, 0, 1);
-        elseif ((player:getTP() >= 271) and (player:getTP() <= 279)) then
+        elseif ((tp >= 271) and (tp <= 279)) then
             player:addStatusEffect(EFFECT_AFTERMATH_LV2, 52, 0, 180, 0, 1);
-        elseif ((player:getTP() >= 281) and (player:getTP() <= 289)) then
+        elseif ((tp >= 281) and (tp <= 289)) then
             player:addStatusEffect(EFFECT_AFTERMATH_LV2, 56, 0, 180, 0, 1);
-        elseif ((player:getTP() >= 291) and (player:getTP() <= 299)) then
+        elseif ((tp >= 291) and (tp <= 299)) then
             player:addStatusEffect(EFFECT_AFTERMATH_LV2, 59, 0, 180, 0, 1);
 
 -- AFTERMATH LEVEL 3
 
-        elseif ((player:getTP() == 300)) then
+        elseif ((tp == 300)) then
             player:addStatusEffect(EFFECT_AFTERMATH_LV3, 45, 0, 120, 0, 1);
             end
         end

--- a/scripts/globals/weaponskills/tachi_hobaku.lua
+++ b/scripts/globals/weaponskills/tachi_hobaku.lua
@@ -33,7 +33,7 @@ function onUseWeaponSkill(player, target, wsID, tp, primary)
 
     local damage, criticalHit, tpHits, extraHits = doPhysicalWeaponskill(player, target, wsID, params, tp, primary);
 
-    local chance = player:getTP()-100 > math.random()*150;
+    local chance = tp-100 > math.random()*150;
     if (damage > 0 and chance) then
         if (target:hasStatusEffect(EFFECT_STUN) == false) then
             target:addStatusEffect(EFFECT_STUN, 1, 0, 4);

--- a/scripts/globals/weaponskills/tachi_kaiten.lua
+++ b/scripts/globals/weaponskills/tachi_kaiten.lua
@@ -39,7 +39,7 @@ function onUseWeaponSkill(player, target, wsID, tp, primary)
     local damage, criticalHit, tpHits, extraHits = doPhysicalWeaponskill(player, target, wsID, params, tp, primary);
     -- TODO: Whoever codes those level 85 weapons with the latent that grants this WS needs to code a check to not give the aftermath effect.
     if (damage > 0) then
-        local amDuration = 20 * math.floor(player:getTP()/100);
+        local amDuration = 20 * math.floor(tp/100);
         player:addStatusEffect(EFFECT_AFTERMATH, 7, 0, amDuration, 0, 8);
     end
 

--- a/scripts/globals/weaponskills/tachi_rana.lua
+++ b/scripts/globals/weaponskills/tachi_rana.lua
@@ -40,56 +40,56 @@ function onUseWeaponSkill(player, target, wsID, tp, primary)
 
 --        AFTERMATH LV1
 
-        if ((player:getTP() >= 100) and (player:getTP() <= 110)) then
+        if ((tp >= 100) and (tp <= 110)) then
             player:addStatusEffect(EFFECT_AFTERMATH_LV1, 10, 0, 180, 0, 1);
-    elseif ((player:getTP() >= 111) and (player:getTP() <= 120)) then
+    elseif ((tp >= 111) and (tp <= 120)) then
             player:addStatusEffect(EFFECT_AFTERMATH_LV1, 11, 0, 180, 0, 1);
-    elseif ((player:getTP() >= 121) and (player:getTP() <= 130)) then
+    elseif ((tp >= 121) and (tp <= 130)) then
             player:addStatusEffect(EFFECT_AFTERMATH_LV1, 12, 0, 180, 0, 1);
-    elseif ((player:getTP() >= 131) and (player:getTP() <= 140)) then
+    elseif ((tp >= 131) and (tp <= 140)) then
             player:addStatusEffect(EFFECT_AFTERMATH_LV1, 13, 0, 180, 0, 1);
-    elseif ((player:getTP() >= 141) and (player:getTP() <= 150)) then
+    elseif ((tp >= 141) and (tp <= 150)) then
             player:addStatusEffect(EFFECT_AFTERMATH_LV1, 14, 0, 180, 0, 1);
-    elseif ((player:getTP() >= 151) and (player:getTP() <= 160)) then
+    elseif ((tp >= 151) and (tp <= 160)) then
             player:addStatusEffect(EFFECT_AFTERMATH_LV1, 15, 0, 180, 0, 1);
-    elseif ((player:getTP() >= 161) and (player:getTP() <= 170)) then
+    elseif ((tp >= 161) and (tp <= 170)) then
             player:addStatusEffect(EFFECT_AFTERMATH_LV1, 16, 0, 180, 0, 1);
-    elseif ((player:getTP() >= 171) and (player:getTP() <= 180)) then
+    elseif ((tp >= 171) and (tp <= 180)) then
             player:addStatusEffect(EFFECT_AFTERMATH_LV1, 17, 0, 180, 0, 1);
-    elseif ((player:getTP() >= 181) and (player:getTP() <= 190)) then
+    elseif ((tp >= 181) and (tp <= 190)) then
             player:addStatusEffect(EFFECT_AFTERMATH_LV1, 18, 0, 180, 0, 1);
-    elseif ((player:getTP() >= 191) and (player:getTP() <= 199)) then
+    elseif ((tp >= 191) and (tp <= 199)) then
             player:addStatusEffect(EFFECT_AFTERMATH_LV1, 19, 0, 180, 0, 1);
 
 
 
 --        AFTERMATH LV2
 
-    elseif ((player:getTP() >= 200) and (player:getTP() <= 210)) then
+    elseif ((tp >= 200) and (tp <= 210)) then
             player:addStatusEffect(EFFECT_AFTERMATH_LV2, 24, 0, 180, 0, 1);
-    elseif ((player:getTP() >= 211) and (player:getTP() <= 219)) then
+    elseif ((tp >= 211) and (tp <= 219)) then
             player:addStatusEffect(EFFECT_AFTERMATH_LV2, 28, 0, 180, 0, 1);
-    elseif ((player:getTP() >= 221) and (player:getTP() <= 229)) then
+    elseif ((tp >= 221) and (tp <= 229)) then
             player:addStatusEffect(EFFECT_AFTERMATH_LV2, 32, 0, 180, 0, 1);
-    elseif ((player:getTP() >= 231) and (player:getTP() <= 239)) then
+    elseif ((tp >= 231) and (tp <= 239)) then
             player:addStatusEffect(EFFECT_AFTERMATH_LV2, 36, 0, 180, 0, 1);
-    elseif ((player:getTP() >= 241) and (player:getTP() <= 249)) then
+    elseif ((tp >= 241) and (tp <= 249)) then
             player:addStatusEffect(EFFECT_AFTERMATH_LV2, 40, 0, 180, 0, 1);
-    elseif ((player:getTP() >= 251) and (player:getTP() <= 259)) then
+    elseif ((tp >= 251) and (tp <= 259)) then
             player:addStatusEffect(EFFECT_AFTERMATH_LV2, 44, 0, 180, 0, 1);
-    elseif ((player:getTP() >= 261) and (player:getTP() <= 269)) then
+    elseif ((tp >= 261) and (tp <= 269)) then
             player:addStatusEffect(EFFECT_AFTERMATH_LV2, 48, 0, 180, 0, 1);
-    elseif ((player:getTP() >= 271) and (player:getTP() <= 279)) then
+    elseif ((tp >= 271) and (tp <= 279)) then
             player:addStatusEffect(EFFECT_AFTERMATH_LV2, 52, 0, 180, 0, 1);
-    elseif ((player:getTP() >= 281) and (player:getTP() <= 289)) then
+    elseif ((tp >= 281) and (tp <= 289)) then
             player:addStatusEffect(EFFECT_AFTERMATH_LV2, 56, 0, 180, 0, 1);
-    elseif ((player:getTP() >= 291) and (player:getTP() <= 299)) then
+    elseif ((tp >= 291) and (tp <= 299)) then
             player:addStatusEffect(EFFECT_AFTERMATH_LV2, 59, 0, 180, 0, 1);
 
 
 --        AFTERMATH LV3
 
-        elseif ((player:getTP() == 300)) then
+        elseif ((tp == 300)) then
             player:addStatusEffect(EFFECT_AFTERMATH_LV3, 45, 0, 120, 0, 1);
 
             end

--- a/scripts/globals/weaponskills/trueflight.lua
+++ b/scripts/globals/weaponskills/trueflight.lua
@@ -43,56 +43,56 @@ function onUseWeaponSkill(player, target, wsID, tp, primary)
 
 --        AFTERMATH LV1
 
-        if ((player:getTP() >= 100) and (player:getTP() <= 110)) then
+        if ((tp >= 100) and (tp <= 110)) then
             player:addStatusEffect(EFFECT_AFTERMATH_LV1, 10, 0, 180, 0, 3);
-    elseif ((player:getTP() >= 111) and (player:getTP() <= 120)) then
+    elseif ((tp >= 111) and (tp <= 120)) then
             player:addStatusEffect(EFFECT_AFTERMATH_LV1, 11, 0, 180, 0, 3);
-    elseif ((player:getTP() >= 121) and (player:getTP() <= 130)) then
+    elseif ((tp >= 121) and (tp <= 130)) then
             player:addStatusEffect(EFFECT_AFTERMATH_LV1, 12, 0, 180, 0, 3);
-    elseif ((player:getTP() >= 131) and (player:getTP() <= 140)) then
+    elseif ((tp >= 131) and (tp <= 140)) then
             player:addStatusEffect(EFFECT_AFTERMATH_LV1, 13, 0, 180, 0, 3);
-    elseif ((player:getTP() >= 141) and (player:getTP() <= 150)) then
+    elseif ((tp >= 141) and (tp <= 150)) then
             player:addStatusEffect(EFFECT_AFTERMATH_LV1, 14, 0, 180, 0, 3);
-    elseif ((player:getTP() >= 151) and (player:getTP() <= 160)) then
+    elseif ((tp >= 151) and (tp <= 160)) then
             player:addStatusEffect(EFFECT_AFTERMATH_LV1, 15, 0, 180, 0, 3);
-    elseif ((player:getTP() >= 161) and (player:getTP() <= 170)) then
+    elseif ((tp >= 161) and (tp <= 170)) then
             player:addStatusEffect(EFFECT_AFTERMATH_LV1, 16, 0, 180, 0, 3);
-    elseif ((player:getTP() >= 171) and (player:getTP() <= 180)) then
+    elseif ((tp >= 171) and (tp <= 180)) then
             player:addStatusEffect(EFFECT_AFTERMATH_LV1, 17, 0, 180, 0, 3);
-    elseif ((player:getTP() >= 181) and (player:getTP() <= 190)) then
+    elseif ((tp >= 181) and (tp <= 190)) then
             player:addStatusEffect(EFFECT_AFTERMATH_LV1, 18, 0, 180, 0, 3);
-    elseif ((player:getTP() >= 191) and (player:getTP() <= 199)) then
+    elseif ((tp >= 191) and (tp <= 199)) then
             player:addStatusEffect(EFFECT_AFTERMATH_LV1, 19, 0, 180, 0, 3);
 
 
 
 --        AFTERMATH LV2
 
-    elseif ((player:getTP() >= 200) and (player:getTP() <= 210)) then
+    elseif ((tp >= 200) and (tp <= 210)) then
             player:addStatusEffect(EFFECT_AFTERMATH_LV2, 24, 0, 180, 0, 4);
-    elseif ((player:getTP() >= 211) and (player:getTP() <= 219)) then
+    elseif ((tp >= 211) and (tp <= 219)) then
             player:addStatusEffect(EFFECT_AFTERMATH_LV2, 28, 0, 180, 0, 4);
-    elseif ((player:getTP() >= 221) and (player:getTP() <= 229)) then
+    elseif ((tp >= 221) and (tp <= 229)) then
             player:addStatusEffect(EFFECT_AFTERMATH_LV2, 32, 0, 180, 0, 4);
-    elseif ((player:getTP() >= 231) and (player:getTP() <= 239)) then
+    elseif ((tp >= 231) and (tp <= 239)) then
             player:addStatusEffect(EFFECT_AFTERMATH_LV2, 36, 0, 180, 0, 4);
-    elseif ((player:getTP() >= 241) and (player:getTP() <= 249)) then
+    elseif ((tp >= 241) and (tp <= 249)) then
             player:addStatusEffect(EFFECT_AFTERMATH_LV2, 40, 0, 180, 0, 4);
-    elseif ((player:getTP() >= 251) and (player:getTP() <= 259)) then
+    elseif ((tp >= 251) and (tp <= 259)) then
             player:addStatusEffect(EFFECT_AFTERMATH_LV2, 44, 0, 180, 0, 4);
-    elseif ((player:getTP() >= 261) and (player:getTP() <= 269)) then
+    elseif ((tp >= 261) and (tp <= 269)) then
             player:addStatusEffect(EFFECT_AFTERMATH_LV2, 48, 0, 180, 0, 4);
-    elseif ((player:getTP() >= 271) and (player:getTP() <= 279)) then
+    elseif ((tp >= 271) and (tp <= 279)) then
             player:addStatusEffect(EFFECT_AFTERMATH_LV2, 52, 0, 180, 0, 4);
-    elseif ((player:getTP() >= 281) and (player:getTP() <= 289)) then
+    elseif ((tp >= 281) and (tp <= 289)) then
             player:addStatusEffect(EFFECT_AFTERMATH_LV2, 56, 0, 180, 0, 4);
-    elseif ((player:getTP() >= 291) and (player:getTP() <= 299)) then
+    elseif ((tp >= 291) and (tp <= 299)) then
             player:addStatusEffect(EFFECT_AFTERMATH_LV2, 59, 0, 180, 0, 4);
 
 
 --        AFTERMATH LV3
 
-        elseif ((player:getTP() == 300)) then
+        elseif ((tp == 300)) then
             player:addStatusEffect(EFFECT_AFTERMATH_LV3, 45, 0, 120, 0, 2);
 
             end

--- a/scripts/globals/weaponskills/vidohunir.lua
+++ b/scripts/globals/weaponskills/vidohunir.lua
@@ -34,7 +34,6 @@ function onUseWeaponSkill(player, target, wsID, tp, primary)
     local damage, criticalHit, tpHits, extraHits = doMagicWeaponskill(player, target, wsID, params, tp, primary);
 
     if (damage > 0) then
-        local tp = player:getTP();
         local duration = (tp/100 * 60);
         if (target:hasStatusEffect(EFFECT_MAGIC_DEF_DOWN) == false) then
             target:addStatusEffect(EFFECT_MAGIC_DEF_DOWN, 10, 0, duration);
@@ -47,56 +46,56 @@ function onUseWeaponSkill(player, target, wsID, tp, primary)
 
 --        AFTERMATH LV1
 
-        if ((player:getTP() >= 100) and (player:getTP() <= 110)) then
+        if ((tp >= 100) and (tp <= 110)) then
             player:addStatusEffect(EFFECT_AFTERMATH_LV1, 10, 0, 180, 0, 2);
-    elseif ((player:getTP() >= 111) and (player:getTP() <= 120)) then
+    elseif ((tp >= 111) and (tp <= 120)) then
             player:addStatusEffect(EFFECT_AFTERMATH_LV1, 11, 0, 180, 0, 2);
-    elseif ((player:getTP() >= 121) and (player:getTP() <= 130)) then
+    elseif ((tp >= 121) and (tp <= 130)) then
             player:addStatusEffect(EFFECT_AFTERMATH_LV1, 12, 0, 180, 0, 2);
-    elseif ((player:getTP() >= 131) and (player:getTP() <= 140)) then
+    elseif ((tp >= 131) and (tp <= 140)) then
             player:addStatusEffect(EFFECT_AFTERMATH_LV1, 13, 0, 180, 0, 2);
-    elseif ((player:getTP() >= 141) and (player:getTP() <= 150)) then
+    elseif ((tp >= 141) and (tp <= 150)) then
             player:addStatusEffect(EFFECT_AFTERMATH_LV1, 14, 0, 180, 0, 2);
-    elseif ((player:getTP() >= 151) and (player:getTP() <= 160)) then
+    elseif ((tp >= 151) and (tp <= 160)) then
             player:addStatusEffect(EFFECT_AFTERMATH_LV1, 15, 0, 180, 0, 2);
-    elseif ((player:getTP() >= 161) and (player:getTP() <= 170)) then
+    elseif ((tp >= 161) and (tp <= 170)) then
             player:addStatusEffect(EFFECT_AFTERMATH_LV1, 16, 0, 180, 0, 2);
-    elseif ((player:getTP() >= 171) and (player:getTP() <= 180)) then
+    elseif ((tp >= 171) and (tp <= 180)) then
             player:addStatusEffect(EFFECT_AFTERMATH_LV1, 17, 0, 180, 0, 2);
-    elseif ((player:getTP() >= 181) and (player:getTP() <= 190)) then
+    elseif ((tp >= 181) and (tp <= 190)) then
             player:addStatusEffect(EFFECT_AFTERMATH_LV1, 18, 0, 180, 0, 2);
-    elseif ((player:getTP() >= 191) and (player:getTP() <= 199)) then
+    elseif ((tp >= 191) and (tp <= 199)) then
             player:addStatusEffect(EFFECT_AFTERMATH_LV1, 19, 0, 180, 0, 2);
 
 
 
 --        AFTERMATH LV2
 
-    elseif ((player:getTP() >= 200) and (player:getTP() <= 210)) then
+    elseif ((tp >= 200) and (tp <= 210)) then
             player:addStatusEffect(EFFECT_AFTERMATH_LV2, 24, 0, 180, 0, 3);
-    elseif ((player:getTP() >= 211) and (player:getTP() <= 219)) then
+    elseif ((tp >= 211) and (tp <= 219)) then
             player:addStatusEffect(EFFECT_AFTERMATH_LV2, 28, 0, 180, 0, 3);
-    elseif ((player:getTP() >= 221) and (player:getTP() <= 229)) then
+    elseif ((tp >= 221) and (tp <= 229)) then
             player:addStatusEffect(EFFECT_AFTERMATH_LV2, 32, 0, 180, 0, 3);
-    elseif ((player:getTP() >= 231) and (player:getTP() <= 239)) then
+    elseif ((tp >= 231) and (tp <= 239)) then
             player:addStatusEffect(EFFECT_AFTERMATH_LV2, 36, 0, 180, 0, 3);
-    elseif ((player:getTP() >= 241) and (player:getTP() <= 249)) then
+    elseif ((tp >= 241) and (tp <= 249)) then
             player:addStatusEffect(EFFECT_AFTERMATH_LV2, 40, 0, 180, 0, 3);
-    elseif ((player:getTP() >= 251) and (player:getTP() <= 259)) then
+    elseif ((tp >= 251) and (tp <= 259)) then
             player:addStatusEffect(EFFECT_AFTERMATH_LV2, 44, 0, 180, 0, 3);
-    elseif ((player:getTP() >= 261) and (player:getTP() <= 269)) then
+    elseif ((tp >= 261) and (tp <= 269)) then
             player:addStatusEffect(EFFECT_AFTERMATH_LV2, 48, 0, 180, 0, 3);
-    elseif ((player:getTP() >= 271) and (player:getTP() <= 279)) then
+    elseif ((tp >= 271) and (tp <= 279)) then
             player:addStatusEffect(EFFECT_AFTERMATH_LV2, 52, 0, 180, 0, 3);
-    elseif ((player:getTP() >= 281) and (player:getTP() <= 289)) then
+    elseif ((tp >= 281) and (tp <= 289)) then
             player:addStatusEffect(EFFECT_AFTERMATH_LV2, 56, 0, 180, 0, 3);
-    elseif ((player:getTP() >= 291) and (player:getTP() <= 299)) then
+    elseif ((tp >= 291) and (tp <= 299)) then
             player:addStatusEffect(EFFECT_AFTERMATH_LV2, 59, 0, 180, 0, 3);
 
 
 --        AFTERMATH LV3
 
-        elseif ((player:getTP() == 300)) then
+        elseif ((tp == 300)) then
             player:addStatusEffect(EFFECT_AFTERMATH_LV3, 45, 0, 120, 0, 1);
 
             end

--- a/scripts/globals/weaponskills/viper_bite.lua
+++ b/scripts/globals/weaponskills/viper_bite.lua
@@ -36,7 +36,6 @@ function onUseWeaponSkill(player, target, wsID, tp, primary)
     local damage, criticalHit, tpHits, extraHits = doPhysicalWeaponskill(player, target, wsID, params, tp, primary);
 
     if (damage > 0) then
-        local tp = player:getTP();
         local duration = (tp/100 * 60) + 30;
         if (target:hasStatusEffect(EFFECT_POISON) == false) then
             target:addStatusEffect(EFFECT_POISON, 3, 0, duration);

--- a/scripts/globals/weaponskills/wasp_sting.lua
+++ b/scripts/globals/weaponskills/wasp_sting.lua
@@ -34,7 +34,6 @@ function onUseWeaponSkill(player, target, wsID, tp, primary)
     local damage, criticalHit, tpHits, extraHits = doPhysicalWeaponskill(player, target, wsID, params, tp, primary);
 
     if (damage > 0) then
-        local tp = player:getTP();
         local duration = (tp/100 * 15) + 75;
         if (target:hasStatusEffect(EFFECT_POISON) == false) then
             target:addStatusEffect(EFFECT_POISON, 1, 0, duration);

--- a/scripts/globals/weaponskills/weapon_break.lua
+++ b/scripts/globals/weaponskills/weapon_break.lua
@@ -37,7 +37,6 @@ function onUseWeaponSkill(player, target, wsID, tp, primary)
     local damage, criticalHit, tpHits, extraHits = doPhysicalWeaponskill(player, target, wsID, params, tp, primary);
 
     if (damage > 0) then
-        local tp = player:getTP();
         local duration = (tp/100 * 60) + 120;
         if (target:hasStatusEffect(EFFECT_ATTACK_DOWN) == false) then
             target:addStatusEffect(EFFECT_ATTACK_DOWN, 25, 0, duration);


### PR DESCRIPTION
It now returns the TP the player has after the weaponskill has landed - using the tp passed into the weaponskill is what it needs to be.