### PR TITLE
Reversed some BCNM changes Tested on 5-1, Double Draconian

### DIFF
--- a/src/map/battlefield.cpp
+++ b/src/map/battlefield.cpp
@@ -268,11 +268,9 @@ bool CBattlefield::delPlayerFromBcnm(CCharEntity* PChar) {
             PChar->StatusEffectContainer->DelStatusEffectSilent(EFFECT_SJ_RESTRICTION);
             PChar->StatusEffectContainer->DelStatusEffectSilent(EFFECT_BATTLEFIELD);
             PChar->StatusEffectContainer->DelStatusEffectSilent(EFFECT_LEVEL_RESTRICTION);
-            m_PlayerList.erase(m_PlayerList.begin() + i);
-            if (m_PlayerList.empty())
-            {
-                cleanup();
-            }
+            PChar->PAI->Disengage();
+			clearPlayerEnmity(PChar);
+			m_PlayerList.erase(m_PlayerList.begin() + i);
             return true;
         }
     }
@@ -427,19 +425,19 @@ void CBattlefield::beforeCleanup() {
         // enable subjob
         enableSubJob();
     }
-    if (m_PlayerList.empty())
-        cleanup();
-}
+  }
+
+  //  No longer will 5-1 kill you after win or leave the counter on forever in other BCNMS
 
 bool CBattlefield::winBcnm() {
     beforeCleanup();
-    for (auto&& PChar : m_PlayerList)
-    {
-        luautils::OnBcnmLeave(PChar, this, LEAVE_WIN);
-        PChar->PAI->Disengage();
-        clearPlayerEnmity(PChar);
+	for (int i = 0; i < m_PlayerList.size(); i++) {
+		luautils::OnBcnmLeave(m_PlayerList.at(i), this, LEAVE_WIN);
+		if (this->delPlayerFromBcnm(m_PlayerList.at(i))) { i--; }
     }
-    return true;
+	cleanup();
+	return true;
+	
 }
 
 bool CBattlefield::spawnTreasureChest() {
@@ -453,13 +451,13 @@ void CBattlefield::OpenChestinBcnm() {
 
 bool CBattlefield::loseBcnm() {
     beforeCleanup();
-    for (auto&& PChar : m_PlayerList)
-    {
-        luautils::OnBcnmLeave(PChar, this, LEAVE_LOSE);
-        PChar->PAI->Disengage();
-        clearPlayerEnmity(PChar);
+	for (int i = 0; i < m_PlayerList.size(); i++) {
+		luautils::OnBcnmLeave(m_PlayerList.at(i), this, LEAVE_LOSE);
+		if (this->delPlayerFromBcnm(m_PlayerList.at(i))) { i--; }
     }
-    return true;
+	
+	cleanup();
+	return true;
 }
 
 bool CBattlefield::isEnemyBelowHPP(uint8 hpp) {

--- a/src/map/battlefield_handler.cpp
+++ b/src/map/battlefield_handler.cpp
@@ -232,27 +232,37 @@ bool CBattlefieldHandler::disconnectFromBcnm(CCharEntity* PChar) { //includes wa
     }
     return false;
 }
-
+// this thing black screens on Run Away in Horalis Peak, it does end battlefield now. I think the exit cs is broken somewher
 bool CBattlefieldHandler::leaveBcnm(uint16 bcnmid, CCharEntity* PChar) {
-    for (int i = 0; i < m_MaxBattlefields; i++) {
-        if (m_Battlefields[i] != nullptr && m_Battlefields[i]->getID() == bcnmid) {
-            if (m_Battlefields[i]->isPlayerInBcnm(PChar)) {
-                if (m_Battlefields[i] == PChar->PBCNM) {
-                    luautils::OnBcnmLeave(PChar, m_Battlefields[i], LEAVE_EXIT);
-                    return true;
-                }
-            }
-        }
-    }
-    return false;
+	for (int i = 0; i < m_MaxBattlefields; i++) {
+		if (m_Battlefields[i] != nullptr && m_Battlefields[i]->getID() == bcnmid) {
+			if (m_Battlefields[i]->isPlayerInBcnm(PChar)) {
+				if (m_Battlefields[i]->delPlayerFromBcnm(PChar)) {
+					luautils::OnBcnmLeave(PChar, m_Battlefields[i], LEAVE_EXIT);
+					if (!m_Battlefields[i]->isReserved()) {//no more players in BCNM
+						ShowDebug("Detected no more players in BCNM Battlefield %i. Cleaning up. \n",
+							m_Battlefields[i]->getBattlefieldNumber());
+						m_Battlefields[i]->loseBcnm();
+						
+					}
+					return true;
+					
+				}
+				
+			}
+			
+		}
+		
+	}
+	return false;
 }
-
+// this might do something now?
 bool CBattlefieldHandler::winBcnm(uint16 bcnmid, CCharEntity* PChar) {
     for (int i = 0; i < m_MaxBattlefields; i++) {
         if (m_Battlefields[i] != nullptr && m_Battlefields[i]->getID() == bcnmid) {
             if (m_Battlefields[i]->isPlayerInBcnm(PChar)) {
                 m_Battlefields[i]->winBcnm();
-                return true;
+				return true;
             }
         }
     }


### PR DESCRIPTION
delPlayerFromBcnm -- Was missing, basically. 