### PR TITLE
Implements modifiers for macaron foods.

### DIFF
--- a/scripts/globals/items/cherry_macaron.lua
+++ b/scripts/globals/items/cherry_macaron.lua
@@ -14,11 +14,11 @@ require("scripts/globals/status");
 -----------------------------------------
 
 function onItemCheck(target)
-local result = 0;
+    local result = 0;
     if (target:hasStatusEffect(EFFECT_FOOD) == true or target:hasStatusEffect(EFFECT_FIELD_SUPPORT_FOOD) == true) then
         result = 246;
     end
-return result;
+    return result;
 end;
 
 -----------------------------------------

--- a/scripts/globals/items/cherry_macaron.lua
+++ b/scripts/globals/items/cherry_macaron.lua
@@ -1,0 +1,48 @@
+-----------------------------------------
+-- ID: 5779
+-- Item: cherry_macaron
+-- Food Effect: 30Min, All Races
+-----------------------------------------
+-- Increases rate of synthesis success +3%
+-- Increases synthesis skill gain rate +3% 
+-----------------------------------------
+
+require("scripts/globals/status");
+
+-----------------------------------------
+-- OnItemCheck
+-----------------------------------------
+
+function onItemCheck(target)
+local result = 0;
+    if (target:hasStatusEffect(EFFECT_FOOD) == true or target:hasStatusEffect(EFFECT_FIELD_SUPPORT_FOOD) == true) then
+        result = 246;
+    end
+return result;
+end;
+
+-----------------------------------------
+-- OnItemUse
+-----------------------------------------
+
+function onItemUse(target)
+    target:addStatusEffect(EFFECT_FOOD,0,0,1800,5779);
+end;
+
+-----------------------------------
+-- onEffectGain Action
+-----------------------------------
+
+function onEffectGain(target,effect)
+    target:addMod(MOD_SYNTH_SUCCESS, 3);
+    target:addMod(MOD_SYNTH_SKILL_GAIN, 3);
+end;
+
+-----------------------------------------
+-- onEffectLose Action
+-----------------------------------------
+
+function onEffectLose(target,effect)
+    target:delMod(MOD_SYNTH_SUCCESS, 3);
+    target:delMod(MOD_SYNTH_SKILL_GAIN, 3);
+end;

--- a/scripts/globals/items/cherry_macaron.lua
+++ b/scripts/globals/items/cherry_macaron.lua
@@ -15,7 +15,7 @@ require("scripts/globals/status");
 
 function onItemCheck(target)
     local result = 0;
-    if (target:hasStatusEffect(EFFECT_FOOD) == true or target:hasStatusEffect(EFFECT_FIELD_SUPPORT_FOOD) == true) then
+    if (target:hasStatusEffect(EFFECT_FOOD) or target:hasStatusEffect(EFFECT_FIELD_SUPPORT_FOOD)) then
         result = 246;
     end
     return result;

--- a/scripts/globals/items/coffee_macaron.lua
+++ b/scripts/globals/items/coffee_macaron.lua
@@ -14,11 +14,11 @@ require("scripts/globals/status");
 -----------------------------------------
 
 function onItemCheck(target)
-local result = 0;
+    local result = 0;
     if (target:hasStatusEffect(EFFECT_FOOD) == true or target:hasStatusEffect(EFFECT_FIELD_SUPPORT_FOOD) == true) then
         result = 246;
     end
-return result;
+    return result;
 end;
 
 -----------------------------------------

--- a/scripts/globals/items/coffee_macaron.lua
+++ b/scripts/globals/items/coffee_macaron.lua
@@ -15,7 +15,7 @@ require("scripts/globals/status");
 
 function onItemCheck(target)
     local result = 0;
-    if (target:hasStatusEffect(EFFECT_FOOD) == true or target:hasStatusEffect(EFFECT_FIELD_SUPPORT_FOOD) == true) then
+    if (target:hasStatusEffect(EFFECT_FOOD) or target:hasStatusEffect(EFFECT_FIELD_SUPPORT_FOOD)) then
         result = 246;
     end
     return result;

