### PR TITLE
add to Treasure Pool binding

### DIFF
--- a/scripts/commands/addtreasure.lua
+++ b/scripts/commands/addtreasure.lua
@@ -1,0 +1,32 @@
+---------------------------------------------------------------------------------------------------
+-- func: @additem <itemId> <quantity> <aug1> <v1> <aug2> <v2> <aug3> <v3> <aug4> <v4> <trial>
+-- desc: Adds an item to the GMs inventory.
+---------------------------------------------------------------------------------------------------
+
+cmdprops =
+{
+    permission = 1,
+    parameters = "is"
+};
+
+function onTrigger(player, itemId, target)
+    local targ;
+    if (target == nil) then
+        targ = player
+    else
+        targ = GetPlayerByName(target);
+    end
+
+    if (targ == nil) then
+        player:PrintToPlayer(string.format("Player named '%s' not found!", target));
+        return
+    end
+
+    if (itemId == nil or tonumber(itemId) == nil or tonumber(itemId) == 0) then
+        player:PrintToPlayer("You must enter a valid item id.");
+        return;
+    end
+
+    targ:addTreasure(itemId);
+    player:PrintToPlayer(string.format("Item of ID %d was added to the treasure pool of %s or their party/alliance.", itemId, targ:getName()));
+end

--- a/scripts/zones/Behemoths_Dominion/mobs/King_Behemoth.lua
+++ b/scripts/zones/Behemoths_Dominion/mobs/King_Behemoth.lua
@@ -35,6 +35,14 @@ end;
 
 function onMobDeath(mob, player, isKiller)
     player:addTitle(BEHEMOTH_DETHRONER);
+
+    if (isKiller) then -- using killer check to run once
+        if (math.random(1,100) <= 5) then
+            player:addTreasure(13566); -- Defending Ring
+        else
+            player:addTreasure(13415); -- Pixie Earring
+        end
+    end
 end;
 
 -----------------------------------
@@ -42,14 +50,6 @@ end;
 -----------------------------------
 
 function onMobDespawn(mob)
-    -- Todo: move this to SQL after drop slots are a thing
-    if (math.random(1,100) <= 5) then -- Hardcoded "this or this item" drop rate until implemented.
-        SetDropRate(1936,13566,1000); -- Defending Ring
-        SetDropRate(1936,13415,0);
-    else
-        SetDropRate(1936,13566,0);
-        SetDropRate(1936,13415,1000); -- Pixie Earring
-    end
 
     -- Set King_Behemoth's Window Open Time
     if (LandKingSystem_HQ ~= 1) then

--- a/scripts/zones/Castle_Oztroja/mobs/Mee_Deggi_the_Punisher.lua
+++ b/scripts/zones/Castle_Oztroja/mobs/Mee_Deggi_the_Punisher.lua
@@ -4,18 +4,24 @@
 -----------------------------------
 
 -----------------------------------
+-- onMobDeath
+-----------------------------------
+
+function onMobDespawn(mob, player, isKiller)
+    if (isKiller) then -- using killer check to run once
+        if (math.random(1,100) <= 5) then
+            player:addTreasure(14986); -- Ochimusha Kote
+        else
+            player:addTreasure(16703); -- Impact Knuckles
+        end
+    end
+end;
+
+-----------------------------------
 -- onMobDespawn
 -----------------------------------
 
 function onMobDespawn(mob)
-
-    if (math.random(1,100) <= 5) then -- Hardcoded "this or this item" drop rate until implemented.
-        SetDropRate(1936,14986,1000); -- Ochimusha Kote
-        SetDropRate(1936,16703,0);
-    else
-        SetDropRate(1936,14986,0);
-        SetDropRate(1936,16703,1000); -- Impact Knuckles
-    end
 
     -- Set Mee_Deggi_the_Punisher's Window Open Time
     local wait = math.random(3600,10800);

--- a/scripts/zones/Castle_Oztroja/mobs/Moo_Ouzi_the_Swiftblade.lua
+++ b/scripts/zones/Castle_Oztroja/mobs/Moo_Ouzi_the_Swiftblade.lua
@@ -4,18 +4,24 @@
 -----------------------------------
 
 -----------------------------------
