### PR TITLE
Separating conquest/nation variables from quest/mission variables

### DIFF
--- a/scripts/globals/conquest.lua
+++ b/scripts/globals/conquest.lua
@@ -11,11 +11,11 @@ require("scripts/globals/missions");
 -- convenience constants
 -----------------------------------
 
-SANDORIA = 0;
-BASTOK   = 1;
-WINDURST = 2;
-BEASTMEN = 3;
-OTHER    = 4;
+NATION_SANDORIA = 0;
+NATION_BASTOK   = 1;
+NATION_WINDURST = 2;
+BEASTMEN        = 3;
+OTHER           = 4;
 
 RONFAURE        = 0;
 ZULKHEIM        = 1;
@@ -143,7 +143,7 @@ tpFees = { 100, 100, 150, 100, 150, 100, 100, 150, 350, 400, 150, 250, 300, 500,
 
 function tradeConquestGuard(player,npc,trade,guardnation,guardtype)
 
-    -- Nation:    -- SANDORIA, BASTOK, WINDURST, OTHER(Jeuno)
+    -- Nation:    -- NATION_SANDORIA, NATION_BASTOK, NATION_WINDURST, OTHER(Jeuno)
     -- Type:     1: city, 2: foreign, 3: outpost, 4: border
 
     local myCP = player:getCP();
@@ -243,30 +243,30 @@ function getArg1(guardnation,player)
     local output = 0;
     local signet = 0;
 
-    if (guardnation == WINDURST) then
+    if (guardnation == NATION_WINDURST) then
         output = 33;
-    elseif (guardnation == SANDORIA) then
+    elseif (guardnation == NATION_SANDORIA) then
         output = 1;
-    elseif (guardnation == BASTOK) then
+    elseif (guardnation == NATION_BASTOK) then
         output = 17;
     end
 
     if (guardnation == pNation) then
         signet = 0;
-    elseif (pNation == WINDURST) then
-        if (guardnation == BASTOK and windurst_bastok_ally == 1) or (guardnation == SANDORIA and sandy_windurst_ally == 1) then
+    elseif (pNation == NATION_WINDURST) then
+        if (guardnation == NATION_BASTOK and windurst_bastok_ally == 1) or (guardnation == NATION_SANDORIA and sandy_windurst_ally == 1) then
             signet = 1;
         else
             signet = 7;
         end
-    elseif (pNation == BASTOK) then
-        if (guardnation == WINDURST and windurst_bastok_ally == 1) or (guardnation == SANDORIA and sandy_bastok_ally == 1) then
+    elseif (pNation == NATION_BASTOK) then
+        if (guardnation == NATION_WINDURST and windurst_bastok_ally == 1) or (guardnation == NATION_SANDORIA and sandy_bastok_ally == 1) then
             signet = 2;
         else
             signet = 7;
         end
-    elseif (pNation == SANDORIA) then
-        if (guardnation == WINDURST and sandy_windurst_ally == 1) or (guardnation == BASTOK and sandy_bastok_ally == 1) then
+    elseif (pNation == NATION_SANDORIA) then
+        if (guardnation == NATION_WINDURST and sandy_windurst_ally == 1) or (guardnation == NATION_BASTOK and sandy_bastok_ally == 1) then
             signet = 4;
         else
             signet = 7;
@@ -297,7 +297,7 @@ end;
 ------------------------------------------------
 
 function conquestRanking()
-    return getNationRank(SANDORIA) + 4 * getNationRank(BASTOK) + 16 * getNationRank(WINDURST);
+    return getNationRank(NATION_SANDORIA) + 4 * getNationRank(NATION_BASTOK) + 16 * getNationRank(NATION_WINDURST);
 end;
 
 ----------------------------------------------------------------
@@ -346,11 +346,11 @@ function getArg6(player)
     local output = player:getRank();
     local nation = player:getNation();
 
-    if (nation == SANDORIA) then
+    if (nation == NATION_SANDORIA) then
         return output;
-    elseif (nation == BASTOK) then
+    elseif (nation == NATION_BASTOK) then
         return output + 32;
-    elseif (nation == WINDURST) then
+    elseif (nation == NATION_WINDURST) then
         return output + 64;
 
     end
@@ -416,12 +416,12 @@ function hasOutpost(player, region)
     local nation = player:getNation()
     local bit = {};
 
-    if (nation == BASTOK) then
-        supply_quests = player:getNationTeleport(BASTOK);
-    elseif (nation == SANDORIA) then
-        supply_quests = player:getNationTeleport(SANDORIA);
-    elseif (nation == WINDURST) then
-        supply_quests = player:getNationTeleport(WINDURST);
+    if (nation == NATION_BASTOK) then
+        supply_quests = player:getNationTeleport(NATION_BASTOK);
+    elseif (nation == NATION_SANDORIA) then
+        supply_quests = player:getNationTeleport(NATION_SANDORIA);
+    elseif (nation == NATION_WINDURST) then
+        supply_quests = player:getNationTeleport(NATION_WINDURST);
     end;
 
     for i = 23,5,-1 do
@@ -463,9 +463,9 @@ end;
 
 function toHomeNation(player)
 
-    if (player:getNation() == BASTOK) then
+    if (player:getNation() == NATION_BASTOK) then
         player:setPos(89, 0 , -66, 0, 234);
-    elseif (player:getNation() == SANDORIA) then
+    elseif (player:getNation() == NATION_SANDORIA) then
         player:setPos(49, -1 , 29, 164, 231);
     else
         player:setPos(193, -12 , 220, 64, 240);
@@ -590,20 +590,20 @@ switch (region): caseof {
 
     npc  = {
     --
-        Doladepaiton,SANDORIA,        -- Doladepaiton, R.K.
-        Doladepaiton+7,SANDORIA,    -- Ballie, R.K.
-        Doladepaiton+3,SANDORIA,    -- Flag
-        Doladepaiton+11,SANDORIA,    -- Flag
+        Doladepaiton,NATION_SANDORIA,        -- Doladepaiton, R.K.
+        Doladepaiton+7,NATION_SANDORIA,    -- Ballie, R.K.
+        Doladepaiton+3,NATION_SANDORIA,    -- Flag
+        Doladepaiton+11,NATION_SANDORIA,    -- Flag
     --
-        Doladepaiton+1,BASTOK,        -- Yoshihiro, I.M.
-        Doladepaiton+8,BASTOK,        -- Molting Moth, I.M.
-        Doladepaiton+4,BASTOK,        -- Flag
-        Doladepaiton+13,BASTOK,        -- Flag
+        Doladepaiton+1,NATION_BASTOK,        -- Yoshihiro, I.M.
+        Doladepaiton+8,NATION_BASTOK,        -- Molting Moth, I.M.
+        Doladepaiton+4,NATION_BASTOK,        -- Flag
+        Doladepaiton+13,NATION_BASTOK,        -- Flag
     --
-        Doladepaiton+2,WINDURST,    -- Kyanta-Pakyanta, W.W.
-        Doladepaiton+9,WINDURST,    -- Tottoto, W.W.
-        Doladepaiton+5,WINDURST,    -- Flag
-        Doladepaiton+13,WINDURST,    -- Flag
+        Doladepaiton+2,NATION_WINDURST,    -- Kyanta-Pakyanta, W.W.
+        Doladepaiton+9,NATION_WINDURST,    -- Tottoto, W.W.
+        Doladepaiton+5,NATION_WINDURST,    -- Flag
+        Doladepaiton+13,NATION_WINDURST,    -- Flag
     --
         Doladepaiton+6,BEASTMEN,    -- Flag
         Doladepaiton+14,BEASTMEN,    -- Flag
@@ -621,20 +621,20 @@ switch (region): caseof {
 
     npc  = {
     --
-        Quanteilleron,SANDORIA,        -- Quanteilleron, R.K.
-        Quanteilleron+7,SANDORIA,    -- Prunilla, R.K.
-        Quanteilleron+3,SANDORIA,    -- flag
-        Quanteilleron+11,SANDORIA,    -- flag
+        Quanteilleron,NATION_SANDORIA,        -- Quanteilleron, R.K.
+        Quanteilleron+7,NATION_SANDORIA,    -- Prunilla, R.K.
+        Quanteilleron+3,NATION_SANDORIA,    -- flag
+        Quanteilleron+11,NATION_SANDORIA,    -- flag
     --
-        Quanteilleron+1,BASTOK,        -- Tsunashige, I.M.
-        Quanteilleron+8,BASTOK,        -- Fighting Ant, I.M.
-        Quanteilleron+4,BASTOK,        -- flag
-        Quanteilleron+12,BASTOK,    -- flag
+        Quanteilleron+1,NATION_BASTOK,        -- Tsunashige, I.M.
+        Quanteilleron+8,NATION_BASTOK,        -- Fighting Ant, I.M.
+        Quanteilleron+4,NATION_BASTOK,        -- flag
+        Quanteilleron+12,NATION_BASTOK,    -- flag
     --
-        Quanteilleron+2,WINDURST,    -- Nyata-Mobuta, W.W.
-        Quanteilleron+9,WINDURST,    -- Tebubu, W.W.
-        Quanteilleron+5,WINDURST,    -- flag
-        Quanteilleron+13,WINDURST,    -- flag
+        Quanteilleron+2,NATION_WINDURST,    -- Nyata-Mobuta, W.W.
+        Quanteilleron+9,NATION_WINDURST,    -- Tebubu, W.W.
+        Quanteilleron+5,NATION_WINDURST,    -- flag
+        Quanteilleron+13,NATION_WINDURST,    -- flag
     --
         Quanteilleron+6,BEASTMEN,    -- flag
         Quanteilleron+14,BEASTMEN,    -- flag
@@ -652,20 +652,20 @@ switch (region): caseof {
 
     npc  = {
     --
-        Chaplion,SANDORIA,        -- Chaplion, R.K.
-        Chaplion+7,SANDORIA,    -- Taumiale, R.K.
-        Chaplion+3,SANDORIA,    -- flag
-        Chaplion+11,SANDORIA,    -- flag
+        Chaplion,NATION_SANDORIA,        -- Chaplion, R.K.
+        Chaplion+7,NATION_SANDORIA,    -- Taumiale, R.K.
+        Chaplion+3,NATION_SANDORIA,    -- flag
+        Chaplion+11,NATION_SANDORIA,    -- flag
     --
-        Chaplion+1,BASTOK,        -- Takamoto, I.M.
-        Chaplion+8,BASTOK,        -- Pure Heart, I.M.
-        Chaplion+4,BASTOK,        -- flag
-        Chaplion+12,BASTOK,        -- flag
+        Chaplion+1,NATION_BASTOK,        -- Takamoto, I.M.
+        Chaplion+8,NATION_BASTOK,        -- Pure Heart, I.M.
+        Chaplion+4,NATION_BASTOK,        -- flag
+        Chaplion+12,NATION_BASTOK,        -- flag
     --
-        Chaplion+2,WINDURST,    -- Bubchu-Bibinchu, W.W.
-        Chaplion+9,WINDURST,    -- Geruru, W.W.
-        Chaplion+5,WINDURST,    -- flag
-        Chaplion+13,WINDURST,    -- flag
+        Chaplion+2,NATION_WINDURST,    -- Bubchu-Bibinchu, W.W.
+        Chaplion+9,NATION_WINDURST,    -- Geruru, W.W.
+        Chaplion+5,NATION_WINDURST,    -- flag
+        Chaplion+13,NATION_WINDURST,    -- flag
     --
         Chaplion+6,BEASTMEN,    -- flag
         Chaplion+14,BEASTMEN,    -- flag
@@ -683,20 +683,20 @@ switch (region): caseof {
 
     npc  = {
     --
-        Ennigreaud,SANDORIA,    -- Ennigreaud, R.K.
-        Ennigreaud+7,SANDORIA,    -- Quellebie, R.K.
-        Ennigreaud+3,SANDORIA,    -- flag
-        Ennigreaud+11,SANDORIA,    -- flag
+        Ennigreaud,NATION_SANDORIA,    -- Ennigreaud, R.K.
+        Ennigreaud+7,NATION_SANDORIA,    -- Quellebie, R.K.
+        Ennigreaud+3,NATION_SANDORIA,    -- flag
+        Ennigreaud+11,NATION_SANDORIA,    -- flag
     --
-        Ennigreaud+1,BASTOK,    -- Shigezane, I.M.
-        Ennigreaud+8,BASTOK,    -- Heavy Fog, I.M.
-        Ennigreaud+4,BASTOK,    -- flag
-        Ennigreaud+12,BASTOK,    -- flag
+        Ennigreaud+1,NATION_BASTOK,    -- Shigezane, I.M.
+        Ennigreaud+8,NATION_BASTOK,    -- Heavy Fog, I.M.
+        Ennigreaud+4,NATION_BASTOK,    -- flag
+        Ennigreaud+12,NATION_BASTOK,    -- flag
     --
-        Ennigreaud+2,WINDURST,    -- Kuuwari-Aori, W.W.
-        Ennigreaud+9,WINDURST,    -- Butsutsu, W.W.
-        Ennigreaud+5,WINDURST,    -- flag
-        Ennigreaud+13,WINDURST,    -- flag
+        Ennigreaud+2,NATION_WINDURST,    -- Kuuwari-Aori, W.W.
+        Ennigreaud+9,NATION_WINDURST,    -- Butsutsu, W.W.
+        Ennigreaud+5,NATION_WINDURST,    -- flag
+        Ennigreaud+13,NATION_WINDURST,    -- flag
     --
         Ennigreaud+6,BEASTMEN,    -- flag
         Ennigreaud+14,BEASTMEN,    -- flag
@@ -714,20 +714,20 @@ switch (region): caseof {
 
     npc  = {
     --
-        Mesachedeau,SANDORIA,        -- Mesachedeau, R.K.
-        Mesachedeau+7,SANDORIA,        -- Ioupie, R.K.
-        Mesachedeau+3,SANDORIA,        -- flag
-        Mesachedeau+11,SANDORIA,    -- flag
+        Mesachedeau,NATION_SANDORIA,        -- Mesachedeau, R.K.
+        Mesachedeau+7,NATION_SANDORIA,        -- Ioupie, R.K.
+        Mesachedeau+3,NATION_SANDORIA,        -- flag
+        Mesachedeau+11,NATION_SANDORIA,    -- flag
     --
-        Mesachedeau+1,BASTOK,        -- Souun, I.M.
-        Mesachedeau+8,BASTOK,        -- Sharp Tooth, I.M.
-        Mesachedeau+4,BASTOK,        -- flag
-        Mesachedeau+12,BASTOK,        -- flag
+        Mesachedeau+1,NATION_BASTOK,        -- Souun, I.M.
+        Mesachedeau+8,NATION_BASTOK,        -- Sharp Tooth, I.M.
+        Mesachedeau+4,NATION_BASTOK,        -- flag
+        Mesachedeau+12,NATION_BASTOK,        -- flag
     --
-        Mesachedeau+2,WINDURST,        -- Mokto-Lankto, W.W.
-        Mesachedeau+9,WINDURST,        -- Shikoko, W.W.
-        Mesachedeau+5,WINDURST,        -- flag
-        Mesachedeau+13,WINDURST,    -- flag
+        Mesachedeau+2,NATION_WINDURST,        -- Mokto-Lankto, W.W.
+        Mesachedeau+9,NATION_WINDURST,        -- Shikoko, W.W.
+        Mesachedeau+5,NATION_WINDURST,        -- flag
+        Mesachedeau+13,NATION_WINDURST,    -- flag
     --
         Mesachedeau+6,BEASTMEN,        -- flag
         Mesachedeau+14,BEASTMEN,    -- flag
@@ -745,20 +745,20 @@ switch (region): caseof {
 
     npc  = {
     --
-        Naguipeillont,SANDORIA,        -- Naguipeillont, R.K.
-        Naguipeillont+7,SANDORIA,    -- Banege, R.K.
-        Naguipeillont+3,SANDORIA,    -- flag
-        Naguipeillont+11,SANDORIA,    -- flag
+        Naguipeillont,NATION_SANDORIA,        -- Naguipeillont, R.K.
+        Naguipeillont+7,NATION_SANDORIA,    -- Banege, R.K.
+        Naguipeillont+3,NATION_SANDORIA,    -- flag
+        Naguipeillont+11,NATION_SANDORIA,    -- flag
     --
-        Naguipeillont+1,BASTOK,        -- Ryokei, I.M.
-        Naguipeillont+8,BASTOK,        -- Slow Axe, I.M.
-        Naguipeillont+4,BASTOK,        -- flag
-        Naguipeillont+12,BASTOK,    -- flag
+        Naguipeillont+1,NATION_BASTOK,        -- Ryokei, I.M.
+        Naguipeillont+8,NATION_BASTOK,        -- Slow Axe, I.M.
+        Naguipeillont+4,NATION_BASTOK,        -- flag
+        Naguipeillont+12,NATION_BASTOK,    -- flag
     --
-        Naguipeillont+2,WINDURST,    -- Roshina-Kuleshuna, W.W.
-        Naguipeillont+9,WINDURST,    -- Darumomo, W.W.
-        Naguipeillont+5,WINDURST,    -- flag
-        Naguipeillont+13,WINDURST,    -- flag
+        Naguipeillont+2,NATION_WINDURST,    -- Roshina-Kuleshuna, W.W.
+        Naguipeillont+9,NATION_WINDURST,    -- Darumomo, W.W.
+        Naguipeillont+5,NATION_WINDURST,    -- flag
+        Naguipeillont+13,NATION_WINDURST,    -- flag
     --
         Naguipeillont+6,BEASTMEN,    -- flag
         Naguipeillont+14,BEASTMEN,    -- flag
@@ -776,20 +776,20 @@ switch (region): caseof {
 
     npc  = {
     --
-        Bonbavour,SANDORIA,    -- Bonbavour, R.K.
-        Bonbavour+7,SANDORIA,    -- Craigine, R.K.
-        Bonbavour+3,SANDORIA,    -- flag
-        Bonbavour+11,SANDORIA,    -- flag
+        Bonbavour,NATION_SANDORIA,    -- Bonbavour, R.K.
+        Bonbavour+7,NATION_SANDORIA,    -- Craigine, R.K.
+        Bonbavour+3,NATION_SANDORIA,    -- flag
+        Bonbavour+11,NATION_SANDORIA,    -- flag
     --
-        Bonbavour+1,BASTOK,    -- Ishin, I.M.
-        Bonbavour+8,BASTOK,    -- Wise Turtle, I.M.
-        Bonbavour+4,BASTOK,    -- flag
-        Bonbavour+12,BASTOK,    -- flag
+        Bonbavour+1,NATION_BASTOK,    -- Ishin, I.M.
+        Bonbavour+8,NATION_BASTOK,    -- Wise Turtle, I.M.
+        Bonbavour+4,NATION_BASTOK,    -- flag
+        Bonbavour+12,NATION_BASTOK,    -- flag
     --
-        Bonbavour+2,WINDURST,    -- Ganemu-Punnemu, W.W.
-        Bonbavour+9,WINDURST,    -- Mashasha, W.W.
-        Bonbavour+5,WINDURST,    -- flag
-        Bonbavour+13,WINDURST,    -- flag
+        Bonbavour+2,NATION_WINDURST,    -- Ganemu-Punnemu, W.W.
+        Bonbavour+9,NATION_WINDURST,    -- Mashasha, W.W.
+        Bonbavour+5,NATION_WINDURST,    -- flag
+        Bonbavour+13,NATION_WINDURST,    -- flag
     --
         Bonbavour+6,BEASTMEN,    -- flag
         Bonbavour+14,BEASTMEN,    -- flag
@@ -807,20 +807,20 @@ switch (region): caseof {
 
     npc  = {
     --
-        Chegourt,SANDORIA,    -- Chegourt, R.K.
-        Chegourt+7,SANDORIA,    -- Buliame, R.K.
-        Chegourt+3,SANDORIA,    -- flag
-        Chegourt+11,SANDORIA,    -- flag
+        Chegourt,NATION_SANDORIA,    -- Chegourt, R.K.
+        Chegourt+7,NATION_SANDORIA,    -- Buliame, R.K.
+        Chegourt+3,NATION_SANDORIA,    -- flag
+        Chegourt+11,NATION_SANDORIA,    -- flag
     --
-        Chegourt+1,BASTOK,    -- Akane, I.M.
-        Chegourt+8,BASTOK,    -- Three Steps, I.M.
-        Chegourt+4,BASTOK,    -- flag
-        Chegourt+12,BASTOK,    -- flag
+        Chegourt+1,NATION_BASTOK,    -- Akane, I.M.
+        Chegourt+8,NATION_BASTOK,    -- Three Steps, I.M.
+        Chegourt+4,NATION_BASTOK,    -- flag
+        Chegourt+12,NATION_BASTOK,    -- flag
     --
-        Chegourt+2,WINDURST,    -- Donmo-Boronmo, W.W.
-        Chegourt+9,WINDURST,    -- Daruru, W.W.
-        Chegourt+5,WINDURST,    -- flag
-        Chegourt+13,WINDURST,    -- flag
+        Chegourt+2,NATION_WINDURST,    -- Donmo-Boronmo, W.W.
+        Chegourt+9,NATION_WINDURST,    -- Daruru, W.W.
+        Chegourt+5,NATION_WINDURST,    -- flag
+        Chegourt+13,NATION_WINDURST,    -- flag
     --
         Chegourt+6,BEASTMEN,    -- flag
         Chegourt+14,BEASTMEN,    -- flag
@@ -838,20 +838,20 @@ switch (region): caseof {
 
     npc  = {
     --
-        Parledaire,SANDORIA,        -- Parledaire, R.K.
-        Parledaire+7,SANDORIA,        -- Leaufetie, R.K.
-        Parledaire+3,SANDORIA,        -- flag
-        Parledaire+11,SANDORIA,        -- flag
+        Parledaire,NATION_SANDORIA,        -- Parledaire, R.K.
+        Parledaire+7,NATION_SANDORIA,        -- Leaufetie, R.K.
+        Parledaire+3,NATION_SANDORIA,        -- flag
+        Parledaire+11,NATION_SANDORIA,        -- flag
     --
-        Parledaire+1,BASTOK,        -- Akane, I.M.
-        Parledaire+8,BASTOK,        -- Rattling Rain, I.M.
-        Parledaire+4,BASTOK,        -- flag
-        Parledaire+12,BASTOK,        -- flag
+        Parledaire+1,NATION_BASTOK,        -- Akane, I.M.
+        Parledaire+8,NATION_BASTOK,        -- Rattling Rain, I.M.
+        Parledaire+4,NATION_BASTOK,        -- flag
+        Parledaire+12,NATION_BASTOK,        -- flag
     --
-        Parledaire+2,WINDURST,        -- Ryunchi-Pauchi, W.W.
-        Parledaire+9,WINDURST,        -- Chopapa, W.W.
-        Parledaire+5,WINDURST,        -- flag
-        Parledaire+13,WINDURST,        -- flag
+        Parledaire+2,NATION_WINDURST,        -- Ryunchi-Pauchi, W.W.
+        Parledaire+9,NATION_WINDURST,        -- Chopapa, W.W.
+        Parledaire+5,NATION_WINDURST,        -- flag
+        Parledaire+13,NATION_WINDURST,        -- flag
     --
         Parledaire+6,BEASTMEN,        -- flag
         Parledaire+14,BEASTMEN,        -- flag
@@ -869,20 +869,20 @@ switch (region): caseof {
 
     npc  = {
     --
-        Jeantelas,SANDORIA,            -- Jeantelas, R.K.
-        Jeantelas+7,SANDORIA,        -- Pilcha, R.K.
-        Jeantelas+3,SANDORIA,        -- flag
-        Jeantelas+11,SANDORIA,        -- flag
+        Jeantelas,NATION_SANDORIA,            -- Jeantelas, R.K.
+        Jeantelas+7,NATION_SANDORIA,        -- Pilcha, R.K.
+        Jeantelas+3,NATION_SANDORIA,        -- flag
+        Jeantelas+11,NATION_SANDORIA,        -- flag
     --    
-        Jeantelas+1,BASTOK,            -- Kaya, I.M.
-        Jeantelas+8,BASTOK,            -- Heavy Bear, I.M.
-        Jeantelas+4,BASTOK,            -- flag
-        Jeantelas+12,BASTOK,        -- flag
+        Jeantelas+1,NATION_BASTOK,            -- Kaya, I.M.
+        Jeantelas+8,NATION_BASTOK,            -- Heavy Bear, I.M.
+        Jeantelas+4,NATION_BASTOK,            -- flag
+        Jeantelas+12,NATION_BASTOK,        -- flag
     --    
-        Jeantelas+2,WINDURST,        -- Magumo-Yagimo, W.W.
-        Jeantelas+9,WINDURST,        -- Tememe, W.W.
-        Jeantelas+5,WINDURST,        -- flag
-        Jeantelas+13,WINDURST,        -- flag
+        Jeantelas+2,NATION_WINDURST,        -- Magumo-Yagimo, W.W.
+        Jeantelas+9,NATION_WINDURST,        -- Tememe, W.W.
+        Jeantelas+5,NATION_WINDURST,        -- flag
+        Jeantelas+13,NATION_WINDURST,        -- flag
     --    
         Jeantelas+6,BEASTMEN,        -- flag
         Jeantelas+14,BEASTMEN,        -- flag
@@ -900,20 +900,20 @@ switch (region): caseof {
 
     npc  = {
     --
-        Pitoire,SANDORIA,    -- Pitoire, R.K.
-        Pitoire+7,SANDORIA,    -- Matica, R.K.
-        Pitoire+3,SANDORIA,    -- flag
-        Pitoire+11,SANDORIA,    -- flag
+        Pitoire,NATION_SANDORIA,    -- Pitoire, R.K.
+        Pitoire+7,NATION_SANDORIA,    -- Matica, R.K.
+        Pitoire+3,NATION_SANDORIA,    -- flag
+        Pitoire+11,NATION_SANDORIA,    -- flag
     --
-        Pitoire+1,BASTOK,    -- Sasa, I.M.
-        Pitoire+8,BASTOK,    -- Singing Blade, I.M.
-        Pitoire+4,BASTOK,    -- flag
-        Pitoire+12,BASTOK,    -- flag
+        Pitoire+1,NATION_BASTOK,    -- Sasa, I.M.
+        Pitoire+8,NATION_BASTOK,    -- Singing Blade, I.M.
+        Pitoire+4,NATION_BASTOK,    -- flag
+        Pitoire+12,NATION_BASTOK,    -- flag
     --
-        Pitoire+2,WINDURST,    -- Tsonga-Hoponga, W.W.
-        Pitoire+9,WINDURST,    -- Numumu, W.W.
-        Pitoire+5,WINDURST,    -- flag
-        Pitoire+13,WINDURST,    -- flag
+        Pitoire+2,NATION_WINDURST,    -- Tsonga-Hoponga, W.W.
+        Pitoire+9,NATION_WINDURST,    -- Numumu, W.W.
+        Pitoire+5,NATION_WINDURST,    -- flag
+        Pitoire+13,NATION_WINDURST,    -- flag
     --
         Pitoire+6,BEASTMEN,    -- flag
         Pitoire+14,BEASTMEN,    -- flag
@@ -931,20 +931,20 @@ switch (region): caseof {
 
     npc  = {
     --
-        Credaurion,SANDORIA,        -- Credaurion, R.K.
-        Credaurion+7,SANDORIA,        -- Limion, R.K.
-        Credaurion+3,SANDORIA,        -- flag
-        Credaurion+11,SANDORIA,        -- flag
+        Credaurion,NATION_SANDORIA,        -- Credaurion, R.K.
+        Credaurion+7,NATION_SANDORIA,        -- Limion, R.K.
+        Credaurion+3,NATION_SANDORIA,        -- flag
+        Credaurion+11,NATION_SANDORIA,        -- flag
     --    
-        Credaurion+1,BASTOK,        -- Calliope, I.M.
-        Credaurion+8,BASTOK,        -- Dedden, I.M.
-        Credaurion+4,BASTOK,        -- flag
-        Credaurion+12,BASTOK,        -- flag
+        Credaurion+1,NATION_BASTOK,        -- Calliope, I.M.
+        Credaurion+8,NATION_BASTOK,        -- Dedden, I.M.
+        Credaurion+4,NATION_BASTOK,        -- flag
+        Credaurion+12,NATION_BASTOK,        -- flag
     --    
-        Credaurion+2,WINDURST,        -- Ajimo-Majimo, W.W.
-        Credaurion+9,WINDURST,        -- Ochocho, W.W.
-        Credaurion+5,WINDURST,        -- flag
-        Credaurion+13,WINDURST,        -- flag
+        Credaurion+2,NATION_WINDURST,        -- Ajimo-Majimo, W.W.
+        Credaurion+9,NATION_WINDURST,        -- Ochocho, W.W.
+        Credaurion+5,NATION_WINDURST,        -- flag
+        Credaurion+13,NATION_WINDURST,        -- flag
     --    
         Credaurion+6,BEASTMEN,        -- flag
         Credaurion+14,BEASTMEN,        -- flag
@@ -962,20 +962,20 @@ switch (region): caseof {
 
     npc  = {
     --
-        Eaulevisat,SANDORIA,    -- Eaulevisat, R.K.
-        Eaulevisat+7,SANDORIA,    -- Laimeve, R.K.
-        Eaulevisat+3,SANDORIA,    -- flag
-        Eaulevisat+11,SANDORIA,    -- flag
+        Eaulevisat,NATION_SANDORIA,    -- Eaulevisat, R.K.
+        Eaulevisat+7,NATION_SANDORIA,    -- Laimeve, R.K.
+        Eaulevisat+3,NATION_SANDORIA,    -- flag
+        Eaulevisat+11,NATION_SANDORIA,    -- flag
     --
-        Eaulevisat+1,BASTOK,    -- Lindgard, I.M.
-        Eaulevisat+8,BASTOK,    -- Daborn, I.M.
-        Eaulevisat+4,BASTOK,    -- flag
-        Eaulevisat+12,BASTOK,    -- flag
+        Eaulevisat+1,NATION_BASTOK,    -- Lindgard, I.M.
+        Eaulevisat+8,NATION_BASTOK,    -- Daborn, I.M.
+        Eaulevisat+4,NATION_BASTOK,    -- flag
+        Eaulevisat+12,NATION_BASTOK,    -- flag
     --
-        Eaulevisat+2,WINDURST,    -- Variko-Njariko, W.W.
-        Eaulevisat+9,WINDURST,    -- Sahgygy, W.W.
-        Eaulevisat+5,WINDURST,    -- flag
-        Eaulevisat+13,WINDURST,    -- flag
+        Eaulevisat+2,NATION_WINDURST,    -- Variko-Njariko, W.W.
+        Eaulevisat+9,NATION_WINDURST,    -- Sahgygy, W.W.
+        Eaulevisat+5,NATION_WINDURST,    -- flag
+        Eaulevisat+13,NATION_WINDURST,    -- flag
     --
         Eaulevisat+6,BEASTMEN,    -- flag
         Eaulevisat+14,BEASTMEN,    -- flag
@@ -993,20 +993,20 @@ switch (region): caseof {
 
     npc  = {
     --
-        Salimardi,SANDORIA,    -- Salimardi, R.K.
-        Salimardi+7,SANDORIA,    -- Paise, R.K.
-        Salimardi+3,SANDORIA,    -- flag
-        Salimardi+11,SANDORIA,    -- flag
+        Salimardi,NATION_SANDORIA,    -- Salimardi, R.K.
+        Salimardi+7,NATION_SANDORIA,    -- Paise, R.K.
+        Salimardi+3,NATION_SANDORIA,    -- flag
+        Salimardi+11,NATION_SANDORIA,    -- flag
     --
-        Salimardi+1,BASTOK,    -- Sarmistha, I.M.
-        Salimardi+8,BASTOK,    -- Dultwa, I.M.
-        Salimardi+4,BASTOK,    -- flag
-        Salimardi+12,BASTOK,    -- flag
+        Salimardi+1,NATION_BASTOK,    -- Sarmistha, I.M.
+        Salimardi+8,NATION_BASTOK,    -- Dultwa, I.M.
+        Salimardi+4,NATION_BASTOK,    -- flag
+        Salimardi+12,NATION_BASTOK,    -- flag
     --
-        Salimardi+2,WINDURST,    -- Voranbo-Natanbo, W.W.
-        Salimardi+9,WINDURST,    -- Orukeke, W.W.
-        Salimardi+5,WINDURST,    -- flag
-        Salimardi+13,WINDURST,    -- flag
+        Salimardi+2,NATION_WINDURST,    -- Voranbo-Natanbo, W.W.
+        Salimardi+9,NATION_WINDURST,    -- Orukeke, W.W.
+        Salimardi+5,NATION_WINDURST,    -- flag
+        Salimardi+13,NATION_WINDURST,    -- flag
     --
         Salimardi+6,BEASTMEN,    -- flag
         Salimardi+14,BEASTMEN,    -- flag
@@ -1024,20 +1024,20 @@ switch (region): caseof {
 
     npc  = {
     --
-        Zorchorevi,SANDORIA,    -- Zorchorevi, R.K.
-        Zorchorevi+7,SANDORIA,    -- Mupia, R.K.
-        Zorchorevi+3,SANDORIA,    -- flag
-        Zorchorevi+11,SANDORIA,    -- flag
+        Zorchorevi,NATION_SANDORIA,    -- Zorchorevi, R.K.
+        Zorchorevi+7,NATION_SANDORIA,    -- Mupia, R.K.
+        Zorchorevi+3,NATION_SANDORIA,    -- flag
+        Zorchorevi+11,NATION_SANDORIA,    -- flag
     --
-        Zorchorevi+1,BASTOK,    -- Mahol, I.M.
-        Zorchorevi+8,BASTOK,    -- Bammiro, I.M.
-        Zorchorevi+4,BASTOK,    -- flag
-        Zorchorevi+12,BASTOK,    -- flag
+        Zorchorevi+1,NATION_BASTOK,    -- Mahol, I.M.
+        Zorchorevi+8,NATION_BASTOK,    -- Bammiro, I.M.
+        Zorchorevi+4,NATION_BASTOK,    -- flag
+        Zorchorevi+12,NATION_BASTOK,    -- flag
     --
-        Zorchorevi+2,WINDURST,    -- Uphra-Kophra, W.W.
-        Zorchorevi+9,WINDURST,    -- Richacha, W.W.
-        Zorchorevi+5,WINDURST,    -- flag
-        Zorchorevi+13,WINDURST,    -- flag
+        Zorchorevi+2,NATION_WINDURST,    -- Uphra-Kophra, W.W.
+        Zorchorevi+9,NATION_WINDURST,    -- Richacha, W.W.
+        Zorchorevi+5,NATION_WINDURST,    -- flag
+        Zorchorevi+13,NATION_WINDURST,    -- flag
     --
         Zorchorevi+6,BEASTMEN,    -- flag
         Zorchorevi+14,BEASTMEN,    -- flag
@@ -1055,20 +1055,20 @@ switch (region): caseof {
 
     npc  ={
     --
-        Ilieumort,SANDORIA,        -- Ilieumort, R.K.
-        Ilieumort+7,SANDORIA,    -- Emila, R.K.
-        Ilieumort+3,SANDORIA,    -- flag
-        Ilieumort+11,SANDORIA,    -- flag
+        Ilieumort,NATION_SANDORIA,        -- Ilieumort, R.K.
+        Ilieumort+7,NATION_SANDORIA,    -- Emila, R.K.
+        Ilieumort+3,NATION_SANDORIA,    -- flag
+        Ilieumort+11,NATION_SANDORIA,    -- flag
     --
-        Ilieumort+1,BASTOK,        -- Mintoo, I.M.
-        Ilieumort+8,BASTOK,        -- Guddal, I.M.
-        Ilieumort+4,BASTOK,        -- flag
-        Ilieumort+12,BASTOK,    -- flag
+        Ilieumort+1,NATION_BASTOK,        -- Mintoo, I.M.
+        Ilieumort+8,NATION_BASTOK,        -- Guddal, I.M.
+        Ilieumort+4,NATION_BASTOK,        -- flag
+        Ilieumort+12,NATION_BASTOK,    -- flag
     --
-        Ilieumort+2,WINDURST,    -- Etaj-Pohtaj, W.W.
-        Ilieumort+9,WINDURST,    -- Ghantata, W.W.
-        Ilieumort+5,WINDURST,    -- flag
-        Ilieumort+13,WINDURST,    -- flag
+        Ilieumort+2,NATION_WINDURST,    -- Etaj-Pohtaj, W.W.
+        Ilieumort+9,NATION_WINDURST,    -- Ghantata, W.W.
+        Ilieumort+5,NATION_WINDURST,    -- flag
+        Ilieumort+13,NATION_WINDURST,    -- flag
     --
         Ilieumort+6,BEASTMEN,    -- flag
         Ilieumort+14,BEASTMEN,    -- flag
@@ -1086,11 +1086,11 @@ switch (region): caseof {
 
     npc  = {
     --
-        RuAun_Banner,SANDORIA,        -- flag
+        RuAun_Banner,NATION_SANDORIA,        -- flag
     --
-        RuAun_Banner+1,BASTOK,        -- flag
+        RuAun_Banner+1,NATION_BASTOK,        -- flag
     --
-        RuAun_Banner+2,WINDURST,    -- flag
+        RuAun_Banner+2,NATION_WINDURST,    -- flag
     --
         RuAun_Banner+3,BEASTMEN,    -- flag
     }
@@ -1105,11 +1105,11 @@ switch (region): caseof {
 
     npc  = {
     --
-        Oldton_Banner_Offset,SANDORIA,        -- flag
+        Oldton_Banner_Offset,NATION_SANDORIA,        -- flag
     --
-        Oldton_Banner_Offset+1,BASTOK,        -- flag
+        Oldton_Banner_Offset+1,NATION_BASTOK,        -- flag
     --
-        Oldton_Banner_Offset+2,WINDURST,    -- flag
+        Oldton_Banner_Offset+2,NATION_WINDURST,    -- flag
     --
         Oldton_Banner_Offset+3,BEASTMEN,    -- flag
     }
@@ -1124,20 +1124,20 @@ switch (region): caseof {
 
     npc  = {
     --
-        Jemmoquel,SANDORIA,        -- Jemmoquel, R.K.
-        Jemmoquel+7,SANDORIA,    -- Chilaumme, R.K.
-        Jemmoquel+3,SANDORIA,    -- flag
-        Jemmoquel+11,SANDORIA,    -- flag
+        Jemmoquel,NATION_SANDORIA,        -- Jemmoquel, R.K.
+        Jemmoquel+7,NATION_SANDORIA,    -- Chilaumme, R.K.
+        Jemmoquel+3,NATION_SANDORIA,    -- flag
+        Jemmoquel+11,NATION_SANDORIA,    -- flag
     --
-        Jemmoquel+1,BASTOK,        -- Yoram, I.M.
-        Jemmoquel+8,BASTOK,        -- Ghost Talker, I.M.
-        Jemmoquel+4,BASTOK,        -- flag
-        Jemmoquel+12,BASTOK,    -- flag
+        Jemmoquel+1,NATION_BASTOK,        -- Yoram, I.M.
+        Jemmoquel+8,NATION_BASTOK,        -- Ghost Talker, I.M.
+        Jemmoquel+4,NATION_BASTOK,        -- flag
+        Jemmoquel+12,NATION_BASTOK,    -- flag
     --
-        Jemmoquel+2,WINDURST,    -- Teldo-Moroldo, W.W.
-        Jemmoquel+9,WINDURST,    -- Cotete, W.W.
-        Jemmoquel+5,WINDURST,    -- flag
-        Jemmoquel+13,WINDURST,    -- flag
+        Jemmoquel+2,NATION_WINDURST,    -- Teldo-Moroldo, W.W.
+        Jemmoquel+9,NATION_WINDURST,    -- Cotete, W.W.
+        Jemmoquel+5,NATION_WINDURST,    -- flag
+        Jemmoquel+13,NATION_WINDURST,    -- flag
     --
         Jemmoquel+6,BEASTMEN,    -- flag
         Jemmoquel+14,BEASTMEN,    -- flag

--- a/scripts/globals/icanheararainbow.lua
+++ b/scripts/globals/icanheararainbow.lua
@@ -58,7 +58,7 @@ function triggerLightCutscene( player)
     local weather = player:getWeather();
 
     if (player:hasItem( 1125, 0)) then -- Player has Carbuncle's Ruby?
-        if (player:getQuestStatus( WINDURST, I_CAN_HEAR_A_RAINBOW) == QUEST_ACCEPTED) then
+        if (player:getQuestStatus(WINDURST, I_CAN_HEAR_A_RAINBOW) == QUEST_ACCEPTED) then
             if (player:getMaskBit(player:getVar("I_CAN_HEAR_A_RAINBOW"),0) == false and (weather == WEATHER_HOT_SPELL or weather == WEATHER_HEAT_WAVE)) then
                 if (colorsAvailable[zone][RED]) then
                     cutsceneTriggered = true;

--- a/scripts/globals/missions.lua
+++ b/scripts/globals/missions.lua
@@ -1,4 +1,12 @@
 -----------------------------------
+--  Nation IDs
+-----------------------------------
+
+NATION_SANDORIA = 0;
+NATION_BASTOK   = 1;
+NATION_WINDURST = 2;
+
+-----------------------------------
 -- Areas  ID     mission step var
 -----------------------------------
 
@@ -687,7 +695,7 @@ function getMissionMask(player)
     first_mission = 0;
     repeat_mission = 0;
 
-    if (nation == WINDURST) then
+    if (nation == NATION_WINDURST) then
         if (rank >= 1) then
             if (player:hasCompletedMission(WINDURST,THE_HORUTOTO_RUINS_EXPERIMENT) == false) then
                 -- 1-1 NOTE: This mission will not be listed in the Mission List for Windurst
@@ -784,7 +792,7 @@ function getMissionMask(player)
                 first_mission = first_mission + 8388608;
             end
         end
-    elseif (nation == SANDORIA) then
+    elseif (nation == NATION_SANDORIA) then
         if (rank >= 1) then
             if (player:hasCompletedMission(SANDORIA,SMASH_THE_ORCISH_SCOUTS) == false) then -- The first mission is repeatable in San d'Oria
                 -- 1-1
@@ -882,7 +890,7 @@ function getMissionMask(player)
 
             end
         end
-    elseif (nation == BASTOK) then
+    elseif (nation == NATION_BASTOK) then
         if (rank >= 1) then
             if (player:hasCompletedMission(BASTOK,THE_ZERUHN_REPORT) == false) then
                 -- 1-1 NOTE: This mission will not be listed in the Mission List for Bastok
@@ -992,7 +1000,7 @@ function getMissionOffset(player,guard,pMission,MissionStatus)
     offset = 0; cs = 0; params = {0,0,0,0,0,0,0,0};
     nation = player:getNation();
 
-    if (nation == SANDORIA) then
+    if (nation == NATION_SANDORIA) then
 
             if (guard == 1) then GuardCS = {0x03fe,0x03fd,0x0401,0x03ec,0x0400,0x03ed,0x03ee,0x0404,0x0405,0x03f4,0x0407};
         elseif (guard == 2) then GuardCS = {0x07e6,0x07e5,0x07e9,0x07d4,0x07e8,0x07d5,0x07d6,0x07ec,0x07ed,0x07dc,0x07ef};
@@ -1019,7 +1027,7 @@ function getMissionOffset(player,guard,pMission,MissionStatus)
         }
         return cs, params, offset;
 
-    elseif (nation == BASTOK) then
+    elseif (nation == NATION_BASTOK) then
 
         switch (pMission) : caseof {
             [0] = function (x) offset = 0; end,
@@ -1044,7 +1052,7 @@ function getMissionOffset(player,guard,pMission,MissionStatus)
         }
         return cs, params, offset;
 
-    elseif (nation == WINDURST) then
+    elseif (nation == NATION_WINDURST) then
 
             if (guard == 1) then GuardCS = {0x007F,0x0088,0x0096,0x009A,0x00A0,0x01D9,0x00b1};
         elseif (guard == 2) then GuardCS = {0x007b,0x0083,0x0136,0x0094,0x009c,0x00b1,0x00d7};
@@ -1086,7 +1094,7 @@ function finishMissionTimeline(player,guard,csid,option)
     -- 13: player:addTitle(number);
     -- 14: player:setVar("MissionStatus",value);
 
-    if (nation == SANDORIA) then
+    if (nation == NATION_SANDORIA) then
         if ((csid == 0x03f1 or csid == 0x07d9) and option ~= 1073741824 and option ~= 31) then
             if (option > 100) then
                 badoption = {101,1,102,2,104,4,110,10,111,11};
@@ -1135,7 +1143,7 @@ function finishMissionTimeline(player,guard,csid,option)
                 0,{0,0},{0,0},{0,0},{0,0},{0},{0,0},{0,0},{0,0},{0,0},{0}, ]]--
                         };
         end
-    elseif (nation == BASTOK) then
+    elseif (nation == NATION_BASTOK) then
         if (csid == 0x03E9 and option ~= 1073741824 and option ~= 31) then
             timeline = {option,{0x03E9,option},{0,0},{0,0},{0,0},{{1},{2}}};
         else
@@ -1164,7 +1172,7 @@ function finishMissionTimeline(player,guard,csid,option)
                 
                         };
         end
-    elseif (nation == WINDURST) then
+    elseif (nation == NATION_WINDURST) then
         guardlist = {0x0072,0x006f,0x004e,0x005d};
         if (csid == guardlist[guard] and option ~= 1073741824 and option ~= 31) then
             timeline = {option,{guardlist[guard],option},{guardlist[guard],option},{guardlist[guard],option},{guardlist[guard],option},{{1},{2}}};

--- a/scripts/globals/quests.lua
+++ b/scripts/globals/quests.lua
@@ -1,4 +1,11 @@
-require("scripts/globals/npc_util");
+-----------------------------------
+--  Nation IDs
+-----------------------------------
+
+NATION_SANDORIA = 0;
+NATION_BASTOK   = 1;
+NATION_WINDURST = 2;
+
 -----------------------------------
 --
 --  QUESTS ID

--- a/scripts/zones/Bastok_Markets/npcs/Balthilda.lua
+++ b/scripts/zones/Bastok_Markets/npcs/Balthilda.lua
@@ -42,7 +42,7 @@ function onTrigger(player,npc)
         0x32B9,  1495,3,     --Holly Clogs
         0x349D,  1150,3      --Leather Ring
     }
-    showNationShop(player, BASTOK, stock);
+    showNationShop(player, NATION_BASTOK, stock);
 
 end;
 

--- a/scripts/zones/Bastok_Markets/npcs/Brunhilde.lua
+++ b/scripts/zones/Bastok_Markets/npcs/Brunhilde.lua
@@ -36,7 +36,7 @@ function onTrigger(player,npc)
         0x3190,  1071,3,     --Scale Finger Gauntlets
         0x3191,  9273,3      --Brass Finger Gauntlets
     }
-    showNationShop(player, BASTOK, stock);
+    showNationShop(player, NATION_BASTOK, stock);
 
 end; 
 

--- a/scripts/zones/Bastok_Markets/npcs/Carmelide.lua
+++ b/scripts/zones/Bastok_Markets/npcs/Carmelide.lua
@@ -35,7 +35,7 @@ function onTrigger(player,npc)
         0x031C,  1676,2,     --Light Opal
         0x348E,    68,3      --Copper Ring
     }
-    showNationShop(player, SANDORIA, stock);
+    showNationShop(player, NATION_SANDORIA, stock);
 
 end; 
 

--- a/scripts/zones/Bastok_Markets/npcs/Charging_Chocobo.lua
+++ b/scripts/zones/Bastok_Markets/npcs/Charging_Chocobo.lua
@@ -37,7 +37,7 @@ function onTrigger(player,npc)
         0x3388,   382,3,     --Leather Belt
         0x338C, 10166,3      --Silver Belt
     }
-    showNationShop(player, BASTOK, stock);
+    showNationShop(player, NATION_BASTOK, stock);
 
 end;
 

--- a/scripts/zones/Bastok_Markets/npcs/Ciqala.lua
+++ b/scripts/zones/Bastok_Markets/npcs/Ciqala.lua
@@ -44,7 +44,7 @@ function onTrigger(player,npc)
         0x42C0,    57,3,     --Ash Staff
         0x42C7,   386,3      --Ash Pole
     }
-    showNationShop(player, BASTOK, stock);
+    showNationShop(player, NATION_BASTOK, stock);
 
 end;
 

--- a/scripts/zones/Bastok_Markets/npcs/Cleades.lua
+++ b/scripts/zones/Bastok_Markets/npcs/Cleades.lua
@@ -41,7 +41,7 @@ end;
 
 function onTrigger(player,npc)
     
-    if (player:getNation() ~= BASTOK) then
+    if (player:getNation() ~= NATION_BASTOK) then
         player:startEvent(0x03eb); -- For non-Bastokian
     else
         local CurrentMission = player:getCurrentMission(BASTOK);

--- a/scripts/zones/Bastok_Markets/npcs/Harmodios.lua
+++ b/scripts/zones/Bastok_Markets/npcs/Harmodios.lua
@@ -49,7 +49,7 @@ function onTrigger(player,npc)
             0x43C1,    43,3,     --Flute
             0x13B5, 54000,3      --Scroll of Bewitching Etude
         }
-        showNationShop(player, BASTOK, stock);
+        showNationShop(player, NATION_BASTOK, stock);
 
     end;
 end; 

--- a/scripts/zones/Bastok_Markets/npcs/Hortense.lua
+++ b/scripts/zones/Bastok_Markets/npcs/Hortense.lua
@@ -40,7 +40,7 @@ function onTrigger(player,npc)
         0x138C,  5544,3,     --Scroll of Valor Minuet III
         0x138E, 53820,3      --Scroll of Valor Minuet V
     }
-    showNationShop(player, BASTOK, stock);
+    showNationShop(player, NATION_BASTOK, stock);
 
 end; 
 

--- a/scripts/zones/Bastok_Markets/npcs/Mjoll.lua
+++ b/scripts/zones/Bastok_Markets/npcs/Mjoll.lua
@@ -37,7 +37,7 @@ function onTrigger(player,npc)
         0x43B8,     3,3,     --Crossbow Bolt
         0x43B9,    21,3,     --Mythril Bolt
     }
-    showNationShop(player, BASTOK, stock);
+    showNationShop(player, NATION_BASTOK, stock);
 
 end;
 

--- a/scripts/zones/Bastok_Markets/npcs/Oggodett.lua
+++ b/scripts/zones/Bastok_Markets/npcs/Oggodett.lua
@@ -25,7 +25,7 @@ end;
 function onTrigger(player,npc)
 
     RegionOwner = GetRegionOwner(ARAGONEU);
-    if (RegionOwner ~= BASTOK) then 
+    if (RegionOwner ~= NATION_BASTOK) then 
         player:showText(npc,OGGODETT_CLOSED_DIALOG);
     else
         player:showText(npc,OGGODETT_OPEN_DIALOG);

--- a/scripts/zones/Bastok_Markets/npcs/Olwyn.lua
+++ b/scripts/zones/Bastok_Markets/npcs/Olwyn.lua
@@ -35,7 +35,7 @@ function onTrigger(player,npc)
         0x1036,  2387,3,     --Eye Drops
         0x1034,   290,3      --Antidote
     }
-    showNationShop(player, BASTOK, stock);
+    showNationShop(player, NATION_BASTOK, stock);
 
 end;
 

--- a/scripts/zones/Bastok_Markets/npcs/Peritrage.lua
+++ b/scripts/zones/Bastok_Markets/npcs/Peritrage.lua
@@ -35,7 +35,7 @@ function onTrigger(player,npc)
         0x4041,   837,3,     --Brass Dagger
         0x4042,  1827,3      --Dagger
     }
-    showNationShop(player, BASTOK, stock);
+    showNationShop(player, NATION_BASTOK, stock);
 
 end; 
 

--- a/scripts/zones/Bastok_Markets/npcs/Rabid_Wolf_IM.lua
+++ b/scripts/zones/Bastok_Markets/npcs/Rabid_Wolf_IM.lua
@@ -16,7 +16,7 @@ require("scripts/globals/conquest");
 require("scripts/globals/common");
 require("scripts/zones/Bastok_Markets/TextIDs");
 
-local guardnation = BASTOK; -- SANDORIA, BASTOK, WINDURST, JEUNO
+local guardnation = NATION_BASTOK; -- SANDORIA, BASTOK, WINDURST, JEUNO
 local guardtype   = 1;      -- 1: city, 2: foreign, 3: outpost, 4: border
 local size        = table.getn(BastInv);
 local inventory   = BastInv;

--- a/scripts/zones/Bastok_Markets/npcs/Raghd.lua
+++ b/scripts/zones/Bastok_Markets/npcs/Raghd.lua
@@ -32,7 +32,7 @@ function onTrigger(player,npc)
 
         0x348E,    68,3      --Copper Ring
     }
-    showNationShop(player, BASTOK, stock);
+    showNationShop(player, NATION_BASTOK, stock);
 
 end; 
 

--- a/scripts/zones/Bastok_Markets/npcs/Somn-Paemn.lua
+++ b/scripts/zones/Bastok_Markets/npcs/Somn-Paemn.lua
@@ -25,7 +25,7 @@ end;
 function onTrigger(player,npc)
     RegionOwner = GetRegionOwner(SARUTABARUTA);
 
-    if (RegionOwner ~= BASTOK) then 
+    if (RegionOwner ~= NATION_BASTOK) then 
         player:showText(npc,SOMNPAEMN_CLOSED_DIALOG);
     else
         player:showText(npc,SOMNPAEMN_OPEN_DIALOG);

--- a/scripts/zones/Bastok_Markets/npcs/Sororo.lua
+++ b/scripts/zones/Bastok_Markets/npcs/Sororo.lua
@@ -45,7 +45,7 @@ function onTrigger(player,npc)
         0x1237,   368,3,     --Aquaveil
         0x1271, 29700,3      --Repose
     }
-    showNationShop(player, BASTOK, stock);
+    showNationShop(player, NATION_BASTOK, stock);
 
 end; 
 

--- a/scripts/zones/Bastok_Markets/npcs/Yafafa.lua
+++ b/scripts/zones/Bastok_Markets/npcs/Yafafa.lua
@@ -25,7 +25,7 @@ end;
 function onTrigger(player,npc)
     RegionOwner = GetRegionOwner(KOLSHUSHU);
 
-    if (RegionOwner ~= BASTOK) then 
+    if (RegionOwner ~= NATION_BASTOK) then 
         player:showText(npc,YAFAFA_CLOSED_DIALOG);
     else
         player:showText(npc,YAFAFA_OPEN_DIALOG);

--- a/scripts/zones/Bastok_Markets/npcs/Zaira.lua
+++ b/scripts/zones/Bastok_Markets/npcs/Zaira.lua
@@ -44,7 +44,7 @@ function onTrigger(player,npc)
         0x12EB,  4644,3,     --Scroll of Burn
         0x12F0,  6366,3,     --Scroll of Drown
     }
-    showNationShop(player, BASTOK, stock);
+    showNationShop(player, NATION_BASTOK, stock);
 
 end;
 

--- a/scripts/zones/Bastok_Markets/npcs/Zhikkom.lua
+++ b/scripts/zones/Bastok_Markets/npcs/Zhikkom.lua
@@ -34,7 +34,7 @@ function onTrigger(player,npc)
         0x40B5,1674,3,       --Spatha
         0x4080,3215,3        --Bilbo (value may be off)
     }
-showNationShop(player, BASTOK, stock);
+showNationShop(player, NATION_BASTOK, stock);
 end; 
 
 -----------------------------------

--- a/scripts/zones/Bastok_Mines/npcs/Aulavia.lua
+++ b/scripts/zones/Bastok_Mines/npcs/Aulavia.lua
@@ -26,7 +26,7 @@ end;
 function onTrigger(player,npc)
     RegionOwner = GetRegionOwner(VOLLBOW);
 
-    if (RegionOwner ~= BASTOK) then
+    if (RegionOwner ~= NATION_BASTOK) then
         player:showText(npc,AULAVIA_CLOSED_DIALOG);
     else
         player:showText(npc,AULAVIA_OPEN_DIALOG);

--- a/scripts/zones/Bastok_Mines/npcs/Boytz.lua
+++ b/scripts/zones/Bastok_Mines/npcs/Boytz.lua
@@ -38,7 +38,7 @@ function onTrigger(player,npc)
         0x43B8,     5,3      --Crossbow Bolt
     }
 
-    rank = getNationRank(BASTOK);
+    rank = getNationRank(NATION_BASTOK);
     if (rank ~= 1) then
         table.insert(stock,0x03fe); --Thief's Tools
         table.insert(stock,3643);
@@ -50,7 +50,7 @@ function onTrigger(player,npc)
         table.insert(stock,3);
     end
 
-    showNationShop(player, BASTOK, stock);
+    showNationShop(player, NATION_BASTOK, stock);
 
 end;
 

--- a/scripts/zones/Bastok_Mines/npcs/Conrad.lua
+++ b/scripts/zones/Bastok_Mines/npcs/Conrad.lua
@@ -10,7 +10,7 @@ package.loaded["scripts/zones/Bastok_Mines/TextIDs"] = nil;
 require("scripts/globals/conquest");
 require("scripts/zones/Bastok_Mines/TextIDs");
 
-guardnation = BASTOK;
+guardnation = NATION_BASTOK;
 csid         = 0x0245;
 
 -----------------------------------

--- a/scripts/zones/Bastok_Mines/npcs/Crying_Wind_IM.lua
+++ b/scripts/zones/Bastok_Mines/npcs/Crying_Wind_IM.lua
@@ -16,7 +16,7 @@ require("scripts/globals/conquest");
 require("scripts/globals/common");
 require("scripts/zones/Bastok_Mines/TextIDs");
 
-local guardnation = BASTOK; -- SANDORIA, BASTOK, WINDURST, JEUNO
+local guardnation = NATION_BASTOK; -- SANDORIA, BASTOK, WINDURST, JEUNO
 local guardtype   = 1;      -- 1: city, 2: foreign, 3: outpost, 4: border
 local size        = table.getn(BastInv);
 local inventory   = BastInv;

--- a/scripts/zones/Bastok_Mines/npcs/Deegis.lua
+++ b/scripts/zones/Bastok_Mines/npcs/Deegis.lua
@@ -41,7 +41,7 @@ function onTrigger(player,npc)
         0x31A0,   126,3,     --Bronze Mittens
         0x3188,  7614,3         --Chain Mittens
     }
-    showNationShop(player, BASTOK, stock);
+    showNationShop(player, NATION_BASTOK, stock);
 
 end; 
 

--- a/scripts/zones/Bastok_Mines/npcs/Emaliveulaux.lua
+++ b/scripts/zones/Bastok_Mines/npcs/Emaliveulaux.lua
@@ -29,7 +29,7 @@ RegionOwner = GetRegionOwner(TAVNAZIANARCH);
 cop = 40; --player:getVar("chainsOfPromathiaMissions");
 
 if (cop >= 40) then
-        if (RegionOwner ~= BASTOK) then
+        if (RegionOwner ~= NATION_BASTOK) then
                 player:showText(npc,EMALIVEULAUX_CLOSED_DIALOG);
         else
                 player:showText(npc,EMALIVEULAUX_OPEN_DIALOG);

--- a/scripts/zones/Bastok_Mines/npcs/Faustin.lua
+++ b/scripts/zones/Bastok_Mines/npcs/Faustin.lua
@@ -24,7 +24,7 @@ end;
 
 function onTrigger(player,npc)
     RegionOwner = GetRegionOwner(RONFAURE);
-    if (RegionOwner ~= BASTOK) then
+    if (RegionOwner ~= NATION_BASTOK) then
         player:showText(npc,FAUSTIN_CLOSED_DIALOG);
     else
         player:showText(npc,FAUSTIN_OPEN_DIALOG);

--- a/scripts/zones/Bastok_Mines/npcs/Galdeo.lua
+++ b/scripts/zones/Bastok_Mines/npcs/Galdeo.lua
@@ -22,7 +22,7 @@ end;
 
 function onTrigger(player,npc)
     RegionOwner = GetRegionOwner(LITELOR);
-    if (RegionOwner ~= BASTOK) then 
+    if (RegionOwner ~= NATION_BASTOK) then 
         player:showText(npc,GALDEO_CLOSED_DIALOG);
     else
         player:showText(npc,GALDEO_OPEN_DIALOG);

--- a/scripts/zones/Bastok_Mines/npcs/Gelzerio.lua
+++ b/scripts/zones/Bastok_Mines/npcs/Gelzerio.lua
@@ -42,7 +42,7 @@ function onTrigger(player,npc)
         0x3230,  1899,3,     --Brais
         0x32B0,  1269,3         --Gaiters
     }
-    showNationShop(player, BASTOK, stock);
+    showNationShop(player, NATION_BASTOK, stock);
 
 end; 
 

--- a/scripts/zones/Bastok_Mines/npcs/Griselda.lua
+++ b/scripts/zones/Bastok_Mines/npcs/Griselda.lua
@@ -43,7 +43,7 @@ function onTrigger(player,npc)
             0x1118,   108,3,     --Strip of meat jerky
             0x119D,    10,3      --Flask of distilled water
         }
-        showNationShop(player, BASTOK, stock);
+        showNationShop(player, NATION_BASTOK, stock);
         
     end
 

--- a/scripts/zones/Bastok_Mines/npcs/Mille.lua
+++ b/scripts/zones/Bastok_Mines/npcs/Mille.lua
@@ -24,7 +24,7 @@ end;
 
 function onTrigger(player,npc)
     RegionOwner = GetRegionOwner(NORVALLEN);
-    if (RegionOwner ~= BASTOK) then
+    if (RegionOwner ~= NATION_BASTOK) then
         player:showText(npc,MILLE_CLOSED_DIALOG);
     else
         player:showText(npc,MILLE_OPEN_DIALOG);

--- a/scripts/zones/Bastok_Mines/npcs/Neigepance.lua
+++ b/scripts/zones/Bastok_Mines/npcs/Neigepance.lua
@@ -35,7 +35,7 @@ function onTrigger(player,npc)
         0x45CA,   695,3,     --Carrion Broth
         0x13D1, 50784,3      --Scroll of Chocobo Mazurka
     } 
-    showNationShop(player, BASTOK, stock);
+    showNationShop(player, NATION_BASTOK, stock);
 
 end; 
 

--- a/scripts/zones/Bastok_Mines/npcs/Rashid.lua
+++ b/scripts/zones/Bastok_Mines/npcs/Rashid.lua
@@ -41,7 +41,7 @@ end;
 
 function onTrigger(player,npc)
     
-    if (player:getNation() ~= BASTOK) then
+    if (player:getNation() ~= NATION_BASTOK) then
         player:startEvent(0x03eb); -- For non-Bastokian
     else
         local CurrentMission = player:getCurrentMission(BASTOK);

--- a/scripts/zones/Bastok_Mines/npcs/Rodellieux.lua
+++ b/scripts/zones/Bastok_Mines/npcs/Rodellieux.lua
@@ -22,7 +22,7 @@ end;
 
 function onTrigger(player,npc)
     RegionOwner = GetRegionOwner(FAUREGANDI);
-    if (RegionOwner ~= BASTOK) then 
+    if (RegionOwner ~= NATION_BASTOK) then 
         player:showText(npc,RODELLIEUX_CLOSED_DIALOG);
     else
         player:showText(npc,RODELLIEUX_OPEN_DIALOG);

--- a/scripts/zones/Bastok_Mines/npcs/Tibelda.lua
+++ b/scripts/zones/Bastok_Mines/npcs/Tibelda.lua
@@ -22,7 +22,7 @@ end;
 
 function onTrigger(player,npc)
     RegionOwner = GetRegionOwner(VALDEAUNIA);
-    if (RegionOwner ~= BASTOK) then 
+    if (RegionOwner ~= NATION_BASTOK) then 
         player:showText(npc,TIBELDA_CLOSED_DIALOG);
     else
         player:showText(npc,TIBELDA_OPEN_DIALOG);

--- a/scripts/zones/Bastok_Mines/npcs/Zemedars.lua
+++ b/scripts/zones/Bastok_Mines/npcs/Zemedars.lua
@@ -42,7 +42,7 @@ function onTrigger(player,npc)
         0x3002,   556,3,      --Maple Shield
         0x3001,   110,3      --Lauan Shield
     }
-    showNationShop(player, BASTOK, stock);
+    showNationShop(player, NATION_BASTOK, stock);
 
 end;
 

--- a/scripts/zones/Beaucedine_Glacier/npcs/Akane_IM.lua
+++ b/scripts/zones/Beaucedine_Glacier/npcs/Akane_IM.lua
@@ -10,7 +10,7 @@ package.loaded["scripts/zones/Beaucedine_Glacier/TextIDs"] = nil;
 require("scripts/globals/conquest");
 require("scripts/zones/Beaucedine_Glacier/TextIDs");
 
-local guardnation = BASTOK; -- SANDORIA, BASTOK, WINDURST, 4 = jeuno
+local guardnation = NATION_BASTOK; -- SANDORIA, BASTOK, WINDURST, 4 = jeuno
 local guardtype   = 3;      -- 1: city, 2: foreign, 3: outpost, 4: border
 local region      = FAUREGANDI;
 local csid        = 0x7ff9;

--- a/scripts/zones/Beaucedine_Glacier/npcs/Chopapa_WW.lua
+++ b/scripts/zones/Beaucedine_Glacier/npcs/Chopapa_WW.lua
@@ -10,7 +10,7 @@ package.loaded["scripts/zones/Beaucedine_Glacier/TextIDs"] = nil;
 require("scripts/globals/conquest");
 require("scripts/zones/Beaucedine_Glacier/TextIDs");
 
-local guardnation = WINDURST; -- SANDORIA, BASTOK, WINDURST, 4 = jeuno
+local guardnation = NATION_WINDURST; -- SANDORIA, BASTOK, WINDURST, 4 = jeuno
 local guardtype   = 4;        -- 1: city, 2: foreign, 3: outpost, 4: border
 local region      = FAUREGANDI;
 local csid        = 0x7ff6;

--- a/scripts/zones/Beaucedine_Glacier/npcs/Leaufetie_RK.lua
+++ b/scripts/zones/Beaucedine_Glacier/npcs/Leaufetie_RK.lua
@@ -10,7 +10,7 @@ package.loaded["scripts/zones/Beaucedine_Glacier/TextIDs"] = nil;
 require("scripts/globals/conquest");
 require("scripts/zones/Beaucedine_Glacier/TextIDs");
 
-local guardnation = SANDORIA; -- SANDORIA, BASTOK, WINDURST, 4 = jeuno
+local guardnation = NATION_SANDORIA; -- SANDORIA, BASTOK, WINDURST, 4 = jeuno
 local guardtype   = 4;        -- 1: city, 2: foreign, 3: outpost, 4: border
 local region      = FAUREGANDI;
 local csid        = 0x7ffa;

--- a/scripts/zones/Beaucedine_Glacier/npcs/Parledaire_RK.lua
+++ b/scripts/zones/Beaucedine_Glacier/npcs/Parledaire_RK.lua
@@ -10,7 +10,7 @@ package.loaded["scripts/zones/Beaucedine_Glacier/TextIDs"] = nil;
 require("scripts/globals/conquest");
 require("scripts/zones/Beaucedine_Glacier/TextIDs");
 
-local guardnation = SANDORIA; -- SANDORIA, BASTOK, WINDURST, 4 = jeuno
+local guardnation = NATION_SANDORIA; -- SANDORIA, BASTOK, WINDURST, 4 = jeuno
 local guardtype   = 3;        -- 1: city, 2: foreign, 3: outpost, 4: border
 local region      = FAUREGANDI;
 local csid        = 0x7ffb;

--- a/scripts/zones/Beaucedine_Glacier/npcs/Rattling_Rain_IM.lua
+++ b/scripts/zones/Beaucedine_Glacier/npcs/Rattling_Rain_IM.lua
@@ -10,7 +10,7 @@ package.loaded["scripts/zones/Beaucedine_Glacier/TextIDs"] = nil;
 require("scripts/globals/conquest");
 require("scripts/zones/Beaucedine_Glacier/TextIDs");
 
-local guardnation = BASTOK; -- SANDORIA, BASTOK, WINDURST, 4 = jeuno
+local guardnation = NATION_BASTOK; -- SANDORIA, BASTOK, WINDURST, 4 = jeuno
 local guardtype   = 4;      -- 1: city, 2: foreign, 3: outpost, 4: border
 local region      = FAUREGANDI;
 local csid        = 0x7ff8;

--- a/scripts/zones/Beaucedine_Glacier/npcs/Ryunchi-Pauchi_WW.lua
+++ b/scripts/zones/Beaucedine_Glacier/npcs/Ryunchi-Pauchi_WW.lua
@@ -10,7 +10,7 @@ package.loaded["scripts/zones/Beaucedine_Glacier/TextIDs"] = nil;
 require("scripts/globals/conquest");
 require("scripts/zones/Beaucedine_Glacier/TextIDs");
 
-local guardnation = WINDURST; -- SANDORIA, BASTOK, WINDURST, 4 = jeuno
+local guardnation = NATION_WINDURST; -- SANDORIA, BASTOK, WINDURST, 4 = jeuno
 local guardtype   = 3;        -- 1: city, 2: foreign, 3: outpost, 4: border
 local region      = FAUREGANDI;
 local csid        = 0x7ff7;

--- a/scripts/zones/Bibiki_Bay/npcs/Pohka_Chichiyowahl.lua
+++ b/scripts/zones/Bibiki_Bay/npcs/Pohka_Chichiyowahl.lua
@@ -30,7 +30,7 @@ function onTrigger(player,npc)
         0x1034,   290, 3  -- Antidote
     }
 
-    showNationShop(player, WINDURST, stock);
+    showNationShop(player, NATION_WINDURST, stock);
 end;
 
 -----------------------------------

--- a/scripts/zones/Buburimu_Peninsula/npcs/Bonbavour_RK.lua
+++ b/scripts/zones/Buburimu_Peninsula/npcs/Bonbavour_RK.lua
@@ -10,7 +10,7 @@ package.loaded["scripts/zones/Buburimu_Peninsula/TextIDs"] = nil;
 require("scripts/globals/conquest");
 require("scripts/zones/Buburimu_Peninsula/TextIDs");
 
-local guardnation = SANDORIA; -- SANDORIA, BASTOK, WINDURST, 4 = jeuno
+local guardnation = NATION_SANDORIA; -- SANDORIA, BASTOK, WINDURST, 4 = jeuno
 local guardtype   = 3;        -- 1: city, 2: foreign, 3: outpost, 4: border
 local region      = KOLSHUSHU;
 local csid        = 0x7ffb;

--- a/scripts/zones/Buburimu_Peninsula/npcs/Craigine_RK.lua
+++ b/scripts/zones/Buburimu_Peninsula/npcs/Craigine_RK.lua
@@ -10,7 +10,7 @@ package.loaded["scripts/zones/Buburimu_Peninsula/TextIDs"] = nil;
 require("scripts/globals/conquest");
 require("scripts/zones/Buburimu_Peninsula/TextIDs");
 
-local guardnation = SANDORIA; -- SANDORIA, BASTOK, WINDURST, 4 = jeuno
+local guardnation = NATION_SANDORIA; -- SANDORIA, BASTOK, WINDURST, 4 = jeuno
 local guardtype   = 4;        -- 1: city, 2: foreign, 3: outpost, 4: border
 local region      = KOLSHUSHU;
 local csid        = 0x7ffa;

--- a/scripts/zones/Buburimu_Peninsula/npcs/Ganemu-Punnemu_WW.lua
+++ b/scripts/zones/Buburimu_Peninsula/npcs/Ganemu-Punnemu_WW.lua
@@ -10,7 +10,7 @@ package.loaded["scripts/zones/Buburimu_Peninsula/TextIDs"] = nil;
 require("scripts/globals/conquest");
 require("scripts/zones/Buburimu_Peninsula/TextIDs");
 
-local guardnation = WINDURST; -- SANDORIA, BASTOK, WINDURST, 4 = jeuno
+local guardnation = NATION_WINDURST; -- SANDORIA, BASTOK, WINDURST, 4 = jeuno
 local guardtype   = 3;        -- 1: city, 2: foreign, 3: outpost, 4: border
 local region      = KOLSHUSHU;
 local csid        = 0x7ff7;

--- a/scripts/zones/Buburimu_Peninsula/npcs/Ishin_IM.lua
+++ b/scripts/zones/Buburimu_Peninsula/npcs/Ishin_IM.lua
@@ -10,7 +10,7 @@ package.loaded["scripts/zones/Buburimu_Peninsula/TextIDs"] = nil;
 require("scripts/globals/conquest");
 require("scripts/zones/Buburimu_Peninsula/TextIDs");
 
-local guardnation = BASTOK; -- SANDORIA, BASTOK, WINDURST, 4 = jeuno
+local guardnation = NATION_BASTOK; -- SANDORIA, BASTOK, WINDURST, 4 = jeuno
 local guardtype   = 3;      -- 1: city, 2: foreign, 3: outpost, 4: border
 local region      = KOLSHUSHU;
 local csid        = 0x7ff9;

--- a/scripts/zones/Buburimu_Peninsula/npcs/Mashasha_WW.lua
+++ b/scripts/zones/Buburimu_Peninsula/npcs/Mashasha_WW.lua
@@ -10,7 +10,7 @@ package.loaded["scripts/zones/Buburimu_Peninsula/TextIDs"] = nil;
 require("scripts/globals/conquest");
 require("scripts/zones/Buburimu_Peninsula/TextIDs");
 
-local guardnation = WINDURST; -- SANDORIA, BASTOK, WINDURST, 4 = jeuno
+local guardnation = NATION_WINDURST; -- SANDORIA, BASTOK, WINDURST, 4 = jeuno
 local guardtype   = 4;        -- 1: city, 2: foreign, 3: outpost, 4: border
 local region      = KOLSHUSHU;
 local csid        = 0x7ff6;

--- a/scripts/zones/Buburimu_Peninsula/npcs/Wise_Turtle_IM.lua
+++ b/scripts/zones/Buburimu_Peninsula/npcs/Wise_Turtle_IM.lua
@@ -10,7 +10,7 @@ package.loaded["scripts/zones/Buburimu_Peninsula/TextIDs"] = nil;
 require("scripts/globals/conquest");
 require("scripts/zones/Buburimu_Peninsula/TextIDs");
 
-local guardnation = BASTOK; -- SANDORIA, BASTOK, WINDURST, 4 = jeuno
+local guardnation = NATION_BASTOK; -- SANDORIA, BASTOK, WINDURST, 4 = jeuno
 local guardtype   = 4;      -- 1: city, 2: foreign, 3: outpost, 4: border
 local region      = KOLSHUSHU;
 local csid        = 0x7ff8;

--- a/scripts/zones/Cape_Teriggan/npcs/Dultwa_IM.lua
+++ b/scripts/zones/Cape_Teriggan/npcs/Dultwa_IM.lua
@@ -10,7 +10,7 @@ package.loaded["scripts/zones/Cape_Teriggan/TextIDs"] = nil;
 require("scripts/globals/conquest");
 require("scripts/zones/Cape_Teriggan/TextIDs");
 
-local guardnation = BASTOK; -- SANDORIA, BASTOK, WINDURST, 4 = jeuno
+local guardnation = NATION_BASTOK; -- SANDORIA, BASTOK, WINDURST, 4 = jeuno
 local guardtype   = 4;      -- 1: city, 2: foreign, 3: outpost, 4: border
 local region      = VOLLBOW;
 local csid        = 0x7ff8;

--- a/scripts/zones/Cape_Teriggan/npcs/Orukeke_WW.lua
+++ b/scripts/zones/Cape_Teriggan/npcs/Orukeke_WW.lua
@@ -10,7 +10,7 @@ package.loaded["scripts/zones/Cape_Teriggan/TextIDs"] = nil;
 require("scripts/globals/conquest");
 require("scripts/zones/Cape_Teriggan/TextIDs");
 
-local guardnation = WINDURST; -- SANDORIA, BASTOK, WINDURST, 4 = jeuno
+local guardnation = NATION_WINDURST; -- SANDORIA, BASTOK, WINDURST, 4 = jeuno
 local guardtype   = 4;        -- 1: city, 2: foreign, 3: outpost, 4: border
 local region      = VOLLBOW;
 local csid        = 0x7ff6;

--- a/scripts/zones/Cape_Teriggan/npcs/Paise_RK.lua
+++ b/scripts/zones/Cape_Teriggan/npcs/Paise_RK.lua
@@ -10,7 +10,7 @@ package.loaded["scripts/zones/Cape_Teriggan/TextIDs"] = nil;
 require("scripts/globals/conquest");
 require("scripts/zones/Cape_Teriggan/TextIDs");
 
-local guardnation = SANDORIA; -- SANDORIA, BASTOK, WINDURST, 4 = jeuno
+local guardnation = NATION_SANDORIA; -- SANDORIA, BASTOK, WINDURST, 4 = jeuno
 local guardtype   = 4;        -- 1: city, 2: foreign, 3: outpost, 4: border
 local region      = VOLLBOW;
 local csid        = 0x7ffa;

--- a/scripts/zones/Cape_Teriggan/npcs/Salimardi_RK.lua
+++ b/scripts/zones/Cape_Teriggan/npcs/Salimardi_RK.lua
@@ -10,7 +10,7 @@ package.loaded["scripts/zones/Cape_Teriggan/TextIDs"] = nil;
 require("scripts/globals/conquest");
 require("scripts/zones/Cape_Teriggan/TextIDs");
 
-local guardnation = SANDORIA; -- SANDORIA, BASTOK, WINDURST, 4 = jeuno
+local guardnation = NATION_SANDORIA; -- SANDORIA, BASTOK, WINDURST, 4 = jeuno
 local guardtype   = 3;        -- 1: city, 2: foreign, 3: outpost, 4: border
 local region      = VOLLBOW;
 local csid        = 0x7ffb;

--- a/scripts/zones/Cape_Teriggan/npcs/Sarmistha_IM.lua
+++ b/scripts/zones/Cape_Teriggan/npcs/Sarmistha_IM.lua
@@ -10,7 +10,7 @@ package.loaded["scripts/zones/Cape_Teriggan/TextIDs"] = nil;
 require("scripts/globals/conquest");
 require("scripts/zones/Cape_Teriggan/TextIDs");
 
-local guardnation = BASTOK; -- SANDORIA, BASTOK, WINDURST, 4 = jeuno
+local guardnation = NATION_BASTOK; -- SANDORIA, BASTOK, WINDURST, 4 = jeuno
 local guardtype   = 3;      -- 1: city, 2: foreign, 3: outpost, 4: border
 local region      = VOLLBOW;
 local csid        = 0x7ff9;

--- a/scripts/zones/Cape_Teriggan/npcs/Voranbo-Natanbo_WW.lua
+++ b/scripts/zones/Cape_Teriggan/npcs/Voranbo-Natanbo_WW.lua
@@ -10,7 +10,7 @@ package.loaded["scripts/zones/Cape_Teriggan/TextIDs"] = nil;
 require("scripts/globals/conquest");
 require("scripts/zones/Cape_Teriggan/TextIDs");
 
-local guardnation = WINDURST; -- SANDORIA, BASTOK, WINDURST, 4 = jeuno
+local guardnation = NATION_WINDURST; -- SANDORIA, BASTOK, WINDURST, 4 = jeuno
 local guardtype   = 3;        -- 1: city, 2: foreign, 3: outpost, 4: border
 local region      = VOLLBOW;
 local csid        = 0x7ff7;

--- a/scripts/zones/Chateau_dOraguille/npcs/Halver.lua
+++ b/scripts/zones/Chateau_dOraguille/npcs/Halver.lua
@@ -59,7 +59,7 @@ function onTrigger(player,npc)
         player:startEvent(564);
     elseif (player:getCurrentMission(TOAU) == EASTERLY_WINDS and player:getVar("AhtUrganStatus") == 0) then
         player:startEvent(565);
-    elseif (pNation == SANDORIA) then
+    elseif (pNation == NATION_SANDORIA) then
         -- Mission San D'Oria 9-2 The Heir to the Light
         if (player:hasCompletedMission(SANDORIA,THE_HEIR_TO_THE_LIGHT)) then
             player:startEvent(31);
@@ -110,7 +110,7 @@ function onTrigger(player,npc)
         elseif (currentMission == JOURNEY_ABROAD) then
             player:startEvent(532);
         end
-    elseif (pNation == BASTOK) then
+    elseif (pNation == NATION_BASTOK) then
         -- Bastok 2-3 San -> Win
         if (currentMission == THE_EMISSARY) then
             if (MissionStatus == 3) then
@@ -129,7 +129,7 @@ function onTrigger(player,npc)
         else
             player:showText(npc,HALVER_OFFSET+1092);
         end
-    elseif (pNation == WINDURST) then
+    elseif (pNation == NATION_WINDURST) then
         -- Windurst 2-3
         if (currentMission == THE_THREE_KINGDOMS and MissionStatus < 3) then
             player:startEvent(532);

--- a/scripts/zones/East_Sarutabaruta/Zone.lua
+++ b/scripts/zones/East_Sarutabaruta/Zone.lua
@@ -76,7 +76,7 @@ function onZoneIn( player, prevZone)
     end
 
     -- Check if we are on Windurst Mission 1-2
-    if (player:getCurrentMission( WINDURST) == THE_HEART_OF_THE_MATTER and player:getVar( "MissionStatus") == 5 and prevZone == 194) then
+    if (player:getCurrentMission(WINDURST) == THE_HEART_OF_THE_MATTER and player:getVar( "MissionStatus") == 5 and prevZone == 194) then
         cs = 0x0030;
     elseif (triggerLightCutscene(player)) then -- Quest: I Can Hear A Rainbow
         cs = 0x0032;

--- a/scripts/zones/Eastern_Altepa_Desert/npcs/Daborn_IM.lua
+++ b/scripts/zones/Eastern_Altepa_Desert/npcs/Daborn_IM.lua
@@ -10,7 +10,7 @@ package.loaded["scripts/zones/Eastern_Altepa_Desert/TextIDs"] = nil;
 require("scripts/globals/conquest");
 require("scripts/zones/Eastern_Altepa_Desert/TextIDs");
 
-local guardnation = BASTOK; -- SANDORIA, BASTOK, WINDURST, 4 = jeuno
+local guardnation = NATION_BASTOK; -- SANDORIA, BASTOK, WINDURST, 4 = jeuno
 local guardtype   = 4;      -- 1: city, 2: foreign, 3: outpost, 4: border
 local region      = KUZOTZ;
 local csid        = 0x7ff8;

--- a/scripts/zones/Eastern_Altepa_Desert/npcs/Eaulevisat_RK.lua
+++ b/scripts/zones/Eastern_Altepa_Desert/npcs/Eaulevisat_RK.lua
@@ -10,7 +10,7 @@ package.loaded["scripts/zones/Eastern_Altepa_Desert/TextIDs"] = nil;
 require("scripts/globals/conquest");
 require("scripts/zones/Eastern_Altepa_Desert/TextIDs");
 
-local guardnation = SANDORIA; -- SANDORIA, BASTOK, WINDURST, 4 = jeuno
+local guardnation = NATION_SANDORIA; -- SANDORIA, BASTOK, WINDURST, 4 = jeuno
 local guardtype   = 3;        -- 1: city, 2: foreign, 3: outpost, 4: border
 local region      = KUZOTZ;
 local csid        = 0x7ffb;

--- a/scripts/zones/Eastern_Altepa_Desert/npcs/Laimeve_RK.lua
+++ b/scripts/zones/Eastern_Altepa_Desert/npcs/Laimeve_RK.lua
@@ -10,7 +10,7 @@ package.loaded["scripts/zones/Eastern_Altepa_Desert/TextIDs"] = nil;
 require("scripts/globals/conquest");
 require("scripts/zones/Eastern_Altepa_Desert/TextIDs");
 
-local guardnation = SANDORIA; -- SANDORIA, BASTOK, WINDURST, 4 = jeuno
+local guardnation = NATION_SANDORIA; -- SANDORIA, BASTOK, WINDURST, 4 = jeuno
 local guardtype   = 4;        -- 1: city, 2: foreign, 3: outpost, 4: border
 local region      = KUZOTZ;
 local csid        = 0x7ffa;

--- a/scripts/zones/Eastern_Altepa_Desert/npcs/Lindgard_IM.lua
+++ b/scripts/zones/Eastern_Altepa_Desert/npcs/Lindgard_IM.lua
@@ -10,7 +10,7 @@ package.loaded["scripts/zones/Eastern_Altepa_Desert/TextIDs"] = nil;
 require("scripts/globals/conquest");
 require("scripts/zones/Eastern_Altepa_Desert/TextIDs");
 
-local guardnation = BASTOK; -- SANDORIA, BASTOK, WINDURST, 4 = jeuno
+local guardnation = NATION_BASTOK; -- SANDORIA, BASTOK, WINDURST, 4 = jeuno
 local guardtype   = 3;      -- 1: city, 2: foreign, 3: outpost, 4: border
 local region      = KUZOTZ;
 local csid        = 0x7ff9;

--- a/scripts/zones/Eastern_Altepa_Desert/npcs/Sahgygy_WW.lua
+++ b/scripts/zones/Eastern_Altepa_Desert/npcs/Sahgygy_WW.lua
@@ -10,7 +10,7 @@ package.loaded["scripts/zones/Eastern_Altepa_Desert/TextIDs"] = nil;
 require("scripts/globals/conquest");
 require("scripts/zones/Eastern_Altepa_Desert/TextIDs");
 
-local guardnation = WINDURST; -- SANDORIA, BASTOK, WINDURST, 4 = jeuno
+local guardnation = NATION_WINDURST; -- SANDORIA, BASTOK, WINDURST, 4 = jeuno
 local guardtype   = 4;        -- 1: city, 2: foreign, 3: outpost, 4: border
 local region      = KUZOTZ;
 local csid        = 0x7ff6;

--- a/scripts/zones/Eastern_Altepa_Desert/npcs/Variko-Njariko_WW.lua
+++ b/scripts/zones/Eastern_Altepa_Desert/npcs/Variko-Njariko_WW.lua
@@ -10,7 +10,7 @@ package.loaded["scripts/zones/Eastern_Altepa_Desert/TextIDs"] = nil;
 require("scripts/globals/conquest");
 require("scripts/zones/Eastern_Altepa_Desert/TextIDs");
 
-local guardnation = WINDURST; -- SANDORIA, BASTOK, WINDURST, 4 = jeuno
+local guardnation = NATION_WINDURST; -- SANDORIA, BASTOK, WINDURST, 4 = jeuno
 local guardtype   = 3;        -- 1: city, 2: foreign, 3: outpost, 4: border
 local region      = KUZOTZ;
 local csid        = 0x7ff7;

--- a/scripts/zones/Heavens_Tower/Zone.lua
+++ b/scripts/zones/Heavens_Tower/Zone.lua
@@ -96,7 +96,7 @@ function onEventFinish(player,csid,option)
         player:setVar("MissionStatus",2);
     elseif (csid == 42) then
         -- This cs should only play if you visit Windurst first.
-        if (player:getNation() == SANDORIA) then
+        if (player:getNation() == NATION_SANDORIA) then
             player:setVar("MissionStatus",4);
         else
             player:setVar("MissionStatus",3);

--- a/scripts/zones/Heavens_Tower/npcs/Kupipi.lua
+++ b/scripts/zones/Heavens_Tower/npcs/Kupipi.lua
@@ -27,7 +27,7 @@ function onTrade(player,npc,trade)
             player:messageSpecial(KEYITEM_OBTAINED,SPIRITED_STONE);
         end
     end
-    if (trade:hasItemQty(4365,1) and trade:getItemCount() == 1 and player:getNation() == WINDURST and player:getRank() >= 2 and player:hasKeyItem(PORTAL_CHARM) == false) then -- Trade Rolanberry
+    if (trade:hasItemQty(4365,1) and trade:getItemCount() == 1 and player:getNation() == NATION_WINDURST and player:getRank() >= 2 and player:hasKeyItem(PORTAL_CHARM) == false) then -- Trade Rolanberry
         if (player:hasCompletedMission(WINDURST,WRITTEN_IN_THE_STARS)) then
             player:startEvent(0x0123); -- Qualifies for the reward immediately
         else
@@ -46,7 +46,7 @@ function onTrigger(player,npc)
     local currentMission = player:getCurrentMission(pNation);
     local MissionStatus = player:getVar("MissionStatus");
     
-    if (pNation == SANDORIA) then
+    if (pNation == NATION_SANDORIA) then
         -- San d'Oria Mission 2-3 Part I - Windurst > Bastok
         if (currentMission == JOURNEY_TO_WINDURST) then
             if (MissionStatus == 4) then
@@ -70,7 +70,7 @@ function onTrigger(player,npc)
         else
             player:startEvent(0x00fb);
         end
-    elseif (pNation == BASTOK) then
+    elseif (pNation == NATION_BASTOK) then
         -- Bastok Mission 2-3 Part I - Windurst > San d'Oria
         if (currentMission == THE_EMISSARY_WINDURST) then
             if (MissionStatus == 3) then
@@ -94,7 +94,7 @@ function onTrigger(player,npc)
         else
             player:startEvent(0x00fb);
         end
-    elseif (pNation == WINDURST) then
+    elseif (pNation == NATION_WINDURST) then
         if (currentMission == THE_THREE_KINGDOMS and MissionStatus == 0) then
             player:startEvent(0x005F,0,0,0,LETTER_TO_THE_CONSULS_WINDURST);
         elseif (currentMission == THE_THREE_KINGDOMS and MissionStatus == 11) then
@@ -137,7 +137,7 @@ function onEventFinish(player,csid,option)
     -- printf("RESULT: %u",option);
     
     if (csid == 0x00ee) then
-        if (player:getNation() == BASTOK) then
+        if (player:getNation() == NATION_BASTOK) then
             player:setVar("MissionStatus",4);
             player:addKeyItem(SWORD_OFFERING);
             player:messageSpecial(KEYITEM_OBTAINED,SWORD_OFFERING);

--- a/scripts/zones/Heavens_Tower/npcs/Rakano-Marukano.lua
+++ b/scripts/zones/Heavens_Tower/npcs/Rakano-Marukano.lua
@@ -22,7 +22,7 @@ end;
 
 function onTrigger(player,npc)
     
-    local new_nation = WINDURST;
+    local new_nation = NATION_WINDURST;
     local old_nation = player:getNation();
     local rank = getNationRank(new_nation);
     
@@ -69,7 +69,7 @@ function onEventFinish(player,csid,option)
     -- printf("RESULT: %u",option);
     
     if (csid == 0x2712 and option == 1) then
-        local new_nation = WINDURST;
+        local new_nation = NATION_WINDURST;
         local rank = getNationRank(new_nation);
         local cost = 0;
         

--- a/scripts/zones/Jugner_Forest/npcs/Bubchu-Bibinchu_WW.lua
+++ b/scripts/zones/Jugner_Forest/npcs/Bubchu-Bibinchu_WW.lua
@@ -10,7 +10,7 @@ package.loaded["scripts/zones/Jugner_Forest/TextIDs"] = nil;
 require("scripts/globals/conquest");
 require("scripts/zones/Jugner_Forest/TextIDs");
 
-local guardnation = WINDURST; -- SANDORIA, BASTOK, WINDURST, 4 = jeuno
+local guardnation = NATION_WINDURST; -- SANDORIA, BASTOK, WINDURST, 4 = jeuno
 local guardtype   = 3;        -- 1: city, 2: foreign, 3: outpost, 4: border
 local region      = NORVALLEN;
 local csid        = 0x7ff7;

--- a/scripts/zones/Jugner_Forest/npcs/Chaplion_RK.lua
+++ b/scripts/zones/Jugner_Forest/npcs/Chaplion_RK.lua
@@ -10,7 +10,7 @@ package.loaded["scripts/zones/Jugner_Forest/TextIDs"] = nil;
 require("scripts/globals/conquest");
 require("scripts/zones/Jugner_Forest/TextIDs");
 
-local guardnation = SANDORIA; -- SANDORIA, BASTOK, WINDURST, 4 = jeuno
+local guardnation = NATION_SANDORIA; -- SANDORIA, BASTOK, WINDURST, 4 = jeuno
 local guardtype   = 3;        -- 1: city, 2: foreign, 3: outpost, 4: border
 local region      = NORVALLEN;
 local csid        = 0x7ffb;

--- a/scripts/zones/Jugner_Forest/npcs/Geruru_WW.lua
+++ b/scripts/zones/Jugner_Forest/npcs/Geruru_WW.lua
@@ -10,7 +10,7 @@ package.loaded["scripts/zones/Jugner_Forest/TextIDs"] = nil;
 require("scripts/globals/conquest");
 require("scripts/zones/Jugner_Forest/TextIDs");
 
-local guardnation = WINDURST; -- SANDORIA, BASTOK, WINDURST, 4 = jeuno
+local guardnation = NATION_WINDURST; -- SANDORIA, BASTOK, WINDURST, 4 = jeuno
 local guardtype   = 4;        -- 1: city, 2: foreign, 3: outpost, 4: border
 local region      = NORVALLEN;
 local csid        = 0x7ff6;

--- a/scripts/zones/Jugner_Forest/npcs/Pure_Heart_IM.lua
+++ b/scripts/zones/Jugner_Forest/npcs/Pure_Heart_IM.lua
@@ -10,7 +10,7 @@ package.loaded["scripts/zones/Jugner_Forest/TextIDs"] = nil;
 require("scripts/globals/conquest");
 require("scripts/zones/Jugner_Forest/TextIDs");
 
-local guardnation = BASTOK; -- SANDORIA, BASTOK, WINDURST, 4 = jeuno
+local guardnation = NATION_BASTOK; -- SANDORIA, BASTOK, WINDURST, 4 = jeuno
 local guardtype   = 4;      -- 1: city, 2: foreign, 3: outpost, 4: border
 local region      = NORVALLEN;
 local csid        = 0x7ff8;

--- a/scripts/zones/Jugner_Forest/npcs/Takamoto_IM.lua
+++ b/scripts/zones/Jugner_Forest/npcs/Takamoto_IM.lua
@@ -10,7 +10,7 @@ package.loaded["scripts/zones/Jugner_Forest/TextIDs"] = nil;
 require("scripts/globals/conquest");
 require("scripts/zones/Jugner_Forest/TextIDs");
 
-local guardnation = BASTOK; -- SANDORIA, BASTOK, WINDURST, 4 = jeuno
+local guardnation = NATION_BASTOK; -- SANDORIA, BASTOK, WINDURST, 4 = jeuno
 local guardtype   = 3;      -- 1: city, 2: foreign, 3: outpost, 4: border
 local region      = NORVALLEN;
 local csid        = 0x7ff9;

--- a/scripts/zones/Jugner_Forest/npcs/Taumiale_RK.lua
+++ b/scripts/zones/Jugner_Forest/npcs/Taumiale_RK.lua
@@ -10,7 +10,7 @@ package.loaded["scripts/zones/Jugner_Forest/TextIDs"] = nil;
 require("scripts/globals/conquest");
 require("scripts/zones/Jugner_Forest/TextIDs");
 
-local guardnation = SANDORIA; -- SANDORIA, BASTOK, WINDURST, 4 = jeuno
+local guardnation = NATION_SANDORIA; -- SANDORIA, BASTOK, WINDURST, 4 = jeuno
 local guardtype   = 4;        -- 1: city, 2: foreign, 3: outpost, 4: border
 local region      = NORVALLEN;
 local csid        = 0x7ffa;

--- a/scripts/zones/La_Theine_Plateau/Zone.lua
+++ b/scripts/zones/La_Theine_Plateau/Zone.lua
@@ -203,8 +203,8 @@ function onEventFinish( player, csid, option)
         player:addItem( 14096);
         player:messageSpecial( ITEM_OBTAINED, 14096); -- Chaos Sollerets
         player:setVar( "darkPuppetCS", 0);
-        player:addFame( BASTOK, AF2_FAME);
-        player:completeQuest( BASTOK,DARK_PUPPET);
+        player:addFame(BASTOK, AF2_FAME);
+        player:completeQuest(BASTOK,DARK_PUPPET);
     end
 end;
 

--- a/scripts/zones/Lufaise_Meadows/npcs/Chilaumme_RK.lua
+++ b/scripts/zones/Lufaise_Meadows/npcs/Chilaumme_RK.lua
@@ -10,7 +10,7 @@ package.loaded["scripts/zones/Lufaise_Meadows/TextIDs"] = nil;
 require("scripts/globals/conquest");
 require("scripts/zones/Lufaise_Meadows/TextIDs");
 
-local guardnation = SANDORIA; -- SANDORIA, BASTOK, WINDURST, 4 = jeuno
+local guardnation = NATION_SANDORIA; -- SANDORIA, BASTOK, WINDURST, 4 = jeuno
 local guardtype   = 4;        -- 1: city, 2: foreign, 3: outpost, 4: border
 local region      = TAVNAZIANARCH;
 local csid        = 0x7ffa;

--- a/scripts/zones/Lufaise_Meadows/npcs/Cotete_WW.lua
+++ b/scripts/zones/Lufaise_Meadows/npcs/Cotete_WW.lua
@@ -10,7 +10,7 @@ package.loaded["scripts/zones/Lufaise_Meadows/TextIDs"] = nil;
 require("scripts/globals/conquest");
 require("scripts/zones/Lufaise_Meadows/TextIDs");
 
-local guardnation = WINDURST; -- SANDORIA, BASTOK, WINDURST, 4 = jeuno
+local guardnation = NATION_WINDURST; -- SANDORIA, BASTOK, WINDURST, 4 = jeuno
 local guardtype   = 4;        -- 1: city, 2: foreign, 3: outpost, 4: border
 local region      = TAVNAZIANARCH;
 local csid        = 0x7ff6;

--- a/scripts/zones/Lufaise_Meadows/npcs/Ghost_Talker_IM.lua
+++ b/scripts/zones/Lufaise_Meadows/npcs/Ghost_Talker_IM.lua
@@ -10,7 +10,7 @@ package.loaded["scripts/zones/Lufaise_Meadows/TextIDs"] = nil;
 require("scripts/globals/conquest");
 require("scripts/zones/Lufaise_Meadows/TextIDs");
 
-local guardnation = BASTOK; -- SANDORIA, BASTOK, WINDURST, 4 = jeuno
+local guardnation = NATION_BASTOK; -- SANDORIA, BASTOK, WINDURST, 4 = jeuno
 local guardtype   = 4;      -- 1: city, 2: foreign, 3: outpost, 4: border
 local region      = TAVNAZIANARCH;
 local csid        = 0x7ff8;

--- a/scripts/zones/Lufaise_Meadows/npcs/Jemmoquel_RK.lua
+++ b/scripts/zones/Lufaise_Meadows/npcs/Jemmoquel_RK.lua
@@ -10,7 +10,7 @@ package.loaded["scripts/zones/Lufaise_Meadows/TextIDs"] = nil;
 require("scripts/globals/conquest");
 require("scripts/zones/Lufaise_Meadows/TextIDs");
 
-local guardnation = SANDORIA; -- SANDORIA, BASTOK, WINDURST, 4 = jeuno
+local guardnation = NATION_SANDORIA; -- SANDORIA, BASTOK, WINDURST, 4 = jeuno
 local guardtype   = 3;        -- 1: city, 2: foreign, 3: outpost, 4: border
 local region      = TAVNAZIANARCH;
 local csid        = 0x7ffb;

--- a/scripts/zones/Lufaise_Meadows/npcs/Teldo-Moroldo_WW.lua
+++ b/scripts/zones/Lufaise_Meadows/npcs/Teldo-Moroldo_WW.lua
@@ -10,7 +10,7 @@ package.loaded["scripts/zones/Lufaise_Meadows/TextIDs"] = nil;
 require("scripts/globals/conquest");
 require("scripts/zones/Lufaise_Meadows/TextIDs");
 
-local guardnation = WINDURST; -- SANDORIA, BASTOK, WINDURST, 4 = jeuno
+local guardnation = NATION_WINDURST; -- SANDORIA, BASTOK, WINDURST, 4 = jeuno
 local guardtype   = 3;        -- 1: city, 2: foreign, 3: outpost, 4: border
 local region      = TAVNAZIANARCH;
 local csid        = 0x7ff7;

--- a/scripts/zones/Lufaise_Meadows/npcs/Yoram_IM.lua
+++ b/scripts/zones/Lufaise_Meadows/npcs/Yoram_IM.lua
@@ -10,7 +10,7 @@ package.loaded["scripts/zones/Lufaise_Meadows/TextIDs"] = nil;
 require("scripts/globals/conquest");
 require("scripts/zones/Lufaise_Meadows/TextIDs");
 
-local guardnation = BASTOK; -- SANDORIA, BASTOK, WINDURST, 4 = jeuno
+local guardnation = NATION_BASTOK; -- SANDORIA, BASTOK, WINDURST, 4 = jeuno
 local guardtype   = 3;      -- 1: city, 2: foreign, 3: outpost, 4: border
 local region      = TAVNAZIANARCH;
 local csid        = 0x7ff9;

--- a/scripts/zones/Meriphataud_Mountains/npcs/Akane_IM.lua
+++ b/scripts/zones/Meriphataud_Mountains/npcs/Akane_IM.lua
@@ -10,7 +10,7 @@ package.loaded["scripts/zones/Meriphataud_Mountains/TextIDs"] = nil;
 require("scripts/globals/conquest");
 require("scripts/zones/Meriphataud_Mountains/TextIDs");
 
-local guardnation = BASTOK; -- SANDORIA, BASTOK, WINDURST, 4 = jeuno
+local guardnation = NATION_BASTOK; -- SANDORIA, BASTOK, WINDURST, 4 = jeuno
 local guardtype   = 3;      -- 1: city, 2: foreign, 3: outpost, 4: border
 local region      = ARAGONEU;
 local csid        = 0x7ff9;

--- a/scripts/zones/Meriphataud_Mountains/npcs/Buliame_RK.lua
+++ b/scripts/zones/Meriphataud_Mountains/npcs/Buliame_RK.lua
@@ -10,7 +10,7 @@ package.loaded["scripts/zones/Meriphataud_Mountains/TextIDs"] = nil;
 require("scripts/globals/conquest");
 require("scripts/zones/Meriphataud_Mountains/TextIDs");
 
-local guardnation = SANDORIA; -- SANDORIA, BASTOK, WINDURST, 4 = jeuno
+local guardnation = NATION_SANDORIA; -- SANDORIA, BASTOK, WINDURST, 4 = jeuno
 local guardtype   = 4;        -- 1: city, 2: foreign, 3: outpost, 4: border
 local region      = ARAGONEU;
 local csid        = 0x7ffa;

--- a/scripts/zones/Meriphataud_Mountains/npcs/Chegourt_RK.lua
+++ b/scripts/zones/Meriphataud_Mountains/npcs/Chegourt_RK.lua
@@ -10,7 +10,7 @@ package.loaded["scripts/zones/Meriphataud_Mountains/TextIDs"] = nil;
 require("scripts/globals/conquest");
 require("scripts/zones/Meriphataud_Mountains/TextIDs");
 
-local guardnation = SANDORIA; -- SANDORIA, BASTOK, WINDURST, 4 = jeuno
+local guardnation = NATION_SANDORIA; -- SANDORIA, BASTOK, WINDURST, 4 = jeuno
 local guardtype   = 3;        -- 1: city, 2: foreign, 3: outpost, 4: border
 local region      = ARAGONEU;
 local csid        = 0x7ffb;

--- a/scripts/zones/Meriphataud_Mountains/npcs/Daruru_WW.lua
+++ b/scripts/zones/Meriphataud_Mountains/npcs/Daruru_WW.lua
@@ -10,7 +10,7 @@ package.loaded["scripts/zones/Meriphataud_Mountains/TextIDs"] = nil;
 require("scripts/globals/conquest");
 require("scripts/zones/Meriphataud_Mountains/TextIDs");
 
-local guardnation = WINDURST; -- SANDORIA, BASTOK, WINDURST, 4 = jeuno
+local guardnation = NATION_WINDURST; -- SANDORIA, BASTOK, WINDURST, 4 = jeuno
 local guardtype   = 4;        -- 1: city, 2: foreign, 3: outpost, 4: border
 local region      = ARAGONEU;
 local csid        = 0x7ff6;

--- a/scripts/zones/Meriphataud_Mountains/npcs/Donmo-Boronmo_WW.lua
+++ b/scripts/zones/Meriphataud_Mountains/npcs/Donmo-Boronmo_WW.lua
@@ -10,7 +10,7 @@ package.loaded["scripts/zones/Meriphataud_Mountains/TextIDs"] = nil;
 require("scripts/globals/conquest");
 require("scripts/zones/Meriphataud_Mountains/TextIDs");
 
-local guardnation = WINDURST; -- SANDORIA, BASTOK, WINDURST, 4 = jeuno
+local guardnation = NATION_WINDURST; -- SANDORIA, BASTOK, WINDURST, 4 = jeuno
 local guardtype   = 3;        -- 1: city, 2: foreign, 3: outpost, 4: border
 local region      = ARAGONEU;
 local csid        = 0x7ff7;

--- a/scripts/zones/Meriphataud_Mountains/npcs/Three_Steps_IM.lua
+++ b/scripts/zones/Meriphataud_Mountains/npcs/Three_Steps_IM.lua
@@ -10,7 +10,7 @@ package.loaded["scripts/zones/Meriphataud_Mountains/TextIDs"] = nil;
 require("scripts/globals/conquest");
 require("scripts/zones/Meriphataud_Mountains/TextIDs");
 
-local guardnation = BASTOK; -- SANDORIA, BASTOK, WINDURST, 4 = jeuno
+local guardnation = NATION_BASTOK; -- SANDORIA, BASTOK, WINDURST, 4 = jeuno
 local guardtype   = 4;      -- 1: city, 2: foreign, 3: outpost, 4: border
 local region      = ARAGONEU;
 local csid        = 0x7ff8;

--- a/scripts/zones/Metalworks/npcs/Glarociquet_TK.lua
+++ b/scripts/zones/Metalworks/npcs/Glarociquet_TK.lua
@@ -16,7 +16,7 @@ require("scripts/globals/conquest");
 require("scripts/globals/common");
 require("scripts/zones/Metalworks/TextIDs");
 
-local guardnation = SANDORIA; -- SANDORIA, BASTOK, WINDURST, JEUNO
+local guardnation = NATION_SANDORIA; -- SANDORIA, BASTOK, WINDURST, JEUNO
 local guardtype   = 2;        -- 1: city, 2: foreign, 3: outpost, 4: border
 local size        = table.getn(SandInv);
 local inventory   = SandInv;

--- a/scripts/zones/Metalworks/npcs/Lexun-Marixun_WW.lua
+++ b/scripts/zones/Metalworks/npcs/Lexun-Marixun_WW.lua
@@ -16,7 +16,7 @@ require("scripts/globals/conquest");
 require("scripts/globals/common");
 require("scripts/zones/Metalworks/TextIDs");
 
-local guardnation = WINDURST; -- SANDORIA, BASTOK, WINDURST, JEUNO
+local guardnation = NATION_WINDURST; -- SANDORIA, BASTOK, WINDURST, JEUNO
 local guardtype   = 2;        -- 1: city, 2: foreign, 3: outpost, 4: border
 local size        = table.getn(WindInv);
 local inventory   = WindInv;

--- a/scripts/zones/Metalworks/npcs/Malduc.lua
+++ b/scripts/zones/Metalworks/npcs/Malduc.lua
@@ -41,7 +41,7 @@ end;
 
 function onTrigger(player,npc)
     
-    if (player:getNation() ~= BASTOK) then
+    if (player:getNation() ~= NATION_BASTOK) then
         player:startEvent(0x03eb); -- For non-Bastokian
     else
         local CurrentMission = player:getCurrentMission(BASTOK);

--- a/scripts/zones/Metalworks/npcs/Mythily.lua
+++ b/scripts/zones/Metalworks/npcs/Mythily.lua
@@ -20,7 +20,7 @@ end;
 
 function onTrigger(player,npc)
     
-    local new_nation = BASTOK;
+    local new_nation = NATION_BASTOK;
     local old_nation = player:getNation();
     local rank = getNationRank(new_nation);
     
@@ -67,7 +67,7 @@ function onEventFinish(player,csid,option)
     -- printf("RESULT: %u",option);
     
     if (csid == 0x0168 and option == 1) then
-        local new_nation = BASTOK;
+        local new_nation = NATION_BASTOK;
         local rank = getNationRank(new_nation);
         local cost = 0;
         

--- a/scripts/zones/Metalworks/npcs/Nogga.lua
+++ b/scripts/zones/Metalworks/npcs/Nogga.lua
@@ -29,7 +29,7 @@ stock = {0x43A4,675,2,        -- Bomb Arm
      0x43A1,1083,3,        -- Grenade
      0x0ae8,92,3}        -- Catalytic Oil
  
-showNationShop(player, BASTOK, stock);
+showNationShop(player, NATION_BASTOK, stock);
 end; 
 
 -----------------------------------

--- a/scripts/zones/Metalworks/npcs/Olaf.lua
+++ b/scripts/zones/Metalworks/npcs/Olaf.lua
@@ -28,7 +28,7 @@ stock = {0x4360,46836,2,        -- Arquebus
         0x43BC,90,3,        -- Bullet
         0x03A0,463,3}        -- Bomb Ash
  
-showNationShop(player, BASTOK, stock);
+showNationShop(player, NATION_BASTOK, stock);
 end; 
 
 -----------------------------------

--- a/scripts/zones/Metalworks/npcs/Takiyah.lua
+++ b/scripts/zones/Metalworks/npcs/Takiyah.lua
@@ -23,7 +23,7 @@ end;
 
 function onTrigger(player,npc)
 
-    if (GetRegionOwner(QUFIMISLAND) ~= BASTOK) then 
+    if (GetRegionOwner(QUFIMISLAND) ~= NATION_BASTOK) then 
         player:showText(npc,TAKIYAH_CLOSED_DIALOG);
     else
         player:showText(npc,TAKIYAH_OPEN_DIALOG);

--- a/scripts/zones/Metalworks/npcs/Tomasa.lua
+++ b/scripts/zones/Metalworks/npcs/Tomasa.lua
@@ -38,7 +38,7 @@ stock = {0x112C,257,1,        -- Sausage Roll
      0x1167,184,3,        -- Pebble Soup
      0x119D,10,3}        -- Distilled Water
  
-showNationShop(player, BASTOK, stock);
+showNationShop(player, NATION_BASTOK, stock);
 end; 
 
 -----------------------------------

--- a/scripts/zones/North_Gustaberg/npcs/Butsutsu_WW.lua
+++ b/scripts/zones/North_Gustaberg/npcs/Butsutsu_WW.lua
@@ -10,7 +10,7 @@ package.loaded["scripts/zones/North_Gustaberg/TextIDs"] = nil;
 require("scripts/globals/conquest");
 require("scripts/zones/North_Gustaberg/TextIDs");
 
-local guardnation = WINDURST; -- SANDORIA, BASTOK, WINDURST, 4 = jeuno
+local guardnation = NATION_WINDURST; -- SANDORIA, BASTOK, WINDURST, 4 = jeuno
 local guardtype   = 4;        -- 1: city, 2: foreign, 3: outpost, 4: border
 local region      = GUSTABERG;
 local csid        = 0x7ff6;

--- a/scripts/zones/North_Gustaberg/npcs/Ennigreaud_RK.lua
+++ b/scripts/zones/North_Gustaberg/npcs/Ennigreaud_RK.lua
@@ -10,7 +10,7 @@ package.loaded["scripts/zones/North_Gustaberg/TextIDs"] = nil;
 require("scripts/globals/conquest");
 require("scripts/zones/North_Gustaberg/TextIDs");
 
-local guardnation = SANDORIA; -- SANDORIA, BASTOK, WINDURST, 4 = jeuno
+local guardnation = NATION_SANDORIA; -- SANDORIA, BASTOK, WINDURST, 4 = jeuno
 local guardtype   = 3;        -- 1: city, 2: foreign, 3: outpost, 4: border
 local region      = GUSTABERG;
 local csid        = 0x7ffb;

--- a/scripts/zones/North_Gustaberg/npcs/Heavy_Fog_IM.lua
+++ b/scripts/zones/North_Gustaberg/npcs/Heavy_Fog_IM.lua
@@ -10,7 +10,7 @@ package.loaded["scripts/zones/North_Gustaberg/TextIDs"] = nil;
 require("scripts/globals/conquest");
 require("scripts/zones/North_Gustaberg/TextIDs");
 
-local guardnation = BASTOK; -- SANDORIA, BASTOK, WINDURST, 4 = jeuno
+local guardnation = NATION_BASTOK; -- SANDORIA, BASTOK, WINDURST, 4 = jeuno
 local guardtype   = 4;      -- 1: city, 2: foreign, 3: outpost, 4: border
 local region      = GUSTABERG;
 local csid        = 0x7ff8;

--- a/scripts/zones/North_Gustaberg/npcs/Kuuwari-Aori_WW.lua
+++ b/scripts/zones/North_Gustaberg/npcs/Kuuwari-Aori_WW.lua
@@ -10,7 +10,7 @@ package.loaded["scripts/zones/North_Gustaberg/TextIDs"] = nil;
 require("scripts/globals/conquest");
 require("scripts/zones/North_Gustaberg/TextIDs");
 
-local guardnation = WINDURST; -- SANDORIA, BASTOK, WINDURST, 4 = jeuno
+local guardnation = NATION_WINDURST; -- SANDORIA, BASTOK, WINDURST, 4 = jeuno
 local guardtype   = 3;        -- 1: city, 2: foreign, 3: outpost, 4: border
 local region      = GUSTABERG;
 local csid        = 0x7ff7;

--- a/scripts/zones/North_Gustaberg/npcs/Quellebie_RK.lua
+++ b/scripts/zones/North_Gustaberg/npcs/Quellebie_RK.lua
@@ -10,7 +10,7 @@ package.loaded["scripts/zones/North_Gustaberg/TextIDs"] = nil;
 require("scripts/globals/conquest");
 require("scripts/zones/North_Gustaberg/TextIDs");
 
-local guardnation = SANDORIA; -- SANDORIA, BASTOK, WINDURST, 4 = jeuno
+local guardnation = NATION_SANDORIA; -- SANDORIA, BASTOK, WINDURST, 4 = jeuno
 local guardtype   = 4;        -- 1: city, 2: foreign, 3: outpost, 4: border
 local region      = GUSTABERG;
 local csid        = 0x7ffa;

--- a/scripts/zones/North_Gustaberg/npcs/Shigezane_IM.lua
+++ b/scripts/zones/North_Gustaberg/npcs/Shigezane_IM.lua
@@ -10,7 +10,7 @@ package.loaded["scripts/zones/North_Gustaberg/TextIDs"] = nil;
 require("scripts/globals/conquest");
 require("scripts/zones/North_Gustaberg/TextIDs");
 
-local guardnation = BASTOK; -- SANDORIA, BASTOK, WINDURST, 4 = jeuno
+local guardnation = NATION_BASTOK; -- SANDORIA, BASTOK, WINDURST, 4 = jeuno
 local guardtype   = 3;      -- 1: city, 2: foreign, 3: outpost, 4: border
 local region      = GUSTABERG;
 local csid        = 0x7ff9;

--- a/scripts/zones/Northern_San_dOria/npcs/Achantere_TK.lua
+++ b/scripts/zones/Northern_San_dOria/npcs/Achantere_TK.lua
@@ -16,7 +16,7 @@ require("scripts/globals/conquest");
 require("scripts/globals/common");
 require("scripts/zones/Northern_San_dOria/TextIDs");
 
-local guardnation = SANDORIA; -- SANDORIA, BASTOK, WINDURST, JEUNO
+local guardnation = NATION_SANDORIA; -- SANDORIA, BASTOK, WINDURST, JEUNO
 local guardtype   = 1;        -- 1: city, 2: foreign, 3: outpost, 4: border
 local size        = table.getn(SandInv);
 local inventory   = SandInv;

--- a/scripts/zones/Northern_San_dOria/npcs/Antonian.lua
+++ b/scripts/zones/Northern_San_dOria/npcs/Antonian.lua
@@ -36,7 +36,7 @@ function onTrigger(player,npc)
 
 RegionOwner = GetRegionOwner(ARAGONEU);
 
-        if (RegionOwner ~= SANDORIA) then
+        if (RegionOwner ~= NATION_SANDORIA) then
                 player:showText(npc,ANTONIAN_CLOSED_DIALOG);
         else
                 player:showText(npc,ANTONIAN_OPEN_DIALOG);

--- a/scripts/zones/Northern_San_dOria/npcs/Arlenne.lua
+++ b/scripts/zones/Northern_San_dOria/npcs/Arlenne.lua
@@ -53,7 +53,7 @@ function onTrigger(player,npc)
              16833,792,3,   --Bronze Spear 
              16768,309,3}   --Bronze Zaghnal 
      
-    showNationShop(player, SANDORIA, stock);
+    showNationShop(player, NATION_SANDORIA, stock);
 end; 
 
 -----------------------------------

--- a/scripts/zones/Northern_San_dOria/npcs/Attarena.lua
+++ b/scripts/zones/Northern_San_dOria/npcs/Attarena.lua
@@ -35,7 +35,7 @@ function onTrigger(player,npc)
 
 RegionOwner = GetRegionOwner(LITELOR);
 
-        if (RegionOwner ~= SANDORIA) then
+        if (RegionOwner ~= NATION_SANDORIA) then
                 player:showText(npc,ATTARENA_CLOSED_DIALOG);
         else
                 player:showText(npc,ATTARENA_OPEN_DIALOG);

--- a/scripts/zones/Northern_San_dOria/npcs/Baraka.lua
+++ b/scripts/zones/Northern_San_dOria/npcs/Baraka.lua
@@ -37,9 +37,9 @@ function onTrigger(player,npc)
     else
         local pNation = player:getNation();
 
-        if (pNation == SANDORIA) then
+        if (pNation == NATION_SANDORIA) then
             player:startEvent(580);
-        elseif (pNation == WINDURST) then
+        elseif (pNation == NATION_WINDURST) then
             player:startEvent(579);
         else
             player:startEvent(539);

--- a/scripts/zones/Northern_San_dOria/npcs/Beriphaule.lua
+++ b/scripts/zones/Northern_San_dOria/npcs/Beriphaule.lua
@@ -20,7 +20,7 @@ end;
 
 function onTrigger(player,npc)
     
-    local new_nation = SANDORIA;
+    local new_nation = NATION_SANDORIA;
     local old_nation = player:getNation();
     local rank = getNationRank(new_nation);
     
@@ -66,7 +66,7 @@ function onEventFinish(player,csid,option)
     -- printf("RESULT: %u",option);
     
     if (csid == 0x025e and option == 1) then
-        local new_nation = SANDORIA;
+        local new_nation = NATION_SANDORIA;
         local rank = getNationRank(new_nation);
         local cost = 0;
         

--- a/scripts/zones/Northern_San_dOria/npcs/Boncort.lua
+++ b/scripts/zones/Northern_San_dOria/npcs/Boncort.lua
@@ -47,7 +47,7 @@ function onTrigger(player,npc)
         0x119d,10,3,    --Distilled Water 
         0x138F,163,3    --Scroll of Sword Madrigal 
     }
-    showNationShop(player, SANDORIA, stock);
+    showNationShop(player, NATION_SANDORIA, stock);
 end; 
 
 -----------------------------------

--- a/scripts/zones/Northern_San_dOria/npcs/Chapal-Afal_WW.lua
+++ b/scripts/zones/Northern_San_dOria/npcs/Chapal-Afal_WW.lua
@@ -16,7 +16,7 @@ require("scripts/globals/conquest");
 require("scripts/globals/common");
 require("scripts/zones/Northern_San_dOria/TextIDs");
 
-local guardnation = WINDURST; -- SANDORIA, BASTOK, WINDURST, JEUNO
+local guardnation = NATION_WINDURST; -- SANDORIA, BASTOK, WINDURST, JEUNO
 local guardtype   = 2;        -- 1: city, 2: foreign, 3: outpost, 4: border
 local size        = table.getn(WindInv);
 local inventory   = WindInv;

--- a/scripts/zones/Northern_San_dOria/npcs/Eugballion.lua
+++ b/scripts/zones/Northern_San_dOria/npcs/Eugballion.lua
@@ -31,7 +31,7 @@ end;
 
 function onTrigger(player,npc)
     
-    if (GetRegionOwner(QUFIMISLAND) ~= SANDORIA) then 
+    if (GetRegionOwner(QUFIMISLAND) ~= NATION_SANDORIA) then 
         player:showText(npc,EUGBALLION_CLOSED_DIALOG);
     else
         player:showText(npc,EUGBALLION_OPEN_DIALOG);

--- a/scripts/zones/Northern_San_dOria/npcs/Grilau.lua
+++ b/scripts/zones/Northern_San_dOria/npcs/Grilau.lua
@@ -54,7 +54,7 @@ function onTrigger(player,npc)
 
 local PresOfPapsqueCompleted = player:hasCompletedMission(SANDORIA,PRESTIGE_OF_THE_PAPSQUE);
     
-    if (player:getNation() ~= SANDORIA) then
+    if (player:getNation() ~= NATION_SANDORIA) then
         player:startEvent(0x03f3); -- for Non-San d'Orians
     else
         CurrentMission = player:getCurrentMission(SANDORIA);

--- a/scripts/zones/Northern_San_dOria/npcs/Heruze-Moruze.lua
+++ b/scripts/zones/Northern_San_dOria/npcs/Heruze-Moruze.lua
@@ -33,15 +33,15 @@ function onTrigger(player,npc)
     pNation = player:getNation();
     currentMission = player:getCurrentMission(pNation);
     
-    if (pNation == WINDURST) then
+    if (pNation == NATION_WINDURST) then
         if (currentMission == THE_THREE_KINGDOMS and player:getVar("MissionStatus") == 1) then
             player:startEvent(0x0246);
         else
             player:startEvent(0x022a);
         end
-    elseif (pNation == BASTOK) then
+    elseif (pNation == NATION_BASTOK) then
         player:startEvent(0x0242);
-    elseif (pNation == SANDORIA) then
+    elseif (pNation == NATION_SANDORIA) then
         player:startEvent(0x0241);
     end
     

--- a/scripts/zones/Northern_San_dOria/npcs/Jeanvirgaud.lua
+++ b/scripts/zones/Northern_San_dOria/npcs/Jeanvirgaud.lua
@@ -10,7 +10,7 @@ package.loaded["scripts/zones/Northern_San_dOria/TextIDs"] = nil;
 require("scripts/globals/conquest");
 require("scripts/zones/Northern_San_dOria/TextIDs");
 
-guardnation = SANDORIA;
+guardnation = NATION_SANDORIA;
 csid         = 0x02cc;
 
 -----------------------------------

--- a/scripts/zones/Northern_San_dOria/npcs/Justi.lua
+++ b/scripts/zones/Northern_San_dOria/npcs/Justi.lua
@@ -47,7 +47,7 @@ function onTrigger(player,npc)
              0x0018,129168,3, --Oak Table
              0x005d,518,3}    --Water Cask
 
-    showNationShop(player, SANDORIA, stock);
+    showNationShop(player, NATION_SANDORIA, stock);
     
 end; 
 

--- a/scripts/zones/Northern_San_dOria/npcs/Kasaroro.lua
+++ b/scripts/zones/Northern_San_dOria/npcs/Kasaroro.lua
@@ -32,7 +32,7 @@ end;
 function onTrigger(player,npc)
     
     pNation = player:getNation();
-    if (pNation == WINDURST) then
+    if (pNation == NATION_WINDURST) then
         currentMission = player:getCurrentMission(pNation);
         MissionStatus = player:getVar("MissionStatus");
     

--- a/scripts/zones/Northern_San_dOria/npcs/Millechuca.lua
+++ b/scripts/zones/Northern_San_dOria/npcs/Millechuca.lua
@@ -37,7 +37,7 @@ function onTrigger(player,npc)
 
     local RegionOwner = GetRegionOwner(VOLLBOW);
 
-    if (RegionOwner ~= SANDORIA) then 
+    if (RegionOwner ~= NATION_SANDORIA) then 
         player:showText(npc,MILLECHUCA_CLOSED_DIALOG);
     else
         player:showText(npc,MILLECHUCA_OPEN_DIALOG);

--- a/scripts/zones/Northern_San_dOria/npcs/Palguevion.lua
+++ b/scripts/zones/Northern_San_dOria/npcs/Palguevion.lua
@@ -35,7 +35,7 @@ function onTrigger(player,npc)
 
     local RegionOwner = GetRegionOwner(VALDEAUNIA);
 
-if (RegionOwner ~= SANDORIA) then 
+if (RegionOwner ~= NATION_SANDORIA) then 
     player:showText(npc,PALGUEVION_CLOSED_DIALOG);
 else
     player:showText(npc,PALGUEVION_OPEN_DIALOG);

--- a/scripts/zones/Northern_San_dOria/npcs/Pirvidiauce.lua
+++ b/scripts/zones/Northern_San_dOria/npcs/Pirvidiauce.lua
@@ -50,7 +50,7 @@ function onTrigger(player,npc)
              0x43a6,3,3,    --Wooden Arrow
              0x0b2e,9200,3}    --Kingdom Waystone
 
-    showNationShop(player, SANDORIA, stock);
+    showNationShop(player, NATION_SANDORIA, stock);
 end; 
 
 -----------------------------------

--- a/scripts/zones/Northern_San_dOria/npcs/Tavourine.lua
+++ b/scripts/zones/Northern_San_dOria/npcs/Tavourine.lua
@@ -49,7 +49,7 @@ function onTrigger(player,npc)
         17059,90,3,    -- Bronze Rod
         17034,169,3    -- Bronze Mace 
     }
-    showNationShop(player, SANDORIA, stock);
+    showNationShop(player, NATION_SANDORIA, stock);
 end; 
 
 -----------------------------------

--- a/scripts/zones/Northern_San_dOria/npcs/Vichuel.lua
+++ b/scripts/zones/Northern_San_dOria/npcs/Vichuel.lua
@@ -34,7 +34,7 @@ end;
 function onTrigger(player,npc)
     local RegionOwner = GetRegionOwner(FAUREGANDI);
 
-    if (RegionOwner ~= SANDORIA) then
+    if (RegionOwner ~= NATION_SANDORIA) then
         player:showText(npc,VICHUEL_CLOSED_DIALOG);
     else
         player:showText(npc,VICHUEL_OPEN_DIALOG);

--- a/scripts/zones/Northern_San_dOria/npcs/Yevgeny_IM.lua
+++ b/scripts/zones/Northern_San_dOria/npcs/Yevgeny_IM.lua
@@ -16,7 +16,7 @@ require("scripts/globals/conquest");
 require("scripts/globals/common");
 require("scripts/zones/Northern_San_dOria/TextIDs");
 
-local guardnation = BASTOK; -- SANDORIA, BASTOK, WINDURST, JEUNO
+local guardnation = NATION_BASTOK; -- SANDORIA, BASTOK, WINDURST, JEUNO
 local guardtype   = 2;      -- 1: city, 2: foreign, 3: outpost, 4: border
 local size        = table.getn(BastInv);
 local inventory   = BastInv;

--- a/scripts/zones/Ordelles_Caves/npcs/Ruillont.lua
+++ b/scripts/zones/Ordelles_Caves/npcs/Ruillont.lua
@@ -39,7 +39,7 @@ function onTrigger(player,npc)
             player:showText(npc, RUILLONT_INITIAL_DIALOG + 9);
         elseif (MissionStatus >= 8) then
             player:showText(npc, RUILLONT_INITIAL_DIALOG);
-        elseif (player:getNation() == SANDORIA) then
+        elseif (player:getNation() == NATION_SANDORIA) then
             player:showText(npc, RUILLONT_INITIAL_DIALOG + 2);
         else
             player:showText(npc, RUILLONT_INITIAL_DIALOG + 1);

--- a/scripts/zones/Pashhow_Marshlands/Zone.lua
+++ b/scripts/zones/Pashhow_Marshlands/Zone.lua
@@ -76,7 +76,7 @@ function onZoneIn( player, prevZone)
         player:setPos( 547.841, 23.192, 696.323, 136);
     end
 
-    if (prevZone == 147 and player:getCurrentMission( BASTOK) == THE_FOUR_MUSKETEERS) then
+    if (prevZone == 147 and player:getCurrentMission(BASTOK) == THE_FOUR_MUSKETEERS) then
         missionStatus = player:getVar("MissionStatus");
         if (missionStatus < 22) then
             cs = 0x000a;

--- a/scripts/zones/Pashhow_Marshlands/npcs/Ioupie_RK.lua
+++ b/scripts/zones/Pashhow_Marshlands/npcs/Ioupie_RK.lua
@@ -10,7 +10,7 @@ package.loaded["scripts/zones/Pashhow_Marshlands/TextIDs"] = nil;
 require("scripts/globals/conquest");
 require("scripts/zones/Pashhow_Marshlands/TextIDs");
 
-local guardnation = SANDORIA; -- SANDORIA, BASTOK, WINDURST, 4 = jeuno
+local guardnation = NATION_SANDORIA; -- SANDORIA, BASTOK, WINDURST, 4 = jeuno
 local guardtype   = 4;        -- 1: city, 2: foreign, 3: outpost, 4: border
 local region      = DERFLAND;
 local csid        = 0x7ffa;

--- a/scripts/zones/Pashhow_Marshlands/npcs/Mesachedeau_RK.lua
+++ b/scripts/zones/Pashhow_Marshlands/npcs/Mesachedeau_RK.lua
@@ -10,7 +10,7 @@ package.loaded["scripts/zones/Pashhow_Marshlands/TextIDs"] = nil;
 require("scripts/globals/conquest");
 require("scripts/zones/Pashhow_Marshlands/TextIDs");
 
-local guardnation = SANDORIA; -- SANDORIA, BASTOK, WINDURST, 4 = jeuno
+local guardnation = NATION_SANDORIA; -- SANDORIA, BASTOK, WINDURST, 4 = jeuno
 local guardtype   = 3;        -- 1: city, 2: foreign, 3: outpost, 4: border
 local region      = DERFLAND;
 local csid        = 0x7ffb;

--- a/scripts/zones/Pashhow_Marshlands/npcs/Mokto-Lankto_WW.lua
+++ b/scripts/zones/Pashhow_Marshlands/npcs/Mokto-Lankto_WW.lua
@@ -10,7 +10,7 @@ package.loaded["scripts/zones/Pashhow_Marshlands/TextIDs"] = nil;
 require("scripts/globals/conquest");
 require("scripts/zones/Pashhow_Marshlands/TextIDs");
 
-local guardnation = WINDURST; -- SANDORIA, BASTOK, WINDURST, 4 = jeuno
+local guardnation = NATION_WINDURST; -- SANDORIA, BASTOK, WINDURST, 4 = jeuno
 local guardtype   = 3;        -- 1: city, 2: foreign, 3: outpost, 4: border
 local region      = DERFLAND
 local csid        = 0x7ff7;

--- a/scripts/zones/Pashhow_Marshlands/npcs/Sharp_Tooth_IM.lua
+++ b/scripts/zones/Pashhow_Marshlands/npcs/Sharp_Tooth_IM.lua
@@ -10,7 +10,7 @@ package.loaded["scripts/zones/Pashhow_Marshlands/TextIDs"] = nil;
 require("scripts/globals/conquest");
 require("scripts/zones/Pashhow_Marshlands/TextIDs");
 
-local guardnation = BASTOK; -- SANDORIA, BASTOK, WINDURST, 4 = jeuno
+local guardnation = NATION_BASTOK; -- SANDORIA, BASTOK, WINDURST, 4 = jeuno
 local guardtype   = 4;      -- 1: city, 2: foreign, 3: outpost, 4: border
 local region      = DERFLAND;
 local csid        = 0x7ff8;

--- a/scripts/zones/Pashhow_Marshlands/npcs/Shikoko_WW.lua
+++ b/scripts/zones/Pashhow_Marshlands/npcs/Shikoko_WW.lua
@@ -10,7 +10,7 @@ package.loaded["scripts/zones/Pashhow_Marshlands/TextIDs"] = nil;
 require("scripts/globals/conquest");
 require("scripts/zones/Pashhow_Marshlands/TextIDs");
 
-local guardnation = WINDURST; -- SANDORIA, BASTOK, WINDURST, 4 = jeuno
+local guardnation = NATION_WINDURST; -- SANDORIA, BASTOK, WINDURST, 4 = jeuno
 local guardtype   = 4;        -- 1: city, 2: foreign, 3: outpost, 4: border
 local region      = DERFLAND
 local csid        = 0x7ff6;

--- a/scripts/zones/Pashhow_Marshlands/npcs/Souun_IM.lua
+++ b/scripts/zones/Pashhow_Marshlands/npcs/Souun_IM.lua
@@ -10,7 +10,7 @@ package.loaded["scripts/zones/Pashhow_Marshlands/TextIDs"] = nil;
 require("scripts/globals/conquest");
 require("scripts/zones/Pashhow_Marshlands/TextIDs");
 
-local guardnation = BASTOK; -- SANDORIA, BASTOK, WINDURST, 4 = jeuno
+local guardnation = NATION_BASTOK; -- SANDORIA, BASTOK, WINDURST, 4 = jeuno
 local guardtype   = 3;      -- 1: city, 2: foreign, 3: outpost, 4: border
 local region      = DERFLAND;
 local csid        = 0x7ff9;

--- a/scripts/zones/Port_Bastok/npcs/Argus.lua
+++ b/scripts/zones/Port_Bastok/npcs/Argus.lua
@@ -41,7 +41,7 @@ end;
 
 function onTrigger(player,npc)
     
-    if (player:getNation() ~= BASTOK) then
+    if (player:getNation() ~= NATION_BASTOK) then
         player:startEvent(0x03eb); -- For non-Bastokian
     else
         local CurrentMission = player:getCurrentMission(BASTOK);

--- a/scripts/zones/Port_Bastok/npcs/Bagnobrok.lua
+++ b/scripts/zones/Port_Bastok/npcs/Bagnobrok.lua
@@ -24,7 +24,7 @@ end;
 function onTrigger(player,npc)
     RegionOwner = GetRegionOwner(MOVALPOLOS);
 
-    if (RegionOwner ~= BASTOK) then 
+    if (RegionOwner ~= NATION_BASTOK) then 
         player:showText(npc,BAGNOBROK_CLOSED_DIALOG);
     else
         player:showText(npc,BAGNOBROK_OPEN_DIALOG);

--- a/scripts/zones/Port_Bastok/npcs/Belka.lua
+++ b/scripts/zones/Port_Bastok/npcs/Belka.lua
@@ -23,7 +23,7 @@ end;
 
 function onTrigger(player,npc)
     RegionOwner = GetRegionOwner(DERFLAND);
-    if (RegionOwner ~= BASTOK) then 
+    if (RegionOwner ~= NATION_BASTOK) then 
         player:showText(npc,BELKA_CLOSED_DIALOG);
     else
         player:showText(npc,BELKA_OPEN_DIALOG);

--- a/scripts/zones/Port_Bastok/npcs/Denvihr.lua
+++ b/scripts/zones/Port_Bastok/npcs/Denvihr.lua
@@ -37,7 +37,7 @@ function onTrigger(player,npc)
         0x0280,    10,3,     --Copper Ore
         0x0088,  1800,3      --Kaiserin Cosmetics
     }
-    showNationShop(player, BASTOK, stock);
+    showNationShop(player, NATION_BASTOK, stock);
 
 end; 
 

--- a/scripts/zones/Port_Bastok/npcs/Dhen_Tevryukoh.lua
+++ b/scripts/zones/Port_Bastok/npcs/Dhen_Tevryukoh.lua
@@ -26,7 +26,7 @@ end;
 
 function onTrigger(player,npc)
     RegionOwner = GetRegionOwner(ELSHIMOUPLANDS);
-    if (RegionOwner ~= BASTOK) then 
+    if (RegionOwner ~= NATION_BASTOK) then 
         player:showText(npc,DHENTEVRYUKOH_CLOSED_DIALOG);
     else
         player:showText(npc,DHENTEVRYUKOH_OPEN_DIALOG);

--- a/scripts/zones/Port_Bastok/npcs/Evelyn.lua
+++ b/scripts/zones/Port_Bastok/npcs/Evelyn.lua
@@ -23,7 +23,7 @@ end;
 
 function onTrigger(player,npc)
     RegionOwner = GetRegionOwner(GUSTABERG);
-    if (RegionOwner ~= BASTOK) then 
+    if (RegionOwner ~= NATION_BASTOK) then 
         player:showText(npc,EVELYN_CLOSED_DIALOG);
     else
         player:showText(npc,EVELYN_OPEN_DIALOG);

--- a/scripts/zones/Port_Bastok/npcs/Flying_Axe_IM.lua
+++ b/scripts/zones/Port_Bastok/npcs/Flying_Axe_IM.lua
@@ -16,7 +16,7 @@ require("scripts/globals/conquest");
 require("scripts/globals/common");
 require("scripts/zones/Port_Bastok/TextIDs");
 
-local guardnation = BASTOK; -- SANDORIA, BASTOK, WINDURST, JEUNO
+local guardnation = NATION_BASTOK; -- SANDORIA, BASTOK, WINDURST, JEUNO
 local guardtype   = 1;      -- 1: city, 2: foreign, 3: outpost, 4: border
 local size        = table.getn(BastInv);
 local inventory   = BastInv;

--- a/scripts/zones/Port_Bastok/npcs/Galvin.lua
+++ b/scripts/zones/Port_Bastok/npcs/Galvin.lua
@@ -34,7 +34,7 @@ function onTrigger(player,npc)
         0x43A8,     7,3,     --Iron Arrow
         0x43B8,     5,3      --Crossbow Bolt
     }
-    showNationShop(player, BASTOK, stock);
+    showNationShop(player, NATION_BASTOK, stock);
 
 end; 
 

--- a/scripts/zones/Port_Bastok/npcs/Melloa.lua
+++ b/scripts/zones/Port_Bastok/npcs/Melloa.lua
@@ -38,7 +38,7 @@ function onTrigger(player,npc)
         0x1167,   184,3,     --Pebble Soup
         0x119D,    10,3      --Distilled Water
     } 
-    showNationShop(player, BASTOK, stock);
+    showNationShop(player, NATION_BASTOK, stock);
 
 end; 
 

--- a/scripts/zones/Port_Bastok/npcs/Numa.lua
+++ b/scripts/zones/Port_Bastok/npcs/Numa.lua
@@ -43,7 +43,7 @@ function onTrigger(player,npc)
         0x16EC, 18000,3,     --Toolbag (Shika)
         0x16ED, 18000,3      --Toolbag (Cho)
     }
-     showNationShop(player, BASTOK, stock);
+     showNationShop(player, NATION_BASTOK, stock);
 end; 
 
 -----------------------------------

--- a/scripts/zones/Port_Bastok/npcs/Rosswald.lua
+++ b/scripts/zones/Port_Bastok/npcs/Rosswald.lua
@@ -23,7 +23,7 @@ end;
 
 function onTrigger(player,npc)
     RegionOwner = GetRegionOwner(ZULKHEIM);
-    if (RegionOwner ~= BASTOK) then 
+    if (RegionOwner ~= NATION_BASTOK) then 
         player:showText(npc,ROSSWALD_CLOSED_DIALOG);
     else
         player:showText(npc,ROSSWALD_OPEN_DIALOG);

--- a/scripts/zones/Port_Bastok/npcs/Sawyer.lua
+++ b/scripts/zones/Port_Bastok/npcs/Sawyer.lua
@@ -38,7 +38,7 @@ function onTrigger(player,npc)
         0x1167,   184,3,     --Pebble Soup
         0x119D,    10,3      --Distilled Water
     }
-    showNationShop(player, BASTOK, stock);
+    showNationShop(player, NATION_BASTOK, stock);
 
 end; 
 

--- a/scripts/zones/Port_Bastok/npcs/Sugandhi.lua
+++ b/scripts/zones/Port_Bastok/npcs/Sugandhi.lua
@@ -40,7 +40,7 @@ function onTrigger(player,npc)
         0x4085,  9201,3,     --Degen
         0x40A7,   698,3      --Sapara
     }
