### PR TITLE
SQL/Scripts: Better handling of Pamamas-related latents

### DIFF
--- a/scripts/globals/equipment.lua
+++ b/scripts/globals/equipment.lua
@@ -37,28 +37,3 @@ function ChocoboShirt(player)
     end
     return power;
 end;
-
--- Provides a power for using a equipment modifiers with bunch of wild pamamas or pamamas
-function PamamasEquip(player)
-    local head = target:getEquipID(SLOT_HEAD);
-    local main = target:getEquipID(SLOT_MAIN);
-    local power = 0;
-   
-    if (head == 13870) then -- Opo-Opo Crown
-        power = 1;
-    end
-    if (main == 17592 or main == 17590) then -- Kinkobo - Primate Staff
-        power = 2;
-    elseif (main == 17591) then -- Primate Staff +1
-        power = 3;
-    end
-   
-    if (head == 13870 and (main == 17592 or main == 17590)) then -- Opo-Opo Crown and Kinkobo or Primate Staff
-        power = 4;
-    end
-   
-    if (head == 13870 and main == 17591) then -- Opo-Opo Crown and Primate Staff +1
-        power = 5;
-    end
-    return power;
-end;

--- a/scripts/globals/items/bunch_of_pamamas.lua
+++ b/scripts/globals/items/bunch_of_pamamas.lua
@@ -37,7 +37,7 @@ end;
 -----------------------------------------
 
 function onItemUse(target)
-    target:addStatusEffect(EFFECT_FOOD,PamamasEquip(target),0,1800,4468);
+    target:addStatusEffect(EFFECT_FOOD,0,0,1800,4468);
 end;
 
 -----------------------------------
@@ -45,21 +45,6 @@ end;
 -----------------------------------
 
 function onEffectGain(target,effect)
-    local power = effect:getPower();
-    if (power == 1 or power == 4 or power == 5) then
-        target:addMod(MOD_HP, 50);
-        target:addMod(MOD_MP, 50);
-        target:addMod(MOD_AGI, -3);
-        target:addMod(MOD_CHR, 14);
-    end
-    if (power == 2 or power == 4) then
-        target:addMod(MOD_DELAY, -90);
-        target:addMod(MOD_ACC, 10);
-    end
-    if (power == 3 or power == 5) then
-        target:addMod(MOD_DELAY, -80);
-        target:addMod(MOD_ACC, 12);
-    end
     target:addMod(MOD_STR, -3);
     target:addMod(MOD_INT, 1);
 end;
@@ -69,21 +54,6 @@ end;
 -----------------------------------------
 
 function onEffectLose(target,effect)
-    local power = effect:getPower();
-    if (power == 1 or power == 4 or power == 5) then
-        target:delMod(MOD_HP, 50);
-        target:delMod(MOD_MP, 50);
-        target:delMod(MOD_AGI, -3);
-        target:delMod(MOD_CHR, 14);
-    end
-    if (power == 2 or power == 4) then
-        target:delMod(MOD_DELAY, -90);
-        target:delMod(MOD_ACC, 10);
-    end
-    if (power == 3 or power == 5) then
-        target:delMod(MOD_DELAY, -80);
-        target:delMod(MOD_ACC, 12);
-    end
     target:delMod(MOD_STR, -3);
     target:delMod(MOD_INT, 1);
 end;

--- a/scripts/globals/items/bunch_of_wild_pamamas.lua
+++ b/scripts/globals/items/bunch_of_wild_pamamas.lua
@@ -37,8 +37,7 @@ end;
 -----------------------------------------
 
 function onItemUse(target)
-
-    target:addStatusEffect(EFFECT_FOOD,PamamasEquip(target),0,1800,4596);
+    target:addStatusEffect(EFFECT_FOOD,0,0,1800,4596);
 end;
 
 -----------------------------------
@@ -46,21 +45,6 @@ end;
 -----------------------------------
 
 function onEffectGain(target,effect)
-    local power = effect:getPower();
-    if (power == 1 or power == 4 or power == 5) then
-        target:addMod(MOD_HP, 50);
-        target:addMod(MOD_MP, 50);
-        target:addMod(MOD_AGI, -3);
-        target:addMod(MOD_CHR, 14);
-    end
-    if (power == 2 or power == 4) then
-        target:addMod(MOD_DELAY, -90);
-        target:addMod(MOD_ACC, 10);
-    end
-    if (power == 3 or power == 5) then
-        target:addMod(MOD_DELAY, -80);
-        target:addMod(MOD_ACC, 12);
-    end
     target:addMod(MOD_STR, -3);
     target:addMod(MOD_INT, 1);
 end;
@@ -70,21 +54,6 @@ end;
 -----------------------------------------
 
 function onEffectLose(target,effect)
