### PR TITLE
Door: House of the Hero: don't use a hard-coded value for "The doors are firmly sealed shut."

### DIFF
--- a/scripts/zones/Windurst_Walls/npcs/_6n2.lua
+++ b/scripts/zones/Windurst_Walls/npcs/_6n2.lua
@@ -60,7 +60,7 @@ function onTrigger(player,npc)
         elseif (player:getQuestStatus(WINDURST,I_CAN_HEAR_A_RAINBOW) == QUEST_ACCEPTED) then
             player:startEvent(0x0181,1125,1125,1125,1125,1125,1125,1125,1125);
         else
-            player:messageSpecial(7532); -- "The doors are firmly sealed shut."
+            player:messageSpecial(DOORS_SEALED_SHUT); -- "The doors are firmly sealed shut."
         end;
     end;
 


### PR DESCRIPTION
It has a constant in scripts/zones/Windurst_Walls/TextIDs.lua, so there's no reason not to use it (right?).