### PR TITLE
Implemented Ikishoten and fixed Shikikoyo upgrades.

### DIFF
--- a/scripts/globals/abilities/shikikoyo.lua
+++ b/scripts/globals/abilities/shikikoyo.lua
@@ -30,7 +30,7 @@ end;
 -----------------------------------
 
 function onUseAbility(player,target,ability)
-    local pTP = player:getTP() - 1000 + (player:getMerit(MERIT_SHIKIKOYO) - 12);
+    local pTP = (player:getTP() - 1000) * (1 + ((player:getMerit(MERIT_SHIKIKOYO) - 12) / 100));
     pTP = utils.clamp(pTP, 0, 3000 - target:getTP());
 
     player:setTP(1000);

--- a/sql/merits.sql
+++ b/sql/merits.sql
@@ -242,7 +242,7 @@ INSERT INTO `merits` VALUES ('2692', 'snapshot', '5', '2', '1024', '7', '41');
 INSERT INTO `merits` VALUES ('2694', 'recycle', '5', '5', '1024', '7', '41');
 INSERT INTO `merits` VALUES ('2752', 'shikikoyo', '5', '12', '2048', '7', '42');
 INSERT INTO `merits` VALUES ('2754', 'blade_bash', '5', '15', '2048', '7', '42');
-INSERT INTO `merits` VALUES ('2756', 'ikishoten', '5', '3', '2048', '7', '42');
+INSERT INTO `merits` VALUES ('2756', 'ikishoten', '5', '30', '2048', '7', '42');
 INSERT INTO `merits` VALUES ('2758', 'overwhelm', '5', '1', '2048', '7', '42');
 INSERT INTO `merits` VALUES ('2816', 'sange', '5', '25', '4096', '7', '43');
 INSERT INTO `merits` VALUES ('2818', 'ninja_tool_expertise', '5', '5', '4096', '7', '43');

--- a/src/map/entities/battleentity.cpp
+++ b/src/map/entities/battleentity.cpp
@@ -1435,7 +1435,7 @@ bool CBattleEntity::OnAttack(CAttackState& state, action_t& action)
 
                         float DamageRatio = battleutils::GetDamageRatio(PTarget, this, attack.IsCritical(), 0);
                         auto damage = ((PTarget->GetMainWeaponDmg() + naturalh2hDMG + battleutils::GetFSTR(PTarget, this, SLOT_MAIN)) * DamageRatio);
-                        actionTarget.spikesParam = battleutils::TakePhysicalDamage(PTarget, this, damage, false, SLOT_MAIN, 1, nullptr, true, false, true);
+                        actionTarget.spikesParam = battleutils::TakePhysicalDamage(PTarget, this, attack.GetAttackType(), damage, false, SLOT_MAIN, 1, nullptr, true, false, true);
                         actionTarget.spikesMessage = 33;
                         if (PTarget->objtype == TYPE_PC)
                         {
@@ -1485,7 +1485,7 @@ bool CBattleEntity::OnAttack(CAttackState& state, action_t& action)
                     actionTarget.reaction = REACTION_BLOCK;
                 }
 
-                actionTarget.param = battleutils::TakePhysicalDamage(this, PTarget, attack.GetDamage(), attack.IsBlocked(), attack.GetWeaponSlot(), 1, attackRound.GetTAEntity(), true, true);
+                actionTarget.param = battleutils::TakePhysicalDamage(this, PTarget, attack.GetAttackType(), attack.GetDamage(), attack.IsBlocked(), attack.GetWeaponSlot(), 1, attackRound.GetTAEntity(), true, true);
                 if (actionTarget.param < 0)
                 {
                     actionTarget.param = -(actionTarget.param);

--- a/src/map/entities/charentity.cpp
+++ b/src/map/entities/charentity.cpp
@@ -55,6 +55,7 @@
 #include "../ability.h"
 #include "../conquest_system.h"
 #include "../spell.h"
+#include "../attack.h"
 #include "../utils/attackutils.h"
 #include "../utils/charutils.h"
 #include "../utils/battleutils.h"

--- a/src/map/entities/charentity.cpp
+++ b/src/map/entities/charentity.cpp
@@ -1269,7 +1269,7 @@ void CCharEntity::OnRangedAttack(CRangeState& state, action_t& action)
             actionTarget.speceffect = SPECEFFECT_CRITICAL_HIT;
         }
 
