### PR TITLE
SMN Pet bodyguard fix, Pets respawn in valid zone, pets despawn on chocobo mount and respawn on dismount

### DIFF
--- a/src/map/ai/controllers/mob_controller.cpp
+++ b/src/map/ai/controllers/mob_controller.cpp
@@ -502,15 +502,6 @@ void CMobController::DoCombatTick(time_point tick)
 
     luautils::OnMobFight(PMob, PTarget);
 
-	//Check for SMN pet and sets pet to auto attack
-	if (PTarget->PPet != nullptr && PTarget->PPet->GetBattleTargetID() == 0)
-	{
-		if (PTarget->PPet->objtype == TYPE_PET && ((CPetEntity*)PTarget->PPet)->getPetType() == PETTYPE_AVATAR)
-		{
-			petutils::AttackTarget(PTarget, PMob);
-		}
-	}
-
     // Try to spellcast (this is done first so things like Chainspell spam is prioritised over TP moves etc.
     if (IsSpecialSkillReady(currentDistance) && TrySpecialSkill())
     {

--- a/src/map/ai/controllers/mob_controller.cpp
+++ b/src/map/ai/controllers/mob_controller.cpp
@@ -36,6 +36,7 @@ This file is part of DarkStar-server source code.
 #include "../../entities/mobentity.h"
 #include "../../utils/battleutils.h"
 #include "../../../common/utils.h"
+#include "../../utils/petutils.h"
 
 CMobController::CMobController(CMobEntity* PEntity) :
     CController(PEntity),
@@ -135,7 +136,7 @@ void CMobController::TryLink()
     {
         if (PTarget->PPet->objtype == TYPE_PET && ((CPetEntity*)PTarget->PPet)->getPetType() == PETTYPE_AVATAR)
         {
-            PTarget->PPet->PAI->Engage(PMob->id);
+			petutils::AttackTarget(PTarget, PMob);
         }
     }
 
@@ -500,6 +501,15 @@ void CMobController::DoCombatTick(time_point tick)
     float currentDistance = distance(PMob->loc.p, PTarget->loc.p);
 
     luautils::OnMobFight(PMob, PTarget);
+
+	//Check for SMN pet and sets pet to auto attack
+	if (PTarget->PPet != nullptr && PTarget->PPet->GetBattleTargetID() == 0)
+	{
+		if (PTarget->PPet->objtype == TYPE_PET && ((CPetEntity*)PTarget->PPet)->getPetType() == PETTYPE_AVATAR)
+		{
+			petutils::AttackTarget(PTarget, PMob);
+		}
+	}
 
     // Try to spellcast (this is done first so things like Chainspell spam is prioritised over TP moves etc.
     if (IsSpecialSkillReady(currentDistance) && TrySpecialSkill())
@@ -978,11 +988,10 @@ bool CMobController::CanAggroTarget(CBattleEntity* PTarget)
         return false;
     }
 
-    if (PMob->PMaster == nullptr && PMob->PAI->IsSpawned() && !PMob->PAI->IsEngaged() && CanDetectTarget(PTarget))
-    {
-        return true;
-    }
-
+	if (PMob->PMaster == nullptr && PMob->PAI->IsSpawned() && !PMob->PAI->IsEngaged() && CanDetectTarget(PTarget))
+	{
+		return true;
+	}
     return false;
 }
 

--- a/src/map/lua/lua_baseentity.cpp
+++ b/src/map/lua/lua_baseentity.cpp
@@ -6280,6 +6280,7 @@ inline int32 CLuaBaseEntity::despawnPet(lua_State *L)
     if (((CBattleEntity*)m_PBaseEntity)->PPet != nullptr)
     {
         petutils::DespawnPet((CBattleEntity*)m_PBaseEntity);
+		charutils::SaveCharStats((CCharEntity*)m_PBaseEntity);
     }
     return 0;
 }

--- a/src/map/packet_system.cpp
+++ b/src/map/packet_system.cpp
@@ -436,6 +436,7 @@ void SmallPacket0x00D(map_session_data_t* session, CCharEntity* PChar, CBasicPac
         PChar->loc.zone->DecreaseZoneCounter(PChar);
     }
 
+	charutils::LoadCharPetStats(PChar);
     charutils::SaveCharStats(PChar);
     charutils::SaveCharExp(PChar, PChar->GetMJob());
     charutils::SaveCharPoints(PChar);
