### PR TITLE
Fixed issue that was causing Trick Attack damage to always be applied to Weaponskills

### DIFF
--- a/src/map/lua/luautils.cpp
+++ b/src/map/lua/luautils.cpp
@@ -3105,8 +3105,16 @@ namespace luautils
         CLuaAction LuaAction(&action);
         Lunar<CLuaAction>::push(LuaHandle, &LuaAction);
 
-        CLuaBaseEntity LuaTrickAttackEntity(taChar);
-        Lunar<CLuaBaseEntity>::push(LuaHandle, &LuaTrickAttackEntity);
+        if (taChar == nullptr)
+        {
+            lua_pushnil(LuaHandle);
+        }
+        else
+        {
+            CLuaBaseEntity LuaTrickAttackEntity(taChar);
+            Lunar<CLuaBaseEntity>::push(LuaHandle, &LuaTrickAttackEntity);
+        }
+        
 
         if (lua_pcall(LuaHandle, 7, LUA_MULTRET, 0))
         {


### PR DESCRIPTION
An empty Entity object was always being passed to weaponskills.lua as taChar so it always thought there was a valid Trick target leading to THFs always getting bonus damage on their weaponskills (and probably generating no enmity too as it would try to apply it to a non-existent character).