### PR TITLE
Drg and Bst Ability Fixes (Initial)

### DIFF
--- a/scripts/globals/abilities/deep_breathing.lua
+++ b/scripts/globals/abilities/deep_breathing.lua
@@ -15,7 +15,7 @@ require("scripts/globals/status");
 function onAbilityCheck(player,target,ability)
     if (player:getPet() == nil) then
         return MSGBASIC_REQUIRES_A_PET,0;
-   elseif (player:getPetID() ~= 48) then
+   elseif (player:getPetID() ~= PET_WYVERN) then
       return MSGBASIC_NO_EFFECT_ON_PET,0;
     else
       return 0,0;

--- a/scripts/globals/abilities/gauge.lua
+++ b/scripts/globals/abilities/gauge.lua
@@ -13,7 +13,7 @@ require("scripts/globals/status");
 -- onAbilityCheck
 -----------------------------------
 
-function onAbilityCheck(player,target,ability)
+function onAbilityCheck(player, target, ability)
     if (player:getPet() ~= nil ) then
         return MSGBASIC_ALREADY_HAS_A_PET,0;
     else
@@ -25,6 +25,20 @@ end;
 -- onUseAbility
 -----------------------------------
 
-function onUseAbility(player,target,ability)
+function onUseAbility(player, target, ability)
+
+    local charmChance = player:getCharmChance(target, false);
+    
+    if (charmChance >= 75) then
+        ability:setMsg(MSGBASIC_SHOULD_BE_ABLE_CHARM);  -- The <player> should be able to charm <target>.
+    elseif (charmChance >= 50) then
+        ability:setMsg(MSGBASIC_MIGHT_BE_ABLE_CHARM);   -- The <player> might be able to charm <target>.
+    elseif (charmChance >= 25) then
+        ability:setMsg(MSGBASIC_DIFFICULT_TO_CHARM);    -- It would be difficult for the <player> to charm <target>.
+    elseif (charmChance >= 1) then
+        ability:setMsg(MSGBASIC_VERY_DIFFICULT_CHARM);  -- It would be very difficult for the <player> to charm <target>.
+    else
+        ability:setMsg(MSGBASIC_CANNOT_CHARM);          -- The <player> cannot charm <target>!
+    end
 
 end;

--- a/scripts/globals/abilities/super_jump.lua
+++ b/scripts/globals/abilities/super_jump.lua
@@ -8,6 +8,7 @@
 
 require("scripts/globals/settings");
 require("scripts/globals/status");
+require("scripts/globals/pets");
 
 -----------------------------------
 -- onAbilityCheck
@@ -22,4 +23,21 @@ end;
 -----------------------------------
 
 function onUseAbility(player,target,ability)
+
+    -- Reduce 99% of total accumulated enmity
+    if (target:isMob()) then
+        target:lowerEnmity(player, 99);
+    end
+    
+    ability:setMsg(0);
+    
+    -- Prevent the player from performing actions while in the air
+    player:stun(5000);
+    
+    -- If the Dragoon's wyvern is out and alive, tell it to use Super Climb
+    local wyvern = player:getPet();
+    if (wyvern ~= nil and player:getPetID() == PET_WYVERN and wyvern:getHP() > 0) then 
+        wyvern:useJobAbility(636, wyvern);
+    end
+
 end;

--- a/scripts/globals/abilities/tame.lua
+++ b/scripts/globals/abilities/tame.lua
@@ -1,8 +1,8 @@
 -----------------------------------
--- Ability: Super Climb
--- Used by the Wyvern when the Dragoon uses Super Jump. 
--- Does not shed hate, but allows the wyvern to dodge any attack like the Dragoon.
--- Obtained: Dragoon Level 50
+-- Ability: Tame
+-- Makes target docile and more susceptible to charm.
+-- Obtained: Beastmaster Level 30
+-- Recast Time: 10:00
 -- Duration: Instant
 -----------------------------------
 
@@ -22,5 +22,4 @@ end;
 -----------------------------------
 
 function onUseAbility(player,target,ability)
-
 end;

--- a/scripts/globals/pets.lua
+++ b/scripts/globals/pets.lua
@@ -1176,11 +1176,6 @@ PET_ODIN                  = 18;
 PET_ATOMOS                = 19;
 PET_CAIT_SITH             = 20;
 
-PET_AUTOMATON     = 69;
-
-PET_WYVERN                = 48;
-
-
 -----------------------------------
 --  Beastmaster
 -----------------------------------
@@ -1212,3 +1207,15 @@ PET_LIFEDRINKER_LARS      = 44;
 PET_PANZER_GALAHAD        = 45;
 PET_CHOPSUEY_CHUCKY       = 46;
 PET_AMIGO_SABOTENDER      = 47;