@@ -2629,7 +2630,7 @@ void SmallPacket0x05D(map_session_data_t* session, CCharEntity* PChar, CBasicPac
 void SmallPacket0x05E(map_session_data_t* session, CCharEntity* PChar, CBasicPacket data)
 {
     // handle pets on zone
-    if (PChar->PPet != nullptr)
+    if (PChar->PPet != nullptr && !PChar->StatusEffectContainer->HasStatusEffect(EFFECT_CHOCOBO))
     {
         CPetEntity* PPet = (CPetEntity*)PChar->PPet;
 
@@ -2645,17 +2646,18 @@ void SmallPacket0x05E(map_session_data_t* session, CCharEntity* PChar, CBasicPac
             case PETTYPE_JUG_PET:
             case PETTYPE_AUTOMATON:
             case PETTYPE_WYVERN:
+			case PETTYPE_AVATAR:
                 PChar->petZoningInfo.petHP = PPet->health.hp;
                 PChar->petZoningInfo.petTP = PPet->health.tp;
                 PChar->petZoningInfo.respawnPet = true;
                 PChar->petZoningInfo.petType = PPet->getPetType();
+				PChar->petZoningInfo.petID = PPet->m_PetID;
+				charutils::SaveCharStats(PChar);
                 petutils::DespawnPet(PChar);
                 break;
 
-            case PETTYPE_AVATAR:
-                petutils::DespawnPet(PChar);
-
             default:
+				petutils::DespawnPet(PChar);
                 break;
             }
         }

--- a/src/map/packet_system.cpp
+++ b/src/map/packet_system.cpp
@@ -343,8 +343,8 @@ void SmallPacket0x00C(map_session_data_t* session, CCharEntity* PChar, CBasicPac
     // respawn any pets from last zone
     if (PChar->petZoningInfo.respawnPet == true)
     {
-        // only repawn pet in valid zones
-        if (PChar->loc.zone->CanUseMisc(MISC_PET) && !PChar->m_moghouseID)
+        // only repawn pet in valid zones and if not on chocobo
+        if (PChar->loc.zone->CanUseMisc(MISC_PET) && !PChar->m_moghouseID && !PChar->StatusEffectContainer->HasStatusEffect(EFFECT_CHOCOBO))
         {
             switch (PChar->petZoningInfo.petType)
             {

--- a/src/map/utils/charutils.cpp
+++ b/src/map/utils/charutils.cpp
@@ -4298,6 +4298,36 @@ namespace charutils
         return false;
     }
 
+	/************************************************************************
+	*                                                                       *
+	*     Load CharStats to get pet info for respawning after dismount      *
+	*                                                                       *
+	************************************************************************/
+
+	void LoadCharPetStats(CCharEntity* PChar)
+	{
+
+		const int8* fmtQuery = "SELECT nameflags, mjob, sjob, hp, mp, mhflag, title, bazaar_message, zoning, "
+			"pet_id, pet_type, pet_hp, pet_mp "
+			"FROM char_stats WHERE charid = %u;";
+		int32 ret = Sql_Query(SqlHandle, fmtQuery, PChar->id);
+		//uint8 zoning = Sql_GetUIntData(SqlHandle, 8);
+
+		if (ret != SQL_ERROR &&
+			Sql_NumRows(SqlHandle) != 0 &&
+			Sql_NextRow(SqlHandle) == SQL_SUCCESS)
+		{
+			int16 petHP = Sql_GetUIntData(SqlHandle, 11);
+			if (petHP) {
+				PChar->petZoningInfo.petHP = petHP;
+				PChar->petZoningInfo.petID = Sql_GetUIntData(SqlHandle, 9);
+				PChar->petZoningInfo.petMP = Sql_GetIntData(SqlHandle, 12);
+				PChar->petZoningInfo.petType = (PETTYPE)Sql_GetUIntData(SqlHandle, 10);
+				PChar->petZoningInfo.respawnPet = true;
+			}
+		}
+	}
+
     /************************************************************************
     *                                                                       *
     *                                                                       *

--- a/src/map/utils/charutils.h
+++ b/src/map/utils/charutils.h
@@ -152,6 +152,7 @@ namespace charutils
     void	SaveDeathTime(CCharEntity* PChar);							// Saves when this character last died.
     void	SavePlayTime(CCharEntity* PChar);							// Saves this characters total play time.
     bool	hasMogLockerAccess(CCharEntity* PChar);						// true if have access, false otherwise.
+	void    LoadCharPetStats(CCharEntity* PChar);                       // For Loading Pet status  
 
     uint32  AddExpBonus(CCharEntity* PChar, uint32 exp);
 


### PR DESCRIPTION
Fix for SMN Pet behavior to act as a bodyguard, attacking anything that aggros/has hate on Master or that Master attacks provided pet has no battle target.  

SMN pets will now respawn after zoning.  

Pets will despawn on chocobo mounting.  

I dont know if this is retail behavior but I also made them respawn on chocobo dismount.  

Known issue:  The automatic chocobo dismount on zone (when zoning into an area chcobo's are not allowed) will not respawn pet