-    showNationShop(player, BASTOK, stock);
+    showNationShop(player, NATION_BASTOK, stock);
 
 end; 
 

--- a/scripts/zones/Port_Bastok/npcs/Vattian.lua
+++ b/scripts/zones/Port_Bastok/npcs/Vattian.lua
@@ -23,7 +23,7 @@ end;
 
 function onTrigger(player,npc)
     RegionOwner = GetRegionOwner(KUZOTZ);
-    if (RegionOwner ~= BASTOK) then 
+    if (RegionOwner ~= NATION_BASTOK) then 
         player:showText(npc,VATTIAN_CLOSED_DIALOG);
     else
         player:showText(npc,VATTIAN_OPEN_DIALOG);

--- a/scripts/zones/Port_Bastok/npcs/Zoby_Quhyo.lua
+++ b/scripts/zones/Port_Bastok/npcs/Zoby_Quhyo.lua
@@ -23,7 +23,7 @@ end;
 
 function onTrigger(player,npc)
     RegionOwner = GetRegionOwner(ELSHIMOLOWLANDS);
-    if (RegionOwner ~= BASTOK) then 
+    if (RegionOwner ~= NATION_BASTOK) then 
         player:showText(npc,ZOBYQUHYO_CLOSED_DIALOG);
     else
         player:showText(npc,ZOBYQUHYO_OPEN_DIALOG);

