### PR TITLE
Scripts: Make Quick Draw give TP to user, Spirits Within enmity gain

### DIFF
--- a/scripts/globals/abilities/earth_shot.lua
+++ b/scripts/globals/abilities/earth_shot.lua
@@ -7,6 +7,7 @@
 require("scripts/globals/settings");
 require("scripts/globals/status");
 require("scripts/globals/magic");
+require("scripts/globals/weaponskills");
 
 -----------------------------------
 -- onAbilityCheck
@@ -37,9 +38,7 @@ function onUseAbility(player,target,ability)
     dmg = dmg * applyResistanceAbility(player,target,ELE_EARTH,SKILL_MRK, (player:getStat(MOD_AGI)/2) + player:getMerit(MERIT_QUICK_DRAW_ACCURACY));
     dmg = adjustForTarget(target,dmg,ELE_EARTH);
     
-    dmg = utils.stoneskin(target, dmg);
-        
-    target:delHP(dmg);
+    target:takeWeaponskillDamage(player, dmg, SLOT_RANGED, 1, 0, 0); -- targetTPMult is 0 because Quick Draw gives no TP to the mob
     target:updateEnmityFromDamage(player,dmg);
     
     local effects = {};

--- a/scripts/globals/abilities/fire_shot.lua
+++ b/scripts/globals/abilities/fire_shot.lua
@@ -7,6 +7,7 @@
 require("scripts/globals/settings");
 require("scripts/globals/status");
 require("scripts/globals/magic");
+require("scripts/globals/weaponskills");
 
 -----------------------------------
 -- onAbilityCheck
@@ -36,10 +37,8 @@ function onUseAbility(player,target,ability)
     dmg  = addBonusesAbility(player, ELE_FIRE, target, dmg, params);
     dmg = dmg * applyResistanceAbility(player,target,ELE_FIRE,SKILL_MRK, (player:getStat(MOD_AGI)/2) + player:getMerit(MERIT_QUICK_DRAW_ACCURACY));
     dmg = adjustForTarget(target,dmg,ELE_FIRE);
-    
-    dmg = utils.stoneskin(target, dmg);
         
-    target:delHP(dmg);
+    target:takeWeaponskillDamage(player, dmg, SLOT_RANGED, 1, 0, 0); -- targetTPMult is 0 because Quick Draw gives no TP to the mob
     target:updateEnmityFromDamage(player,dmg);
     
     local effects = {};

--- a/scripts/globals/abilities/ice_shot.lua
+++ b/scripts/globals/abilities/ice_shot.lua
@@ -7,6 +7,7 @@
 require("scripts/globals/settings");
 require("scripts/globals/status");
 require("scripts/globals/magic");
+require("scripts/globals/weaponskills");
 
 -----------------------------------
 -- onAbilityCheck
@@ -37,9 +38,7 @@ function onUseAbility(player,target,ability)
     dmg = dmg * applyResistanceAbility(player,target,ELE_ICE,SKILL_MRK, (player:getStat(MOD_AGI)/2) + player:getMerit(MERIT_QUICK_DRAW_ACCURACY));
     dmg = adjustForTarget(target,dmg,ELE_ICE);
     
-    dmg = utils.stoneskin(target, dmg);
-        
-    target:delHP(dmg);
+    target:takeWeaponskillDamage(player, dmg, SLOT_RANGED, 1, 0, 0); -- targetTPMult is 0 because Quick Draw gives no TP to the mob
     target:updateEnmityFromDamage(player,dmg);
     
     local effects = {};

--- a/scripts/globals/abilities/thunder_shot.lua
+++ b/scripts/globals/abilities/thunder_shot.lua
@@ -7,6 +7,7 @@
 require("scripts/globals/settings");
 require("scripts/globals/status");
 require("scripts/globals/magic");
+require("scripts/globals/weaponskills");
 
 -----------------------------------
 -- onAbilityCheck
