### PR TITLE
Add script for Distract II spell and and update scripts/globals/spells/distract.lua with BG's data.

### DIFF
--- a/scripts/globals/spells/distract_ii.lua
+++ b/scripts/globals/spells/distract_ii.lua
@@ -1,5 +1,5 @@
 -----------------------------------------
--- Spell: Distract
+-- Spell: Distract II
 -----------------------------------------
 
 require("scripts/globals/status");
@@ -14,17 +14,11 @@ function onMagicCastingCheck(caster,target,spell)
 end;
 
 function onSpellCast(caster,target,spell)
-
-    -- Pull base stats.
     local dMND = (caster:getStat(MOD_MND) - target:getStat(MOD_MND));
-    
-    -- Base power.  May need more research.
-    local power = 35;
-
-    -- Duration, including resistance.  Unconfirmed.
+    local power = utils.clamp(40+(math.floor(dMND/5), 40, 50);
     local duration = 120 * applyResistanceEffect(caster,spell,target,dMND,35,0,EFFECT_EVASION_DOWN);
 
-    if (duration >= 60) then -- Do it!
+    if (duration >= 60) then
         if (target:addStatusEffect(EFFECT_EVASION_DOWN,power,0,duration)) then
             spell:setMsg(236);
         else


### PR DESCRIPTION
According to BG math folks these are in fact MND based despite being categorized as black magic.

https://www.bg-wiki.com/bg/Distract_II

https://www.bluegartr.com/threads/108196-Random-Facts-Thread-Magic?p=6201332&viewfull=1#post6201332

Other wiki has at least partially wrong data, so was likely just filled in by someone who made assumptions and never actually tested anything.
