### PR TITLE
Fixed avatars using wrong animations

### DIFF
--- a/src/map/entities/mobentity.cpp
+++ b/src/map/entities/mobentity.cpp
@@ -637,8 +637,9 @@ void CMobEntity::OnMobSkillFinished(CMobSkillState& state, action_t& action)
     }
 
     action.id = id;
-    if (objtype == TYPE_PET && static_cast<CPetEntity*>(this)->getPetType() == PETTYPE_JUG_PET &&
-        static_cast<CPetEntity*>(this)->getPetType() == PETTYPE_AUTOMATON)
+    if (objtype == TYPE_PET && (
+        static_cast<CPetEntity*>(this)->getPetType() == PETTYPE_AUTOMATON ||
+        static_cast<CPetEntity*>(this)->getPetType() == PETTYPE_AVATAR))
         action.actiontype = ACTION_PET_MOBABILITY_FINISH;
     else if (PSkill->getID() < 256)
         action.actiontype = ACTION_WEAPONSKILL_FINISH;


### PR DESCRIPTION
After testing out Summoner, I noticed none of the avatars were not using the correct animations. I dug around in the code and I found that lines 640-641 could not possibly evaluate to true. This led to avatars and automatons using ACTION_MOBABILITY_FINISH, which results in the wrong animation being used.

 The problem doesn't exist for jug bets because they should be using ACTION_MOBABILITY_FINISH (which is why I don't check for == PETTYPE_JUG_PET in my edit).