### PR TITLE
Added fix for pets to not respawn on zone if on chocobo

### DIFF
--- a/src/map/packet_system.cpp
+++ b/src/map/packet_system.cpp
@@ -343,8 +343,8 @@ void SmallPacket0x00C(map_session_data_t* session, CCharEntity* PChar, CBasicPac
     // respawn any pets from last zone
     if (PChar->petZoningInfo.respawnPet == true)
     {
-        // only repawn pet in valid zones
-        if (PChar->loc.zone->CanUseMisc(MISC_PET) && !PChar->m_moghouseID)
+        // only repawn pet in valid zones and if not on chocobo
+        if (PChar->loc.zone->CanUseMisc(MISC_PET) && !PChar->m_moghouseID && !PChar->StatusEffectContainer->HasStatusEffect(EFFECT_CHOCOBO))
         {
             switch (PChar->petZoningInfo.petType)
             {


### PR DESCRIPTION
SMN pet behavior update to retail behavior.  Pet's automatically attack whatever aggro's Master if not already attacking a mob.