### PR TITLE
Fix: charutils seenKeyItem() checks wrong bit

### DIFF
--- a/src/map/utils/charutils.cpp
+++ b/src/map/utils/charutils.cpp
@@ -2755,7 +2755,7 @@ namespace charutils
     bool seenKeyItem(CCharEntity* PChar, uint16 KeyItemID)
     {
         auto table = KeyItemID / 512;
-        return PChar->keys.tables[table].keyList[KeyItemID % 512];
+        return PChar->keys.tables[table].seenList[KeyItemID % 512];
     }
 
     void unseenKeyItem(CCharEntity* PChar, uint16 KeyItemID)


### PR DESCRIPTION
Fix for a bug In charutils.cpp seenKeyItem() that was checking whether the character owns, rather than has viewed, the key item in question.