### PR TITLE
Core: Remove forced 1 exp if in alliance outside of Dynamis

### DIFF
--- a/src/map/utils/charutils.cpp
+++ b/src/map/utils/charutils.cpp
@@ -3303,12 +3303,7 @@ namespace charutils
                             PMember->PTreasurePool->AddItem(4095 + PMob->m_Element, PMob);
                         }
                     }
-                    if (PMember->PParty != nullptr && PMember->PParty->m_PAlliance != nullptr && PMob->m_Type == MOBTYPE_NORMAL)
-                    {
-                        if ((Pzone > 38 && Pzone < 43) || (Pzone > 133 && Pzone < 136) || (Pzone > 184 && Pzone < 189)) charutils::AddExperiencePoints(false, PMember, PMob, exp, 1, false);
-                        else charutils::AddExperiencePoints(false, PMember, PMob, 1, 1, false);
-                    }
-                    else charutils::AddExperiencePoints(false, PMember, PMob, exp, baseexp, chainactive);
+                    charutils::AddExperiencePoints(false, PMember, PMob, exp, baseexp, chainactive);
                 }
             }
         });


### PR DESCRIPTION
Fixes https://github.com/DarkstarProject/darkstar/issues/2429

Alliance EXP split was fixed a while ago here: https://github.com/DarkstarProject/darkstar/pull/2337

So there's no need to keep this penalty around. Also alliances are supposed to be able to build exp chains so that entire check is no longer necessary.