### PR TITLE
Internal table for quest logs, mission logs, and fame.

### DIFF
--- a/scripts/commands/addmission.lua
+++ b/scripts/commands/addmission.lua
@@ -13,7 +13,13 @@ cmdprops =
 
 function onTrigger(player, logId, missionId, target)
     
+    local logName;
     logId = tonumber(logId) or _G[logId];
+    if ((type(logId) == "table")) then
+        logName = logId["full_name"];
+        logId = logId["mission_log"];
+    end
+
     missionId = tonumber(missionId) or _G[missionId];
     
     if (missionId == nil or logId == nil) then
@@ -29,7 +35,11 @@ function onTrigger(player, logId, missionId, target)
     local targ = GetPlayerByName( target );
     if (targ ~= nil) then
         targ:addMission( logId, missionId );
-        player:PrintToPlayer( string.format( "Added Mission for log %u with ID %u to %s", logId, missionId, target ) );
+        if (logName) then
+            player:PrintToPlayer( string.format( "Added %s Mission with ID %u for %s", logName, missionId, target ) );
+        else
+            player:PrintToPlayer( string.format( "Added Mission for log %u with ID %u to %s", logId, missionId, target ) );
+        end
     else
         player:PrintToPlayer( string.format( "Player named '%s' not found!", target ) );
         player:PrintToPlayer( "@addmission <logID> <missionID> <player>" );

--- a/scripts/commands/addmission.lua
+++ b/scripts/commands/addmission.lua
@@ -16,8 +16,8 @@ function onTrigger(player, logId, missionId, target)
     local logName;
     logId = tonumber(logId) or _G[logId];
     if ((type(logId) == "table")) then
-        logName = logId["full_name"];
-        logId = logId["mission_log"];
+        logName = logId.full_name;
+        logId = logId.mission_log;
     end
 
     missionId = tonumber(missionId) or _G[missionId];

--- a/scripts/commands/addquest.lua
+++ b/scripts/commands/addquest.lua
@@ -13,7 +13,13 @@ cmdprops =
 
 function onTrigger(player, logId, questId, target)
     
+    local logName;
     logId = tonumber(logId) or _G[logId];
+    if ((type(logId) == "table")) then
+        logName = logId["full_name"];
+        logId = logId["quest_log"];
+    end
+
     questId = tonumber(questId) or _G[questId];
     
     if (questId == nil or logId == nil) then
@@ -29,7 +35,11 @@ function onTrigger(player, logId, questId, target)
     local targ = GetPlayerByName(target);
     if (targ ~= nil) then
         targ:addQuest( logId, questId );
-        player:PrintToPlayer( string.format( "Added Quest for log %u with ID %u to %s", logId, questId, target ) );
+        if (logName) then
+            player:PrintToPlayer( string.format( "Added %s Quest with ID %u for %s", logName, questId, target ) );
+        else
+            player:PrintToPlayer( string.format( "Added Quest for log %u with ID %u to %s", logId, questId, target ) );
+        end
     else
         player:PrintToPlayer( string.format( "Player named '%s' not found!", target ) );
         player:PrintToPlayer( "@addquest <logID> <questID> <player>" );

--- a/scripts/commands/addquest.lua
+++ b/scripts/commands/addquest.lua
@@ -16,8 +16,8 @@ function onTrigger(player, logId, questId, target)
     local logName;
     logId = tonumber(logId) or _G[logId];
     if ((type(logId) == "table")) then
-        logName = logId["full_name"];
-        logId = logId["quest_log"];
+        logName = logId.full_name;
+        logId = logId.quest_log;
     end
 
     questId = tonumber(questId) or _G[questId];

--- a/scripts/commands/checkmission.lua
+++ b/scripts/commands/checkmission.lua
@@ -13,7 +13,15 @@ cmdprops =
 
 function onTrigger(player,logId,target)
     
+    local logName;
     logId = tonumber(logId) or _G[logId];
+    if ((type(logId) == "table")) then
+        logName = logId["full_name"];
+        logId = logId["mission_log"];
+    else
+        local missionAreas = {SANDORIA, BASTOK, WINDURST, ZILART, TOAU, WOTG, COP, ASSAULT, CAMPAIGN, ACP, AMK, ASA, SOA, ROV};
+        logName = missionAreas[logId + 1]["full_name"];
+    end
     
     if (logId == nil) then
         player:PrintToPlayer( "You must enter a valid LogID!" );
@@ -28,52 +36,18 @@ function onTrigger(player,logId,target)
     local targ = GetPlayerByName(target);
     local Log = targ:getCurrentMission(logId)
     -- Todo: loop through missionIDs and output mission name, not just a number.
-    -- Hopefully can use same method to replace this annoying pile of elseif's.
     if (targ ~= nil) then
-        if (logId == 12) then    -- Seekers of Adoulin
-            player:PrintToPlayer( string.format( "Current Seekers of Adoulin Mission ID is: '%s' !", Log ) );
-        elseif (logId == 11) then -- A Shantotto Ascension
-            player:PrintToPlayer( string.format( "Current Shantotto Ascension Mission ID is: '%s' !", Log ) );
-        elseif (logId == 10) then -- A moogle Kupo d'Etat
-            player:PrintToPlayer( string.format( "Current moogle Kupo dEtat Mission ID is: '%s' !", Log ) );
-        elseif (logId == 9) then -- A Crystalline Prophecy
-            player:PrintToPlayer( string.format( "Current Crystalline Prophecy Mission ID is: '%s' !", Log ) );
-        elseif (logId == 8) then -- Campaign
-            player:PrintToPlayer( string.format( "Current Campaign OPs ID is: '%s' !", Log ) );
-        elseif (logId == 7) then -- Assault
-            player:PrintToPlayer( string.format( "Current Assault Mission ID is: '%s' !", Log ) );
-        elseif (logId == 6) then -- Chains of Promathia
-            player:PrintToPlayer( string.format( "Current Chains of Promathia Mission ID is: '%s' !", Log ) );
-        elseif (logId == 5) then -- Wings of the Goddess
-            player:PrintToPlayer( string.format( "Current Wings of the Goddess Mission ID is: '%s' !", Log ) );
-        elseif (logId == 4) then -- Treasures of Aht Urgan
-            player:PrintToPlayer( string.format( "Current Treasures of Aht Urgan Mission ID is: '%s' !", Log ) );
-        elseif (logId == 3) then -- Rise of the Zilart
-            if (Log == 255) then
-                player:PrintToPlayer( "No current Rise of the Zilart mission." );
+        if (logId <= 13) then
+            if ((logId <= 3) and (Log == 255)) then
+                player:PrintToPlayer( string.format( "No current %s mission.", logName ) );
             else
-                player:PrintToPlayer( string.format( "Current Rise of the Zilart Mission ID is: '%s' !", Log ) );
-            end
-        elseif (logId == 2) then -- Windurst
-            if (Log == 255) then
-                player:PrintToPlayer( "No current Windurst mission." );
-            else
-                player:PrintToPlayer( string.format( "Current Windurst Mission ID is: '%s' !", Log ) );
-            end
-        elseif (logId == 1) then -- Bastok
-            if (Log == 255) then
-                player:PrintToPlayer( "No current Bastok mission." );
-            else
-                player:PrintToPlayer( string.format( "Current Bastok Mission ID is: '%s' !", Log ) );
-            end
-        elseif (logId == 0) then -- San d'Orea
-            if (Log == 255) then
-                player:PrintToPlayer( "No current San d'Orea mission." );
-            else
-                player:PrintToPlayer( string.format( "Current San dOrea Mission ID is: '%s' !", Log ) );
+                player:PrintToPlayer( string.format( "Current %s Mission ID is: '%s' !", logName, Log ) );
             end
         else     -- Everything not valid or not currently handled
-            player:PrintToPlayer("Invalid or unsupported LogID. The LogID must be 0-12.");
+            player:PrintToPlayer("Invalid or unsupported LogID. The LogID must be 0-13.");
         end
+    else
+        player:PrintToPlayer( string.format( "Player named '%s' not found!", target ) );
+        player:PrintToPlayer( "@checkmission <logID> <player>" );
     end
 end

--- a/scripts/commands/checkmission.lua
+++ b/scripts/commands/checkmission.lua
@@ -16,11 +16,11 @@ function onTrigger(player,logId,target)
     local logName;
     logId = tonumber(logId) or _G[logId];
     if ((type(logId) == "table")) then
-        logName = logId["full_name"];
-        logId = logId["mission_log"];
+        logName = logId.full_name;
+        logId = logId.mission_log;
     else
         local missionAreas = {SANDORIA, BASTOK, WINDURST, ZILART, TOAU, WOTG, COP, ASSAULT, CAMPAIGN, ACP, AMK, ASA, SOA, ROV};
-        logName = missionAreas[logId + 1]["full_name"];
+        logName = missionAreas[logId + 1].full_name;
     end
     
     if (logId == nil) then

--- a/scripts/commands/checkmission.lua
+++ b/scripts/commands/checkmission.lua
@@ -19,8 +19,13 @@ function onTrigger(player,logId,target)
         logName = logId.full_name;
         logId = logId.mission_log;
     else
-        local missionAreas = {SANDORIA, BASTOK, WINDURST, ZILART, TOAU, WOTG, COP, ASSAULT, CAMPAIGN, ACP, AMK, ASA, SOA, ROV};
-        logName = missionAreas[logId + 1].full_name;
+        if (logId <= 2) then
+            local logNames = {"San d'Oria", "Bastok", "Windurst"}
+            logName = logNames[logId + 1];
+        else
+            local missionAreas = {ZILART, TOAU, WOTG, COP, ASSAULT, CAMPAIGN, ACP, AMK, ASA, SOA, ROV};
+            logName = missionAreas[logId - 2].full_name;
+        end
     end
     
     if (logId == nil) then

--- a/scripts/commands/completemission.lua
+++ b/scripts/commands/completemission.lua
@@ -12,8 +12,14 @@ cmdprops =
 };
 
 function onTrigger(player, logId, missionId, target)
-    
+
+    local logName;
     logId = tonumber(logId) or _G[logId];
+    if ((type(logId) == "table")) then
+        logName = logId["full_name"];
+        logId = logId["mission_log"];
+    end
+
     missionId = tonumber(missionId) or _G[missionId];
 
     if (missionId == nil or logId == nil) then
@@ -29,7 +35,11 @@ function onTrigger(player, logId, missionId, target)
     local targ = GetPlayerByName( target );
     if (targ ~= nil) then
         targ:completeMission( logId, missionId );
-        player:PrintToPlayer( string.format( "Completed Mission for log %u with ID %u for %s", logId, missionId, target ) );
+        if (logName) then
+            player:PrintToPlayer( string.format( "Completed %s Mission with ID %u for %s", logName, missionId, target ) );
+        else
+            player:PrintToPlayer( string.format( "Completed Mission for log %u with ID %u for %s", logId, missionId, target ) );
+        end
     else
         player:PrintToPlayer( string.format( "Player named '%s' not found!", target ) );
         player:PrintToPlayer( "@completemission <logID> <missionID> <player>" );

--- a/scripts/commands/completemission.lua
+++ b/scripts/commands/completemission.lua
@@ -16,8 +16,8 @@ function onTrigger(player, logId, missionId, target)
     local logName;
     logId = tonumber(logId) or _G[logId];
     if ((type(logId) == "table")) then
-        logName = logId["full_name"];
-        logId = logId["mission_log"];
+        logName = logId.full_name;
+        logId = logId.mission_log;
     end
 
     missionId = tonumber(missionId) or _G[missionId];

--- a/scripts/commands/completequest.lua
+++ b/scripts/commands/completequest.lua
@@ -13,7 +13,13 @@ cmdprops =
 
 function onTrigger(player, logId, questId, target)
 
+    local logName;
     logId = tonumber(logId) or _G[logId];
+    if ((type(logId) == "table")) then
+        logName = logId["full_name"];
+        logId = logId["quest_log"];
+    end
+
     questId = tonumber(questId) or _G[questId];
     
     if (questId == nil or logId == nil) then
@@ -29,7 +35,11 @@ function onTrigger(player, logId, questId, target)
     local targ = GetPlayerByName(target);
     if (targ ~= nil) then
         targ:completeQuest( logId, questId );
-        player:PrintToPlayer( string.format( "Completed Quest for log %u with ID %u for %s", logId, questId, target ) );
+        if (logName) then
+            player:PrintToPlayer( string.format( "Completed %s Quest with ID %u for %s", logName, questId, target ) );
+        else
+            player:PrintToPlayer( string.format( "Completed Quest for log %u with ID %u for %s", logId, questId, target ) );
+        end
     else
         player:PrintToPlayer( string.format( "Player named '%s' not found!", target ) );
         player:PrintToPlayer( "@completequest <logID> <questID> <player>" );

--- a/scripts/commands/completequest.lua
+++ b/scripts/commands/completequest.lua
@@ -16,8 +16,8 @@ function onTrigger(player, logId, questId, target)
     local logName;
     logId = tonumber(logId) or _G[logId];
     if ((type(logId) == "table")) then
-        logName = logId["full_name"];
-        logId = logId["quest_log"];
+        logName = logId.full_name;
+        logId = logId.quest_log;
     end
 
     questId = tonumber(questId) or _G[questId];

--- a/scripts/commands/delmission.lua
+++ b/scripts/commands/delmission.lua
@@ -13,7 +13,13 @@ cmdprops =
 
 function onTrigger(player, logId, missionId, target)
     
+    local logName;
     logId = tonumber(logId) or _G[logId];
+    if ((type(logId) == "table")) then
+        logName = logId["full_name"];
+        logId = logId["mission_log"];
+    end
+
     missionId = tonumber(missionId) or _G[missionId];
     
     if (missionId == nil or logId == nil) then
@@ -29,7 +35,11 @@ function onTrigger(player, logId, missionId, target)
     local targ = GetPlayerByName(target);
     if (targ ~= nil) then
         targ:delMission( logId, missionId );
-        player:PrintToPlayer( string.format( "Deleted Mission for log %u with ID %u from %s", logId, missionId, target ) );
+        if (logName) then
+            player:PrintToPlayer( string.format( "Deleted %s Mission with ID %u for %s", logName, missionId, target ) );
+        else
+            player:PrintToPlayer( string.format( "Deleted Mission for log %u with ID %u from %s", logId, missionId, target ) );
+        end
     else
         player:PrintToPlayer( string.format( "Player named '%s' not found!", target ) );
         player:PrintToPlayer( "@delmission <logID> <missionID> <player>" );

--- a/scripts/commands/delmission.lua
+++ b/scripts/commands/delmission.lua
@@ -16,8 +16,8 @@ function onTrigger(player, logId, missionId, target)
     local logName;
     logId = tonumber(logId) or _G[logId];
     if ((type(logId) == "table")) then
-        logName = logId["full_name"];
-        logId = logId["mission_log"];
+        logName = logId.full_name;
+        logId = logId.mission_log;
     end
 
     missionId = tonumber(missionId) or _G[missionId];

--- a/scripts/commands/delquest.lua
+++ b/scripts/commands/delquest.lua
@@ -12,8 +12,14 @@ cmdprops =
 };
 
 function onTrigger(player, logId, questId, target)
-    
+
+    local logName;
     logId = tonumber(logId) or _G[logId];
+    if ((type(logId) == "table")) then
+        logName = logId["full_name"];
+        logId = logId["quest_log"];
+    end
+
     questId = tonumber(questId) or _G[questId];
     
     if (questId == nil or logId == nil) then
@@ -29,7 +35,11 @@ function onTrigger(player, logId, questId, target)
     local targ = GetPlayerByName(target);
     if (targ ~= nil) then
         targ:delQuest( logId, questId );
-        player:PrintToPlayer( string.format( "Deleted Quest for log %u with ID %u from %s", logId, questId, target ) );
+        if (logName) then
+            player:PrintToPlayer( string.format( "Deleted %s Quest with ID %u for %s", logName, questId, target ) );
+        else
+            player:PrintToPlayer( string.format( "Deleted Quest for log %u with ID %u from %s", logId, questId, target ) );
+        end
     else
         player:PrintToPlayer( string.format( "Player named '%s' not found!", target ) );
         player:PrintToPlayer( "@delquest <logID> <questID> <player>" );

--- a/scripts/commands/delquest.lua
+++ b/scripts/commands/delquest.lua
@@ -16,8 +16,8 @@ function onTrigger(player, logId, questId, target)
     local logName;
     logId = tonumber(logId) or _G[logId];
     if ((type(logId) == "table")) then
-        logName = logId["full_name"];
-        logId = logId["quest_log"];
+        logName = logId.full_name;
+        logId = logId.quest_log;
     end
 
     questId = tonumber(questId) or _G[questId];

--- a/scripts/globals/log_ids.lua
+++ b/scripts/globals/log_ids.lua
@@ -2,42 +2,220 @@
 --  Area/Content Identifiers
 -----------------------------------
 