+-- onMobDeath
+-----------------------------------
+
+function onMobDespawn(mob, player, isKiller)
+    if (isKiller) then -- using killer check to run once
+        if (math.random(1,100) <= 14) then
+            player:addTreasure(16936); -- Demonic Sword
+        else
+            player:addTreasure(16935); -- Barbarians Sword
+        end
+    end
+end;
+
+-----------------------------------
 -- onMobDespawn
 -----------------------------------
 
 function onMobDespawn(mob)
-
-    if (math.random(1,100) <= 14) then -- Hardcoded "this or this item" drop rate until implemented.
-        SetDropRate(1936,16936,1000); -- Demonic Sword
-        SetDropRate(1936,16935,0);
-    else
-        SetDropRate(1936,16936,0);
-        SetDropRate(1936,16935,1000); -- Barbarians Sword
-    end
 
     -- Set Moo_Ouzi_the_Swiftblade's Window Open Time
     local wait = math.random(3600,10800);

--- a/scripts/zones/Castle_Oztroja/mobs/Quu_Domi_the_Gallant.lua
+++ b/scripts/zones/Castle_Oztroja/mobs/Quu_Domi_the_Gallant.lua
@@ -4,18 +4,24 @@
 -----------------------------------
 
 -----------------------------------
+-- onMobDeath
+-----------------------------------
+
+function onMobDespawn(mob, player, isKiller)
+    if (isKiller) then -- using killer check to run once
+        if (math.random(1,100) <= 7) then
+            player:addTreasure(15737); -- Sarutobi Kyahan
+        else
+            player:addTreasure(16820); -- Strider Sword
+        end
+    end
+end;
+
+-----------------------------------
 -- onMobDespawn
 -----------------------------------
 
 function onMobDespawn(mob)
-
-    if (math.random(1,100) <= 7) then -- Hardcoded "this or this item" drop rate until implemented.
-        SetDropRate(1936,15737,1000); -- Sarutobi Kyahan
-        SetDropRate(1936,16820,0);
-    else
-        SetDropRate(1936,15737,0);
-        SetDropRate(1936,16820,1000); -- Strider Sword
-    end
 
     -- Set Quu_Domi_the_Gallant's Window Open Time
     local wait = math.random(3600,10800);

--- a/sql/mob_droplist.sql
+++ b/sql/mob_droplist.sql
@@ -12102,8 +12102,8 @@ INSERT INTO `mob_droplist` VALUES (1935,0,4174,1000);
 INSERT INTO `mob_droplist` VALUES (1935,0,12924,1000);
 INSERT INTO `mob_droplist` VALUES (1935,0,15899,80);
 INSERT INTO `mob_droplist` VALUES (1936,0,831,530);
-INSERT INTO `mob_droplist` VALUES (1936,0,13415,950);
-INSERT INTO `mob_droplist` VALUES (1936,0,13566,50);
+INSERT INTO `mob_droplist` VALUES (1936,0,13415,0); -- handled in script
+INSERT INTO `mob_droplist` VALUES (1936,0,13566,0); -- handled in script
 INSERT INTO `mob_droplist` VALUES (1936,0,1527,670);
 INSERT INTO `mob_droplist` VALUES (1936,0,1322,320);
 INSERT INTO `mob_droplist` VALUES (1936,0,1322,160);
@@ -13434,8 +13434,8 @@ INSERT INTO `mob_droplist` VALUES (2236,0,3250,100);
 INSERT INTO `mob_droplist` VALUES (2237,0,2357,80);
 INSERT INTO `mob_droplist` VALUES (2237,0,14959,100);
 INSERT INTO `mob_droplist` VALUES (2238,2,656,0);
-INSERT INTO `mob_droplist` VALUES (2238,0,14986,50);
-INSERT INTO `mob_droplist` VALUES (2238,0,16703,950);
+INSERT INTO `mob_droplist` VALUES (2238,0,14986,0); -- handled in script
+INSERT INTO `mob_droplist` VALUES (2238,0,16703,0); -- handled in script
 INSERT INTO `mob_droplist` VALUES (2239,0,1640,70);
 INSERT INTO `mob_droplist` VALUES (2239,0,1680,10);
 INSERT INTO `mob_droplist` VALUES (2239,0,1718,70);
