### PR TITLE
Phalanx II and NORMAL_MOB_MAX_LEVEL_RANGE corrections

### DIFF
--- a/scripts/globals/spells/phalanx_ii.lua
+++ b/scripts/globals/spells/phalanx_ii.lua
@@ -28,10 +28,6 @@ function onSpellCast(caster,target,spell)
 
     final = (enhskill / 25) + merits + 1;
 
-    if (final>35) then
-        final = 35;
-    end
-
     if (target:addStatusEffect(EFFECT_PHALANX,final,0,duration)) then
         spell:setMsg(230);
     else

--- a/src/map/utils/zoneutils.cpp
+++ b/src/map/utils/zoneutils.cpp
@@ -461,12 +461,12 @@ void LoadMOBList()
                 PMob->m_flags = (uint32)Sql_GetIntData(SqlHandle, 51);
 
                 // Cap Level if Necessary (Don't Cap NMs)
-                if (normalLevelRangeMin > 0 && PMob->m_Type != MOBTYPE_NOTORIOUS && PMob->m_minLevel > normalLevelRangeMin)
+                if (normalLevelRangeMin > 0 && !(PMob->m_Type & MOBTYPE_NOTORIOUS) && PMob->m_minLevel > normalLevelRangeMin)
                 {
                     PMob->m_minLevel = normalLevelRangeMin;
                 }
 
-                if (normalLevelRangeMax > 0 && PMob->m_Type != MOBTYPE_NOTORIOUS && PMob->m_maxLevel > normalLevelRangeMax)
+                if (normalLevelRangeMax > 0 && !(PMob->m_Type & MOBTYPE_NOTORIOUS) && PMob->m_maxLevel > normalLevelRangeMax)
                 {
                     PMob->m_maxLevel = normalLevelRangeMax;
                 }


### PR DESCRIPTION
1) Phalanx II should have a hard cap.  The following link illustrates the skill necessary to pass 35 damage absorbed.
http://ffxiclopedia.wikia.com/wiki/Phalanx_II

2) NORMAL_MOB_MAX_LEVEL_RANGE_MIN and NORMAL_MOB_MAX_LEVEL_RANGE_MAX are not applied correctly