### PR TITLE
Scripts: Remove some redundancy with BRD enfeebles/refine scripts

### DIFF
--- a/scripts/globals/magic.lua
+++ b/scripts/globals/magic.lua
@@ -480,7 +480,7 @@ function getEffectResistance(target, effect)
         effectres = MOD_CURSERES;
     elseif (effect == EFFECT_WEIGHT) then
         effectres = MOD_GRAVITYRES;
-    elseif (effect == EFFECT_SLOW) then
+    elseif (effect == EFFECT_SLOW or effect == EFFECT_ELEGY) then
         effectres = MOD_SLOWRES;
     elseif (effect == EFFECT_STUN) then
         effectres = MOD_STUNRES;

--- a/scripts/globals/spells/battlefield_elegy.lua
+++ b/scripts/globals/spells/battlefield_elegy.lua
@@ -18,14 +18,10 @@ function onSpellCast(caster,target,spell)
     local pCHR = caster:getStat(MOD_CHR);
     local mCHR = target:getStat(MOD_CHR);
     local dCHR = (pCHR - mCHR);
-    local resm = applyResistance(caster,spell,target,dCHR,SINGING_SKILL,0);
-    if (resm < 0.5) then
-        spell:setMsg(85);--resist message
-        return 1;
-    end
+    local resm = applyResistanceEffect(caster,spell,target,dCHR,SINGING_SKILL,0,EFFECT_ELEGY);
 
-    if (100 * math.random() < target:getMod(MOD_SLOWRES)) then
-        spell:setMsg(85); -- resisted spell
+    if (resm < 0.5) then
+        spell:setMsg(85); -- resist message
     else
         local iBoost = caster:getMod(MOD_ELEGY_EFFECT) + caster:getMod(MOD_ALL_SONGS_EFFECT);
         power = power + iBoost*10;

--- a/scripts/globals/spells/carnage_elegy.lua
+++ b/scripts/globals/spells/carnage_elegy.lua
@@ -1,5 +1,5 @@
 -----------------------------------------
--- Spell: Battlefield Elegy
+-- Spell: Carnage Elegy
 -----------------------------------------
 require("scripts/globals/status");
 require("scripts/globals/magic");
@@ -18,14 +18,10 @@ function onSpellCast(caster,target,spell)
     local pCHR = caster:getStat(MOD_CHR);
     local mCHR = target:getStat(MOD_CHR);
     local dCHR = (pCHR - mCHR);
-    local resm = applyResistance(caster,spell,target,dCHR,SINGING_SKILL,0);
-    if (resm < 0.5) then
-        spell:setMsg(85);--resist message
-        return 1;
-    end
+    local resm = applyResistanceEffect(caster,spell,target,dCHR,SINGING_SKILL,0,EFFECT_ELEGY);
 
-    if (100 * math.random() < target:getMod(MOD_SLOWRES)) then
-        spell:setMsg(85); -- resisted spell
+    if (resm < 0.5) then
+        spell:setMsg(85); -- resist message
     else
         local iBoost = caster:getMod(MOD_ELEGY_EFFECT) + caster:getMod(MOD_ALL_SONGS_EFFECT);
         power = power + iBoost*10;
@@ -49,6 +45,7 @@ function onSpellCast(caster,target,spell)
         else
             spell:setMsg(75); -- no effect
         end
+
     end
 
     return EFFECT_ELEGY;

--- a/scripts/globals/spells/foe_lullaby.lua
+++ b/scripts/globals/spells/foe_lullaby.lua
@@ -16,17 +16,11 @@ function onSpellCast(caster,target,spell)
     local pCHR = caster:getStat(MOD_CHR);
     local mCHR = target:getStat(MOD_CHR);
     local dCHR = (pCHR - mCHR);
-    local resm = applyResistanceEffect(caster,spell,target,dCHR,SKILL_SNG,0,EFFECT_LULLABY);
+    local resm = applyResistanceEffect(caster,spell,target,dCHR,SINGING_SKILL,0,EFFECT_LULLABY);
+
     if (resm < 0.5) then
         spell:setMsg(85);--resist message
-        return EFFECT_LULLABY;
-    end
-
-    if (target:hasImmunity(1) or 100 * math.random() < target:getMod(MOD_LULLABYRES)) then
-        --No effect
-        spell:setMsg(75);
     else
-
         local iBoost = caster:getMod(MOD_LULLABY_EFFECT) + caster:getMod(MOD_ALL_SONGS_EFFECT);
 
         duration = duration * ((iBoost * 0.1) + (caster:getMod(MOD_SONG_DURATION_BONUS)/100) + 1);

--- a/scripts/globals/spells/foe_lullaby_ii.lua
+++ b/scripts/globals/spells/foe_lullaby_ii.lua
@@ -1,5 +1,5 @@
 -----------------------------------------
--- Spell: Foe Lullaby
+-- Spell: Foe Lullaby II
 -----------------------------------------
 require("scripts/globals/status");
 require("scripts/globals/magic");
@@ -16,17 +16,11 @@ function onSpellCast(caster,target,spell)
     local pCHR = caster:getStat(MOD_CHR);
     local mCHR = target:getStat(MOD_CHR);
     local dCHR = (pCHR - mCHR);
-    local resm = applyResistanceEffect(caster,spell,target,dCHR,SKILL_SNG,0,EFFECT_LULLABY);
+    local resm = applyResistanceEffect(caster,spell,target,dCHR,SINGING_SKILL,0,EFFECT_LULLABY);
+
     if (resm < 0.5) then
         spell:setMsg(85);--resist message
