### PR TITLE
Add IP address logging to lobby server.

### DIFF
--- a/conf/login_darkstar.conf
+++ b/conf/login_darkstar.conf
@@ -74,3 +74,6 @@ servername: DarkStar
 #Central message server settings (ensure these are the same on both all map servers and the central (lobby) server
 msg_server_port: 54003
 msg_server_ip: 127.0.0.1
+
+#Logging of user IP address to database (true/false)
+log_user_ip: false

--- a/sql/account_ip_record.sql
+++ b/sql/account_ip_record.sql
@@ -1,0 +1,20 @@
+-- MySQL dump 10.13  Distrib 5.6.17, for Win64 (x86_64)
+--
+-- Host: localhost    Database: dspdb
+-- ------------------------------------------------------
+-- Server version	5.6.21-log
+
+--
+-- Table structure for table `account_ip_record`
+--
+
+DROP TABLE IF EXISTS `account_ip_record`;
+CREATE TABLE `account_ip_record` (
+  `login_time` datetime NOT NULL DEFAULT '0000-00-00 00:00:00',
+  `accid` int(10) NOT NULL,
+  `charid` int(10) NOT NULL,
+  `client_ip` tinytext NOT NULL,
+  PRIMARY KEY (`login_time`,`accid`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+
+-- Dump completed on 2016-04-03 15:35:56

--- a/src/login/login.cpp
+++ b/src/login/login.cpp
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
 
-  Copyright (c) 2010-2015 Darkstar Dev Teams
+  Copyright (c) 2010-2016 Darkstar Dev Teams
 
   This program is free software: you can redistribute it and/or modify
   it under the terms of the GNU General Public License as published by
@@ -352,6 +352,10 @@ int32 login_config_read(const char *cfgName)
         {
             login_config.msg_server_ip = aStrdup(w2);
         }
+        else if (strcmp(w1, "log_user_ip") == 0)
+        {
+            login_config.log_user_ip = aStrdup(w2);
+        }
         else
         {
             ShowWarning("Unknown setting '%s' in file %s\n", w1, cfgName);
@@ -419,6 +423,8 @@ int32 login_config_default()
     login_config.search_server_port = 54002;
     login_config.msg_server_port = 54003;
     login_config.msg_server_ip = "127.0.0.1";
+
+    login_config.log_user_ip = "false";
     return 0;
 }
 

--- a/src/login/login.h
+++ b/src/login/login.h
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
 
-  Copyright (c) 2010-2015 Darkstar Dev Teams
+  Copyright (c) 2010-2016 Darkstar Dev Teams
 
   This program is free software: you can redistribute it and/or modify
   it under the terms of the GNU General Public License as published by
@@ -39,8 +39,8 @@ extern lan_config_t lan_config;
 
 struct login_config_t
 {
-    uint16 usLoginAuthPort;			// authentification port of login server      ->  54231
-    uint32 uiLoginAuthIp;			// authentification ip of login server	      -> INADDR_ANY
+    uint16 usLoginAuthPort;         // authentication port of login server ->  54231
+    uint32 uiLoginAuthIp;           // authentication ip of login server   -> INADDR_ANY
 
     uint16 usLobbyDataPort;
     uint32 uiLobbyDataIp;
@@ -52,16 +52,17 @@ struct login_config_t
 
     const char* servername;
 
-    const char* mysql_host;			// mysql addr     -> localhost:3306
-    uint16      mysql_port;			// mysql port     -> 3306
+    const char* mysql_host;         // mysql addr     -> localhost:3306
+    uint16      mysql_port;         // mysql port     -> 3306
     const char* mysql_login;        // mysql login    -> default root
     const char* mysql_password;     // mysql pass     -> default NULL
-    const char* mysql_database;		// mysql database -> default dspdb
+    const char* mysql_database;     // mysql database -> default dspdb
 
-    uint32 search_server_port;		// search_server_port	-> 54002
+    uint32 search_server_port;      // search_server_port -> 54002
 
-    uint16 msg_server_port;			// chat server port
-    const char* msg_server_ip;		// chat server IP
+    uint16 msg_server_port;         // chat server port
+    const char* msg_server_ip;      // chat server IP
+    bool  log_user_ip;              // log user ip -> default false
 };
 
 struct version_info_t


### PR DESCRIPTION
Does for login IP addresses what audit_chat settings do for chat messages. When enabled, every time a player logs in a character the date time account ID character ID and IP address will be stored for easy querying later.