### PR TITLE
Fixed sleep unclaim bug (or at least one cause of it)

### DIFF
--- a/src/map/ai/controllers/mob_controller.cpp
+++ b/src/map/ai/controllers/mob_controller.cpp
@@ -111,7 +111,11 @@ bool CMobController::CheckHide(CBattleEntity* PTarget)
 
 bool CMobController::CheckDetection(CBattleEntity* PTarget)
 {
-    if (CanDetectTarget(PTarget) || CanPursueTarget(PTarget) || PMob->StatusEffectContainer->HasStatusEffect(EFFECT_BIND))
+    if (CanDetectTarget(PTarget) || CanPursueTarget(PTarget) || 
+        PMob->StatusEffectContainer->HasStatusEffect(EFFECT_BIND) || 
+        PMob->StatusEffectContainer->HasStatusEffect(EFFECT_SLEEP) || 
+        PMob->StatusEffectContainer->HasStatusEffect(EFFECT_SLEEP_II) ||
+        PMob->StatusEffectContainer->HasStatusEffect(EFFECT_LULLABY))
     {
         TapDeaggroTime();
     }


### PR DESCRIPTION
Ref #3252

I added a bunch of debug messaging, spawned Fafnir, punched him in the mouth and slept him. A handful of seconds later he unclaims and my debug messaging showed it was because the CheckDetection method returned true causing TryDeaggro to remove me from the enmity list, leading to an empty list and an unclaimed Fafnir. I added additional conditions to extend the deaggro time, similar to the already existing condition for Bind, for each type of Sleep. In further testing, I was unable to get him to deaggro while asleep.