### PR TITLE
Party exp outside heals

### DIFF
--- a/src/map/enmity_container.cpp
+++ b/src/map/enmity_container.cpp
@@ -123,10 +123,21 @@ void CEnmityContainer::UpdateEnmity(CBattleEntity* PEntity, int16 CE, int16 VE, 
         CE = 0;
         VE = 0;
     }
-
-    auto PMob = dynamic_cast<CMobEntity*>(m_EnmityHolder);
-    if (PMob && PMob->m_HiPCLvl < PEntity->GetMLevel())
-        PMob->m_HiPCLvl = PEntity->GetMLevel();
+	
+	// Set mob highest level PC attacker to that of the person with enmity if they are solo, a party member, or alliance member (Fixes spell only kills not getting FoV/GoV credit)
+	auto PChar = static_cast<CCharEntity*>(PEntity);
+	auto PMob = dynamic_cast<CMobEntity*>(m_EnmityHolder);
+	std::vector<CCharEntity*> members;
+	// Get a list of all valid party members
+	PChar->ForAlliance([PMob, &members](CBattleEntity* PPartyMember)
+	{
+		// Check to see if they are in the same zone as the mob and within 100 yalms
+		if (PPartyMember->getZone() == PMob->getZone() && distance(PPartyMember->loc.p, PMob->loc.p) < 100)
+		{
+			// Set the mobs highest level PC attacker to this PC
+			PMob->m_HiPCLvl = PPartyMember->GetMLevel();
+		}
+	});
 
     auto enmity_obj = m_EnmityList.find(PEntity->id);
 

--- a/src/map/enmity_container.cpp
+++ b/src/map/enmity_container.cpp
@@ -127,9 +127,8 @@ void CEnmityContainer::UpdateEnmity(CBattleEntity* PEntity, int16 CE, int16 VE, 
 	// Set mob highest level PC attacker to that of the person with enmity if they are solo, a party member, or alliance member (Fixes spell only kills not getting FoV/GoV credit)
 	auto PChar = static_cast<CCharEntity*>(PEntity);
 	auto PMob = dynamic_cast<CMobEntity*>(m_EnmityHolder);
-	std::vector<CCharEntity*> members;
 	// Get a list of all valid party members
-	PChar->ForAlliance([PMob, &members](CBattleEntity* PPartyMember)
+	PChar->ForAlliance([PMob](CBattleEntity* PPartyMember)
 	{
 		// Check to see if they are in the same zone as the mob and within 100 yalms
 		if (PPartyMember->getZone() == PMob->getZone() && distance(PPartyMember->loc.p, PMob->loc.p) < 100)

--- a/version.info
+++ b/version.info
@@ -1,7 +1,7 @@
 #DarkStar Version Info
 
 #Expected Client version (wrong version cannot log in)
-CLIENT_VER: 30160728_0
+CLIENT_VER: 30160831_0
 
 #Current Server Version. Not the same thing as source revision.
 #DSP_VER: Unused because we aren't even close to a "release" yet.

--- a/version.info
+++ b/version.info
@@ -1,7 +1,7 @@
 #DarkStar Version Info
 
 #Expected Client version (wrong version cannot log in)
-CLIENT_VER: 30160831_0
+CLIENT_VER: 30160728_0
 
 #Current Server Version. Not the same thing as source revision.
 #DSP_VER: Unused because we aren't even close to a "release" yet.


### PR DESCRIPTION
This resolves an issue where healing magic from outside the party, alliance, or solo player will result in no experience points or treasure being awarded.
It does so by checking if a PC with enmity is a party member before assigning that player's level to the highest level attacker of the mob.

Resolves issue #3002 
This issue was introduced with commit d3fee59d0d47d57760db06b9d277d50fb7d65ee6 which resolved issue #2698 wherein attacking a mob with only magic gives no FoV credit.

I have done extensive testing and all have passed: The correct EXP / FoV credit is awarded in all of the following scenarios:
solo
solo FoV
solo with PL
solo FoV with PL
solo magic only kill
solo FoV magic only kill
solo magic only kill with PL
solo FoV magic only kill with PL
party
party FoV
party with PL
party FoV with PL
party magic only kill
party FoV magic only kill
party magic only kill with PL
party FoV magic only kill with PL
alliance
alliance FoV
alliance with PL
alliance FoV with PL
alliance magic only kill
alliance FoV magic only kill
alliance magic only kill with PL
alliance FoV magic only kill with PL