### PR TITLE
Various bug fixes

### DIFF
--- a/scripts/globals/abilities/box_step.lua
+++ b/scripts/globals/abilities/box_step.lua
@@ -95,13 +95,13 @@ function onUseAbility(player,target,ability,action)
                 else
                     daze = 2;
                 end
-                target:addStatusEffect(EFFECT_SLUGGISH_DAZE_2,1,0,duration+30);
+                target:addStatusEffect(EFFECT_SLUGGISH_DAZE_5,1,0,duration+30);
                 effect = 5;
 
             elseif (target:hasStatusEffect(EFFECT_SLUGGISH_DAZE_5)) then
                 local duration = target:getStatusEffect(EFFECT_SLUGGISH_DAZE_5):getDuration();
                 target:delStatusEffectSilent(EFFECT_SLUGGISH_DAZE_5);
-                target:addStatusEffect(EFFECT_SLUGGISH_DAZE_3,1,0,duration+30);
+                target:addStatusEffect(EFFECT_SLUGGISH_DAZE_5,1,0,duration+30);
                 daze = 1;
                 effect = 5;
 

--- a/scripts/globals/abilities/quickstep.lua
+++ b/scripts/globals/abilities/quickstep.lua
@@ -95,13 +95,13 @@ function onUseAbility(player,target,ability,action)
                 else
                     daze = 2;
                 end
-                target:addStatusEffect(EFFECT_LETHARGIC_DAZE_2,1,0,duration+30);
+                target:addStatusEffect(EFFECT_LETHARGIC_DAZE_5,1,0,duration+30);
                 effect = 5;
 
             elseif (target:hasStatusEffect(EFFECT_LETHARGIC_DAZE_5)) then
                 local duration = target:getStatusEffect(EFFECT_LETHARGIC_DAZE_5):getDuration();
                 target:delStatusEffectSilent(EFFECT_LETHARGIC_DAZE_5);
-                target:addStatusEffect(EFFECT_LETHARGIC_DAZE_3,1,0,duration+30);
+                target:addStatusEffect(EFFECT_LETHARGIC_DAZE_5,1,0,duration+30);
                 daze = 1;
                 effect = 5;
 

--- a/scripts/globals/abilities/stutter_step.lua
+++ b/scripts/globals/abilities/stutter_step.lua
@@ -95,13 +95,13 @@ function onUseAbility(player,target,ability,action)
                 else
                     daze = 2;
                 end
-                target:addStatusEffect(EFFECT_WEAKENED_DAZE_2,1,0,duration+30);
+                target:addStatusEffect(EFFECT_WEAKENED_DAZE_5,1,0,duration+30);
                 effect = 5;
 
             elseif (target:hasStatusEffect(EFFECT_WEAKENED_DAZE_5)) then
                 local duration = target:getStatusEffect(EFFECT_WEAKENED_DAZE_5):getDuration();
                 target:delStatusEffectSilent(EFFECT_WEAKENED_DAZE_5);
-                target:addStatusEffect(EFFECT_WEAKENED_DAZE_3,1,0,duration+30);
+                target:addStatusEffect(EFFECT_WEAKENED_DAZE_5,1,0,duration+30);
                 daze = 1;
                 effect = 5;
 

--- a/scripts/globals/mobskills/freezebite.lua
+++ b/scripts/globals/mobskills/freezebite.lua
@@ -30,10 +30,10 @@ function onMobWeaponSkill(target, mob, skill)
     params.canCrit = false;
     params.acc100 = 0.0; params.acc200= 0.0; params.acc300= 0.0;
     params.atkmulti = 1;
-    local damage, criticalHit, tpHits, extraHits = doPhysicalWeaponskill(mob, target, params);
+    local damage, criticalHit, tpHits, extraHits = doPhysicalWeaponskill(mob, target, 0, 0, true, nil, nil, params);
     
-       target:delHP(dmg);
-    return dmg;
+    target:delHP(damage);
+    return damage;
 end;
     
     

--- a/src/map/lua/lua_statuseffect.cpp
+++ b/src/map/lua/lua_statuseffect.cpp
@@ -101,7 +101,7 @@ inline int32 CLuaStatusEffect::getDuration(lua_State* L)
 {
     DSP_DEBUG_BREAK_IF(m_PLuaStatusEffect == nullptr);
 
-    lua_pushinteger(L, m_PLuaStatusEffect->GetDuration());
+    lua_pushinteger(L, m_PLuaStatusEffect->GetDuration() / 1000);
     return 1;
 }
 

--- a/src/map/utils/battleutils.cpp
+++ b/src/map/utils/battleutils.cpp
@@ -2005,8 +2005,10 @@ namespace battleutils
 
             if (giveTPtoAttacker)
             {
-                if (attackType == PHYSICAL_ATTACK_TYPE::ZANSHIN)
+                if (PAttacker->objtype == TYPE_PC && attackType == PHYSICAL_ATTACK_TYPE::ZANSHIN)
+                {
                     baseTp += ((CCharEntity*)PAttacker)->PMeritPoints->GetMeritValue(MERIT_IKISHOTEN, (CCharEntity*)PAttacker);
+                }
 
                 PAttacker->addTP(tpMultiplier * (baseTp * (1.0f + 0.01f * (float)((PAttacker->getMod(MOD_STORETP) + getStoreTPbonusFromMerit(PAttacker))))));
             }


### PR DESCRIPTION
All of the DNC steps had what was probably a copy/paste issue. If it was at 4 stacks, it went down to 2, and if it was 5, it went down to 3. I changed them to 5 as they should be.

I fixed the duration bug in all steps and other abilities by converting the duration from milliseconds to seconds in lua_statuseffect.cpp.

Freezebite got overlooked during the weaponskill param change since it's a mobskill. It also, apparently, was passing a nil value for damage every time previously.

Fixed a crashed caused by a mob using Zanshin by verifying the Attacker is a PC and actually has merits to check.