### PR TITLE
Fix issue #2951

### DIFF
--- a/src/map/battlefield.cpp
+++ b/src/map/battlefield.cpp
@@ -237,19 +237,25 @@ void CBattlefield::pushMessageToAllInBcnm(uint16 msg, uint16 param) {
     }
 }
 
-bool CBattlefield::addPlayerToBcnm(CCharEntity* PChar) {
+bool CBattlefield::addPlayerToBcnm(CCharEntity* PChar)
+{
     //split to get the reason for debugging
-    if (m_PlayerList.size() >= m_MaxParticipants) {
+    if (m_PlayerList.size() >= m_MaxParticipants)
+    {
         ShowDebug("Cannot add %s to BCNM list, max size reached.\n", PChar->GetName()); return false;
     }
-    if (PChar->StatusEffectContainer->HasStatusEffect(EFFECT_BATTLEFIELD)) {
+
+    if (PChar->StatusEffectContainer->HasStatusEffect(EFFECT_BATTLEFIELD))
+    {
         ShowDebug("Cannot add %s to BCNM list, they have BC effect.\n", PChar->GetName()); return false;
     }
+
     if (PChar->getZone() != m_ZoneID) {
         ShowDebug("Cannot add %s to BCNM list, not in right zone.\n", PChar->GetName()); return false;
     }
 
     m_PlayerList.push_back(PChar);
+    PChar->StatusEffectContainer->DelStatusEffect(EFFECT_LEVEL_SYNC);
     PChar->StatusEffectContainer->AddStatusEffect(new CStatusEffect(EFFECT_BATTLEFIELD, EFFECT_BATTLEFIELD, this->m_BcnmID, 0, 0), true);
     this->capPlayerToBCNM();
     return true;

--- a/src/map/utils/charutils.cpp
+++ b/src/map/utils/charutils.cpp
@@ -4519,7 +4519,10 @@ namespace charutils
             }
 
             CBattleEntity* PSyncTarget = PChar->PParty->GetSyncTarget();
-            if (PSyncTarget && !(PChar->StatusEffectContainer->HasStatusEffect(EFFECT_LEVEL_SYNC)) && PChar->getZone() == PSyncTarget->getZone() && PSyncTarget->StatusEffectContainer->HasStatusEffect(EFFECT_LEVEL_SYNC) && PSyncTarget->StatusEffectContainer->GetStatusEffect(EFFECT_LEVEL_SYNC)->GetDuration() == 0)
+            if (PSyncTarget && PChar->getZone() == PSyncTarget->getZone()
+                && !(PChar->StatusEffectContainer->HasStatusEffect(EFFECT_LEVEL_SYNC))
+                && PSyncTarget->StatusEffectContainer->HasStatusEffect(EFFECT_LEVEL_SYNC)
+                && PSyncTarget->StatusEffectContainer->GetStatusEffect(EFFECT_LEVEL_SYNC)->GetDuration() == 0)
             {
                 PChar->pushPacket(new CMessageBasicPacket(PChar, PChar, 0, PSyncTarget->GetMLevel(), 540));
                 PChar->StatusEffectContainer->AddStatusEffect(new CStatusEffect(


### PR DESCRIPTION
No more exploiting level sync to uncap BCNMs..

I also broke up an extremely long line (4522 of charutils) without changing what it does, because that was crazy and I hate left/right scrolling to read code.

@Hozu thanks for checking in game for me