### PR TITLE
Add issue template to pre fill some required github issue text.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,13 +1,18 @@
 # Issue Report Contributions:
 
 * Issues will be closed without being looked into if the following information is missing (unless its not applicable).
- * Branch name \(such as [stable](https://github.com/DarkstarProject/darkstar/tree/stable) or [master](https://github.com/DarkstarProject/darkstar/tree/master))
- * Client version (type `/ver` in game)
- * Darkstar revision (type `@revision` in game)
+* Client version (type `/ver` in game)
+* Darkstar revision (type `@revision` in game)
+* Branch name \(such as [stable](https://github.com/DarkstarProject/darkstar/tree/stable) or [master](https://github.com/DarkstarProject/darkstar/tree/master))
 
 
 ----
 
 # Pull Request Contributions:
 
-* See the [Style Guide](https://github.com/DarkstarProject/darkstar/blob/master/STYLE.md)
+### Style Guide
+
+* *detailed examples coming soon*
+* 4 space indents, not tabs.
+* Braces go on a new line ([allman](https://en.wikipedia.org/wiki/Indent_style#Allman_style) style)
+* Don't leave line breaks in the middle of SQL statements

--- a/ISSUE_TEMPLATE.md
+++ b/ISSUE_TEMPLATE.md
@@ -1,0 +1,11 @@
+**_Client Version_** (type `/ver` in game) **:**
+
+
+**_Server Version_** (type `@revision` in game) **:**
+
+
+**_Source Branch_** (master/stable) **:**
+
+
+**_Additional Information_** (Steps to reproduce/Expected behavior) **:**
+

--- a/STYLE.md
+++ b/STYLE.md
@@ -1,6 +1,0 @@
-# Style Guide
-
-* *detailed examples coming soon*
- * 4 space indents, not tabs.
- * Braces go on a new line ([allman](https://en.wikipedia.org/wiki/Indent_style#Allman_style) style)
- * Don't leave line breaks in the middle of SQL statements


### PR DESCRIPTION
This was actually the file that does what I was saying in last nights pull request comment, my bad. The other one I did last night creates the link both on issues and pull requests to let you give users more verbose information about things they should or should not be doing.