--- a/scripts/zones/Port_Jeuno/npcs/Sugandhi.lua
+++ b/scripts/zones/Port_Jeuno/npcs/Sugandhi.lua
@@ -39,7 +39,7 @@ stock = {0x4059,5589,1,        -- Kukri
      0x4085,9201,3,        -- Degen
      0x40A7,698,3}        -- Sapara
  
-showNationShop(player, BASTOK, stock);
+showNationShop(player, NATION_BASTOK, stock);
 end; 
 
 -----------------------------------

--- a/scripts/zones/Port_San_dOria/npcs/Albinie.lua
+++ b/scripts/zones/Port_San_dOria/npcs/Albinie.lua
@@ -40,7 +40,7 @@ stock =
     0x02ba,86,3,   --Ash Log 
     0x0001,1800,3  --Chocobo Bedding 
 }
-showNationShop(player, SANDORIA, stock);
+showNationShop(player, NATION_SANDORIA, stock);
 end; 
 
 -----------------------------------

--- a/scripts/zones/Port_San_dOria/npcs/Bonmaurieut.lua
+++ b/scripts/zones/Port_San_dOria/npcs/Bonmaurieut.lua
@@ -35,7 +35,7 @@ function onTrigger(player,npc)
 
     local RegionOwner = GetRegionOwner(ELSHIMOUPLANDS);
 