@@ -13898,8 +13898,8 @@ INSERT INTO `mob_droplist` VALUES (2340,0,922,160);
 INSERT INTO `mob_droplist` VALUES (2341,0,858,300);
 INSERT INTO `mob_droplist` VALUES (2341,0,940,150);
 INSERT INTO `mob_droplist` VALUES (2342,0,4277,100);
-INSERT INTO `mob_droplist` VALUES (2343,0,16935,840);
-INSERT INTO `mob_droplist` VALUES (2343,0,16936,140);
+INSERT INTO `mob_droplist` VALUES (2343,0,16935,0); -- handled in script
+INSERT INTO `mob_droplist` VALUES (2343,0,16936,0); -- handled in script
 INSERT INTO `mob_droplist` VALUES (2344,0,557,140);
 INSERT INTO `mob_droplist` VALUES (2344,2,921,0);
 INSERT INTO `mob_droplist` VALUES (2344,0,921,500);
@@ -17240,8 +17240,8 @@ INSERT INTO `mob_droplist` VALUES (2914,0,4514,50);
 INSERT INTO `mob_droplist` VALUES (2914,0,17503,420);
 INSERT INTO `mob_droplist` VALUES (2915,0,5365,200);
 INSERT INTO `mob_droplist` VALUES (2915,0,5366,190);
-INSERT INTO `mob_droplist` VALUES (2916,0,15737,70);
-INSERT INTO `mob_droplist` VALUES (2916,0,16820,930);
+INSERT INTO `mob_droplist` VALUES (2916,0,15737,0); -- handled in script
+INSERT INTO `mob_droplist` VALUES (2916,0,16820,0); -- handled in script
 INSERT INTO `mob_droplist` VALUES (2917,0,856,150);
 INSERT INTO `mob_droplist` VALUES (2917,2,4358,0);
 INSERT INTO `mob_droplist` VALUES (2917,0,4358,120);

