### PR TITLE
Correct the maximum value allowed in the aggro column of mob pools..

### DIFF
--- a/sql/mob_pools.sql
+++ b/sql/mob_pools.sql
@@ -33,7 +33,7 @@ CREATE TABLE `mob_pools` (
   `cmbDelay` smallint(3) unsigned NOT NULL DEFAULT '240',
   `cmbDmgMult` smallint(4) unsigned NOT NULL DEFAULT '100',
   `behavior` smallint(5) unsigned NOT NULL DEFAULT '0',
-  `aggro` tinyint(1) unsigned NOT NULL DEFAULT '0',
+  `aggro` smallint(3) unsigned NOT NULL DEFAULT '0',
   `true_detection` tinyint(1) unsigned NOT NULL DEFAULT '0',
   `links` tinyint(1) unsigned NOT NULL DEFAULT '0',
   `mobType` smallint(5) unsigned NOT NULL DEFAULT '0',


### PR DESCRIPTION
..It was defined as tinyint which stops at 255 for unsigned values, but the maximum flag value currently defined is 256, using all flags at once even higher..Thus we need smallint here.