-if (RegionOwner ~= SANDORIA) then 
+if (RegionOwner ~= NATION_SANDORIA) then 
     player:showText(npc,BONMAURIEUT_CLOSED_DIALOG);
 else
     player:showText(npc,BONMAURIEUT_OPEN_DIALOG);

--- a/scripts/zones/Port_San_dOria/npcs/Coullave.lua
+++ b/scripts/zones/Port_San_dOria/npcs/Coullave.lua
@@ -50,7 +50,7 @@ stock = {0x1020,4445,1, --Ether
          0x1036,2387,3, --Eye Drops
          0x349d,1150,3} --Leather Ring
  
-showNationShop(player, SANDORIA, stock);
+showNationShop(player, NATION_SANDORIA, stock);
 end; 
 
 -----------------------------------

--- a/scripts/zones/Port_San_dOria/npcs/Croumangue.lua
+++ b/scripts/zones/Port_San_dOria/npcs/Croumangue.lua
@@ -48,7 +48,7 @@ stock = {0x1159,837,1,  --Grape Juice
          0x119d,10,3,   --Distilled Water 
          0x1167,180,3}  --Pebble Soup
  
-showNationShop(player, SANDORIA, stock);
+showNationShop(player, NATION_SANDORIA, stock);
 end; 
 
 -----------------------------------

