### PR TITLE
Various bug fixes from previous commit

### DIFF
--- a/scripts/globals/abilities/high_jump.lua
+++ b/scripts/globals/abilities/high_jump.lua
@@ -46,8 +46,13 @@ function onUseAbility(player,target,ability,action)
         end
         target:lowerEnmity(player, enmityShed + player:getMod(MOD_HIGH_JUMP_ENMITY_REDUCTION)); -- reduce total accumulated enmity
     end
+    
+    local taChar = nil
+    if (player:hasStatusEffect(EFFECT_TRICK_ATTACK)) then
+        taChar = player:getTrickAttackChar(target)
+    end
 
-    local damage, criticalHit, tpHits, extraHits = doPhysicalWeaponskill(player, target, 0, 0, true, action, nullptr, params);
+    local damage, criticalHit, tpHits, extraHits = doPhysicalWeaponskill(player, target, 0, 0, true, action, taChar, params);
 
     if (tpHits + extraHits > 0) then
         -- Under Spirit Surge, High Jump reduces TP of target

--- a/scripts/globals/abilities/high_jump.lua
+++ b/scripts/globals/abilities/high_jump.lua
@@ -47,7 +47,7 @@ function onUseAbility(player,target,ability,action)
         target:lowerEnmity(player, enmityShed + player:getMod(MOD_HIGH_JUMP_ENMITY_REDUCTION)); -- reduce total accumulated enmity
     end
 
-    local damage, criticalHit, tpHits, extraHits = doPhysicalWeaponskill(player, target, 0, params, 0, true)
+    local damage, criticalHit, tpHits, extraHits = doPhysicalWeaponskill(player, target, 0, 0, true, action, nullptr, params);
 
     if (tpHits + extraHits > 0) then
         -- Under Spirit Surge, High Jump reduces TP of target

--- a/scripts/globals/abilities/high_jump.lua
+++ b/scripts/globals/abilities/high_jump.lua
@@ -47,10 +47,7 @@ function onUseAbility(player,target,ability,action)
         target:lowerEnmity(player, enmityShed + player:getMod(MOD_HIGH_JUMP_ENMITY_REDUCTION)); -- reduce total accumulated enmity
     end
     
-    local taChar = nil
-    if (player:hasStatusEffect(EFFECT_TRICK_ATTACK)) then
-        taChar = player:getTrickAttackChar(target)
-    end
+    local taChar = player:getTrickAttackChar(target);
 
     local damage, criticalHit, tpHits, extraHits = doPhysicalWeaponskill(player, target, 0, 0, true, action, taChar, params);
 

--- a/scripts/globals/abilities/jump.lua
+++ b/scripts/globals/abilities/jump.lua
@@ -37,8 +37,13 @@ function onUseAbility(player,target,ability,action)
     params.acc100 = 0.0; params.acc200= 0.0; params.acc300= 0.0;
     params.atkmulti = (player:getMod(MOD_JUMP_ATT_BONUS) + 100) / 100
     params.bonusTP = player:getMod(MOD_JUMP_TP_BONUS)
+    
+    local taChar = nil
+    if (player:hasStatusEffect(EFFECT_TRICK_ATTACK)) then
+        taChar = player:getTrickAttackChar(target)
+    end
 
-    local damage, criticalHit, tpHits, extraHits = doPhysicalWeaponskill(player, target, 0, 0, true, action, nullptr, params);
+    local damage, criticalHit, tpHits, extraHits = doPhysicalWeaponskill(player, target, 0, 0, true, action, taChar, params);
 
     if (tpHits + extraHits > 0) then
         -- Under Spirit Surge, Jump also decreases target defence by 20% for 60 seconds

--- a/scripts/globals/abilities/jump.lua
+++ b/scripts/globals/abilities/jump.lua
@@ -38,10 +38,7 @@ function onUseAbility(player,target,ability,action)
     params.atkmulti = (player:getMod(MOD_JUMP_ATT_BONUS) + 100) / 100
     params.bonusTP = player:getMod(MOD_JUMP_TP_BONUS)
     
-    local taChar = nil
-    if (player:hasStatusEffect(EFFECT_TRICK_ATTACK)) then
-        taChar = player:getTrickAttackChar(target)
-    end
+    local taChar = player:getTrickAttackChar(target);
 
     local damage, criticalHit, tpHits, extraHits = doPhysicalWeaponskill(player, target, 0, 0, true, action, taChar, params);
 

--- a/scripts/globals/abilities/jump.lua
+++ b/scripts/globals/abilities/jump.lua
@@ -38,7 +38,7 @@ function onUseAbility(player,target,ability,action)
     params.atkmulti = (player:getMod(MOD_JUMP_ATT_BONUS) + 100) / 100
     params.bonusTP = player:getMod(MOD_JUMP_TP_BONUS)
 
-    local damage, criticalHit, tpHits, extraHits = doPhysicalWeaponskill(player, target, 0, params, 0, true)
+    local damage, criticalHit, tpHits, extraHits = doPhysicalWeaponskill(player, target, 0, 0, true, action, nullptr, params);
 
     if (tpHits + extraHits > 0) then
         -- Under Spirit Surge, Jump also decreases target defence by 20% for 60 seconds

--- a/scripts/globals/weaponskills/spirits_within.lua
+++ b/scripts/globals/weaponskills/spirits_within.lua
@@ -23,21 +23,21 @@ function onUseWeaponSkill(player, target, wsID, tp, primary, action, taChar)
     local WSC = 0;
     local tpHits = 0;
     -- Damage calculations based on https://www.bg-wiki.com/index.php?title=Spirits_Within&oldid=269806
-    if (TP == 3000) then
+    if (tp == 3000) then
         WSC = math.floor(HP * 120/256);
-    elseif (TP >= 2000) then
-        WSC = math.floor(HP * (math.floor(0.072 * TP) - 96) / 256)
-    elseif (TP >= 1000) then
-        WSC = math.floor(HP * (math.floor(0.016 * TP) + 16) / 256)
+    elseif (tp >= 2000) then
+        WSC = math.floor(HP * (math.floor(0.072 * tp) - 96) / 256)
+    elseif (tp >= 1000) then
+        WSC = math.floor(HP * (math.floor(0.016 * tp) + 16) / 256)
     end
 
     if (USE_ADOULIN_WEAPON_SKILL_CHANGES == true) then
         -- Damage calculations changed based on: http://www.bg-wiki.com/bg/Spirits_Within http://www.bluegartr.com/threads/121610-Rehauled-Weapon-Skills-tier-lists?p=6142188&viewfull=1#post6142188
-        if (TP == 3000) then
+        if (tp == 3000) then
             WSC = HP;
-        elseif (TP >= 2000) then
+        elseif (tp >= 2000) then
             WSC = math.floor(HP * .5);
-        elseif (TP >= 1000) then
+        elseif (tp >= 1000) then
             WSC = math.floor(HP * .125);
         end
     end


### PR DESCRIPTION
The Trick Attack fix got put live on Era recently and mass testing caught a few more things.

Jump and High Jump got missed when doPhysicalWeaponskill params were changed.
Spirits Within used a different variable syntax that was broken by a mass edit.