### PR TITLE
Scripts/SQL: Fix Nidhogg not using "super buff"

### DIFF
--- a/scripts/globals/mobskills/Super_Buff.lua
+++ b/scripts/globals/mobskills/Super_Buff.lua
@@ -10,7 +10,7 @@ require("scripts/globals/monstertpmoves");
 ---------------------------------------------------
 
 function onMobSkillCheck(target,mob,skill)
-    return 1;
+    return 0;
 end;
 
 function onMobWeaponSkill(target, mob, skill)

--- a/sql/mob_skill_lists.sql
+++ b/sql/mob_skill_lists.sql
@@ -1123,7 +1123,6 @@ INSERT INTO `mob_skill_lists` VALUES ('NidhoggWyrm',263,952);
 INSERT INTO `mob_skill_lists` VALUES ('NidhoggWyrm',263,953);
 INSERT INTO `mob_skill_lists` VALUES ('NidhoggWyrm',263,957);
 INSERT INTO `mob_skill_lists` VALUES ('NidhoggWyrm',263,1046);
-INSERT INTO `mob_skill_lists` VALUES ('NidhoggWyrm',263,956);
 INSERT INTO `mob_skill_lists` VALUES ('SimorgWyvern',265,813);
 INSERT INTO `mob_skill_lists` VALUES ('SimorgWyvern',265,814);
 INSERT INTO `mob_skill_lists` VALUES ('SimorgWyvern',265,815);


### PR DESCRIPTION
Made the onMobSkillCheck return 0, and removed the skill from its mobskill list so it doesn't use it whenever. Since forced mobskills don't need to be in the list, and they still do the onMobSkillCheck.