### PR TITLE
Fixed Kirin spawning multiple adds at a time

### DIFF
--- a/scripts/zones/The_Shrine_of_RuAvitau/mobs/Kirin.lua
+++ b/scripts/zones/The_Shrine_of_RuAvitau/mobs/Kirin.lua
@@ -23,6 +23,7 @@ end
 
 function onMobSpawn(mob)
     mob:setMod(MOD_WINDRES, -64);
+	mob:setLocalVar("numAdds", 1);
 end
 
 -----------------------------------
@@ -36,7 +37,8 @@ function onMobFight( mob, target )
         mob:spawnPet();
         mob:setLocalVar("astralFlow", 1);
     end
-    if (mob:getBattleTime() ~= 0 and mob:getBattleTime() % 180 == 0) then
+	local numAdds = mob:getLocalVar("numAdds");
+    if (mob:getBattleTime() / 180 == numAdds) then
         -- Ensure we have not spawned all pets yet..
         local genbu = mob:getLocalVar("genbu");
         local seiryu = mob:getLocalVar("seiryu");
@@ -71,6 +73,7 @@ function onMobFight( mob, target )
 
         -- Update Kirins extra vars..
         mob:setLocalVar(newVar, 1);
+		mob:setLocalVar("numAdds", numAdds + 1);
     end
 
     -- Ensure all spawned pets are doing stuff..

--- a/scripts/zones/The_Shrine_of_RuAvitau/mobs/Kirin.lua
+++ b/scripts/zones/The_Shrine_of_RuAvitau/mobs/Kirin.lua
@@ -23,7 +23,7 @@ end
 
 function onMobSpawn(mob)
     mob:setMod(MOD_WINDRES, -64);
-	mob:setLocalVar("numAdds", 1);
+    mob:setLocalVar("numAdds", 1);
 end
 
 -----------------------------------
@@ -37,7 +37,7 @@ function onMobFight( mob, target )
         mob:spawnPet();
         mob:setLocalVar("astralFlow", 1);
     end
-	local numAdds = mob:getLocalVar("numAdds");
+    local numAdds = mob:getLocalVar("numAdds");
     if (mob:getBattleTime() / 180 == numAdds) then
         -- Ensure we have not spawned all pets yet..
         local genbu = mob:getLocalVar("genbu");
@@ -73,7 +73,7 @@ function onMobFight( mob, target )
 
         -- Update Kirins extra vars..
         mob:setLocalVar(newVar, 1);
-		mob:setLocalVar("numAdds", numAdds + 1);
+        mob:setLocalVar("numAdds", numAdds + 1);
     end
 
     -- Ensure all spawned pets are doing stuff..


### PR DESCRIPTION
Fixed issue #2733 

The intention of the code is clearly to spawn one lesser god every 3 minutes. In game we were seeing 2-3 spawn at a time. I believe it was because the function was being run multiple times per second so the condition mob:getBattleTime() % 180 == 0 was passing multiple times in a row. I reworked the condition and it now behaves correctly in game.