### PR TITLE
Core: Fix BLM T1 merit fetching

### DIFF
--- a/src/map/merit.cpp
+++ b/src/map/merit.cpp
@@ -465,7 +465,7 @@ int32 CMeritPoints::GetMeritValue(MERIT_TYPE merit, CCharEntity* PChar)
         if (PMerit->catid < 5 || (PMerit->jobs & (1 << (PChar->GetMJob() - 1)) && PChar->GetMLevel() >= 75))
             meritValue = dsp_min(PMerit->count, cap[PChar->GetMLevel()]);
 
-        if (PMerit->catid == 8 && PChar->GetMLevel() < 96)
+        if (PMerit->catid == 25 && PChar->GetMLevel() < 96) // categoryID 25 is for merit weaponskills, which only apply if the player is lv 96+
             meritValue = 0;
 
         meritValue *= PMerit->value;


### PR DESCRIPTION
The check to disable merit WS merits below level 96 was using the wrong category ID. Fixes https://github.com/DarkstarProject/darkstar/issues/2311