@@ -37,9 +38,7 @@ function onUseAbility(player,target,ability)
     dmg = dmg * applyResistanceAbility(player,target,ELE_LIGHTNING,SKILL_MRK, (player:getStat(MOD_AGI)/2) + player:getMerit(MERIT_QUICK_DRAW_ACCURACY));
     dmg = adjustForTarget(target,dmg,ELE_LIGHTNING);
     
-    dmg = utils.stoneskin(target, dmg);
-        
-    target:delHP(dmg);
+    target:takeWeaponskillDamage(player, dmg, SLOT_RANGED, 1, 0, 0); -- targetTPMult is 0 because Quick Draw gives no TP to the mob
     target:updateEnmityFromDamage(player,dmg);
     
     local effects = {};

--- a/scripts/globals/abilities/water_shot.lua
+++ b/scripts/globals/abilities/water_shot.lua
@@ -7,6 +7,7 @@
 require("scripts/globals/settings");
 require("scripts/globals/status");
 require("scripts/globals/magic");
+require("scripts/globals/weaponskills");
 
 -----------------------------------
 -- onAbilityCheck
@@ -37,9 +38,7 @@ function onUseAbility(player,target,ability)
     dmg = dmg * applyResistanceAbility(player,target,ELE_WATER,SKILL_MRK, (player:getStat(MOD_AGI)/2) + player:getMerit(MERIT_QUICK_DRAW_ACCURACY));
     dmg = adjustForTarget(target,dmg,ELE_WATER);
     
-    dmg = utils.stoneskin(target, dmg);
-        
-    target:delHP(dmg);
+    target:takeWeaponskillDamage(player, dmg, SLOT_RANGED, 1, 0, 0); -- targetTPMult is 0 because Quick Draw gives no TP to the mob
     target:updateEnmityFromDamage(player,dmg);
     
     local effects = {};

--- a/scripts/globals/abilities/wind_shot.lua
+++ b/scripts/globals/abilities/wind_shot.lua
@@ -7,6 +7,7 @@
 require("scripts/globals/settings");
 require("scripts/globals/status");
 require("scripts/globals/magic");
+require("scripts/globals/weaponskills");
 
 -----------------------------------
 -- onAbilityCheck
@@ -37,9 +38,7 @@ function onUseAbility(player,target,ability)
     dmg = dmg * applyResistanceAbility(player,target,ELE_WIND,SKILL_MRK, (player:getStat(MOD_AGI)/2) + player:getMerit(MERIT_QUICK_DRAW_ACCURACY));
     dmg = adjustForTarget(target,dmg,ELE_WIND);
     
-    dmg = utils.stoneskin(target, dmg);
-        
-    target:delHP(dmg);
+    target:takeWeaponskillDamage(player, dmg, SLOT_RANGED, 1, 0, 0); -- targetTPMult is 0 because Quick Draw gives no TP to the mob
     target:updateEnmityFromDamage(player,dmg);
     
     local effects = {};

--- a/scripts/globals/weaponskills/spirits_within.lua
+++ b/scripts/globals/weaponskills/spirits_within.lua
@@ -47,7 +47,8 @@ function onUseWeaponSkill(player, target, wsID, TP, primary)
         damage = damage * (100 + attacker:getMod(MOD_WEAPONSKILL_DAMAGE_BASE + wsID))/100
     end
 
-    damage = target:takeWeaponskillDamage(player, damage, SLOT_MAIN, 1, 0, 1)
+    damage = target:takeWeaponskillDamage(player, damage, SLOT_MAIN, 1, 0, 1);
+    target:updateEnmityFromDamage(player, damage);
     return 1, 0, false, damage;
 
 end


### PR DESCRIPTION
Silly confusing function in weaponskills.lua and the lua binding both called takeWeaponskillDamage, I didn't realize that Spirits Within wasn't generating enmity. Note that Light/Dark shot don't generate TP as they do 0 damage.