### PR TITLE
Healing configuration patches

### DIFF
--- a/conf/map_darkstar.conf
+++ b/conf/map_darkstar.conf
@@ -165,6 +165,9 @@ audit_yell: 0
 audit_linkshell: 0
 audit_party: 0
 
+#Seconds between healing ticks. Default is 10
+healing_tick_delay = 10
+
 #Central message server settings (ensure these are the same on both all map servers and the central (lobby) server
 msg_server_port: 54003
 msg_server_ip: 127.0.0.1

--- a/scripts/globals/effects/healing.lua
+++ b/scripts/globals/effects/healing.lua
@@ -6,6 +6,7 @@
 -----------------------------------
 
 require("scripts/globals/status");
+require("scripts/globals/settings");
 
 -----------------------------------
 -- onEffectGain Action
@@ -30,7 +31,7 @@ function onEffectTick(target,effect)
             if (target:getContinentID() == 1 and target:hasStatusEffect(EFFECT_SIGNET)) then
                 healHP = 10+(3*math.floor(target:getMainLvl()/10))+(healtime-2)*(1+math.floor(target:getMaxHP()/300))+(target:getMod(MOD_HPHEAL));
             else
-                target:addTP(-100);
+                target:addTP(HEALING_TP_CHANGE);
                 healHP = 10+(healtime-2)+(target:getMod(MOD_HPHEAL));
             end
 

--- a/scripts/globals/settings.lua
+++ b/scripts/globals/settings.lua
@@ -69,6 +69,8 @@ EXCAVATION_RATE         = 0.50; -- % chance to recieve an item from excavation. 
 LOGGING_RATE            = 0.50; -- % chance to recieve an item from logging.  Set between 0 and 1.
 MINING_RATE             = 50; -- % chance to recieve an item from mining.  Set between 0 and 100. 
 
+HEALING_TP_CHANGE       = -100; -- Change in TP for each healing tick. Default is -100
+
 -- SE implemented coffer/chest illusion time in order to prevent coffer farming. No-one in the same area can open a chest or coffer for loot (gil, gems & items)
 -- till a random time between MIN_ILLSION_TIME and MAX_ILLUSION_TIME. During this time players can loot keyitem and item related to quests (AF, maps... etc.)
 COFFER_MAX_ILLUSION_TIME = 3600;  -- 1 hour

--- a/src/map/ai/controllers/pet_controller.cpp
+++ b/src/map/ai/controllers/pet_controller.cpp
@@ -86,7 +86,7 @@ bool CPetController::PetIsHealing()
     if (isMasterHealing && !isPetHealing && !PPet->StatusEffectContainer->HasPreventActionEffect()) {
         //animation down
         PPet->animation = ANIMATION_HEALING;
-        PPet->StatusEffectContainer->AddStatusEffect(new CStatusEffect(EFFECT_HEALING, 0, 0, 10, 0));
+        PPet->StatusEffectContainer->AddStatusEffect(new CStatusEffect(EFFECT_HEALING, 0, 0, map_config.healing_tick_delay, 0));
         PPet->updatemask |= UPDATE_HP;
         return true;
     }

--- a/src/map/map.cpp
+++ b/src/map/map.cpp
@@ -978,6 +978,7 @@ int32 map_config_default()
     map_config.audit_linkshell = 0;
     map_config.msg_server_port = 54003;
     map_config.msg_server_ip = "127.0.0.1";
+    map_config.healing_tick_delay = 10;
     return 0;
 }
 
@@ -1270,6 +1271,10 @@ int32 map_config_read(const int8* cfgName)
         else if (strcmp(w1, "mob_no_despawn") == 0)
         {
             map_config.mob_no_despawn = atoi(w2);
+        }
+        else if (strcmp(w1, "healing_tick_delay") == 0)
+        {
+            map_config.healing_tick_delay = atoi(w2);
         }
         else
         {

--- a/src/map/map.h
+++ b/src/map/map.h
@@ -122,6 +122,7 @@ struct map_config_t
     bool   audit_yell;
     bool   audit_linkshell;
     bool   audit_party;
+    uint8  healing_tick_delay;
     uint16 msg_server_port;           // central message server port
     const char* msg_server_ip;        // central message server IP
 };

--- a/src/map/packet_system.cpp
+++ b/src/map/packet_system.cpp
@@ -4535,7 +4535,7 @@ void SmallPacket0x0E7(map_session_data_t* session, CCharEntity* PChar, CBasicPac
             (PChar->PPet->m_EcoSystem != SYSTEM_AVATAR &&
             PChar->PPet->m_EcoSystem != SYSTEM_ELEMENTAL))
         {
-            PChar->StatusEffectContainer->AddStatusEffect(new CStatusEffect(EFFECT_HEALING, 0, 0, 10, 0));
+            PChar->StatusEffectContainer->AddStatusEffect(new CStatusEffect(EFFECT_HEALING, 0, 0, map_config.healing_tick_delay, 0));
         }
         PChar->StatusEffectContainer->AddStatusEffect(new CStatusEffect(EFFECT_LEAVEGAME, 0, ExitType, 5, 0));
     }
@@ -4583,7 +4583,7 @@ void SmallPacket0x0E8(map_session_data_t* session, CCharEntity* PChar, CBasicPac
             {
                 PChar->PPet->PAI->Disengage();
             }
-            PChar->StatusEffectContainer->AddStatusEffect(new CStatusEffect(EFFECT_HEALING, 0, 0, 10, 0));
+            PChar->StatusEffectContainer->AddStatusEffect(new CStatusEffect(EFFECT_HEALING, 0, 0, map_config.healing_tick_delay, 0));
             return;
         }
         PChar->pushPacket(new CMessageBasicPacket(PChar, PChar, 0, 0, 345));


### PR DESCRIPTION
Add HEALING_TP_CHANGE configurable option
    HEALING_TP_CHANGE allows the change of TP loss/gain during healing.

Add healing_tick_delay configurable option
    Allows the configuration of the number of seconds of delay between healing
    ticks.