### PR TITLE
FIX DRG AF2 NM

### DIFF
--- a/scripts/zones/Batallia_Downs/mobs/Sturmtiger.lua
+++ b/scripts/zones/Batallia_Downs/mobs/Sturmtiger.lua
@@ -16,8 +16,8 @@ end;
 -- onMobDeath Action
 -----------------------------------
 
-function onMobDeath(mob, player)
-    if (player:getVar("ChasingQuotas_Progress") == 5) then
-        player:setVar("SturmtigerKilled",1);
+function onMobDeath(mob,killer,ally)
+    if (ally:getVar("ChasingQuotas_Progress") == 5) then
+        ally:setVar("SturmtigerKilled",1);
     end
 end;


### PR DESCRIPTION
This file escaped the onMobDeath conversion from (mob, killer) to (mob, killer, ally) because it was using (mob, player). @Hozu  gave me the idea :100: 