### PR TITLE
Fame for Abyssea and Adoulin

### DIFF
--- a/scripts/globals/quests.lua
+++ b/scripts/globals/quests.lua
@@ -26,27 +26,6 @@ ADOULIN     = 9;
 COALITION   = 10;
 
 -----------------------------------
---  Fame IDs
------------------------------------
-
-FAME_SANDORIA           = 0;
-FAME_BASTOK             = 1;
-FAME_WINDURST           = 2;
-FAME_JEUNO              = 3;
-FAME_SELBINA_RABAO      = 4;
-FAME_NORG               = 5;
-FAME_ABYSSEA_KONSCHTAT  = 6;
-FAME_ABYSSEA_TAHRONGI   = 7;
-FAME_ABYSSEA_LATHEINE   = 8;
-FAME_ABYSSEA_MISAREAUX  = 9;
-FAME_ABYSSEA_VUNKERL    = 10;
-FAME_ABYSSEA_ATTOHWA    = 11;
-FAME_ABYSSEA_ALTEPA     = 12;
-FAME_ABYSSEA_GRAUBERG   = 13;
-FAME_ABYSSEA_ULEGUERAND = 14;
-FAME_ADOULIN            = 15;
-
------------------------------------
 --  San d'Oria - 0
 -----------------------------------
 

--- a/scripts/globals/quests.lua
+++ b/scripts/globals/quests.lua
@@ -26,6 +26,27 @@ ADOULIN     = 9;
 COALITION   = 10;
 
 -----------------------------------
+--  Fame IDs
+-----------------------------------
+
+FAME_SANDORIA           = 0;
+FAME_BASTOK             = 1;
+FAME_WINDURST           = 2;
+FAME_JEUNO              = 3;
+FAME_SELBINA_RABAO      = 4;
+FAME_NORG               = 5;
+FAME_ABYSSEA_KONSCHTAT  = 6;
+FAME_ABYSSEA_TAHRONGI   = 7;
+FAME_ABYSSEA_LATHEINE   = 8;
+FAME_ABYSSEA_MISAREAUX  = 9;
+FAME_ABYSSEA_VUNKERL    = 10;
+FAME_ABYSSEA_ATTOHWA    = 11;
+FAME_ABYSSEA_ALTEPA     = 12;
+FAME_ABYSSEA_GRAUBERG   = 13;
+FAME_ABYSSEA_ULEGUERAND = 14;
+FAME_ADOULIN            = 15;
+
+-----------------------------------
 --  San d'Oria - 0
 -----------------------------------
 
@@ -1011,7 +1032,7 @@ KEEP_YOUR_BLOOMERS_ON_ERISA     = 71;
 SCAREDYCATS                     = 72;
 RAPTOR_RAPTURE                  = 73;
 EXOTIC_DELICACIES               = 74;
-A_PIONEERS_BEST_IMAGINARY_FRIEND= 75;
+A_PIONEERS_BEST_IMAGINARY_FRIEND= 75; 
 HUNGER_STRIKES                  = 76;
 THE_OLD_MAN_AND_THE_HARPOON     = 77;
 A_CERTAIN_SUBSTITUTE_PATROLMAN  = 78;

--- a/scripts/globals/shop.lua
+++ b/scripts/globals/shop.lua
@@ -10,16 +10,17 @@ require("scripts/globals/conquest");
 -- Nations
 -----------------------------------
 
-SANDORIA = 0;
-  BASTOK = 1;
-WINDURST = 2;
-  KAZHAM = 2;
-   JEUNO = 3;
- SELBINA = 4;
-   RABAO = 4;
-    NORG = 5;
-TAVNAZIA = 6;
-  STATIC = 7;
+SANDORIA     = 0;
+  BASTOK     = 1;
+WINDURST     = 2;
+  KAZHAM     = 2;
+   JEUNO     = 3;
+ SELBINA     = 4;
+   RABAO     = 4;
+    NORG     = 5;
+TAVNAZIA     = 6;
+  STATIC     = 7;
+FAME_ADOULIN = 15;
 
 -----------------------------------
 -- function showShop

