### PR TITLE
Fixed issues with the quest 'Mom, the Adventurer?'

### DIFF
--- a/scripts/zones/Bastok_Markets/npcs/Nbu_Latteh.lua
+++ b/scripts/zones/Bastok_Markets/npcs/Nbu_Latteh.lua
@@ -6,42 +6,53 @@
 -----------------------------------
 package.loaded["scripts/zones/Bastok_Markets/TextIDs"] = nil;
 -----------------------------------
-require("scripts/globals/settings");
-require("scripts/globals/keyitems");
-require("scripts/globals/titles");
-require("scripts/globals/quests");
-require("scripts/zones/Bastok_Markets/TextIDs");
+require( "scripts/globals/settings" );
+require( "scripts/globals/keyitems" );
+require( "scripts/globals/titles" );
+require( "scripts/globals/quests" );
+require( "scripts/zones/Bastok_Markets/TextIDs" );
 
 -----------------------------------
 -- onTrade Action
 -----------------------------------
 
-function onTrade(player,npc,trade)
+function onTrade( player, npc, trade )
 end;
 
 -----------------------------------
 -- onTrigger Action
 -----------------------------------
 
-function onTrigger(player,npc)
-    local pFame = player:getFameLevel(BASTOK);
-    local MomTheAdventurer = player:getQuestStatus(BASTOK,MOM_THE_ADVENTURER)
-    local questStatus = player:getVar("MomTheAdventurer_Event");
+function onTrigger( player, npc )
 
-    if (player:needToZone()) then
-        player:startEvent(127); -- chat about my work
-    elseif (pFame < 2 and MomTheAdventurer ~= QUEST_ACCEPTED and questStatus == 0) then
-            player:startEvent(0x00e6);  
-    elseif (MomTheAdventurer >= QUEST_ACCEPTED and questStatus == 2) then
-        if (player:seenKeyItem(LETTER_FROM_ROH_LATTEH)) then
-            player:startEvent(0x00ea);
-        elseif (player:hasKeyItem(LETTER_FROM_ROH_LATTEH)) then
-            player:startEvent(0x00e9);
+    local pFame = player:getFameLevel( BASTOK );
+
+    local MomTheAdventurer = player:getQuestStatus( BASTOK, MOM_THE_ADVENTURER );
+    local TheSignpostMarksTheSpot = player:getQuestStatus( BASTOK, THE_SIGNPOST_MARKS_THE_SPOT );
+
+    local questStatus = player:getVar( "MomTheAdventurer_Event" );
+
+    -- Fix for players who had this quest bugged and rendered incompletable.
+    -- If it is still accepted, but the player var is missing, just re-add the var.
+    if( MomTheAdventurer == QUEST_ACCEPTED and questStatus <= 0 )  then
+        player:setVar( "MomTheAdventurer_Event", 1 );
+        questStatus = 1;
+    end
+    
+    if( player:needToZone() ) then
+        player:startEvent( 127 ); -- chat about my work
+    elseif( ( MomTheAdventurer ~= QUEST_COMPLETED or pFame < 2 ) and MomTheAdventurer ~= QUEST_ACCEPTED and questStatus == 0 ) then
+            player:startEvent( 0x00e6 );  
+    elseif( MomTheAdventurer >= QUEST_ACCEPTED and questStatus == 2 ) then
+        if( player:seenKeyItem( LETTER_FROM_ROH_LATTEH ) ) then
+            player:startEvent( 0x00ea );
+        elseif( player:hasKeyItem( LETTER_FROM_ROH_LATTEH ) ) then
+            player:startEvent( 0x00e9 );
         end
-    elseif (pFame >= 2 and player:getQuestStatus(BASTOK,THE_SIGNPOST_MARKS_THE_SPOT) == QUEST_AVAILABLE) then
-        player:startEvent(0x00eb);
+    elseif( MomTheAdventurer >= QUEST_COMPLETED and pFame >= 2 and TheSignpostMarksTheSpot == QUEST_AVAILABLE ) then
+        player:startEvent( 0x00eb );
     else
-        player:startEvent(0x007f);
+        player:startEvent( 0x007f );
     end
 
 end;
