### PR TITLE
Fix for the Norg NPC Fouvia the wyvern re-namer. 

### DIFF
--- a/scripts/zones/Norg/TextIDs.lua
+++ b/scripts/zones/Norg/TextIDs.lua
@@ -22,7 +22,7 @@ YOU_CAN_NOW_BECOME_A_SAMURAI = 10189; -- You can now become a samurai.
 
              AVATAR_UNLOCKED = 10460; -- You are now able to summon
          NOMAD_MOOGLE_DIALOG = 10528; -- I'm a traveling moogle, kupo. I help adventurers in the Outlands access items they have stored in a Mog House elsewhere, kupo.
-               FOUIVA_DIALOG = 10552; -- Oi 'av naw business wi' de likes av you.
+               FOUIVA_DIALOG = 10557; -- Oi 'av naw business wi' de likes av you.
 
 -- Shop Texts
    JIROKICHI_SHOP_DIALOG = 10336; -- Heh-heh-heh. Feast your eyes on these beauties. You won't find stuff like this anywhere!


### PR DESCRIPTION
It seemed that her base dialog ID was off causing her to display dialog from another NPC.

**Notes:**

Fouvia Dialog:

10553: ( Seems to be the base list? )
Select a name for your Wyvern.
Azure, Cerulean, Rygor, Firewing, Delphyne, ..., Khocha

10554:
10555:
Your wyvern has a new name.

10556:
Is this the name you really want?
- This is the one.
- I need more time to think.
- Forget about it.

10557:
Oi 'av naw business wi' de likes av you.

10558:
Oi spy ye've got a gran' wyvern dare witcha.

10559:
Ye gave a name ter yer wyvern whaen yer made yer pact, roi? Well, I'll let ye in on a secret. Did ye know ye can change yer wyvern's name?

10560:
If ye pay me a fee of X gil, oi can 'elp yer. Waaat do yer say? You can alwus back oyt at any time.

10561:
Ye want ter change yer wyvern's name again? Jes pay me fee of X gil, an' oi can 'elp yer.

10562:
Ask the woman for her help?
- Yes.
- No.

10563:
A wyvern's name is a part av its destiny. A change may be good for it. Come back if ye change yer mind.

10564:
Choose a name from de followin'. An' don't go givin' yer wyvern de seem name, now, hear?

10565:
Waaat a gran' name ye 'av chosen. Good day!

10566:
You don't 'av enough gil. Come back whaen ye do.

10567:
Wyvern Names 1

10568:
Wyvern Names 2

10569:
Wyvern Names 3

10570:
Wyvern Names 4