### PR TITLE
Fixes for MOBMOD_IDLE_DESPAWN

### DIFF
--- a/src/map/ai/controllers/mob_controller.cpp
+++ b/src/map/ai/controllers/mob_controller.cpp
@@ -918,7 +918,7 @@ void CMobController::Disengage()
 
     if (PMob->getMobMod(MOBMOD_IDLE_DESPAWN))
     {
-        PMob->SetDespawnTime(std::chrono::milliseconds(PMob->getMobMod(MOBMOD_IDLE_DESPAWN)));
+        PMob->SetDespawnTime(std::chrono::seconds(PMob->getMobMod(MOBMOD_IDLE_DESPAWN)));
     }
 
     PMob->delRageMode();

--- a/src/map/entities/mobentity.cpp
+++ b/src/map/entities/mobentity.cpp
@@ -992,7 +992,7 @@ void CMobEntity::OnDisengage(CAttackState& state)
 
     if (getMobMod(MOBMOD_IDLE_DESPAWN))
     {
-        SetDespawnTime(std::chrono::milliseconds(getMobMod(MOBMOD_IDLE_DESPAWN)));
+        SetDespawnTime(std::chrono::seconds(getMobMod(MOBMOD_IDLE_DESPAWN)));
     }
     // this will let me decide to walk home or despawn
     m_neutral = true;


### PR DESCRIPTION
It's using getMobMod instead of getBigMobMod, and it should be applied to every mob on init/spawn(not just onDisenage) as some mobs are using it that way.