### PR TITLE
Cosmetic fixes to Land King pops

### DIFF
--- a/scripts/zones/Behemoths_Dominion/Zone.lua
+++ b/scripts/zones/Behemoths_Dominion/Zone.lua
@@ -19,8 +19,9 @@ function onInitialize(zone)
     
     SetFieldManual(manuals);
     
-    -- Behemoth
-    SetRespawnTime(17297440, 900, 10800);
+    if (LandKingSystem_NQ ~= 1) then
+        SetRespawnTime(17297440, 900, 10800); -- Behemoth
+    end
 end;
 
 -----------------------------------        

--- a/scripts/zones/Behemoths_Dominion/mobs/Behemoth.lua
+++ b/scripts/zones/Behemoths_Dominion/mobs/Behemoth.lua
@@ -15,6 +15,16 @@ function onMobInitialize(mob)
 end;
 
 -----------------------------------
+-- onMobSpawn
+-----------------------------------
+
+function onMobSpawn(mob)
+    if (LandKingSystem_NQ > 0 or LandKingSystem_HQ > 0) then
+        GetNPCByID(17297459):setStatus(STATUS_DISAPPEAR);
+    end
+end;
+
+-----------------------------------
 -- onMobDeath
 -----------------------------------
 
@@ -48,5 +58,9 @@ function onMobDespawn(mob)
             mob:setRespawnTime(math.random(75600,86400));
             SetServerVariable("[PH]King_Behemoth", kills + 1);
         end
+    end
+
+    if (LandKingSystem_NQ > 0 or LandKingSystem_HQ > 0) then
+        GetNPCByID(17297459):updateNPCHideTime(FORCE_SPAWN_QM_RESET_TIME);
     end
 end;

--- a/scripts/zones/Behemoths_Dominion/mobs/King_Behemoth.lua
+++ b/scripts/zones/Behemoths_Dominion/mobs/King_Behemoth.lua
@@ -20,6 +20,10 @@ function onMobSpawn(mob)
         SetDropRate(1936,13566,0);
         SetDropRate(1936,13415,1000); -- Pixie Earring
     end
+
+    if (LandKingSystem_NQ > 0 or LandKingSystem_HQ > 0) then
+        GetNPCByID(17297459):setStatus(STATUS_DISAPPEAR);
+    end
 end;
 
 -----------------------------------
@@ -73,5 +77,9 @@ function onMobDespawn(mob)
         DeterMob(Behemoth, false);
         UpdateNMSpawnPoint(Behemoth);
         GetMobByID(Behemoth):setRespawnTime(math.random(75600,86400));
+    end
+
+    if (LandKingSystem_NQ > 0 or LandKingSystem_HQ > 0) then
+        GetNPCByID(17297459):updateNPCHideTime(FORCE_SPAWN_QM_RESET_TIME);
     end
 end;

--- a/scripts/zones/Behemoths_Dominion/npcs/qm2.lua
+++ b/scripts/zones/Behemoths_Dominion/npcs/qm2.lua
@@ -11,6 +11,16 @@ require("scripts/globals/settings");
 require("scripts/globals/status");
 
 -----------------------------------
+-- onSpawn Action
+-----------------------------------
+
+function onSpawn(npc)
+    if (LandKingSystem_NQ < 1 and LandKingSystem_HQ < 1) then
+        npc:setStatus(STATUS_DISAPPEAR);
+    end
+end;
+
+-----------------------------------
 -- onTrade Action
 -----------------------------------
 
@@ -25,12 +35,14 @@ function onTrade(player,npc,trade)
             if (LandKingSystem_NQ ~= 0) then
                 player:tradeComplete();
                 SpawnMob(17297440):updateClaim(player);
+                npc:setStatus(STATUS_DISAPPEAR);
             end
         -- Trade Savory Shank
         elseif (trade:hasItemQty(3342,1) and trade:getItemCount() == 1) then
             if (LandKingSystem_HQ ~= 0) then
                 player:tradeComplete();
                 SpawnMob(17297441):updateClaim(player);
+                npc:setStatus(STATUS_DISAPPEAR);
             end
         end
     end

