### PR TITLE
Core/Scripts: Implement the rest of the Innin/Yonin directional checks

### DIFF
--- a/scripts/globals/effects/innin.lua
+++ b/scripts/globals/effects/innin.lua
@@ -9,10 +9,8 @@ require("scripts/globals/status");
 -----------------------------------
 
 function onEffectGain(target,effect) --power=30 initially, subpower=20 for enmity
-    target:addMod(MOD_ACC,effect:getPower());
     target:addMod(MOD_EVA,-effect:getPower());
     target:addMod(MOD_ENMITY,-effect:getSubPower());
-    target:addMod(MOD_CRITHITRATE,effect:getPower());
 end;
 
 -----------------------------------
@@ -22,9 +20,7 @@ end;
 function onEffectTick(target,effect)
     --tick down the effect and reduce the overall power
     effect:setPower(effect:getPower()-1);
-    target:delMod(MOD_ACC,1);
     target:delMod(MOD_EVA,-1);
-    target:delMod(MOD_CRITHITRATE,1);
     if (effect:getPower() % 2 == 0) then -- enmity- decays from -20 to -10, so half as often as the rest.
         effect:setSubPower(effect:getSubPower()-1);
         target:delMod(MOD_ENMITY,-1);
@@ -37,8 +33,6 @@ end;
 
 function onEffectLose(target,effect)
     --remove the remaining power
-    target:delMod(MOD_ACC,effect:getPower());
     target:delMod(MOD_EVA,-effect:getPower());
-    target:delMod(MOD_CRITHITRATE,effect:getPower());
     target:delMod(MOD_ENMITY,-effect:getSubPower());
 end;

--- a/scripts/globals/effects/yonin.lua
+++ b/scripts/globals/effects/yonin.lua
@@ -10,7 +10,6 @@ require("scripts/globals/status");
 
 function onEffectGain(target,effect) --power=30 initially, subpower=20 for enmity
     target:addMod(MOD_ACC,-effect:getPower());
-    target:addMod(MOD_EVA,effect:getPower());
     target:addMod(MOD_NINJA_TOOL,effect:getPower());
     target:addMod(MOD_ENMITY,effect:getSubPower());
 end;
@@ -23,7 +22,6 @@ function onEffectTick(target,effect)
     --tick down the effect and reduce the overall power
     effect:setPower(effect:getPower()-1);
     target:delMod(MOD_ACC,-1);
-    target:delMod(MOD_EVA,1);
     target:delMod(MOD_NINJA_TOOL,1);
     if (effect:getPower() % 2 == 0) then -- enmity+ decays from 20 to 10, so half as often as the rest.
         effect:setSubPower(effect:getSubPower()-1);
@@ -38,7 +36,6 @@ end;
 function onEffectLose(target,effect)
     --remove the remaining power
     target:delMod(MOD_ACC,-effect:getPower());
-    target:delMod(MOD_EVA,effect:getPower());
     target:delMod(MOD_NINJA_TOOL,effect:getPower());
     target:delMod(MOD_ENMITY,effect:getSubPower());
 end;

