### PR TITLE
Correct onMobDeath to onMobDespawn for previous PR

### DIFF
--- a/scripts/zones/East_Ronfaure/mobs/Rambukk.lua
+++ b/scripts/zones/East_Ronfaure/mobs/Rambukk.lua
@@ -11,9 +11,9 @@ function onMobSpawn(mob)
 end;
 
 -----------------------------------
--- onMobDeath
+-- onMobDespawn
 -----------------------------------
 
-function onMobDeath(mob, player, isKiller)
+function onMobDespawn(mob)
     UpdateNMSpawnPoint(mob:getID());
 end;

--- a/scripts/zones/Maze_of_Shakhrami/mobs/Argus.lua
+++ b/scripts/zones/Maze_of_Shakhrami/mobs/Argus.lua
@@ -6,10 +6,10 @@
 require("scripts/zones/Maze_of_Shakhrami/MobIDs");
 
 -----------------------------------
--- onMobDeath
+-- onMobDespawn
 -----------------------------------
 
-function onMobDeath(mob, player, isKiller)
+function onMobDespawn(mob)
     local whichNM = math.random(0,19);
 
     if (whichNM < 10) then

--- a/scripts/zones/Maze_of_Shakhrami/mobs/Leech_King.lua
+++ b/scripts/zones/Maze_of_Shakhrami/mobs/Leech_King.lua
@@ -6,10 +6,10 @@
 require("scripts/zones/Maze_of_Shakhrami/MobIDs");
 
 -----------------------------------
--- onMobDeath
+-- onMobDespawn
 -----------------------------------
 
-function onMobDeath(mob, player, isKiller)
+function onMobDespawn(mob)
     local whichNM = math.random(0,19);
 
     if (whichNM < 10) then

--- a/scripts/zones/Valkurm_Dunes/mobs/Hippomaritimus.lua
+++ b/scripts/zones/Valkurm_Dunes/mobs/Hippomaritimus.lua
@@ -11,10 +11,10 @@ function onMobSpawn(mob)
 end;
 
 -----------------------------------
--- onMobDeath
+-- onMobDespawn
 -----------------------------------
 
-function onMobDeath(mob, player, isKiller)
+function onMobDespawn(mob)
     UpdateNMSpawnPoint(mob:getID());
     mob:setRespawnTime(math.random(3600,5400)); -- 60-90min repop
 end;

--- a/scripts/zones/West_Sarutabaruta/mobs/Numbing_Norman.lua
+++ b/scripts/zones/West_Sarutabaruta/mobs/Numbing_Norman.lua
@@ -33,5 +33,12 @@ end;
 
 function onMobDeath(mob, player, isKiller)
     checkRegime(player,mob,61,2);
+end;
+
+-----------------------------------
+-- onMobDespawn
+-----------------------------------
+
+function onMobDespawn(mob)
     UpdateNMSpawnPoint(mob:getID());
 end;

--- a/scripts/zones/Yuhtunga_Jungle/mobs/Koropokkur.lua
+++ b/scripts/zones/Yuhtunga_Jungle/mobs/Koropokkur.lua
@@ -11,10 +11,10 @@ function onMobSpawn(mob)
 end;
 
 -----------------------------------
--- onMobDeath
+-- onMobDespawn
 -----------------------------------
 
-function onMobDeath(mob, player, isKiller)
+function onMobDespawn(mob)
     UpdateNMSpawnPoint(mob:getID());
     mob:setRespawnTime(math.random(3600,5400)); -- 60-90min repop
 end;


### PR DESCRIPTION
While correcting these, I noticed that alot of mobs (from AV to Leaping Lizzy and PHs) suffer from the same problem.

wouldn't that make it way more easy to pop these NMs with more ppl in a pt?