### PR TITLE
HAAAALLLLVVVEEEERRRRR!

### DIFF
--- a/scripts/zones/Chateau_dOraguille/npcs/Halver.lua
+++ b/scripts/zones/Chateau_dOraguille/npcs/Halver.lua
@@ -1,6 +1,6 @@
 -----------------------------------
 -- Area: Chateau d'Oraguille
--- NPC:  Halver
+--  NPC: Halver
 -- Involved in Mission 2-3, 3-3, 5-1, 5-2, 8-1
 -- Involved in Quest: Lure of the Wildcat (San d'Oria)
 -- @pos 2 0.1 0.1 233
@@ -184,7 +184,7 @@ function onEventFinish(player,csid,option)
         player:setVar("MissionStatus",9);
     elseif (csid == 546) then
         player:setVar("MissionStatus",1);
-    elseif (csid == 507 or 548 or 533 or 534) then
+    elseif (csid == 507 or csid == 533 or csid == 534 or csid == 548) then
         finishMissionTimeline(player,3,csid,option);
     elseif (csid == 25) then
         player:setVar("MissionStatus",1);


### PR DESCRIPTION
@teschnei I can't locate the issue but there was one where I questioned this type of logic being used, and you told me it was both legit and preferred. I'm now wondering if that only works for variable declarations or if our specific implementation we use just doesn't like it. My google fu only turns up examples where its used in a local variable declaration and nothing else, so I'm thinking that's why it doesn't work here.

@xdemolish thanks for the assist