### PR TITLE
Re-write Virelai spell script, re-indent paralyze/paralyze2 scripts.

### DIFF
--- a/scripts/globals/spells/maidens_virelai.lua
+++ b/scripts/globals/spells/maidens_virelai.lua
@@ -2,8 +2,9 @@
 -- Spell: Maiden's Virelai
 -- Charms pet
 -----------------------------------------
-
 require("scripts/globals/status");
+require("scripts/globals/magic");
+require("scripts/globals/pets");
 
 -----------------------------------------
 -- OnSpellCast
@@ -11,18 +12,42 @@ require("scripts/globals/status");
 
 function onMagicCastingCheck(caster,target,spell)
     -- Ix'Aern DRG pets are Wyverns that 2hour.
-    if (mob:getID() >= 16921023 and mob:getID() <= 16921025) then
-        if (caster:getStatusEffect(EFFECT_SOUL_VOICE)  == nil) then
+    if (caster:getID() >= 16921023 and caster:getID() <= 16921025) then
+        -- This would probably be better to handle in the mobs script but eh w/e..
+        if (caster:getStatusEffect(EFFECT_SOUL_VOICE) == nil) then
             return 1;
         end
+    elseif (caster:getPet() ~= nil) then
+        return MSGBASIC_ALREADY_HAS_A_PET;
+    elseif (target:getMaster() ~= nil and target:getMaster():isPC()) then
+        return MSGBASIC_THAT_SOMEONES_PET;
     end
-    
+
+    -- Per wiki, Virelai wipes all shadows even if it resists or the target is immune to charm
+    -- This can't be done in the onSpellCast function, so its here.
+    target:delStatusEffect(EFFECT_COPY_IMAGE);
+    target:delStatusEffect(EFFECT_BLINK);
+
     return 0;
 end;
 
 function onSpellCast(caster,target,spell)
+    local dCHR = (caster:getStat(MOD_CHR) - target:getStat(MOD_CHR));
+    local bonus = 0; -- No idea what value, but seems likely to need this edited later to get retail resist rates.
+    local resist = applyResistanceEffect(caster,spell,target,dCHR,SINGING_SKILL,bonus,EFFECT_CHARM_I);
 
-    spell:setMsg(137);
+    if (resist >= 0.25 and caster:getCharmChance(target, false) > 0) then
+        spell:setMsg(236);
+        if (caster:isMob())then
+            target:addStatusEffect(EFFECT_CHARM_I, 0, 0, 30*resist);
+            caster:charm(target);
+        else
+            caster:charmPet(target);
+        end
+    else
+        -- resist
+        spell:setMsg(85);
+    end
 
-    return EFFECT_CHARM;
+    return EFFECT_CHARM_I;
 end;

--- a/scripts/globals/spells/paralyze.lua
+++ b/scripts/globals/spells/paralyze.lua
@@ -16,37 +16,36 @@ end;
 
 function onSpellCast(caster,target,spell)
 
-    if (target:hasStatusEffect(EFFECT_PARALYSIS)) then --effect already on, do nothing
+    if (target:hasStatusEffect(EFFECT_PARALYSIS)) then -- Effect already on, do nothing
         spell:setMsg(75);
     else
         -- Calculate duration.
-        local duration = math.random(20,120);
-        
-            if (caster:hasStatusEffect(EFFECT_SABOTEUR)) then
-        duration = duration * 2;
-    end
+        local duration = math.random(20,120); -- There should probably be non random math here.
+
+        if (caster:hasStatusEffect(EFFECT_SABOTEUR)) then
+            duration = duration * 2;
+        end
 
         -- Grabbing variables for paralyze potency
         local pMND = caster:getStat(MOD_MND);
         local mMND = target:getStat(MOD_MND);
-
         local dMND = (pMND - mMND);
 
         -- Calculate potency.
-        local potency = (pMND + dMND)/5; --simplified from (2 * (pMND + dMND)) / 10
-
-        if potency > 25 then
+        local potency = (pMND + dMND)/5; -- Simplified from (2 * (pMND + dMND)) / 10
+        if (potency > 25) then
             potency = 25;
         end
