### PR TITLE
Scripts: Make offensive Wyvern breaths deplete TP on use.

### DIFF
--- a/scripts/globals/abilities/pets/flame_breath.lua
+++ b/scripts/globals/abilities/pets/flame_breath.lua
@@ -30,6 +30,7 @@ function onUseAbility(pet, target, skill, action)
 
     local dmgmod = MobBreathMove(pet, target, 0.185, pet:getMainLvl()*15, ELE_FIRE); -- Works out to (hp/6) + 15, as desired
     dmgmod = (dmgmod * (1+gear))*deep;
+    pet:setTP(0)
 
     local dmg = AbilityFinalAdjustments(dmgmod,pet,skill,target,MOBSKILL_MAGICAL,MOBPARAM_FIRE,MOBPARAM_IGNORE_SHADOWS);
     target:delHP(dmg);

--- a/scripts/globals/abilities/pets/frost_breath.lua
+++ b/scripts/globals/abilities/pets/frost_breath.lua
@@ -30,6 +30,8 @@ function onUseAbility(pet, target, skill, action)
 
     local dmgmod = MobBreathMove(pet, target, 0.185, pet:getMainLvl()*15, ELE_ICE); -- Works out to (hp/6) + 15, as desired
     dmgmod = (dmgmod * (1+gear))*deep;
+    pet:setTP(0)
+
     local dmg = AbilityFinalAdjustments(dmgmod,pet,skill,target,MOBSKILL_MAGICAL,MOBPARAM_ICE,MOBPARAM_IGNORE_SHADOWS);
     target:delHP(dmg);
     return dmg;

--- a/scripts/globals/abilities/pets/gust_breath.lua
+++ b/scripts/globals/abilities/pets/gust_breath.lua
@@ -30,6 +30,7 @@ function onUseAbility(pet, target, skill, action)
 
     local dmgmod = MobBreathMove(pet, target, 0.185, pet:getMainLvl()*15, ELE_WIND); -- Works out to (hp/6) + 15, as desired
     dmgmod = (dmgmod * (1+gear))*deep;
+    pet:setTP(0)
 
     local dmg = AbilityFinalAdjustments(dmgmod,pet,skill,target,MOBSKILL_MAGICAL,MOBPARAM_WIND,MOBPARAM_IGNORE_SHADOWS);
     target:delHP(dmg);

--- a/scripts/globals/abilities/pets/hydro_breath.lua
+++ b/scripts/globals/abilities/pets/hydro_breath.lua
@@ -30,6 +30,8 @@ function onUseAbility(pet, target, skill, action)
 
     local dmgmod = MobBreathMove(pet, target, 0.185, pet:getMainLvl()*15, ELE_WATER); -- Works out to (hp/6) + 15, as desired
     dmgmod = (dmgmod * (1+gear))*deep;
+    pet:setTP(0)
+
     local dmg = AbilityFinalAdjustments(dmgmod,pet,skill,target,MOBSKILL_MAGICAL,MOBPARAM_WATER,MOBPARAM_IGNORE_SHADOWS);
     target:delHP(dmg);
     return dmg;

--- a/scripts/globals/abilities/pets/lightning_breath.lua
+++ b/scripts/globals/abilities/pets/lightning_breath.lua
@@ -30,6 +30,8 @@ function onUseAbility(pet, target, skill, action)
 
     local dmgmod = MobBreathMove(pet, target, 0.185, pet:getMainLvl()*15, ELE_LIGHTNING); -- Works out to (hp/6) + 15, as desired
     dmgmod = (dmgmod * (1+gear))*deep;
+    pet:setTP(0)
+
     local dmg = AbilityFinalAdjustments(dmgmod,pet,skill,target,MOBSKILL_MAGICAL,MOBPARAM_THUNDER,MOBPARAM_IGNORE_SHADOWS);
     target:delHP(dmg);
     return dmg;

--- a/scripts/globals/abilities/pets/sand_breath.lua
+++ b/scripts/globals/abilities/pets/sand_breath.lua
@@ -30,6 +30,7 @@ function onUseAbility(pet, target, skill, action)
 
     local dmgmod = MobBreathMove(pet, target, 0.185, pet:getMainLvl()*15, ELE_EARTH);  -- Works out to (hp/6) + 15, as desired
     dmgmod = (dmgmod * (1+gear))*deep;
+    pet:setTP(0)
 
     local dmg = AbilityFinalAdjustments(dmgmod,pet,skill,target,MOBSKILL_MAGICAL,MOBPARAM_EARTH,MOBPARAM_IGNORE_SHADOWS);
     target:delHP(dmg);


### PR DESCRIPTION
They're supposed to have TP depleted when the breath actually goes off - it doesn't deplete when the ability begins to be readied, unlike player WSs/mobskills. This important distinction is what allows DRGs to use Spirit Link right after they WS to perform a self skillchain.