--- a/scripts/zones/Dragons_Aery/Zone.lua
+++ b/scripts/zones/Dragons_Aery/Zone.lua
@@ -15,10 +15,9 @@ require("scripts/zones/Dragons_Aery/TextIDs");
 -----------------------------------
 
 function onInitialize(zone)
-
-    -- Fafnir
-    SetRespawnTime(17408018, 900, 10800);
-
+    if (LandKingSystem_NQ ~= 1) then
+        SetRespawnTime(17408018, 900, 10800); -- Fafnir
+    end
 end;
 
 -----------------------------------

--- a/scripts/zones/Dragons_Aery/mobs/Fafnir.lua
+++ b/scripts/zones/Dragons_Aery/mobs/Fafnir.lua
@@ -15,6 +15,16 @@ function onMobInitialize(mob)
 end;
 
 -----------------------------------
+-- onMobSpawn
+-----------------------------------
+
+function onMobSpawn(mob)
+    if (LandKingSystem_NQ > 0 or LandKingSystem_HQ > 0) then
+        GetNPCByID(17408033):setStatus(STATUS_DISAPPEAR);
+    end
+end;
+
+-----------------------------------
 -- onMobDeath
 -----------------------------------
 
@@ -48,5 +58,9 @@ function onMobDespawn(mob)
             mob:setRespawnTime(math.random(75600,86400));
             SetServerVariable("[PH]Nidhogg", kills + 1);
         end
+    end
+
+    if (LandKingSystem_NQ > 0 or LandKingSystem_HQ > 0) then
+        GetNPCByID(17408033):updateNPCHideTime(FORCE_SPAWN_QM_RESET_TIME);
     end
 end;

--- a/scripts/zones/Dragons_Aery/mobs/Nidhogg.lua
+++ b/scripts/zones/Dragons_Aery/mobs/Nidhogg.lua
@@ -15,6 +15,16 @@ function onMobInitialize(mob)
 end;
 
 -----------------------------------
+-- onMobSpawn
+-----------------------------------
+
+function onMobSpawn(mob)
+    if (LandKingSystem_NQ > 0 or LandKingSystem_HQ > 0) then
+        GetNPCByID(17408033):setStatus(STATUS_DISAPPEAR);
+    end
+end;
+
+-----------------------------------
 -- onMobFight Action
 -----------------------------------
 
@@ -65,4 +75,7 @@ function onMobDespawn(mob)
         GetMobByID(Fafnir):setRespawnTime(math.random(75600,86400));
     end
 
+    if (LandKingSystem_NQ > 0 or LandKingSystem_HQ > 0) then
+        GetNPCByID(17408033):updateNPCHideTime(FORCE_SPAWN_QM_RESET_TIME);
+    end
 end;

--- a/scripts/zones/Dragons_Aery/npcs/qm0.lua
+++ b/scripts/zones/Dragons_Aery/npcs/qm0.lua
@@ -11,6 +11,16 @@ require("scripts/globals/settings");
 require("scripts/globals/status");
 
 -----------------------------------
+-- onSpawn Action
+-----------------------------------
+
+function onSpawn(npc)
+    if (LandKingSystem_NQ < 1 and LandKingSystem_HQ < 1) then
+        npc:setStatus(STATUS_DISAPPEAR);
+    end
+end;
+
+-----------------------------------
 -- onTrade Action
 -----------------------------------
 
@@ -25,12 +35,14 @@ function onTrade(player,npc,trade)
             if (LandKingSystem_NQ ~= 0) then
                 player:tradeComplete();
                 SpawnMob(17408018):updateClaim(player);
+                npc:setStatus(STATUS_DISAPPEAR);
             end
         -- Trade Cup of Sweet Tea
         elseif (trade:hasItemQty(3340,1) and trade:getItemCount() == 1) then
             if (LandKingSystem_HQ ~= 0) then
                 player:tradeComplete();
                 SpawnMob(17408019):updateClaim(player);
+                npc:setStatus(STATUS_DISAPPEAR);
             end
         end
     end

