### PR TITLE
Exclude certain NPC's from widescan

### DIFF
--- a/src/map/entities/npcentity.cpp
+++ b/src/map/entities/npcentity.cpp
@@ -100,6 +100,7 @@ CNpcEntity::CNpcEntity()
 {
 	objtype = TYPE_NPC;
 	look.face = 0x32;
+        widescan = 1;
 	allegiance = ALLEGIANCE_MOB;
     PAI = std::make_unique<CAIContainer>(this);
 }

--- a/src/map/entities/npcentity.h
+++ b/src/map/entities/npcentity.h
@@ -39,6 +39,7 @@ public:
 
     uint32      m_flags;
     uint8       name_prefix;
+    uint8       widescan;
     void        HideModel(bool hide);                    // hide / show model
     bool        IsModelHidden();
     void        HideHP(bool hide);

--- a/src/map/instance_loader.cpp
+++ b/src/map/instance_loader.cpp
@@ -233,7 +233,7 @@ CInstance* CInstanceLoader::LoadInstance(CInstance* instance)
         Query =
             "SELECT npcid, name, pos_rot, pos_x, pos_y, pos_z,\
 			flag, speed, speedsub, animation, animationsub, namevis,\
-			status, flags, look, name_prefix \
+			status, flags, look, name_prefix, widescan \
 			FROM instance_entities INNER JOIN npc_list ON \
 			(instance_entities.id = npc_list.npcid) \
 			WHERE instanceid = %u AND npcid >= %u and npcid < %u;";
@@ -271,6 +271,7 @@ CInstance* CInstanceLoader::LoadInstance(CInstance* instance)
                 PNpc->m_flags = (uint32)Sql_GetUIntData(SqlInstanceHandle, 13);
 
                 PNpc->name_prefix = (uint8)Sql_GetIntData(SqlInstanceHandle, 15);
+                PNpc->widescan = (uint8)Sql_GetIntData(SqlInstanceHandle, 16);
 
                 memcpy(&PNpc->look, Sql_GetData(SqlInstanceHandle, 14), 20);
 

--- a/src/map/utils/zoneutils.cpp
+++ b/src/map/utils/zoneutils.cpp
@@ -273,7 +273,8 @@ void LoadNPCList()
           flags,\
           look,\
           name_prefix, \
-          required_expansion \
+          required_expansion, \
+          widescan \
         FROM npc_list INNER JOIN zone_settings \
         ON (npcid & 0xFFF000) >> 12 = zone_settings.zoneid \
         WHERE IF(%d <> 0, '%s' = zoneip AND %d = zoneport, TRUE);";
@@ -320,6 +321,7 @@ void LoadNPCList()
                 PNpc->m_flags = (uint32)Sql_GetUIntData(SqlHandle, 13);
 
                 PNpc->name_prefix = (uint8)Sql_GetIntData(SqlHandle, 15);
+                PNpc->widescan = (uint8)Sql_GetIntData(SqlHandle, 17);
 
                 memcpy(&PNpc->look, Sql_GetData(SqlHandle, 14), 20);
 

--- a/src/map/zone_entities.cpp
+++ b/src/map/zone_entities.cpp
@@ -914,7 +914,7 @@ void CZoneEntities::WideScan(CCharEntity* PChar, uint16 radius)
     for (EntityList_t::const_iterator it = m_npcList.begin(); it != m_npcList.end(); ++it)
     {
         CNpcEntity* PNpc = (CNpcEntity*)it->second;
-        if (PNpc->status == STATUS_NORMAL && !PNpc->IsNameHidden() && !PNpc->IsUntargetable())
+        if (PNpc->status == STATUS_NORMAL && !PNpc->IsNameHidden() && !PNpc->IsUntargetable() && PNpc->widescan == 1)
         {
             if (distance(PChar->loc.p, PNpc->loc.p) < radius)
             {


### PR DESCRIPTION
Added an extra field `widescan` to the npc_list table, which is checked before returning the npclist.
At the moment I only set it to 0 for the most obvious types: Treasures, QM/???, Door's, HELM Points

