### PR TITLE
Scripts: Add same-element mdb to barspells on Afflatus Solace effect.

### DIFF
--- a/scripts/globals/effects/afflatus_solace.lua
+++ b/scripts/globals/effects/afflatus_solace.lua
@@ -12,6 +12,7 @@ require("scripts/globals/status");
 
 function onEffectGain(target,effect)
     target:addMod(MOD_AFFLATUS_SOLACE,0);
+    target:addMod(MOD_BARSPELL_MDEF_BONUS,5);
 end;
 
 -----------------------------------
@@ -27,4 +28,5 @@ end;
 
 function onEffectLose(target,effect)
     target:delMod(MOD_AFFLATUS_SOLACE,0);
+    target:delMod(MOD_BARSPELL_MDEF_BONUS,5);
 end;


### PR DESCRIPTION
https://www.bg-wiki.com/bg/Afflatus_Solace "Adds 5 Magic Defense Bonus of the related element to Barspells."