--- a/scripts/zones/Port_San_dOria/npcs/Deguerendars.lua
+++ b/scripts/zones/Port_San_dOria/npcs/Deguerendars.lua
@@ -38,7 +38,7 @@ function onTrigger(player,npc)
 cop = 40; --player:getVar("chainsOfPromathiaMissions");
 
 if (cop >= 40) then
-    if (RegionOwner ~= SANDORIA) then 
+    if (RegionOwner ~= NATION_SANDORIA) then 
         player:showText(npc,DEGUERENDARS_CLOSED_DIALOG);
     else
         player:showText(npc,DEGUERENDARS_OPEN_DIALOG);

--- a/scripts/zones/Port_San_dOria/npcs/Fiva.lua
+++ b/scripts/zones/Port_San_dOria/npcs/Fiva.lua
@@ -35,7 +35,7 @@ function onTrigger(player,npc)
 
     local RegionOwner = GetRegionOwner(KOLSHUSHU);
 
-if (RegionOwner ~= SANDORIA) then 
+if (RegionOwner ~= NATION_SANDORIA) then 
     player:showText(npc,FIVA_CLOSED_DIALOG);
 else
     player:showText(npc,FIVA_OPEN_DIALOG);

--- a/scripts/zones/Port_San_dOria/npcs/Milva.lua
+++ b/scripts/zones/Port_San_dOria/npcs/Milva.lua
@@ -34,7 +34,7 @@ end;
 function onTrigger(player,npc)
     local RegionOwner = GetRegionOwner(SARUTABARUTA);
 
-    if (RegionOwner ~= SANDORIA) then 
+    if (RegionOwner ~= NATION_SANDORIA) then 
         player:showText(npc,MILVA_CLOSED_DIALOG);
     else
         player:showText(npc,MILVA_OPEN_DIALOG);

--- a/scripts/zones/Port_San_dOria/npcs/Nimia.lua
+++ b/scripts/zones/Port_San_dOria/npcs/Nimia.lua
@@ -35,7 +35,7 @@ end;
 function onTrigger(player,npc)
     local RegionOwner = GetRegionOwner(ELSHIMOLOWLANDS);
 
-    if (RegionOwner ~= SANDORIA) then 
+    if (RegionOwner ~= NATION_SANDORIA) then 
         player:showText(npc,NIMIA_CLOSED_DIALOG);
     else
         player:showText(npc,NIMIA_OPEN_DIALOG);

--- a/scripts/zones/Port_San_dOria/npcs/Patolle.lua
+++ b/scripts/zones/Port_San_dOria/npcs/Patolle.lua
@@ -36,7 +36,7 @@ function onTrigger(player,npc)
 
     local RegionOwner = GetRegionOwner(KUZOTZ);
 