--- a/scripts/globals/items/coffee_macaron.lua
+++ b/scripts/globals/items/coffee_macaron.lua
@@ -1,0 +1,48 @@
+-----------------------------------------
+-- ID: 5780
+-- Item: coffee_macaron
+-- Food Effect: 30Min, All Races
+-----------------------------------------
+-- Increases rate of synthesis success +5%
+-- Increases synthesis skill gain rate +5% 
+-----------------------------------------
+
+require("scripts/globals/status");
+
+-----------------------------------------
+-- OnItemCheck
+-----------------------------------------
+
+function onItemCheck(target)
+local result = 0;
+    if (target:hasStatusEffect(EFFECT_FOOD) == true or target:hasStatusEffect(EFFECT_FIELD_SUPPORT_FOOD) == true) then
+        result = 246;
+    end
+return result;
+end;
+
+-----------------------------------------
+-- OnItemUse
+-----------------------------------------
+
+function onItemUse(target)
+    target:addStatusEffect(EFFECT_FOOD,0,0,1800,5780);
+end;
+
+-----------------------------------
+-- onEffectGain Action
+-----------------------------------
+
+function onEffectGain(target,effect)
+    target:addMod(MOD_SYNTH_SUCCESS, 5);
+    target:addMod(MOD_SYNTH_SKILL_GAIN, 5);
+end;
+
+-----------------------------------------
+-- onEffectLose Action
+-----------------------------------------
+
+function onEffectLose(target,effect)
+    target:delMod(MOD_SYNTH_SUCCESS, 5);
+    target:delMod(MOD_SYNTH_SKILL_GAIN, 5);
+end;

--- a/scripts/globals/items/kitron_macaron.lua
+++ b/scripts/globals/items/kitron_macaron.lua
@@ -14,11 +14,11 @@ require("scripts/globals/status");
 -----------------------------------------
 
 function onItemCheck(target)
-local result = 0;
+    local result = 0;
     if (target:hasStatusEffect(EFFECT_FOOD) == true or target:hasStatusEffect(EFFECT_FIELD_SUPPORT_FOOD) == true) then
         result = 246;
     end
-return result;
+    return result;
 end;
 
 -----------------------------------------

--- a/scripts/globals/items/kitron_macaron.lua
+++ b/scripts/globals/items/kitron_macaron.lua
@@ -1,0 +1,48 @@
+-----------------------------------------
+-- ID: 5781
+-- Item: kitron_macaron
+-- Food Effect: 30Min, All Races
+-----------------------------------------
+-- Increases rate of synthesis success +7%
+-- Increases synthesis skill gain rate +7% 
+-----------------------------------------
+
+require("scripts/globals/status");
+
+-----------------------------------------
+-- OnItemCheck
+-----------------------------------------
+
+function onItemCheck(target)
+local result = 0;
+    if (target:hasStatusEffect(EFFECT_FOOD) == true or target:hasStatusEffect(EFFECT_FIELD_SUPPORT_FOOD) == true) then
+        result = 246;
+    end
+return result;
+end;
+
+-----------------------------------------
+-- OnItemUse
+-----------------------------------------
+
+function onItemUse(target)
+    target:addStatusEffect(EFFECT_FOOD,0,0,1800,5781);
+end;
+
+-----------------------------------
+-- onEffectGain Action
+-----------------------------------
+
+function onEffectGain(target,effect)
+    target:addMod(MOD_SYNTH_SUCCESS, 7);
+    target:addMod(MOD_SYNTH_SKILL_GAIN, 7);
+end;
+
+-----------------------------------------
+-- onEffectLose Action
+-----------------------------------------
+
+function onEffectLose(target,effect)
+    target:delMod(MOD_SYNTH_SUCCESS, 7);
+    target:delMod(MOD_SYNTH_SKILL_GAIN, 7);
+end;

--- a/scripts/globals/items/kitron_macaron.lua
+++ b/scripts/globals/items/kitron_macaron.lua
@@ -15,7 +15,7 @@ require("scripts/globals/status");
 
 function onItemCheck(target)
     local result = 0;
-    if (target:hasStatusEffect(EFFECT_FOOD) == true or target:hasStatusEffect(EFFECT_FIELD_SUPPORT_FOOD) == true) then
+    if (target:hasStatusEffect(EFFECT_FOOD) or target:hasStatusEffect(EFFECT_FIELD_SUPPORT_FOOD)) then
         result = 246;
     end
     return result;