-STATIC             = -1;
-SANDORIA           =  0;
-BASTOK             =  1;
-WINDURST           =  2;
-JEUNO              =  3;
-SELBINA            =  4;
-MHAURA             =  5;
-RABAO              =  6;
-KAZHAM             =  7;
-NORG               =  8;
-TAVNAZIA           =  9;
-OTHER_AREAS        =  9;
-OUTLANDS           = 10;
-ZILART             = 11;
-COP                = 12;
-AHT_URHGAN         = 13;
-TOAU               = 13;
-ASSAULT            = 14;
-CRYSTAL_WAR        = 15;
-WOTG               = 15;
-CAMPAIGN           = 16;
--- CAMPAIGN2       = 17;
-ACP                = 18;
-AMK                = 19;
-ASA                = 20;
-ABYSSEA            = 21;
-ABYSSEA_KONSCHTAT  = 22;
-ABYSSEA_TAHRONGI   = 23;
-ABYSSEA_LATHEINE   = 24;
-ABYSSEA_MISAREAUX  = 25;
-ABYSSEA_VUNKERL    = 26;
-ABYSSEA_ATTOHWA    = 27;
-ABYSSEA_ALTEPA     = 28;
-ABYSSEA_GRAUBERG   = 29;
-ABYSSEA_ULEGUERAND = 30;
-ADOULIN            = 31;
-SOA                = 31;
-COALITION          = 32;
-ROV                = 33;
+STATIC = -1; -- Just so shop NPC scripts have something to check against. Not sent to core.
+SANDORIA =
+{
+    ['full_name'] = "San d' Oria",
+    ['mission_log']= 0,
+    ['quest_log']= 0,
+    ['fame_area']= 0
+};
+BASTOK =
+{
+    ['full_name'] = "Bastok",
+    ['mission_log']= 1,
+    ['quest_log']= 1,
+    ['fame_area']= 1
+};
+WINDURST =
+{
+    ['full_name'] = "Windurst",
+    ['mission_log']= 2,
+    ['quest_log']= 2,
+    ['fame_area']= 2
+};
+JEUNO =
+{
+    ['full_name'] = "Jeuno",
+    ['quest_log']= 3,
+    ['fame_area']= 3
+};
+SELBINA =
+{
+    ['full_name'] = "Selbina",
+    ['quest_log']= 4,
+    ['fame_area']= 4
+};
+MHAURA =
+{
+    ['full_name'] = "Mhaura",
+    ['quest_log']= 4,
+    ['fame_area']= 2
+};
+RABAO =
+{
+    ['full_name'] = "Rabao",
+    ['quest_log']= 5,
+    ['fame_area']= 4
+};
+KAZHAM =
+{
+    ['full_name'] = "Kazham",
+    ['quest_log']= 5,
+    ['fame_area']= 2
+};
+NORG =
+{
+    ['full_name'] = "Norg",
+    ['quest_log']= 5,
+    ['fame_area']= 5
+};
+OTHER_AREAS =
+{
+    ['full_name'] = "Other Areas",
+    ['quest_log']= 4
+};
+TAVNAZIA =
+{
+    ['full_name'] = "Tavnazian Safehold",
+    ['quest_log']= 4
+};
+OUTLANDS =
+{
+    ['full_name'] = "Outlands",
+    ['quest_log']= 5
+};
+ZILART =
+{
+    ['full_name'] = "Rise of the Zilart",
+    ['mission_log']= 3,
+    ['quest_log']= 5
+};
+COP =
+{
+    ['full_name'] = "Chains of Promathia",
+    ['mission_log']= 6,
+    ['quest_log']= 4
+};
+TOAU =
+{
+    ['full_name'] = "Treasures of Aht Urhgan",
+    ['mission_log']= 4,
+    ['quest_log']= 6
+};
+AHT_URHGAN =
+{
+    ['full_name'] = "Aht Urhgan",
+    ['mission_log']= 4,
+    ['quest_log']= 6
+};
+ASSAULT =
+{
+    ['full_name'] = "Assault",
+    ['mission_log']= 7
+};
+WOTG =
+{
+    ['full_name'] = "Wings of the Goddess",
+    ['mission_log']= 5,
+    ['quest_log']= 7
+};
+CRYSTAL_WAR =
+{
+    ['full_name'] = "Crystal War",
+    ['mission_log']= 5,
+    ['quest_log']= 7
+};
+CAMPAIGN =
+{
+    ['full_name'] = "Campaign",
+    ['mission_log']= 8
+};
+ACP =
+{
+    ['full_name'] = "A Crystalline Prophecy",
+    ['mission_log']= 9
+};
+AMK =
+{
+    ['full_name'] = "A Moogle Kupo d'Etat",
+    ['mission_log']= 10
+};
+ASA =
+{
+    ['full_name'] = "A Shantotto Ascension",
+    ['mission_log']= 11
+};
+ABYSSEA =
+{
+    ['full_name'] = "Abyssea",
+    ['quest_log']= 8
+};
+ABYSSEA_KONSCHTAT =
+{
+    ['full_name'] = "Abyssea - Konschtat",
+    ['quest_log']= 8,
+    ['fame_area']= 6
+};
+ABYSSEA_TAHRONGI =
+{
+    ['full_name'] = "Abyssea - Tahrongi",
+    ['quest_log']= 8,
+    ['fame_area']= 7
+};
+ABYSSEA_LATHEINE =
+{
+    ['full_name'] = "Abyssea - La'Theine",
+    ['quest_log']= 8,
+    ['fame_area']= 8
+};
+ABYSSEA_MISAREAUX =
+{
+    ['full_name'] = "Abyssea - Misareaux",
+    ['quest_log']= 8,
+    ['fame_area']= 9
+};
+ABYSSEA_VUNKERL =
+{
+    ['full_name'] = "Abyssea - Vunkerl",
+    ['quest_log']= 8,
+    ['fame_area']= 10
+};
+ABYSSEA_ATTOHWA =
+{
+    ['full_name'] = "Abyssea - Attohwa",
+    ['quest_log']= 8,
+    ['fame_area']= 11
+};
+ABYSSEA_ALTEPA =
+{
+    ['full_name'] = "Abyssea - Altepa",
+    ['quest_log']= 8,
+    ['fame_area']= 12
+};
+ABYSSEA_GRAUBERG =
+{
+    ['full_name'] = "Abyssea - Grauberg",
+    ['quest_log']= 8,
+    ['fame_area']= 13
+};
+ABYSSEA_ULEGUERAND =
+{
+    ['full_name'] = "Abyssea - Uleguerand",
+    ['quest_log']= 8,
+    ['fame_area']= 14
+};
+SOA =
+{
+    ['full_name'] = "Seekers of Adoulin",
+    ['mission_log']= 12,
+    ['quest_log']= 9,
+    ['fame_area']= 15
+};
+ADOULIN =
+{
+    ['full_name'] = "Adoulin",
+    ['mission_log']= 12,
+    ['quest_log']= 9,
+    ['fame_area']= 15
+};
+COALITION =
+{
+    ['full_name'] = "Coalition",
+    ['quest_log']= 10
+};
+ROV =
+{
+    ['full_name'] = "Rhapsodies of Vana'diel",
+    ['mission_log']= 13
+};

--- a/scripts/globals/log_ids.lua
+++ b/scripts/globals/log_ids.lua
@@ -3,35 +3,27 @@
 -----------------------------------
 
 STATIC = -1; -- Just so shop NPC scripts have something to check against. Not sent to core.
-
--- Tables for nations currently commented out due to potential conflicts with Conquest system and player nation checks.
--- They can be reintroduced when the scripts expect them and/or don't overwrite their value.
---  SANDORIA =
---  {
---      ['full_name'] = "San d' Oria",
---      ['mission_log']= 0,
---      ['quest_log']= 0,
---      ['fame_area']= 0
---  };
---  BASTOK =
---  {
---      ['full_name'] = "Bastok",
---      ['mission_log']= 1,
---      ['quest_log']= 1,
---      ['fame_area']= 1
---  };
---  WINDURST =
---  {
---      ['full_name'] = "Windurst",
---      ['mission_log']= 2,
---      ['quest_log']= 2,
---      ['fame_area']= 2
---  };
-
-SANDORIA = 0;
-BASTOK = 1;
-WINDURST = 2;
-
+SANDORIA =
+{
+    ['full_name'] = "San d' Oria",
+    ['mission_log']= 0,
+    ['quest_log']= 0,
+    ['fame_area']= 0
+};
+BASTOK =
+{
+    ['full_name'] = "Bastok",
+    ['mission_log']= 1,
+    ['quest_log']= 1,
+    ['fame_area']= 1
+};
+WINDURST =
+{
+    ['full_name'] = "Windurst",
+    ['mission_log']= 2,
+    ['quest_log']= 2,
+    ['fame_area']= 2
+};
 JEUNO =
 {
     ['full_name'] = "Jeuno",

--- a/scripts/globals/log_ids.lua
+++ b/scripts/globals/log_ids.lua
@@ -3,27 +3,35 @@
 -----------------------------------
 
 STATIC = -1; -- Just so shop NPC scripts have something to check against. Not sent to core.
-SANDORIA =
-{
-    ['full_name'] = "San d' Oria",
-    ['mission_log']= 0,
-    ['quest_log']= 0,
-    ['fame_area']= 0
-};
-BASTOK =
-{
-    ['full_name'] = "Bastok",
-    ['mission_log']= 1,
-    ['quest_log']= 1,
-    ['fame_area']= 1
-};
-WINDURST =
-{
-    ['full_name'] = "Windurst",
-    ['mission_log']= 2,
-    ['quest_log']= 2,
-    ['fame_area']= 2
-};
+
+-- Tables for nations currently commented out due to potential conflicts with Conquest system and player nation checks.
+-- They can be reintroduced when the scripts expect them and/or don't overwrite their value.
+--  SANDORIA =
+--  {
+--      ['full_name'] = "San d' Oria",
+--      ['mission_log']= 0,
+--      ['quest_log']= 0,
+--      ['fame_area']= 0
+--  };
+--  BASTOK =
+--  {
+--      ['full_name'] = "Bastok",
+--      ['mission_log']= 1,
+--      ['quest_log']= 1,
+--      ['fame_area']= 1
+--  };
+--  WINDURST =
+--  {
+--      ['full_name'] = "Windurst",
+--      ['mission_log']= 2,
+--      ['quest_log']= 2,
+--      ['fame_area']= 2
+--  };
+
+SANDORIA = 0;
+BASTOK = 1;
+WINDURST = 2;
+
 JEUNO =
 {
     ['full_name'] = "Jeuno",

--- a/scripts/globals/log_ids.lua
+++ b/scripts/globals/log_ids.lua
@@ -1,0 +1,43 @@
+-----------------------------------
+--  Area/Content Identifiers
+-----------------------------------
+
+STATIC             = -1;
+SANDORIA           =  0;
+BASTOK             =  1;
+WINDURST           =  2;
+JEUNO              =  3;
+SELBINA            =  4;
+MHAURA             =  5;
+RABAO              =  6;
+KAZHAM             =  7;
+NORG               =  8;
+TAVNAZIA           =  9;
+OTHER_AREAS        =  9;
+OUTLANDS           = 10;
+ZILART             = 11;
+COP                = 12;
+AHT_URHGAN         = 13;
+TOAU               = 13;
+ASSAULT            = 14;
+CRYSTAL_WAR        = 15;
+WOTG               = 15;
+CAMPAIGN           = 16;
+-- CAMPAIGN2       = 17;
+ACP                = 18;
+AMK                = 19;
+ASA                = 20;
+ABYSSEA            = 21;
+ABYSSEA_KONSCHTAT  = 22;
+ABYSSEA_TAHRONGI   = 23;
+ABYSSEA_LATHEINE   = 24;
+ABYSSEA_MISAREAUX  = 25;
+ABYSSEA_VUNKERL    = 26;
+ABYSSEA_ATTOHWA    = 27;
+ABYSSEA_ALTEPA     = 28;
+ABYSSEA_GRAUBERG   = 29;
+ABYSSEA_ULEGUERAND = 30;
+ADOULIN            = 31;
+SOA                = 31;
+COALITION          = 32;
+ROV                = 33;

--- a/scripts/globals/missions.lua
+++ b/scripts/globals/missions.lua
@@ -1,3 +1,5 @@
+require("scripts/globals/log_ids");
+
 -----------------------------------
 --  Nation IDs
 -----------------------------------
@@ -5,25 +7,6 @@
 NATION_SANDORIA = 0;
 NATION_BASTOK   = 1;
 NATION_WINDURST = 2;
-
------------------------------------
--- Areas  ID     mission step var
------------------------------------
-
-SANDORIA = 0;  -- MissionStatus
-BASTOK   = 1;  -- MissionStatus
-WINDURST = 2;  -- MissionStatus
-ZILART   = 3;  -- ZilartStatus
-TOAU     = 4;  -- AhtUrganStatus
-WOTG     = 5;  -- AltanaStatus
-COP      = 6;  -- PromathiaStatus
-ASSAULT  = 7;  -- n/a
-CAMPAIGN = 8;  -- n/a
-ACP      = 9;  -- n/a
-AMK      = 10; -- n/a
-ASA      = 11; -- n/a
-SOA      = 12; -- AdoulinStatus
-ROV      = 13; -- RhapsodiesStatus
 
 -----------------------------------
 --  San d'Oria (0)

--- a/scripts/globals/quests.lua
+++ b/scripts/globals/quests.lua
@@ -1,3 +1,5 @@
+require("scripts/globals/log_ids");
+
 -----------------------------------
 --  Nation IDs
 -----------------------------------
@@ -15,22 +17,6 @@ NATION_WINDURST = 2;
 QUEST_AVAILABLE = 0;
 QUEST_ACCEPTED  = 1;
 QUEST_COMPLETED = 2;
-
------------------------------------
---  Areas ID
------------------------------------
-
-SANDORIA    = 0;
-BASTOK      = 1;
-WINDURST    = 2;
-JEUNO       = 3;
-OTHER_AREAS = 4;
-OUTLANDS    = 5;
-AHT_URHGAN  = 6;
-CRYSTAL_WAR = 7;
-ABYSSEA     = 8;
-ADOULIN     = 9;
-COALITION   = 10;
 
 -----------------------------------
 --  San d'Oria - 0

--- a/scripts/globals/shop.lua
+++ b/scripts/globals/shop.lua
@@ -5,22 +5,7 @@
 
 require("scripts/globals/settings");
 require("scripts/globals/conquest");
-
------------------------------------
--- Nations
------------------------------------
-
-SANDORIA     = 0;
-  BASTOK     = 1;
-WINDURST     = 2;
-  KAZHAM     = 2;
-   JEUNO     = 3;
- SELBINA     = 4;
-   RABAO     = 4;
-    NORG     = 5;
-TAVNAZIA     = 6;
-  STATIC     = 7;
-FAME_ADOULIN = 15;
+require("scripts/globals/log_ids");
 
 -----------------------------------
 -- function showShop

--- a/src/map/entities/charentity.h
+++ b/src/map/entities/charentity.h
@@ -35,23 +35,6 @@ This file is part of DarkStar-server source code.
 #include "battleentity.h"
 #include "petentity.h"
 
-// Quest Areas
-
-enum QUESTAREA
-{
-    QUESTS_SANDORIA = 0,
-    QUESTS_BASTOK = 1,
-    QUESTS_WINDURST = 2,
-    QUESTS_JEUNO = 3,
-    QUESTS_OTHER = 4,
-    QUESTS_OUTLANDS = 5,
-    QUESTS_AHTURHGAN = 6,
-    QUESTS_CRYSTALWAR = 7,
-    QUESTS_ABYSSEA = 8,
-    QUESTS_ADOULIN = 9,
-    QUESTS_COALITION = 10
-};
-
 #define MAX_QUESTAREA	 11
 #define MAX_QUESTID     256
 #define MAX_MISSIONAREA	 15

--- a/src/map/lua/lua_baseentity.cpp
+++ b/src/map/lua/lua_baseentity.cpp
@@ -1435,7 +1435,7 @@ inline int32 CLuaBaseEntity::addQuest(lua_State *L)
         if ((current == 0) && (complete == 0))
         {
             PChar->m_questLog[questLogID].current[questID / 8] |= (1 << (questID % 8));
-            PChar->pushPacket(new CQuestMissionLogPacket(PChar, questLogID, LOG_QUEST_CURR));
+            PChar->pushPacket(new CQuestMissionLogPacket(PChar, questLogID, LOG_QUEST_CURRENT));
 
             charutils::SaveQuestsList(PChar);
         }
@@ -1476,8 +1476,8 @@ inline int32 CLuaBaseEntity::delQuest(lua_State *L)
             PChar->m_questLog[questLogID].current[questID / 8] &= ~(1 << (questID % 8));
             PChar->m_questLog[questLogID].complete[questID / 8] &= ~(1 << (questID % 8));
 
-            PChar->pushPacket(new CQuestMissionLogPacket(PChar, questLogID, LOG_QUEST_CURR));
-            PChar->pushPacket(new CQuestMissionLogPacket(PChar, questLogID, LOG_QUEST_COMP));
+            PChar->pushPacket(new CQuestMissionLogPacket(PChar, questLogID, LOG_QUEST_CURRENT));
+            PChar->pushPacket(new CQuestMissionLogPacket(PChar, questLogID, LOG_QUEST_COMPLETE));
 
             charutils::SaveQuestsList(PChar);
         }
@@ -1551,8 +1551,8 @@ inline int32 CLuaBaseEntity::completeQuest(lua_State *L)
             PChar->m_questLog[questLogID].current[questID / 8] &= ~(1 << (questID % 8));
             PChar->m_questLog[questLogID].complete[questID / 8] |= (1 << (questID % 8));
 
-            PChar->pushPacket(new CQuestMissionLogPacket(PChar, questLogID, LOG_QUEST_CURR));
-            PChar->pushPacket(new CQuestMissionLogPacket(PChar, questLogID, LOG_QUEST_COMP));
+            PChar->pushPacket(new CQuestMissionLogPacket(PChar, questLogID, LOG_QUEST_CURRENT));
+            PChar->pushPacket(new CQuestMissionLogPacket(PChar, questLogID, LOG_QUEST_COMPLETE));
         }
         charutils::SaveQuestsList(PChar);
     }
@@ -1628,7 +1628,7 @@ inline int32 CLuaBaseEntity::addMission(lua_State *L)
             ShowWarning(CL_YELLOW"Lua::addMission: player has a current mission\n" CL_RESET, missionLogID);
         }
         PChar->m_missionLog[missionLogID].current = MissionID;
-        PChar->pushPacket(new CQuestMissionLogPacket(PChar, missionLogID, LOG_MISS_CURR));
+        PChar->pushPacket(new CQuestMissionLogPacket(PChar, missionLogID, LOG_MISSION_CURRENT));
 
         charutils::SaveMissionsList(PChar);
     }
@@ -1671,12 +1671,12 @@ inline int32 CLuaBaseEntity::delMission(lua_State *L)
         if (current == MissionID)
         {
             PChar->m_missionLog[missionLogID].current = missionLogID > 2 ? 0 : -1;
-            PChar->pushPacket(new CQuestMissionLogPacket(PChar, missionLogID, LOG_MISS_CURR));
+            PChar->pushPacket(new CQuestMissionLogPacket(PChar, missionLogID, LOG_MISSION_CURRENT));
         }
         if (complete)
         {
             PChar->m_missionLog[missionLogID].complete[MissionID] = false;
-            PChar->pushPacket(new CQuestMissionLogPacket(PChar, missionLogID, LOG_MISS_COMP));
+            PChar->pushPacket(new CQuestMissionLogPacket(PChar, missionLogID, LOG_MISSION_COMPLETE));
         }
         charutils::SaveMissionsList(PChar);
     }
@@ -1793,9 +1793,9 @@ inline int32 CLuaBaseEntity::completeMission(lua_State *L)
             if ((missionLogID != MISSION_COP) && (MissionID < 64))
             {
                 PChar->m_missionLog[missionLogID].complete[MissionID] = true;
-                PChar->pushPacket(new CQuestMissionLogPacket(PChar, missionLogID, LOG_MISS_COMP));
+                PChar->pushPacket(new CQuestMissionLogPacket(PChar, missionLogID, LOG_MISSION_COMPLETE));
             }
-            PChar->pushPacket(new CQuestMissionLogPacket(PChar, missionLogID, LOG_MISS_CURR));
+            PChar->pushPacket(new CQuestMissionLogPacket(PChar, missionLogID, LOG_MISSION_CURRENT));
 
             charutils::SaveMissionsList(PChar);
         }
@@ -1823,7 +1823,7 @@ inline int32 CLuaBaseEntity::addAssault(lua_State *L)
         ShowWarning(CL_YELLOW"Lua::addAssault: player has a current assault\n" CL_RESET);
     }
     PChar->m_assaultLog.current = MissionID;