--- a/src/map/entities/mobentity.cpp
+++ b/src/map/entities/mobentity.cpp
@@ -800,7 +800,7 @@ void CMobEntity::DropItems()
                     uint8 bonus = (m_THLvl > 2 ? (m_THLvl - 2) * 10 : 0);
                     while (tries < maxTries)
                     {
-                        if (dsprand::GetRandomNumber(1000) < DropList->at(i).DropRate * map_config.drop_rate_multiplier + bonus)
+                        if (DropList->at(i).DropRate > 0 && dsprand::GetRandomNumber(1000) < DropList->at(i).DropRate * map_config.drop_rate_multiplier + bonus)
                         {
                             PChar->PTreasurePool->AddItem(DropList->at(i).ItemID, this);
                             break;

--- a/src/map/lua/lua_baseentity.cpp
+++ b/src/map/lua/lua_baseentity.cpp
@@ -130,6 +130,7 @@
 #include "../ai/states/magic_state.h"
 
 #include "../transport.h"
+#include "../treasure_pool.h"
 #include "../mob_modifier.h"
 
 CLuaBaseEntity::CLuaBaseEntity(lua_State* L)
@@ -711,6 +712,28 @@ inline int32 CLuaBaseEntity::getSpawnPos(lua_State* L)
     lua_setfield(L, newTable, "rot");
 
     return 1;
+}
+
+//==========================================================//
+
+inline int32 CLuaBaseEntity::addTreasure(lua_State *L)
+{
+    DSP_DEBUG_BREAK_IF(m_PBaseEntity == nullptr);
+    DSP_DEBUG_BREAK_IF(m_PBaseEntity->objtype != TYPE_PC);
+
+    DSP_DEBUG_BREAK_IF(lua_isnil(L, 1) || !lua_isnumber(L, 1));
+
+    CCharEntity* PChar = (CCharEntity*)m_PBaseEntity;
+
+    if (PChar->PTreasurePool != nullptr)
+    {
+        PChar->PTreasurePool->AddItem((uint16)lua_tointeger(L, 1), PChar);
+    }
+    else
+    {
+        ShowError(CL_RED"Lua::addTreasure: Tried to add item to a treasure pool that was nullptr! \n" CL_RESET);
+    }
+    return 0;
 }
 
 //==========================================================//
@@ -10601,7 +10624,7 @@ inline int32 CLuaBaseEntity::getNearbyEntities(lua_State* L)
 
     lua_newtable(L);
     int newTable = lua_gettop(L);
-    
+
     for (auto&& list : {iterTarget->SpawnMOBList, iterTarget->SpawnPCList, iterTarget->SpawnPETList})
     {
         for (auto&& entity : list)
@@ -10672,6 +10695,7 @@ Lunar<CLuaBaseEntity>::Register_t CLuaBaseEntity::methods[] =
     LUNAR_DECLARE_METHOD(CLuaBaseEntity,getStat),
     LUNAR_DECLARE_METHOD(CLuaBaseEntity,getMaxHP),
     LUNAR_DECLARE_METHOD(CLuaBaseEntity,getMaxMP),
+    LUNAR_DECLARE_METHOD(CLuaBaseEntity,addTreasure),
     LUNAR_DECLARE_METHOD(CLuaBaseEntity,addItem),
     LUNAR_DECLARE_METHOD(CLuaBaseEntity,addTempItem),
     LUNAR_DECLARE_METHOD(CLuaBaseEntity,delItem),

--- a/src/map/lua/lua_baseentity.h
+++ b/src/map/lua/lua_baseentity.h
@@ -144,7 +144,7 @@ public:
     int32 delMission(lua_State*);           // Delete Mission from Mission Log
     int32 hasCompletedMission(lua_State*);  // Checks if mission has been completed
     int32 getCurrentMission(lua_State*);    // Gets the current mission
-    int32 completeMission(lua_State*);      // Complete Missiony
+    int32 completeMission(lua_State*);      // Complete Mission
 
     int32 addAssault(lua_State*);           // Add Mission
     int32 delAssault(lua_State*);           // Delete Mission from Mission Log

--- a/src/map/lua/lua_baseentity.h
+++ b/src/map/lua/lua_baseentity.h
@@ -59,7 +59,7 @@ public:
 
     int32 getHPP(lua_State*);               // Returns Entity Health %
     int32 getHP(lua_State*);                // Returns Entity Health
-    int32 getGender(lua_State*);			// Returns the player character's gender
+    int32 getGender(lua_State*);            // Returns the player character's gender
     int32 getBaseHP(lua_State*);            // Returns Entity base Health before modifiers
     int32 addHP(lua_State*);                // Modify hp of Entity +/-
     int32 restoreHP(lua_State*);            // Modify hp of Entity, but check if alive first
@@ -114,11 +114,12 @@ public:
     int32 setAnimation(lua_State*);         // Set Entity Animation
     int32 AnimationSub(lua_State*);         // get or set animationsub
     int32 costume(lua_State*);              // get or set user costume
-    int32 costume2(lua_State*);				// set monstrosity costume
+    int32 costume2(lua_State*);             // set monstrosity costume
     int32 canUseCostume(lua_State*);        // check to see if character can use costume, 0 if so
     int32 canUseChocobo(lua_State *L);      // check to see if character can use chocobo, 0 if so
     int32 canUsePet(lua_State *L);          // check to see if character can call pet, 0 if so
 
+    int32 addTreasure(lua_State*);          // Add item to directly to treasure pool
     int32 addItem(lua_State*);              // Add item to Entity inventory (additem(itemNumber,quantity))
     int32 hasItem(lua_State*);              // Check to see if Entity has item in inventory (hasItem(itemNumber))
     int32 addTempItem(lua_State*);          // Add temp item to Entity Temp inventory
@@ -143,7 +144,7 @@ public:
     int32 delMission(lua_State*);           // Delete Mission from Mission Log
     int32 hasCompletedMission(lua_State*);  // Checks if mission has been completed
     int32 getCurrentMission(lua_State*);    // Gets the current mission
-    int32 completeMission(lua_State*);      // Complete Mission
+    int32 completeMission(lua_State*);      // Complete Missiony
 
     int32 addAssault(lua_State*);           // Add Mission
     int32 delAssault(lua_State*);           // Delete Mission from Mission Log


### PR DESCRIPTION
This was way less effort than finding out why setdroprate is broken (~~it seems to do nothing, no matter where you place it, this was already reported and I have no idea and no time to figure out whats wrong or how to fix it - don't ask me to~~ may have to do with people calling the wrong drop ID so they set rate on things that don't even exist cough cough) or fixing my broken attempt at a new "slot/group" column in the mob_drops table which I may try again on later. This is more reliable and harder for people to screw up in the meantime..

Fair warning, I only did minimal testing. Seems to work fine after an odd delay before the messages hit client.