-            if (caster:hasStatusEffect(EFFECT_SABOTEUR)) then
-        potency = potency * 2;
-    end
-    caster:delStatusEffect(EFFECT_SABOTEUR);
-        --printf("Duration : %u",duration);
-        --printf("Potency : %u",potency);
+
+        if (caster:hasStatusEffect(EFFECT_SABOTEUR)) then
+            potency = potency * 2;
+            caster:delStatusEffect(EFFECT_SABOTEUR);
+        end
+        -- printf("Duration : %u",duration);
+        -- printf("Potency : %u",potency);
         local resist = applyResistanceEffect(caster,spell,target,dMND,35,0,EFFECT_PARALYSIS);
 
-        if (resist >= 0.5) then --there are no quarter or less hits, if target resists more than .5 spell is resisted completely
+        if (resist >= 0.5) then -- There are no quarter or less hits, if target resists more than .5 spell is resisted completely
             if (target:addStatusEffect(EFFECT_PARALYSIS,potency,0,duration*resist)) then
                 spell:setMsg(236);
             else

--- a/scripts/globals/spells/paralyze_ii.lua
+++ b/scripts/globals/spells/paralyze_ii.lua
@@ -18,42 +18,39 @@ end;
 
 function onSpellCast(caster,target,spell)
 
-    if (target:hasStatusEffect(EFFECT_PARALYSIS)) then --effect already on, do nothing
+    if (target:hasStatusEffect(EFFECT_PARALYSIS)) then -- Effect already on, do nothing
         spell:setMsg(75);
     else
         -- Calculate duration.
         local duration = 180;
-        
-            if (caster:hasStatusEffect(EFFECT_SABOTEUR)) then
-        duration = duration * 2;
-    end
+
+        if (caster:hasStatusEffect(EFFECT_SABOTEUR)) then
+            duration = duration * 2;
+        end
 
         -- Grabbing variables for paralyze potency
         local pMND = caster:getStat(MOD_MND);
         local mMND = target:getStat(MOD_MND);
-
         local merits = caster:getMerit(MERIT_PARALYZE_II);
-
         local dMND = (pMND - mMND);
 
         -- Calculate potency.
-        local potency = (pMND + dMND)/5; --simplified from (2 * (pMND + dMND)) / 10
-
+        local potency = (pMND + dMND)/5; -- Simplified from (2 * (pMND + dMND)) / 10
         if (potency > 30) then
             potency = 30;
         end
-            if (caster:hasStatusEffect(EFFECT_SABOTEUR)) then
-        potency = potency * 2;
-    end
-    caster:delStatusEffect(EFFECT_SABOTEUR);
+
+        if (caster:hasStatusEffect(EFFECT_SABOTEUR)) then
+            potency = potency * 2;
+            caster:delStatusEffect(EFFECT_SABOTEUR);
+        end
 
         potency = potency + merits; --similar to Slow II, merit potency bonus is added after the cap
-
-        --printf("Duration : %u",duration);
-        --printf("Potency : %u",potency);
+        -- printf("Duration : %u",duration);
+        -- printf("Potency : %u",potency);
         local resist = applyResistanceEffect(caster,spell,target,dMND,35,merits*2,EFFECT_PARALYSIS);
 
-        if (resist >= 0.5) then --there are no quarter or less hits, if target resists more than .5 spell is resisted completely
+        if (resist >= 0.5) then -- There are no quarter or less hits, if target resists more than .5 spell is resisted completely
             if (target:addStatusEffect(EFFECT_PARALYSIS,potency,0,duration*resist)) then
                 spell:setMsg(236);
             else


### PR DESCRIPTION
In addition to someone adding that broken casting check, the spell never worked even before that anyway. It simply set an (incorrect) message and returned the effect type without ever doing anything.

I've changed it to check the caster as intended, and also made it you know, actually try to charm the target.. 

**Tested both mob and player using this, I used `@exec` for force a mob to cast on me.** It's probably much easier to resist this spell than retail. Someone with better knowledge of that will have to tweak it later if so.