### PR TITLE
Take into account gear under level restriction

### DIFF
--- a/scripts/globals/abilities/meditate.lua
+++ b/scripts/globals/abilities/meditate.lua
@@ -31,11 +31,13 @@ function onUseAbility(player,target,ability)
     local sHands = target:getEquipID(SLOT_HANDS);
     local sHead = target:getEquipID(SLOT_HEAD);
     -- Todo: change these item checks into a modifier.
-    if (sHands == 15113 or sHands == 14920) then
-        extratick = 1;
-    end
-    if (sHead == 13868 or sHead == 15236) then
-        extratick = extratick + 1;
+    if (player:getMainLvl() >= 60) then --wrap this to account for level sync
+        if (sHands == 15113 or sHands == 14920) then
+            extratick = 1;
+        end
+        if (sHead == 13868 or sHead == 15236) then
+            extratick = extratick + 1;
+        end
     end
     if (extratick == 1) then
         extratick = math.random(1,2);


### PR DESCRIPTION
AF head / relic hands giving tp bonus under level restriction. Wrapping the extra tick check with a player level >= 60 will account for all sync as there is no level restriction post 60. Just to be safe