--- a/sql/char_profile.sql
+++ b/sql/char_profile.sql
@@ -37,5 +37,15 @@ CREATE TABLE IF NOT EXISTS `char_profile` (
   `fame_windurst` smallint(5) unsigned NOT NULL DEFAULT '0',
   `fame_norg` smallint(5) unsigned NOT NULL DEFAULT '0',
   `fame_jeuno` smallint(5) unsigned NOT NULL DEFAULT '0',
+  `fame_aby_konschtat` smallint(5) unsigned NOT NULL DEFAULT '0',
+  `fame_aby_tahrongi` smallint(5) unsigned NOT NULL DEFAULT '0',
+  `fame_aby_latheine` smallint(5) unsigned NOT NULL DEFAULT '0',
+  `fame_aby_misareaux` smallint(5) unsigned NOT NULL DEFAULT '0',
+  `fame_aby_vunkerl` smallint(5) unsigned NOT NULL DEFAULT '0',
+  `fame_aby_attohwa` smallint(5) unsigned NOT NULL DEFAULT '0',
+  `fame_aby_altepa` smallint(5) unsigned NOT NULL DEFAULT '0',
+  `fame_aby_grauberg` smallint(5) unsigned NOT NULL DEFAULT '0',
+  `fame_aby_uleguerand` smallint(5) unsigned NOT NULL DEFAULT '0',
+  `fame_adoulin` smallint(5) unsigned NOT NULL DEFAULT '0',
   PRIMARY KEY (`charid`)
 ) ENGINE=MyISAM DEFAULT CHARSET=utf8;

--- a/src/map/entities/charentity.h
+++ b/src/map/entities/charentity.h
@@ -91,7 +91,7 @@ struct profile_t
     uint8	   nation;			// принадлежность к государству
     uint8	   mhflag;			// флаг выхода из MogHouse
     uint16	   title;			// звание
-    uint16     fame[5];			// известность
+    uint16     fame[15];		// известность
     uint8 	   rank[3];			// рагн в трех государствах
     uint32	   rankpoints;	    // очки ранга в трех государствах
     location_t home_point;		// точка возрождения персонажа

--- a/src/map/lua/lua_baseentity.cpp
+++ b/src/map/lua/lua_baseentity.cpp
@@ -4010,6 +4010,21 @@ inline int32 CLuaBaseEntity::getFame(lua_State *L)
         case 5: // Norg
             fame = PChar->profile.fame[3]*fameMultiplier;
             break;
+        // Abyssea
+        case 6: // Konschtat
+        case 7: // Tahrongi
+        case 8: // La Theine
+        case 9: // Misareaux
+        case 10: // Vunkerl
+        case 11: // Attohwa
+        case 12: // Altepa
+        case 13: // Grauberg
+        case 14: // Uleguerand
+            fame = PChar->profile.fame[fameArea-1] * fameMultiplier;
+            break;
+        case 15: // Adoulin
+            fame = PChar->profile.fame[14] * fameMultiplier;
+            break;
     }
     lua_pushinteger(L, fame);
     return 1;
@@ -4026,6 +4041,7 @@ inline int32 CLuaBaseEntity::getFameLevel(lua_State *L)
     DSP_DEBUG_BREAK_IF(m_PBaseEntity == nullptr);
     DSP_DEBUG_BREAK_IF(m_PBaseEntity->objtype != TYPE_PC);
 
+    uint8  fameArea = (uint8)lua_tointeger(L, 1);
     this->getFame(L);
 
     uint16 fame = (uint16)lua_tointeger(L, -1);
@@ -4047,6 +4063,9 @@ inline int32 CLuaBaseEntity::getFameLevel(lua_State *L)
         fameLevel = 3;
     else if (fame >= 50)
         fameLevel = 2;
+
+    if ((fameArea >= 6) && (fameArea <= 14) && (fameLevel >= 6))
+        fameLevel = 6; // Abyssea areas cap out at level 6 fame.
 
     lua_pushinteger(L, fameLevel);
     return 1;
@@ -4085,6 +4104,21 @@ inline int32 CLuaBaseEntity::setFame(lua_State *L)
             break;
         case 5: // Norg
             ((CCharEntity*)m_PBaseEntity)->profile.fame[3] = fame;
+            break;
+        // Abyssea
+        case 6: // Konschtat
+        case 7: // Tahrongi
+        case 8: // La Theine
+        case 9: // Misareaux
+        case 10: // Vunkerl
+        case 11: // Attohwa
+        case 12: // Altepa
+        case 13: // Grauberg
+        case 14: // Uleguerand
+            ((CCharEntity*)m_PBaseEntity)->profile.fame[fameArea-1] = fame;
+            break;
+        case 15: // Adoulin
+            ((CCharEntity*)m_PBaseEntity)->profile.fame[14] = fame;
             break;
     }
     charutils::SaveFame((CCharEntity*)m_PBaseEntity);
