### PR TITLE
Added a subjob check to mobutils::SetupJob

### DIFF
--- a/src/map/utils/mobutils.cpp
+++ b/src/map/utils/mobutils.cpp
@@ -588,6 +588,7 @@ void CalculateStats(CMobEntity * PMob)
 void SetupJob(CMobEntity* PMob)
 {
     JOBTYPE mJob = PMob->GetMJob();
+    JOBTYPE sJob = PMob->GetSJob();
 
     switch(mJob)
     {
@@ -692,19 +693,41 @@ void SetupJob(CMobEntity* PMob)
             PMob->defaultMobMod(MOBMOD_GA_CHANCE, 25);
             PMob->defaultMobMod(MOBMOD_BUFF_CHANCE, 60);
             PMob->defaultMobMod(MOBMOD_MAGIC_DELAY, 10);
+            break;
         case JOB_BLU:
             PMob->defaultMobMod(MOBMOD_MAGIC_COOL, 35);
+            break;
         case JOB_RDM:
             PMob->defaultMobMod(MOBMOD_MAGIC_COOL, 35);
             PMob->defaultMobMod(MOBMOD_GA_CHANCE, 15);
             PMob->defaultMobMod(MOBMOD_BUFF_CHANCE, 40);
             PMob->defaultMobMod(MOBMOD_MAGIC_DELAY, 10);
+            break;
         case JOB_SMN:
             PMob->defaultMobMod(MOBMOD_MAGIC_COOL, 70);
             // smn only has "buffs"
             PMob->defaultMobMod(MOBMOD_BUFF_CHANCE, 100);
     }
 
+    // Just a fallback at the moment
+    switch(sJob)
+    {
+        case JOB_BLM:
+        case JOB_WHM:
+        case JOB_RDM:
+        case JOB_DRK:
+        case JOB_BLU:
+        case JOB_SMN:
+        case JOB_BRD:
+        case JOB_NIN:
+            if(PMob->getMobMod(MOBMOD_MP_BASE))
+            {
+                PMob->defaultMobMod(MOBMOD_MAGIC_COOL, 35);
+                PMob->defaultMobMod(MOBMOD_GA_CHANCE, 15);
+                PMob->defaultMobMod(MOBMOD_BUFF_CHANCE, 40);
+                PMob->defaultMobMod(MOBMOD_MAGIC_DELAY, 10);
+            }
+    }
 }
 
 void SetupRoaming(CMobEntity* PMob)


### PR DESCRIPTION
Some mobs (atm only Ahriman's (war/blm) that I know of, but probably some NMs aswell) are missing MOBMOD_MAGIC_COOL/DELAY/etc because their main job doesn't have mp.