--- a/scripts/zones/Valley_of_Sorrows/Zone.lua
+++ b/scripts/zones/Valley_of_Sorrows/Zone.lua
@@ -19,8 +19,9 @@ function onInitialize(zone)
 
     SetFieldManual(manuals);
 
-    -- Adamantoise
-    SetRespawnTime(17301537, 900, 10800);
+    if (LandKingSystem_NQ ~= 1) then
+        SetRespawnTime(17301537, 900, 10800); -- Adamantoise
+    end
 end;
 
 -----------------------------------

--- a/scripts/zones/Valley_of_Sorrows/mobs/Adamantoise.lua
+++ b/scripts/zones/Valley_of_Sorrows/mobs/Adamantoise.lua
@@ -15,6 +15,16 @@ function onMobInitialize(mob)
 end;
 
 -----------------------------------
+-- onMobSpawn
+-----------------------------------
+
+function onMobSpawn(mob)
+    if (LandKingSystem_NQ > 0 or LandKingSystem_HQ > 0) then
+        GetNPCByID(17301567):setStatus(STATUS_DISAPPEAR);
+    end
+end;
+
+-----------------------------------
 -- onMobDeath
 -----------------------------------
 
@@ -48,5 +58,9 @@ function onMobDespawn(mob)
             mob:setRespawnTime(math.random(75600,86400));
             SetServerVariable("[PH]Aspidochelone", kills + 1);
         end
+    end
+
+    if (LandKingSystem_NQ > 0 or LandKingSystem_HQ > 0) then
+        GetNPCByID(17301567):updateNPCHideTime(FORCE_SPAWN_QM_RESET_TIME);
     end
 end;

--- a/scripts/zones/Valley_of_Sorrows/mobs/Aspidochelone.lua
+++ b/scripts/zones/Valley_of_Sorrows/mobs/Aspidochelone.lua
@@ -15,6 +15,16 @@ function onMobInitialize(mob)
 end;
 
 -----------------------------------
+-- onMobSpawn
+-----------------------------------
+
+function onMobSpawn(mob)
+    if (LandKingSystem_NQ > 0 or LandKingSystem_HQ > 0) then
+        GetNPCByID(17301567):setStatus(STATUS_DISAPPEAR);
+    end
+end;
+
+-----------------------------------
 -- onMobDeath
 -----------------------------------
 
@@ -46,4 +56,7 @@ function onMobDespawn(mob)
         GetMobByID(Adamantoise):setRespawnTime(math.random(75600,86400));
     end
 
+    if (LandKingSystem_NQ > 0 or LandKingSystem_HQ > 0) then
+        GetNPCByID(17301567):updateNPCHideTime(FORCE_SPAWN_QM_RESET_TIME);
+    end
 end;

--- a/scripts/zones/Valley_of_Sorrows/npcs/qm1.lua
+++ b/scripts/zones/Valley_of_Sorrows/npcs/qm1.lua
@@ -11,6 +11,16 @@ require("scripts/globals/settings");
 require("scripts/globals/status");
 
 -----------------------------------
+-- onSpawn Action
+-----------------------------------
+
+function onSpawn(npc)
+    if (LandKingSystem_NQ < 1 and LandKingSystem_HQ < 1) then
+        npc:setStatus(STATUS_DISAPPEAR);
+    end
+end;
+
+-----------------------------------
 -- onTrade Action
 -----------------------------------
 
@@ -25,12 +35,14 @@ function onTrade(player,npc,trade)
             if (LandKingSystem_NQ ~= 0) then
                 player:tradeComplete();
                 SpawnMob(17301537):updateClaim(player);
+                npc:setStatus(STATUS_DISAPPEAR);
             end
         -- Trade Clump of Red Pondweed
         elseif (trade:hasItemQty(3344,1) and trade:getItemCount() == 1) then
             if (LandKingSystem_HQ ~= 0) then
                 player:tradeComplete();
                 SpawnMob(17301538):updateClaim(player);
+                npc:setStatus(STATUS_DISAPPEAR);
             end
         end
     end


### PR DESCRIPTION
- Do not spawn HNM's unconditionaly (honor spawn condition in settings.lua)
- do not overlap HNM and QM (hide QM on trade and on HNM spawn [in case only NQ or HQ is force popped])