@@ -4126,6 +4160,21 @@ inline int32 CLuaBaseEntity::addFame(lua_State *L)
             break;
         case 5: // Norg
             PChar->profile.fame[3] += fame;
+            break;
+        // Abyssea
+        case 6: // Konschtat
+        case 7: // Tahrongi
+        case 8: // La Theine
+        case 9: // Misareaux
+        case 10: // Vunkerl
+        case 11: // Attohwa
+        case 12: // Altepa
+        case 13: // Grauberg
+        case 14: // Uleguerand
+            PChar->profile.fame[fameArea-1] += fame;
+            break;
+        case 15: // Adoulin
+            PChar->profile.fame[14] += fame;
             break;
     }
     charutils::SaveFame(PChar);
@@ -10679,7 +10728,7 @@ inline int32 CLuaBaseEntity::getNearbyEntities(lua_State* L)
 
     lua_newtable(L);
     int newTable = lua_gettop(L);
-
+    
     for (auto&& list : {iterTarget->SpawnMOBList, iterTarget->SpawnPCList, iterTarget->SpawnPETList})
     {
         for (auto&& entity : list)

--- a/src/map/utils/charutils.cpp
+++ b/src/map/utils/charutils.cpp
@@ -439,15 +439,25 @@ namespace charutils
 
         fmtQuery =
             "SELECT "
-            "rank_points,"    // 0
-            "rank_sandoria,"  // 1
-            "rank_bastok,"    // 2
-            "rank_windurst,"  // 3
-            "fame_sandoria,"  // 4
-            "fame_bastok,"    // 5
-            "fame_windurst,"  // 6
-            "fame_norg, "     // 7
-            "fame_jeuno "     // 8
+            "rank_points,"          // 0
+            "rank_sandoria,"        // 1
+            "rank_bastok,"          // 2
+            "rank_windurst,"        // 3
+            "fame_sandoria,"        // 4
+            "fame_bastok,"          // 5
+            "fame_windurst,"        // 6
+            "fame_norg, "           // 7
+            "fame_jeuno, "          // 8
+            "fame_aby_konschtat, "  // 9
+            "fame_aby_tahrongi, "   // 10
+            "fame_aby_latheine, "   // 11
+            "fame_aby_misareaux, "  // 12
+            "fame_aby_vunkerl, "    // 13
+            "fame_aby_attohwa, "    // 14
+            "fame_aby_altepa, "     // 15
+            "fame_aby_grauberg, "   // 16
+            "fame_aby_uleguerand, " // 17
+            "fame_adoulin "         // 18
             "FROM char_profile "
             "WHERE charid = %u;";
 
@@ -463,11 +473,21 @@ namespace charutils
             PChar->profile.rank[1] = (uint8)Sql_GetIntData(SqlHandle, 2);
             PChar->profile.rank[2] = (uint8)Sql_GetIntData(SqlHandle, 3);
 
-            PChar->profile.fame[0] = (uint16)Sql_GetIntData(SqlHandle, 4);  //Sandoria
-            PChar->profile.fame[1] = (uint16)Sql_GetIntData(SqlHandle, 5);  //Bastok
-            PChar->profile.fame[2] = (uint16)Sql_GetIntData(SqlHandle, 6);  //Windurst
-            PChar->profile.fame[3] = (uint16)Sql_GetIntData(SqlHandle, 7);  //Norg
-            PChar->profile.fame[4] = (uint16)Sql_GetIntData(SqlHandle, 8);  //Jeuno
+            PChar->profile.fame[0] = (uint16)Sql_GetIntData(SqlHandle, 4);    //Sandoria
+            PChar->profile.fame[1] = (uint16)Sql_GetIntData(SqlHandle, 5);    //Bastok
+            PChar->profile.fame[2] = (uint16)Sql_GetIntData(SqlHandle, 6);    //Windurst
+            PChar->profile.fame[3] = (uint16)Sql_GetIntData(SqlHandle, 7);    //Norg
+            PChar->profile.fame[4] = (uint16)Sql_GetIntData(SqlHandle, 8);    //Jeuno
+            PChar->profile.fame[5] = (uint16)Sql_GetIntData(SqlHandle, 9);    //AbysseaKonschtat
+            PChar->profile.fame[6] = (uint16)Sql_GetIntData(SqlHandle, 10);   //AbysseaTahrongi
+            PChar->profile.fame[7] = (uint16)Sql_GetIntData(SqlHandle, 11);   //AbysseaLaTheine
+            PChar->profile.fame[8] = (uint16)Sql_GetIntData(SqlHandle, 12);   //AbysseaMisareaux
+            PChar->profile.fame[9] = (uint16)Sql_GetIntData(SqlHandle, 13);   //AbysseaVunkerl
+            PChar->profile.fame[10] = (uint16)Sql_GetIntData(SqlHandle, 14);  //AbysseaAttohwa
+            PChar->profile.fame[11] = (uint16)Sql_GetIntData(SqlHandle, 15);  //AbysseaAltepa
+            PChar->profile.fame[12] = (uint16)Sql_GetIntData(SqlHandle, 16);  //AbysseaGrauberg
+            PChar->profile.fame[13] = (uint16)Sql_GetIntData(SqlHandle, 17);  //AbysseaUleguerand
+            PChar->profile.fame[14] = (uint16)Sql_GetIntData(SqlHandle, 18);  //Adoulin
         }
 
         fmtQuery =
