### PR TITLE
Core/Scripts/SQL: Spell interrupt adjustments

### DIFF
--- a/scripts/globals/effects/aquaveil.lua
+++ b/scripts/globals/effects/aquaveil.lua
@@ -11,7 +11,6 @@ require("scripts/globals/status");
 -----------------------------------
 
 function onEffectGain(target,effect)
-    target:addMod(MOD_SPELLINTERRUPT,effect:getPower());
 end;
 
 -----------------------------------
@@ -26,5 +25,4 @@ end;
 -----------------------------------
 
 function onEffectLose(target,effect)
-    target:delMod(MOD_SPELLINTERRUPT,effect:getPower());
 end;

--- a/scripts/globals/settings.lua
+++ b/scripts/globals/settings.lua
@@ -124,7 +124,7 @@ BLINK_SHADOWS = 2;   -- number of shadows supplied by Blink spell
 ENSPELL_DURATION = 180; -- duration of RDM en-spells
 SPIKE_EFFECT_DURATION = 180; -- the duration of RDM, BLM spikes effects (not Reprisal)
 ELEMENTAL_DEBUFF_DURATION = 120; -- base duration of elemental debuffs
-AQUAVEIL_INTERR_RATE = 25;  -- percent spell interruption rate reduction from Aquaveil (see http://www.bluegartrls.com/forum/82143-spell-interruption-down-cap-aquaveil-tests.html)
+AQUAVEIL_COUNTER = 1;  -- Base amount of hits Aquaveil absorbs to prevent spell interrupts. Retail is 1.
 ABSORB_SPELL_AMOUNT = 8; -- how much of a stat gets absorbed by DRK absorb spells - expected to be a multiple of 8.
 ABSORB_SPELL_TICK = 9; -- duration of 1 absorb spell tick
 SNEAK_INVIS_DURATION_MULTIPLIER = 1; -- multiplies duration of sneak,invis,deodorize to reduce player torture. 1 = retail behavior.

--- a/scripts/globals/spells/aquaveil.lua
+++ b/scripts/globals/spells/aquaveil.lua
@@ -23,14 +23,20 @@ function onSpellCast(caster,target,spell)
     -- tests that quantify the relationship so I'm using 5 minutes for now.
 
     local duration = 300;
+    local power = AQUAVEIL_COUNTER + caster:getMod(MOD_AQUAVEIL_COUNT);
+    if (caster:getSkillLevel(ENHANCING_MAGIC_SKILL) >= 200) then -- cutoff point is estimated. https://www.bg-wiki.com/bg/Aquaveil
+        power = power + 1;
+    end
+    if (power < 1) then -- this shouldn't happen but it's probably best to prevent someone from accidentally underflowing the counter...
+        power = 1;
+    end;
 
     if (caster:hasStatusEffect(EFFECT_COMPOSURE) == true and caster:getID() == target:getID()) then
         duration = duration * 3;
     end
 
-    target:addStatusEffect(EFFECT_AQUAVEIL,AQUAVEIL_INTERR_RATE,0,duration);
-        spell:setMsg(230);
+    target:addStatusEffect(EFFECT_AQUAVEIL,power,0,duration);
+    spell:setMsg(230);
 
     return EFFECT_AQUAVEIL;
-
 end;

--- a/scripts/globals/status.lua
+++ b/scripts/globals/status.lua
@@ -1278,6 +1278,7 @@ MOD_BARSPELL_MDEF_BONUS       = 827 -- Extra magic defense bonus granted to the 
 MOD_RAPTURE_AMOUNT            = 568 -- Bonus amount added to Rapture effect
 MOD_EBULLIENCE_AMOUNT         = 569 -- Bonus amount added to Ebullience effect
 MOD_WYVERN_EFFECTIVE_BREATH   = 829 -- Increases the threshold for triggering healing breath
+MOD_AQUAVEIL_COUNT            = 832 -- Modifies the amount of hits that Aquaveil absorbs before being removed
 
 -- Mythic Weapon Mods
 MOD_AUGMENTS_ABSORB           = 521 -- Direct Absorb spell increase while Liberator is equipped (percentage based)
@@ -1303,8 +1304,8 @@ MOD_WEAPONSKILL_DAMAGE_BASE = 570 -- See modifier.h for how this is used
 -- MOD_SPARE = 98, -- stuff
 -- MOD_SPARE = 99, -- stuff
 -- MOD_SPARE = 100, -- stuff
--- MOD_SPARE = 829, -- stuff
--- MOD_SPARE = 830, -- stuff
+-- MOD_SPARE = 833, -- stuff
+-- MOD_SPARE = 834, -- stuff
 
 ------------------------------------
 -- Merit Definitions

--- a/sql/item_mods.sql
+++ b/sql/item_mods.sql
@@ -336,6 +336,7 @@ INSERT INTO `item_mods` VALUES (10329,1,40); -- Shedir Seraweels - DEF +40
 INSERT INTO `item_mods` VALUES (10329,539,35); -- Stoneskin +35
 INSERT INTO `item_mods` VALUES (10329,113,15); -- Enhancing Magic Skill +15
 INSERT INTO `item_mods` VALUES (10329,567,15); -- Barspell potency +15
+INSERT INTO `item_mods` VALUES (10329,832,1); -- Aquaveil count +1
 INSERT INTO `item_mods` VALUES (10330,1,1);
 INSERT INTO `item_mods` VALUES (10331,1,1);
 INSERT INTO `item_mods` VALUES (10332,1,1);
@@ -4570,6 +4571,7 @@ INSERT INTO `item_mods` VALUES (11751,384,60);
 INSERT INTO `item_mods` VALUES (11753,1,5);
 INSERT INTO `item_mods` VALUES (11753,5,20);
 INSERT INTO `item_mods` VALUES (11753,168,12);
+INSERT INTO `item_mods` VALUES (11753,832,1);
 INSERT INTO `item_mods` VALUES (11754,1,8);
 INSERT INTO `item_mods` VALUES (11754,8,5);
 INSERT INTO `item_mods` VALUES (11754,11,5);

--- a/src/map/modifier.h
+++ b/src/map/modifier.h
@@ -612,6 +612,7 @@ enum MODIFIER
     MOD_BARSPELL_MDEF_BONUS       = 827, // Extra magic defense bonus granted to the bar- spell effect
     MOD_RAPTURE_AMOUNT            = 568, // Bonus amount added to Rapture effect
     MOD_EBULLIENCE_AMOUNT         = 569, // Bonus amount added to Ebullience effect
+    MOD_AQUAVEIL_COUNT            = 832, // Modifies the amount of hits that Aquaveil absorbs before being removed
 
     // Weaponskill %damage modifiers
     // The following modifier should not ever be set, but %damage modifiers to weaponskills use the next 255 IDs (this modifier + the WSID)
@@ -633,8 +634,8 @@ enum MODIFIER
     // MOD_SPARE = 543, // stuff
     // MOD_SPARE = 552, // stuff
     // MOD_SPARE = 561, // stuff
-    // MOD_SPARE = 831, // stuff
-    // MOD_SPARE = 832, // stuff
+    // MOD_SPARE = 833, // stuff
+    // MOD_SPARE = 834, // stuff
 
 };
 


### PR DESCRIPTION
-Changed Aquaveil from increasing interrupt rate to a counter that prevents interrupts while it remains. Also added the modifier for the gear that currently exists in the DB. The interrupt rate setting was modified to be the base counter so people can change the amount of hits it will absorb if they'd like.
-Made songs unable to be interrupted by physical attacks.