### PR TITLE
Stop Jailers of Prudence, Hope, Justice, and Love from instantly despawning the second they go unclaimed.

### DIFF
--- a/scripts/zones/AlTaieu/mobs/Jailer_of_Prudence.lua
+++ b/scripts/zones/AlTaieu/mobs/Jailer_of_Prudence.lua
@@ -1,13 +1,12 @@
 -----------------------------------
 -- Area: Al'Taieu
--- NM:  Jailer of Prudence
+--  NM:  Jailer of Prudence
 -- IDs: 16912846, 16912847
 -- AnimationSubs: 0 - Normal, 3 - Mouth Open
 -- Wiki: http://ffxiclopedia.wikia.com/wiki/Jailer_of_Prudence
 -----------------------------------
-
-require("scripts/globals/status");
 require("scripts/zones/AlTaieu/mobIDs");
+require("scripts/globals/status");
 
 -----------------------------------
 -- onMobInitialize Action
@@ -77,6 +76,13 @@ end;
 -----------------------------------
 
 function onMobDeath(mob, player, isKiller)
+end;
+
+-----------------------------------
+-- onMobDespawn
+-----------------------------------
+
+function onMobDespawn(mob)
     local firstPrudence     = GetMobByID(PrudenceOne);
     local secondPrudence    = GetMobByID(PrudenceTwo);
     if (mob:getID() == PrudenceOne) then

--- a/scripts/zones/AlTaieu/npcs/qm1.lua
+++ b/scripts/zones/AlTaieu/npcs/qm1.lua
@@ -1,12 +1,11 @@
 -----------------------------------
 -- Area: Al'Taieu
--- NPC:  ??? (Jailer of Hope Spawn)
+--  NPC: ??? (Jailer of Hope Spawn)
 -- Allows players to spawn the Jailer of Hope by trading the First Virtue, Deed of Placidity and HQ Phuabo Organ to a ???.
 -- @pos -693 -1 -62 33
 -----------------------------------
 package.loaded["scripts/zones/AlTaieu/TextIDs"] = nil;
 -----------------------------------
-
 require("scripts/zones/AlTaieu/TextIDs");
 
 -----------------------------------
@@ -14,11 +13,10 @@ require("scripts/zones/AlTaieu/TextIDs");
 -----------------------------------
 
 function onTrade(player,npc,trade)
-
     -- Trade the First Virtue, Deed of Placidity and HQ Phuabo Organ
     if (GetMobAction(16912838) == 0 and trade:hasItemQty(1850,1) and trade:hasItemQty(1851,1) and trade:hasItemQty(1852,1) and trade:getItemCount() == 3) then
         player:tradeComplete();
-        SpawnMob(16912838,900):updateClaim(player); -- Spawn Jailer of Hope
+        SpawnMob(16912838):updateClaim(player); -- Spawn Jailer of Hope
     end
 end; 
 
@@ -34,15 +32,15 @@ end;
 -----------------------------------
 
 function onEventUpdate(player,csid,option)
---printf("onUpdate CSID: %u",csid);
---printf("onUpdate RESULT: %u",option);
+    -- printf("onUpdate CSID: %u",csid);
+    -- printf("onUpdate RESULT: %u",option);
 end;
 
 -----------------------------------
--- onEventFinish Action 
+-- onEventFinish Action
 -----------------------------------
 
 function onEventFinish(player,csid,option)
---printf("onFinish CSID: %u",csid);
---printf("onFinish RESULT: %u",option);
+    -- printf("onFinish CSID: %u",csid);
+    -- printf("onFinish RESULT: %u",option);
 end;

--- a/scripts/zones/AlTaieu/npcs/qm2.lua
+++ b/scripts/zones/AlTaieu/npcs/qm2.lua
@@ -1,25 +1,26 @@
 -----------------------------------
 -- Area: Al'Taieu
--- NPC:  ??? (Jailer of Justice Spawn)
+--  NPC: ??? (Jailer of Justice Spawn)
 -- Allows players to spawn the Jailer of Justice by trading the Second Virtue, Deed of Moderation, and HQ Xzomit Organ to a ???.
 -- @pos , -278 0 -463
 -----------------------------------
 package.loaded["scripts/zones/AlTaieu/TextIDs"] = nil;
 -----------------------------------
