### PR TITLE
Noticed some mob names longer than max size allows in mob_skill_lists…

### DIFF
--- a/sql/mob_skill_lists.sql
+++ b/sql/mob_skill_lists.sql
@@ -27,7 +27,7 @@ SET SQL_MODE="NO_AUTO_VALUE_ON_ZERO";
 
 DROP TABLE IF EXISTS `mob_skill_lists`;
 CREATE TABLE IF NOT EXISTS `mob_skill_lists` (
-  `skill_list_name` char(20) DEFAULT NULL,
+  `skill_list_name` varchar(40) DEFAULT NULL,
   `skill_list_id` smallint(5) unsigned NOT NULL,
   `mob_skill_id` smallint(3) unsigned NOT NULL,
   PRIMARY KEY (`skill_list_id`,`mob_skill_id`)


### PR DESCRIPTION
Example: _[Murk-Veined_Baneberry](http://ffxiclopedia.wikia.com/wiki/Murk-Veined_Baneberry)_ is longer than the current limit of 20 when we follow our usual naming convention, though not by much. I've bumped the field to 40 because I don't feel like searching to find what the longest name in existence in game is, and changed it to  varchar like is use din other tables (according to mysql documentation char is intended for fixed length text).