### PR TITLE
Core/SQL: Fix Overwhelm check

### DIFF
--- a/sql/merits.sql
+++ b/sql/merits.sql
@@ -243,7 +243,7 @@ INSERT INTO `merits` VALUES ('2694', 'recycle', '5', '5', '1024', '7', '41');
 INSERT INTO `merits` VALUES ('2752', 'shikikoyo', '5', '12', '2048', '7', '42');
 INSERT INTO `merits` VALUES ('2754', 'blade_bash', '5', '15', '2048', '7', '42');
 INSERT INTO `merits` VALUES ('2756', 'ikishoten', '5', '3', '2048', '7', '42');
-INSERT INTO `merits` VALUES ('2758', 'overwhelm', '5', '5', '2048', '7', '42');
+INSERT INTO `merits` VALUES ('2758', 'overwhelm', '5', '1', '2048', '7', '42');
 INSERT INTO `merits` VALUES ('2816', 'sange', '5', '25', '4096', '7', '43');
 INSERT INTO `merits` VALUES ('2818', 'ninja_tool_expertise', '5', '5', '4096', '7', '43');
 INSERT INTO `merits` VALUES ('2820', 'katon_san', '5', '5', '4096', '7', '43');

--- a/src/map/utils/battleutils.cpp
+++ b/src/map/utils/battleutils.cpp
@@ -2042,6 +2042,10 @@ namespace battleutils
             damage = HandleStoneskin(PDefender, damage);
             HandleAfflatusMiseryDamage(PDefender, damage);
         }
+        if (!isRanged)
+        {
+            damage = getOverWhelmDamageBonus(PChar, PDefender, (uint16)damage);
+        }
         damage = dsp_cap(damage, -99999, 99999);
 
         int32 corrected = PDefender->addHP(-damage);
@@ -2057,7 +2061,6 @@ namespace battleutils
 
         if (damage > 0)
         {
-            damage = getOverWhelmDamageBonus(PChar, PDefender, (uint16)damage);
             PDefender->StatusEffectContainer->DelStatusEffectsByFlag(EFFECTFLAG_DAMAGE);
 
             // Check for bind breaking
@@ -3639,27 +3642,25 @@ namespace battleutils
     ************************************************************************/
     uint16 getOverWhelmDamageBonus(CCharEntity* m_PChar, CBattleEntity* PDefender, uint16 damage)
     {
-        if (m_PChar->GetMJob() == JOB_SAM || m_PChar->GetSJob() == JOB_SAM) // only allow if player 75 or more
+        if (m_PChar->objtype == TYPE_PC) // Some mobskills use TakeWeaponskillDamage function, which calls upon this one.
         {
-            if (m_PChar->GetMLevel() >= 75)
+            // must be facing mob
+            if (isFaceing(PDefender->loc.p, m_PChar->loc.p, 90))
             {
-                // must be facing mob
-                if (isFaceing(PDefender->loc.p, m_PChar->loc.p, 90))
-                {
-                    uint8 meritCount = m_PChar->PMeritPoints->GetMeritValue(MERIT_OVERWHELM, m_PChar);
-                    float tmpDamage = damage;
+                uint8 meritCount = m_PChar->PMeritPoints->GetMeritValue(MERIT_OVERWHELM, m_PChar);
+                // ShowDebug("Merits: %u\n", meritCount);
+                float tmpDamage = damage;
 
-                    switch (meritCount)
-                    {
-                        case 1:	tmpDamage += tmpDamage * 0.05f; break;
-                        case 2:	tmpDamage += tmpDamage * 0.10f; break;
-                        case 3:	tmpDamage += tmpDamage * 0.15f; break;
-                        case 4:	tmpDamage += tmpDamage * 0.17f; break;
-                        case 5:	tmpDamage += tmpDamage * 0.19f; break;
-                        default: break;
-                    }
-                    damage = (uint16)floor(tmpDamage);
+                switch (meritCount)
+                {
+                    case 1:	tmpDamage += tmpDamage * 0.05f; break;
+                    case 2:	tmpDamage += tmpDamage * 0.10f; break;
+                    case 3:	tmpDamage += tmpDamage * 0.15f; break;
+                    case 4:	tmpDamage += tmpDamage * 0.17f; break;
+                    case 5:	tmpDamage += tmpDamage * 0.19f; break;
+                    default: break;
                 }
+                damage = (uint16)floor(tmpDamage);
             }
         }
         return damage;


### PR DESCRIPTION
-Moved the check to before damage was actually dealt to the target.
-Added a check to make Overwhelm only apply to melee Weaponskills.
-Replaced the redundant job/level check (since it's already done when fetching merit value) with an objtype check, since there are some mobskills that use battleutils::TakeWeaponskillDamage (and thus battleutils::getOverWhelmDamageBonus).
-Fixed the merit power value since the value fetched for merits is the total power value, not the amount of upgrades in the category.