### PR TITLE
Created new mob mod 'MOBMOD_MULTI_HIT'

### DIFF
--- a/scripts/globals/status.lua
+++ b/scripts/globals/status.lua
@@ -1970,6 +1970,7 @@ MOBMOD_NO_STANDBACK   = 62
 MOBMOD_ATTACK_SKILL_LIST = 63
 MOBMOD_CHARMABLE      = 64
 MOBMOD_NO_MOVE        = 65
+MOBMOD_MULTI_HIT      = 66
 
 ------------------------------------
 -- Skills

--- a/scripts/zones/Sea_Serpent_Grotto/mobs/Charybdis.lua
+++ b/scripts/zones/Sea_Serpent_Grotto/mobs/Charybdis.lua
@@ -1,7 +1,17 @@
 ----------------------------------
--- Area: Valkurm Dunes
+-- Area: Sea Serpent Grotto
 --   NM: Charybdis
 -----------------------------------
+
+-----------------------------------
+-- onMobInitialize
+-----------------------------------
+
+function onMobInitialize(mob)
+
+    mob:setMobMod(MOBMOD_MULTI_HIT, 5);
+
+end;
 
 -----------------------------------
 -- onMobDespawn

--- a/src/map/attackround.cpp
+++ b/src/map/attackround.cpp
@@ -199,11 +199,22 @@ void CAttackRound::DeleteAttackSwing()
 void CAttackRound::CreateAttacks(CItemWeapon* PWeapon, PHYSICAL_ATTACK_DIRECTION direction)
 {
     uint8 num = 1;
+    
+    bool isPC = m_attacker->objtype == TYPE_PC;
 
     // Checking the players weapon hit count
     if (PWeapon->getReqLvl() <= m_attacker->GetMLevel())
     {
         num = PWeapon->getHitCount();
+    }
+    
+    // If the attacker is a mobentity or derived from mobentity, check to see if it has any special mutli-hit capabilties
+    if (dynamic_cast<CMobEntity*>(m_attacker))
+    {
+        auto multiHitMax = static_cast<CMobEntity*>(m_attacker)->getMobMod(MOBMOD_MULTI_HIT);
+        
+        if (multiHitMax > 0)
+            num = 1 + battleutils::getHitCount(multiHitMax);
     }
 
     AddAttackSwing(PHYSICAL_ATTACK_TYPE::NORMAL, direction, num);
@@ -214,7 +225,7 @@ void CAttackRound::CreateAttacks(CItemWeapon* PWeapon, PHYSICAL_ATTACK_DIRECTION
     int16 quadAttack = m_attacker->getMod(MOD_QUAD_ATTACK);
 
     //check for merit upgrades
-    if (m_attacker->objtype == TYPE_PC)
+    if (isPC)
     {
         CCharEntity* PChar = (CCharEntity*)m_attacker;
 
@@ -245,7 +256,7 @@ void CAttackRound::CreateAttacks(CItemWeapon* PWeapon, PHYSICAL_ATTACK_DIRECTION
         AddAttackSwing(PHYSICAL_ATTACK_TYPE::DOUBLE, direction, 1);
 
     // Ammo extra swing - players only
-    if (m_attacker->objtype == TYPE_PC && m_attacker->getMod(MOD_AMMO_SWING) > 0)
+    if (isPC && m_attacker->getMod(MOD_AMMO_SWING) > 0)
     {
         // Check for ammo
         CCharEntity* PChar = (CCharEntity*)m_attacker;

--- a/src/map/mob_modifier.h
+++ b/src/map/mob_modifier.h
@@ -94,7 +94,8 @@ enum MOBMODIFIER : int
     MOBMOD_NO_STANDBACK       = 62, // Mob will never standback
     MOBMOD_ATTACK_SKILL_LIST  = 63, // skill list to use in place of regular attacks
     MOBMOD_CHARMABLE          = 64, // mob is charmable
-    MOBMOD_NO_MOVE            = 65  // Mob will not be able to move
+    MOBMOD_NO_MOVE            = 65, // Mob will not be able to move
+    MOBMOD_MULTI_HIT          = 66  // Mob will not be able to move
 };
 
 #endif

--- a/src/map/utils/battleutils.cpp
+++ b/src/map/utils/battleutils.cpp
@@ -2515,52 +2515,6 @@ namespace battleutils
 
     /************************************************************************
     *                                                                       *
-    *  Returns a mob / pets multihits								        *
-    *                                                                       *
-    ************************************************************************/
-
-    uint8 CheckMobMultiHits(CBattleEntity* PEntity)
-    {
-
-        if (PEntity->objtype == TYPE_MOB || PEntity->objtype == TYPE_PET)
-        {
-            uint8 num = 1;
-
-            //Monk
-            if (PEntity->GetMJob() == JOB_MNK)
-            {
-                num = 2;
-            }
-
-            //check for unique mobs
-            switch (PEntity->id)
-            {
-                case 17498522:// Charybdis 2-6
-                    return (1 + getHitCount(5));
-
-                default:
-                    break;
-            }
-
-            int16 tripleAttack = PEntity->getMod(MOD_TRIPLE_ATTACK);
-            int16 doubleAttack = PEntity->getMod(MOD_DOUBLE_ATTACK);
-            doubleAttack = dsp_cap(doubleAttack, 0, 100);
-            tripleAttack = dsp_cap(tripleAttack, 0, 100);
-            if (dsprand::GetRandomNumber(100) < tripleAttack)
-            {
-                num += 2;
-            }
-            else if (dsprand::GetRandomNumber(100) < doubleAttack)
-            {
-                num += 1;
-            }
-            return num;
-        }
-        return 0;
-    }
-
-    /************************************************************************
-    *                                                                       *
     *  Returns the number of hits for multihit weapons if applicable        *
     *  (Keeping this for backwards compatibility with the old system)       *
     ************************************************************************/

--- a/src/map/utils/mobutils.cpp
+++ b/src/map/utils/mobutils.cpp
@@ -992,7 +992,6 @@ void InitializeMob(CMobEntity* PMob, CZone* PZone)
     PMob->defaultMobMod(MOBMOD_SIGHT_RANGE, CMobEntity::sight_range);
     PMob->defaultMobMod(MOBMOD_SOUND_RANGE, CMobEntity::sound_range);
 
-
     // Killer Effect
     switch (PMob->m_EcoSystem)
       {
@@ -1018,7 +1017,6 @@ void InitializeMob(CMobEntity* PMob, CZone* PZone)
             ShowError("Mob %s level is 0! zoneid %d, poolid %d\n", PMob->GetName(), PMob->getZone(), PMob->m_Pool);
         }
     }
-
 }
 
 /*


### PR DESCRIPTION
Created new mob mod 'MOBMOD_MULTI_HIT' for specifying if a mob has the capability of attacking more than once per round. e.g. Charybdis.

I also went ahead and deleted the old and unused method **CheckMobMultiHits**.

Now, if a mob has special mutli-hit requirements, **setMobMod** just needs to be called in the mob's **onMobInitialize** of its associated lua script.

Fixes issue #3269