-    local power = effect:getPower();
-    if (power == 1 or power == 4 or power == 5) then
-        target:delMod(MOD_HP, 50);
-        target:delMod(MOD_MP, 50);
-        target:delMod(MOD_AGI, -3);
-        target:delMod(MOD_CHR, 14);
-    end
-    if (power == 2 or power == 4) then
-        target:delMod(MOD_DELAY, -90);
-        target:delMod(MOD_ACC, 10);
-    end
-    if (power == 3 or power == 5) then
-        target:delMod(MOD_DELAY, -80);
-        target:delMod(MOD_ACC, 12);
-    end
     target:delMod(MOD_STR, -3);
     target:delMod(MOD_INT, 1);
 end;

--- a/sql/item_latents.sql
+++ b/sql/item_latents.sql
@@ -61,18 +61,24 @@ INSERT INTO `item_latents` VALUES(16014, 23, 4, 22, 1); -- Stormer Earring, ATT+
 INSERT INTO `item_latents` VALUES(16020, 10, 1, 22, 7); -- Survivor Earring, VIT+1 if PLD is in party
 INSERT INTO `item_latents` VALUES(16033, 71, 1, 22, 20); -- Sylph Earring, Healing MP +1 if SCH is in party
 
-INSERT INTO `item_latents` VALUES(13870, 14, 14, 49, 4468);
-INSERT INTO `item_latents` VALUES(13870, 12, 1, 49, 4468);
-INSERT INTO `item_latents` VALUES(13870, 11, -3, 49, 4468); -- Opo-opo Crown, AGI+1 to AGI-2
-INSERT INTO `item_latents` VALUES(13870, 8, -3, 49, 4468); -- Opo-opo Crown, STR+1 to STR-2
-INSERT INTO `item_latents` VALUES(13870, 5, 50, 49, 4468);
-INSERT INTO `item_latents` VALUES(13870, 2, 50, 49, 4468);
-INSERT INTO `item_latents` VALUES(13870, 14, 14, 49, 4596);
-INSERT INTO `item_latents` VALUES(13870, 12, 1, 49, 4596);
-INSERT INTO `item_latents` VALUES(13870, 11, -3, 49, 4596); -- Opo-opo Crown, AGI+1 to AGI-2
-INSERT INTO `item_latents` VALUES(13870, 8, -3, 49, 4596); -- Opo-opo Crown, STR+1 to STR-2
-INSERT INTO `item_latents` VALUES(13870, 5, 50, 49, 4596);
-INSERT INTO `item_latents` VALUES(13870, 2, 50, 49, 4596);
+INSERT INTO `item_latents` VALUES(13870, 2, 50, 49, 4468); -- Opo-opo crown HP +50 (pamamas)
+INSERT INTO `item_latents` VALUES(13870, 5, 50, 49, 4468); -- MP +50
+INSERT INTO `item_latents` VALUES(13870, 14, 14, 49, 4468); -- CHR +14
+INSERT INTO `item_latents` VALUES(13870, 2, 50, 49, 4596); -- Opo-opo crown HP +50 (wild pamamas)
+INSERT INTO `item_latents` VALUES(13870, 5, 50, 49, 4596); -- MP +50
+INSERT INTO `item_latents` VALUES(13870, 14, 14, 49, 4596); -- CHR +14
+INSERT INTO `item_latents` VALUES(17590, 171, 83, 49, 4468); -- Primate Staff
+INSERT INTO `item_latents` VALUES(17590, 25, 10, 49, 4468);
+INSERT INTO `item_latents` VALUES(17590, 171, 83, 49, 4596); 
+INSERT INTO `item_latents` VALUES(17590, 25, 10, 49, 4596);
+INSERT INTO `item_latents` VALUES(17591, 171, 80, 49, 4468); -- Primate Staff +1
+INSERT INTO `item_latents` VALUES(17591, 25, 12, 49, 4468);
+INSERT INTO `item_latents` VALUES(17591, 171, 80, 49, 4596); 
+INSERT INTO `item_latents` VALUES(17591, 25, 12, 49, 4596);
+INSERT INTO `item_latents` VALUES(17592, 171, 83, 49, 4468); -- Kinkobo
+INSERT INTO `item_latents` VALUES(17592, 25, 10, 49, 4468);
+INSERT INTO `item_latents` VALUES(17592, 171, 83, 49, 4596); 
+INSERT INTO `item_latents` VALUES(17592, 25, 10, 49, 4596);
 INSERT INTO `item_latents` VALUES(17073, 406, 30, 7, 2); -- Mistilteinn drains 30TP if TP >= 30
 INSERT INTO `item_latents` VALUES(17073, 369, 1, 7, 2); -- Mistilteinn adds Refresh 1MP per tick
 


### PR DESCRIPTION
Put the bonuses as latents for the gear instead of the food effect. Prevents equipping the gear then using Pamamas, then unequipping the gear to keep the bonus. Also fixes the issue where Pamamas yield no effect (might need to have one of the offending items equipped).