### PR TITLE
misplaced parenthesis

### DIFF
--- a/scripts/globals/spells/distract_ii.lua
+++ b/scripts/globals/spells/distract_ii.lua
@@ -15,7 +15,7 @@ end;
 
 function onSpellCast(caster,target,spell)
     local dMND = (caster:getStat(MOD_MND) - target:getStat(MOD_MND));
-    local power = utils.clamp(40+(math.floor(dMND/5), 40, 50));
+    local power = utils.clamp(40+math.floor(dMND/5), 40, 50);
     local duration = 120 * applyResistanceEffect(caster,spell,target,dMND,35,0,EFFECT_EVASION_DOWN);
 
     if (duration >= 60) then


### PR DESCRIPTION
Something something spoiler alert, something something testing blah blah etc. etc.


Compounding mistakes ftl.
I thought I had a missing one, when I had 1 too many, so I made it 2 too many..

(to be fair, the spell DID cast so looked like it worked, it just had the wrong value).