### PR TITLE
Scripts/SQL: Fix some mob spawn point locations

### DIFF
--- a/scripts/zones/Sauromugue_Champaign/npcs/qm2.lua
+++ b/scripts/zones/Sauromugue_Champaign/npcs/qm2.lua
@@ -50,9 +50,9 @@ function onTrigger(player,npc)
     
     if (thickAsThieves == QUEST_ACCEPTED) then
         if (thickAsThievesGrapplingCS == 2) then
-            player:messageSpecial(THF_AF_MOB);    
-            SpawnMob(17269107,120):updateClaim(player); -- Climbpix Highrise
-            setMobPos(17269107,193,32,211,0);    
+            player:messageSpecial(THF_AF_MOB);
+            GetMobByID(17269107):setSpawn(193,32,211);
+            SpawnMob(17269107,120):updateClaim(player); -- Climbpix Highrise 
         elseif (thickAsThievesGrapplingCS == 0 or thickAsThievesGrapplingCS == 1 or
             thickAsThievesGrapplingCS == 3 or thickAsThievesGrapplingCS == 4 or
             thickAsThievesGrapplingCS == 5 or thickAsThievesGrapplingCS == 6 or
@@ -60,9 +60,9 @@ function onTrigger(player,npc)
             player:messageSpecial(THF_AF_WALL_OFFSET);    --  It is impossible to climb this wall with your bare hands.
         elseif (thickAsThievesGrapplingCS == 8) then
             player:messageSpecial(THF_AF_WALL_OFFSET+1); -- There is no longer any need to climb the tower.
-        end    
+        end
     else 
-        player:messageSpecial(NOTHING_OUT_OF_ORDINARY);            
+        player:messageSpecial(NOTHING_OUT_OF_ORDINARY);
     end
     
 end;

--- a/scripts/zones/Sauromugue_Champaign/npcs/qm3.lua
+++ b/scripts/zones/Sauromugue_Champaign/npcs/qm3.lua
@@ -38,9 +38,9 @@ function onTrigger(player,npc)
     
     if (thickAsThieves == QUEST_ACCEPTED) then    
         if (thickAsThievesGrapplingCS == 3) then
-            player:messageSpecial(THF_AF_MOB);    
-            SpawnMob(17269107,120):updateClaim(player); -- Climbpix Highrise
-            setMobPos(17269107,414,16,-131,0);        
+            player:messageSpecial(THF_AF_MOB);
+            GetMobByID(17269107):setSpawn(414,16,-131);
+            SpawnMob(17269107,120):updateClaim(player); -- Climbpix Highrise        
         elseif (thickAsThievesGrapplingCS == 0 or thickAsThievesGrapplingCS == 1 or
             thickAsThievesGrapplingCS == 2 or thickAsThievesGrapplingCS == 4 or
             thickAsThievesGrapplingCS == 5 or thickAsThievesGrapplingCS == 6 or

--- a/scripts/zones/Sauromugue_Champaign/npcs/qm4.lua
+++ b/scripts/zones/Sauromugue_Champaign/npcs/qm4.lua
@@ -39,8 +39,8 @@ function onTrigger(player,npc)
     if (thickAsThieves == QUEST_ACCEPTED) then
         if (thickAsThievesGrapplingCS == 4) then
             player:messageSpecial(THF_AF_MOB);
-            SpawnMob(17269107,120):updateClaim(player); -- Climbpix Highrise
-            setMobPos(17269107,122,0,230,0);    
+            GetMobByID(17269107):setSpawn(122,0,230); 
+            SpawnMob(17269107,120):updateClaim(player); -- Climbpix Highrise   
         elseif (thickAsThievesGrapplingCS == 0 or thickAsThievesGrapplingCS == 1 or
             thickAsThievesGrapplingCS == 2 or thickAsThievesGrapplingCS == 3 or
             thickAsThievesGrapplingCS == 5 or thickAsThievesGrapplingCS == 6 or

--- a/scripts/zones/Sauromugue_Champaign/npcs/qm5.lua
+++ b/scripts/zones/Sauromugue_Champaign/npcs/qm5.lua
@@ -38,9 +38,9 @@ function onTrigger(player,npc)
     
     if (thickAsThieves == QUEST_ACCEPTED) then    
         if (thickAsThievesGrapplingCS == 5) then
-            player:messageSpecial(THF_AF_MOB);    
-            SpawnMob(17269107,120):updateClaim(player); -- Climbpix Highrise
-            setMobPos(17269107,114,16,51,0);        
+            player:messageSpecial(THF_AF_MOB);
+            GetMobByID(17269107):setSpawn(114,16,51); 
+            SpawnMob(17269107,120):updateClaim(player); -- Climbpix Highrise       
         elseif (thickAsThievesGrapplingCS == 0 or thickAsThievesGrapplingCS == 1 or
             thickAsThievesGrapplingCS == 2 or thickAsThievesGrapplingCS == 3 or
             thickAsThievesGrapplingCS == 4 or thickAsThievesGrapplingCS == 6 or

--- a/scripts/zones/Sauromugue_Champaign/npcs/qm6.lua
+++ b/scripts/zones/Sauromugue_Champaign/npcs/qm6.lua
@@ -38,9 +38,9 @@ function onTrigger(player,npc)
     
     if (thickAsThieves == QUEST_ACCEPTED) then
         if (thickAsThievesGrapplingCS == 6) then
-            player:messageSpecial(THF_AF_MOB);    
-            SpawnMob(17269107,120):updateClaim(player); -- Climbpix Highrise
-            setMobPos(17269107,371,24,8,0);    
+            player:messageSpecial(THF_AF_MOB);
+            GetMobByID(17269107):setSpawn(371,24,8); 
+            SpawnMob(17269107,120):updateClaim(player); -- Climbpix Highrise   
         elseif (thickAsThievesGrapplingCS == 0 or thickAsThievesGrapplingCS == 1 or
             thickAsThievesGrapplingCS == 2 or thickAsThievesGrapplingCS == 3 or
             thickAsThievesGrapplingCS == 4 or thickAsThievesGrapplingCS == 5 or

--- a/scripts/zones/Sauromugue_Champaign/npcs/qm7.lua
+++ b/scripts/zones/Sauromugue_Champaign/npcs/qm7.lua
@@ -38,9 +38,9 @@ function onTrigger(player,npc)
     
     if (thickAsThieves == QUEST_ACCEPTED) then
         if (thickAsThievesGrapplingCS == 7) then
-            player:messageSpecial(THF_AF_MOB);    
-            SpawnMob(17269107,120):updateClaim(player); -- Climbpix Highrise
-            setMobPos(17269107,194,15,269,0);        
+            player:messageSpecial(THF_AF_MOB);
+            GetMobByID(17269107):setSpawn(194,15,269); 
+            SpawnMob(17269107,120):updateClaim(player); -- Climbpix Highrise       
         elseif (thickAsThievesGrapplingCS == 0 or thickAsThievesGrapplingCS == 1 or
             thickAsThievesGrapplingCS == 2 or thickAsThievesGrapplingCS == 3 or
             thickAsThievesGrapplingCS == 4 or thickAsThievesGrapplingCS == 5 or


### PR DESCRIPTION
For the one THF AF NM, I made it set the spawn point before spawning it, instead of attempting to move a mob that's in combat. Since the function that was used before explicitly has a comment saying not to use it on mobs in combat. For Armed Gears, I just set the spawn point to the pos of the ??? that spawns it, which is a hell of a lot more correct than spawning outside of the room and in the floor.