-
 require("scripts/zones/AlTaieu/TextIDs");
 
 -----------------------------------
 -- onTrade Action
 -----------------------------------
 
-function onTrade(player,npc,trade)  
+function onTrade(player,npc,trade)
+    --[[
     -- Trade the Second Virtue, Deed of Moderation, and HQ Xzomit Organ
-    --[[if (GetMobAction(16912839) == 0 and trade:hasItemQty(1853,1) and trade:hasItemQty(1854,1) and trade:hasItemQty(1785,1) and
+    if (GetMobAction(16912839) == 0 and trade:hasItemQty(1853,1) and trade:hasItemQty(1854,1) and trade:hasItemQty(1785,1) and
     trade:getItemCount() == 3) then
         player:tradeComplete();
-        SpawnMob(16912839,900):updateClaim(player); -- Spawn Jailer of Justice
-    end]]
+        SpawnMob(16912839):updateClaim(player); -- Spawn Jailer of Justice
+    end
+    ]]
 end; 
 
 -----------------------------------
@@ -34,15 +35,15 @@ end;
 -----------------------------------
 
 function onEventUpdate(player,csid,option)
---printf("onUpdate CSID: %u",csid);
---printf("onUpdate RESULT: %u",option);
+    -- printf("onUpdate CSID: %u",csid);
+    -- printf("onUpdate RESULT: %u",option);
 end;
 
 -----------------------------------
--- onEventFinish Action 
+-- onEventFinish Action
 -----------------------------------
 
 function onEventFinish(player,csid,option)
---printf("onFinish CSID: %u",csid);
---printf("onFinish RESULT: %u",option);
+    -- printf("onFinish CSID: %u",csid);
+    -- printf("onFinish RESULT: %u",option);
 end;

--- a/scripts/zones/AlTaieu/npcs/qm3.lua
+++ b/scripts/zones/AlTaieu/npcs/qm3.lua
@@ -1,12 +1,11 @@
 -----------------------------------
 -- Area: Al'Taieu
--- NPC:  ??? (Jailer of Prudence Spawn)
+--  NPC: ??? (Jailer of Prudence Spawn)
 -- Allows players to spawn the Jailer of Prudence by trading the Third Virtue, Deed of Sensibility, and High-Quality Hpemde Organ to a ???.
--- @pos , 706 -1 22 
+-- @pos , 706 -1 22
 -----------------------------------
 package.loaded["scripts/zones/AlTaieu/TextIDs"] = nil;
 -----------------------------------
-
 require("scripts/zones/AlTaieu/TextIDs");
 require("scripts/zones/AlTaieu/mobIDs");
 
@@ -19,8 +18,8 @@ function onTrade(player,npc,trade)
     if (GetMobAction(16912846) == 0 and GetMobAction(16912847) == 0 and trade:hasItemQty(1856,1) and trade:hasItemQty(1870,1) and 
     trade:hasItemQty(1871,1) and trade:getItemCount() == 3) then
         player:tradeComplete();
-        SpawnMob(PrudenceOne,900):updateClaim(player); -- Spawn Jailer of Prudence 1
-        SpawnMob(PrudenceTwo,900);                     -- Spawn Jailer of Prudence 2 unclaimed
+        SpawnMob(PrudenceOne):updateClaim(player); -- Spawn Jailer of Prudence 1
+        SpawnMob(PrudenceTwo);                     -- Spawn Jailer of Prudence 2 unclaimed
     end
 end; 
 
@@ -36,15 +35,15 @@ end;
 -----------------------------------
 
 function onEventUpdate(player,csid,option)
---printf("onUpdate CSID: %u",csid);
---printf("onUpdate RESULT: %u",option);
+    -- printf("onUpdate CSID: %u",csid);
+    -- printf("onUpdate RESULT: %u",option);
 end;
 
 -----------------------------------
--- onEventFinish Action 
+-- onEventFinish Action
 -----------------------------------
 
 function onEventFinish(player,csid,option)
---printf("onFinish CSID: %u",csid);
---printf("onFinish RESULT: %u",option);
+    -- printf("onFinish CSID: %u",csid);
+    -- printf("onFinish RESULT: %u",option);
 end;

--- a/scripts/zones/AlTaieu/npcs/qm4.lua
+++ b/scripts/zones/AlTaieu/npcs/qm4.lua
@@ -1,29 +1,27 @@
 -----------------------------------
 -- Area: Al'Taieu
--- NPC:  ??? (Jailer of Love and Absolute Virtue Spawn)
+--  NPC: ??? (Jailer of Love and Absolute Virtue Spawn)
 -- Allows players to spawn the Jailer of Love by trading the Fourth Virtue, Fifth Virtue and Sixth Virtue to a ???.
 -- Allows players to spawn Absolute Virtue by killing Jailer of Love.
--- @pos , 431 -0 -603 
+-- @pos , 431 -0 -603
 -----------------------------------
 package.loaded["scripts/zones/AlTaieu/TextIDs"] = nil;
 -----------------------------------
-
 require("scripts/zones/AlTaieu/TextIDs");
-
 
 -----------------------------------
 -- onTrade Action
 -----------------------------------
 
 function onTrade(player,npc,trade)
-    
+    --[[
     -- Trade the Fourth Virtue, Fifth Virtue and Sixth Virtue
-    --[[if (GetMobAction(16912848) == 0 and GetMobAction(16912876) == 0 and trade:hasItemQty(1848,1) and trade:hasItemQty(1847,1) and 
+    if (GetMobAction(16912848) == 0 and GetMobAction(16912876) == 0 and trade:hasItemQty(1848,1) and trade:hasItemQty(1847,1) and 
     trade:hasItemQty(1849,1) and trade:getItemCount() == 3) then
         player:tradeComplete();
-        SpawnMob(16912848,900):updateClaim(player); -- Spawn Jailer of Love
-    end]]
-    
+        SpawnMob(16912848):updateClaim(player); -- Spawn Jailer of Love
+    end
+    ]]
 end; 
 
 -----------------------------------
@@ -38,15 +36,15 @@ end;
 -----------------------------------
 
 function onEventUpdate(player,csid,option)
---printf("onUpdate CSID: %u",csid);
---printf("onUpdate RESULT: %u",option);
+    -- printf("onUpdate CSID: %u",csid);
+    -- printf("onUpdate RESULT: %u",option);
 end;
 
 -----------------------------------
--- onEventFinish Action 
+-- onEventFinish Action
 -----------------------------------
 
 function onEventFinish(player,csid,option)
---printf("onFinish CSID: %u",csid);
---printf("onFinish RESULT: %u",option);
+    -- printf("onFinish CSID: %u",csid);
+    -- printf("onFinish RESULT: %u",option);
 end;

--- a/sql/mob_spawn_mods.sql
+++ b/sql/mob_spawn_mods.sql
@@ -242,6 +242,13 @@ INSERT INTO `mob_spawn_mods` VALUES (17428811,2,5625,1);
 INSERT INTO `mob_spawn_mods` VALUES (16986431,16,1,1); -- Tinnin 2hour
 
 -- Timers for mobs that depop when idle+unclaimed
+-- Sea
+INSERT INTO `mob_spawn_mods` VALUES (16912838,55,300,1);
+INSERT INTO `mob_spawn_mods` VALUES (16912839,55,300,1);
+INSERT INTO `mob_spawn_mods` VALUES (16912846,55,300,1);
+INSERT INTO `mob_spawn_mods` VALUES (16912847,55,300,1);
+INSERT INTO `mob_spawn_mods` VALUES (16912848,55,300,1);
+-- ZNM
 INSERT INTO `mob_spawn_mods` VALUES (16986428,55,180,1);
 INSERT INTO `mob_spawn_mods` VALUES (16986429,55,180,1);
 INSERT INTO `mob_spawn_mods` VALUES (16986430,55,180,1);


### PR DESCRIPTION
Note the comment in Jailer of Prudence's script : I don't have time to research this before I go offline for the weekend, but its no more broken than before I touched it and can easily be adjusted.

If anyone has any input before tomorrow afternoon I can do a quick amend for this if needed.