### PR TITLE
Update getMagicHitRate to be SJ aware

### DIFF
--- a/scripts/globals/magic.lua
+++ b/scripts/globals/magic.lua
@@ -403,7 +403,10 @@ function getMagicHitRate(caster, target, skillType, element, percentBonus, bonus
 
     magicacc = magicacc + bonusAcc;
 
-    return calculateMagicHitRate(magicacc, magiceva, percentBonus, caster:getMainLvl(), target:getMainLvl());
+    if (caster:getMaxSkillLevel(skillType,caster:getMainJob(),caster:getMainlvl()) == 0) --player is using a subjob spell
+        return calculateMagicHitRate(magicacc, magiceva, percentBonus, caster:getSubLvl(), target:getMainLvl()); --use subjob for resist
+    else
+        return calculateMagicHitRate(magicacc, magiceva, percentBonus, caster:getMainLvl(), target:getMainLvl());  --this is a main job skill, use main job level
 end
 
 function calculateMagicHitRate(magicacc, magiceva, percentBonus, casterLvl, targetLvl)


### PR DESCRIPTION
Currently uses main level regardless of whether main has the skill or not. This change will take into account if it is from a sub and use the appropriate level. Ie 75SAM/37BLM should not have the same resist rate based on level differential as 75BLM/37RDM
Logic pulled from Hozu's commit for Spell Interrupt
Yes, I'm aware there's an odd space. i think the old one was a tab I forgot to fix. Sorry