### PR TITLE
Scripts: Correct the position check on one of the doors in the Aqueducts

### DIFF
--- a/scripts/zones/Phomiuna_Aqueducts/npcs/_ir7.lua
+++ b/scripts/zones/Phomiuna_Aqueducts/npcs/_ir7.lua
@@ -15,7 +15,7 @@ require("scripts/zones/Phomiuna_Aqueducts/TextIDs");
 
 function onTrade(player,npc,trade)
     
-    if (player:getXPos() >= 70 and npc:getAnimation() == 9) then -- only if they're on the locked side and gate is closed.
+    if (player:getXPos() >= -70 and npc:getAnimation() == 9) then -- only if they're on the locked side and gate is closed.
         if (trade:hasItemQty(1660,1) and trade:getItemCount() == 1) then -- Bronze Key
             player:tradeComplete();
             npc:openDoor(15);


### PR DESCRIPTION
-70, not 70. (other door is 70)