@@ -3712,7 +3732,17 @@ namespace charutils
             "fame_bastok = %u,"
             "fame_windurst = %u,"
             "fame_norg = %u,"
-            "fame_jeuno = %u "
+            "fame_jeuno = %u,"
+            "fame_aby_konschtat = %u,"
+            "fame_aby_tahrongi = %u,"
+            "fame_aby_latheine = %u,"
+            "fame_aby_misareaux = %u,"
+            "fame_aby_vunkerl = %u,"
+            "fame_aby_attohwa = %u,"
+            "fame_aby_altepa = %u,"
+            "fame_aby_grauberg = %u,"
+            "fame_aby_uleguerand = %u,"
+            "fame_adoulin = %u "
             "WHERE charid = %u;";
 
         Sql_Query(SqlHandle, Query,
@@ -3721,6 +3751,16 @@ namespace charutils
             PChar->profile.fame[2],
             PChar->profile.fame[3],
             PChar->profile.fame[4],
+            PChar->profile.fame[5],
+            PChar->profile.fame[6],
+            PChar->profile.fame[7],
+            PChar->profile.fame[8],
+            PChar->profile.fame[9],
+            PChar->profile.fame[10],
+            PChar->profile.fame[11],
+            PChar->profile.fame[12],
+            PChar->profile.fame[13],
+            PChar->profile.fame[14],
             PChar->id);
     }
 


### PR DESCRIPTION
Adding fame tracking and levels for Abyssea areas and Adoulin.

Only thing of real note is the addition of FAME_AREA constants in `scripts/globals/quests.lua`.

At the moment, all NPCs that deal with fame use the area's name defined in `quests.lua` or `shop.lua` (BASTOK, WINDURST, etc), which works for them because the quest log IDs and fame area IDs just happen to be the same - you can do `player:addFame(BASTOK)`, `showShop(player, BASTOK, stock)`, and `player:completeQuest(BASTOK, QUEST)` without worrying about conflicts between `quests.lua` and `shop.lua` depending on which you've included (either one, or both, depending on the NPC).

However, each Abyssea area has its own separate fame, with all sharing the same quest log ID. This also posed an issue for Adoulin, because with 9 areas of fame between it (quest log = 9) and Norg (quest log = 5), you couldn't very well have ADOULIN be the same value in reference to both Fame and Quests (ie: Adoulin fame can't also be 9 like its quest log).

So I tacked on FAME_ as a prefix (similar to how a couple C headers use MISSION_ and QUEST_) to be used when distinctly referencing Abyssea/Adoulin Fame (but not Quests):

```
player:completeQuest(ABYSSEA, QUEST_NAME)
player:addFame(FAME_ABYSSEA_LATHEINE)
player:completeQuest(ADOULIN, QUEST_NAME)
player:addFame(FAME_ADOULIN, 60)
```

Existing NPCs are unaffected.

Part of me feels that currently existing NPC references should be made more specific (ie: FAME_BASTOK, QUEST_BASTOK, MISSION_BASTOK instead of just BASTOK in all cases), but if the same value works for all three types, there's really no added benefit to doing so other than maybe consistency with Abyssea/Adoulin.