### PR TITLE
Update Condition for New Players to flag ZM1

### DIFF
--- a/scripts/zones/Throne_Room/bcnms/shadow_lord_battle.lua
+++ b/scripts/zones/Throne_Room/bcnms/shadow_lord_battle.lua
@@ -53,7 +53,7 @@ function onEventFinish(player,csid,option)
     
     if (csid == 0x7d01) then
         if (player:getCurrentMission(player:getNation()) == 15 and player:getVar("MissionStatus") == 3) then
-            if (player:getCurrentMission(ZILART) < THE_NEW_FRONTIER) then
+            if (player:getCurrentMission(ZILART) == 255) then
                 -- Don't add missions we already completed..Players who change nation will hit this.
                 player:addMission(ZILART,THE_NEW_FRONTIER);
             end

--- a/src/map/lua/lua_baseentity.cpp
+++ b/src/map/lua/lua_baseentity.cpp
@@ -167,6 +167,47 @@ inline int32 CLuaBaseEntity::leavegame(lua_State *L)
 }
 
 //==========================================================//
+inline int32 CLuaBaseEntity::AddLinkpearl(lua_State* L)
+{
+    DSP_DEBUG_BREAK_IF(m_PBaseEntity->objtype == TYPE_NPC);
+
+    const int8* linkshellName = lua_tostring(L, 1);
+    const int8* Query = "SELECT name FROM linkshells WHERE name='%s'";
+    int32 ret = Sql_Query(SqlHandle, Query, linkshellName);
+
+    if (ret != SQL_ERROR && Sql_NumRows(SqlHandle) != 0 && Sql_NextRow(SqlHandle) == SQL_SUCCESS)
+    {
+        CCharEntity* PChar = (CCharEntity*)m_PBaseEntity;
+        uint8 invSlotID = charutils::AddItem(PChar, LOC_INVENTORY, 515, 1);
+        CItem* PItem = PChar->getStorage(LOC_INVENTORY)->GetItem(invSlotID);
+
+        if (PItem != NULL)
+        {
+            std::string qStr = ("UPDATE char_inventory SET signature='");
+            qStr += linkshellName;
+            qStr += "' WHERE charid = " + std::to_string(PChar->id);
+            qStr += " AND itemId = 515 AND signature = ''";
+            Sql_Query(SqlHandle, qStr.c_str());
+
+            Query = "SELECT linkshellid,color FROM linkshells WHERE name='%s'";
+            ret = Sql_Query(SqlHandle, Query, linkshellName);
+            if (ret != SQL_ERROR && Sql_NumRows(SqlHandle) != 0 && Sql_NextRow(SqlHandle) == SQL_SUCCESS)
+            {
+                CItemLinkshell* PLinkshell = NULL;
+
+                // Update item with name & color //
+                int8 EncodedString[16];
+                EncodeStringLinkshell((int8*)linkshellName, EncodedString);
+                PItem->setSignature(EncodedString);
+                ((CItemLinkshell*)PItem)->SetLSID(Sql_GetUIntData(SqlHandle, 0));
+                ((CItemLinkshell*)PItem)->SetLSColor(Sql_GetIntData(SqlHandle, 2));
+
+			}  
+          }
+    }
+
+    return 1;
+}
 
 inline int32 CLuaBaseEntity::ChangeMusic(lua_State *L)
 {


### PR DESCRIPTION
Previously this caused ZM1 not to be flagged. Changed the condition to add ZM1 to a new player. Having no mission has a value of 255.