+
+-----------------------------------
+--  Dragoon
+-----------------------------------
+
+PET_WYVERN                = 48;
+
+-----------------------------------
+--  Puppetmaster
+-----------------------------------
+
+PET_AUTOMATON             = 69;

--- a/scripts/globals/pets/wyvern.lua
+++ b/scripts/globals/pets/wyvern.lua
@@ -27,9 +27,8 @@ local wyvernTypes = {
     [JOBS.PUP] = WYVERN_OFFENSIVE,
     [JOBS.DNC] = WYVERN_OFFENSIVE,
     [JOBS.SCH] = WYVERN_DEFENSIVE,
-    --These two might not be right (I'd guess GEO is multi)
-    [JOBS.GEO] = WYVERN_OFFENSIVE,
-    [JOBS.RUN] = WYVERN_OFFENSIVE
+    [JOBS.GEO] = WYVERN_DEFENSIVE,
+    [JOBS.RUN] = WYVERN_MULTI
 }
 
 -----------------------------------

--- a/src/map/lua/lua_baseentity.cpp
+++ b/src/map/lua/lua_baseentity.cpp
@@ -366,6 +366,28 @@ inline int32 CLuaBaseEntity::isJugPet(lua_State* L)
 
 //======================================================//
 
+inline int32 CLuaBaseEntity::getCharmChance(lua_State* L)
+{
+    DSP_DEBUG_BREAK_IF(m_PBaseEntity == nullptr || m_PBaseEntity->objtype == TYPE_NPC);
+    DSP_DEBUG_BREAK_IF(lua_isnil(L, 1) || !lua_isuserdata(L, 1));
+
+    CLuaBaseEntity* PLuaBaseEntity = Lunar<CLuaBaseEntity>::check(L, 1);
+    
+    auto PCharmer = static_cast<CBattleEntity*>(m_PBaseEntity);
+    auto PTarget = static_cast<CBattleEntity*>(PLuaBaseEntity->GetBaseEntity());
+    
+    bool includeCharmAffinityAndChanceMods = true;
+    if (!lua_isnil(L, 2) && lua_isboolean(L, 2))
+        includeCharmAffinityAndChanceMods = lua_toboolean(L, 2);;
+    
+    float charmChance = battleutils::GetCharmChance(PCharmer, PTarget, includeCharmAffinityAndChanceMods);
+    lua_pushnumber(L, charmChance);
+
+    return 1;
+}
+
+//======================================================//
+
 inline int32 CLuaBaseEntity::getMP(lua_State *L)
 {
     DSP_DEBUG_BREAK_IF(m_PBaseEntity == nullptr);
@@ -11008,6 +11030,7 @@ Lunar<CLuaBaseEntity>::Register_t CLuaBaseEntity::methods[] =
     LUNAR_DECLARE_METHOD(CLuaBaseEntity,familiar),
     LUNAR_DECLARE_METHOD(CLuaBaseEntity,getPetID),
     LUNAR_DECLARE_METHOD(CLuaBaseEntity,isJugPet),
+    LUNAR_DECLARE_METHOD(CLuaBaseEntity,getCharmChance),
     LUNAR_DECLARE_METHOD(CLuaBaseEntity,needToZone),
     LUNAR_DECLARE_METHOD(CLuaBaseEntity,getContainerSize),
     LUNAR_DECLARE_METHOD(CLuaBaseEntity,changeContainerSize),

--- a/src/map/lua/lua_baseentity.h
+++ b/src/map/lua/lua_baseentity.h
@@ -378,6 +378,7 @@ public:
     int32 getPet(lua_State*);                // Creates an LUA reference to a pet entity
     int32 getPetID(lua_State*);              // If the entity has a pet, returns the PetID to identify pet type.
     int32 isJugPet(lua_State*);              // If the entity has a pet, test if it is a jug pet.
+    int32 getCharmChance(lua_State*);        // Gets the chance the entity has to charm its target.
     int32 familiar(lua_State*);              // familiar on pet
 
     int32 wakeUp(lua_State*);                //wakes target if necessary

--- a/src/map/utils/battleutils.cpp
+++ b/src/map/utils/battleutils.cpp
@@ -3898,7 +3898,6 @@ namespace battleutils
         //IT				30 seconds	guess
 
         uint32 CharmTime = 0;
-        uint32 base = 0;
 
         // player charming mob
         if (PVictim->objtype == TYPE_MOB && PCharmer->objtype == TYPE_PC)
@@ -3920,31 +3919,24 @@ namespace battleutils
 
             if (baseExp >= 400) {//IT
                 CharmTime = 22500;
-                base = 90;
             }
             else if (baseExp >= 240) {//VT
                 CharmTime = 45000;
-                base = 75;
             }
             else if (baseExp >= 120) {//T
                 CharmTime = 90000;
-                base = 60;
             }
             else if (baseExp == 100) {//EM
                 CharmTime = 180000;
-                base = 40;
             }
             else if (baseExp >= 75) {//DC
                 CharmTime = 600000;
-                base = 30;
             }
             else if (baseExp >= 15) {//EP
                 CharmTime = 1200000;
-                base = 20;
             }
             else if (baseExp == 0) {//TW
                 CharmTime = 1800000;
-                base = 10;
             }
 
             //apply charm time extension from gear
@@ -3959,8 +3951,7 @@ namespace battleutils
                 CharmTime *= dsprand::GetRandomNumber(0.75f, 1.25f);
             }
 
-
-            if (TryCharm(PCharmer, PVictim, base) == false)
+            if (TryCharm(PCharmer, PVictim) == false)
             {
                 //player failed to charm mob - agro mob
                 battleutils::ClaimMob(PVictim, PCharmer);
@@ -4042,11 +4033,11 @@ namespace battleutils
 
     /************************************************************************
     *                                                                       *
-    *	calculate if charm is successful                                    *
+    *	Returns the percentage chance that one entity has to charm another. *
     *                                                                       *
     ************************************************************************/
 
-    bool TryCharm(CBattleEntity* PCharmer, CBattleEntity* PVictim, uint32 base)
+    float GetCharmChance(CBattleEntity* PCharmer, CBattleEntity* PTarget, bool includeCharmAffinityAndChanceMods)
     {
         //---------------------------------------------------------
         //	chance of charm is based on:
@@ -4055,39 +4046,107 @@ namespace battleutils
         //  -charmers BST level (not main level)
         //
         //  -75 with a BST SJ lvl10 will struggle on EP
-        //	-75 with a BST SJ lvl75 will not - thats player has bst leveled to 75 and is using it as SJ
+        //	-75 with a BST SJ lvl75 will not - this player has bst leveled to 75 and is using it as SJ
         //---------------------------------------------------------
-
+        
+        float charmChance = 0.0f;
+        
+        if (PCharmer == nullptr || PTarget == nullptr)
+            return charmChance;
+            
+        // Can the target even be charmed?
+        auto PTargetAsMob = dynamic_cast<CMobEntity*>(PTarget);
+        if (PTargetAsMob)
+        {
+            if (PTargetAsMob->m_Type & MOBTYPE_NOTORIOUS || 
+                PTargetAsMob->getMobMod(MOBMOD_CHARMABLE) == 0 ||
+                PTargetAsMob->PMaster != nullptr) 
+            {
+                // 0% chance to charm an NM, non-charmable mob, or pet
+                return charmChance;
+            }
+        }
+        
+        uint8 charmerLvl = PCharmer->GetMLevel();
+        uint8 targetLvl = PTarget->GetMLevel();
+        
+        //printf("Charmer = %s, Lvl. %u\n", PCharmer->name.c_str(), charmerLvl);
+        //printf("Target = %s, Lvl. %u\n", PTarget->name.c_str(), targetLvl);
+        
+        uint32 base = 0;
+        uint16 baseExp = charutils::GetRealExp(charmerLvl, targetLvl);
+    
+        //printf("baseExp = %u\n", baseExp);
+        if (baseExp >= 400) // IT 
+            base = 90;
+        else if (baseExp >= 240) // VT
+            base = 75;
+        else if (baseExp >= 120) // T
+            base = 60;
+        else if (baseExp == 100) // EM
+            base = 40;
+        else if (baseExp >= 75) // DC
+            base = 30;
+        else if (baseExp >= 15) // EP
+            base = 20;
+        else if (baseExp == 0) // TW
+            base = 10;
+        
         uint8 charmerBSTlevel = 0;
-
+    
         if (PCharmer->objtype == TYPE_PC)
-            charmerBSTlevel = ((CCharEntity*)PCharmer)->jobs.job[JOB_BST];
-
+            charmerBSTlevel = static_cast<CCharEntity*>(PCharmer)->jobs.job[JOB_BST];
         else if (PCharmer->objtype == TYPE_MOB)
-            charmerBSTlevel = PCharmer->GetMLevel();
-
-
-        float check = base;
-
-        float levelRatio = (float)(PVictim->GetMLevel()) / charmerBSTlevel;
-        check *= levelRatio;
-
-        float chrRatio = (float)PVictim->CHR() / PCharmer->CHR();
-        check *= chrRatio;
-
-        float charmChanceMods = PCharmer->getMod(MOD_CHARM_CHANCE);
-        // NQ elemental staves have 2 affinity, HQ have 3 affinity. Boost is 10/15% respectively so multiply by 5.
-        float charmAffintyMods = 5 * (PCharmer->getMod(MOD_LIGHT_AFFINITY_ACC));
-        check *= ((float)((100.0f - charmChanceMods - charmAffintyMods) / 100.0f));
-
-
-        //cap chance at 95%
-        if (check < 5) {
-            check = 5;
+            charmerBSTlevel = charmerLvl;
+    
+        //printf("base = %u\n", base);
+        charmChance = base;
+    
+        float levelRatio = float(targetLvl) / charmerBSTlevel;
+        charmChance *= levelRatio;
+        //printf("levelRatio = %f\n", levelRatio);
+    
+        float chrRatio = float(PTarget->CHR()) / PCharmer->CHR();
+        charmChance *= chrRatio;
+        //printf("chrRatio = %f\n", chrRatio);
+    
+        // Retail doesn't take light/apollo into account for Gauge
+        if (includeCharmAffinityAndChanceMods)
+        {
+            // NQ elemental staves have 2 affinity, HQ have 3 affinity. Boost is 10/15% respectively so multiply by 5.
+            float charmAffintyMods = 5 * (PCharmer->getMod(MOD_LIGHT_AFFINITY_ACC));
+            float charmChanceMods = PCharmer->getMod(MOD_CHARM_CHANCE);
+        
+            charmChance *= ((float)((100.0f - charmChanceMods - charmAffintyMods) / 100.0f));
         }
-        if (check < dsprand::GetRandomNumber(100)) {
+    
+        // Cap chance at 95%
+        if (charmChance < 5) 
+            charmChance = 5;
+            
+        charmChance = 100 - charmChance;
+        
+        if (charmChance < 0)
+            charmChance = 0;
+        else if (charmChance > 100)
+            charmChance = 100;
+            
+        return charmChance;
+    }
+
+    /************************************************************************
+    *                                                                       *
+    *	calculate if charm is successful                                    *
+    *                                                                       *
+    ************************************************************************/
+
+    bool TryCharm(CBattleEntity* PCharmer, CBattleEntity* PVictim)
+    {
+        float charmChance = GetCharmChance(PCharmer, PVictim);
+        
+        if (charmChance >= dsprand::GetRandomNumber(100)) 
             return true;
-        }
+        
         return false;
     }
 

--- a/src/map/utils/battleutils.h
+++ b/src/map/utils/battleutils.h
@@ -119,7 +119,7 @@ namespace battleutils
 
     CWeaponSkill*	GetWeaponSkill(uint16 WSkillID);
     CMobSkill*		GetMobSkill(uint16 SkillID);
-    CMobSkill*          GetTwoHourMobSkill(JOBTYPE job, uint16 familyId);
+    CMobSkill*      GetTwoHourMobSkill(JOBTYPE job, uint16 familyId);
 
     const std::list<CWeaponSkill*>& GetWeaponSkills(uint8 skill);
     const std::vector<uint16>& GetMobSkillList(uint16 ListID);
@@ -179,7 +179,8 @@ namespace battleutils
 
     bool				HasNinjaTool(CBattleEntity* PEntity, CSpell* PSpell, bool ConsumeTool);
 
-    bool				TryCharm(CBattleEntity* PCharmer, CBattleEntity* PVictim, uint32 base);
+    float               GetCharmChance(CBattleEntity* PCharmer, CBattleEntity* PTarget, bool includeCharmAffinityAndChanceMods = true);
+    bool				TryCharm(CBattleEntity* PCharmer, CBattleEntity* PVictim);
     void				tryToCharm(CBattleEntity* PCharmer, CBattleEntity* PVictim);
     void                applyCharm(CBattleEntity* PCharmer, CBattleEntity* PVictim, duration charmTime = 0s);
     void                unCharm(CBattleEntity* PEntity);


### PR DESCRIPTION
- Implemented the emnity reduction and super climb triggering functionality of Super Jump
- Implemented Gauge.
- Added new blank tame script.
- Fixed wyvern types for GEO and RUN.

NOTE:
I originally had Gauge taking the light/apollo staves into account, but have read that they didn't effect Gauge's message on retail. EDIT: The GetCharmChance function takes a boolean (defaulted to true) to specify whether to use Charm affinity/chance mods in the calculation. Gauge.lua passes in false to ignore those mods, which should reflect retail more. If we ever want to diverge a bit and have Gauge report a more accurate analysis, we can just remove the "false".

TODO:
I was planning on adding logic for the invincibility frames of Super Jump and Super Climb, but wanted to get some input on how best to implement it. I initially was thinking of adding a new effect e.g "EFFECT_SUPER_JUMP". This will be added in a later PR.