### PR TITLE
Version update 2016/09/13 (client: 30160831_1)

### DIFF
--- a/version.info
+++ b/version.info
@@ -1,7 +1,7 @@
 #DarkStar Version Info
 
 #Expected Client version (wrong version cannot log in)
-CLIENT_VER: 30160831_0
+CLIENT_VER: 30160831_1
 
 #Current Server Version. Not the same thing as source revision.
 #DSP_VER: Unused because we aren't even close to a "release" yet.


### PR DESCRIPTION
No changes to dialog tables despite the purpose of the update.

I'm not certain if these NPC ID changes were due to the update (would be weird), or if they were missed before. I popped into Mog Garden before/after importing and these new ones do appear to be correct.