-if (RegionOwner ~= SANDORIA) then 
+if (RegionOwner ~= NATION_SANDORIA) then 
     player:showText(npc,PATOLLE_CLOSED_DIALOG);
 else
     player:showText(npc,PATOLLE_OPEN_DIALOG);

--- a/scripts/zones/Port_San_dOria/npcs/Regine.lua
+++ b/scripts/zones/Port_San_dOria/npcs/Regine.lua
@@ -125,7 +125,7 @@ function onEventFinish(player,csid,option)
                 0x122b,219,3,  -- Scroll of Protect
                 0x1230,1584,3  -- Scroll of Shell
             }
-            showNationShop(player, SANDORIA, stockA);
+            showNationShop(player, NATION_SANDORIA, stockA);
         elseif (option == 1) then
             local stockB =
             {
@@ -147,7 +147,7 @@ function onEventFinish(player,csid,option)
                 0x12a4,3261,3, -- Scroll of Thunder
                 0x12a9,140,3   -- Scroll of Water
             }
-            showNationShop(player, SANDORIA, stockB);
+            showNationShop(player, NATION_SANDORIA, stockB);
         end
     end
 end;

--- a/scripts/zones/Port_San_dOria/npcs/Vendavoq.lua
+++ b/scripts/zones/Port_San_dOria/npcs/Vendavoq.lua
@@ -37,7 +37,7 @@ function onTrigger(player,npc)
 
     local RegionOwner = GetRegionOwner(MOVALPOLOS);
 
-if (RegionOwner ~= SANDORIA) then 
+if (RegionOwner ~= NATION_SANDORIA) then 
     player:showText(npc,VENDAVOQ_CLOSED_DIALOG);
 else
     player:showText(npc,VENDAVOQ_OPEN_DIALOG);

--- a/scripts/zones/Port_Windurst/npcs/Alizabe.lua
+++ b/scripts/zones/Port_Windurst/npcs/Alizabe.lua
@@ -27,7 +27,7 @@ function onTrigger(player,npc)
     cop = 40; --player:getVar("chainsOfPromathiaMissions");
 
     if (cop >= 40) then
-        if (RegionOwner ~= WINDURST) then 
+        if (RegionOwner ~= NATION_WINDURST) then 
             player:showText(npc,ALIZABE_CLOSED_DIALOG);
         else
             player:showText(npc,ALIZABE_OPEN_DIALOG);

--- a/scripts/zones/Port_Windurst/npcs/Aroro.lua
+++ b/scripts/zones/Port_Windurst/npcs/Aroro.lua
@@ -43,7 +43,7 @@ function onTrigger(player,npc)
         0x12EF,  1393,3,     --Shock
         0x12F0,  6508,3      --Drown
     }
-    showNationShop(player, WINDURST, stock);
+    showNationShop(player, NATION_WINDURST, stock);
 
 end;
 

--- a/scripts/zones/Port_Windurst/npcs/Guruna-Maguruna.lua
+++ b/scripts/zones/Port_Windurst/npcs/Guruna-Maguruna.lua
@@ -41,7 +41,7 @@ function onTrigger(player,npc)
         0x31B0,  1363,3,     --Gloves
         0x31B8,   118,3      --Cuffs
     } 
-    showNationShop(player, WINDURST, stock);
+    showNationShop(player, NATION_WINDURST, stock);
 
 end; 
 

--- a/scripts/zones/Port_Windurst/npcs/Hohbiba-Mubiba.lua
+++ b/scripts/zones/Port_Windurst/npcs/Hohbiba-Mubiba.lua
@@ -41,7 +41,7 @@ function onTrigger(player,npc)
         0x42C7,   386,3,     --Ash Pole
         0x4040,   143,3      --Bronze Dagger
     }
-    showNationShop(player, WINDURST, stock);
+    showNationShop(player, NATION_WINDURST, stock);
 
 end; 
 

--- a/scripts/zones/Port_Windurst/npcs/Janshura-Rashura.lua
+++ b/scripts/zones/Port_Windurst/npcs/Janshura-Rashura.lua
@@ -20,7 +20,7 @@ require("scripts/zones/Port_Windurst/TextIDs");
 
 function onTrigger(player,npc)
     
-    if (player:getNation() ~= WINDURST) then
+    if (player:getNation() ~= NATION_WINDURST) then
         player:startEvent(0x0047); -- for other nation
     else
         CurrentMission = player:getCurrentMission(WINDURST);

--- a/scripts/zones/Port_Windurst/npcs/Kumama.lua
+++ b/scripts/zones/Port_Windurst/npcs/Kumama.lua
@@ -41,7 +41,7 @@ function onTrigger(player,npc)
         0x32b8,   111,3,     --Ash Clogs
         0x3001,   110,3      --Lauan Shield
     }
-    showNationShop(player, WINDURST, stock);
+    showNationShop(player, NATION_WINDURST, stock);
 end; 
 
 -----------------------------------

--- a/scripts/zones/Port_Windurst/npcs/Kususu.lua
+++ b/scripts/zones/Port_Windurst/npcs/Kususu.lua
@@ -43,7 +43,7 @@ function onTrigger(player,npc)
         0x1230,  1584,3,     --Shell
         0x1237,   360,3      --Aquaveil
     }
-    showNationShop(player, WINDURST, stock);
+    showNationShop(player, NATION_WINDURST, stock);
 
 end; 
 

--- a/scripts/zones/Port_Windurst/npcs/Lebondur.lua
+++ b/scripts/zones/Port_Windurst/npcs/Lebondur.lua
@@ -24,7 +24,7 @@ end;
 
 function onTrigger(player,npc)
     RegionOwner = GetRegionOwner(VOLLBOW);
-    if (RegionOwner ~= WINDURST) then 
+    if (RegionOwner ~= NATION_WINDURST) then 
         player:showText(npc,LEBONDUR_CLOSED_DIALOG);
     else
         player:showText(npc,LEBONDUR_OPEN_DIALOG);

--- a/scripts/zones/Port_Windurst/npcs/Melek.lua
+++ b/scripts/zones/Port_Windurst/npcs/Melek.lua
@@ -30,7 +30,7 @@ function onTrigger(player,npc)
     if (player:getCurrentMission(BASTOK) ~= 255) then
         currentMission = player:getCurrentMission(pNation);
 
-        if (pNation == BASTOK) then
+        if (pNation == NATION_BASTOK) then
             missionStatus = player:getVar("MissionStatus");
             if (currentMission == THE_EMISSARY) then
                 -- Bastok Mission 2-3 Part I - Windurst > San d'Oria

--- a/scripts/zones/Port_Windurst/npcs/Milma-Hapilma_WW.lua
+++ b/scripts/zones/Port_Windurst/npcs/Milma-Hapilma_WW.lua
@@ -16,7 +16,7 @@ require("scripts/globals/conquest");
 require("scripts/globals/common");
 require("scripts/zones/Port_Windurst/TextIDs");
 
-local guardnation = WINDURST; -- SANDORIA, BASTOK, WINDURST, JEUNO
+local guardnation = NATION_WINDURST; -- SANDORIA, BASTOK, WINDURST, JEUNO
 local guardtype   = 1;        -- 1: city, 2: foreign, 3: outpost, 4: border
 local size        = table.getn(WindInv);
 local inventory   = WindInv;

--- a/scripts/zones/Port_Windurst/npcs/Posso_Ruhbini.lua
+++ b/scripts/zones/Port_Windurst/npcs/Posso_Ruhbini.lua
@@ -24,7 +24,7 @@ end;
 
 function onTrigger(player,npc)
     RegionOwner = GetRegionOwner(NORVALLEN);
-    if (RegionOwner ~= WINDURST) then 
+    if (RegionOwner ~= NATION_WINDURST) then 
         player:showText(npc,POSSORUHBINI_CLOSED_DIALOG);
     else
         player:showText(npc,POSSORUHBINI_OPEN_DIALOG);

--- a/scripts/zones/Port_Windurst/npcs/Rottata.lua
+++ b/scripts/zones/Port_Windurst/npcs/Rottata.lua
@@ -10,7 +10,7 @@ package.loaded["scripts/zones/Port_Windurst/TextIDs"] = nil;
 require("scripts/globals/conquest");
 require("scripts/zones/Port_Windurst/TextIDs");
 
-guardnation = WINDURST;
+guardnation = NATION_WINDURST;
 csid         = 0x0228;
 
 -----------------------------------

--- a/scripts/zones/Port_Windurst/npcs/Sachetan_IM.lua
+++ b/scripts/zones/Port_Windurst/npcs/Sachetan_IM.lua
@@ -16,7 +16,7 @@ require("scripts/globals/conquest");
 require("scripts/globals/common");
 require("scripts/zones/Port_Windurst/TextIDs");
 
-local guardnation = BASTOK; -- SANDORIA, BASTOK, WINDURST, JEUNO
+local guardnation = NATION_BASTOK; -- SANDORIA, BASTOK, WINDURST, JEUNO
 local guardtype   = 2;      -- 1: city, 2: foreign, 3: outpost, 4: border
 local size        = table.getn(BastInv);
 local inventory   = BastInv;

--- a/scripts/zones/Port_Windurst/npcs/Sattsuh_Ahkanpari.lua
+++ b/scripts/zones/Port_Windurst/npcs/Sattsuh_Ahkanpari.lua
@@ -24,7 +24,7 @@ end;
 
 function onTrigger(player,npc)
     RegionOwner = GetRegionOwner(ELSHIMOUPLANDS);
-    if (RegionOwner ~= WINDURST) then 
+    if (RegionOwner ~= NATION_WINDURST) then 
         player:showText(npc,SATTSUHAHKANPARI_CLOSED_DIALOG);
     else
         player:showText(npc,SATTSUHAHKANPARI_OPEN_DIALOG);

--- a/scripts/zones/Port_Windurst/npcs/Sheia_Pohrichamaha.lua
+++ b/scripts/zones/Port_Windurst/npcs/Sheia_Pohrichamaha.lua
@@ -24,7 +24,7 @@ end;
 function onTrigger(player,npc)
     RegionOwner = GetRegionOwner(FAUREGANDI);
 
-    if (RegionOwner ~= WINDURST) then 
+    if (RegionOwner ~= NATION_WINDURST) then 
         player:showText(npc,SHEIAPOHRICHAMAHA_CLOSED_DIALOG);
     else
         player:showText(npc,SHEIAPOHRICHAMAHA_OPEN_DIALOG);

--- a/scripts/zones/Port_Windurst/npcs/Taniko-Maniko.lua
+++ b/scripts/zones/Port_Windurst/npcs/Taniko-Maniko.lua
@@ -43,7 +43,7 @@ function onTrigger(player,npc)
         0x4300,    39,3,     --Shortbow
         0x43A7,     4,3      --Bone Arrow
     }
-    showNationShop(player, WINDURST, stock);
+    showNationShop(player, NATION_WINDURST, stock);
 
 end; 
 

--- a/scripts/zones/Port_Windurst/npcs/Uli_Pehkowa.lua
+++ b/scripts/zones/Port_Windurst/npcs/Uli_Pehkowa.lua
@@ -37,7 +37,7 @@ function onTrigger(player,npc)
         0x0341,    18,3,     --Moko Grass
         0x0072,  1840,3      --My First Magic Kit
     }
-    showNationShop(player, WINDURST, stock);
+    showNationShop(player, NATION_WINDURST, stock);
 
 end;
 

--- a/scripts/zones/Port_Windurst/npcs/Zoreen.lua
+++ b/scripts/zones/Port_Windurst/npcs/Zoreen.lua
@@ -24,7 +24,7 @@ end;
 
 function onTrigger(player,npc)
     RegionOwner = GetRegionOwner(VALDEAUNIA);
-    if (RegionOwner ~= WINDURST) then 
+    if (RegionOwner ~= NATION_WINDURST) then 
         player:showText(npc,ZOREEN_CLOSED_DIALOG);
     else
         player:showText(npc,ZOREEN_OPEN_DIALOG);

--- a/scripts/zones/Qufim_Island/npcs/Matica_RK.lua
+++ b/scripts/zones/Qufim_Island/npcs/Matica_RK.lua
@@ -10,7 +10,7 @@ package.loaded["scripts/zones/Qufim_Island/TextIDs"] = nil;
 require("scripts/globals/conquest");
 require("scripts/zones/Qufim_Island/TextIDs");
 
-local guardnation = SANDORIA; -- SANDORIA, BASTOK, WINDURST, 4 = jeuno
+local guardnation = NATION_SANDORIA; -- SANDORIA, BASTOK, WINDURST, 4 = jeuno
 local guardtype   = 4;        -- 1: city, 2: foreign, 3: outpost, 4: border
 local region      = QUFIMISLAND;
 local csid        = 0x7ffa;

--- a/scripts/zones/Qufim_Island/npcs/Numumu_WW.lua
+++ b/scripts/zones/Qufim_Island/npcs/Numumu_WW.lua
@@ -10,7 +10,7 @@ package.loaded["scripts/zones/Qufim_Island/TextIDs"] = nil;
 require("scripts/globals/conquest");
 require("scripts/zones/Qufim_Island/TextIDs");
 
-local guardnation = WINDURST; -- SANDORIA, BASTOK, WINDURST, 4 = jeuno
+local guardnation = NATION_WINDURST; -- SANDORIA, BASTOK, WINDURST, 4 = jeuno
 local guardtype   = 4;        -- 1: city, 2: foreign, 3: outpost, 4: border
 local region      = QUFIMISLAND;
 local csid        = 0x7ff6;

--- a/scripts/zones/Qufim_Island/npcs/Pitoire_RK.lua
+++ b/scripts/zones/Qufim_Island/npcs/Pitoire_RK.lua
@@ -10,7 +10,7 @@ package.loaded["scripts/zones/Qufim_Island/TextIDs"] = nil;
 require("scripts/globals/conquest");
 require("scripts/zones/Qufim_Island/TextIDs");
 
-local guardnation = SANDORIA; -- SANDORIA, BASTOK, WINDURST, 4 = jeuno
+local guardnation = NATION_SANDORIA; -- SANDORIA, BASTOK, WINDURST, 4 = jeuno
 local guardtype   = 3;        -- 1: city, 2: foreign, 3: outpost, 4: border
 local region      = QUFIMISLAND;
 local csid        = 0x7ffb;

--- a/scripts/zones/Qufim_Island/npcs/Sasa_IM.lua
+++ b/scripts/zones/Qufim_Island/npcs/Sasa_IM.lua
@@ -10,7 +10,7 @@ package.loaded["scripts/zones/Qufim_Island/TextIDs"] = nil;
 require("scripts/globals/conquest");
 require("scripts/zones/Qufim_Island/TextIDs");
 
-local guardnation = BASTOK; -- SANDORIA, BASTOK, WINDURST, 4 = jeuno
+local guardnation = NATION_BASTOK; -- SANDORIA, BASTOK, WINDURST, 4 = jeuno
 local guardtype   = 3;      -- 1: city, 2: foreign, 3: outpost, 4: border
 local region      = QUFIMISLAND;
 local csid        = 0x7ff9;

--- a/scripts/zones/Qufim_Island/npcs/Singing_Blade_IM.lua
+++ b/scripts/zones/Qufim_Island/npcs/Singing_Blade_IM.lua
@@ -10,7 +10,7 @@ package.loaded["scripts/zones/Qufim_Island/TextIDs"] = nil;
 require("scripts/globals/conquest");
 require("scripts/zones/Qufim_Island/TextIDs");
 
-local guardnation = BASTOK; -- SANDORIA, BASTOK, WINDURST, 4 = jeuno
+local guardnation = NATION_BASTOK; -- SANDORIA, BASTOK, WINDURST, 4 = jeuno
 local guardtype   = 4;      -- 1: city, 2: foreign, 3: outpost, 4: border
 local region      = QUFIMISLAND;
 local csid        = 0x7ff8;

--- a/scripts/zones/Qufim_Island/npcs/Tsonga-Hoponga_WW.lua
+++ b/scripts/zones/Qufim_Island/npcs/Tsonga-Hoponga_WW.lua
@@ -10,7 +10,7 @@ package.loaded["scripts/zones/Qufim_Island/TextIDs"] = nil;
 require("scripts/globals/conquest");
 require("scripts/zones/Qufim_Island/TextIDs");
 
-local guardnation = WINDURST; -- SANDORIA, BASTOK, WINDURST, 4 = jeuno
+local guardnation = NATION_WINDURST; -- SANDORIA, BASTOK, WINDURST, 4 = jeuno
 local guardtype   = 3;        -- 1: city, 2: foreign, 3: outpost, 4: border
 local region      = QUFIMISLAND;
 local csid        = 0x7ff7;

--- a/scripts/zones/RuLude_Gardens/npcs/Goggehn.lua
+++ b/scripts/zones/RuLude_Gardens/npcs/Goggehn.lua
@@ -51,9 +51,9 @@ function onTrigger(player,npc)
         player:startEvent(0x0023);
     elseif (player:hasKeyItem(MESSAGE_TO_JEUNO_BASTOK)) then
         player:startEvent(0x0037);
-    elseif (pNation == WINDURST) then
+    elseif (pNation == NATION_WINDURST) then
         player:startEvent(0x0004);
-    elseif (pNation == SANDORIA) then
+    elseif (pNation == NATION_SANDORIA) then
         player:startEvent(0x0002);
     else
         player:startEvent(0x0065);

--- a/scripts/zones/RuLude_Gardens/npcs/Nelcabrit.lua
+++ b/scripts/zones/RuLude_Gardens/npcs/Nelcabrit.lua
@@ -46,9 +46,9 @@ function onTrigger(player,npc)
         player:startEvent(0x0024);
     elseif (player:hasKeyItem(MESSAGE_TO_JEUNO_SANDORIA)) then
         player:startEvent(0x0038);
-    elseif (pNation == WINDURST) then
+    elseif (pNation == NATION_WINDURST) then
         player:startEvent(0x002F);
-    elseif (pNation == BASTOK) then
+    elseif (pNation == NATION_BASTOK) then
         player:startEvent(0x002E);
     else
         player:startEvent(0x0066);

--- a/scripts/zones/RuLude_Gardens/npcs/Pakh_Jatalfih.lua
+++ b/scripts/zones/RuLude_Gardens/npcs/Pakh_Jatalfih.lua
@@ -24,7 +24,7 @@ function onTrigger(player,npc)
     
     local pNation = player:getNation();
     
-    if (pNation == WINDURST) then
+    if (pNation == NATION_WINDURST) then
         currentMission = player:getCurrentMission(pNation);
         MissionStatus = player:getVar("MissionStatus");
         
@@ -53,9 +53,9 @@ function onTrigger(player,npc)
         else
             player:startEvent(0x006b);
         end
-    elseif (pNation == SANDORIA) then
+    elseif (pNation == NATION_SANDORIA) then
         player:startEvent(0x0034);
-    elseif (pNation == BASTOK) then
+    elseif (pNation == NATION_BASTOK) then
         player:startEvent(0x0033);
     end
     

--- a/scripts/zones/Southern_San_dOria/npcs/Ambrotien.lua
+++ b/scripts/zones/Southern_San_dOria/npcs/Ambrotien.lua
@@ -54,7 +54,7 @@ function onTrigger(player,npc)
 
 local PresOfPapsqueCompleted = player:hasCompletedMission(SANDORIA,PRESTIGE_OF_THE_PAPSQUE);
     
-    if (player:getNation() ~= SANDORIA) then
+    if (player:getNation() ~= NATION_SANDORIA) then
         player:startEvent(0x07db); -- for Non-San d'Orians
     else
         CurrentMission = player:getCurrentMission(SANDORIA);

--- a/scripts/zones/Southern_San_dOria/npcs/Apairemant.lua
+++ b/scripts/zones/Southern_San_dOria/npcs/Apairemant.lua
@@ -34,7 +34,7 @@ end;
 function onTrigger(player,npc)
     local RegionOwner = GetRegionOwner(GUSTABERG);
 
-    if (RegionOwner ~= SANDORIA) then
+    if (RegionOwner ~= NATION_SANDORIA) then
             player:showText(npc,APAIREMANT_CLOSED_DIALOG);
     else
             player:showText(npc,APAIREMANT_OPEN_DIALOG);

--- a/scripts/zones/Southern_San_dOria/npcs/Aravoge_TK.lua
+++ b/scripts/zones/Southern_San_dOria/npcs/Aravoge_TK.lua
@@ -16,7 +16,7 @@ require("scripts/globals/conquest");
 require("scripts/globals/common");
 require("scripts/zones/Southern_San_dOria/TextIDs");
 
-local guardnation = SANDORIA; -- SANDORIA, BASTOK, WINDURST, JEUNO
+local guardnation = NATION_SANDORIA; -- SANDORIA, BASTOK, WINDURST, JEUNO
 local guardtype   = 1;        -- 1: city, 2: foreign, 3: outpost, 4: border
 local size        = table.getn(SandInv);
 local inventory   = SandInv;

--- a/scripts/zones/Southern_San_dOria/npcs/Arpevion_TK.lua
+++ b/scripts/zones/Southern_San_dOria/npcs/Arpevion_TK.lua
@@ -15,7 +15,7 @@ package.loaded["scripts/zones/Southern_San_dOria/TextIDs"] = nil;
 require("scripts/globals/conquest");
 require("scripts/zones/Southern_San_dOria/TextIDs");
 
-local guardnation = SANDORIA; -- SANDORIA, BASTOK, WINDURST, JEUNO
+local guardnation = NATION_SANDORIA; -- SANDORIA, BASTOK, WINDURST, JEUNO
 local guardtype   = 1;        -- 1: city, 2: foreign, 3: outpost, 4: border
 local size        = table.getn(SandInv);
 local inventory   = SandInv;

--- a/scripts/zones/Southern_San_dOria/npcs/Ashene.lua
+++ b/scripts/zones/Southern_San_dOria/npcs/Ashene.lua
@@ -55,7 +55,7 @@ function onTrigger(player,npc)
              0x4097,241,3,        --Bronze Sword
              0x40b5,1674,3}        --Spatha
      
-    showNationShop(player, SANDORIA, stock);
+    showNationShop(player, NATION_SANDORIA, stock);
 
 end; 
 

--- a/scripts/zones/Southern_San_dOria/npcs/Aveline.lua
+++ b/scripts/zones/Southern_San_dOria/npcs/Aveline.lua
@@ -51,7 +51,7 @@ function onTrigger(player,npc)
              0x1125,28,3,    --San d'Orian Carrot
              0x114f,68,3}    --San d'Orian Grape
      
-    showNationShop(player, SANDORIA, stock);
+    showNationShop(player, NATION_SANDORIA, stock);
 
 end; 
 

--- a/scripts/zones/Southern_San_dOria/npcs/Benaige.lua
+++ b/scripts/zones/Southern_San_dOria/npcs/Benaige.lua
@@ -53,7 +53,7 @@ function onTrigger(player,npc)
              0x119d,10,3,    --Distilled Water
              0x1472,198,3}    --Cibol
      
-    showNationShop(player, SANDORIA, stock);
+    showNationShop(player, NATION_SANDORIA, stock);
 
 end; 
 

--- a/scripts/zones/Southern_San_dOria/npcs/Carautia.lua
+++ b/scripts/zones/Southern_San_dOria/npcs/Carautia.lua
@@ -54,7 +54,7 @@ function onTrigger(player,npc)
              0x32a1,1116,3,     --Brass Leggings
              0x3298,302,3}         --Leather Highboots
      
-    showNationShop(player, SANDORIA, stock);
+    showNationShop(player, NATION_SANDORIA, stock);
 
 end; 
 

--- a/scripts/zones/Southern_San_dOria/npcs/Corua.lua
+++ b/scripts/zones/Southern_San_dOria/npcs/Corua.lua
@@ -36,7 +36,7 @@ function onTrigger(player,npc)
 
         local RegionOwner = GetRegionOwner(RONFAURE);
 -- player:startEvent(0x0351) - are you the chicks owner
-        if (RegionOwner ~= SANDORIA) then
+        if (RegionOwner ~= NATION_SANDORIA) then
                 player:showText(npc,CORUA_CLOSED_DIALOG);
         else
                 player:showText(npc,CORUA_OPEN_DIALOG);

--- a/scripts/zones/Southern_San_dOria/npcs/Endracion.lua
+++ b/scripts/zones/Southern_San_dOria/npcs/Endracion.lua
@@ -54,7 +54,7 @@ function onTrigger(player,npc)
 
 local PresOfPapsqueCompleted = player:hasCompletedMission(SANDORIA,PRESTIGE_OF_THE_PAPSQUE);
 
-    if (player:getNation() ~= SANDORIA) then
+    if (player:getNation() ~= NATION_SANDORIA) then
         player:startEvent(0x03F3); -- for Non-San d'Orians
     else
         CurrentMission = player:getCurrentMission(SANDORIA);

--- a/scripts/zones/Southern_San_dOria/npcs/Ferdoulemiont.lua
+++ b/scripts/zones/Southern_San_dOria/npcs/Ferdoulemiont.lua
@@ -54,7 +54,7 @@ function onTrigger(player,npc)
              0x1387,5148,3,  --Scroll of Knight's Minne III
              0x0927,1984,3}  --La Theine Millet
      
-    showNationShop(player, SANDORIA, stock);
+    showNationShop(player, NATION_SANDORIA, stock);
 
 end; 
 

--- a/scripts/zones/Southern_San_dOria/npcs/Lusiane.lua
+++ b/scripts/zones/Southern_San_dOria/npcs/Lusiane.lua
@@ -46,7 +46,7 @@ function onTrigger(player,npc)
              0x13ca,1265,3,        -- Scroll of Lightning Threnoldy
              0x43ef,66,3}        -- Willow Fishing Rod
      
-    showNationShop(player, SANDORIA, stock);
+    showNationShop(player, NATION_SANDORIA, stock);
 
 end; 
 

--- a/scripts/zones/Southern_San_dOria/npcs/Machielle.lua
+++ b/scripts/zones/Southern_San_dOria/npcs/Machielle.lua
@@ -32,7 +32,7 @@ function onTrigger(player,npc)
 
     local RegionOwner = GetRegionOwner(NORVALLEN);
 
-if (RegionOwner ~= SANDORIA) then
+if (RegionOwner ~= NATION_SANDORIA) then
         player:showText(npc,MACHIELLE_CLOSED_DIALOG);
 else
         player:showText(npc,MACHIELLE_OPEN_DIALOG);

--- a/scripts/zones/Southern_San_dOria/npcs/Miogique.lua
+++ b/scripts/zones/Southern_San_dOria/npcs/Miogique.lua
@@ -55,7 +55,7 @@ function onTrigger(player,npc)
              0x3198,331,3,        -- Leather Gloves
              0x3118,618,3}        -- Leather Vest
      
-    showNationShop(player, SANDORIA, stock);
+    showNationShop(player, NATION_SANDORIA, stock);
 
 end; 
 

--- a/scripts/zones/Southern_San_dOria/npcs/Ostalie.lua
+++ b/scripts/zones/Southern_San_dOria/npcs/Ostalie.lua
@@ -53,7 +53,7 @@ function onTrigger(player,npc)
              0x3138,216,3,    -- Robe
              0x3238,172,3}    -- Slops
              
-    rank = getNationRank(SANDORIA);
+    rank = getNationRank(NATION_SANDORIA);
 
         if (rank ~= 1) then
             table.insert(stock,0x03fe); --Thief's Tools
@@ -66,7 +66,7 @@ function onTrigger(player,npc)
             table.insert(stock,3);
         end
 
-    showNationShop(player, SANDORIA, stock);
+    showNationShop(player, NATION_SANDORIA, stock);
 
 end; 
 

--- a/scripts/zones/Southern_San_dOria/npcs/Phamelise.lua
+++ b/scripts/zones/Southern_San_dOria/npcs/Phamelise.lua
@@ -35,7 +35,7 @@ function onTrigger(player,npc)
 
     local RegionOwner = GetRegionOwner(ZULKHEIM);
 
-    if (RegionOwner ~= SANDORIA) then
+    if (RegionOwner ~= NATION_SANDORIA) then
         player:showText(npc,PHAMELISE_CLOSED_DIALOG);
     else
         player:showText(npc,PHAMELISE_OPEN_DIALOG);

--- a/scripts/zones/Southern_San_dOria/npcs/Pourette.lua
+++ b/scripts/zones/Southern_San_dOria/npcs/Pourette.lua
@@ -32,7 +32,7 @@ function onTrigger(player,npc)
 
     local RegionOwner = GetRegionOwner(DERFLAND);
     
-    if (RegionOwner ~= SANDORIA) then
+    if (RegionOwner ~= NATION_SANDORIA) then
         player:showText(npc,POURETTE_CLOSED_DIALOG);
     else
         player:showText(npc,POURETTE_OPEN_DIALOG);

--- a/scripts/zones/Southern_San_dOria/npcs/Shilah.lua
+++ b/scripts/zones/Southern_San_dOria/npcs/Shilah.lua
@@ -54,7 +54,7 @@ function onTrigger(player,npc)
         0x119d,10,3,    --Distilled Water
         0x15a5,1260,3    --Royal Grape
     }
-    showNationShop(player, SANDORIA, stock);
+    showNationShop(player, NATION_SANDORIA, stock);
 
 end; 
 

--- a/scripts/zones/Southern_San_dOria/npcs/Thadiene.lua
+++ b/scripts/zones/Southern_San_dOria/npcs/Thadiene.lua
@@ -51,7 +51,7 @@ function onTrigger(player,npc)
              0x43a6,3,3,     --Wooden Arrow
              0x13a5,4320,3}     --Scroll of Battlefield Elegy
 
