### PR TITLE
Change condition to add ZM1

### DIFF
--- a/scripts/zones/Throne_Room/bcnms/shadow_lord_battle.lua
+++ b/scripts/zones/Throne_Room/bcnms/shadow_lord_battle.lua
@@ -53,7 +53,7 @@ function onEventFinish(player,csid,option)
     
     if (csid == 0x7d01) then
         if (player:getCurrentMission(player:getNation()) == 15 and player:getVar("MissionStatus") == 3) then
-            if (player:getCurrentMission(ZILART) < THE_NEW_FRONTIER) then
+            if ((not player:hasCompletedMission(ZILART, THE_NEW_FRONTIER) and (player:getCurrentMission(ZILART) ~= THE_NEW_FRONTIER) then
                 -- Don't add missions we already completed..Players who change nation will hit this.
                 player:addMission(ZILART,THE_NEW_FRONTIER);
             end


### PR DESCRIPTION
Previously the condition checked if current Zilart mission was less than ZM1. Player having no mission had a value of 255 and failed this condition and ZM1 wasn't added.

The above condition will check if the player has not completed the mission and the current Zilart mission isn't THE_NEW_FRONTIER.

Thanks to ibm2431 for the suggestion.