--- a/scripts/globals/status.lua
+++ b/scripts/globals/status.lua
@@ -1338,6 +1338,10 @@ MOD_JUG_LEVEL_RANGE           = 564 -- Decreases the level range of spawned jug 
 MOD_FORCE_JUMP_CRIT           = 828 -- Critical hit rate bonus for jump and high jump
 MOD_QUICK_DRAW_DMG_PERCENT    = 834 -- Percentage increase to QD damage
 
+-- Crafting food effects
+MOD_SYNTH_SUCCESS    = 851 -- Rate of synthesis success
+MOD_SYNTH_SKILL_GAIN = 852 -- Synthesis skill gain rate
+
 MOD_WEAPONSKILL_DAMAGE_BASE = 570 -- See modifier.h for how this is used
 
 -- The entire mod list is in desperate need of kind of some organizing.

--- a/src/map/modifier.h
+++ b/src/map/modifier.h
@@ -629,6 +629,10 @@ enum MODIFIER
     MOD_EBULLIENCE_AMOUNT         = 569, // Bonus amount added to Ebullience effect
     MOD_AQUAVEIL_COUNT            = 832, // Modifies the amount of hits that Aquaveil absorbs before being removed
 
+    // Crafting food effects
+    MOD_SYNTH_SUCCESS             = 851, // Rate of synthesis success
+    MOD_SYNTH_SKILL_GAIN          = 852, // Synthesis skill gain rate
+
     // Weaponskill %damage modifiers
     // The following modifier should not ever be set, but %damage modifiers to weaponskills use the next 255 IDs (this modifier + the WSID)
     // For example, +10% damage to Chant du Cygne would be ID 570 + 225 (795)

--- a/src/map/utils/synthutils.cpp
+++ b/src/map/utils/synthutils.cpp
@@ -355,11 +355,26 @@ uint8 calcSynthResult(CCharEntity* PChar)
 				#endif
 			}
 
+			// Apply synthesis success rate modifier
+			int16 modSynthSuccess = PChar->getMod(MOD_SYNTH_SUCCESS);
+			success += (double)modSynthSuccess * 0.01;
+
             if(!canSynthesizeHQ(PChar,skillID))
             {
                 success += 0.01; //the crafting rings that block HQ synthesis all also increase their respective craft's success rate by 1%
                 canHQ = false; //assuming here that if a crafting ring is used matching a recipe's subsynth, overall HQ will still be blocked
             }
+
+			if (success > 0.99)
+			{
+				// Clamp success rate to 0.99
+				// Even if using kitron macaron, breaks can still happen
+				// https://www.bluegartr.com/threads/120352-CraftyMath
+				//   "I get a 99% success rate, so Kitron is doing something and it's not small."
+				// http://www.ffxiah.com/item/5781/kitron-macaron
+				//   "According to one of the Japanese wikis, it is said to decrease the minimum break rate from ~5% to 0.5%-2%."
+				success = 0.99;
+			}
 
 			double random = dsprand::GetRandomNumber(1.);
 			#ifdef _DSP_SYNTH_DEBUG_MESSAGES_
@@ -515,6 +530,11 @@ int32 doSynthSkillUp(CCharEntity* PChar)
 		if (charSkill < maxSkill)
 		{
 			double skillUpChance = ((double)baseDiff*(map_config.craft_chance_multiplier - (log(1.2 + charSkill/100))))/10;
+
+			// Apply synthesis skill gain rate modifier before synthesis fail modifier
+			int16 modSynthSkillGain = PChar->getMod(MOD_SYNTH_SKILL_GAIN);
+			skillUpChance += (double)modSynthSkillGain * 0.01;
+
 			skillUpChance = skillUpChance/(1 + (PChar->CraftContainer->getQuantity(0) == SYNTHESIS_FAIL));		// результат синтеза хранится в quantity нулевой ячейки
 
             double random = dsprand::GetRandomNumber(1.);


### PR DESCRIPTION
Implements synthesis success and synthesis skill gain from Cherry Macaron, Coffee Macaron, and Kitron Macaron.

Clamped success rate to 99% since people were still reporting breaks even with Kitron Macaron (+7% success rate). References cited in source code comments.