-    showNationShop(player, SANDORIA, stock);
+    showNationShop(player, NATION_SANDORIA, stock);
 
 end; 
 

--- a/scripts/zones/The_Sanctuary_of_ZiTah/npcs/Ajimo-Majimo_WW.lua
+++ b/scripts/zones/The_Sanctuary_of_ZiTah/npcs/Ajimo-Majimo_WW.lua
@@ -10,7 +10,7 @@ package.loaded["scripts/zones/The_Sanctuary_of_ZiTah/TextIDs"] = nil;
 require("scripts/globals/conquest");
 require("scripts/zones/The_Sanctuary_of_ZiTah/TextIDs");
 
-local guardnation = WINDURST; -- SANDORIA, BASTOK, WINDURST, 4 = jeuno
+local guardnation = NATION_WINDURST; -- SANDORIA, BASTOK, WINDURST, 4 = jeuno
 local guardtype   = 3;        -- 1: city, 2: foreign, 3: outpost, 4: border
 local region      = LITELOR;
 local csid        = 0x7ff7;

--- a/scripts/zones/The_Sanctuary_of_ZiTah/npcs/Calliope_IM.lua
+++ b/scripts/zones/The_Sanctuary_of_ZiTah/npcs/Calliope_IM.lua
@@ -10,7 +10,7 @@ package.loaded["scripts/zones/The_Sanctuary_of_ZiTah/TextIDs"] = nil;
 require("scripts/globals/conquest");
 require("scripts/zones/The_Sanctuary_of_ZiTah/TextIDs");
 
-local guardnation = BASTOK; -- SANDORIA, BASTOK, WINDURST, 4 = jeuno
+local guardnation = NATION_BASTOK; -- SANDORIA, BASTOK, WINDURST, 4 = jeuno
 local guardtype   = 3;      -- 1: city, 2: foreign, 3: outpost, 4: border
 local region      = LITELOR;
 local csid        = 0x7ff9;

--- a/scripts/zones/The_Sanctuary_of_ZiTah/npcs/Credaurion_RK.lua
+++ b/scripts/zones/The_Sanctuary_of_ZiTah/npcs/Credaurion_RK.lua
@@ -11,7 +11,7 @@ require("scripts/globals/keyitems");
 require("scripts/globals/conquest");
 require("scripts/zones/The_Sanctuary_of_ZiTah/TextIDs");
 
-local guardnation = SANDORIA; -- SANDORIA, BASTOK, WINDURST, 4 = jeuno
+local guardnation = NATION_SANDORIA; -- SANDORIA, BASTOK, WINDURST, 4 = jeuno
 local guardtype   = 3;        -- 1: city, 2: foreign, 3: outpost, 4: border
 local region      = LITELOR;
 local csid        = 0x7ffb;

--- a/scripts/zones/The_Sanctuary_of_ZiTah/npcs/Dedden_IM.lua
+++ b/scripts/zones/The_Sanctuary_of_ZiTah/npcs/Dedden_IM.lua
@@ -10,7 +10,7 @@ package.loaded["scripts/zones/The_Sanctuary_of_ZiTah/TextIDs"] = nil;
 require("scripts/globals/conquest");
 require("scripts/zones/The_Sanctuary_of_ZiTah/TextIDs");
 
-local guardnation = BASTOK; -- SANDORIA, BASTOK, WINDURST, 4 = jeuno
+local guardnation = NATION_BASTOK; -- SANDORIA, BASTOK, WINDURST, 4 = jeuno
 local guardtype   = 4;      -- 1: city, 2: foreign, 3: outpost, 4: border
 local region      = LITELOR;
 local csid        = 0x7ff8;

--- a/scripts/zones/The_Sanctuary_of_ZiTah/npcs/Limion_RK.lua
+++ b/scripts/zones/The_Sanctuary_of_ZiTah/npcs/Limion_RK.lua
@@ -11,7 +11,7 @@ require("scripts/globals/keyitems");
 require("scripts/globals/conquest");
 require("scripts/zones/The_Sanctuary_of_ZiTah/TextIDs");
 
-local guardnation = SANDORIA; -- SANDORIA, BASTOK, WINDURST, 4 = jeuno
+local guardnation = NATION_SANDORIA; -- SANDORIA, BASTOK, WINDURST, 4 = jeuno
 local guardtype   = 4;        -- 1: city, 2: foreign, 3: outpost, 4: border
 local region      = LITELOR;
 local csid        = 0x7ffa;

--- a/scripts/zones/The_Sanctuary_of_ZiTah/npcs/Ochocho_WW.lua
+++ b/scripts/zones/The_Sanctuary_of_ZiTah/npcs/Ochocho_WW.lua
@@ -10,7 +10,7 @@ package.loaded["scripts/zones/The_Sanctuary_of_ZiTah/TextIDs"] = nil;
 require("scripts/globals/conquest");
 require("scripts/zones/The_Sanctuary_of_ZiTah/TextIDs");
 
-local guardnation = WINDURST; -- SANDORIA, BASTOK, WINDURST, 4 = jeuno
+local guardnation = NATION_WINDURST; -- SANDORIA, BASTOK, WINDURST, 4 = jeuno
 local guardtype   = 4;        -- 1: city, 2: foreign, 3: outpost, 4: border
 local region      = LITELOR;
 local csid        = 0x7ff6;

--- a/scripts/zones/Valkurm_Dunes/npcs/Fighting_Ant_IM.lua
+++ b/scripts/zones/Valkurm_Dunes/npcs/Fighting_Ant_IM.lua
@@ -10,7 +10,7 @@ package.loaded["scripts/zones/Valkurm_Dunes/TextIDs"] = nil;
 require("scripts/globals/conquest");
 require("scripts/zones/Valkurm_Dunes/TextIDs");
 
-local guardnation = BASTOK; -- SANDORIA, BASTOK, WINDURST, 4 = jeuno
+local guardnation = NATION_BASTOK; -- SANDORIA, BASTOK, WINDURST, 4 = jeuno
 local guardtype   = 4;      -- 1: city, 2: foreign, 3: outpost, 4: border
 local region      = ZULKHEIM;
 local csid        = 0x7ff8;

--- a/scripts/zones/Valkurm_Dunes/npcs/Nyata-Mobuta_WW.lua
+++ b/scripts/zones/Valkurm_Dunes/npcs/Nyata-Mobuta_WW.lua
@@ -10,7 +10,7 @@ package.loaded["scripts/zones/Valkurm_Dunes/TextIDs"] = nil;
 require("scripts/globals/conquest");
 require("scripts/zones/Valkurm_Dunes/TextIDs");
 
-local guardnation = WINDURST; -- SANDORIA, BASTOK, WINDURST, 4 = jeuno
+local guardnation = NATION_WINDURST; -- SANDORIA, BASTOK, WINDURST, 4 = jeuno
 local guardtype   = 3;        -- 1: city, 2: foreign, 3: outpost, 4: border
 local region      = ZULKHEIM;
 local csid        = 0x7ff7;

--- a/scripts/zones/Valkurm_Dunes/npcs/Prunilla_RK.lua
+++ b/scripts/zones/Valkurm_Dunes/npcs/Prunilla_RK.lua
@@ -10,7 +10,7 @@ package.loaded["scripts/zones/Valkurm_Dunes/TextIDs"] = nil;
 require("scripts/globals/conquest");
 require("scripts/zones/Valkurm_Dunes/TextIDs");
 
-local guardnation = SANDORIA; -- SANDORIA, BASTOK, WINDURST, 4 = jeuno
+local guardnation = NATION_SANDORIA; -- SANDORIA, BASTOK, WINDURST, 4 = jeuno
 local guardtype   = 4;        -- 1: city, 2: foreign, 3: outpost, 4: border
 local region      = ZULKHEIM;
 local csid        = 0x7ffa;

--- a/scripts/zones/Valkurm_Dunes/npcs/Quanteilleron_RK.lua
+++ b/scripts/zones/Valkurm_Dunes/npcs/Quanteilleron_RK.lua
@@ -10,7 +10,7 @@ package.loaded["scripts/zones/Valkurm_Dunes/TextIDs"] = nil;
 require("scripts/globals/conquest");
 require("scripts/zones/Valkurm_Dunes/TextIDs");
 
-local guardnation = SANDORIA; -- SANDORIA, BASTOK, WINDURST, 4 = jeuno
+local guardnation = NATION_SANDORIA; -- SANDORIA, BASTOK, WINDURST, 4 = jeuno
 local guardtype   = 3;        -- 1: city, 2: foreign, 3: outpost, 4: border
 local region      = ZULKHEIM;
 local csid        = 0x7ffb;

--- a/scripts/zones/Valkurm_Dunes/npcs/Tebubu_WW.lua
+++ b/scripts/zones/Valkurm_Dunes/npcs/Tebubu_WW.lua
@@ -10,7 +10,7 @@ package.loaded["scripts/zones/Valkurm_Dunes/TextIDs"] = nil;
 require("scripts/globals/conquest");
 require("scripts/zones/Valkurm_Dunes/TextIDs");
 
-local guardnation = WINDURST; -- SANDORIA, BASTOK, WINDURST, 4 = jeuno
+local guardnation = NATION_WINDURST; -- SANDORIA, BASTOK, WINDURST, 4 = jeuno
 local guardtype   = 4;        -- 1: city, 2: foreign, 3: outpost, 4: border
 local region      = ZULKHEIM;
 local csid        = 0x7ff6;

--- a/scripts/zones/Valkurm_Dunes/npcs/Tsunashige_IM.lua
+++ b/scripts/zones/Valkurm_Dunes/npcs/Tsunashige_IM.lua
@@ -10,7 +10,7 @@ package.loaded["scripts/zones/Valkurm_Dunes/TextIDs"] = nil;
 require("scripts/globals/conquest");
 require("scripts/zones/Valkurm_Dunes/TextIDs");
 
-local guardnation = BASTOK; -- SANDORIA, BASTOK, WINDURST, 4 = jeuno
+local guardnation = NATION_BASTOK; -- SANDORIA, BASTOK, WINDURST, 4 = jeuno
 local guardtype   = 3;      -- 1: city, 2: foreign, 3: outpost, 4: border
 local region      = ZULKHEIM;
 local csid        = 0x7ff9;

--- a/scripts/zones/West_Ronfaure/npcs/Ballie_RK.lua
+++ b/scripts/zones/West_Ronfaure/npcs/Ballie_RK.lua
@@ -10,7 +10,7 @@ package.loaded["scripts/zones/West_Ronfaure/TextIDs"] = nil;
 require("scripts/globals/conquest");
 require("scripts/zones/West_Ronfaure/TextIDs");
 
-local guardnation = SANDORIA; -- SANDORIA, BASTOK, WINDURST, 4 = jeuno
+local guardnation = NATION_SANDORIA; -- SANDORIA, BASTOK, WINDURST, 4 = jeuno
 local guardtype   = 4;        -- 1: city, 2: foreign, 3: outpost, 4: border
 local region      = RONFAURE;
 local csid        = 0x7ffa;

--- a/scripts/zones/West_Ronfaure/npcs/Doladepaiton_RK.lua
+++ b/scripts/zones/West_Ronfaure/npcs/Doladepaiton_RK.lua
@@ -10,7 +10,7 @@ package.loaded["scripts/zones/West_Ronfaure/TextIDs"] = nil;
 require("scripts/globals/conquest");
 require("scripts/zones/West_Ronfaure/TextIDs");
 
-local guardnation = SANDORIA; -- SANDORIA, BASTOK, WINDURST, 4 = jeuno
+local guardnation = NATION_SANDORIA; -- SANDORIA, BASTOK, WINDURST, 4 = jeuno
 local guardtype   = 3;        -- 1: city, 2: foreign, 3: outpost, 4: border
 local region      = RONFAURE;
 local csid        = 0x7ffb;

--- a/scripts/zones/West_Ronfaure/npcs/Kyanta-Pakyanta_WW.lua
+++ b/scripts/zones/West_Ronfaure/npcs/Kyanta-Pakyanta_WW.lua
@@ -10,7 +10,7 @@ package.loaded["scripts/zones/West_Ronfaure/TextIDs"] = nil;
 require("scripts/globals/conquest");
 require("scripts/zones/West_Ronfaure/TextIDs");
 
-local guardnation = WINDURST; -- SANDORIA, BASTOK, WINDURST, 4 = jeuno
+local guardnation = NATION_WINDURST; -- SANDORIA, BASTOK, WINDURST, 4 = jeuno
 local guardtype   = 3;        -- 1: city, 2: foreign, 3: outpost, 4: border
 local region      = RONFAURE;
 local csid        = 0x7ff7;

--- a/scripts/zones/West_Ronfaure/npcs/Molting_Moth_IM.lua
+++ b/scripts/zones/West_Ronfaure/npcs/Molting_Moth_IM.lua
@@ -10,7 +10,7 @@ package.loaded["scripts/zones/West_Ronfaure/TextIDs"] = nil;
 require("scripts/globals/conquest");
 require("scripts/zones/West_Ronfaure/TextIDs");
 
-local guardnation = BASTOK; -- SANDORIA, BASTOK, WINDURST, 4 = jeuno
+local guardnation = NATION_BASTOK; -- SANDORIA, BASTOK, WINDURST, 4 = jeuno
 local guardtype   = 4;      -- 1: city, 2: foreign, 3: outpost, 4: border
 local region      = RONFAURE;
 local csid        = 0x7ff8;

--- a/scripts/zones/West_Ronfaure/npcs/Tottoto_WW.lua
+++ b/scripts/zones/West_Ronfaure/npcs/Tottoto_WW.lua
@@ -10,7 +10,7 @@ package.loaded["scripts/zones/West_Ronfaure/TextIDs"] = nil;
 require("scripts/globals/conquest");
 require("scripts/zones/West_Ronfaure/TextIDs");
 
-local guardnation = WINDURST; -- SANDORIA, BASTOK, WINDURST, 4 = jeuno
+local guardnation = NATION_WINDURST; -- SANDORIA, BASTOK, WINDURST, 4 = jeuno
 local guardtype   = 4;        -- 1: city, 2: foreign, 3: outpost, 4: border
 local region      = RONFAURE;
 local csid        = 0x7ff6;

--- a/scripts/zones/West_Ronfaure/npcs/Yoshihiro_IM.lua
+++ b/scripts/zones/West_Ronfaure/npcs/Yoshihiro_IM.lua
@@ -10,7 +10,7 @@ package.loaded["scripts/zones/West_Ronfaure/TextIDs"] = nil;
 require("scripts/globals/conquest");
 require("scripts/zones/West_Ronfaure/TextIDs");
 
-local guardnation = BASTOK; -- SANDORIA, BASTOK, WINDURST, 4 = jeuno
+local guardnation = NATION_BASTOK; -- SANDORIA, BASTOK, WINDURST, 4 = jeuno
 local guardtype   = 3;      -- 1: city, 2: foreign, 3: outpost, 4: border
 local region      = RONFAURE;
 local csid        = 0x7ff9;

--- a/scripts/zones/West_Sarutabaruta/npcs/Banege_RK.lua
+++ b/scripts/zones/West_Sarutabaruta/npcs/Banege_RK.lua
@@ -10,7 +10,7 @@ package.loaded["scripts/zones/West_Sarutabaruta/TextIDs"] = nil;
 require("scripts/globals/conquest");
 require("scripts/zones/West_Sarutabaruta/TextIDs");
 
-local guardnation = SANDORIA; -- SANDORIA, BASTOK, WINDURST, 4 = jeuno
+local guardnation = NATION_SANDORIA; -- SANDORIA, BASTOK, WINDURST, 4 = jeuno
 local guardtype   = 4;        -- 1: city, 2: foreign, 3: outpost, 4: border
 local region      = SARUTABARUTA;
 local csid        = 0x7ffa;

--- a/scripts/zones/West_Sarutabaruta/npcs/Darumomo_WW.lua
+++ b/scripts/zones/West_Sarutabaruta/npcs/Darumomo_WW.lua
@@ -10,7 +10,7 @@ package.loaded["scripts/zones/West_Sarutabaruta/TextIDs"] = nil;
 require("scripts/globals/conquest");
 require("scripts/zones/West_Sarutabaruta/TextIDs");
 
-local guardnation = WINDURST; -- SANDORIA, BASTOK, WINDURST, 4 = jeuno
+local guardnation = NATION_WINDURST; -- SANDORIA, BASTOK, WINDURST, 4 = jeuno
 local guardtype   = 4;        -- 1: city, 2: foreign, 3: outpost, 4: border
 local region      = SARUTABARUTA;
 local csid        = 0x7ff6;

--- a/scripts/zones/West_Sarutabaruta/npcs/Naguipeillont_RK.lua
+++ b/scripts/zones/West_Sarutabaruta/npcs/Naguipeillont_RK.lua
@@ -10,7 +10,7 @@ package.loaded["scripts/zones/West_Sarutabaruta/TextIDs"] = nil;
 require("scripts/globals/conquest");
 require("scripts/zones/West_Sarutabaruta/TextIDs");
 
-local guardnation = SANDORIA; -- SANDORIA, BASTOK, WINDURST, 4 = jeuno
+local guardnation = NATION_SANDORIA; -- SANDORIA, BASTOK, WINDURST, 4 = jeuno
 local guardtype   = 3;        -- 1: city, 2: foreign, 3: outpost, 4: border
 local region      = SARUTABARUTA;
 local csid        = 0x7ffb;

--- a/scripts/zones/West_Sarutabaruta/npcs/Roshina-Kuleshuna_WW.lua
+++ b/scripts/zones/West_Sarutabaruta/npcs/Roshina-Kuleshuna_WW.lua
@@ -10,7 +10,7 @@ package.loaded["scripts/zones/West_Sarutabaruta/TextIDs"] = nil;
 require("scripts/globals/conquest");
 require("scripts/zones/West_Sarutabaruta/TextIDs");
 
-local guardnation = WINDURST; -- SANDORIA, BASTOK, WINDURST, 4 = jeuno
+local guardnation = NATION_WINDURST; -- SANDORIA, BASTOK, WINDURST, 4 = jeuno
 local guardtype   = 3;        -- 1: city, 2: foreign, 3: outpost, 4: border
 local region      = SARUTABARUTA;
 local csid        = 0x7ff7;

--- a/scripts/zones/West_Sarutabaruta/npcs/Ryokei_IM.lua
+++ b/scripts/zones/West_Sarutabaruta/npcs/Ryokei_IM.lua
@@ -10,7 +10,7 @@ package.loaded["scripts/zones/West_Sarutabaruta/TextIDs"] = nil;
 require("scripts/globals/conquest");
 require("scripts/zones/West_Sarutabaruta/TextIDs");
 
-local guardnation = BASTOK; -- SANDORIA, BASTOK, WINDURST, 4 = jeuno
+local guardnation = NATION_BASTOK; -- SANDORIA, BASTOK, WINDURST, 4 = jeuno
 local guardtype   = 3;      -- 1: city, 2: foreign, 3: outpost, 4: border
 local region      = SARUTABARUTA;
 local csid        = 0x7ff9;

--- a/scripts/zones/West_Sarutabaruta/npcs/Slow_Axe_IM.lua
+++ b/scripts/zones/West_Sarutabaruta/npcs/Slow_Axe_IM.lua
@@ -10,7 +10,7 @@ package.loaded["scripts/zones/West_Sarutabaruta/TextIDs"] = nil;
 require("scripts/globals/conquest");
 require("scripts/zones/West_Sarutabaruta/TextIDs");
 
-local guardnation = BASTOK; -- SANDORIA, BASTOK, WINDURST, 4 = jeuno
+local guardnation = NATION_BASTOK; -- SANDORIA, BASTOK, WINDURST, 4 = jeuno
 local guardtype   = 4;      -- 1: city, 2: foreign, 3: outpost, 4: border
 local region      = SARUTABARUTA;
 local csid        = 0x7ff8;

--- a/scripts/zones/Windurst_Walls/npcs/Shantotto.lua
+++ b/scripts/zones/Windurst_Walls/npcs/Shantotto.lua
@@ -83,14 +83,14 @@ function onTrigger(player,npc)
     
         
     -- Curses,Foiled...Again!?
-    elseif (foiledAgain == QUEST_COMPLETED and CFA2 == QUEST_AVAILABLE and player:getFameLevel (WINDURST) >= 2 and player:getMainLvl() >= 5 and CFAtimer == 1) then
+    elseif (foiledAgain == QUEST_COMPLETED and CFA2 == QUEST_AVAILABLE and player:getFameLevel(WINDURST) >= 2 and player:getMainLvl() >= 5 and CFAtimer == 1) then
         player:startEvent(0x00B4,0,0,0,0,928,880,17316,940);        -- Quest Start
     elseif (CFA2 == QUEST_ACCEPTED) then
         player:startEvent(0x00B5,0,0,0,0,0,0,17316,940);  -- Reminder dialog
     
         
     -- Curses,Foiled A-Golem!?
-    elseif (CFA2 == QUEST_COMPLETED and FoiledAGolem == QUEST_AVAILABLE and player:getFameLevel (WINDURST) >= 4 and player:getMainLvl() >= 10) then
+    elseif (CFA2 == QUEST_COMPLETED and FoiledAGolem == QUEST_AVAILABLE and player:getFameLevel(WINDURST) >= 4 and player:getMainLvl() >= 10) then
         player:startEvent(0x0154);  --quest start
     elseif (golemdelivery == 1) then
         player:startEvent(0x0156);  -- finish

--- a/scripts/zones/Windurst_Walls/npcs/Zokima-Rokima.lua
+++ b/scripts/zones/Windurst_Walls/npcs/Zokima-Rokima.lua
@@ -20,7 +20,7 @@ require("scripts/zones/Windurst_Walls/TextIDs");
 
 function onTrigger(player,npc)
     
-    if (player:getNation() ~= WINDURST) then
+    if (player:getNation() ~= NATION_WINDURST) then
         player:startEvent(0x0057); -- for other nation
     else
         CurrentMission = player:getCurrentMission(WINDURST);

--- a/scripts/zones/Windurst_Waters/npcs/Ahyeekih.lua
+++ b/scripts/zones/Windurst_Waters/npcs/Ahyeekih.lua
@@ -25,7 +25,7 @@ end;
 
 function onTrigger(player,npc)
     RegionOwner = GetRegionOwner(KOLSHUSHU);
-    if (RegionOwner ~= WINDURST) then
+    if (RegionOwner ~= NATION_WINDURST) then
         player:showText(npc,AHYEEKIH_CLOSED_DIALOG);
     else
         player:showText(npc,AHYEEKIH_OPEN_DIALOG);

--- a/scripts/zones/Windurst_Waters/npcs/Baehu-Faehu.lua
+++ b/scripts/zones/Windurst_Waters/npcs/Baehu-Faehu.lua
@@ -23,7 +23,7 @@ end;
 
 function onTrigger(player,npc)
     RegionOwner = GetRegionOwner(SARUTABARUTA);
-    if (RegionOwner ~= WINDURST) then 
+    if (RegionOwner ~= NATION_WINDURST) then 
         player:showText(npc,BAEHUFAEHU_CLOSED_DIALOG);
     else
         player:showText(npc,BAEHUFAEHU_OPEN_DIALOG);

--- a/scripts/zones/Windurst_Waters/npcs/Ensasa.lua
+++ b/scripts/zones/Windurst_Waters/npcs/Ensasa.lua
@@ -43,7 +43,7 @@ function onTrigger(player,npc)
         0x005C,   905,3,     --Tarutaru Stool
         0x006E,  4744,3      --White Jar
     } 
-    showNationShop(player, WINDURST, stock);
+    showNationShop(player, NATION_WINDURST, stock);
 
 end;
 

--- a/scripts/zones/Windurst_Waters/npcs/Fomina.lua
+++ b/scripts/zones/Windurst_Waters/npcs/Fomina.lua
@@ -23,7 +23,7 @@ end;
 
 function onTrigger(player,npc)
     RegionOwner = GetRegionOwner(ELSHIMOLOWLANDS);
-    if (RegionOwner ~= WINDURST) then 
+    if (RegionOwner ~= NATION_WINDURST) then 
         player:showText(npc,FOMINA_CLOSED_DIALOG);
     else
         player:showText(npc,FOMINA_OPEN_DIALOG);

--- a/scripts/zones/Windurst_Waters/npcs/Hilkomu-Makimu.lua
+++ b/scripts/zones/Windurst_Waters/npcs/Hilkomu-Makimu.lua
@@ -43,7 +43,7 @@ function onTrigger(player,npc)
         0x1296, 22356,3,     --Scroll of Blizzard II
         0x12A5, 28520,3      --Scroll of Thunder II
     } 
-    showNationShop(player, WINDURST, stock);
+    showNationShop(player, NATION_WINDURST, stock);
 end;
 
 -----------------------------------

--- a/scripts/zones/Windurst_Waters/npcs/Jourille.lua
+++ b/scripts/zones/Windurst_Waters/npcs/Jourille.lua
@@ -23,7 +23,7 @@ end;
 
 function onTrigger(player,npc)
     RegionOwner = GetRegionOwner(RONFAURE);
-    if (RegionOwner ~= WINDURST) then 
+    if (RegionOwner ~= NATION_WINDURST) then 
         player:showText(npc,JOURILLE_CLOSED_DIALOG);
     else
         player:showText(npc,JOURILLE_OPEN_DIALOG);

--- a/scripts/zones/Windurst_Waters/npcs/Leepe-Hoppe.lua
+++ b/scripts/zones/Windurst_Waters/npcs/Leepe-Hoppe.lua
@@ -159,7 +159,7 @@ function onEventFinish(player,csid,option)
             player:messageSpecial(ITEM_OBTAINED,reward);
         end
 
-        if (player:getNation() == WINDURST and player:getRank() == 10 and player:getQuestStatus(WINDURST,THE_PROMISE) == QUEST_COMPLETED) then
+        if (player:getNation() == NATION_WINDURST and player:getRank() == 10 and player:getQuestStatus(WINDURST,THE_PROMISE) == QUEST_COMPLETED) then
             player:addKeyItem(DARK_MANA_ORB);
             player:messageSpecial(KEYITEM_OBTAINED,DARK_MANA_ORB);
         end
@@ -188,7 +188,7 @@ function onEventFinish(player,csid,option)
             player:messageSpecial(ITEM_OBTAINED,reward);
         end
 
-        if (player:getNation() == WINDURST and player:getRank() == 10 and player:getQuestStatus(WINDURST,THE_PROMISE) == QUEST_COMPLETED) then
+        if (player:getNation() == NATION_WINDURST and player:getRank() == 10 and player:getQuestStatus(WINDURST,THE_PROMISE) == QUEST_COMPLETED) then
             player:addKeyItem(DARK_MANA_ORB);
             player:messageSpecial(KEYITEM_OBTAINED,DARK_MANA_ORB);
         end

--- a/scripts/zones/Windurst_Waters/npcs/Maqu_Molpih.lua
+++ b/scripts/zones/Windurst_Waters/npcs/Maqu_Molpih.lua
@@ -25,7 +25,7 @@ end;
 
 function onTrigger(player,npc)
     RegionOwner = GetRegionOwner(ARAGONEU);
-    if (RegionOwner ~= WINDURST) then
+    if (RegionOwner ~= NATION_WINDURST) then
         player:showText(npc,MAQUMOLPIH_CLOSED_DIALOG);
     else
         player:showText(npc,MAQUMOLPIH_OPEN_DIALOG);

--- a/scripts/zones/Windurst_Waters/npcs/Mokyokyo.lua
+++ b/scripts/zones/Windurst_Waters/npcs/Mokyokyo.lua
@@ -20,7 +20,7 @@ require("scripts/zones/Windurst_Waters/TextIDs");
 
 function onTrigger(player,npc)
     
-    if (player:getNation() ~= WINDURST) then
+    if (player:getNation() ~= NATION_WINDURST) then
         player:startEvent(0x0067); -- for other nation
     else
         CurrentMission = player:getCurrentMission(WINDURST);

--- a/scripts/zones/Windurst_Waters/npcs/Ness_Rugetomal.lua
+++ b/scripts/zones/Windurst_Waters/npcs/Ness_Rugetomal.lua
@@ -40,7 +40,7 @@ function onTrigger(player,npc)
         0x119D,    10,3,     --Distilled Water
         0x11BA,   846,3      --Roast Pipira
     }
-    showNationShop(player, WINDURST, stock);
+    showNationShop(player, NATION_WINDURST, stock);
 
 end;
 

--- a/scripts/zones/Windurst_Waters/npcs/Orez-Ebrez.lua
+++ b/scripts/zones/Windurst_Waters/npcs/Orez-Ebrez.lua
@@ -43,7 +43,7 @@ function onTrigger(player,npc)
         0x30A0,   151,3,     --Bronze Cap
         0x30A1,  1471,3      --Brass Cap
     } 
-    showNationShop(player, WINDURST, stock);
+    showNationShop(player, NATION_WINDURST, stock);
 
 end;
 

--- a/scripts/zones/Windurst_Waters/npcs/Otete.lua
+++ b/scripts/zones/Windurst_Waters/npcs/Otete.lua
@@ -23,7 +23,7 @@ end;
 
 function onTrigger(player,npc)
     RegionOwner = GetRegionOwner(LITELOR);
-    if (RegionOwner ~= WINDURST) then 
+    if (RegionOwner ~= NATION_WINDURST) then 
         player:showText(npc,OTETE_CLOSED_DIALOG);
     else
         player:showText(npc,OTETE_OPEN_DIALOG);