-        return EFFECT_LULLABY;
-    end
-
-    if (target:hasImmunity(1) or 100 * math.random() < target:getMod(MOD_LULLABYRES)) then
-        --No effect
-        spell:setMsg(75);
     else
-
         local iBoost = caster:getMod(MOD_LULLABY_EFFECT) + caster:getMod(MOD_ALL_SONGS_EFFECT);
 
         duration = duration * ((iBoost * 0.1) + (caster:getMod(MOD_SONG_DURATION_BONUS)/100) + 1);

--- a/scripts/globals/spells/horde_lullaby.lua
+++ b/scripts/globals/spells/horde_lullaby.lua
@@ -16,17 +16,11 @@ function onSpellCast(caster,target,spell)
     local pCHR = caster:getStat(MOD_CHR);
     local mCHR = target:getStat(MOD_CHR);
     local dCHR = (pCHR - mCHR);
-    local resm = applyResistanceEffect(caster,spell,target,dCHR,SKILL_SNG,0,EFFECT_LULLABY);
+    local resm = applyResistanceEffect(caster,spell,target,dCHR,SINGING_SKILL,0,EFFECT_LULLABY);
+
     if (resm < 0.5) then
         spell:setMsg(85);--resist message
-        return EFFECT_LULLABY;
-    end
-
-    if (target:hasImmunity(1) or 100 * math.random() < target:getMod(MOD_LULLABYRES)) then
-        --No effect
-        spell:setMsg(75);
     else
-    
         local iBoost = caster:getMod(MOD_LULLABY_EFFECT) + caster:getMod(MOD_ALL_SONGS_EFFECT);
 
         duration = duration * ((iBoost * 0.1) + (caster:getMod(MOD_SONG_DURATION_BONUS)/100) + 1);

--- a/scripts/globals/spells/horde_lullaby_ii.lua
+++ b/scripts/globals/spells/horde_lullaby_ii.lua
@@ -1,5 +1,5 @@
 -----------------------------------------
--- Spell: Horde Lullaby
+-- Spell: Horde Lullaby II
 -----------------------------------------
 require("scripts/globals/status");
 require("scripts/globals/magic");
@@ -16,15 +16,10 @@ function onSpellCast(caster,target,spell)
     local pCHR = caster:getStat(MOD_CHR);
     local mCHR = target:getStat(MOD_CHR);
     local dCHR = (pCHR - mCHR);
-    local resm = applyResistanceEffect(caster,spell,target,dCHR,SKILL_SNG,0,EFFECT_LULLABY);
+    local resm = applyResistanceEffect(caster,spell,target,dCHR,SINGING_SKILL,0,EFFECT_LULLABY);
+
     if (resm < 0.5) then
         spell:setMsg(85);--resist message
-        return EFFECT_LULLABY;
-    end
-
-    if (target:hasImmunity(1) or 100 * math.random() < target:getMod(MOD_LULLABYRES)) then
-        --No effect
-        spell:setMsg(75);
     else
         local iBoost = caster:getMod(MOD_LULLABY_EFFECT) + caster:getMod(MOD_ALL_SONGS_EFFECT);
 

--- a/scripts/globals/spells/massacre_elegy.lua
+++ b/scripts/globals/spells/massacre_elegy.lua
@@ -1,5 +1,5 @@
 -----------------------------------------
--- Spell: Battlefield Elegy
+-- Spell: Massacre Elegy
 -----------------------------------------
 require("scripts/globals/status");
 require("scripts/globals/magic");
@@ -18,14 +18,10 @@ function onSpellCast(caster,target,spell)
     local pCHR = caster:getStat(MOD_CHR);
     local mCHR = target:getStat(MOD_CHR);
     local dCHR = (pCHR - mCHR);
-    local resm = applyResistance(caster,spell,target,dCHR,SINGING_SKILL,0);
-    if (resm < 0.5) then
-        spell:setMsg(85);--resist message
-        return 1;
-    end
+    local resm = applyResistanceEffect(caster,spell,target,dCHR,SINGING_SKILL,0,EFFECT_ELEGY);
 
-    if (100 * math.random() < target:getMod(MOD_SLOWRES)) then
-        spell:setMsg(85); -- resisted spell
+    if (resm < 0.5) then
+        spell:setMsg(85); -- resist message
     else
         local iBoost = caster:getMod(MOD_ELEGY_EFFECT) + caster:getMod(MOD_ALL_SONGS_EFFECT);
         power = power + iBoost*10;
@@ -44,10 +40,7 @@ function onSpellCast(caster,target,spell)
         end
 
         -- Try to overwrite weaker elegy
-        if (canOverwrite(target, EFFECT_ELEGY, power)) then
-            -- overwrite them
-            target:delStatusEffect(EFFECT_ELEGY);
-            target:addStatusEffect(EFFECT_ELEGY,power,0,duration);
+        if (target:addStatusEffect(EFFECT_ELEGY,power,0,duration)) then
             spell:setMsg(237);
         else
             spell:setMsg(75); -- no effect


### PR DESCRIPTION
-Made Elegy effect check against MOD_SLOWRES for applyResistanceEffect
-Made Elegy use applyResistanceEffect instead of applyResistance
-Remove second resistance check on each of the spells because why is it being checked twice?
-Cleaned up scripts so they're consistent.