### PR TITLE
Fix Rolanberry Zone.lua for non-abyssea users

### DIFF
--- a/scripts/zones/Rolanberry_Fields/Zone.lua
+++ b/scripts/zones/Rolanberry_Fields/Zone.lua
@@ -61,7 +61,9 @@ function onInitialize(zone)
     local rift = GetNPCByID(17228385);
 
     book:setPos(-98,-9,-655,216);
-    rift:setPos(-90.707,-7.899,-663.99,216);
+    if (rift ~= nil) then
+        rift:setPos(-90.707,-7.899,-663.99,216);
+    end    
     SetFieldManual(manuals);
 
     -- Simurgh


### PR DESCRIPTION
Adds an if statement for setting the rift position.  If required expansion does not include abyssea, rift was returning nil and crashing the script, rendering much of the content in the zone useless.