--- a/scripts/zones/Windurst_Waters/npcs/Prestapiq.lua
+++ b/scripts/zones/Windurst_Waters/npcs/Prestapiq.lua
@@ -23,7 +23,7 @@ end;
 
 function onTrigger(player,npc)
     RegionOwner = GetRegionOwner(MOVALPOLOS);
-    if (RegionOwner ~= WINDURST) then 
+    if (RegionOwner ~= NATION_WINDURST) then 
         player:showText(npc,PRESTAPIQ_CLOSED_DIALOG);
     else
         player:showText(npc,PRESTAPIQ_OPEN_DIALOG);

--- a/scripts/zones/Windurst_Waters/npcs/Puroiko-Maiko_WW.lua
+++ b/scripts/zones/Windurst_Waters/npcs/Puroiko-Maiko_WW.lua
@@ -15,7 +15,7 @@ require("scripts/globals/conquest");
 require("scripts/globals/common");
 require("scripts/zones/Windurst_Waters/TextIDs");
 
-local guardnation = WINDURST; -- SANDORIA, BASTOK, WINDURST, JEUNO
+local guardnation = NATION_WINDURST; -- SANDORIA, BASTOK, WINDURST, JEUNO
 local guardtype   = 1;        -- 1: city, 2: foreign, 3: outpost, 4: border
 local size      = table.getn(WindInv);
 local inventory = WindInv;

--- a/scripts/zones/Windurst_Waters/npcs/Shohrun-Tuhrun.lua
+++ b/scripts/zones/Windurst_Waters/npcs/Shohrun-Tuhrun.lua
@@ -43,7 +43,7 @@ function onTrigger(player,npc)
         0x1280, 74520,3,     --Scroll of Protectra IV
         0x1304, 64400,3      --Scroll of Dispel
     }
-    showNationShop(player, WINDURST, stock);
+    showNationShop(player, NATION_WINDURST, stock);
 
 end;
 

--- a/scripts/zones/Windurst_Waters/npcs/Taajiji.lua
+++ b/scripts/zones/Windurst_Waters/npcs/Taajiji.lua
@@ -42,7 +42,7 @@ function onTrigger(player,npc)
         0x118D,   184,3,     --Windurstian Tea
         0x11CB,  1711,3      --Windurst Salad
     }
-    showNationShop(player, WINDURST, stock);
+    showNationShop(player, NATION_WINDURST, stock);
 
 end;
 

--- a/scripts/zones/Windurst_Waters/npcs/Upih_Khachla.lua
+++ b/scripts/zones/Windurst_Waters/npcs/Upih_Khachla.lua
@@ -45,7 +45,7 @@ function onTrigger(player,npc)
         0x04D9,   354,3      --Twinkle Powder
     }               
 
-    rank = getNationRank(WINDURST);
+    rank = getNationRank(NATION_WINDURST);
     if (rank ~= 1) then
         table.insert(stock,0x03fe); --Thief's Tools
         table.insert(stock,3643);
@@ -56,7 +56,7 @@ function onTrigger(player,npc)
         table.insert(stock,5520);
         table.insert(stock,3);
     end
-    showNationShop(player, WINDURST, stock);
+    showNationShop(player, NATION_WINDURST, stock);
 
 end;
 

--- a/scripts/zones/Windurst_Woods/npcs/Apururu.lua
+++ b/scripts/zones/Windurst_Woods/npcs/Apururu.lua
@@ -107,7 +107,7 @@ local MissionStatus = player:getVar("MissionStatus");
             end
         
     -- Can Cardians Cry?
-    elseif (ANC3K == QUEST_COMPLETED and C3 == QUEST_AVAILABLE and player:getFameLevel (WINDURST) >= 5) then
+    elseif (ANC3K == QUEST_COMPLETED and C3 == QUEST_AVAILABLE and player:getFameLevel(WINDURST) >= 5) then
         player:startEvent(0x013F,0,6000); -- start C3
     elseif (C3 == QUEST_ACCEPTED) then
         player:startEvent(0x0140,0,6000); -- C3 reminder

--- a/scripts/zones/Windurst_Woods/npcs/Bin_Stejihna.lua
+++ b/scripts/zones/Windurst_Woods/npcs/Bin_Stejihna.lua
@@ -23,12 +23,12 @@ end;
 
 function onTrigger(player,npc)
     RegionOwner = GetRegionOwner(ZULKHEIM);
-    if (RegionOwner ~= WINDURST) then 
+    if (RegionOwner ~= NATION_WINDURST) then 
         player:showText(npc,BIN_STEJIHNA_CLOSED_DIALOG);
     else
         player:showText(npc,BIN_STEJIHNA_OPEN_DIALOG);
 
-        rank = getNationRank(BASTOK);
+        rank = getNationRank(NATION_WINDURST);
         if (rank ~= 3) then
             table.insert(stock,0x0730); --Semolina
             table.insert(stock,1840);

--- a/scripts/zones/Windurst_Woods/npcs/Harara_WW.lua
+++ b/scripts/zones/Windurst_Woods/npcs/Harara_WW.lua
@@ -16,7 +16,7 @@ require("scripts/globals/conquest");
 require("scripts/globals/common");
 require("scripts/zones/Windurst_Woods/TextIDs");
 
-local guardnation = WINDURST; -- SANDORIA, BASTOK, WINDURST, JEUNO
+local guardnation = NATION_WINDURST; -- SANDORIA, BASTOK, WINDURST, JEUNO
 local guardtype   = 1;        -- 1: city, 2: foreign, 3: outpost, 4: border
 local size      = table.getn(WindInv);
 local inventory = WindInv;

--- a/scripts/zones/Windurst_Woods/npcs/Kopuro-Popuro.lua
+++ b/scripts/zones/Windurst_Woods/npcs/Kopuro-Popuro.lua
@@ -77,7 +77,7 @@ local LPB = player:getQuestStatus(WINDURST,LEGENDARY_PLAN_B);
 local ANC3K = player:getQuestStatus(WINDURST,THE_ALL_NEW_C_3000);
 
     -- The All New C-3000
-    if (LPB == QUEST_COMPLETED and ANC3K == QUEST_AVAILABLE and player:getFameLevel (WINDURST) >= 4) then
+    if (LPB == QUEST_COMPLETED and ANC3K == QUEST_AVAILABLE and player:getFameLevel(WINDURST) >= 4) then
         if (player:needToZone()) then
             player:startEvent(0x013c); -- Post quest text from LPB
         else
@@ -93,7 +93,7 @@ local ANC3K = player:getQuestStatus(WINDURST,THE_ALL_NEW_C_3000);
         player:startEvent(0x012D); -- Supplemental text when AGreetingCardian in progress, right before completion
     
     -- Legendary Plan B
-    elseif (AGreetingCardian == QUEST_COMPLETED and LPB == QUEST_AVAILABLE and player:getFameLevel (WINDURST) >= 3) then
+    elseif (AGreetingCardian == QUEST_COMPLETED and LPB == QUEST_AVAILABLE and player:getFameLevel(WINDURST) >= 3) then
         if (player:needToZone()) then
             player:startEvent(0x0132); -- Supplemental text for AGreetingCardian before start of LPB
         else

--- a/scripts/zones/Windurst_Woods/npcs/Kororo.lua
+++ b/scripts/zones/Windurst_Woods/npcs/Kororo.lua
@@ -37,7 +37,7 @@ local AGCcs = player:getVar("AGreetingCardian_Event");
 local AGCtime = player:getVar("AGreetingCardian_timer");
     
     -- A Greeting Cardian 
-    if (C2000 == QUEST_COMPLETED and AGreetingCardian == QUEST_AVAILABLE and player:getFameLevel (WINDURST) >= 3) then
+    if (C2000 == QUEST_COMPLETED and AGreetingCardian == QUEST_AVAILABLE and player:getFameLevel(WINDURST) >= 3) then
         player:startEvent(0x0128); -- A Greeting Cardian quest start
     elseif (AGreetingCardian == QUEST_ACCEPTED and AGCcs == 3) then
         if (player:needToZone() or tonumber(os.date("%j")) == AGCtime) then

--- a/scripts/zones/Windurst_Woods/npcs/Kuoh_Rhel.lua
+++ b/scripts/zones/Windurst_Woods/npcs/Kuoh_Rhel.lua
@@ -34,7 +34,7 @@ function onTrigger(player,npc)
     IASvar = player:getVar("IASvar");
     
     -- In a Stew
-    if (IAS == QUEST_AVAILABLE and chocobilious == QUEST_COMPLETED and player:getFameLevel (WINDURST) >= 3) then
+    if (IAS == QUEST_AVAILABLE and chocobilious == QUEST_COMPLETED and player:getFameLevel(WINDURST) >= 3) then
         if (player:needToZone()) then
             player:startEvent(0x00E8); -- Post quest dialog from Chocobilious
         else

--- a/scripts/zones/Windurst_Woods/npcs/Millerovieunet.lua
+++ b/scripts/zones/Windurst_Woods/npcs/Millerovieunet.lua
@@ -25,7 +25,7 @@ end;
 -----------------------------------
 
 function onTrigger(player,npc)
-    if (GetRegionOwner(QUFIMISLAND) ~= WINDURST) then
+    if (GetRegionOwner(QUFIMISLAND) ~= NATION_WINDURST) then
         player:showText(npc,MILLEROVIEUNET_CLOSED_DIALOG);
     else
         player:showText(npc,MILLEROVIEUNET_OPEN_DIALOG);

--- a/scripts/zones/Windurst_Woods/npcs/Mono_Nchaa.lua
+++ b/scripts/zones/Windurst_Woods/npcs/Mono_Nchaa.lua
@@ -32,7 +32,7 @@ function onTrigger(player,npc)
         0x43B8,     5,3,     --Crossbow Bolt
         0x1391,  2649,3      --Scroll of Hunter's Prelude
     }
-    showNationShop(player, WINDURST, stock);
+    showNationShop(player, NATION_WINDURST, stock);
 
 end; 
 

--- a/scripts/zones/Windurst_Woods/npcs/Nanaa_Mihgo.lua
+++ b/scripts/zones/Windurst_Woods/npcs/Nanaa_Mihgo.lua
@@ -125,7 +125,7 @@ function onTrigger(player,npc)
         
         
         -- Rock Racketeer (listed as ROCK_RACKETTER in quests.lua)
-        elseif (MihgosAmigo == QUEST_COMPLETED and RockRacketeer == QUEST_AVAILABLE and player:getFameLevel (WINDURST) >= 3) then
+        elseif (MihgosAmigo == QUEST_COMPLETED and RockRacketeer == QUEST_AVAILABLE and player:getFameLevel(WINDURST) >= 3) then
             if (player:needToZone()) then
                 player:startEvent(0x0059); -- Mihgos Amigo complete text
             else

--- a/scripts/zones/Windurst_Woods/npcs/Nhobi_Zalkia.lua
+++ b/scripts/zones/Windurst_Woods/npcs/Nhobi_Zalkia.lua
@@ -25,7 +25,7 @@ end;
 
 function onTrigger(player,npc)
     RegionOwner = GetRegionOwner(KUZOTZ);
-    if (RegionOwner ~= WINDURST) then
+    if (RegionOwner ~= NATION_WINDURST) then
         player:showText(npc,NHOBI_ZALKIA_CLOSED_DIALOG);
     else
         player:showText(npc,NHOBI_ZALKIA_OPEN_DIALOG);

--- a/scripts/zones/Windurst_Woods/npcs/Nya_Labiccio.lua
+++ b/scripts/zones/Windurst_Woods/npcs/Nya_Labiccio.lua
@@ -23,7 +23,7 @@ end;
 
 function onTrigger(player,npc)
     RegionOwner = GetRegionOwner(GUSTABERG);
-    if (RegionOwner ~= WINDURST) then 
+    if (RegionOwner ~= NATION_WINDURST) then 
         player:showText(npc,NYALABICCIO_CLOSED_DIALOG);
     else
         player:showText(npc,NYALABICCIO_OPEN_DIALOG);

--- a/scripts/zones/Windurst_Woods/npcs/Panoquieur_TK.lua
+++ b/scripts/zones/Windurst_Woods/npcs/Panoquieur_TK.lua
@@ -16,7 +16,7 @@ require("scripts/globals/conquest");
 require("scripts/globals/common");
 require("scripts/zones/Windurst_Woods/TextIDs");
 
-local guardnation = SANDORIA; -- SANDORIA, BASTOK, WINDURST, JEUNO
+local guardnation = NATION_SANDORIA; -- SANDORIA, BASTOK, WINDURST, JEUNO
 local guardtype   = 2;        -- 1: city, 2: foreign, 3: outpost, 4: border
 local size        = table.getn(SandInv);
 local inventory   = SandInv;

--- a/scripts/zones/Windurst_Woods/npcs/Quesse.lua
+++ b/scripts/zones/Windurst_Woods/npcs/Quesse.lua
@@ -38,7 +38,7 @@ function onTrigger(player,npc)
         0x45CA,   695,3,     --Carrion Broth
         0x13D1, 50784,3      --Scroll of Chocobo Mazurka
     } 
-    showNationShop(player, WINDURST, stock);
+    showNationShop(player, NATION_WINDURST, stock);
 
 end; 
 

--- a/scripts/zones/Windurst_Woods/npcs/Rakoh_Buuma.lua
+++ b/scripts/zones/Windurst_Woods/npcs/Rakoh_Buuma.lua
@@ -20,7 +20,7 @@ require("scripts/zones/Windurst_Woods/TextIDs");
 
 function onTrigger(player,npc)
     
-    if (player:getNation() ~= WINDURST) then
+    if (player:getNation() ~= NATION_WINDURST) then
         player:startEvent(0x0069); -- for other nation
     else
         CurrentMission = player:getCurrentMission(WINDURST);

--- a/scripts/zones/Windurst_Woods/npcs/Taraihi-Perunhi.lua
+++ b/scripts/zones/Windurst_Woods/npcs/Taraihi-Perunhi.lua
@@ -25,7 +25,7 @@ end;
 
 function onTrigger(player,npc)
     RegionOwner = GetRegionOwner(DERFLAND);
-    if (RegionOwner ~= WINDURST) then
+    if (RegionOwner ~= NATION_WINDURST) then
         player:showText(npc,TARAIHIPERUNHI_CLOSED_DIALOG);
     else
         player:showText(npc,TARAIHIPERUNHI_OPEN_DIALOG);

--- a/scripts/zones/Xarcabard/npcs/Heavy_Bear_IM.lua
+++ b/scripts/zones/Xarcabard/npcs/Heavy_Bear_IM.lua
@@ -10,7 +10,7 @@ package.loaded["scripts/zones/Xarcabard/TextIDs"] = nil;
 require("scripts/globals/conquest");
 require("scripts/zones/Xarcabard/TextIDs");
 
-local guardnation = BASTOK; -- SANDORIA, BASTOK, WINDURST, 4 = jeuno
+local guardnation = NATION_BASTOK; -- SANDORIA, BASTOK, WINDURST, 4 = jeuno
 local guardtype   = 4;      -- 1: city, 2: foreign, 3: outpost, 4: border
 local region      = VALDEAUNIA;
 local csid        = 0x7ff8;

--- a/scripts/zones/Xarcabard/npcs/Jeantelas_RK.lua
+++ b/scripts/zones/Xarcabard/npcs/Jeantelas_RK.lua
@@ -10,7 +10,7 @@ package.loaded["scripts/zones/Xarcabard/TextIDs"] = nil;
 require("scripts/globals/conquest");
 require("scripts/zones/Xarcabard/TextIDs");
 
-local guardnation = SANDORIA; -- SANDORIA, BASTOK, WINDURST, 4 = jeuno
+local guardnation = NATION_SANDORIA; -- SANDORIA, BASTOK, WINDURST, 4 = jeuno
 local guardtype   = 3;        -- 1: city, 2: foreign, 3: outpost, 4: border
 local region      = VALDEAUNIA;
 local csid        = 0x7ffb;

--- a/scripts/zones/Xarcabard/npcs/Kaya_IM.lua
+++ b/scripts/zones/Xarcabard/npcs/Kaya_IM.lua
@@ -10,7 +10,7 @@ package.loaded["scripts/zones/Xarcabard/TextIDs"] = nil;
 require("scripts/globals/conquest");
 require("scripts/zones/Xarcabard/TextIDs");
 
-local guardnation = BASTOK; -- SANDORIA, BASTOK, WINDURST, 4 = jeuno
+local guardnation = NATION_BASTOK; -- SANDORIA, BASTOK, WINDURST, 4 = jeuno
 local guardtype   = 3;      -- 1: city, 2: foreign, 3: outpost, 4: border
 local region      = VALDEAUNIA;
 local csid        = 0x7ff9;

--- a/scripts/zones/Xarcabard/npcs/Magumo-Yagimo_WW.lua
+++ b/scripts/zones/Xarcabard/npcs/Magumo-Yagimo_WW.lua
@@ -10,7 +10,7 @@ package.loaded["scripts/zones/Xarcabard/TextIDs"] = nil;
 require("scripts/globals/conquest");
 require("scripts/zones/Xarcabard/TextIDs");
 
-local guardnation = WINDURST; -- SANDORIA, BASTOK, WINDURST, 4 = jeuno
+local guardnation = NATION_WINDURST; -- SANDORIA, BASTOK, WINDURST, 4 = jeuno
 local guardtype   = 3;        -- 1: city, 2: foreign, 3: outpost, 4: border
 local region      = VALDEAUNIA;
 local csid        = 0x7ff7;

--- a/scripts/zones/Xarcabard/npcs/Pilcha_RK.lua
+++ b/scripts/zones/Xarcabard/npcs/Pilcha_RK.lua
@@ -10,7 +10,7 @@ package.loaded["scripts/zones/Xarcabard/TextIDs"] = nil;
 require("scripts/globals/conquest");
 require("scripts/zones/Xarcabard/TextIDs");
 
-local guardnation = SANDORIA; -- SANDORIA, BASTOK, WINDURST, 4 = jeuno
+local guardnation = NATION_SANDORIA; -- SANDORIA, BASTOK, WINDURST, 4 = jeuno
 local guardtype   = 4;        -- 1: city, 2: foreign, 3: outpost, 4: border
 local region      = VALDEAUNIA;
 local csid        = 0x7ffa;

--- a/scripts/zones/Xarcabard/npcs/Tememe_WW.lua
+++ b/scripts/zones/Xarcabard/npcs/Tememe_WW.lua
@@ -10,7 +10,7 @@ package.loaded["scripts/zones/Xarcabard/TextIDs"] = nil;
 require("scripts/globals/conquest");
 require("scripts/zones/Xarcabard/TextIDs");
 
-local guardnation = WINDURST; -- SANDORIA, BASTOK, WINDURST, 4 = jeuno
+local guardnation = NATION_WINDURST; -- SANDORIA, BASTOK, WINDURST, 4 = jeuno
 local guardtype   = 4;        -- 1: city, 2: foreign, 3: outpost, 4: border
 local region      = VALDEAUNIA;
 local csid        = 0x7ff6;

--- a/scripts/zones/Yhoator_Jungle/npcs/Emila_RK.lua
+++ b/scripts/zones/Yhoator_Jungle/npcs/Emila_RK.lua
@@ -10,7 +10,7 @@ package.loaded["scripts/zones/Yhoator_Jungle/TextIDs"] = nil;
 require("scripts/globals/conquest");
 require("scripts/zones/Yhoator_Jungle/TextIDs");
 
-local guardnation = SANDORIA; -- SANDORIA, BASTOK, WINDURST, 4 = jeuno
+local guardnation = NATION_SANDORIA; -- SANDORIA, BASTOK, WINDURST, 4 = jeuno
 local guardtype   = 4;        -- 1: city, 2: foreign, 3: outpost, 4: border
 local region      = ELSHIMOUPLANDS;
 local csid        = 0x7ffa;

--- a/scripts/zones/Yhoator_Jungle/npcs/Etaj-Pohtaj_WW.lua
+++ b/scripts/zones/Yhoator_Jungle/npcs/Etaj-Pohtaj_WW.lua
@@ -10,7 +10,7 @@ package.loaded["scripts/zones/Yhoator_Jungle/TextIDs"] = nil;
 require("scripts/globals/conquest");
 require("scripts/zones/Yhoator_Jungle/TextIDs");
 
-local guardnation = WINDURST; -- SANDORIA, BASTOK, WINDURST, 4 = jeuno
+local guardnation = NATION_WINDURST; -- SANDORIA, BASTOK, WINDURST, 4 = jeuno
 local guardtype   = 3;        -- 1: city, 2: foreign, 3: outpost, 4: border
 local region      = ELSHIMOUPLANDS;
 local csid        = 0x7ff7;

--- a/scripts/zones/Yhoator_Jungle/npcs/Ghantata_WW.lua
+++ b/scripts/zones/Yhoator_Jungle/npcs/Ghantata_WW.lua
@@ -10,7 +10,7 @@ package.loaded["scripts/zones/Yhoator_Jungle/TextIDs"] = nil;
 require("scripts/globals/conquest");
 require("scripts/zones/Yhoator_Jungle/TextIDs");
 
-local guardnation = WINDURST; -- SANDORIA, BASTOK, WINDURST, 4 = jeuno
+local guardnation = NATION_WINDURST; -- SANDORIA, BASTOK, WINDURST, 4 = jeuno
 local guardtype   = 4;        -- 1: city, 2: foreign, 3: outpost, 4: border
 local region      = ELSHIMOUPLANDS;
 local csid        = 0x7ff6;

--- a/scripts/zones/Yhoator_Jungle/npcs/Guddal_IM.lua
+++ b/scripts/zones/Yhoator_Jungle/npcs/Guddal_IM.lua
@@ -10,7 +10,7 @@ package.loaded["scripts/zones/Yhoator_Jungle/TextIDs"] = nil;
 require("scripts/globals/conquest");
 require("scripts/zones/Yhoator_Jungle/TextIDs");
 
-local guardnation = BASTOK; -- SANDORIA, BASTOK, WINDURST, 4 = jeuno
+local guardnation = NATION_BASTOK; -- SANDORIA, BASTOK, WINDURST, 4 = jeuno
 local guardtype   = 4;      -- 1: city, 2: foreign, 3: outpost, 4: border
 local region      = ELSHIMOUPLANDS;
 local csid        = 0x7ff8;

--- a/scripts/zones/Yhoator_Jungle/npcs/Ilieumort_RK.lua
+++ b/scripts/zones/Yhoator_Jungle/npcs/Ilieumort_RK.lua
@@ -10,7 +10,7 @@ package.loaded["scripts/zones/Yhoator_Jungle/TextIDs"] = nil;
 require("scripts/globals/conquest");
 require("scripts/zones/Yhoator_Jungle/TextIDs");
 
-local guardnation = SANDORIA; -- SANDORIA, BASTOK, WINDURST, 4 = jeuno
+local guardnation = NATION_SANDORIA; -- SANDORIA, BASTOK, WINDURST, 4 = jeuno
 local guardtype   = 3;        -- 1: city, 2: foreign, 3: outpost, 4: border
 local region      = ELSHIMOUPLANDS;
 local csid        = 0x7ffb;

--- a/scripts/zones/Yhoator_Jungle/npcs/Mintoo_IM.lua
+++ b/scripts/zones/Yhoator_Jungle/npcs/Mintoo_IM.lua
@@ -10,7 +10,7 @@ package.loaded["scripts/zones/Yhoator_Jungle/TextIDs"] = nil;
 require("scripts/globals/conquest");
 require("scripts/zones/Yhoator_Jungle/TextIDs");
 
-local guardnation = BASTOK; -- SANDORIA, BASTOK, WINDURST, 4 = jeuno
+local guardnation = NATION_BASTOK; -- SANDORIA, BASTOK, WINDURST, 4 = jeuno
 local guardtype   = 3;      -- 1: city, 2: foreign, 3: outpost, 4: border
 local region      = ELSHIMOUPLANDS;
 local csid        = 0x7ff9;

--- a/scripts/zones/Yuhtunga_Jungle/npcs/Bammiro_IM.lua
+++ b/scripts/zones/Yuhtunga_Jungle/npcs/Bammiro_IM.lua
@@ -10,7 +10,7 @@ package.loaded["scripts/zones/Yuhtunga_Jungle/TextIDs"] = nil;
 require("scripts/globals/conquest");
 require("scripts/zones/Yuhtunga_Jungle/TextIDs");
 
-local guardnation = BASTOK; -- SANDORIA, BASTOK, WINDURST, 4 = jeuno
+local guardnation = NATION_BASTOK; -- SANDORIA, BASTOK, WINDURST, 4 = jeuno
 local guardtype   = 4;      -- 1: city, 2: foreign, 3: outpost, 4: border
 local region      = ELSHIMOLOWLANDS;
 local csid        = 0x7ff8;

--- a/scripts/zones/Yuhtunga_Jungle/npcs/Mahol_IM.lua
+++ b/scripts/zones/Yuhtunga_Jungle/npcs/Mahol_IM.lua
@@ -10,7 +10,7 @@ package.loaded["scripts/zones/Yuhtunga_Jungle/TextIDs"] = nil;
 require("scripts/globals/conquest");
 require("scripts/zones/Yuhtunga_Jungle/TextIDs");
 
-local guardnation = BASTOK; -- SANDORIA, BASTOK, WINDURST, 4 = jeuno
+local guardnation = NATION_BASTOK; -- SANDORIA, BASTOK, WINDURST, 4 = jeuno
 local guardtype   = 3;      -- 1: city, 2: foreign, 3: outpost, 4: border
 local region      = ELSHIMOLOWLANDS;
 local csid        = 0x7ff9;

--- a/scripts/zones/Yuhtunga_Jungle/npcs/Mupia_RK.lua
+++ b/scripts/zones/Yuhtunga_Jungle/npcs/Mupia_RK.lua
@@ -10,7 +10,7 @@ package.loaded["scripts/zones/Yuhtunga_Jungle/TextIDs"] = nil;
 require("scripts/globals/conquest");
 require("scripts/zones/Yuhtunga_Jungle/TextIDs");
 
-local guardnation = SANDORIA; -- SANDORIA, BASTOK, WINDURST, 4 = jeuno
+local guardnation = NATION_SANDORIA; -- SANDORIA, BASTOK, WINDURST, 4 = jeuno
 local guardtype   = 4;        -- 1: city, 2: foreign, 3: outpost, 4: border
 local region      = ELSHIMOLOWLANDS;
 local csid        = 0x7ffa;

--- a/scripts/zones/Yuhtunga_Jungle/npcs/Richacha_WW.lua
+++ b/scripts/zones/Yuhtunga_Jungle/npcs/Richacha_WW.lua
@@ -10,7 +10,7 @@ package.loaded["scripts/zones/Yuhtunga_Jungle/TextIDs"] = nil;
 require("scripts/globals/conquest");
 require("scripts/zones/Yuhtunga_Jungle/TextIDs");
 
-local guardnation = WINDURST; -- SANDORIA, BASTOK, WINDURST, 4 = jeuno
+local guardnation = NATION_WINDURST; -- SANDORIA, BASTOK, WINDURST, 4 = jeuno
 local guardtype   = 4;        -- 1: city, 2: foreign, 3: outpost, 4: border
 local region      = ELSHIMOLOWLANDS;
 local csid        = 0x7ff6;

--- a/scripts/zones/Yuhtunga_Jungle/npcs/Uphra-Kophra_WW.lua
+++ b/scripts/zones/Yuhtunga_Jungle/npcs/Uphra-Kophra_WW.lua
@@ -10,7 +10,7 @@ package.loaded["scripts/zones/Yuhtunga_Jungle/TextIDs"] = nil;
 require("scripts/globals/conquest");
 require("scripts/zones/Yuhtunga_Jungle/TextIDs");
 
-local guardnation = WINDURST; -- SANDORIA, BASTOK, WINDURST, 4 = jeuno
+local guardnation = NATION_WINDURST; -- SANDORIA, BASTOK, WINDURST, 4 = jeuno
 local guardtype   = 3;        -- 1: city, 2: foreign, 3: outpost, 4: border
 local region      = ELSHIMOLOWLANDS;
 local csid        = 0x7ff7;

--- a/scripts/zones/Yuhtunga_Jungle/npcs/Zorchorevi_RK.lua
+++ b/scripts/zones/Yuhtunga_Jungle/npcs/Zorchorevi_RK.lua
@@ -10,7 +10,7 @@ package.loaded["scripts/zones/Yuhtunga_Jungle/TextIDs"] = nil;
 require("scripts/globals/conquest");
 require("scripts/zones/Yuhtunga_Jungle/TextIDs");
 
-local guardnation = SANDORIA; -- SANDORIA, BASTOK, WINDURST, 4 = jeuno
+local guardnation = NATION_SANDORIA; -- SANDORIA, BASTOK, WINDURST, 4 = jeuno
 local guardtype   = 3;        -- 1: city, 2: foreign, 3: outpost, 4: border
 local region      = ELSHIMOLOWLANDS;
 local csid        = 0x7ffb;


### PR DESCRIPTION
As I mentioned in #3292, a lot of conquest and nation-related NPCs use integer constants to represent nations. Since these constants are (currently) simply `SANDORIA`, `BASTOK`, and `WINDURST`, this prevents those variables from being repurposed into tables for quests and missions (or anything else for that matter), because doing so would break aforementioned NPCs.

So as an initial step in the goal of table-lizing quest/mission variables, I've separated references to nations in the context of Conquest and checking the player's home nation (variables now given an enum-esque prefix of `NATION_`) from references to areas in the context of quests and missions (left alone). Now the variables for those two contexts can be modified later without influencing each other.