### PR TITLE
Add spellflag so virelai can be done right ..

### DIFF
--- a/scripts/globals/spells/maidens_virelai.lua
+++ b/scripts/globals/spells/maidens_virelai.lua
@@ -11,22 +11,15 @@ require("scripts/globals/pets");
 -----------------------------------------
 
 function onMagicCastingCheck(caster,target,spell)
-    -- Ix'Aern DRG pets are Wyverns that 2hour.
-    if (caster:getID() >= 16921023 and caster:getID() <= 16921025) then
-        -- This would probably be better to handle in the mobs script but eh w/e..
-        if (caster:getStatusEffect(EFFECT_SOUL_VOICE) == nil) then
-            return 1;
-        end
-    elseif (caster:getPet() ~= nil) then
+    if (caster:getPet() ~= nil) then
         return MSGBASIC_ALREADY_HAS_A_PET;
     elseif (target:getMaster() ~= nil and target:getMaster():isPC()) then
         return MSGBASIC_THAT_SOMEONES_PET;
     end
 
     -- Per wiki, Virelai wipes all shadows even if it resists or the target is immune to charm
-    -- This can't be done in the onSpellCast function, so its here.
-    target:delStatusEffect(EFFECT_COPY_IMAGE);
-    target:delStatusEffect(EFFECT_BLINK);
+    -- This can't be done in the onSpellCast function (that runs after it "hits")
+    spell:setFlag(SPELLFLAG_WIPE_SHADOWS);
 
     return 0;
 end;
@@ -35,7 +28,7 @@ function onSpellCast(caster,target,spell)
     local dCHR = (caster:getStat(MOD_CHR) - target:getStat(MOD_CHR));
     local bonus = 0; -- No idea what value, but seems likely to need this edited later to get retail resist rates.
     local resist = applyResistanceEffect(caster,spell,target,dCHR,SINGING_SKILL,bonus,EFFECT_CHARM_I);
-
+    -- print(resist);
     if (resist >= 0.25 and caster:getCharmChance(target, false) > 0) then
         spell:setMsg(236);
         if (caster:isMob())then
@@ -45,7 +38,7 @@ function onSpellCast(caster,target,spell)
             caster:charmPet(target);
         end
     else
-        -- resist
+        -- Resist
         spell:setMsg(85);
     end
 

--- a/scripts/globals/status.lua
+++ b/scripts/globals/status.lua
@@ -2171,8 +2171,9 @@ SPELLAOE_DIFFUSION   = 6; -- AOE when under Diffusion
 -- Spell flag bits
 ------------------------------------
 
-SPELLFLAG_NONE    = 0;
-SPELLFLAG_HIT_ALL = 1; -- hit all targets in range regardless of party
+SPELLFLAG_NONE          = 0x00;
+SPELLFLAG_HIT_ALL       = 0x01; -- Hit all targets in range regardless of party
+SPELLFLAG_WIPE_SHADOWS  = 0x02; -- Wipe shadows even if single target and miss/resist (example: Maiden's Virelai)
 
 ------------------------------------
 -- Behaviour bits

--- a/src/map/entities/battleentity.cpp
+++ b/src/map/entities/battleentity.cpp
@@ -1214,8 +1214,8 @@ void CBattleEntity::OnCastFinished(CMagicState& state, action_t& action)
         auto ce = PSpell->getCE();
         auto ve = PSpell->getVE();
 
-        // take all shadows
-        if (PSpell->canTargetEnemy() && aoeType > 0)
+        // Take all shadows
+        if (PSpell->canTargetEnemy() && (aoeType > 0 || (PSpell->getFlag() & SPELLFLAG_WIPE_SHADOWS)))
         {
             PTarget->StatusEffectContainer->DelStatusEffect(EFFECT_BLINK);
             PTarget->StatusEffectContainer->DelStatusEffect(EFFECT_COPY_IMAGE);

--- a/src/map/spell.h
+++ b/src/map/spell.h
@@ -67,8 +67,9 @@ enum SPELLAOE
 
 enum SPELLFLAG
 {
-    SPELLFLAG_NONE      = 0,
-    SPELLFLAG_HIT_ALL   = 1     // hit all targets in range regardless of party
+    SPELLFLAG_NONE          = 0x00,
+    SPELLFLAG_HIT_ALL       = 0x01, // Hit all targets in range regardless of party
+    SPELLFLAG_WIPE_SHADOWS  = 0x02  // Wipe shadows even if single target and miss/resist (example: Maiden's Virelai)
 };
 
 class CSpell

--- a/src/map/utils/battleutils.cpp
+++ b/src/map/utils/battleutils.cpp
@@ -4042,13 +4042,13 @@ namespace battleutils
     float GetCharmChance(CBattleEntity* PCharmer, CBattleEntity* PTarget, bool includeCharmAffinityAndChanceMods)
     {
         //---------------------------------------------------------
-        //	chance of charm is based on:
-        //	-CHR - both entities
-        //	-Victims M level
-        //  -charmers BST level (not main level)
+        // chance of charm is based on:
+        //  CHR - both entities
+        //  Victims M level
+        //  charmers BST level (not main level)
         //
-        //  -75 with a BST SJ lvl10 will struggle on EP
-        //	-75 with a BST SJ lvl75 will not - this player has bst leveled to 75 and is using it as SJ
+        //  75 with a BST SJ Lvl l0 will struggle on EP
+        //  75 with a BST SJ Lvl 75 will not - this player has bst leveled to 75 and is using it as SJ
         //---------------------------------------------------------
 
         float charmChance = 0.0f;
@@ -4097,9 +4097,18 @@ namespace battleutils
         uint8 charmerBSTlevel = 0;
 
         if (PCharmer->objtype == TYPE_PC)
+        {
+            uint8 charmerBRDlevel = static_cast<CCharEntity*>(PCharmer)->jobs.job[JOB_BRD];
             charmerBSTlevel = static_cast<CCharEntity*>(PCharmer)->jobs.job[JOB_BST];
+            if (PCharmer->GetMJob() == JOB_BRD && charmerBRDlevel > charmerBSTlevel)
+            {
+                charmerBSTlevel = charmerBRDlevel;
+            }
+        }
         else if (PCharmer->objtype == TYPE_MOB)
+        {
             charmerBSTlevel = charmerLvl;
+        }
 
         //printf("base = %u\n", base);
         charmChance = base;


### PR DESCRIPTION
.. and check bard level when bard is mainjob
(virelai is 75 you won't have it from sub, so don't need worry about whm/brd or something trying to land charm)

Since I was brd/bst yesterday (derp) I failed to notice that virelai had a 100% chance to fail if your bst level was zero. Thats fixed now, in a passable way (other than being CHR based, I don't know that level should be involved at all. wiki doesn't say, I just presumed it calculates the way bst charm would, but as a bard). Better than the nothing we started with.