### PR TITLE
Fixed cutscene ID for exiting to Caedarva via Nasheefa.

### DIFF
--- a/scripts/zones/Caedarva_Mire/npcs/Nasheefa.lua
+++ b/scripts/zones/Caedarva_Mire/npcs/Nasheefa.lua
@@ -30,7 +30,7 @@ end;
 function onTrigger(player,npc)
     
     if (player:getXPos() < -440) then
-        player:startEvent(0x00be);
+        player:startEvent(0x00b8);
     else
         player:startEvent(0x00b6);
     end


### PR DESCRIPTION
Old CSID (0x00be) moves the NPC to the side but locks the player in place until they hit escape, making it impossible to pass.

New CSID (0x00b8) brings up the "Do you wish to leave the ruins?" menu, and allows the player to pass.

For easy testing:
Nasheefa is @pos -443.524 4 -739.546 79
Imperial Silver Piece is @additem 2185 