### PR TITLE
Blue magic script corrections and additions

### DIFF
--- a/scripts/globals/spells/bluemagic/frypan.lua
+++ b/scripts/globals/spells/bluemagic/frypan.lua
@@ -12,10 +12,9 @@
 -- Skillchain Element(s): Lightning (can open Liquefaction or Detonation; can close Impaction or Fusion)
 -- Combos: Max HP Boost
 -----------------------------------------
-
-require("scripts/globals/magic");
-require("scripts/globals/status");
 require("scripts/globals/bluemagic");
+require("scripts/globals/status");
+require("scripts/globals/magic");
 
 -----------------------------------------
 -- OnMagicCastingCheck
@@ -30,7 +29,8 @@ end;
 -----------------------------------------
 
 function onSpellCast(caster,target,spell)
-
+    local dINT = caster:getStat(MOD_INT) - target:getStat(MOD_INT);
+    local resist = applyResistanceEffect(caster,spell,target,dINT,SKILL_BLU,0,EFFECT_STUN)
     local params = {};
     -- This data should match information on http://wiki.ffxiclopedia.org/wiki/Calculating_Blue_Magic_Damage
         params.tpmod = TPMOD_ACC;
@@ -49,9 +49,12 @@ function onSpellCast(caster,target,spell)
         params.int_wsc = 0.0;
         params.mnd_wsc = 0.2;
         params.chr_wsc = 0.0;
-    damage = BluePhysicalSpell(caster, target, spell, params);
+    local damage = BluePhysicalSpell(caster, target, spell, params);
     damage = BlueFinalAdjustments(caster, target, spell, damage, params);
-   -- Missing AOE STUN
-   
+
+    if (resist > 0.5) then -- This line may need adjusting for retail accuracy.
+        target:addStatusEffect(EFFECT_STUN, 1, 0, 5 * resist); -- pre-resist duration needs confirmed/adjusted
+    end
+
     return damage;
 end;

--- a/scripts/globals/spells/bluemagic/sudden_lunge.lua
+++ b/scripts/globals/spells/bluemagic/sudden_lunge.lua
@@ -1,23 +1,23 @@
 -----------------------------------------
--- Spell: Head Butt
--- Damage varies with TP. Additional effect: "Stun"
--- Spell cost: 12 MP
--- Monster Type: Beastmen
--- Spell Type: Physical (Blunt)
--- Blue Magic Points: 3
--- Stat Bonus: DEX+2
--- Level: 12
+-- Spell: Sudden Lunge
+-- Damage varies with TP. Additional effect: "Stun."
+-- Spell cost: 18 MP
+-- Monster Type: Vermin
+-- Spell Type: Physical (Slashing)
+-- Blue Magic Points: 4
+-- Stat Bonus: HP-5 MP-5 DEX+1 AGI+1
+-- Level: 95
 -- Casting Time: 0.5 seconds
--- Recast Time: 10 seconds
--- Skillchain Element(s): Lightning (can open Liquefaction or Detonation; can close Impaction or Fusion)
--- Combos: None
+-- Recast Time: 15 seconds
+-- Skillchain Element(s):
+-- Combos: Store TP
 -----------------------------------------
 require("scripts/globals/bluemagic");
 require("scripts/globals/status");
 require("scripts/globals/magic");
 
 -----------------------------------------
--- OnMagicCastingCheck
+-- onMagicCastingCheck
 -----------------------------------------
 
 function onMagicCastingCheck(caster,target,spell)
@@ -32,28 +32,28 @@ function onSpellCast(caster,target,spell)
     local dINT = caster:getStat(MOD_INT) - target:getStat(MOD_INT);
     local resist = applyResistanceEffect(caster,spell,target,dINT,SKILL_BLU,0,EFFECT_STUN)
     local params = {};
-    -- This data should match information on http://wiki.ffxiclopedia.org/wiki/Calculating_Blue_Magic_Damage
+    -- Todo: determine if these param values are retail
         params.tpmod = TPMOD_DAMAGE;