-    PChar->pushPacket(new CQuestMissionLogPacket(PChar, MISSION_ASSAULT, LOG_MISS_CURR));
+    PChar->pushPacket(new CQuestMissionLogPacket(PChar, MISSION_ASSAULT, LOG_MISSION_CURRENT));
 
     charutils::SaveMissionsList(PChar);
 
@@ -1847,7 +1847,7 @@ inline int32 CLuaBaseEntity::delAssault(lua_State *L)
     if (current == MissionID)
     {
         PChar->m_assaultLog.current = 0;
-        PChar->pushPacket(new CQuestMissionLogPacket(PChar, MISSION_ASSAULT, LOG_MISS_CURR));
+        PChar->pushPacket(new CQuestMissionLogPacket(PChar, MISSION_ASSAULT, LOG_MISSION_CURRENT));
     }
     charutils::SaveMissionsList(PChar);
 
@@ -1897,8 +1897,8 @@ inline int32 CLuaBaseEntity::completeAssault(lua_State *L)
     }
     PChar->m_assaultLog.current = 0;
     PChar->m_assaultLog.complete[MissionID] = true;
-    PChar->pushPacket(new CQuestMissionLogPacket(PChar, MISSION_ASSAULT, LOG_MISS_CURR));
-    PChar->pushPacket(new CQuestMissionLogPacket(PChar, MISSION_ASSAULT, LOG_MISS_COMP));
+    PChar->pushPacket(new CQuestMissionLogPacket(PChar, MISSION_ASSAULT, LOG_MISSION_CURRENT));
+    PChar->pushPacket(new CQuestMissionLogPacket(PChar, MISSION_ASSAULT, LOG_MISSION_COMPLETE));
 
     charutils::SaveMissionsList(PChar);
 

--- a/src/map/lua/lua_baseentity.cpp
+++ b/src/map/lua/lua_baseentity.cpp
@@ -1421,8 +1421,8 @@ inline int32 CLuaBaseEntity::addQuest(lua_State *L)
     CCharEntity* PChar = (CCharEntity*)m_PBaseEntity;
 
     uint8 questID = (uint8)lua_tointeger(L, -1);
-    uint8 ContentID = (uint8)lua_tointeger(L, -2);
-    int8 QuestLogID = LOG_TYPES[ContentID][QUEST_LOG];
+    uint8 subjectID = (uint8)lua_tointeger(L, -2);
+    int8 QuestLogID = LOG_TYPES[subjectID][QUEST_LOG];
 
     if (QuestLogID >= 0 && QuestLogID < MAX_QUESTAREA && questID < MAX_QUESTID)
     {
@@ -1432,14 +1432,14 @@ inline int32 CLuaBaseEntity::addQuest(lua_State *L)
         if ((current == 0) && (complete == 0))
         {
             PChar->m_questLog[QuestLogID].current[questID / 8] |= (1 << (questID % 8));
-            PChar->pushPacket(new CQuestMissionLogPacket(PChar, ContentID, STATUS_QUEST_CURR));
+            PChar->pushPacket(new CQuestMissionLogPacket(PChar, subjectID, STATUS_QUEST_CURR));
 
             charutils::SaveQuestsList(PChar);
         }
     }
     else
     {
-        ShowError(CL_RED"Lua::addQuest: ContentID %i or QuestID %i is invalid\n" CL_RESET, ContentID, questID);
+        ShowError(CL_RED"Lua::addQuest: subjectID %i or QuestID %i is invalid\n" CL_RESET, subjectID, questID);
     }
     return 0;
 }
@@ -1457,8 +1457,8 @@ inline int32 CLuaBaseEntity::delQuest(lua_State *L)
     CCharEntity* PChar = (CCharEntity*)m_PBaseEntity;
 
     uint8 questID = (uint8)lua_tointeger(L, -1);
-    uint8 ContentID = (uint8)lua_tointeger(L, -2);
-    int8 QuestLogID = LOG_TYPES[ContentID][QUEST_LOG];
+    uint8 subjectID = (uint8)lua_tointeger(L, -2);
+    int8 QuestLogID = LOG_TYPES[subjectID][QUEST_LOG];
 
     if (QuestLogID >= 0 && QuestLogID < MAX_QUESTAREA && questID < MAX_QUESTID)
     {
@@ -1470,15 +1470,15 @@ inline int32 CLuaBaseEntity::delQuest(lua_State *L)
             PChar->m_questLog[QuestLogID].current[questID / 8] &= ~(1 << (questID % 8));
             PChar->m_questLog[QuestLogID].complete[questID / 8] &= ~(1 << (questID % 8));
 
-            PChar->pushPacket(new CQuestMissionLogPacket(PChar, ContentID, STATUS_QUEST_CURR));
-            PChar->pushPacket(new CQuestMissionLogPacket(PChar, ContentID, STATUS_QUEST_COMP));
+            PChar->pushPacket(new CQuestMissionLogPacket(PChar, subjectID, STATUS_QUEST_CURR));
+            PChar->pushPacket(new CQuestMissionLogPacket(PChar, subjectID, STATUS_QUEST_COMP));
 
             charutils::SaveQuestsList(PChar);
         }
     }
     else
     {
-        ShowError(CL_RED"Lua::delQuest: ContentID %i or QuestID %i is invalid\n" CL_RESET, ContentID, questID);
+        ShowError(CL_RED"Lua::delQuest: subjectID %i or QuestID %i is invalid\n" CL_RESET, subjectID, questID);
     }
     return 0;
 }
@@ -1494,8 +1494,8 @@ inline int32 CLuaBaseEntity::getQuestStatus(lua_State *L)
     DSP_DEBUG_BREAK_IF(lua_isnil(L, -2) || !lua_isnumber(L, -2));
 
     uint8 questID = (uint8)lua_tointeger(L, -1);
-    uint8 ContentID = (uint8)lua_tointeger(L, -2);
-    int8 QuestLogID = LOG_TYPES[ContentID][QUEST_LOG];
+    uint8 subjectID = (uint8)lua_tointeger(L, -2);
+    int8 QuestLogID = LOG_TYPES[subjectID][QUEST_LOG];
 
     if (QuestLogID >= 0 && QuestLogID < MAX_QUESTAREA && questID < MAX_QUESTID)
     {
@@ -1507,7 +1507,7 @@ inline int32 CLuaBaseEntity::getQuestStatus(lua_State *L)
     }
     else
     {
-        ShowError(CL_RED"Lua::getQuestStatus: ContentID %i or QuestID %i is invalid\n" CL_RESET, ContentID, questID);
+        ShowError(CL_RED"Lua::getQuestStatus: subjectID %i or QuestID %i is invalid\n" CL_RESET, subjectID, questID);
     }
     lua_pushnil(L);
     return 1;
@@ -1526,8 +1526,8 @@ inline int32 CLuaBaseEntity::completeQuest(lua_State *L)
     CCharEntity* PChar = (CCharEntity*)m_PBaseEntity;
 
     uint8 questID = (uint8)lua_tointeger(L, -1);
-    uint8 ContentID = (uint8)lua_tointeger(L, -2);
-    int8 QuestLogID = LOG_TYPES[ContentID][QUEST_LOG];
+    uint8 subjectID = (uint8)lua_tointeger(L, -2);
+    int8 QuestLogID = LOG_TYPES[subjectID][QUEST_LOG];
 
     if (QuestLogID >= 0 && QuestLogID < MAX_QUESTAREA && questID < MAX_QUESTID)
     {
@@ -1538,14 +1538,14 @@ inline int32 CLuaBaseEntity::completeQuest(lua_State *L)
             PChar->m_questLog[QuestLogID].current[questID / 8] &= ~(1 << (questID % 8));
             PChar->m_questLog[QuestLogID].complete[questID / 8] |= (1 << (questID % 8));
 
-            PChar->pushPacket(new CQuestMissionLogPacket(PChar, ContentID, STATUS_QUEST_CURR));
-            PChar->pushPacket(new CQuestMissionLogPacket(PChar, ContentID, STATUS_QUEST_COMP));
+            PChar->pushPacket(new CQuestMissionLogPacket(PChar, subjectID, STATUS_QUEST_CURR));
+            PChar->pushPacket(new CQuestMissionLogPacket(PChar, subjectID, STATUS_QUEST_COMP));
         }
         charutils::SaveQuestsList(PChar);
     }
     else
     {
-        ShowError(CL_RED"Lua::completeQuest: ContentID %i or QuestID %i is invalid\n" CL_RESET, ContentID, questID);
+        ShowError(CL_RED"Lua::completeQuest: subjectID %i or QuestID %i is invalid\n" CL_RESET, subjectID, questID);
     }
     return 0;
 }
@@ -1565,8 +1565,8 @@ inline int32 CLuaBaseEntity::hasCompleteQuest(lua_State *L)
     DSP_DEBUG_BREAK_IF(lua_isnil(L, -2) || !lua_isnumber(L, -2));
 
     uint8 questID = (uint8)lua_tointeger(L, -1);
-    uint8 ContentID = (uint8)lua_tointeger(L, -2);
-    int8 QuestLogID = LOG_TYPES[ContentID][QUEST_LOG];
+    uint8 subjectID = (uint8)lua_tointeger(L, -2);
+    int8 QuestLogID = LOG_TYPES[subjectID][QUEST_LOG];
 
     if (QuestLogID >= 0 && QuestLogID < MAX_QUESTAREA && questID < MAX_QUESTID)
     {
@@ -1575,7 +1575,7 @@ inline int32 CLuaBaseEntity::hasCompleteQuest(lua_State *L)
         lua_pushboolean(L, (complete != 0));
         return 1;
     }
-    ShowError(CL_RED"Lua::hasCompleteQuest: ContentID %i or QuestID %i is invalid\n" CL_RESET, ContentID, questID);
+    ShowError(CL_RED"Lua::hasCompleteQuest: subjectID %i or QuestID %i is invalid\n" CL_RESET, subjectID, questID);
     lua_pushboolean(L, false);
     return 1;
 }
@@ -1595,9 +1595,9 @@ inline int32 CLuaBaseEntity::addMission(lua_State *L)
     DSP_DEBUG_BREAK_IF(lua_isnil(L, 1) || !lua_isnumber(L, 1));
     DSP_DEBUG_BREAK_IF(lua_isnil(L, 2) || !lua_isnumber(L, 2));
 
-    uint8 ContentID = (uint8)lua_tointeger(L, 1);
+    uint8 subjectID = (uint8)lua_tointeger(L, 1);
     uint8 MissionID = (uint8)lua_tointeger(L, 2);
-    int8 MissionLogID = LOG_TYPES[ContentID][MISSION_LOG];
+    int8 MissionLogID = LOG_TYPES[subjectID][MISSION_LOG];
 
     if (MissionLogID >= 0 && MissionLogID < MAX_MISSIONAREA && MissionID < MAX_MISSIONID)
     {
@@ -1608,13 +1608,13 @@ inline int32 CLuaBaseEntity::addMission(lua_State *L)
             ShowWarning(CL_YELLOW"Lua::addMission: player has a current mission\n" CL_RESET, MissionLogID);
         }
         PChar->m_missionLog[MissionLogID].current = MissionID;
-        PChar->pushPacket(new CQuestMissionLogPacket(PChar, ContentID, STATUS_MISS_CURR));
+        PChar->pushPacket(new CQuestMissionLogPacket(PChar, subjectID, STATUS_MISS_CURR));
 
         charutils::SaveMissionsList(PChar);
     }
     else
     {
-        ShowError(CL_RED"Lua::delMission: ContentID %i or Mission %i is invalid\n" CL_RESET, ContentID, MissionID);
+        ShowError(CL_RED"Lua::delMission: subjectID %i or Mission %i is invalid\n" CL_RESET, subjectID, MissionID);
     }
     return 0;
 }
@@ -1633,32 +1633,32 @@ inline int32 CLuaBaseEntity::delMission(lua_State *L)
     DSP_DEBUG_BREAK_IF(lua_isnil(L, 1) || !lua_isnumber(L, 1));
     DSP_DEBUG_BREAK_IF(lua_isnil(L, 2) || !lua_isnumber(L, 2));
 
-    uint8 ContentID = (uint8)lua_tointeger(L, 1);
+    uint8 subjectID = (uint8)lua_tointeger(L, 1);
     uint8 MissionID = (uint8)lua_tointeger(L, 2);
-    int8 MissionLogID = LOG_TYPES[ContentID][MISSION_LOG];
+    int8 MissionLogID = LOG_TYPES[subjectID][MISSION_LOG];
 
     if (MissionLogID >= 0 && MissionLogID < MAX_MISSIONAREA && MissionID < MAX_MISSIONID)
     {
         CCharEntity* PChar = (CCharEntity*)m_PBaseEntity;
 
         uint8 current = PChar->m_missionLog[MissionLogID].current;
-        bool complete = (ContentID == LOG_COP || MissionID >= 64) ? false : PChar->m_missionLog[MissionLogID].complete[MissionID];
+        bool complete = (subjectID == LOG_COP || MissionID >= 64) ? false : PChar->m_missionLog[MissionLogID].complete[MissionID];
 
         if (current == MissionID)
         {
             PChar->m_missionLog[MissionLogID].current = MissionLogID > 2 ? 0 : -1;
-            PChar->pushPacket(new CQuestMissionLogPacket(PChar, ContentID, STATUS_MISS_CURR));
+            PChar->pushPacket(new CQuestMissionLogPacket(PChar, subjectID, STATUS_MISS_CURR));
         }
         if (complete)
         {
             PChar->m_missionLog[MissionLogID].complete[MissionID] = false;
-            PChar->pushPacket(new CQuestMissionLogPacket(PChar, ContentID, STATUS_MISS_COMP));
+            PChar->pushPacket(new CQuestMissionLogPacket(PChar, subjectID, STATUS_MISS_COMP));
         }
         charutils::SaveMissionsList(PChar);
     }
     else
     {
-        ShowError(CL_RED"Lua::delMission: ContentID %i or Mission %i is invalid\n" CL_RESET, ContentID, MissionID);
+        ShowError(CL_RED"Lua::delMission: subjectID %i or Mission %i is invalid\n" CL_RESET, subjectID, MissionID);
     }
     return 0;
 }
@@ -1677,20 +1677,20 @@ inline int32 CLuaBaseEntity::hasCompletedMission(lua_State *L)
     DSP_DEBUG_BREAK_IF(lua_isnil(L, 1) || !lua_isnumber(L, 1));
     DSP_DEBUG_BREAK_IF(lua_isnil(L, 2) || !lua_isnumber(L, 2));
 
-    uint8 ContentID = (uint8)lua_tointeger(L, 1);
+    uint8 subjectID = (uint8)lua_tointeger(L, 1);
     uint8 MissionID = (uint8)lua_tointeger(L, 2);
-    int8 MissionLogID = LOG_TYPES[ContentID][MISSION_LOG];
+    int8 MissionLogID = LOG_TYPES[subjectID][MISSION_LOG];
 
     bool complete = false;
 
     if (MissionLogID >= 0 && MissionLogID < MAX_MISSIONAREA && MissionID < MAX_MISSIONID)
     {
-        complete = (ContentID == LOG_COP || MissionID >= 64) ? MissionID < ((CCharEntity*)m_PBaseEntity)->m_missionLog[MissionLogID].current :
+        complete = (subjectID == LOG_COP || MissionID >= 64) ? MissionID < ((CCharEntity*)m_PBaseEntity)->m_missionLog[MissionLogID].current :
             ((CCharEntity*)m_PBaseEntity)->m_missionLog[MissionLogID].complete[MissionID];
     }
     else
     {
-        ShowError(CL_RED"Lua::completeMission: ContentID %i or Mission %i is invalid\n" CL_RESET, ContentID, MissionID);
+        ShowError(CL_RED"Lua::completeMission: subjectID %i or Mission %i is invalid\n" CL_RESET, subjectID, MissionID);
     }
     lua_pushboolean(L, complete);
     return 1;
@@ -1709,9 +1709,9 @@ inline int32 CLuaBaseEntity::getCurrentMission(lua_State *L)
 
     DSP_DEBUG_BREAK_IF(lua_isnil(L, 1) || !lua_isnumber(L, 1));
 
-    uint8 ContentID = (uint8)lua_tointeger(L, 1);
+    uint8 subjectID = (uint8)lua_tointeger(L, 1);
     uint8 MissionID = 0;
-    int8  MissionLogID = LOG_TYPES[ContentID][MISSION_LOG];
+    int8  MissionLogID = LOG_TYPES[subjectID][MISSION_LOG];
 
     if (MissionLogID >= 0 && MissionLogID < MAX_MISSIONAREA)
     {
@@ -1719,7 +1719,7 @@ inline int32 CLuaBaseEntity::getCurrentMission(lua_State *L)
     }
     else
     {
-        ShowError(CL_RED"Lua::completeMission: ContentID %i is invalid\n" CL_RESET, ContentID);
+        ShowError(CL_RED"Lua::completeMission: subjectID %i is invalid\n" CL_RESET, subjectID);
     }
     lua_pushinteger(L, MissionID);
     return 1;
@@ -1739,9 +1739,9 @@ inline int32 CLuaBaseEntity::completeMission(lua_State *L)
     DSP_DEBUG_BREAK_IF(lua_isnil(L, 1) || !lua_isnumber(L, 1));
     DSP_DEBUG_BREAK_IF(lua_isnil(L, 2) || !lua_isnumber(L, 2));
 
-    uint8 ContentID = (uint8)lua_tointeger(L, 1);
+    uint8 subjectID = (uint8)lua_tointeger(L, 1);
     uint8 MissionID = (uint8)lua_tointeger(L, 2);
-    int8  MissionLogID = LOG_TYPES[ContentID][MISSION_LOG];
+    int8  MissionLogID = LOG_TYPES[subjectID][MISSION_LOG];
 
     if (MissionLogID >= 0 && MissionLogID < MAX_MISSIONAREA && MissionID < MAX_MISSIONID)
     {
@@ -1754,19 +1754,19 @@ inline int32 CLuaBaseEntity::completeMission(lua_State *L)
         else
         {
             PChar->m_missionLog[MissionLogID].current = MissionLogID > 2 ? 0 : -1;
-            if ((ContentID != LOG_COP) && (MissionID < 64))
+            if ((subjectID != LOG_COP) && (MissionID < 64))
             {
                 PChar->m_missionLog[MissionLogID].complete[MissionID] = true;
-                PChar->pushPacket(new CQuestMissionLogPacket(PChar, ContentID, STATUS_MISS_COMP));
+                PChar->pushPacket(new CQuestMissionLogPacket(PChar, subjectID, STATUS_MISS_COMP));
             }
-            PChar->pushPacket(new CQuestMissionLogPacket(PChar, ContentID, STATUS_MISS_CURR));
+            PChar->pushPacket(new CQuestMissionLogPacket(PChar, subjectID, STATUS_MISS_CURR));
 
             charutils::SaveMissionsList(PChar);
         }
     }
     else
     {
-        ShowError(CL_RED"Lua::completeMission: ContentID %i or Mission %i is invalid\n" CL_RESET, ContentID, MissionID);
+        ShowError(CL_RED"Lua::completeMission: subjectID %i or Mission %i is invalid\n" CL_RESET, subjectID, MissionID);
     }
     return 0;
 }
