### PR TITLE
Stopped wallhack from generating an error in console log.

### DIFF
--- a/scripts/commands/wallhack.lua
+++ b/scripts/commands/wallhack.lua
@@ -1,5 +1,5 @@
 ---------------------------------------------------------------------------------------------------
--- func: wallhack
+-- func: wallhack <optional target>
 -- desc: Allows the player to walk through walls.
 ---------------------------------------------------------------------------------------------------
 
@@ -10,6 +10,23 @@ cmdprops =
 };
 
 function onTrigger(player, target)
-    target = GetPlayerByName(target) or player;
-    target:setFlag( 0x00000200 );
+    local targ;
+    if (target == nil) then
+        targ = player;
+    else
+        targ = GetPlayerByName(target);
+    end
+
+    if (targ == nil) then
+        player:PrintToPlayer(string.format("Player named '%s' not found!", target));
+        return;
+    end
+
+    if (targ:checkNameFlags(0x00000200)) then
+        targ:setFlag(0x00000200);
+        player:PrintToPlayer("Toggled wallhack flag OFF.");
+    else
+        targ:setFlag(0x00000200);
+        player:PrintToPlayer("Toggled wallhack flag ON.");
+    end
 end


### PR DESCRIPTION
Was generating an error even while working just fine, because the logic would hit a nil on `GetPlayerByName` when no target was needed.

Also it now prints status of flag in chatlog when changing wallhack on/off. 