### PR TITLE
Client Flags for Mog Wardrobe 3/4

### DIFF
--- a/conf/login_darkstar.conf
+++ b/conf/login_darkstar.conf
@@ -79,6 +79,30 @@ search_server_port: 54002
 
 expansions: 30
 
+#Account features - 2 Bytes?
+#
+#Byte 1
+#00000001 Bit0 - Secure Token Icon
+#00000010 Bit1 - Unknown - Not Used
+#00000100 Bit2 - Mog Wardrobe 3
+#00001000 Bit3 - Mog Wardrobe 4
+#00010000 Bit4 - Not Used
+#00100000 Bit5 - Not Used
+#01000000 Bit6 - Not Used
+#10000000 Bit7 - Not Used
+#
+#Byte 2 - Not Used
+#00000001 Bit0 - Not Used
+#00000010 Bit1 - Not Used
+#00000100 Bit2 - Not Used
+#00001000 Bit3 - Not Used
+#00010000 Bit4 - Not Used
+#00100000 Bit5 - Not Used
+#01000000 Bit6 - Not Used
+#10000000 Bit7 - Not Used
+
+features: 12
+
 #Server name (not longer than 15 characters)
 servername: DarkStar
 

--- a/src/login/lobby.cpp
+++ b/src/login/lobby.cpp
@@ -494,6 +494,7 @@ int32 lobbyview_parse(int32 fd)
             {
                 LOBBY_026_RESERVEPACKET(ReservePacket);
                 WBUFW(ReservePacket, 32) = login_config.expansions; // BitMask for expansions;
+                WBUFW(ReservePacket, 36) = login_config.features; // Bitmask for account features
                 memcpy(MainReservePacket, ReservePacket, sendsize);
             }
             //Хеширование пакета, и запись значения Хеш функции в пакет

--- a/src/login/login.cpp
+++ b/src/login/login.cpp
@@ -359,6 +359,10 @@ int32 login_config_read(const char *cfgName)
         {
             login_config.expansions = atoi(w2);
         }
+        else if (strcmp(w1, "features") == 0)
+        {
+            login_config.features = atoi(w2);
+        }
         else if (strcmp(w1, "servername") == 0)
         {
             login_config.servername = aStrdup(w2);

--- a/src/login/login.h
+++ b/src/login/login.h
@@ -49,6 +49,7 @@ struct login_config_t
     const char* login_view_ip;
 
     uint16 expansions;
+    uint16 features;
 
     const char* servername;
 


### PR DESCRIPTION
Adds settings to login_darkstar.conf to globally set account flags for security token and enable or disable access to mog wardrobe 3/4.