### PR TITLE
Core/Scripts: Properly implement Atonement (mostly)

### DIFF
--- a/scripts/globals/weaponskills.lua
+++ b/scripts/globals/weaponskills.lua
@@ -11,45 +11,17 @@
 require("scripts/globals/status");
 require("scripts/globals/utils");
 require("scripts/globals/magic");
+require("scripts/globals/magicburst");
 
-local elementalGorget = { 15495, 15498, 15500, 15497, 15496, 15499, 15501, 15502 };
-local elementalBelt =   { 11755, 11758, 11760, 11757, 11756, 11759, 11761, 11762 };
 
 -- params contains: ftp100, ftp200, ftp300, str_wsc, dex_wsc, vit_wsc, int_wsc, mnd_wsc, canCrit, crit100, crit200, crit300, acc100, acc200, acc300, ignoresDef, ignore100, ignore200, ignore300, atkmulti
 function doPhysicalWeaponskill(attacker, target, wsID, params, tp, primary)
 
     local criticalHit = false;
-    local bonusacc = attacker:getMod(MOD_WSACC);
-    local bonusfTP = 0;
     local bonusTP = params.bonusTP or 0
     local multiHitfTP = params.multiHitfTP or false
-
-    if (attacker:getObjType() == TYPE_PC) then
-        local neck = attacker:getEquipID(SLOT_NECK);
-        local belt = attacker:getEquipID(SLOT_WAIST);
-        local SCProp1, SCProp2, SCProp3 = attacker:getWSSkillchainProp();
-
-        for i,v in ipairs(elementalGorget) do
-            if (neck == v) then
-                if (doesElementMatchWeaponskill(i, SCProp1) or doesElementMatchWeaponskill(i, SCProp2) or doesElementMatchWeaponskill(i, SCProp3)) then
-                    bonusacc = bonusacc + 10;
-                    bonusfTP = bonusfTP + 0.1;
-                end
-                break;
-            end
-        end
-
-        for i,v in ipairs(elementalBelt) do
-            if (belt == v) then
-                if (doesElementMatchWeaponskill(i, SCProp1) or doesElementMatchWeaponskill(i, SCProp2) or doesElementMatchWeaponskill(i, SCProp3)) then
-                    bonusacc = bonusacc + 10;
-                    bonusfTP = bonusfTP + 0.1;
-                end
-                break;
-            end
-        end
-        -- printf("bonusacc = %u bonusfTP = %f", bonusacc, bonusfTP);
-    end
+    local bonusfTP, bonusacc = handleWSGorgetBelt(attacker);
+    bonusacc = bonusacc + attacker:getMod(MOD_WSACC);
 
     -- get fstr
     local fstr = fSTR(attacker:getStat(MOD_STR),target:getStat(MOD_VIT),attacker:getWeaponDmgRank());
@@ -258,36 +230,9 @@ end;
 
 function doMagicWeaponskill(attacker, target, wsID, params, tp, primary)
 
-    local bonusacc = attacker:getMod(MOD_WSACC);
-    local bonusfTP = 0;
     local bonusTP = params.bonusTP or 0
