### PR TITLE
Fix variable name in onMobDeath of Old Sabertooth

### DIFF
--- a/scripts/zones/Sauromugue_Champaign/mobs/Old_Sabertooth.lua
+++ b/scripts/zones/Sauromugue_Champaign/mobs/Old_Sabertooth.lua
@@ -22,7 +22,7 @@ end;
 
 function onMobDeath(mob, player, isKiller)
 
-    if (killer == nil) then
+    if (player == nil) then
     
         local players = mob:getZone():getPlayers();
         for i, player in pairs(players) do


### PR DESCRIPTION
It wasn't changed when onMobDeath was modified.