### PR TITLE
Scripts: Fix DRG AF1 NM

### DIFF
--- a/scripts/zones/Eastern_Altepa_Desert/mobs/Decurio_I-III.lua
+++ b/scripts/zones/Eastern_Altepa_Desert/mobs/Decurio_I-III.lua
@@ -16,10 +16,10 @@ end;
 -- onMobDeath Action
 -----------------------------------
 
-function onMobDeath(mob, player)
+function onMobDeath(mob,killer,ally)
 
-    if (player:getVar("aCraftsmanWork") == 1) then
-        player:setVar("Decurio_I_IIIKilled",1);
+    if (ally:getVar("aCraftsmanWork") == 1) then
+        ally:setVar("Decurio_I_IIIKilled",1);
     end
 
 end;


### PR DESCRIPTION
This file escaped the onMobDeath conversion from (mob, killer) to (mob, killer, ally) because it was using (mob, player).