--- a/scripts/globals/magic.lua
+++ b/scripts/globals/magic.lua
@@ -1130,6 +1130,12 @@ function doDivineNuke(V,M,caster,spell,target,hasMultipleTargetReduction,resistB
 end
 
 function doNinjutsuNuke(V,M,caster,spell,target,hasMultipleTargetReduction,resistBonus,mabBonus)
+    mabBonus = mabBonus or 0;
+
+    mabBonus = mabBonus + caster:getMod(MOD_NIN_NUKE_BONUS); -- "enhances ninjutsu damage" bonus
+    if (caster:hasStatusEffect(EFFECT_INNIN) and caster:isBehind(target, 23)) then -- Innin mag atk bonus from behind, guesstimating angle at 23 degrees
+        mabBonus = mabBonus + caster:getStatusEffect(EFFECT_INNIN):getPower();
+    end
     return doNuke(V,M,caster,spell,target,hasMultipleTargetReduction,resistBonus,NINJUTSU_SKILL,MOD_INT,mabBonus);
 end
 

--- a/scripts/globals/monstertpmoves.lua
+++ b/scripts/globals/monstertpmoves.lua
@@ -125,6 +125,10 @@ function MobPhysicalMove(mob,target,skill,numberofhits,accmod,dmgmod,tpeffect,mt
     local lvltarget = target:getMainLvl();
     local acc = mob:getACC();
     local eva = target:getEVA();
+    if (target:hasStatusEffect(EFFECT_YONIN) and mob:isFacing(target, 23)) then -- Yonin evasion boost if mob is facing target
+        eva = eva + target:getStatusEffect(EFFECT_YONIN):getPower();
+    end
+
     --apply WSC
     local base = mob:getWeaponDmg() + dstr; --todo: change to include WSC
     if (base < 1) then

--- a/scripts/globals/spells/doton_ichi.lua
+++ b/scripts/globals/spells/doton_ichi.lua
@@ -18,11 +18,7 @@ function onSpellCast(caster,target,spell)
     --doNinjutsuNuke(V,M,caster,spell,target,hasMultipleTargetReduction,resistBonus)
     local duration = 15 + caster:getMerit(MERIT_DOTON_EFFECT) -- T1 bonus debuff duration
     local bonusAcc = 0;
-    local bonusMab = caster:getMerit(MERIT_DOTON_EFFECT) + caster:getMod(MOD_NIN_NUKE_BONUS); -- T1 mag atk + "enhances Ninjustu damage" mod
-
-    if (caster:isBehind(target,15) and caster:hasStatusEffect(EFFECT_INNIN)) then -- Innin mag atk bonus from behind, guesstimating angle at 15 degrees
-        bonusMab = bonusMab + caster:getStatusEffect(EFFECT_INNIN):getPower();
-    end
+    local bonusMab = caster:getMerit(MERIT_DOTON_EFFECT); -- T1 mag atk
 
     local dmg = doNinjutsuNuke(28,0.5,caster,spell,target,false,bonusAcc,bonusMab);
     handleNinjutsuDebuff(caster,target,spell,30,duration,MOD_WINDRES);

--- a/scripts/globals/spells/doton_ni.lua
+++ b/scripts/globals/spells/doton_ni.lua
@@ -18,11 +18,7 @@ function onSpellCast(caster,target,spell)
     --doNinjutsuNuke(V,M,caster,spell,target,hasMultipleTargetReduction,resistBonus)
     local duration = 15 + caster:getMerit(MERIT_DOTON_EFFECT) -- T1 bonus debuff duration
     local bonusAcc = 0;
-    local bonusMab = caster:getMerit(MERIT_DOTON_EFFECT) + caster:getMod(MOD_NIN_NUKE_BONUS); -- T1 mag atk + "enhances Ninjustu damage" mod
-
-    if (caster:isBehind(target,15) and caster:hasStatusEffect(EFFECT_INNIN)) then -- Innin mag atk bonus from behind, guesstimating angle at 15 degrees
-        bonusMab = bonusMab + caster:getStatusEffect(EFFECT_INNIN):getPower();
-    end
+    local bonusMab = caster:getMerit(MERIT_DOTON_EFFECT); -- T1 mag atk
 
     local dmg = doNinjutsuNuke(69,1,caster,spell,target,false,bonusAcc,bonusMab);
     handleNinjutsuDebuff(caster,target,spell,30,duration,MOD_WINDRES);

--- a/scripts/globals/spells/doton_san.lua
+++ b/scripts/globals/spells/doton_san.lua
@@ -18,14 +18,11 @@ function onSpellCast(caster,target,spell)
     --doNinjutsuNuke(V,M,caster,spell,target,hasMultipleTargetReduction,resistBonus)
     local duration = 15 + caster:getMerit(MERIT_DOTON_EFFECT) -- T1 bonus debuff duration
     local bonusAcc = 0;
-    local bonusMab = caster:getMerit(MERIT_DOTON_EFFECT) + caster:getMod(MOD_NIN_NUKE_BONUS); -- T1 mag atk + "enhances Ninjustu damage" mod
+    local bonusMab = caster:getMerit(MERIT_DOTON_EFFECT); -- T1 mag atk 
 
     if(caster:getMerit(MERIT_DOTON_SAN) ~= 0) then -- T2 mag atk/mag acc, don't want to give a penalty to entities that can cast this without merits
         bonusMab = bonusMab + caster:getMerit(MERIT_DOTON_SAN) - 5; -- merit gives 5 power but no bonus with one invest, thus subtract 5
         bonusAcc = bonusAcc + caster:getMerit(MERIT_DOTON_SAN) - 5;
-    end;
-    if (caster:isBehind(target,15) and caster:hasStatusEffect(EFFECT_INNIN)) then -- Innin mag atk bonus from behind, guesstimating angle at 15 degrees
-        bonusMab = bonusMab + caster:getStatusEffect(EFFECT_INNIN):getPower();
     end
 
     local dmg = doNinjutsuNuke(134,1.5,caster,spell,target,false,bonusAcc,bonusMab);

--- a/scripts/globals/spells/huton_ichi.lua
+++ b/scripts/globals/spells/huton_ichi.lua
@@ -18,11 +18,7 @@ function onSpellCast(caster,target,spell)
     --doNinjutsuNuke(V,M,caster,spell,target,hasMultipleTargetReduction,resistBonus)
     local duration = 15 + caster:getMerit(MERIT_HUTON_EFFECT) -- T1 bonus debuff duration
     local bonusAcc = 0;
-    local bonusMab = caster:getMerit(MERIT_HUTON_EFFECT) + caster:getMod(MOD_NIN_NUKE_BONUS); -- T1 mag atk + "enhances Ninjustu damage" mod
-
-    if (caster:isBehind(target,15) and caster:hasStatusEffect(EFFECT_INNIN)) then -- Innin mag atk bonus from behind, guesstimating angle at 15 degrees
-        bonusMab = bonusMab + caster:getStatusEffect(EFFECT_INNIN):getPower();
-    end
+    local bonusMab = caster:getMerit(MERIT_HUTON_EFFECT); -- T1 mag atk
 
     local dmg = doNinjutsuNuke(28,0.5,caster,spell,target,false,bonusAcc,bonusMab);
     handleNinjutsuDebuff(caster,target,spell,30,duration,MOD_ICERES);

--- a/scripts/globals/spells/huton_ni.lua
+++ b/scripts/globals/spells/huton_ni.lua
@@ -18,11 +18,7 @@ function onSpellCast(caster,target,spell)
     --doNinjutsuNuke(V,M,caster,spell,target,hasMultipleTargetReduction,resistBonus)
     local duration = 15 + caster:getMerit(MERIT_HUTON_EFFECT) -- T1 bonus debuff duration
     local bonusAcc = 0;
-    local bonusMab = caster:getMerit(MERIT_HUTON_EFFECT) + caster:getMod(MOD_NIN_NUKE_BONUS); -- T1 mag atk + "enhances Ninjustu damage" mod
-
-    if (caster:isBehind(target,15) and caster:hasStatusEffect(EFFECT_INNIN)) then -- Innin mag atk bonus from behind, guesstimating angle at 15 degrees
-        bonusMab = bonusMab + caster:getStatusEffect(EFFECT_INNIN):getPower();
-    end
+    local bonusMab = caster:getMerit(MERIT_HUTON_EFFECT); -- T1 mag atk
 
     local dmg = doNinjutsuNuke(69,1,caster,spell,target,false,bonusAcc,bonusMab);
     handleNinjutsuDebuff(caster,target,spell,30,duration,MOD_ICERES);

--- a/scripts/globals/spells/huton_san.lua
+++ b/scripts/globals/spells/huton_san.lua
@@ -18,14 +18,11 @@ function onSpellCast(caster,target,spell)
     --doNinjutsuNuke(V,M,caster,spell,target,hasMultipleTargetReduction,resistBonus)
     local duration = 15 + caster:getMerit(MERIT_HUTON_EFFECT) -- T1 bonus debuff duration
     local bonusAcc = 0;
-    local bonusMab = caster:getMerit(MERIT_HUTON_EFFECT) + caster:getMod(MOD_NIN_NUKE_BONUS); -- T1 mag atk + "enhances Ninjustu damage" mod
+    local bonusMab = caster:getMerit(MERIT_HUTON_EFFECT); -- T1 mag atk
 
     if(caster:getMerit(MERIT_HUTON_SAN) ~= 0) then -- T2 mag atk/mag acc, don't want to give a penalty to entities that can cast this without merits
         bonusMab = bonusMab + caster:getMerit(MERIT_HUTON_SAN) - 5; -- merit gives 5 power but no bonus with one invest, thus subtract 5
         bonusAcc = bonusAcc + caster:getMerit(MERIT_HUTON_SAN) - 5;
-    end;
-    if (caster:isBehind(target,15) and caster:hasStatusEffect(EFFECT_INNIN)) then -- Innin mag atk bonus from behind, guesstimating angle at 15 degrees
-        bonusMab = bonusMab + caster:getStatusEffect(EFFECT_INNIN):getPower();
     end
 
     local dmg = doNinjutsuNuke(134,1.5,caster,spell,target,false,bonusAcc,bonusMab);

--- a/scripts/globals/spells/hyoton_ichi.lua
+++ b/scripts/globals/spells/hyoton_ichi.lua
@@ -18,11 +18,7 @@ function onSpellCast(caster,target,spell)
     --doNinjutsuNuke(V,M,caster,spell,target,hasMultipleTargetReduction,resistBonus)
     local duration = 15 + caster:getMerit(MERIT_HYOTON_EFFECT) -- T1 bonus debuff duration
     local bonusAcc = 0;
-    local bonusMab = caster:getMerit(MERIT_HYOTON_EFFECT) + caster:getMod(MOD_NIN_NUKE_BONUS); -- T1 mag atk + "enhances Ninjustu damage" mod
-
-    if (caster:isBehind(target,15) and caster:hasStatusEffect(EFFECT_INNIN)) then -- Innin mag atk bonus from behind, guesstimating angle at 15 degrees
-        bonusMab = bonusMab + caster:getStatusEffect(EFFECT_INNIN):getPower();
-    end
+    local bonusMab = caster:getMerit(MERIT_HYOTON_EFFECT); -- T1 mag atk
 
     local dmg = doNinjutsuNuke(28,0.5,caster,spell,target,false,bonusAcc,bonusMab);
     handleNinjutsuDebuff(caster,target,spell,30,duration,MOD_FIRERES);

--- a/scripts/globals/spells/hyoton_ni.lua
+++ b/scripts/globals/spells/hyoton_ni.lua
@@ -18,11 +18,7 @@ function onSpellCast(caster,target,spell)
     --doNinjutsuNuke(V,M,caster,spell,target,hasMultipleTargetReduction,resistBonus)
     local duration = 15 + caster:getMerit(MERIT_HYOTON_EFFECT) -- T1 bonus debuff duration
     local bonusAcc = 0;
-    local bonusMab = caster:getMerit(MERIT_HYOTON_EFFECT) + caster:getMod(MOD_NIN_NUKE_BONUS); -- T1 mag atk + "enhances Ninjustu damage" mod
-
-    if (caster:isBehind(target,15) and caster:hasStatusEffect(EFFECT_INNIN)) then -- Innin mag atk bonus from behind, guesstimating angle at 15 degrees
-        bonusMab = bonusMab + caster:getStatusEffect(EFFECT_INNIN):getPower();
-    end
+    local bonusMab = caster:getMerit(MERIT_HYOTON_EFFECT)-- T1 mag atk
 
     local dmg = doNinjutsuNuke(69,1,caster,spell,target,false,bonusAcc,bonusMab);
     handleNinjutsuDebuff(caster,target,spell,30,duration,MOD_FIRERES);

--- a/scripts/globals/spells/hyoton_san.lua
+++ b/scripts/globals/spells/hyoton_san.lua
@@ -18,14 +18,11 @@ function onSpellCast(caster,target,spell)
     --doNinjutsuNuke(V,M,caster,spell,target,hasMultipleTargetReduction,resistBonus)
     local duration = 15 + caster:getMerit(MERIT_HYOTON_EFFECT) -- T1 bonus debuff duration
     local bonusAcc = 0;
-    local bonusMab = caster:getMerit(MERIT_HYOTON_EFFECT) + caster:getMod(MOD_NIN_NUKE_BONUS); -- T1 mag atk + "enhances Ninjustu damage" mod
+    local bonusMab = caster:getMerit(MERIT_HYOTON_EFFECT); -- T1 mag atk
 
     if(caster:getMerit(MERIT_HYOTON_SAN) ~= 0) then -- T2 mag atk/mag acc, don't want to give a penalty to entities that can cast this without merits
         bonusMab = bonusMab + caster:getMerit(MERIT_HYOTON_SAN) - 5; -- merit gives 5 power but no bonus with one invest, thus subtract 5
         bonusAcc = bonusAcc + caster:getMerit(MERIT_HYOTON_SAN) - 5;
-    end;
-    if (caster:isBehind(target,15) and caster:hasStatusEffect(EFFECT_INNIN)) then -- Innin mag atk bonus from behind, guesstimating angle at 15 degrees
-        bonusMab = bonusMab + caster:getStatusEffect(EFFECT_INNIN):getPower();
     end
 
     local dmg = doNinjutsuNuke(134,1.5,caster,spell,target,false,bonusAcc,bonusMab);

--- a/scripts/globals/spells/katon_ichi.lua
+++ b/scripts/globals/spells/katon_ichi.lua
@@ -18,11 +18,7 @@ function onSpellCast(caster,target,spell)
     --doNinjutsuNuke(V,M,caster,spell,target,hasMultipleTargetReduction,resistBonus)
     local duration = 15 + caster:getMerit(MERIT_KATON_EFFECT) -- T1 bonus debuff duration
     local bonusAcc = 0;
-    local bonusMab = caster:getMerit(MERIT_KATON_EFFECT) + caster:getMod(MOD_NIN_NUKE_BONUS); -- T1 mag atk + "enhances Ninjustu damage" mod
-
-    if (caster:isBehind(target,15) and caster:hasStatusEffect(EFFECT_INNIN)) then -- Innin mag atk bonus from behind, guesstimating angle at 15 degrees
-        bonusMab = bonusMab + caster:getStatusEffect(EFFECT_INNIN):getPower();
-    end
+    local bonusMab = caster:getMerit(MERIT_KATON_EFFECT); -- T1 mag atk
 
     local dmg = doNinjutsuNuke(28,0.5,caster,spell,target,false,bonusAcc,bonusMab);
     handleNinjutsuDebuff(caster,target,spell,30,duration,MOD_WATERRES);

--- a/scripts/globals/spells/katon_ni.lua
+++ b/scripts/globals/spells/katon_ni.lua
@@ -18,11 +18,7 @@ function onSpellCast(caster,target,spell)
     --doNinjutsuNuke(V,M,caster,spell,target,hasMultipleTargetReduction,resistBonus)
     local duration = 15 + caster:getMerit(MERIT_KATON_EFFECT) -- T1 bonus debuff duration
     local bonusAcc = 0;
-    local bonusMab = caster:getMerit(MERIT_KATON_EFFECT) + caster:getMod(MOD_NIN_NUKE_BONUS); -- T1 mag atk + "enhances Ninjustu damage" mod
-
-    if (caster:isBehind(target,15) and caster:hasStatusEffect(EFFECT_INNIN)) then -- Innin mag atk bonus from behind, guesstimating angle at 15 degrees
-        bonusMab = bonusMab + caster:getStatusEffect(EFFECT_INNIN):getPower();
-    end
+    local bonusMab = caster:getMerit(MERIT_KATON_EFFECT); -- T1 mag atk
 
     local dmg = doNinjutsuNuke(69,1,caster,spell,target,false,bonusAcc,bonusMab);
     handleNinjutsuDebuff(caster,target,spell,30,duration,MOD_WATERRES);

--- a/scripts/globals/spells/katon_san.lua
+++ b/scripts/globals/spells/katon_san.lua
@@ -18,14 +18,11 @@ function onSpellCast(caster,target,spell)
     --doNinjutsuNuke(V,M,caster,spell,target,hasMultipleTargetReduction,resistBonus)
     local duration = 15 + caster:getMerit(MERIT_KATON_EFFECT) -- T1 bonus debuff duration
     local bonusAcc = 0;
-    local bonusMab = caster:getMerit(MERIT_KATON_EFFECT) + caster:getMod(MOD_NIN_NUKE_BONUS); -- T1 mag atk + "enhances Ninjustu damage" mod
+    local bonusMab = caster:getMerit(MERIT_KATON_EFFECT); -- T1 mag atk
 
     if(caster:getMerit(MERIT_KATON_SAN) ~= 0) then -- T2 mag atk/mag acc, don't want to give a penalty to entities that can cast this without merits
         bonusMab = bonusMab + caster:getMerit(MERIT_KATON_SAN) - 5; -- merit gives 5 power but no bonus with one invest, thus subtract 5
         bonusAcc = bonusAcc + caster:getMerit(MERIT_KATON_SAN) - 5;
-    end;
-    if (caster:isBehind(target,15) and caster:hasStatusEffect(EFFECT_INNIN)) then -- Innin mag atk bonus from behind, guesstimating angle at 15 degrees
-        bonusMab = bonusMab + caster:getStatusEffect(EFFECT_INNIN):getPower();
     end
 
     local dmg = doNinjutsuNuke(134,1.5,caster,spell,target,false,bonusAcc,bonusMab);

--- a/scripts/globals/spells/raiton_ichi.lua
+++ b/scripts/globals/spells/raiton_ichi.lua
@@ -18,11 +18,7 @@ function onSpellCast(caster,target,spell)
     --doNinjutsuNuke(V,M,caster,spell,target,hasMultipleTargetReduction,resistBonus)
     local duration = 15 + caster:getMerit(MERIT_RAITON_EFFECT) -- T1 bonus debuff duration
     local bonusAcc = 0;
-    local bonusMab = caster:getMerit(MERIT_RAITON_EFFECT) + caster:getMod(MOD_NIN_NUKE_BONUS); -- T1 mag atk + "enhances Ninjustu damage" mod
-
-    if (caster:isBehind(target,15) and caster:hasStatusEffect(EFFECT_INNIN)) then -- Innin mag atk bonus from behind, guesstimating angle at 15 degrees
-        bonusMab = bonusMab + caster:getStatusEffect(EFFECT_INNIN):getPower();
-    end
+    local bonusMab = caster:getMerit(MERIT_RAITON_EFFECT); -- T1 mag atk
 
     local dmg = doNinjutsuNuke(28,0.5,caster,spell,target,false,bonusAcc,bonusMab);
     handleNinjutsuDebuff(caster,target,spell,30,duration,MOD_EARTHRES);

--- a/scripts/globals/spells/raiton_ni.lua
+++ b/scripts/globals/spells/raiton_ni.lua
@@ -18,11 +18,7 @@ function onSpellCast(caster,target,spell)
     --doNinjutsuNuke(V,M,caster,spell,target,hasMultipleTargetReduction,resistBonus)
     local duration = 15 + caster:getMerit(MERIT_RAITON_EFFECT) -- T1 bonus debuff duration
     local bonusAcc = 0;
-    local bonusMab = caster:getMerit(MERIT_RAITON_EFFECT) + caster:getMod(MOD_NIN_NUKE_BONUS); -- T1 mag atk + "enhances Ninjustu damage" mod
-
-    if (caster:isBehind(target,15) and caster:hasStatusEffect(EFFECT_INNIN)) then -- Innin mag atk bonus from behind, guesstimating angle at 15 degrees
-        bonusMab = bonusMab + caster:getStatusEffect(EFFECT_INNIN):getPower();
-    end
+    local bonusMab = caster:getMerit(MERIT_RAITON_EFFECT); -- T1 mag atk
 
     local dmg = doNinjutsuNuke(69,1,caster,spell,target,false,bonusAcc,bonusMab);
     handleNinjutsuDebuff(caster,target,spell,30,duration,MOD_EARTHRES);

--- a/scripts/globals/spells/raiton_san.lua
+++ b/scripts/globals/spells/raiton_san.lua
@@ -18,14 +18,11 @@ function onSpellCast(caster,target,spell)
     --doNinjutsuNuke(V,M,caster,spell,target,hasMultipleTargetReduction,resistBonus)
     local duration = 15 + caster:getMerit(MERIT_RAITON_EFFECT) -- T1 bonus debuff duration
     local bonusAcc = 0;
-    local bonusMab = caster:getMerit(MERIT_RAITON_EFFECT) + caster:getMod(MOD_NIN_NUKE_BONUS); -- T1 mag atk + "enhances Ninjustu damage" mod
+    local bonusMab = caster:getMerit(MERIT_RAITON_EFFECT); -- T1 mag atk
 
     if(caster:getMerit(MERIT_RAITON_SAN) ~= 0) then -- T2 mag atk/mag acc, don't want to give a penalty to entities that can cast this without merits
         bonusMab = bonusMab + caster:getMerit(MERIT_RAITON_SAN) - 5; -- merit gives 5 power but no bonus with one invest, thus subtract 5
         bonusAcc = bonusAcc + caster:getMerit(MERIT_RAITON_SAN) - 5;
-    end;
-    if (caster:isBehind(target,15) and caster:hasStatusEffect(EFFECT_INNIN)) then -- Innin mag atk bonus from behind, guesstimating angle at 15 degrees
-        bonusMab = bonusMab + caster:getStatusEffect(EFFECT_INNIN):getPower();
     end
 
     local dmg = doNinjutsuNuke(134,1.5,caster,spell,target,false,bonusAcc,bonusMab);

--- a/scripts/globals/spells/suiton_ichi.lua
+++ b/scripts/globals/spells/suiton_ichi.lua
@@ -18,11 +18,7 @@ function onSpellCast(caster,target,spell)
     --doNinjutsuNuke(V,M,caster,spell,target,hasMultipleTargetReduction,resistBonus)
     local duration = 15 + caster:getMerit(MERIT_SUITON_EFFECT) -- T1 bonus debuff duration
     local bonusAcc = 0;
-    local bonusMab = caster:getMerit(MERIT_SUITON_EFFECT) + caster:getMod(MOD_NIN_NUKE_BONUS); -- T1 mag atk + "enhances Ninjustu damage" mod
-
-    if (caster:isBehind(target,15) and caster:hasStatusEffect(EFFECT_INNIN)) then -- Innin mag atk bonus from behind, guesstimating angle at 15 degrees
-        bonusMab = bonusMab + caster:getStatusEffect(EFFECT_INNIN):getPower();
-    end
+    local bonusMab = caster:getMerit(MERIT_SUITON_EFFECT); -- T1 mag atk
 
     local dmg = doNinjutsuNuke(28,0.5,caster,spell,target,false,bonusAcc,bonusMab);
     handleNinjutsuDebuff(caster,target,spell,30,duration,MOD_THUNDERRES);

--- a/scripts/globals/spells/suiton_ni.lua
+++ b/scripts/globals/spells/suiton_ni.lua
@@ -18,11 +18,7 @@ function onSpellCast(caster,target,spell)
     --doNinjutsuNuke(V,M,caster,spell,target,hasMultipleTargetReduction,resistBonus)
     local duration = 15 + caster:getMerit(MERIT_SUITON_EFFECT) -- T1 bonus debuff duration
     local bonusAcc = 0;
-    local bonusMab = caster:getMerit(MERIT_SUITON_EFFECT) + caster:getMod(MOD_NIN_NUKE_BONUS); -- T1 mag atk + "enhances Ninjustu damage" mod
-
-    if (caster:isBehind(target,15) and caster:hasStatusEffect(EFFECT_INNIN)) then -- Innin mag atk bonus from behind, guesstimating angle at 15 degrees
-        bonusMab = bonusMab + caster:getStatusEffect(EFFECT_INNIN):getPower();
-    end
+    local bonusMab = caster:getMerit(MERIT_SUITON_EFFECT); -- T1 mag atk
 
     local dmg = doNinjutsuNuke(69,1,caster,spell,target,false,bonusAcc,bonusMab);
     handleNinjutsuDebuff(caster,target,spell,30,duration,MOD_THUNDERRES);

--- a/scripts/globals/spells/suiton_san.lua
+++ b/scripts/globals/spells/suiton_san.lua
@@ -18,14 +18,11 @@ function onSpellCast(caster,target,spell)
     --doNinjutsuNuke(V,M,caster,spell,target,hasMultipleTargetReduction,resistBonus)
     local duration = 15 + caster:getMerit(MERIT_SUITON_EFFECT) -- T1 bonus debuff duration
     local bonusAcc = 0;
-    local bonusMab = caster:getMerit(MERIT_SUITON_EFFECT) + caster:getMod(MOD_NIN_NUKE_BONUS); -- T1 mag atk + "enhances Ninjustu damage" mod
+    local bonusMab = caster:getMerit(MERIT_SUITON_EFFECT); -- T1 mag atk
 
     if(caster:getMerit(MERIT_SUITON_SAN) ~= 0) then -- T2 mag atk/mag acc, don't want to give a penalty to entities that can cast this without merits
         bonusMab = bonusMab + caster:getMerit(MERIT_SUITON_SAN) - 5; -- merit gives 5 power but no bonus with one invest, thus subtract 5
         bonusAcc = bonusAcc + caster:getMerit(MERIT_SUITON_SAN) - 5;
-    end;
-    if (caster:isBehind(target,15) and caster:hasStatusEffect(EFFECT_INNIN)) then -- Innin mag atk bonus from behind, guesstimating angle at 15 degrees
-        bonusMab = bonusMab + caster:getStatusEffect(EFFECT_INNIN):getPower();
     end
 
     local dmg = doNinjutsuNuke(134,1.5,caster,spell,target,false,bonusAcc,bonusMab);

--- a/src/map/lua/lua_baseentity.cpp
+++ b/src/map/lua/lua_baseentity.cpp
@@ -8209,11 +8209,8 @@ inline int32 CLuaBaseEntity::isBehind(lua_State *L)
     DSP_DEBUG_BREAK_IF(lua_isnil(L, 1) || !lua_isuserdata(L, 1));
 
     CLuaBaseEntity* PLuaBaseEntity = Lunar<CLuaBaseEntity>::check(L, 1);
-    uint8 angle = 42;
-    if (lua_gettop(L) > 1)
-    {
-        angle = lua_tonumber(L, 2);
-    }
+
+    uint8 angle = lua_gettop(L) > 1 ? lua_tointeger(L, 2) : 42;
 
     uint8 turn = PLuaBaseEntity->GetBaseEntity()->loc.p.rotation - getangle(PLuaBaseEntity->GetBaseEntity()->loc.p, m_PBaseEntity->loc.p);
 
@@ -8235,9 +8232,11 @@ inline int32 CLuaBaseEntity::isFacing(lua_State *L)
 
     CLuaBaseEntity* PLuaBaseEntity = Lunar<CLuaBaseEntity>::check(L, 1);
 
+    uint8 angle = lua_gettop(L) > 1 ? lua_tointeger(L, 2) : 45;
+
     DSP_DEBUG_BREAK_IF(PLuaBaseEntity == nullptr);
 
-    lua_pushboolean(L, isFaceing(m_PBaseEntity->loc.p, PLuaBaseEntity->GetBaseEntity()->loc.p, 45));
+    lua_pushboolean(L, isFaceing(m_PBaseEntity->loc.p, PLuaBaseEntity->GetBaseEntity()->loc.p, angle));
     return 1;
 }
 

--- a/src/map/utils/battleutils.h
+++ b/src/map/utils/battleutils.h
@@ -138,10 +138,10 @@ namespace battleutils
     bool			IsIntimidated(CBattleEntity* PAttacker, CBattleEntity* PDefender);
 
     int32				GetFSTR(CBattleEntity* PAttacker, CBattleEntity* PDefender, uint8 SlotID);
-    uint8				GetHitRateEx(CBattleEntity* PAttacker, CBattleEntity* PDefender, uint8 attackNumber, uint8 offsetAccuracy);
+    uint8				GetHitRateEx(CBattleEntity* PAttacker, CBattleEntity* PDefender, uint8 attackNumber, int8 offsetAccuracy);
     uint8				GetHitRate(CBattleEntity* PAttacker, CBattleEntity* PDefender);
     uint8				GetHitRate(CBattleEntity* PAttacker, CBattleEntity* PDefender, uint8 attackNumber);
-    uint8				GetHitRate(CBattleEntity* PAttacker, CBattleEntity* PDefender, uint8 attackNumber, uint8 offsetAccuracy);
+    uint8				GetHitRate(CBattleEntity* PAttacker, CBattleEntity* PDefender, uint8 attackNumber, int8 offsetAccuracy);
     uint8				GetCritHitRate(CBattleEntity* PAttacker, CBattleEntity* PDefender, bool ignoreSneakTrickAttack);
     uint8				GetBlockRate(CBattleEntity* PAttacker, CBattleEntity* PDefender);
     uint8				GetParryRate(CBattleEntity* PAttacker, CBattleEntity* PDefender);


### PR DESCRIPTION
-Crit hit bonus/acc bonus from behind with Innin, Enemy crit hit reduction/evasion bonus while in front with Yonin. Note the Enemy crit hit rate bonus was previously missing. Using 23 degrees to match Sneak Attack (seems reasonable). Affects standard melee attacks, physical weaponskills (and ranged for the evasion bonus), and physical mobskills. Note that mobskills can't crit currently...
-Moved the Innin damage bonus to Ninjutsu magic from the individual spell script into doNinjutsuNuke, and changed the angle from 15 to 23.
-Added optional parameter for angle to the isFacing lua binding.
-Changed offsetAccuracy in getHitRateEx from uint8 to int8 to prevent underflow, fixes a bug with Closed Position as well.
-Added enemy crit hit rate merit reduction into weaponskills.lua since there are a handful of mobskills that use it. Also added the entire crit hit rate mod + crit hit rate merits - enemy crit hit rate merits into ranged weaponskill crit hit rate calculation.