### PR TITLE
Fix missing return error in scripts/globals/mobskills/Depuration.lua

### DIFF
--- a/scripts/globals/mobskills/Depuration.lua
+++ b/scripts/globals/mobskills/Depuration.lua
@@ -1,33 +1,31 @@
 ---------------------------------------------
---  Depuration
---  Family: Aern
---  Type: Healing
---  Can be dispelled: N/A
---  Utsusemi/Blink absorb: N/A
---  Range: Self
---  Notes: Erases all negative effects on the mob. Aerns will generally not attempt to use this ability if no erasable effects exist on them.
+-- Depuration
+-- Family: Aern
+-- Type: Healing
+-- Can be dispelled: N/A
+-- Utsusemi/Blink absorb: N/A
+-- Range: Self
+-- Notes: Erases all negative effects on the mob.
+-- Aerns will generally not attempt to use this ability if no erasable effects exist on them.
 ---------------------------------------------
-
+require("scripts/globals/monstertpmoves");
 require("scripts/globals/settings");
 require("scripts/globals/status");
-require("scripts/globals/monstertpmoves");
-
 ---------------------------------------------
 
 function onMobSkillCheck(target,mob,skill)
-    
     local dispel = target:eraseStatusEffect();
-    
+
     if (dispel ~= EFFECT_NONE) then
         return 0;
     end
 
     return 1;
-
 end;
 
 function onMobWeaponSkill(target, mob, skill)
 
     mob:eraseAllStatusEffect();
 
+    return 0;
 end;


### PR DESCRIPTION
I do not know if this should have a message being returned. If it does it is probably msg ID 400.