@@ -4015,8 +4015,8 @@ inline int32 CLuaBaseEntity::getFame(lua_State *L)
 
     DSP_DEBUG_BREAK_IF(lua_isnil(L, 1) || !lua_isnumber(L, 1));
 
-    uint8 ContentID = (uint8)lua_tointeger(L, 1);
-    int8  fameArea = LOG_TYPES[ContentID][FAME];
+    uint8 subjectID = (uint8)lua_tointeger(L, 1);
+    int8  fameArea = LOG_TYPES[subjectID][FAME];
 
     if (fameArea >= 0)
     {
@@ -4060,7 +4060,7 @@ inline int32 CLuaBaseEntity::getFame(lua_State *L)
     }
     else
     {
-        ShowError(CL_RED"Lua::getFame: ContentID %i is invalid\n" CL_RESET, ContentID);
+        ShowError(CL_RED"Lua::getFame: subjectID %i is invalid\n" CL_RESET, subjectID);
         lua_pushinteger(L, 0);
     }
     return 1;
@@ -4077,8 +4077,8 @@ inline int32 CLuaBaseEntity::getFameLevel(lua_State *L)
     DSP_DEBUG_BREAK_IF(m_PBaseEntity == nullptr);
     DSP_DEBUG_BREAK_IF(m_PBaseEntity->objtype != TYPE_PC);
 
-    uint8  ContentID = (uint8)lua_tointeger(L, 1);
-    int8   fameArea = LOG_TYPES[ContentID][FAME];
+    uint8  subjectID = (uint8)lua_tointeger(L, 1);
+    int8   fameArea = LOG_TYPES[subjectID][FAME];
 
     if (fameArea >= 0)
     {
@@ -4110,7 +4110,7 @@ inline int32 CLuaBaseEntity::getFameLevel(lua_State *L)
     }
     else
     {
-        ShowError(CL_RED"Lua::getFameLevel: ContentID %i is invalid\n" CL_RESET, ContentID);
+        ShowError(CL_RED"Lua::getFameLevel: subjectID %i is invalid\n" CL_RESET, subjectID);
         lua_pushinteger(L, 1);
     }
     return 1;
@@ -4130,9 +4130,9 @@ inline int32 CLuaBaseEntity::setFame(lua_State *L)
     DSP_DEBUG_BREAK_IF(lua_isnil(L, -1) || !lua_isnumber(L, -1));
     DSP_DEBUG_BREAK_IF(lua_isnil(L, -2) || !lua_isnumber(L, -2));
 
-    uint8  ContentID = (uint8)lua_tointeger(L, -2);
+    uint8  subjectID = (uint8)lua_tointeger(L, -2);
     uint16 fame = (uint16)lua_tointeger(L, -1);
-    int8   fameArea = LOG_TYPES[ContentID][FAME];
+    int8   fameArea = LOG_TYPES[subjectID][FAME];
 
     if (fameArea >= 0)
     {
@@ -4173,7 +4173,7 @@ inline int32 CLuaBaseEntity::setFame(lua_State *L)
     }
     else
     {
-        ShowError(CL_RED"Lua::setFame: ContentID %i is invalid\n" CL_RESET, ContentID);
+        ShowError(CL_RED"Lua::setFame: subjectID %i is invalid\n" CL_RESET, subjectID);
     }
     return 0;
 }
@@ -4192,9 +4192,9 @@ inline int32 CLuaBaseEntity::addFame(lua_State *L)
     DSP_DEBUG_BREAK_IF(lua_isnil(L, -1) || !lua_isnumber(L, -1));
     DSP_DEBUG_BREAK_IF(lua_isnil(L, -2) || !lua_isnumber(L, -2));
 
-    uint8  ContentID = (uint8)lua_tointeger(L, -2);
+    uint8  subjectID = (uint8)lua_tointeger(L, -2);
     uint16 fame = (uint16)lua_tointeger(L, -1);
-    int8  fameArea = LOG_TYPES[ContentID][FAME];
+    int8  fameArea = LOG_TYPES[subjectID][FAME];
     
     if (fameArea >= 0)
     {
@@ -4237,7 +4237,7 @@ inline int32 CLuaBaseEntity::addFame(lua_State *L)
     }
     else
     {
-        ShowError(CL_RED"Lua::addFame: ContentID %i is invalid\n" CL_RESET, ContentID);
+        ShowError(CL_RED"Lua::addFame: subjectID %i is invalid\n" CL_RESET, subjectID);
     }
     return 0;
 }

--- a/src/map/packets/quest_mission_log.cpp
+++ b/src/map/packets/quest_mission_log.cpp
@@ -28,7 +28,7 @@
 #include "quest_mission_log.h"
 #include "../entities/charentity.h"
 
-CQuestMissionLogPacket::CQuestMissionLogPacket(CCharEntity * PChar, uint8 logID, uint8 logType)
+CQuestMissionLogPacket::CQuestMissionLogPacket(CCharEntity * PChar, uint8 logID, LOG_TYPE logType)
 {
     this->type = 0x56;
     this->size = 0x14;
@@ -41,7 +41,7 @@ CQuestMissionLogPacket::CQuestMissionLogPacket(CCharEntity * PChar, uint8 logID,
     {
         // We're updating any non-TOAU quest log
         generateQuestPacket(PChar, logID, logType);
-        packetType = QUEST_PACKET_BYTES.at(logID * 2 + logType);
+        packetType = questPacketBytes.at({logID, logType});
     }
     // Then get our mission log updates out of the way
     else if (logType >= LOG_MISS_CURR)
@@ -108,14 +108,14 @@ CQuestMissionLogPacket::CQuestMissionLogPacket(CCharEntity * PChar, uint8 logID,
             // Completed TOAU Quests share a packet with completed Assault Missions
             generateAssaultMissionPacket(PChar); // Writes in same packet
         }
-        packetType = QUEST_PACKET_BYTES.at(logID * 2 + logType);
+        packetType = questPacketBytes.at({logID, logType});
     }
 
     // Write the byte that informs FFXI client what kind of Quest/Mission log update this packet is.
     WBUFW(data, (0x24)) = packetType;
 }
 