-
-    if (attacker:getObjType() == TYPE_PC) then
-        local neck = attacker:getEquipID(SLOT_NECK);
-        local belt = attacker:getEquipID(SLOT_WAIST);
-        local SCProp1, SCProp2, SCProp3 = attacker:getWSSkillchainProp();
-
-        for i,v in ipairs(elementalGorget) do
-            if (neck == v) then
-                if (doesElementMatchWeaponskill(i, SCProp1) or doesElementMatchWeaponskill(i, SCProp2) or doesElementMatchWeaponskill(i, SCProp3)) then
-                    bonusacc = bonusacc + 10;
-                    bonusfTP = bonusfTP + 0.1;
-                end
-                break;
-            end
-        end
-
-        for i,v in ipairs(elementalBelt) do
-            if (belt == v) then
-                if (doesElementMatchWeaponskill(i, SCProp1) or doesElementMatchWeaponskill(i, SCProp2) or doesElementMatchWeaponskill(i, SCProp3)) then
-                    bonusacc = bonusacc + 10;
-                    bonusfTP = bonusfTP + 0.1;
-                end
-                break;
-            end
-        end
-        -- printf("bonusacc = %u bonusfTP = %f", bonusacc, bonusfTP);
-    end
+    local bonusfTP, bonusacc = handleWSGorgetBelt(attacker);
+    bonusacc = bonusacc + attacker:getMod(MOD_WSACC);
 
     local fint = utils.clamp(8 + (attacker:getStat(MOD_INT) - target:getStat(MOD_INT)), -32, 32);
     local dmg = attacker:getMainLvl() + 2 + (attacker:getStat(MOD_STR) * params.str_wsc + attacker:getStat(MOD_DEX) * params.dex_wsc +
@@ -694,37 +639,10 @@ end;
  -- params contains: ftp100, ftp200, ftp300, str_wsc, dex_wsc, vit_wsc, int_wsc, mnd_wsc, canCrit, crit100, crit200, crit300, acc100, acc200, acc300, ignoresDef, ignore100, ignore200, ignore300, atkmulti
  function doRangedWeaponskill(attacker, target, wsID, params, tp, primary)
 
-    local bonusacc = attacker:getMod(MOD_WSACC);
-    local bonusfTP = 0;
     local bonusTP = params.bonusTP or 0
     local multiHitfTP = params.multiHitfTP or false
-
-    if (attacker:getObjType() == TYPE_PC) then
-        local neck = attacker:getEquipID(SLOT_NECK);
-        local belt = attacker:getEquipID(SLOT_WAIST);
-        local SCProp1, SCProp2, SCProp3 = attacker:getWSSkillchainProp();
-
-        for i,v in ipairs(elementalGorget) do
-            if (neck == v) then
-                if (doesElementMatchWeaponskill(i, SCProp1) or doesElementMatchWeaponskill(i, SCProp2) or doesElementMatchWeaponskill(i, SCProp3)) then
-                    bonusacc = bonusacc + 10;
-                    bonusfTP = bonusfTP + 0.1;
-                end
-                break;
-            end
-        end
-
-        for i,v in ipairs(elementalBelt) do
-            if (belt == v) then
-                if (doesElementMatchWeaponskill(i, SCProp1) or doesElementMatchWeaponskill(i, SCProp2) or doesElementMatchWeaponskill(i, SCProp3)) then
-                    bonusacc = bonusacc + 10;
-                    bonusfTP = bonusfTP + 0.1;
-                end
-                break;
-            end
-        end
-        -- printf("bonusacc = %u bonusfTP = %f", bonusacc, bonusfTP);
-    end
+    local bonusfTP, bonusacc = handleWSGorgetBelt(attacker);
+    bonusacc = bonusacc + attacker:getMod(MOD_WSACC);
 
     -- get fstr
     local fstr = fSTR(attacker:getStat(MOD_STR),target:getStat(MOD_VIT),attacker:getRangedDmgForRank());
@@ -1013,4 +931,38 @@ function initAftermathParams()
     params.duration.lv3 = 120
 
     return params
+end;
+
+function handleWSGorgetBelt(attacker)
+    local ftpBonus = 0;
+    local accBonus = 0;
+    if (attacker:getObjType() == TYPE_PC) then
+        -- TODO: Get these out of itemid checks when possible.
+        local elementalGorget = { 15495, 15498, 15500, 15497, 15496, 15499, 15501, 15502 };
+        local elementalBelt =   { 11755, 11758, 11760, 11757, 11756, 11759, 11761, 11762 };
+        local neck = attacker:getEquipID(SLOT_NECK);
+        local belt = attacker:getEquipID(SLOT_WAIST);
+        local SCProp1, SCProp2, SCProp3 = attacker:getWSSkillchainProp();
+
+        for i,v in ipairs(elementalGorget) do
+            if (neck == v) then
+                if (doesElementMatchWeaponskill(i, SCProp1) or doesElementMatchWeaponskill(i, SCProp2) or doesElementMatchWeaponskill(i, SCProp3)) then
+                    accBonus = accBonus + 10;
+                    ftpBonus = ftpBonus + 0.1;
+                end
+                break;
+            end
+        end
+
+        for i,v in ipairs(elementalBelt) do
+            if (belt == v) then
+                if (doesElementMatchWeaponskill(i, SCProp1) or doesElementMatchWeaponskill(i, SCProp2) or doesElementMatchWeaponskill(i, SCProp3)) then
+                    accBonus = accBonus + 10;
+                    ftpBonus = ftpBonus + 0.1;
+                end
+                break;
+            end
+        end
+    end
+    return ftpBonus, accBonus;
 end;

--- a/scripts/globals/weaponskills/atonement.lua
+++ b/scripts/globals/weaponskills/atonement.lua
@@ -8,7 +8,14 @@
 -- Aligned with the Aqua Gorget, Flame Gorget & Light Gorget.
 -- Aligned with the Aqua Belt, Flame Belt & Light Belt.
 -- Element: None
--- Modifiers: STR:40% VIT:50%
+-- Modifiers (old): damage varies with enmity
+-- 100%TP    200%TP    300%TP
+-- 0.09      0.11      0.20   -CE
+-- 0.11      0.14      0.25   -VE
+-- Modifiers (new): enmity from damage varies with TP
+-- 100%TP    200%TP    300%TP
+-- 1.00      1.5       2.0
+-- Modifiers (non-mob, wrong): STR:40% VIT:50%
 -- 100%TP    200%TP    300%TP
 -- 1.00      1.25      1.50
 -----------------------------------
@@ -29,16 +36,58 @@ function onUseWeaponSkill(player, target, wsID, tp, primary)
     params.acc100 = 0.0; params.acc200= 0.0; params.acc300= 0.0;
     params.atkmulti = 1;
 
-    if (USE_ADOULIN_WEAPON_SKILL_CHANGES == true) then
-        params.ftp100 = 1; params.ftp200 = 1.5; params.ftp300 = 2.0;
+    local tpHits = 0;
+    local extraHits = 0;
+    local criticalHit = false;
+    local enmityMult = 1;
+    local damage = 0;
+
+    if (target:getObjType() ~= TYPE_MOB) then -- this isn't correct but might as well use what was originally here if someone uses this on a non-mob
+        if (USE_ADOULIN_WEAPON_SKILL_CHANGES == true) then
+            params.ftp100 = 1; params.ftp200 = 1.5; params.ftp300 = 2.0;
+        end
+
+        damage, criticalHit, tpHits, extraHits = doPhysicalWeaponskill(player, target, wsID, params, tp, primary);
+    else
+        local dmg;
+        if (USE_ADOULIN_WEAPON_SKILL_CHANGES == true) then
+            dmg = (target:getCE(player) + target:getVE(player))/6;
+            -- tp affects enmity multiplier, 1.0 at 1k, 1.5 at 2k, 2.0 at 3k. Gorget/Belt adds 100 tp each.
+            enmityMult = enmityMult + (tp + (handleWSGorgetBelt(player) * 1000) - 1000)/2000;
+            enmityMult = utils.clamp(enmityMult, 1, 2); -- necessary because of Gorget/Belt bonus
+        else
+            local effectiveTP = tp + handleWSGorgetBelt(player) * 1000;
+            effectiveTP = utils.clamp(effectiveTP, 0, 3000); -- necessary because of Gorget/Belt bonus
+            local ceMod = fTP(effectiveTP, 0.09, 0.11, 0.20); -- CE portion of Atonement
+            local veMod = fTP(effectiveTP, 0.11, 0.14, 0.25); -- VE portion of Atonement
+            dmg = math.floor(target:getCE(player) * ceMod) + math.floor(target:getVE(player) * veMod);
+        end
+
+        dmg = utils.clamp(dmg, 0, player:getMainLvl() * 10); -- Damage is capped to player's level * 10, before WS damage mods
+        damage = target:breathDmgTaken(dmg);
+        if (player:getMod(MOD_WEAPONSKILL_DAMAGE_BASE + wsID) > 0) then
+            damage = damage * (100 + attacker:getMod(MOD_WEAPONSKILL_DAMAGE_BASE + wsID))/100
+        end
+        damage = damage * WEAPON_SKILL_POWER;
+
+        if (damage > 0) then
+            if (attacker:getOffhandDmg() > 0) then
+                tpHits = 2;
+            else
+                tpHits = 1;
+            end
+            extraHits = 1; -- for whatever reason, Atonement always yields the a TP return of a 2 hit WS, unless it does 0 damage.
+        end
+
+        damage = target:takeWeaponskillDamage(player, damage, SLOT_MAIN, tpHits, extraHits, 1);
+        target:updateEnmityFromDamage(player, damage * enmityMult);
     end
 
-    local damage, criticalHit, tpHits, extraHits = doPhysicalWeaponskill(player, target, wsID, params, tp, primary);
     if ((player:getEquipID(SLOT_MAIN) == 18997) and (player:getMainJob() == JOB_PLD)) then
         if (damage > 0) then
             applyAftermathEffect(player, tp)
         end
     end
-    return tpHits, extraHits, criticalHit, damage;
 
-end
+    return tpHits, extraHits, criticalHit, damage;
+end;

--- a/scripts/globals/weaponskills/spirits_within.lua
+++ b/scripts/globals/weaponskills/spirits_within.lua
@@ -21,6 +21,7 @@ function onUseWeaponSkill(player, target, wsID, TP, primary)
 
     local HP = player:getHP();
     local WSC = 0;
+    local tpHits = 0;
     -- Damage calculations based on https://www.bg-wiki.com/index.php?title=Spirits_Within&oldid=269806
     if (TP == 3000) then
         WSC = math.floor(HP * 120/256);
@@ -42,13 +43,20 @@ function onUseWeaponSkill(player, target, wsID, TP, primary)
     end
 
     local damage = target:breathDmgTaken(WSC);
-    damage = damage * WEAPON_SKILL_POWER
+    if (damage > 0) then
+        if (attacker:getOffhandDmg() > 0) then
+            tpHits = 2;
+        else
+            tpHits = 1;
+        end
+    end
     if (player:getMod(MOD_WEAPONSKILL_DAMAGE_BASE + wsID) > 0) then
         damage = damage * (100 + attacker:getMod(MOD_WEAPONSKILL_DAMAGE_BASE + wsID))/100
     end
+    damage = damage * WEAPON_SKILL_POWER
 
-    damage = target:takeWeaponskillDamage(player, damage, SLOT_MAIN, 1, 0, 1);
+    damage = target:takeWeaponskillDamage(player, damage, SLOT_MAIN, tpHits, 0, 1);
     target:updateEnmityFromDamage(player, damage);
-    return 1, 0, false, damage;
+    return tpHits, 0, false, damage;
 
 end

--- a/src/map/enmity_container.cpp
+++ b/src/map/enmity_container.cpp
@@ -349,6 +349,40 @@ void CEnmityContainer::LowerEnmityByPercent(CBattleEntity* PEntity, uint8 percen
 
 /************************************************************************
 *                                                                       *
+*    Returns the CE or VE for the current entity                        *
+*                                                                       *
+************************************************************************/
+
+uint16 CEnmityContainer::GetCE(CBattleEntity* PEntity)
+{
+    EnmityList_t::iterator PEnmity = m_EnmityList.lower_bound(PEntity->id);
+    int32 CEValue = 0;
+
+    if (PEnmity != m_EnmityList.end() &&
+        !m_EnmityList.key_comp()(PEntity->id, PEnmity->first))
+    {
+        CEValue = (PEnmity->second->CE);
+    }
+    // ShowDebug("Current CE: %u\n", CEValue);
+    return CEValue;
+}
+
+uint16 CEnmityContainer::GetVE(CBattleEntity* PEntity)
+{
+    EnmityList_t::iterator PEnmity = m_EnmityList.lower_bound(PEntity->id);
+    int32 VEValue = 0;
+
+    if (PEnmity != m_EnmityList.end() &&
+        !m_EnmityList.key_comp()(PEntity->id, PEnmity->first))
+    {
+        VEValue = (PEnmity->second->VE);
+    }
+    // ShowDebug("Current VE: %u\n", VEValue);
+    return VEValue;
+}
+
+/************************************************************************
+*                                                                       *
 *                                                                       *
 *                                                                       *
 ************************************************************************/

--- a/src/map/enmity_container.h
+++ b/src/map/enmity_container.h
@@ -50,26 +50,28 @@ public:
 
     CBattleEntity*	GetHighestEnmity();			// Decays VE and gets target with highest enmity
 
-	float   CalculateEnmityBonus(CBattleEntity* PEntity);
-	void	Clear(uint32 EntityID = 0);			// Removes Entries from list
-    void	AddBaseEnmity(CBattleEntity* PEntity);
-	void	UpdateEnmity(CBattleEntity* PEntity, int16 CE, int16 VE, bool withMaster = true, bool aggroEnmity = false);
-	void	UpdateEnmityFromDamage(CBattleEntity* PEntity, uint16 Damage);
-	void	UpdateEnmityFromCure(CBattleEntity* PEntity, uint16 level, uint16 CureAmount, bool isCureV);
-	void	UpdateEnmityFromAttack(CBattleEntity* PEntity,uint16 Damage);
-        void    AddLinkEnmity(CBattleEntity* PEntity);
-        void    AddAggroEnmity(CBattleEntity* PEntity);
-	void	AddPartyEnmity(CCharEntity* PChar);
-	bool    HasTargetID(uint32 TargetID); //true if ID is in the container with non-zero enmity level
-	void    LowerEnmityByPercent(CBattleEntity* PEntity, uint8 percent, CBattleEntity* HateReceiver); // lower % of hate or transfer it
-	void	DecayEnmity();
-  bool  IsWithinEnmityRange(CBattleEntity* PEntity);
+    float   CalculateEnmityBonus(CBattleEntity* PEntity);
+    void    Clear(uint32 EntityID = 0);			// Removes Entries from list
+    void    AddBaseEnmity(CBattleEntity* PEntity);
+    void    UpdateEnmity(CBattleEntity* PEntity, int16 CE, int16 VE, bool withMaster = true, bool aggroEnmity = false);
+    void    UpdateEnmityFromDamage(CBattleEntity* PEntity, uint16 Damage);
+    void    UpdateEnmityFromCure(CBattleEntity* PEntity, uint16 level, uint16 CureAmount, bool isCureV);
+    void    UpdateEnmityFromAttack(CBattleEntity* PEntity,uint16 Damage);
+    void    AddLinkEnmity(CBattleEntity* PEntity);
+    void    AddAggroEnmity(CBattleEntity* PEntity);
+    void    AddPartyEnmity(CCharEntity* PChar);
+    bool    HasTargetID(uint32 TargetID); //true if ID is in the container with non-zero enmity level
+    void    LowerEnmityByPercent(CBattleEntity* PEntity, uint8 percent, CBattleEntity* HateReceiver); // lower % of hate or transfer it
+    uint16  GetCE(CBattleEntity* PEntity);
+    uint16  GetVE(CBattleEntity* PEntity);
+    void    DecayEnmity();
+    bool    IsWithinEnmityRange(CBattleEntity* PEntity);
     uint8   GetHighestTH();
-  EnmityList_t* GetEnmityList();
+    EnmityList_t* GetEnmityList();
 
 private:
 	
-	EnmityList_t	m_EnmityList;
+    EnmityList_t    m_EnmityList;
     CBattleEntity*  m_EnmityHolder; //usually a monster
 };
 

--- a/src/map/lua/lua_baseentity.cpp
+++ b/src/map/lua/lua_baseentity.cpp
@@ -6308,6 +6308,34 @@ inline int32 CLuaBaseEntity::updateEnmityFromDamage(lua_State *L)
 
 /************************************************************************
 *                                                                       *
+*  Returns the CE and VE the mob has towards the player                 *
+*                                                                       *
+************************************************************************/
+
+inline int32 CLuaBaseEntity::getCE(lua_State *L)
+{
+    DSP_DEBUG_BREAK_IF(m_PBaseEntity->objtype != TYPE_MOB);
+    DSP_DEBUG_BREAK_IF(lua_isnil(L, 1) || !lua_isuserdata(L, 1));
+
+    CLuaBaseEntity* PEntity = Lunar<CLuaBaseEntity>::check(L, 1);
+
+    lua_pushinteger(L, ((CMobEntity*)m_PBaseEntity)->PEnmityContainer->GetCE((CBattleEntity*)PEntity->GetBaseEntity()));
+    return 1;
+}
+
+inline int32 CLuaBaseEntity::getVE(lua_State *L)
+{
+    DSP_DEBUG_BREAK_IF(m_PBaseEntity->objtype != TYPE_MOB);
+    DSP_DEBUG_BREAK_IF(lua_isnil(L, 1) || !lua_isuserdata(L, 1));
+
+    CLuaBaseEntity* PEntity = Lunar<CLuaBaseEntity>::check(L, 1);
+
+    lua_pushinteger(L, ((CMobEntity*)m_PBaseEntity)->PEnmityContainer->GetVE((CBattleEntity*)PEntity->GetBaseEntity()));
+    return 1;
+}
+
+/************************************************************************
+*                                                                       *
 *  Adds a specified amount of enmity towards the target if the base     *
 *  entity is a mob, or towards the base entity if the base entity is a  *
 *  player.                                                              *
@@ -10670,6 +10698,8 @@ Lunar<CLuaBaseEntity>::Register_t CLuaBaseEntity::methods[] =
     LUNAR_DECLARE_METHOD(CLuaBaseEntity,lowerEnmity),
     LUNAR_DECLARE_METHOD(CLuaBaseEntity,transferEnmity),
     LUNAR_DECLARE_METHOD(CLuaBaseEntity,updateEnmityFromDamage),
+    LUNAR_DECLARE_METHOD(CLuaBaseEntity,getCE),
+    LUNAR_DECLARE_METHOD(CLuaBaseEntity,getVE),
     LUNAR_DECLARE_METHOD(CLuaBaseEntity,addEnmity),
     LUNAR_DECLARE_METHOD(CLuaBaseEntity,getEquipID),
     LUNAR_DECLARE_METHOD(CLuaBaseEntity,getShieldSize),

--- a/src/map/lua/lua_baseentity.h
+++ b/src/map/lua/lua_baseentity.h
@@ -300,6 +300,8 @@ public:
     int32 resetEnmity(lua_State*);          //resets enmity to player for specificed mob
     int32 lowerEnmity(lua_State*);          //lower enmity to player for specificed mob
     int32 transferEnmity(lua_State*);
+    int32 getCE(lua_State*);                //gets current CE the mob has towards the player
+    int32 getVE(lua_State*);                //gets current VE the mob has towards the player
 
     int32 hasImmunity(lua_State*);          // Check if the mob has immunity for a type of spell (list at mobentity.h)
     int32 getBattleTime(lua_State*);        // Get the time in second of the battle


### PR DESCRIPTION
-Added lua bindings to get current CE and VE a player has on a mob, for the calculation of Atonement's damage.
-Added in the damage formula/type for Atonement vs. mobs. I did not find damage vs. non-mobs (ie. charmed players) so I left in the old damage calculation for that.
-Put WS Gorget/Belt handling into its own function to make things cleaner and so it can be accessed from elsewhere. I couldn't figure out better way to handle the itemid checks though, since you can say... use Flame Gorget + Light Belt for Knights of Round, and if you just add mods to the gorgets/belts it would double count them (once for Light property, and again for Fusion)...
-Updated Spirits Within to check if dual wielding for TP return.

Old Atonement damage source: http://www.ffxionline.com/forums/showthread.php?t=73784
New Atonement damage source: https://www.bg-wiki.com/bg/Talk:Atonement