-        params.dmgtype = DMGTYPE_BLUNT;
-        params.scattr = SC_IMPACTION;
+        params.dmgtype = DMGTYPE_SLASH;
+        params.scattr = SC_DETONATION;
         params.numhits = 1;
-        params.multiplier = 1.75;
-        params.tp150 = 2.125;
-        params.tp300 = 2.25;
-        params.azuretp = 2.375;
-        params.duppercap = 17;
-        params.str_wsc = 0.2;
+        params.multiplier = 1.875;
+        params.tp150 = 1.25;
+        params.tp300 = 1.50;
+        params.azuretp = 1.4375;
+        params.duppercap = 100;
+        params.str_wsc = 0.0;
         params.dex_wsc = 0.0;
         params.vit_wsc = 0.0;
-        params.agi_wsc = 0.0;
-        params.int_wsc = 0.2;
+        params.agi_wsc = 0.4;
+        params.int_wsc = 0.0;
         params.mnd_wsc = 0.0;
         params.chr_wsc = 0.0;
     local damage = BluePhysicalSpell(caster, target, spell, params);
     damage = BlueFinalAdjustments(caster, target, spell, damage, params);
 
     if (resist > 0.25) then -- This line may need adjusting for retail accuracy.
-        target:addStatusEffect(EFFECT_STUN, 1, 0, 5 * resist);
+        target:addStatusEffect(EFFECT_STUN, 1, 0, 20 * resist); -- Wiki says duration of "up to" 20 second..
     end
 
     return damage;

--- a/scripts/globals/spells/bluemagic/tail_slap.lua
+++ b/scripts/globals/spells/bluemagic/tail_slap.lua
@@ -12,10 +12,9 @@
 -- Skillchain Element: Water (can open Impaction and Induration; can close Reverberation and Fragmentation)
 -- Combos: Store TP
 -----------------------------------------
-
-require("scripts/globals/magic");
-require("scripts/globals/status");
 require("scripts/globals/bluemagic");
+require("scripts/globals/status");
+require("scripts/globals/magic");
 
 -----------------------------------------
 -- OnMagicCastingCheck
@@ -30,7 +29,8 @@ end;
 -----------------------------------------
 
 function onSpellCast(caster,target,spell)
-
+    local dINT = caster:getStat(MOD_INT) - target:getStat(MOD_INT);
+    local resist = applyResistanceEffect(caster,spell,target,dINT,SKILL_BLU,0,EFFECT_STUN)
     local params = {};
     -- This data should match information on http://wiki.ffxiclopedia.org/wiki/Calculating_Blue_Magic_Damage
         params.tpmod = TPMOD_ATTACK;
@@ -49,8 +49,12 @@ function onSpellCast(caster,target,spell)
         params.int_wsc = 0.0;
         params.mnd_wsc = 0.0;
         params.chr_wsc = 0.0;
-    damage = BluePhysicalSpell(caster, target, spell, params);
+    local damage = BluePhysicalSpell(caster, target, spell, params);
     damage = BlueFinalAdjustments(caster, target, spell, damage, params);
+
+    if (resist > 0.5) then -- This line may need adjusting for retail accuracy.
+        target:addStatusEffect(EFFECT_STUN, 1, 0, 5 * resist); -- pre-resist duration needs confirmed/adjusted
+    end
 
     return damage;
 end;


### PR DESCRIPTION
Add sudden lunge, add missing stun effect to frypan and tail slap, get rid of potential client crash in head butt

Durations might be off, I erred on the side of being short if data wasn't available (copied head butt duration unless wiki gave me actual duration info).

The stuns don't overwrite, so we don't need to check if the target already has stun effect here.

The crashy message thing has apparently existed since c2d47b3e03308d9d50f0c0bd93b6a8957cda9518 back in the SVN patchfile days. The problem was that it was returning damage values into a message that expected an effect ID, and per discussion with @MalRD in IRC that should never have even been there.