-void CQuestMissionLogPacket::generateQuestPacket(CCharEntity * PChar, uint8 logID, uint8 status)
+void CQuestMissionLogPacket::generateQuestPacket(CCharEntity * PChar, uint8 logID, LOG_TYPE status)
 {
     if (status == LOG_QUEST_CURR)
         memcpy(data + 4, PChar->m_questLog[logID].current, 32);

--- a/src/map/packets/quest_mission_log.cpp
+++ b/src/map/packets/quest_mission_log.cpp
@@ -28,19 +28,19 @@
 #include "quest_mission_log.h"
 #include "../entities/charentity.h"
 
-CQuestMissionLogPacket::CQuestMissionLogPacket(CCharEntity * PChar, uint8 contentID, uint8 status)
+CQuestMissionLogPacket::CQuestMissionLogPacket(CCharEntity * PChar, uint8 subjectID, uint8 status)
 {
     this->type = 0x56;
     this->size = 0x14;
 
-    int16 logType = LOG_TYPES[contentID][status + (status > STATUS_QUEST_COMP ? 1 : 0)];
-    int16 questLogID = LOG_TYPES[contentID][QUEST_LOG];
-    int16 missionLogID = LOG_TYPES[contentID][MISSION_LOG];
+    int16 logType = LOG_TYPES[subjectID][status + (status > STATUS_QUEST_COMP ? 1 : 0)];
+    int16 questLogID = LOG_TYPES[subjectID][QUEST_LOG];
+    int16 missionLogID = LOG_TYPES[subjectID][MISSION_LOG];
 
     // FFXI packs different TOAU information in the same packet as certain other content
-    if ((contentID >= LOG_TOAU) && (contentID <= LOG_CAMPAIGN2))
+    if ((subjectID >= LOG_TOAU) && (subjectID <= LOG_CAMPAIGN2))
     {
-        if ((contentID == LOG_WOTG) && (status <= STATUS_QUEST_COMP))
+        if ((subjectID == LOG_WOTG) && (status <= STATUS_QUEST_COMP))
         {
             // We're updating Crystal War quests
             generateQuestPacket(PChar, questLogID, status);
@@ -60,7 +60,7 @@ CQuestMissionLogPacket::CQuestMissionLogPacket(CCharEntity * PChar, uint8 conten
                     generateAssaultMissionPacket(PChar);            // Writes more to it
                     break;
                 case STATUS_MISS_COMP:
-                    switch (contentID) {
+                    switch (subjectID) {
                     case LOG_TOAU:
                     case LOG_WOTG:
                         // Completed TOAU and WOTG missions share a packet
@@ -90,7 +90,7 @@ CQuestMissionLogPacket::CQuestMissionLogPacket(CCharEntity * PChar, uint8 conten
     }
     else if ((status <= STATUS_MISS_COMP) && (missionLogID >= 0)) 
     {   // We're updating any other mission log
-        if ((contentID <= LOG_ZILART) && (status == STATUS_MISS_COMP))
+        if ((subjectID <= LOG_ZILART) && (status == STATUS_MISS_COMP))
         {
             // Completed Nation and Zilart missions are updated in the same packet
             generateCompleteMissionPacket(PChar);
@@ -157,7 +157,7 @@ void CQuestMissionLogPacket::generateCurrentExpMissionPacket(CCharEntity * PChar
     WBUFW(data, (0x14)) = PChar->m_assaultLog.current;						                // Assault Missions
     WBUFW(data, (0x18)) = PChar->m_missionLog[LOG_TYPES[LOG_TOAU][MISSION_LOG]].current;	// Treasures of Aht Urhgan
     WBUFW(data, (0x1C)) = PChar->m_missionLog[LOG_TYPES[LOG_WOTG][MISSION_LOG]].current;	// Wings of the Goddess
-    WBUFW(data, (0x20)) = PChar->m_campaignLog.current;						                // Campaign Operations
+    WBUFW(data, (0x20)) = PChar->m_campaignLog.current;                                     // Campaign Operations
 }
 
 void CQuestMissionLogPacket::generateCompleteExpMissionPacket(CCharEntity * PChar)

--- a/src/map/packets/quest_mission_log.cpp
+++ b/src/map/packets/quest_mission_log.cpp
@@ -41,7 +41,7 @@ CQuestMissionLogPacket::CQuestMissionLogPacket(CCharEntity * PChar, uint8 logID,
     {
         // We're updating any non-TOAU quest log
         generateQuestPacket(PChar, logID, logType);
-        packetType = QUEST_PACKET_BYTES[logID][logType - 1];
+        packetType = QUEST_PACKET_BYTES.at(logID * 2 + logType);
     }
     // Then get our mission log updates out of the way
     else if (logType >= LOG_MISS_CURR)
@@ -74,7 +74,7 @@ CQuestMissionLogPacket::CQuestMissionLogPacket(CCharEntity * PChar, uint8 logID,
                         // Completed Assault Missions share a packet with completed TOAU quests
                         generateQuestPacket(PChar, QUESTS_TOAU, LOG_QUEST_COMP);
                         generateAssaultMissionPacket(PChar);
-                        packetType = EXP_COMPLETE;
+                        packetType = ASSAULT_COMPLETE;
                         break;
                     case MISSION_CAMPAIGN:
                         // Completed Campaign missions take up two packets. Second half will come in a follow-up packet.
@@ -108,7 +108,7 @@ CQuestMissionLogPacket::CQuestMissionLogPacket(CCharEntity * PChar, uint8 logID,
             // Completed TOAU Quests share a packet with completed Assault Missions
             generateAssaultMissionPacket(PChar); // Writes in same packet
         }
-        packetType = QUEST_PACKET_BYTES[logID][logType - 1];
+        packetType = QUEST_PACKET_BYTES.at(logID * 2 + logType);
     }
 
     // Write the byte that informs FFXI client what kind of Quest/Mission log update this packet is.

--- a/src/map/packets/quest_mission_log.cpp
+++ b/src/map/packets/quest_mission_log.cpp
@@ -28,177 +28,77 @@
 #include "quest_mission_log.h"
 #include "../entities/charentity.h"
 
-
-CQuestMissionLogPacket::CQuestMissionLogPacket(CCharEntity * PChar, uint8 logID, uint8 status)
+CQuestMissionLogPacket::CQuestMissionLogPacket(CCharEntity * PChar, uint8 contentID, uint8 status)
 {
     this->type = 0x56;
     this->size = 0x14;
 
-    // настоятельно советую в switch(logID) ничего не менять,
-    // если вы НЕ УВЕРЕНЫ в том, что делаете
-    // даже простая перестановка case местами может привести к логическим ошибкам
+    int16 logType = LOG_TYPES[contentID][status + (status > STATUS_QUEST_COMP ? 1 : 0)];
+    int16 questLogID = LOG_TYPES[contentID][QUEST_LOG];
+    int16 missionLogID = LOG_TYPES[contentID][MISSION_LOG];
 
-    uint16 logType = 0x0000;
-    switch (logID) {
-    case QUESTS_SANDORIA:
-        generateQuestPacket(PChar, QUESTS_SANDORIA, status);
-        if (status == 0x01)
-            logType = SAN_CURRENT;
-        if (status == 0x02)
-            logType = SAN_COMPLETE;
-        break;
-    case QUESTS_BASTOK:
-        generateQuestPacket(PChar, QUESTS_BASTOK, status);
-        if (status == 0x01)
-            logType = BAS_CURRENT;
-        if (status == 0x02)
-            logType = BAS_COMPLETE;
-        break;
-    case QUESTS_WINDURST:
-        generateQuestPacket(PChar, QUESTS_WINDURST, status);
-        if (status == 0x01)
-            logType = WIN_CURRENT;
-        if (status == 0x02)
-            logType = WIN_COMPLETE;
-        break;
-    case QUESTS_JEUNO:
-        generateQuestPacket(PChar, QUESTS_JEUNO, status);
-        if (status == 0x01)
-            logType = JEU_CURRENT;
-        if (status == 0x02)
-            logType = JEU_COMPLETE;
-        break;
-    case QUESTS_OTHER:
-        generateQuestPacket(PChar, QUESTS_OTHER, status);
-        if (status == 0x01)
-            logType = OTH_CURRENT;
-        if (status == 0x02)
-            logType = OTH_COMPLETE;
-        break;
-    case QUESTS_OUTLANDS:
-        generateQuestPacket(PChar, QUESTS_OUTLANDS, status);
-        if (status == 0x01)
-            logType = OUT_CURRENT;
-        if (status == 0x02)
-            logType = OUT_COMPLETE;
-        break;
-    case QUESTS_CRYSTALWAR:
-        generateQuestPacket(PChar, QUESTS_CRYSTALWAR, status);
-        if (status == 0x01)
-            logType = WAR_CURRENT;
-        if (status == 0x02)
-            logType = WAR_COMPLETE;
-        break;
-    case QUESTS_ABYSSEA:
-        generateQuestPacket(PChar, QUESTS_ABYSSEA, status);
-        if (status == 0x01)
-            logType = ABY_CURRENT;
-        if (status == 0x02)
-            logType = ABY_COMPLETE;
-        break;
-    case QUESTS_ADOULIN:
-        generateQuestPacket(PChar, QUESTS_ADOULIN, status);
-        if (status == 0x01)
-            logType = ADO_CURRENT;
-        if (status == 0x02)
-            logType = ADO_COMPLETE;
-        break;
-    case QUESTS_COALITION:
-        generateQuestPacket(PChar, QUESTS_COALITION, status);
-        if (status == 0x01)
-            logType = COA_CURRENT;
-        if (status == 0x02)
-            logType = COA_COMPLETE;
-        break;
-    case QUESTS_AHTURHGAN:
-    case MISSION_ASSAULT:
-        if (status == 0x02) {
-            generateQuestPacket(PChar, QUESTS_AHTURHGAN, status);
-            generateAssaultMissionPacket(PChar);
-            logType = EXP_COMPLETE;
-            break;
-        }
-    case MISSION_TOAU:
-    case MISSION_WOTG:
-        if (status == 0x02) {
-            generateCompleteExpMissionPacket(PChar);
-            logType = EXP_MISS_COMPLETE;
-            break;
-        }
-    case MISSION_CAMPAIGN:
-        if (status == 0x02) {
-            generateFirstCampaignMissionPacket(PChar);
-            logType = CAMPAIGN_MISSION_UN;
-            break;
-        }
-    case MISSION_CAMPAIGN2:
-        if (status == 0x01) {
-            generateQuestPacket(PChar, QUESTS_AHTURHGAN, status);
-            generateCurrentExpMissionPacket(PChar);
-            logType = EXP_CURRENT;
-            break;
-        }
-        if (status == 0x02) {
-            generateSecondCampaignMissionPacket(PChar);
-            logType = CAMPAIGN_MISSION_DEUX;
-            break;
-        }
-    case MISSION_SANDORIA:
-        if (status == 0x01) {
-            generateCurrentMissionPacket(PChar);
-            logType = MISS_CURRENT;
-            break;
-        }
-        if (status == 0x02) {
-            generateCompleteMissionPacket(PChar);
-            logType = MISS_COMPLETE;
-            break;
-        }
-    case MISSION_BASTOK:
-        if (status == 0x01) {
-            generateCurrentMissionPacket(PChar);
-            logType = MISS_CURRENT;
-            break;
-        }
-        if (status == 0x02) {
-            generateCompleteMissionPacket(PChar);
-            logType = MISS_COMPLETE;
-            break;
-        }
-    case MISSION_WINDURST:
-        if (status == 0x01) {
-            generateCurrentMissionPacket(PChar);
-            logType = MISS_CURRENT;
-            break;
-        }
-        if (status == 0x02) {
-            generateCompleteMissionPacket(PChar);
-            logType = MISS_COMPLETE;
-            break;
-        }
-
-    case MISSION_ZILART:
-        if (status == 0x01) {
-            generateCurrentMissionPacket(PChar);
-            logType = MISS_CURRENT;
-            break;
-        }
-        if (status == 0x02) {
-            generateCompleteMissionPacket(PChar);
-            logType = MISS_COMPLETE;
-            break;
-        }
-    case MISSION_COP:
-    case MISSION_ACP:
-    case MISSION_AMK:
-    case MISSION_ASA:
-    case MISSION_SOA:
-    case MISSION_ROV:
-        if (status == 0x01)
+    // FFXI packs different TOAU information in the same packet as certain other content
+    if ((contentID >= LOG_TOAU) && (contentID <= LOG_CAMPAIGN2))
+    {
+        if ((contentID == LOG_WOTG) && (status <= STATUS_QUEST_COMP))
         {
+            // We're updating Crystal War quests
+            generateQuestPacket(PChar, questLogID, status);
+        }
+        else
+        {
+            switch (status) {
+                case STATUS_QUEST_CURR:
+                case STATUS_MISS_CURR:
+                    // Current TOAU Quests, TOAU, WOTG, Assault, and Campaign Mission all share a packet
+                    generateQuestPacket(PChar, LOG_TYPES[LOG_TOAU][QUEST_LOG], STATUS_QUEST_CURR); // "Base" of the packet
+                    generateCurrentExpMissionPacket(PChar); // Writes 12 bytes in same packet
+                    break;
+                case STATUS_QUEST_COMP:
+                    // Completed TOAU Quests share a packet with completed Assault Missions
+                    generateQuestPacket(PChar, questLogID, status); // "Base" of the packet
+                    generateAssaultMissionPacket(PChar);            // Writes more to it
+                    break;
+                case STATUS_MISS_COMP:
+                    switch (contentID) {
+                    case LOG_TOAU:
+                    case LOG_WOTG:
+                        // Completed TOAU and WOTG missions share a packet
+                        generateCompleteExpMissionPacket(PChar);
+                        break;
+                    case LOG_ASSAULT:
+                        // As before, completed TOAU Quests and Assaults share
+                        generateQuestPacket(PChar, LOG_TOAU, STATUS_QUEST_COMP);
+                        generateAssaultMissionPacket(PChar);
+                        break;
+                    // Completed Campaign missions take up two packets
+                    case LOG_CAMPAIGN:
+                        generateCampaignMissionPacket(PChar, 0);
+                        break;
+                    case LOG_CAMPAIGN2:
+                        generateCampaignMissionPacket(PChar, 256);
+                        break;
+                    }
+                    break;
+            }
+        }
+    }
+    else if ((status <= STATUS_QUEST_COMP) && (questLogID >= 0))
+    {
+        // We're updating any other quest log
+        generateQuestPacket(PChar, questLogID, status);
+    }
+    else if ((status <= STATUS_MISS_COMP) && (missionLogID >= 0)) 
+    {   // We're updating any other mission log
+        if ((contentID <= LOG_ZILART) && (status == STATUS_MISS_COMP))
+        {
+            // Completed Nation and Zilart missions are updated in the same packet
+            generateCompleteMissionPacket(PChar);
+        } 
+        else 
+        {
+            // All others update the mission log with a standard "current mission" update
             generateCurrentMissionPacket(PChar);
-            logType = MISS_CURRENT;
-            break;
         }
     }
 
@@ -207,31 +107,31 @@ CQuestMissionLogPacket::CQuestMissionLogPacket(CCharEntity * PChar, uint8 logID,
 
 void CQuestMissionLogPacket::generateQuestPacket(CCharEntity * PChar, uint8 logID, uint8 status)
 {
-    if (status == 0x01)
+    if (status == STATUS_QUEST_CURR)
         memcpy(data + 4, PChar->m_questLog[logID].current, 32);
-    else if (status == 0x02)
+    else if (status == STATUS_QUEST_COMP)
         memcpy(data + 4, PChar->m_questLog[logID].complete, 32);
 }
 
 void CQuestMissionLogPacket::generateCurrentMissionPacket(CCharEntity * PChar)
 {
     uint16 add_on_scenarios = 0;
-
-    add_on_scenarios += PChar->m_missionLog[MISSION_ACP - 12].current;
-    add_on_scenarios += PChar->m_missionLog[MISSION_AMK - 12].current << 0x04;
-    add_on_scenarios += PChar->m_missionLog[MISSION_ASA - 12].current << 0x08;
+    
+    add_on_scenarios += PChar->m_missionLog[LOG_TYPES[LOG_ACP][MISSION_LOG]].current;
+    add_on_scenarios += PChar->m_missionLog[LOG_TYPES[LOG_AMK][MISSION_LOG]].current << 0x04;
+    add_on_scenarios += PChar->m_missionLog[LOG_TYPES[LOG_ASA][MISSION_LOG]].current << 0x08;
     // Not perfect, but they display and missions DO progress. Can fix properly later. There is a delay before when the menu updates. Zoning will force it.
 
     uint32 chains = 0;
-    chains = PChar->m_missionLog[MISSION_COP - 11].current + 1;
+    chains = PChar->m_missionLog[LOG_TYPES[LOG_COP][MISSION_LOG]].current + 1;
     chains = ((chains * 0x08) + 0x60);
 
-    uint32 soa = (PChar->m_missionLog[MISSION_SOA - 12].current * 2) + 0x6E;
-    uint32 rov = PChar->m_missionLog[MISSION_ROV - 12].current + 0x6C;
+    uint32 soa = (PChar->m_missionLog[LOG_TYPES[LOG_SOA][MISSION_LOG]].current * 2) + 0x6E;
+    uint32 rov = PChar->m_missionLog[LOG_TYPES[LOG_ROV][MISSION_LOG]].current + 0x6C;
 
-    WBUFB(data, (0x04)) = PChar->profile.nation;								// Nation
-    WBUFW(data, (0x08)) = PChar->m_missionLog[PChar->profile.nation].current;	// National Missions
-    WBUFW(data, (0x0C)) = PChar->m_missionLog[MISSION_ZILART - 11].current;		// Rise of the Zilart
+    WBUFB(data, (0x04)) = PChar->profile.nation;								            // Nation
+    WBUFW(data, (0x08)) = PChar->m_missionLog[PChar->profile.nation].current;	            // National Missions
+    WBUFW(data, (0x0C)) = PChar->m_missionLog[LOG_TYPES[LOG_ZILART][MISSION_LOG]].current;  // Rise of the Zilart
 
     WBUFL(data, (0x10)) = chains;												// Chains of Promathia Missions
     //WBUFB(data,(0x16)) = 0x30;                                                // назначение неизвестно
@@ -242,35 +142,39 @@ void CQuestMissionLogPacket::generateCurrentMissionPacket(CCharEntity * PChar)
 
 void CQuestMissionLogPacket::generateCompleteMissionPacket(CCharEntity * PChar)
 {
-    for (uint8 logID = 0x00; logID <= 0x03; logID++)
+    // This packet simultaneously updates completed mission logs for Nation and Zilart missions.
+    uint8 logID = 0x00;
+    uint8 missionAreas[4] = { LOG_SANDORIA, LOG_BASTOK, LOG_WINDURST, LOG_ZILART };
+    for (uint8 i = 0; i <= 3; i++) {
+        logID = LOG_TYPES[missionAreas[i]][MISSION_LOG];
         for (uint8 questMissionID = 0; questMissionID < 64; questMissionID++)
-            data[(questMissionID / 8) + (logID * 0x08) + 4] ^= ((PChar->m_missionLog[logID].complete[questMissionID]) << (questMissionID % 8));
+            data[(questMissionID / 8) + (i * 0x08) + 4] ^= ((PChar->m_missionLog[logID].complete[questMissionID]) << (questMissionID % 8));
+    }
 }
 
 void CQuestMissionLogPacket::generateCurrentExpMissionPacket(CCharEntity * PChar)
 {
-    WBUFW(data, (0x14)) = PChar->m_assaultLog.current;							// Assault Missions
-    WBUFW(data, (0x18)) = PChar->m_missionLog[MISSION_TOAU - 11].current;		// Treasures of Aht Urhgan
-    WBUFW(data, (0x1C)) = PChar->m_missionLog[MISSION_WOTG - 11].current;		// Wings of the Goddess
-    WBUFW(data, (0x20)) = PChar->m_campaignLog.current;						// Campaign Operations
+    WBUFW(data, (0x14)) = PChar->m_assaultLog.current;						                // Assault Missions
+    WBUFW(data, (0x18)) = PChar->m_missionLog[LOG_TYPES[LOG_TOAU][MISSION_LOG]].current;	// Treasures of Aht Urhgan
+    WBUFW(data, (0x1C)) = PChar->m_missionLog[LOG_TYPES[LOG_WOTG][MISSION_LOG]].current;	// Wings of the Goddess
+    WBUFW(data, (0x20)) = PChar->m_campaignLog.current;						                // Campaign Operations
 }
 
 void CQuestMissionLogPacket::generateCompleteExpMissionPacket(CCharEntity * PChar)
 {
-    for (uint8 logID = 0x04; logID <= 0x05; logID++)
-        for (uint8 questMissionID = 0; questMissionID < 64; questMissionID++)
-            data[(questMissionID / 8) + ((logID - 0x04) * 0x08) + 4] ^= ((PChar->m_missionLog[logID].complete[questMissionID]) << (questMissionID % 8));
+    // This packet simultaenously updates completed mission logs for TOAU and WOTG missions.
+    uint8 logID = LOG_TYPES[LOG_TOAU][MISSION_LOG];
+    for (uint8 questMissionID = 0; questMissionID < 64; questMissionID++)
+        data[(questMissionID / 8) + 4] ^= ((PChar->m_missionLog[logID].complete[questMissionID]) << (questMissionID % 8));
+
+    logID = LOG_TYPES[LOG_WOTG][MISSION_LOG];
+    for (uint8 questMissionID = 0; questMissionID < 64; questMissionID++)
+        data[(questMissionID / 8) + 0x08 + 4] ^= ((PChar->m_missionLog[logID].complete[questMissionID]) << (questMissionID % 8));
 }
 
-void CQuestMissionLogPacket::generateFirstCampaignMissionPacket(CCharEntity * PChar)
+void CQuestMissionLogPacket::generateCampaignMissionPacket(CCharEntity * PChar, uint8 startQMID)
 {
-    for (uint16 questMissionID = 0; questMissionID < 256; questMissionID++)
-        data[(questMissionID / 8) + 4] ^= ((PChar->m_campaignLog.complete[questMissionID]) << (questMissionID % 8));
-}
-
-void CQuestMissionLogPacket::generateSecondCampaignMissionPacket(CCharEntity * PChar)
-{
-    for (uint16 questMissionID = 256; questMissionID < 512; questMissionID++)
+    for (uint16 questMissionID = startQMID; questMissionID < (startQMID + 256); questMissionID++)
         data[(questMissionID / 8) + 4] ^= ((PChar->m_campaignLog.complete[questMissionID]) << (questMissionID % 8));
 }
 

--- a/src/map/packets/quest_mission_log.cpp
+++ b/src/map/packets/quest_mission_log.cpp
@@ -28,88 +28,98 @@
 #include "quest_mission_log.h"
 #include "../entities/charentity.h"
 
-CQuestMissionLogPacket::CQuestMissionLogPacket(CCharEntity * PChar, uint8 subjectID, uint8 status)
+CQuestMissionLogPacket::CQuestMissionLogPacket(CCharEntity * PChar, uint8 logID, uint8 logType)
 {
     this->type = 0x56;
     this->size = 0x14;
 
-    int16 logType = LOG_TYPES[subjectID][status + (status > STATUS_QUEST_COMP ? 1 : 0)];
-    int16 questLogID = LOG_TYPES[subjectID][QUEST_LOG];
-    int16 missionLogID = LOG_TYPES[subjectID][MISSION_LOG];
+    uint16 packetType = 0x00;
 
-    // FFXI packs different TOAU information in the same packet as certain other content
-    if ((subjectID >= LOG_TOAU) && (subjectID <= LOG_CAMPAIGN2))
+    // FFXI packs different TOAU information in the same packet as certain other content, so we'll have to work around it.
+    // First, deal with all quest areas which aren't TOAU:
+    if ((logType <= LOG_QUEST_COMP) && (logID != QUESTS_TOAU))
     {
-        if ((subjectID == LOG_WOTG) && (status <= STATUS_QUEST_COMP))
-        {
-            // We're updating Crystal War quests
-            generateQuestPacket(PChar, questLogID, status);
-        }
-        else
-        {
-            switch (status) {
-                case STATUS_QUEST_CURR:
-                case STATUS_MISS_CURR:
-                    // Current TOAU Quests, TOAU, WOTG, Assault, and Campaign Mission all share a packet
-                    generateQuestPacket(PChar, LOG_TYPES[LOG_TOAU][QUEST_LOG], STATUS_QUEST_CURR); // "Base" of the packet
-                    generateCurrentExpMissionPacket(PChar); // Writes 12 bytes in same packet
-                    break;
-                case STATUS_QUEST_COMP:
-                    // Completed TOAU Quests share a packet with completed Assault Missions
-                    generateQuestPacket(PChar, questLogID, status); // "Base" of the packet
-                    generateAssaultMissionPacket(PChar);            // Writes more to it
-                    break;
-                case STATUS_MISS_COMP:
-                    switch (subjectID) {
-                    case LOG_TOAU:
-                    case LOG_WOTG:
-                        // Completed TOAU and WOTG missions share a packet
-                        generateCompleteExpMissionPacket(PChar);
-                        break;
-                    case LOG_ASSAULT:
-                        // As before, completed TOAU Quests and Assaults share
-                        generateQuestPacket(PChar, LOG_TOAU, STATUS_QUEST_COMP);
-                        generateAssaultMissionPacket(PChar);
-                        break;
-                    // Completed Campaign missions take up two packets
-                    case LOG_CAMPAIGN:
-                        generateCampaignMissionPacket(PChar, 0);
-                        break;
-                    case LOG_CAMPAIGN2:
-                        generateCampaignMissionPacket(PChar, 256);
-                        break;
-                    }
-                    break;
-            }
-        }
+        // We're updating any non-TOAU quest log
+        generateQuestPacket(PChar, logID, logType);
+        packetType = QUEST_PACKET_BYTES[logID][logType - 1];
     }
-    else if ((status <= STATUS_QUEST_COMP) && (questLogID >= 0))
+    // Then get our mission log updates out of the way
+    else if (logType >= LOG_MISS_CURR)
     {
-        // We're updating any other quest log
-        generateQuestPacket(PChar, questLogID, status);
-    }
-    else if ((status <= STATUS_MISS_COMP) && (missionLogID >= 0)) 
-    {   // We're updating any other mission log
-        if ((subjectID <= LOG_ZILART) && (status == STATUS_MISS_COMP))
+        if ((logID <= MISSION_ZILART) && (logType == LOG_MISS_COMP))
         {
             // Completed Nation and Zilart missions are updated in the same packet
             generateCompleteMissionPacket(PChar);
-        } 
-        else 
+            packetType = MISS_COMPLETE;
+        }
+        else if ((logID >= MISSION_TOAU) && (logID <= MISSION_CAMPAIGN) && (logID != MISSION_COP))
         {
-            // All others update the mission log with a standard "current mission" update
+            // Deal with compound TOAU/WOTG quest/mission packets
+            switch (logType) {
+                case LOG_MISS_CURR:
+                    // Current TOAU Quests, TOAU Mission, WOTG, Assault, and Campaign Mission all share a packet
+                    generateQuestPacket(PChar, QUESTS_TOAU, LOG_QUEST_CURR);    // "Base" of the packet
+                    generateCurrentExpMissionPacket(PChar);                     // Writes 12 bytes in same packet
+                    packetType = EXP_MISS_CURRENT;
+                    break;
+                case LOG_MISS_COMP:
+                    switch (logID) {
+                    case MISSION_TOAU:
+                    case MISSION_WOTG:
+                        // Completed TOAU and WOTG missions share a packet
+                        generateCompleteExpMissionPacket(PChar);
+                        packetType = EXP_MISS_COMPLETE;
+                        break;
+                    case MISSION_ASSAULT:
+                        // Completed Assault Missions share a packet with completed TOAU quests
+                        generateQuestPacket(PChar, QUESTS_TOAU, LOG_QUEST_COMP);
+                        generateAssaultMissionPacket(PChar);
+                        packetType = EXP_COMPLETE;
+                        break;
+                    case MISSION_CAMPAIGN:
+                        // Completed Campaign missions take up two packets. Second half will come in a follow-up packet.
+                        generateCampaignMissionPacket(PChar, 0);
+                        packetType = CMPGN_MISS_UN;
+                        break;
+                    }
+                    break;
+                case LOG_CAMPAIGN2:
+                    // Second Campaign packet, summoned through logType
+                    generateCampaignMissionPacket(PChar, 256);
+                    packetType = CMPGN_MISS_DEUX;
+                    break;
+            }
+        }
+        else {
+            // All other mission logs update current / completed with a standard "current mission" update
             generateCurrentMissionPacket(PChar);
+            packetType = MISS_CURRENT;
         }
     }
+    else
+    {
+        // Now all that remains is TOAU quests.
+        generateQuestPacket(PChar, QUESTS_TOAU, logType);  // "Base" of the packet
+        if (logType == LOG_QUEST_CURR) {
+            // As before, current TOAU Quests share with TOAU Mission, WOTG, Assault, and Campaign Missions
+            generateCurrentExpMissionPacket(PChar); // Writes 12 bytes in same packet
+        }
+        else {
+            // Completed TOAU Quests share a packet with completed Assault Missions
+            generateAssaultMissionPacket(PChar); // Writes in same packet
+        }
+        packetType = QUEST_PACKET_BYTES[logID][logType - 1];
+    }
 
-    WBUFW(data, (0x24)) = logType;
+    // Write the byte that informs FFXI client what kind of Quest/Mission log update this packet is.
+    WBUFW(data, (0x24)) = packetType;
 }
 
 void CQuestMissionLogPacket::generateQuestPacket(CCharEntity * PChar, uint8 logID, uint8 status)
 {
-    if (status == STATUS_QUEST_CURR)
+    if (status == LOG_QUEST_CURR)
         memcpy(data + 4, PChar->m_questLog[logID].current, 32);
-    else if (status == STATUS_QUEST_COMP)
+    else if (status == LOG_QUEST_COMP)
         memcpy(data + 4, PChar->m_questLog[logID].complete, 32);
 }
 
@@ -117,22 +127,24 @@ void CQuestMissionLogPacket::generateCurrentMissionPacket(CCharEntity * PChar)
 {
     uint16 add_on_scenarios = 0;
     
-    add_on_scenarios += PChar->m_missionLog[LOG_TYPES[LOG_ACP][MISSION_LOG]].current;
-    add_on_scenarios += PChar->m_missionLog[LOG_TYPES[LOG_AMK][MISSION_LOG]].current << 0x04;
-    add_on_scenarios += PChar->m_missionLog[LOG_TYPES[LOG_ASA][MISSION_LOG]].current << 0x08;
+    add_on_scenarios += PChar->m_missionLog[MISSION_ACP].current;
+    add_on_scenarios += PChar->m_missionLog[MISSION_AMK].current << 0x04;
+    add_on_scenarios += PChar->m_missionLog[MISSION_ASA].current << 0x08;
     // Not perfect, but they display and missions DO progress. Can fix properly later. There is a delay before when the menu updates. Zoning will force it.
 
     uint32 chains = 0;
-    chains = PChar->m_missionLog[LOG_TYPES[LOG_COP][MISSION_LOG]].current + 1;
+    chains = PChar->m_missionLog[MISSION_COP].current + 1;
     chains = ((chains * 0x08) + 0x60);
 
-    uint32 soa = (PChar->m_missionLog[LOG_TYPES[LOG_SOA][MISSION_LOG]].current * 2) + 0x6E;
-    uint32 rov = PChar->m_missionLog[LOG_TYPES[LOG_ROV][MISSION_LOG]].current + 0x6C;
+    uint32 soa = (PChar->m_missionLog[MISSION_SOA].current * 2) + 0x6E;
+    uint32 rov = PChar->m_missionLog[MISSION_ROV].current + 0x6C;
 
-    WBUFB(data, (0x04)) = PChar->profile.nation;								            // Nation
-    WBUFW(data, (0x08)) = PChar->m_missionLog[PChar->profile.nation].current;	            // National Missions
-    WBUFW(data, (0x0C)) = PChar->m_missionLog[LOG_TYPES[LOG_ZILART][MISSION_LOG]].current;  // Rise of the Zilart
+    // While current National Missions + Zilart Mission are updated in this packet, completed missions are sent in a separate one.
+    WBUFB(data, (0x04)) = PChar->profile.nation;                                // Nation
+    WBUFW(data, (0x08)) = PChar->m_missionLog[PChar->profile.nation].current;   // National Missions
+    WBUFW(data, (0x0C)) = PChar->m_missionLog[MISSION_ZILART].current;          // Rise of the Zilart
 
+    // But for COP, Add-On Scenarios, SOA, and ROV, sending the current mission will also update that log's completed missions.
     WBUFL(data, (0x10)) = chains;												// Chains of Promathia Missions
     //WBUFB(data,(0x16)) = 0x30;                                                // назначение неизвестно
     WBUFW(data, (0x18)) = add_on_scenarios;                                     // A Crystalline Prophecy, A Moogle Kupo d'Etat, A Shantotto Ascension
@@ -144,9 +156,9 @@ void CQuestMissionLogPacket::generateCompleteMissionPacket(CCharEntity * PChar)
 {
     // This packet simultaneously updates completed mission logs for Nation and Zilart missions.
     uint8 logID = 0x00;
-    uint8 missionAreas[4] = { LOG_SANDORIA, LOG_BASTOK, LOG_WINDURST, LOG_ZILART };
+    uint8 missionAreas[4] = { MISSION_SANDORIA, MISSION_BASTOK, MISSION_WINDURST, MISSION_ZILART };
     for (uint8 i = 0; i <= 3; i++) {
-        logID = LOG_TYPES[missionAreas[i]][MISSION_LOG];
+        logID = missionAreas[i];
         for (uint8 questMissionID = 0; questMissionID < 64; questMissionID++)
             data[(questMissionID / 8) + (i * 0x08) + 4] ^= ((PChar->m_missionLog[logID].complete[questMissionID]) << (questMissionID % 8));
     }
@@ -154,20 +166,22 @@ void CQuestMissionLogPacket::generateCompleteMissionPacket(CCharEntity * PChar)
 
 void CQuestMissionLogPacket::generateCurrentExpMissionPacket(CCharEntity * PChar)
 {
-    WBUFW(data, (0x14)) = PChar->m_assaultLog.current;						                // Assault Missions
-    WBUFW(data, (0x18)) = PChar->m_missionLog[LOG_TYPES[LOG_TOAU][MISSION_LOG]].current;	// Treasures of Aht Urhgan
-    WBUFW(data, (0x1C)) = PChar->m_missionLog[LOG_TYPES[LOG_WOTG][MISSION_LOG]].current;	// Wings of the Goddess
-    WBUFW(data, (0x20)) = PChar->m_campaignLog.current;                                     // Campaign Operations
+    // This function writes the current Assault, TOAU, WOTG, and Campaign mission onto a packet already
+    // being prepared by generateQuestPacket for TOAU quests, since they're all updated simultaneously.
+    WBUFW(data, (0x14)) = PChar->m_assaultLog.current;                  // Assault Missions
+    WBUFW(data, (0x18)) = PChar->m_missionLog[MISSION_TOAU].current;    // Treasures of Aht Urhgan
+    WBUFW(data, (0x1C)) = PChar->m_missionLog[MISSION_WOTG].current;    // Wings of the Goddess
+    WBUFW(data, (0x20)) = PChar->m_campaignLog.current;                 // Campaign Operations
 }
 
 void CQuestMissionLogPacket::generateCompleteExpMissionPacket(CCharEntity * PChar)
 {
     // This packet simultaenously updates completed mission logs for TOAU and WOTG missions.
-    uint8 logID = LOG_TYPES[LOG_TOAU][MISSION_LOG];
+    uint8 logID = MISSION_TOAU;
     for (uint8 questMissionID = 0; questMissionID < 64; questMissionID++)
         data[(questMissionID / 8) + 4] ^= ((PChar->m_missionLog[logID].complete[questMissionID]) << (questMissionID % 8));
 
-    logID = LOG_TYPES[LOG_WOTG][MISSION_LOG];
+    logID = MISSION_WOTG;
     for (uint8 questMissionID = 0; questMissionID < 64; questMissionID++)
         data[(questMissionID / 8) + 0x08 + 4] ^= ((PChar->m_missionLog[logID].complete[questMissionID]) << (questMissionID % 8));
 }

--- a/src/map/packets/quest_mission_log.h
+++ b/src/map/packets/quest_mission_log.h
@@ -25,7 +25,7 @@
 #define _CQUESTMISSIONLOGPACKET_H
 
 #include "../../common/cbasetypes.h"
-#include <map>
+#include <unordered_map>
 
 #include "basic.h"
 
@@ -68,30 +68,20 @@ enum LOG_TYPE
 };
 
 // Quest Log Packet Values
-static const std::map<std::pair<uint8, LOG_TYPE>, uint16> questPacketBytes =
+static const std::unordered_map<uint8, std::pair<uint16, uint16>> questPacketBytes =
 {
-    {{ QUESTS_SANDORIA , LOG_QUEST_CURR }, 0x50   }, // Sandoria Current
-    {{ QUESTS_SANDORIA , LOG_QUEST_COMP }, 0x90   }, // Sandoria Complete
-    {{ QUESTS_BASTOK   , LOG_QUEST_CURR }, 0x58   }, // Bastok Current
-    {{ QUESTS_BASTOK   , LOG_QUEST_COMP }, 0x98   }, // Bastok Complete
-    {{ QUESTS_WINDURST , LOG_QUEST_CURR }, 0x60   }, // Windurst Current
-    {{ QUESTS_WINDURST , LOG_QUEST_COMP }, 0xA0   }, // Windurst Complete
-    {{ QUESTS_JEUNO    , LOG_QUEST_CURR }, 0x68   }, // Jeuno Current
-    {{ QUESTS_JEUNO    , LOG_QUEST_COMP }, 0xA8   }, // Jeuno Complete
-    {{ QUESTS_OTHER    , LOG_QUEST_CURR }, 0x70   }, // Other Areas Current
-    {{ QUESTS_OTHER    , LOG_QUEST_COMP }, 0xB0   }, // Other Areas Complete
-    {{ QUESTS_OUTLANDS , LOG_QUEST_CURR }, 0x78   }, // Outlands Current
-    {{ QUESTS_OUTLANDS , LOG_QUEST_COMP }, 0xB8   }, // Outlands Complete
-    {{ QUESTS_TOAU     , LOG_QUEST_CURR }, 0x80   }, // Aht Urhgan Current
-    {{ QUESTS_TOAU     , LOG_QUEST_COMP }, 0xC0   }, // Aht Urhgan Complete
-    {{ QUESTS_WOTG     , LOG_QUEST_CURR }, 0x88   }, // Crystal War Current
-    {{ QUESTS_WOTG     , LOG_QUEST_COMP }, 0xC8   }, // Crystal War Complete
-    {{ QUESTS_ABYSSEA  , LOG_QUEST_CURR }, 0xE0   }, // Abyssea Current
-    {{ QUESTS_ABYSSEA  , LOG_QUEST_COMP }, 0xE8   }, // Abyssea Complete
-    {{ QUESTS_ADOULIN  , LOG_QUEST_CURR }, 0xF0   }, // Adoulin Current
-    {{ QUESTS_ADOULIN  , LOG_QUEST_COMP }, 0xF8   }, // Adoulin Complete
-    {{ QUESTS_COALITION, LOG_QUEST_CURR }, 0x0100 }, // Coalition Current
-    {{ QUESTS_COALITION, LOG_QUEST_COMP }, 0x0108 }  // Coalition Complete
+    // Quest Log ID   , Current, Complete
+    { QUESTS_SANDORIA , {0x50  , 0x90   }},
+    { QUESTS_BASTOK   , {0x58  , 0x98   }},
+    { QUESTS_WINDURST , {0x60  , 0xA0   }},
+    { QUESTS_JEUNO    , {0x68  , 0xA8   }},
+    { QUESTS_OTHER    , {0x70  , 0xB0   }},
+    { QUESTS_OUTLANDS , {0x78  , 0xB8   }},
+    { QUESTS_TOAU     , {0x80  , 0xC0   }},
+    { QUESTS_WOTG     , {0x88  , 0xC8   }},
+    { QUESTS_ABYSSEA  , {0xE0  , 0xE8   }},
+    { QUESTS_ADOULIN  , {0xF0  , 0xF8   }},
+    { QUESTS_COALITION, {0x0100, 0x0108 }},
 };
 
 // Mission Log Packet Bytes

--- a/src/map/packets/quest_mission_log.h
+++ b/src/map/packets/quest_mission_log.h
@@ -24,8 +24,8 @@
 #ifndef _CQUESTMISSIONLOGPACKET_H
 #define _CQUESTMISSIONLOGPACKET_H
 
-#include <unordered_map>
 #include "../../common/cbasetypes.h"
+#include <map>
 
 #include "basic.h"
 
@@ -57,31 +57,41 @@
 #define MISSION_SOA         12
 #define MISSION_ROV         13
 
-// Quest Log Packet Bytes
-const std::unordered_map<uint8, uint16> QUEST_PACKET_BYTES =
+// Log Types
+enum LOG_TYPE
 {
-    { 1,  0x50   }, // SAN_CURRENT
-    { 2,  0x90   }, // SAN_COMPLETE
-    { 3,  0x58   }, // BAS_CURRENT
-    { 4,  0x98   }, // BAS_COMPLETE
-    { 5,  0x60   }, // WIN_CURRENT
-    { 6,  0xA0   }, // WIN_COMPLETE
-    { 7,  0x68   }, // JEU_CURRENT
-    { 8,  0xA8   }, // JEU_COMPLETE
-    { 9,  0x70   }, // OTH_CURRENT
-    { 10, 0xB0   }, // OTH_COMPLETE
-    { 11, 0x78   }, // OUT_CURRENT
-    { 12, 0xB8   }, // OUT_COMPLETE
-    { 13, 0x80   }, // EXP_CURRENT
-    { 14, 0xC0   }, // EXP_COMPLETE
-    { 15, 0x88   }, // WAR_CURRENT
-    { 16, 0xC8   }, // WAR_COMPLETE
-    { 17, 0xE0   }, // ABY_CURRENT
-    { 18, 0xE8   }, // ABY_COMPLETE
-    { 19, 0xF0   }, // ADO_CURRENT
-    { 20, 0xF8   }, // ADO_COMPLETE
-    { 21, 0x0100 }, // COA_CURRENT
-    { 22, 0x0108 }  // COA_COMPLETE
+    LOG_QUEST_CURR = 1,
+    LOG_QUEST_COMP = 2,
+    LOG_MISS_CURR = 3,
+    LOG_MISS_COMP = 4,
+    LOG_CAMPAIGN2 = 5,
+};
+
+// Quest Log Packet Values
+static const std::map<std::pair<uint8, LOG_TYPE>, uint16> questPacketBytes =
+{
+    {{ QUESTS_SANDORIA , LOG_QUEST_CURR }, 0x50   }, // Sandoria Current
+    {{ QUESTS_SANDORIA , LOG_QUEST_COMP }, 0x90   }, // Sandoria Complete
+    {{ QUESTS_BASTOK   , LOG_QUEST_CURR }, 0x58   }, // Bastok Current
+    {{ QUESTS_BASTOK   , LOG_QUEST_COMP }, 0x98   }, // Bastok Complete
+    {{ QUESTS_WINDURST , LOG_QUEST_CURR }, 0x60   }, // Windurst Current
+    {{ QUESTS_WINDURST , LOG_QUEST_COMP }, 0xA0   }, // Windurst Complete
+    {{ QUESTS_JEUNO    , LOG_QUEST_CURR }, 0x68   }, // Jeuno Current
+    {{ QUESTS_JEUNO    , LOG_QUEST_COMP }, 0xA8   }, // Jeuno Complete
+    {{ QUESTS_OTHER    , LOG_QUEST_CURR }, 0x70   }, // Other Areas Current
+    {{ QUESTS_OTHER    , LOG_QUEST_COMP }, 0xB0   }, // Other Areas Complete
+    {{ QUESTS_OUTLANDS , LOG_QUEST_CURR }, 0x78   }, // Outlands Current
+    {{ QUESTS_OUTLANDS , LOG_QUEST_COMP }, 0xB8   }, // Outlands Complete
+    {{ QUESTS_TOAU     , LOG_QUEST_CURR }, 0x80   }, // Aht Urhgan Current
+    {{ QUESTS_TOAU     , LOG_QUEST_COMP }, 0xC0   }, // Aht Urhgan Complete
+    {{ QUESTS_WOTG     , LOG_QUEST_CURR }, 0x88   }, // Crystal War Current
+    {{ QUESTS_WOTG     , LOG_QUEST_COMP }, 0xC8   }, // Crystal War Complete
+    {{ QUESTS_ABYSSEA  , LOG_QUEST_CURR }, 0xE0   }, // Abyssea Current
+    {{ QUESTS_ABYSSEA  , LOG_QUEST_COMP }, 0xE8   }, // Abyssea Complete
+    {{ QUESTS_ADOULIN  , LOG_QUEST_CURR }, 0xF0   }, // Adoulin Current
+    {{ QUESTS_ADOULIN  , LOG_QUEST_COMP }, 0xF8   }, // Adoulin Complete
+    {{ QUESTS_COALITION, LOG_QUEST_CURR }, 0x0100 }, // Coalition Current
+    {{ QUESTS_COALITION, LOG_QUEST_COMP }, 0x0108 }  // Coalition Complete
 };
 
 // Mission Log Packet Bytes
@@ -92,13 +102,6 @@ const std::unordered_map<uint8, uint16> QUEST_PACKET_BYTES =
 #define ASSAULT_COMPLETE    0xC0
 #define CMPGN_MISS_UN       0x30
 #define CMPGN_MISS_DEUX     0x38
-
-// Log Types
-#define LOG_QUEST_CURR  0x01
-#define LOG_QUEST_COMP  0x02
-#define LOG_MISS_CURR   0x03
-#define LOG_MISS_COMP   0x04
-#define LOG_CAMPAIGN2   0x05
 
 /************************************************************************
 *																		*
@@ -112,13 +115,13 @@ class CQuestMissionLogPacket : public CBasicPacket
 {
 public:
 
-    CQuestMissionLogPacket(CCharEntity* PChar, uint8 logID, uint8 logType);
+    CQuestMissionLogPacket(CCharEntity* PChar, uint8 logID, LOG_TYPE logType);
 private:
 
     // формирование пакетов вынес в отдельные функции, специально для тех,
     // кто захочет понять, что же на самом деле происходит в switch(logID)
 
-    void generateQuestPacket(CCharEntity* PChar, uint8 logID, uint8 status);
+    void generateQuestPacket(CCharEntity* PChar, uint8 logID, LOG_TYPE logType);
     void generateCurrentMissionPacket(CCharEntity* PChar);
     void generateCompleteMissionPacket(CCharEntity* PChar);
     void generateCurrentExpMissionPacket(CCharEntity* PChar);

--- a/src/map/packets/quest_mission_log.h
+++ b/src/map/packets/quest_mission_log.h
@@ -28,7 +28,52 @@
 
 #include "basic.h"
 
-//Quest Log Types
+// Area/Content Identifiers
+#define LOG_SANDORIA             0
+#define LOG_BASTOK               1
+#define LOG_WINDURST             2
+#define LOG_JEUNO                3
+#define LOG_SELBINA              4
+#define LOG_MHAURA               5
+#define LOG_RABAO                6
+#define LOG_KAZHAM               7
+#define LOG_NORG                 8
+#define LOG_OTHER_AREAS          9
+#define LOG_TAVNAZIA             9
+#define LOG_OUTLANDS            10
+#define LOG_ZILART              11
+#define LOG_COP                 12
+#define LOG_AHT_URHGAN          13
+#define LOG_TOAU                13
+#define LOG_ASSAULT             14
+#define LOG_CRYSTAL_WAR         15
+#define LOG_WOTG                15
+#define LOG_CAMPAIGN            16
+#define LOG_CAMPAIGN2           17
+#define LOG_ACP                 18
+#define LOG_AMK                 19
+#define LOG_ASA                 20
+#define LOG_ABYSSEA             21
+#define LOG_ABYSSEA_KONSCHTAT   22
+#define LOG_ABYSSEA_TAHRONGI    23
+#define LOG_ABYSSEA_LATHEINE    24
+#define LOG_ABYSSEA_MISAREAUX   25
+#define LOG_ABYSSEA_VUNKERL     26
+#define LOG_ABYSSEA_ATTOHWA     27
+#define LOG_ABYSSEA_ALTEPA      28
+#define LOG_ABYSSEA_GRAUBERG    29
+#define LOG_ABYSSEA_ULEGUERAND  30
+#define LOG_ADOULIN             31
+#define LOG_SOA                 31
+#define LOG_COALITION           32
+#define LOG_ROV                 33
+
+// Log Types
+#define QUEST_LOG           0x00
+#define MISSION_LOG         0x03
+#define FAME                0x06
+
+//Quest Log Packet Values
 #define SAN_CURRENT			0x50
 #define BAS_CURRENT			0x58
 #define WIN_CURRENT			0x60
@@ -53,38 +98,60 @@
 #define ADO_COMPLETE		0xF8
 #define COA_COMPLETE		0x0108
 
-//Mission Log Types
 #define MISS_COMPLETE		0xD0
 #define MISS_CURRENT		0xFFFF
 
-// MISS_CURRENT	0xFF исключая Add-on Scenarios
+#define EXP_MISS_COMPLETE   0xD8
+#define EXP_MISS_CURRENT    0x80
 
-#define EXP_MISS_COMPLETE               0xD8
-#define EXP_MISS_CURRENT                0x80
+#define CMPGN_MISS_UN       0x30
+#define CMPGN_MISS_DEUX     0x38
 
-#define CAMPAIGN_MISSION_UN             0x30
-#define CAMPAIGN_MISSION_DEUX           0x38
+// Status Types
+#define STATUS_QUEST_CURR   0x01
+#define STATUS_QUEST_COMP   0x02
+#define STATUS_MISS_CURR    0x03
+#define STATUS_MISS_COMP    0x04
 
-// Mission Logs
-#define MISSION_SANDORIA                0x0B
-#define MISSION_BASTOK                  0x0C
-#define MISSION_WINDURST                0x0D
-#define MISSION_ZILART                  0x0E
-#define MISSION_TOAU                    0x0F
-#define MISSION_WOTG                    0x10
-#define MISSION_COP                     0x11
-
-#define MISSION_ASSAULT                 0x12
-
-#define MISSION_CAMPAIGN                0x13
-#define MISSION_CAMPAIGN2               0x14
-
-#define MISSION_ACP                     0x15
-#define MISSION_AMK		                0x16
-#define MISSION_ASA		                0x17
-
-#define MISSION_SOA					    0x18
-#define MISSION_ROV                     0x19
+// Log Types
+const int LOG_TYPES[34][7] =
+{
+    // QL | Quest Cur. | Quest Comp.  | ML | Miss. Curr.     | Miss. Comp     | Fame
+    {  0,  SAN_CURRENT, SAN_COMPLETE,   0,  MISS_CURRENT,     MISS_COMPLETE,      0 }, // SANDORIA
+    {  1,  BAS_CURRENT, BAS_COMPLETE,   1,  MISS_CURRENT,     MISS_COMPLETE,      1 }, // BASTOK
+    {  2,  WIN_CURRENT, WIN_COMPLETE,   2,  MISS_CURRENT,     MISS_COMPLETE,      2 }, // WINDURST
+    {  3,  JEU_CURRENT, JEU_COMPLETE,  -1,  -1,               -1,                 3 }, // JEUNO
+    {  4,  OTH_CURRENT, OTH_COMPLETE,  -1,  -1,               -1,                 4 }, // SELBINA
+    {  4,  OTH_CURRENT, OTH_COMPLETE,  -1,  -1,               -1,                 2 }, // MHAURA
+    {  5,  OUT_CURRENT, OUT_COMPLETE,  -1,  -1,               -1,                 4 }, // RABAO
+    {  5,  OUT_CURRENT, OUT_COMPLETE,  -1,  -1,               -1,                 2 }, // KAZHAM
+    {  5,  OUT_CURRENT, OUT_COMPLETE,  -1,  -1,               -1,                 5 }, // NORG
+    {  4,  OTH_CURRENT, OTH_COMPLETE,  -1,  -1,               -1,                -1 }, // OTHER_AREAS = TAVNAZIA
+    {  5,  OUT_CURRENT, OUT_COMPLETE,  -1,  -1,               -1,                -1 }, // OUTLANDS
+    {  5,  OUT_CURRENT, OUT_COMPLETE,   3,  MISS_CURRENT,     MISS_COMPLETE,     -1 }, // ZILART
+    {  4,  OTH_CURRENT, OTH_COMPLETE,   6,  MISS_CURRENT,     -1,                -1 }, // COP
+    {  6,  EXP_CURRENT, EXP_COMPLETE,   4,  EXP_MISS_CURRENT, EXP_MISS_COMPLETE, -1 }, // AHTURHGAN = TOAU
+    { -1,  -1,          -1,             7,  EXP_MISS_CURRENT, EXP_COMPLETE,      -1 }, // ASSAULT
+    {  7,  WAR_CURRENT, WAR_COMPLETE,   5,  EXP_MISS_CURRENT, EXP_MISS_COMPLETE, -1 }, // CRYSTALWAR = WOTG
+    { -1,  -1,          -1,             8,  EXP_MISS_CURRENT, CMPGN_MISS_UN,     -1 }, // CAMPAIGN
+    { -1,  -1,          -1,             8,  EXP_MISS_CURRENT, CMPGN_MISS_DEUX,   -1 }, // CAMPAIGN2
+    { -1,  -1,          -1,             9,  MISS_CURRENT,     -1,                -1 }, // ACP
+    { -1,  -1,          -1,            10,  MISS_CURRENT,     -1,                -1 }, // AMK
+    { -1,  -1,          -1,            11,  MISS_CURRENT,     -1,                -1 }, // ASA
+    {  8,  ABY_CURRENT, ABY_COMPLETE,  -1,  -1,               -1,                -1 }, // ABYSSEA
+    {  8,  ABY_CURRENT, ABY_COMPLETE,  -1,  -1,               -1,                 6 }, // ABYSSEA_KONSCHTAT
+    {  8,  ABY_CURRENT, ABY_COMPLETE,  -1,  -1,               -1,                 7 }, // ABYSSEA_TAHRONGI
+    {  8,  ABY_CURRENT, ABY_COMPLETE,  -1,  -1,               -1,                 8 }, // ABYSSEA_LATHEINE
+    {  8,  ABY_CURRENT, ABY_COMPLETE,  -1,  -1,               -1,                 9 }, // ABYSSEA_MISAREAUX
+    {  8,  ABY_CURRENT, ABY_COMPLETE,  -1,  -1,               -1,                10 }, // ABYSSEA_VUNKERL
+    {  8,  ABY_CURRENT, ABY_COMPLETE,  -1,  -1,               -1,                11 }, // ABYSSEA_ATTOHWA
+    {  8,  ABY_CURRENT, ABY_COMPLETE,  -1,  -1,               -1,                12 }, // ABYSSEA_ALTEPA
+    {  8,  ABY_CURRENT, ABY_COMPLETE,  -1,  -1,               -1,                13 }, // ABYSSEA_GRAUBERG
+    {  8,  ABY_CURRENT, ABY_COMPLETE,  -1,  -1,               -1,                14 }, // ABYSSEA_ULEGUERAND
+    {  9,  ADO_CURRENT, ADO_COMPLETE,  12,  MISS_CURRENT,     -1,                15 }, // ADOULIN = SOA
+    { 10,  COA_CURRENT, COA_COMPLETE,  -1,  -1,               -1,                -1 }, // COALITION
+    { -1,  -1,          -1,            13,  MISS_CURRENT,     -1,                -1 }  // ROV
+};
 
 /************************************************************************
 *																		*
@@ -109,8 +176,7 @@ private:
     void generateCompleteMissionPacket(CCharEntity* PChar);
     void generateCurrentExpMissionPacket(CCharEntity* PChar);
     void generateCompleteExpMissionPacket(CCharEntity* PChar);
-    void generateFirstCampaignMissionPacket(CCharEntity* PChar);
-    void generateSecondCampaignMissionPacket(CCharEntity* PChar);
+    void generateCampaignMissionPacket(CCharEntity* PChar, uint8 startQMID);
     void generateAssaultMissionPacket(CCharEntity* PChar);
 };
 

--- a/src/map/packets/quest_mission_log.h
+++ b/src/map/packets/quest_mission_log.h
@@ -28,52 +28,35 @@
 
 #include "basic.h"
 
-// Area/Content Identifiers
-#define LOG_SANDORIA             0
-#define LOG_BASTOK               1
-#define LOG_WINDURST             2
-#define LOG_JEUNO                3
-#define LOG_SELBINA              4
-#define LOG_MHAURA               5
-#define LOG_RABAO                6
-#define LOG_KAZHAM               7
-#define LOG_NORG                 8
-#define LOG_OTHER_AREAS          9
-#define LOG_TAVNAZIA             9
-#define LOG_OUTLANDS            10
-#define LOG_ZILART              11
-#define LOG_COP                 12
-#define LOG_AHT_URHGAN          13
-#define LOG_TOAU                13
-#define LOG_ASSAULT             14
-#define LOG_CRYSTAL_WAR         15
-#define LOG_WOTG                15
-#define LOG_CAMPAIGN            16
-#define LOG_CAMPAIGN2           17
-#define LOG_ACP                 18
-#define LOG_AMK                 19
-#define LOG_ASA                 20
-#define LOG_ABYSSEA             21
-#define LOG_ABYSSEA_KONSCHTAT   22
-#define LOG_ABYSSEA_TAHRONGI    23
-#define LOG_ABYSSEA_LATHEINE    24
-#define LOG_ABYSSEA_MISAREAUX   25
-#define LOG_ABYSSEA_VUNKERL     26
-#define LOG_ABYSSEA_ATTOHWA     27
-#define LOG_ABYSSEA_ALTEPA      28
-#define LOG_ABYSSEA_GRAUBERG    29
-#define LOG_ABYSSEA_ULEGUERAND  30
-#define LOG_ADOULIN             31
-#define LOG_SOA                 31
-#define LOG_COALITION           32
-#define LOG_ROV                 33
+// Quest/Mission Area Identifiers
+#define QUESTS_SANDORIA      0
+#define QUESTS_BASTOK        1
+#define QUESTS_WINDURST      2
+#define QUESTS_JEUNO         3
+#define QUESTS_OTHER         4
+#define QUESTS_OUTLANDS      5
+#define QUESTS_TOAU          6
+#define QUESTS_WOTG          7
+#define QUESTS_ABYSSEA       8
+#define QUESTS_ADOULIN       9
+#define QUESTS_COALITION    10
 
-// Log Types
-#define QUEST_LOG           0x00
-#define MISSION_LOG         0x03
-#define FAME                0x06
+#define MISSION_SANDORIA     0
+#define MISSION_BASTOK       1
+#define MISSION_WINDURST     2
+#define MISSION_ZILART       3
+#define MISSION_TOAU         4
+#define MISSION_WOTG         5
+#define MISSION_COP          6
+#define MISSION_ASSAULT      7
+#define MISSION_CAMPAIGN     8
+#define MISSION_ACP          9
+#define MISSION_AMK         10
+#define MISSION_ASA         11
+#define MISSION_SOA         12
+#define MISSION_ROV         13
 
-//Quest Log Packet Values
+// Quest Log Packet Values
 #define SAN_CURRENT			0x50
 #define BAS_CURRENT			0x58
 #define WIN_CURRENT			0x60
@@ -98,60 +81,36 @@
 #define ADO_COMPLETE		0xF8
 #define COA_COMPLETE		0x0108
 
+const int QUEST_PACKET_BYTES[11][2] =
+{
+    // Quest Cur. | Quest Comp.
+    { SAN_CURRENT, SAN_COMPLETE }, // SANDORIA
+    { BAS_CURRENT, BAS_COMPLETE }, // BASTOK
+    { WIN_CURRENT, WIN_COMPLETE }, // WINDURST
+    { JEU_CURRENT, JEU_COMPLETE }, // JEUNO
+    { OTH_CURRENT, OTH_COMPLETE }, // OTHER_AREAS
+    { OUT_CURRENT, OUT_COMPLETE }, // OUTLANDS
+    { EXP_CURRENT, EXP_COMPLETE }, // TOAU
+    { WAR_CURRENT, WAR_COMPLETE }, // WOTG
+    { ABY_CURRENT, ABY_COMPLETE }, // ABYSSEA
+    { ADO_CURRENT, ADO_COMPLETE }, // ADOULIN
+    { COA_CURRENT, COA_COMPLETE }  // COALITION
+};
+
+// Mission Log Packet Bytes
 #define MISS_COMPLETE		0xD0
 #define MISS_CURRENT		0xFFFF
-
 #define EXP_MISS_COMPLETE   0xD8
 #define EXP_MISS_CURRENT    0x80
-
 #define CMPGN_MISS_UN       0x30
 #define CMPGN_MISS_DEUX     0x38
 
-// Status Types
-#define STATUS_QUEST_CURR   0x01
-#define STATUS_QUEST_COMP   0x02
-#define STATUS_MISS_CURR    0x03
-#define STATUS_MISS_COMP    0x04
-
 // Log Types
-const int LOG_TYPES[34][7] =
-{
-    // QL | Quest Cur. | Quest Comp.  | ML | Miss. Curr.     | Miss. Comp     | Fame
-    {  0,  SAN_CURRENT, SAN_COMPLETE,   0,  MISS_CURRENT,     MISS_COMPLETE,      0 }, // SANDORIA
-    {  1,  BAS_CURRENT, BAS_COMPLETE,   1,  MISS_CURRENT,     MISS_COMPLETE,      1 }, // BASTOK
-    {  2,  WIN_CURRENT, WIN_COMPLETE,   2,  MISS_CURRENT,     MISS_COMPLETE,      2 }, // WINDURST
-    {  3,  JEU_CURRENT, JEU_COMPLETE,  -1,  -1,               -1,                 3 }, // JEUNO
-    {  4,  OTH_CURRENT, OTH_COMPLETE,  -1,  -1,               -1,                 4 }, // SELBINA
-    {  4,  OTH_CURRENT, OTH_COMPLETE,  -1,  -1,               -1,                 2 }, // MHAURA
-    {  5,  OUT_CURRENT, OUT_COMPLETE,  -1,  -1,               -1,                 4 }, // RABAO
-    {  5,  OUT_CURRENT, OUT_COMPLETE,  -1,  -1,               -1,                 2 }, // KAZHAM
-    {  5,  OUT_CURRENT, OUT_COMPLETE,  -1,  -1,               -1,                 5 }, // NORG
-    {  4,  OTH_CURRENT, OTH_COMPLETE,  -1,  -1,               -1,                -1 }, // OTHER_AREAS = TAVNAZIA
-    {  5,  OUT_CURRENT, OUT_COMPLETE,  -1,  -1,               -1,                -1 }, // OUTLANDS
-    {  5,  OUT_CURRENT, OUT_COMPLETE,   3,  MISS_CURRENT,     MISS_COMPLETE,     -1 }, // ZILART
-    {  4,  OTH_CURRENT, OTH_COMPLETE,   6,  MISS_CURRENT,     -1,                -1 }, // COP
-    {  6,  EXP_CURRENT, EXP_COMPLETE,   4,  EXP_MISS_CURRENT, EXP_MISS_COMPLETE, -1 }, // AHTURHGAN = TOAU
-    { -1,  -1,          -1,             7,  EXP_MISS_CURRENT, EXP_COMPLETE,      -1 }, // ASSAULT
-    {  7,  WAR_CURRENT, WAR_COMPLETE,   5,  EXP_MISS_CURRENT, EXP_MISS_COMPLETE, -1 }, // CRYSTALWAR = WOTG
-    { -1,  -1,          -1,             8,  EXP_MISS_CURRENT, CMPGN_MISS_UN,     -1 }, // CAMPAIGN
-    { -1,  -1,          -1,             8,  EXP_MISS_CURRENT, CMPGN_MISS_DEUX,   -1 }, // CAMPAIGN2
-    { -1,  -1,          -1,             9,  MISS_CURRENT,     -1,                -1 }, // ACP
-    { -1,  -1,          -1,            10,  MISS_CURRENT,     -1,                -1 }, // AMK
-    { -1,  -1,          -1,            11,  MISS_CURRENT,     -1,                -1 }, // ASA
-    {  8,  ABY_CURRENT, ABY_COMPLETE,  -1,  -1,               -1,                -1 }, // ABYSSEA
-    {  8,  ABY_CURRENT, ABY_COMPLETE,  -1,  -1,               -1,                 6 }, // ABYSSEA_KONSCHTAT
-    {  8,  ABY_CURRENT, ABY_COMPLETE,  -1,  -1,               -1,                 7 }, // ABYSSEA_TAHRONGI
-    {  8,  ABY_CURRENT, ABY_COMPLETE,  -1,  -1,               -1,                 8 }, // ABYSSEA_LATHEINE
-    {  8,  ABY_CURRENT, ABY_COMPLETE,  -1,  -1,               -1,                 9 }, // ABYSSEA_MISAREAUX
-    {  8,  ABY_CURRENT, ABY_COMPLETE,  -1,  -1,               -1,                10 }, // ABYSSEA_VUNKERL
-    {  8,  ABY_CURRENT, ABY_COMPLETE,  -1,  -1,               -1,                11 }, // ABYSSEA_ATTOHWA
-    {  8,  ABY_CURRENT, ABY_COMPLETE,  -1,  -1,               -1,                12 }, // ABYSSEA_ALTEPA
-    {  8,  ABY_CURRENT, ABY_COMPLETE,  -1,  -1,               -1,                13 }, // ABYSSEA_GRAUBERG
-    {  8,  ABY_CURRENT, ABY_COMPLETE,  -1,  -1,               -1,                14 }, // ABYSSEA_ULEGUERAND
-    {  9,  ADO_CURRENT, ADO_COMPLETE,  12,  MISS_CURRENT,     -1,                15 }, // ADOULIN = SOA
-    { 10,  COA_CURRENT, COA_COMPLETE,  -1,  -1,               -1,                -1 }, // COALITION
-    { -1,  -1,          -1,            13,  MISS_CURRENT,     -1,                -1 }  // ROV
-};
+#define LOG_QUEST_CURR  0x01
+#define LOG_QUEST_COMP  0x02
+#define LOG_MISS_CURR   0x03
+#define LOG_MISS_COMP   0x04
+#define LOG_CAMPAIGN2   0x05
 
 /************************************************************************
 *																		*
@@ -165,13 +124,13 @@ class CQuestMissionLogPacket : public CBasicPacket
 {
 public:
 
-    CQuestMissionLogPacket(CCharEntity* PChar, uint8 logID, uint8 status);
+    CQuestMissionLogPacket(CCharEntity* PChar, uint8 logID, uint8 logType);
 private:
 
     // формирование пакетов вынес в отдельные функции, специально для тех,
     // кто захочет понять, что же на самом деле происходит в switch(logID)
 
-    void generateQuestPacket(CCharEntity* PChar, uint8 subjectID, uint8 status);
+    void generateQuestPacket(CCharEntity* PChar, uint8 logID, uint8 status);
     void generateCurrentMissionPacket(CCharEntity* PChar);
     void generateCompleteMissionPacket(CCharEntity* PChar);
     void generateCurrentExpMissionPacket(CCharEntity* PChar);

--- a/src/map/packets/quest_mission_log.h
+++ b/src/map/packets/quest_mission_log.h
@@ -60,11 +60,11 @@
 // Log Types
 enum LOG_TYPE
 {
-    LOG_QUEST_CURR = 1,
-    LOG_QUEST_COMP = 2,
-    LOG_MISS_CURR = 3,
-    LOG_MISS_COMP = 4,
-    LOG_CAMPAIGN2 = 5,
+    LOG_QUEST_CURRENT = 1,
+    LOG_QUEST_COMPLETE = 2,
+    LOG_MISSION_CURRENT = 3,
+    LOG_MISSION_COMPLETE = 4,
+    LOG_CAMPAIGN_TWO = 5,
 };
 
 // Quest Log Packet Values
@@ -85,13 +85,13 @@ static const std::unordered_map<uint8, std::pair<uint16, uint16>> questPacketByt
 };
 
 // Mission Log Packet Bytes
-#define MISS_COMPLETE       0xD0
-#define MISS_CURRENT        0xFFFF
-#define EXP_MISS_COMPLETE   0xD8
-#define EXP_MISS_CURRENT    0x80
-#define ASSAULT_COMPLETE    0xC0
-#define CMPGN_MISS_UN       0x30
-#define CMPGN_MISS_DEUX     0x38
+#define MISSION_CURRENT             0xFFFF
+#define MISSION_COMPLETE            0xD0
+#define TOAU_WOTG_MISSION_CURRENT   0x80
+#define TOAU_WOTG_MISSION_COMPLETE  0xD8
+#define ASSAULT_COMPLETE            0xC0
+#define CAMPAIGN_MISSION_ONE        0x30
+#define CAMPAIGN_MISSION_TWO        0x38
 
 /************************************************************************
 *																		*

--- a/src/map/packets/quest_mission_log.h
+++ b/src/map/packets/quest_mission_log.h
@@ -24,6 +24,7 @@
 #ifndef _CQUESTMISSIONLOGPACKET_H
 #define _CQUESTMISSIONLOGPACKET_H
 
+#include <unordered_map>
 #include "../../common/cbasetypes.h"
 
 #include "basic.h"
@@ -56,52 +57,39 @@
 #define MISSION_SOA         12
 #define MISSION_ROV         13
 
-// Quest Log Packet Values
-#define SAN_CURRENT			0x50
-#define BAS_CURRENT			0x58
-#define WIN_CURRENT			0x60
-#define JEU_CURRENT			0x68
-#define OTH_CURRENT			0x70
-#define OUT_CURRENT			0x78
-#define EXP_CURRENT			0x80
-#define WAR_CURRENT			0x88
-#define ABY_CURRENT			0xE0
-#define ADO_CURRENT			0xF0
-#define COA_CURRENT			0x0100
-
-#define SAN_COMPLETE		0x90
-#define BAS_COMPLETE		0x98
-#define WIN_COMPLETE		0xA0
-#define JEU_COMPLETE		0xA8
-#define OTH_COMPLETE		0xB0
-#define OUT_COMPLETE		0xB8
-#define EXP_COMPLETE		0xC0
-#define WAR_COMPLETE		0xC8
-#define ABY_COMPLETE		0xE8
-#define ADO_COMPLETE		0xF8
-#define COA_COMPLETE		0x0108
-
-const int QUEST_PACKET_BYTES[11][2] =
+// Quest Log Packet Bytes
+const std::unordered_map<uint8, uint16> QUEST_PACKET_BYTES =
 {
-    // Quest Cur. | Quest Comp.
-    { SAN_CURRENT, SAN_COMPLETE }, // SANDORIA
-    { BAS_CURRENT, BAS_COMPLETE }, // BASTOK
-    { WIN_CURRENT, WIN_COMPLETE }, // WINDURST
-    { JEU_CURRENT, JEU_COMPLETE }, // JEUNO
-    { OTH_CURRENT, OTH_COMPLETE }, // OTHER_AREAS
-    { OUT_CURRENT, OUT_COMPLETE }, // OUTLANDS
-    { EXP_CURRENT, EXP_COMPLETE }, // TOAU
-    { WAR_CURRENT, WAR_COMPLETE }, // WOTG
-    { ABY_CURRENT, ABY_COMPLETE }, // ABYSSEA
-    { ADO_CURRENT, ADO_COMPLETE }, // ADOULIN
-    { COA_CURRENT, COA_COMPLETE }  // COALITION
+    { 1,  0x50   }, // SAN_CURRENT
+    { 2,  0x90   }, // SAN_COMPLETE
+    { 3,  0x58   }, // BAS_CURRENT
+    { 4,  0x98   }, // BAS_COMPLETE
+    { 5,  0x60   }, // WIN_CURRENT
+    { 6,  0xA0   }, // WIN_COMPLETE
+    { 7,  0x68   }, // JEU_CURRENT
+    { 8,  0xA8   }, // JEU_COMPLETE
+    { 9,  0x70   }, // OTH_CURRENT
+    { 10, 0xB0   }, // OTH_COMPLETE
+    { 11, 0x78   }, // OUT_CURRENT
+    { 12, 0xB8   }, // OUT_COMPLETE
+    { 13, 0x80   }, // EXP_CURRENT
+    { 14, 0xC0   }, // EXP_COMPLETE
+    { 15, 0x88   }, // WAR_CURRENT
+    { 16, 0xC8   }, // WAR_COMPLETE
+    { 17, 0xE0   }, // ABY_CURRENT
+    { 18, 0xE8   }, // ABY_COMPLETE
+    { 19, 0xF0   }, // ADO_CURRENT
+    { 20, 0xF8   }, // ADO_COMPLETE
+    { 21, 0x0100 }, // COA_CURRENT
+    { 22, 0x0108 }  // COA_COMPLETE
 };
 
 // Mission Log Packet Bytes
-#define MISS_COMPLETE		0xD0
-#define MISS_CURRENT		0xFFFF
+#define MISS_COMPLETE       0xD0
+#define MISS_CURRENT        0xFFFF
 #define EXP_MISS_COMPLETE   0xD8
 #define EXP_MISS_CURRENT    0x80
+#define ASSAULT_COMPLETE    0xC0
 #define CMPGN_MISS_UN       0x30
 #define CMPGN_MISS_DEUX     0x38
 

--- a/src/map/packets/quest_mission_log.h
+++ b/src/map/packets/quest_mission_log.h
@@ -171,7 +171,7 @@ private:
     // формирование пакетов вынес в отдельные функции, специально для тех,
     // кто захочет понять, что же на самом деле происходит в switch(logID)
 
-    void generateQuestPacket(CCharEntity* PChar, uint8 logID, uint8 status);
+    void generateQuestPacket(CCharEntity* PChar, uint8 subjectID, uint8 status);
     void generateCurrentMissionPacket(CCharEntity* PChar);
     void generateCompleteMissionPacket(CCharEntity* PChar);
     void generateCurrentExpMissionPacket(CCharEntity* PChar);

--- a/src/map/utils/charutils.cpp
+++ b/src/map/utils/charutils.cpp
@@ -1029,49 +1029,43 @@ namespace charutils
 
     void SendQuestMissionLog(CCharEntity* PChar)
     {
-        // в нижележащем цикле загружаются все квесты, текущие и выполненные
-        // в одном пакете с текущими квестами Aht Urhgan отправляется информация о текущих миссиях
-        // Treasures of Aht Urhgan
-        // Wings of the Goddess Missions
-        // Assault Missions
-        // Campaign Operations
-        // пакет с завершенными квестами Aht Urhgan содержит завершенные миссии Assault Missions
-
-        for (uint8 status = 0x01; status <= 0x02; ++status)
+        // Quests (Current + Completed):
+        // --------------------------------
+        int8 sentQuestAreas[LOG_ROV] = {0};
+        int8 questLogID = 0;
+        
+        for (int8 areaID = 0; areaID <= LOG_COALITION; areaID++)
         {
-            for (uint8 areaID = 0; areaID <= QUESTS_CRYSTALWAR; ++areaID)
+            questLogID = LOG_TYPES[areaID][QUEST_LOG];
+            if ((questLogID >= 0) && (sentQuestAreas[questLogID] == 0))
             {
-                PChar->pushPacket(new CQuestMissionLogPacket(PChar, areaID, status));
+                PChar->pushPacket(new CQuestMissionLogPacket(PChar, areaID, STATUS_QUEST_CURR));
+                PChar->pushPacket(new CQuestMissionLogPacket(PChar, areaID, STATUS_QUEST_COMP));
+                sentQuestAreas[LOG_TYPES[areaID][QUEST_LOG]] = 1;
             }
         }
 
-        // Treasures of Aht Urhgan
-        // Wings of the Goddess Missions
-        PChar->pushPacket(new CQuestMissionLogPacket(PChar, MISSION_ZILART, 0x02));
-        PChar->pushPacket(new CQuestMissionLogPacket(PChar, MISSION_TOAU, 0x02));
+        // Completed Missions:
+        // --------------------------------
+        // Completed missions for Nation + Zilart Missions are all sent in single packet
+        PChar->pushPacket(new CQuestMissionLogPacket(PChar, LOG_ZILART, STATUS_MISS_COMP));
 
-        // Campaign Operations
-        PChar->pushPacket(new CQuestMissionLogPacket(PChar, MISSION_CAMPAIGN, 0x02));
-        PChar->pushPacket(new CQuestMissionLogPacket(PChar, MISSION_CAMPAIGN2, 0x02));
+        // Completed missions for TOAU and WOTG are sent in the same packet
+        PChar->pushPacket(new CQuestMissionLogPacket(PChar, LOG_TOAU, STATUS_MISS_COMP));
 
-        for (uint8 status = 0x01; status <= 0x02; ++status)
-        {
-            for (uint8 areaID = QUESTS_ABYSSEA; areaID < MAX_QUESTAREA; ++areaID)
-            {
-                PChar->pushPacket(new CQuestMissionLogPacket(PChar, areaID, status));
-            }
-        }
+        // Completed Assaults were sent in the same packet as completed TOAU quests
 
-        // обновляем статус миссий
-        // National Missions
-        // Rise of the Zilart and Chains of Promathia Missions
-        // Add-on Scenarios
-        // так как все эти миссии обновляются вместе,
-        // то достаточно выполнить обновление для MISSION_ZILART
+        // Completed Campaign Operations
+        PChar->pushPacket(new CQuestMissionLogPacket(PChar, LOG_CAMPAIGN, STATUS_MISS_COMP));
+        PChar->pushPacket(new CQuestMissionLogPacket(PChar, LOG_CAMPAIGN2, STATUS_MISS_COMP));
 
-        PChar->pushPacket(new CQuestMissionLogPacket(PChar, MISSION_ZILART, 0x01));
+        // Current Missions:
+        // --------------------------------
+        // Current TOAU, Assault, WOTG, and Campaign mission were sent in the same packet as current TOAU quests
 
-
+        // Current Nation, Zilart, COP, Add-On, SOA, and ROV missions are all sent in a shared, single packet.
+        // So sending this packet updates multiple Mission logs at once.
+        PChar->pushPacket(new CQuestMissionLogPacket(PChar, LOG_ZILART, STATUS_MISS_CURR));
     }
 
     /************************************************************************

--- a/src/map/utils/charutils.cpp
+++ b/src/map/utils/charutils.cpp
@@ -1033,23 +1033,23 @@ namespace charutils
         // --------------------------------
         for (int8 areaID = 0; areaID <= QUESTS_COALITION; areaID++)
         {
-            PChar->pushPacket(new CQuestMissionLogPacket(PChar, areaID, LOG_QUEST_CURR));
-            PChar->pushPacket(new CQuestMissionLogPacket(PChar, areaID, LOG_QUEST_COMP));
+            PChar->pushPacket(new CQuestMissionLogPacket(PChar, areaID, LOG_QUEST_CURRENT));
+            PChar->pushPacket(new CQuestMissionLogPacket(PChar, areaID, LOG_QUEST_COMPLETE));
         }
 
         // Completed Missions:
         // --------------------------------
         // Completed missions for Nation + Zilart Missions are all sent in single packet
-        PChar->pushPacket(new CQuestMissionLogPacket(PChar, MISSION_ZILART, LOG_MISS_COMP));
+        PChar->pushPacket(new CQuestMissionLogPacket(PChar, MISSION_ZILART, LOG_MISSION_COMPLETE));
 
         // Completed missions for TOAU and WOTG are sent in the same packet
-        PChar->pushPacket(new CQuestMissionLogPacket(PChar, MISSION_TOAU, LOG_MISS_COMP));
+        PChar->pushPacket(new CQuestMissionLogPacket(PChar, MISSION_TOAU, LOG_MISSION_COMPLETE));
 
         // Completed Assaults were sent in the same packet as completed TOAU quests
 
         // Completed Campaign Operations
-        PChar->pushPacket(new CQuestMissionLogPacket(PChar, MISSION_CAMPAIGN, LOG_MISS_COMP));
-        PChar->pushPacket(new CQuestMissionLogPacket(PChar, MISSION_CAMPAIGN, LOG_CAMPAIGN2));
+        PChar->pushPacket(new CQuestMissionLogPacket(PChar, MISSION_CAMPAIGN, LOG_MISSION_COMPLETE));
+        PChar->pushPacket(new CQuestMissionLogPacket(PChar, MISSION_CAMPAIGN, LOG_CAMPAIGN_TWO));
 
         // Current Missions:
         // --------------------------------
@@ -1057,7 +1057,7 @@ namespace charutils
 
         // Current Nation, Zilart, COP, Add-On, SOA, and ROV missions are all sent in a shared, single packet.
         // So sending this packet updates multiple Mission logs at once.
-        PChar->pushPacket(new CQuestMissionLogPacket(PChar, MISSION_ZILART, LOG_MISS_CURR));
+        PChar->pushPacket(new CQuestMissionLogPacket(PChar, MISSION_ZILART, LOG_MISSION_CURRENT));
     }
 
     /************************************************************************

--- a/src/map/utils/charutils.cpp
+++ b/src/map/utils/charutils.cpp
@@ -1031,33 +1031,25 @@ namespace charutils
     {
         // Quests (Current + Completed):
         // --------------------------------
-        int8 sentQuestAreas[LOG_ROV] = {0};
-        int8 questLogID = 0;
-        
-        for (int8 areaID = 0; areaID <= LOG_COALITION; areaID++)
+        for (int8 areaID = 0; areaID <= QUESTS_COALITION; areaID++)
         {
-            questLogID = LOG_TYPES[areaID][QUEST_LOG];
-            if ((questLogID >= 0) && (sentQuestAreas[questLogID] == 0))
-            {
-                PChar->pushPacket(new CQuestMissionLogPacket(PChar, areaID, STATUS_QUEST_CURR));
-                PChar->pushPacket(new CQuestMissionLogPacket(PChar, areaID, STATUS_QUEST_COMP));
-                sentQuestAreas[LOG_TYPES[areaID][QUEST_LOG]] = 1;
-            }
+            PChar->pushPacket(new CQuestMissionLogPacket(PChar, areaID, LOG_QUEST_CURR));
+            PChar->pushPacket(new CQuestMissionLogPacket(PChar, areaID, LOG_QUEST_COMP));
         }
 
         // Completed Missions:
         // --------------------------------
         // Completed missions for Nation + Zilart Missions are all sent in single packet
-        PChar->pushPacket(new CQuestMissionLogPacket(PChar, LOG_ZILART, STATUS_MISS_COMP));
+        PChar->pushPacket(new CQuestMissionLogPacket(PChar, MISSION_ZILART, LOG_MISS_COMP));
 
         // Completed missions for TOAU and WOTG are sent in the same packet
-        PChar->pushPacket(new CQuestMissionLogPacket(PChar, LOG_TOAU, STATUS_MISS_COMP));
+        PChar->pushPacket(new CQuestMissionLogPacket(PChar, MISSION_TOAU, LOG_MISS_COMP));
 
         // Completed Assaults were sent in the same packet as completed TOAU quests
 
         // Completed Campaign Operations
-        PChar->pushPacket(new CQuestMissionLogPacket(PChar, LOG_CAMPAIGN, STATUS_MISS_COMP));
-        PChar->pushPacket(new CQuestMissionLogPacket(PChar, LOG_CAMPAIGN2, STATUS_MISS_COMP));
+        PChar->pushPacket(new CQuestMissionLogPacket(PChar, MISSION_CAMPAIGN, LOG_MISS_COMP));
+        PChar->pushPacket(new CQuestMissionLogPacket(PChar, MISSION_CAMPAIGN, LOG_CAMPAIGN2));
 
         // Current Missions:
         // --------------------------------
@@ -1065,7 +1057,7 @@ namespace charutils
 
         // Current Nation, Zilart, COP, Add-On, SOA, and ROV missions are all sent in a shared, single packet.
         // So sending this packet updates multiple Mission logs at once.
-        PChar->pushPacket(new CQuestMissionLogPacket(PChar, LOG_ZILART, STATUS_MISS_CURR));
+        PChar->pushPacket(new CQuestMissionLogPacket(PChar, MISSION_ZILART, LOG_MISS_CURR));
     }
 
     /************************************************************************


### PR DESCRIPTION
This PR addresses the issue(s) raised in #3274 in regards to Lua constants for city/areas having different values depending on context, and potentially conflicting. It does so by using a lookup table, as @TeoTwawki mentioned.


~~Although instead of a Lua global, this uses an internal table in `quest_mission_log.h`. Because having it on the C-side:~~
- Doesn't harm any existing scripts!
- Doesn't require scripts to use a Lua lookup table/function [ex: `player:completeQuest(getlog(BASTOK, QUEST), QUEST_NAME)` ] going into the future. It's still `player:completeQuest(BASTOK, QUEST_NAME)` like normal
- Allows us to greatly simplify `quest_mission_log.cpp` itself! I cut down the crazy-long switch statement, and was able to clarify confusing additions/subtractions like `[MISSION_SOA - 11].current` into `[LOG_SOA].current`
- Can let us abuse context a bit: `player:completeQuest(KAZHAM, QUEST_NAME)`, which I'll explain in a bit.

~~Basically, I defined a set of city/area/mission IDs, taking all quests/missions/fame areas into account. I referred to this as a "content ID" because I couldn't come up with a better variable name. These are synced up with corresponding Lua globals, included into quest/mission/shop files. This gets mapped to the true ID needed via the `LOG_TYPES` table in the `quest_mission_log.h` depending on the function exposed/called via Lunar.~~

I made sure to include all (differing) cities in these content IDs, so they can look up a correct value if used in an appropriate context. For example, Kazham doesn't have its own unique quest log, but all its quests are Outlands quests. So we can (and I did) link Kazham's "quest log" to Outlands, and fame to Windurst, so if someone who is working on a Kazham quest "erroneously" does:
```
player:completeQuest(KAZHAM, QUEST_NAME);
player:addFame(KAZHAM);
```
The correct quest will be completed in the Outlands log, with fame being added for the right Windurst fame area.

Aliases work too, by defining the alias to the same "content ID" as its equivalent. ADOULIN and SOA can be used interchangeably without worry (`player:addFame(ADOULIN), player:getCurrentMission(SOA)`) because they're both LOG_ADOULIN's ID of 31. A quest added in WOTG can be referenced through "WOTG", or by the proper quest log name of "CRYSTAL_WAR".

I considered adding aliases for Nashmau (TOAU) and Shadowreign Cities (CRYSTAL_WAR), but didn't. Someone can do so later if they feel it worthwhile to be able to do something like `completeQuest(WINDURST_S, THE_TIGRESS_STIRS)`.

Other things I did while I was messing with all this:
- Added some verification for fame functions to make sure they were called with a valid fameArea
- Cut down the function(s) for completed Campaign missions from two down to one by adding a variable.
- Made references to current/complete status as a constant instead of non-descriptive hard-coded 0x01s and 0x02s.
- Some more comments explaining how quest_mission_log packets work, in case anyone else finds themselves working with them later.