### PR TITLE
Version update 2016/10/11 (client: 30161004_1)

### DIFF
--- a/scripts/zones/West_Ronfaure/Zone.lua
+++ b/scripts/zones/West_Ronfaure/Zone.lua
@@ -56,7 +56,7 @@ end;
 -----------------------------------
 
 function onInitialize(zone)
-    local manuals = {17187570,17187571};
+    local manuals = {17187563,17187571};
     SetFieldManual(manuals);
 
     local vwnpc = {17187550,17187551,17187552};

--- a/version.info
+++ b/version.info
@@ -1,7 +1,7 @@
 #DarkStar Version Info
 
 #Expected Client version (wrong version cannot log in)
-CLIENT_VER: 30160831_1
+CLIENT_VER: 30161004_1
 
 #Current Server Version. Not the same thing as source revision.
 #DSP_VER: Unused because we aren't even close to a "release" yet.


### PR DESCRIPTION
Not much to note.

- Three NPCs (Aquila, Haudrale, and Lillisette) shifted in Throne Room [S] which I swear also shifted the last time I ran the batch job, which makes me wonder if we're missing some CS versions of them.
- I ran the POLUtils name scraper, and it changed a handful of names.
- No TextID shifts picked up by the tool. Yay!