-        actionTarget.param = battleutils::TakePhysicalDamage(this, PTarget, totalDamage, false, slot, realHits, nullptr, true, true);
+        actionTarget.param = battleutils::TakePhysicalDamage(this, PTarget, RANGED_ATTACK, totalDamage, false, slot, realHits, nullptr, true, true);
 
         // lower damage based on shadows taken
         if (shadowsTaken)

--- a/src/map/utils/battleutils.cpp
+++ b/src/map/utils/battleutils.cpp
@@ -710,7 +710,7 @@ namespace battleutils
                 // FINISH HIM! dun dun dun
                 // TP and stoneskin are handled inside TakePhysicalDamage
                 Action->spikesMessage = 536;
-                Action->spikesParam = battleutils::TakePhysicalDamage(PDefender, PAttacker, dmg, false, SLOT_MAIN, 1, nullptr, true, true, true);
+                Action->spikesParam = battleutils::TakePhysicalDamage(PDefender, PAttacker, ATTACK_NORMAL, dmg, false, SLOT_MAIN, 1, nullptr, true, true, true);
             }
         }
 
@@ -1808,7 +1808,7 @@ namespace battleutils
     *																		*
     ************************************************************************/
 
-    int32 TakePhysicalDamage(CBattleEntity* PAttacker, CBattleEntity* PDefender, int32 damage, bool isBlocked, uint8 slot, uint16 tpMultiplier, CBattleEntity* taChar, bool giveTPtoVictim, bool giveTPtoAttacker, bool isCounter)
+    int32 TakePhysicalDamage(CBattleEntity* PAttacker, CBattleEntity* PDefender, uint16 attackType, int32 damage, bool isBlocked, uint8 slot, uint16 tpMultiplier, CBattleEntity* taChar, bool giveTPtoVictim, bool giveTPtoAttacker, bool isCounter)
     {
         bool isRanged = (slot == SLOT_AMMO || slot == SLOT_RANGED);
         int32 baseDamage = damage;
@@ -2005,6 +2005,9 @@ namespace battleutils
 
             if (giveTPtoAttacker)
             {
+                if (attackType == ZANSHIN_ATTACK)
+                    baseTp += ((CCharEntity*)PAttacker)->PMeritPoints->GetMeritValue(MERIT_IKISHOTEN, (CCharEntity*)PAttacker);
+
                 PAttacker->addTP(tpMultiplier * (baseTp * (1.0f + 0.01f * (float)((PAttacker->getMod(MOD_STORETP) + getStoreTPbonusFromMerit(PAttacker))))));
             }
 
@@ -3910,7 +3913,7 @@ namespace battleutils
             charutils::TrySkillUP((CCharEntity*)PAttacker, (SKILLTYPE)PWeapon->getSkillType(), PVictim->GetMLevel());
 
         // jump + high jump doesn't give any tp to victim
-        battleutils::TakePhysicalDamage(PAttacker, PVictim, totalDamage, false, fstrslot, realHits, nullptr, false, true);
+        battleutils::TakePhysicalDamage(PAttacker, PVictim, ATTACK_NORMAL, totalDamage, false, fstrslot, realHits, nullptr, false, true);
 
         return totalDamage;
     }

--- a/src/map/utils/battleutils.cpp
+++ b/src/map/utils/battleutils.cpp
@@ -1808,7 +1808,7 @@ namespace battleutils
     *																		*
     ************************************************************************/
 
