### PR TITLE
Changed missing script message type to warning so it can be filtered without losing more serious error messages. 

### DIFF
--- a/src/map/lua/luautils.cpp
+++ b/src/map/lua/luautils.cpp
@@ -1446,7 +1446,7 @@ namespace luautils
         auto ret = luaL_loadfile(LuaHandle, File);
         if (ret)
         {
-            ShowError("luautils::%s: %s\n", "onTrigger", lua_tostring(LuaHandle, -1));
+            ShowWarning("luautils::%s: %s\n", "onTrigger", lua_tostring(LuaHandle, -1));
             lua_pop(LuaHandle, 1);
             return -1;
         }
@@ -3114,7 +3114,7 @@ namespace luautils
             CLuaBaseEntity LuaTrickAttackEntity(taChar);
             Lunar<CLuaBaseEntity>::push(LuaHandle, &LuaTrickAttackEntity);
         }
-        
+
 
         if (lua_pcall(LuaHandle, 7, LUA_MULTRET, 0))
         {


### PR DESCRIPTION
Some entities never need a script (primarily doors in towns) and many others are unimplemented, rather than broken/lost/whatever. I figure that's good enough for unimplemented packets, so its good enough for unimplemented scripts too.