@@ -50,7 +61,7 @@ end;
 -- onEventUpdate
 -----------------------------------
 
-function onEventUpdate(player,csid,option)
+function onEventUpdate( player, csid, option )
     -- printf("CSID: %u",csid);
     -- printf("RESULT: %u",option);
 end;
@@ -59,41 +70,41 @@ end;
 -- onEventFinish
 -----------------------------------
 
-function onEventFinish(player,csid,option)
+function onEventFinish( player, csid, option)
     -- printf("CSID: %u",csid);
     -- printf("RESULT: %u",option);
 
-    if (csid == 0x00e6 and option == 0) then
-        if (player:getFreeSlotsCount(0) > 0) then
-            player:addQuest(BASTOK,MOM_THE_ADVENTURER);
-            player:setVar("MomTheAdventurer_Event",1);
-            player:addItem(4096);
-            player:messageSpecial(ITEM_OBTAINED,4096); -- Fire Crystal
+    if( csid == 0x00e6 and option == 0 ) then
+        if( player:getFreeSlotsCount( 0 ) > 0 ) then
+            player:addQuest( BASTOK, MOM_THE_ADVENTURER );
+            player:setVar( "MomTheAdventurer_Event", 1 );
+            player:addItem( 4096 );
+            player:messageSpecial( ITEM_OBTAINED, 4096 ); -- Fire Crystal
         else
-            player:messageSpecial(ITEM_CANNOT_BE_OBTAINED,4096);
+            player:messageSpecial( ITEM_CANNOT_BE_OBTAINED, 4096 );
         end
-    elseif (csid == 0x00e9 or csid == 0x00ea) then
-        if (player:seenKeyItem(LETTER_FROM_ROH_LATTEH)) then
+    elseif( csid == 0x00e9 or csid == 0x00ea ) then
+        if( player:seenKeyItem( LETTER_FROM_ROH_LATTEH ) ) then
             gilReward = 100;
         else
             gilReward = 200;
         end
-        player:needToZone(true);
-        player:delKeyItem(LETTER_FROM_ROH_LATTEH);
-        player:addTitle(RINGBEARER);
-        player:addGil(GIL_RATE*gilReward);
-        player:messageSpecial(GIL_OBTAINED, GIL_RATE*gilReward);
-        player:setVar("MomTheAdventurer_Event",0);
 
-        if (player:getQuestStatus(BASTOK,MOM_THE_ADVENTURER) == QUEST_ACCEPTED) then
-            player:addFame(BASTOK,50);
-            player:completeQuest(BASTOK,MOM_THE_ADVENTURER);
+        player:needToZone( true );
+        player:delKeyItem( LETTER_FROM_ROH_LATTEH );
+        player:addTitle( RINGBEARER );
+        player:addGil( GIL_RATE * gilReward );
+        player:messageSpecial( GIL_OBTAINED, GIL_RATE * gilReward );
+        player:setVar( "MomTheAdventurer_Event", 0 );
+
+        if( player:getQuestStatus( BASTOK, MOM_THE_ADVENTURER ) == QUEST_ACCEPTED ) then
+            player:addFame( BASTOK, 50 );
+            player:completeQuest( BASTOK, MOM_THE_ADVENTURER );
         else
-            player:addFame(BASTOK,8)
+            player:addFame( BASTOK, 8 )
         end
-    elseif (csid == 0x00eb and option == 0) then
-        player:addQuest(BASTOK,THE_SIGNPOST_MARKS_THE_SPOT);
-        player:setVar("MomTheAdventurer_Event",0);
+    elseif( csid == 0x00eb and option == 0 ) then
+        player:addQuest( BASTOK, THE_SIGNPOST_MARKS_THE_SPOT );
    end
 
 end;


### PR DESCRIPTION
Fixed some issues with the quest 'Mom, the Adventurer?'. After reaching
Bastok rep 2 or higher the player was able to start the next quest
without completing this one. In addition, even if this quest had been
accepted, the player would be unable to complete it after reaching rep
2+. A check was also added to fix a player who has already had this
quest bugged for them so they should now be able to complete it.