### PR TITLE
Fix broken Weapon Skills

### DIFF
--- a/scripts/globals/weaponskills/apex_arrow.lua
+++ b/scripts/globals/weaponskills/apex_arrow.lua
@@ -37,7 +37,7 @@ function onUseWeaponSkill(player, target, wsID, tp, primary, action, taChar)
         params.agi_wsc = 0.7 + (player:getMerit(MERIT_APEX_ARROW) / 100);
     end
 
-    local damage, criticalHit, tpHits, extraHits = doRangedWeaponskill(player, target, wsID, tp, primary, action, taChar, params);
+    local damage, criticalHit, tpHits, extraHits = doRangedWeaponskill(player, target, wsID, params, tp, primary);
     return tpHits, extraHits, criticalHit, damage;
 
 end;

--- a/scripts/globals/weaponskills/arching_arrow.lua
+++ b/scripts/globals/weaponskills/arching_arrow.lua
@@ -30,7 +30,7 @@ function onUseWeaponSkill(player, target, wsID, tp, primary, action, taChar)
         params.str_wsc = 0.20; params.agi_wsc = 0.50;
     end
 
-    local damage, criticalHit, tpHits, extraHits = doRangedWeaponskill(player, target, wsID, tp, primary, action, taChar, params);
+    local damage, criticalHit, tpHits, extraHits = doRangedWeaponskill(player, target, wsID, params, tp, primary);
     return tpHits, extraHits, criticalHit, damage;
 
 end


### PR DESCRIPTION
doRangedWeaponskill(player, target, wsID, tp, primary, action, taChar, params); wrong structure
https://github.com/DarkstarProject/darkstar/blob/fcf28b0645f95609659419238b24a30b3b27c74c/scripts/globals/weaponskills.lua#L654
changed to doRangedWeaponskill(player, target, wsID, params, tp, primary);