-    int32 TakePhysicalDamage(CBattleEntity* PAttacker, CBattleEntity* PDefender, uint16 attackType, int32 damage, bool isBlocked, uint8 slot, uint16 tpMultiplier, CBattleEntity* taChar, bool giveTPtoVictim, bool giveTPtoAttacker, bool isCounter)
+    int32 TakePhysicalDamage(CBattleEntity* PAttacker, CBattleEntity* PDefender, PHYSICAL_ATTACK_TYPE attackType, int32 damage, bool isBlocked, uint8 slot, uint16 tpMultiplier, CBattleEntity* taChar, bool giveTPtoVictim, bool giveTPtoAttacker, bool isCounter)
     {
         bool isRanged = (slot == SLOT_AMMO || slot == SLOT_RANGED);
         int32 baseDamage = damage;

--- a/src/map/utils/battleutils.h
+++ b/src/map/utils/battleutils.h
@@ -32,6 +32,7 @@
 #include <list>
 
 #include "../entities/battleentity.h"
+#include "../attack.h"
 
 class CAbility;
 class CItemWeapon;
@@ -148,7 +149,7 @@ namespace battleutils
     uint8				GetGuardRate(CBattleEntity* PAttacker, CBattleEntity* PDefender);
     float				GetDamageRatio(CBattleEntity* PAttacker, CBattleEntity* PDefender, bool isCritical, uint16 bonusAttPercent);
 
-    int32				TakePhysicalDamage(CBattleEntity* PAttacker, CBattleEntity* PDefender, uint16 attackType, int32 damage, bool isBlocked, uint8 slot, uint16 tpMultiplier, CBattleEntity* taChar, bool giveTPtoVictim, bool giveTPtoAttacker, bool isCounter = false);
+    int32				TakePhysicalDamage(CBattleEntity* PAttacker, CBattleEntity* PDefender, PHYSICAL_ATTACK_TYPE attackType, int32 damage, bool isBlocked, uint8 slot, uint16 tpMultiplier, CBattleEntity* taChar, bool giveTPtoVictim, bool giveTPtoAttacker, bool isCounter = false);
     int32				TakeWeaponskillDamage(CCharEntity* PChar, CBattleEntity* PDefender, int32 damage, uint8 slot, float tpMultiplier, uint16 bonusTP, float targetTPMultiplier);
     int32				TakeSkillchainDamage(CBattleEntity* PAttacker, CBattleEntity* PDefender, int32 lastSkillDamage, CBattleEntity* taChar);
 

--- a/src/map/utils/battleutils.h
+++ b/src/map/utils/battleutils.h
@@ -148,7 +148,7 @@ namespace battleutils
     uint8				GetGuardRate(CBattleEntity* PAttacker, CBattleEntity* PDefender);
     float				GetDamageRatio(CBattleEntity* PAttacker, CBattleEntity* PDefender, bool isCritical, uint16 bonusAttPercent);
 
-    int32				TakePhysicalDamage(CBattleEntity* PAttacker, CBattleEntity* PDefender, int32 damage, bool isBlocked, uint8 slot, uint16 tpMultiplier, CBattleEntity* taChar, bool giveTPtoVictim, bool giveTPtoAttacker, bool isCounter = false);
+    int32				TakePhysicalDamage(CBattleEntity* PAttacker, CBattleEntity* PDefender, uint16 attackType, int32 damage, bool isBlocked, uint8 slot, uint16 tpMultiplier, CBattleEntity* taChar, bool giveTPtoVictim, bool giveTPtoAttacker, bool isCounter = false);
     int32				TakeWeaponskillDamage(CCharEntity* PChar, CBattleEntity* PDefender, int32 damage, uint8 slot, float tpMultiplier, uint16 bonusTP, float targetTPMultiplier);
     int32				TakeSkillchainDamage(CBattleEntity* PAttacker, CBattleEntity* PDefender, int32 lastSkillDamage, CBattleEntity* taChar);
 


### PR DESCRIPTION
Fixed #3251 

I recently became the owner of a Nanatsusayanotachi on a 75 cap server only to learn Ikishoten was not implemented yet, which was a bit of a let down. So I implemented it.

http://ffxiclopedia.wikia.com/wiki/Ikishoten

"Adds 30 TP per upgrade to the base weapon TP (before Store TP is applied) gained from a Zanshin attack."

Note: the page actually says 3 because it was never updated after TP changes. The SQL also had 3, probably because it was copied right off that page, so I changed it.

Hasso's wiki page reads: "Occasionally triggers Zanshin after landing a normal attack" so I believe it is correct that Ikishoten's bonus should proc for both a Hasso Zanshin "double attack" as well as a regular ole' Zanshin.

I tested it on my test server with a Nanatsu (base tp gain of 107), with only the base 25% STP from being a 75 SAM, a regular Zanshin gained me (107 + 150) * 1.25 = 321 TP while a Hasso Zanshin gained me (107 * 1.25) + ((107 + 150) * 1.25) = 455. In game I actually saw 454, so I believe we lose 1 TP from integer math.