### PR TITLE
Fix for mobs that have special multi-hit capabilities like Charybdis.…

### DIFF
--- a/src/map/utils/battleutils.cpp
+++ b/src/map/utils/battleutils.cpp
@@ -2521,7 +2521,6 @@ namespace battleutils
 
     uint8 CheckMobMultiHits(CBattleEntity* PEntity)
     {
-
         if (PEntity->objtype == TYPE_MOB || PEntity->objtype == TYPE_PET)
         {
             uint8 num = 1;
@@ -2530,17 +2529,7 @@ namespace battleutils
             if (PEntity->GetMJob() == JOB_MNK)
             {
                 num = 2;
-            }
-
-            //check for unique mobs
-            switch (PEntity->id)
-            {
-                case 17498522:// Charybdis 2-6
-                    return (1 + getHitCount(5));
-
-                default:
-                    break;
-            }
+            }           
 
             int16 tripleAttack = PEntity->getMod(MOD_TRIPLE_ATTACK);
             int16 doubleAttack = PEntity->getMod(MOD_DOUBLE_ATTACK);
@@ -2554,8 +2543,38 @@ namespace battleutils
             {
                 num += 1;
             }
+            
             return num;
         }
+        
+        return 0;
+    }
+    
+    /************************************************************************
+    *                                                                       *
+    *  Returns multihits for special mobs / pets 							*
+    *                                                                       *
+    ************************************************************************/
+    
+    uint8 CheckSpecialMobMultiHits(CBattleEntity* PEntity)
+    {
+        if (PEntity->objtype == TYPE_MOB || PEntity->objtype == TYPE_PET)
+        {
+            uint8 num = 1;
+            
+            // Check for unique mobs
+            switch (PEntity->id)
+            {
+                case 17498522: // Charybdis 2-6
+                    return (1 + getHitCount(5));
+    
+                default:
+                    break;
+            }
+            
+            return num;
+        }
+        
         return 0;
     }
 

--- a/src/map/utils/battleutils.h
+++ b/src/map/utils/battleutils.h
@@ -108,6 +108,7 @@ namespace battleutils
 
     uint8			getHitCount(uint8 hits);
     uint8			CheckMobMultiHits(CBattleEntity* PEntity);
+    uint8           CheckSpecialMobMultiHits(CBattleEntity* PEntity);
 
     int16			GetSnapshotReduction(CCharEntity* m_PChar, int16 delay);
     int32			GetRangedAttackBonuses(CBattleEntity* battleEntity);


### PR DESCRIPTION
… Split the existing CheckMobMultiHits method (which wasn't being called anywhere)  into a new method, CheckSpecialMobMultiHits, that handles calculating number of attacks for mobs specified.

Fix for issue #3269 [https://github.com/DarkstarProject/darkstar/issues/3269](url)

I created the fix based off of the existing code, but perhaps min-max attacks for mobs should be broken out into a lua script or placed in the DB?