### PR TITLE
Twinkle Tree (West Sarutabaruta): don't use hardcoded text ids.

### DIFF
--- a/scripts/zones/West_Sarutabaruta/TextIDs.lua
+++ b/scripts/zones/West_Sarutabaruta/TextIDs.lua
@@ -24,6 +24,10 @@ KOLAPO_OILAPO_DIALOG = 7385; -- Hi-diddly-diddly! This is the gateway to Windurs
         MAATA_ULAATA = 7386; -- Hello-wello! This is the central tower of the Horutoto Ruins. It's one of the several ancient-wancient magic towers which dot these grasslands.
         IPUPU_DIALOG = 7389; -- I decided to take a little strolly-wolly, but before I realized it, I found myself way out here! Now I am sorta stuck... Woe is me!
 
+-- Quest Dialog
+    FROST_DEPOSIT_TWINKLES = 7396; -- A frost deposit at the base of the tree twinkles in the starlight.
+    MELT_BARE_HANDS = 7398; -- It looks like it would melt if you touched it with your bare hands...
+
 -- Other Dialog
         NOTHING_HAPPENS = 7304; -- Nothing happens...
 NOTHING_OUT_OF_ORDINARY = 7399; -- There is nothing out of the ordinary here.

--- a/scripts/zones/West_Sarutabaruta/npcs/Twinkle_Tree.lua
+++ b/scripts/zones/West_Sarutabaruta/npcs/Twinkle_Tree.lua
@@ -19,17 +19,17 @@ require("scripts/zones/West_Sarutabaruta/TextIDs");
 -----------------------------------
 
 function onTrade(player,npc,trade)
-starstatus = player:getQuestStatus(WINDURST,TO_CATCH_A_FALLIHG_STAR);
+    local starstatus = player:getQuestStatus(WINDURST,TO_CATCH_A_FALLIHG_STAR);
     if (starstatus == 1 and VanadielHour() <= 3) then
         if (trade:getGil() == 0 and trade:hasItemQty(868,1) == true and trade:getItemCount() == 1 and player:getVar("QuestCatchAFallingStar_prog") == 0) then
             if (player:getFreeSlotsCount() == 0) then
-                player:messageSpecial(7336);
-                player:messageSpecial(7338);
+                player:messageSpecial(FROST_DEPOSIT_TWINKLES);
+                player:messageSpecial(MELT_BARE_HANDS);
                 player:messageSpecial(ITEM_CANNOT_BE_OBTAINED,546);
             else
                 player:tradeComplete(trade);
-                player:messageSpecial(7336);
-                player:messageSpecial(7338);
+                player:messageSpecial(FROST_DEPOSIT_TWINKLES);
+                player:messageSpecial(MELT_BARE_HANDS);
                 player:addItem(546,1);
                 player:messageSpecial(ITEM_OBTAINED,546); 
                 player:setVar("QuestCatchAFallingStar_prog",1);
@@ -44,10 +44,10 @@ end;
 
 function onTrigger(player,npc)
     if (VanadielHour() <= 3 and player:getVar("QuestCatchAFallingStar_prog") == 0) then
-        player:messageSpecial(7336);
-        player:messageSpecial(7338);
+        player:messageSpecial(FROST_DEPOSIT_TWINKLES);
+        player:messageSpecial(MELT_BARE_HANDS);
     else
-        player:messageSpecial(7339);
+        player:messageSpecial(NOTHING_OUT_OF_ORDINARY);
     end
 end; 
 
@@ -56,8 +56,8 @@ end;
 -----------------------------------
 
 function onEventUpdate(player,csid,option)
---printf("CSID: %u",csid);
---printf("RESULT: %u",option);
+    -- printf("CSID: %u",csid);
+    -- printf("RESULT: %u",option);
 end;
 
 -----------------------------------
@@ -65,8 +65,8 @@ end;
 -----------------------------------
 
 function onEventFinish(player,csid,option)
---printf("CSID: %u",csid);
---printf("RESULT: %u",option);
+    -- printf("CSID: %u",csid);
+    -- printf("RESULT: %u",option);
 end;
 
 


### PR DESCRIPTION
They're now correct, but this NPC is still not 100% retail quality (the event ID is still unknown, I'll try to figure it out in another pull).

Also fixed a couple more indentation problems.