### PR TITLE
Fixed issue #3547

### DIFF
--- a/scripts/globals/settings.lua
+++ b/scripts/globals/settings.lua
@@ -163,7 +163,7 @@ NUMBER_OF_DM_EARRINGS = 1; -- Number of earrings players can simultaneously own 
 HOMEPOINT_TELEPORT = 0; -- Enables the homepoint teleport system
 DIG_ABUNDANCE_BONUS = 0; -- Increase chance of digging up an item (450  = item digup chance +45)
 DIG_FATIGUE = 1; -- Set to 0 to disable Dig Fatigue
-MIASMA_FILTER_COOLDOWN = 5;  -- Number of days a player can obtain a Miasma Filter KI for any of the Boneyard Gully ENMs (Minimum:1)
+ENM_COOLDOWN = 120;  -- Number of hours before a player can obtain same KI for ENMs (default: 5 days)
 FORCE_SPAWN_QM_RESET_TIME = 300; -- Number of seconds the ??? remains hidden for after the despawning of the mob it force spawns.
 
 -- LIMBUS

--- a/scripts/zones/Attohwa_Chasm/npcs/Jakaka.lua
+++ b/scripts/zones/Attohwa_Chasm/npcs/Jakaka.lua
@@ -30,7 +30,7 @@ end;
 function onTrigger(player,npc)
 
     local MiasmaFilterCD = player:getVar("[ENM]MiasmaFilter");
-    
+
     if (player:hasKeyItem(MIASMA_FILTER)) then
         player:startEvent(11);
     else
@@ -39,9 +39,9 @@ function onTrigger(player,npc)
             player:startEvent(14, VanadielTime()+(MiasmaFilterCD-os.time(t)));
         else
             if (player:hasItem(1778)==true or player:hasItem(1777)==true) then -- Parradamo Stones, Flaxen Pouch
-                player:startEvent(15); 
+                player:startEvent(15);
             else
-                player:startEvent(13); 
+                player:startEvent(13);
             end;
         end;
     end;
@@ -66,7 +66,7 @@ function onEventFinish(player,csid,option)
     if (csid == 12) then
         player:addKeyItem(MIASMA_FILTER);
         player:messageSpecial(KEYITEM_OBTAINED,MIASMA_FILTER);
-        player:setVar("[ENM]MiasmaFilter",os.time(t)+86400*MIASMA_FILTER_COOLDOWN); -- Current time + 1dayInSeconds*MIASMA_FILTER_COOLDOWN
+        player:setVar("[ENM]MiasmaFilter",os.time(t)+(ENM_COOLDOWN*3600)); -- Current time + (ENM_COOLDOWN*1hr in seconds)
     elseif (csid == 13) then
         if (player:getFreeSlotsCount() == 0) then
             player:messageSpecial(ITEM_CANNOT_BE_OBTAINED, 1777); -- Flaxen Pouch

--- a/scripts/zones/Bearclaw_Pinnacle/npcs/Armoury_Crate.lua
+++ b/scripts/zones/Bearclaw_Pinnacle/npcs/Armoury_Crate.lua
@@ -2,12 +2,11 @@
 -- Area: Bearclaw Pinnacle
 -- NPC:  Armoury Crate
 -----------------------------------
-package.loaded["scripts/zones/Balgas_Dais/TextIDs"] = nil;
+package.loaded["scripts/zones/Bearclaw_Pinnacle/TextIDs"] = nil;
 -------------------------------------
-
+require("scripts/zones/Bearclaw_Pinnacle/TextIDs");
 require("scripts/globals/titles");
 require("scripts/globals/quests");
-require("scripts/zones/Balgas_Dais/TextIDs");
 
 -----------------------------------
 

--- a/scripts/zones/Uleguerand_Range/npcs/Chamnaet_Spring.lua
+++ b/scripts/zones/Uleguerand_Range/npcs/Chamnaet_Spring.lua
@@ -3,13 +3,11 @@
 --  NPC:  Chamnaet Spring
 --  Receive Chamnaet Ice upon trading Cotton Pouch
 -- @pos -305.240 3.605 17.977
-
 -----------------------------------
 package.loaded["scripts/zones/Uleguerand_Range/TextIDs"] = nil;
 -----------------------------------
-
-require("scripts/globals/keyitems");
 require("scripts/zones/Uleguerand_Range/TextIDs");
+require("scripts/globals/keyitems");
 
 -----------------------------------
 -- onTrade Action
@@ -33,6 +31,4 @@ end;
 -----------------------------------
 
 function onTrigger(player,npc)
-
-    
 end;

--- a/scripts/zones/Uleguerand_Range/npcs/Zebada.lua
+++ b/scripts/zones/Uleguerand_Range/npcs/Zebada.lua
@@ -6,6 +6,8 @@
 -----------------------------------
 package.loaded["scripts/zones/Uleguerand_Range/TextIDs"] = nil;
 -----------------------------------
+require("scripts/zones/Uleguerand_Range/TextIDs");
+require("scripts/globals/keyitems");
 
 -----------------------------------
 -- onTrade Action
@@ -26,7 +28,7 @@ end;
 function onTrigger(player,npc)
 
     local ZephyrFanCD = player:getVar("[ENM]ZephyrFan");
-    
+
     if (player:hasKeyItem(ZEPHYR_FAN)) then
         player:startEvent(12);
     else
@@ -35,9 +37,9 @@ function onTrigger(player,npc)
             player:startEvent(15, VanadielTime()+(ZephyrFanCD-os.time(t)));
         else
             if (player:hasItem(1780) or player:hasItem(1779)) then -- Chamnaet Ice -- Cotton Pouch
-                player:startEvent(16); 
+                player:startEvent(16);
             else
-                player:startEvent(14); 
+                player:startEvent(14);
             end;
         end;
     end;
@@ -59,18 +61,17 @@ end;
 function onEventFinish(player,csid,option)
     -- printf("CSID: %u",csid);
     -- printf("RESULT: %u",option);
-	if (csid == 13) then
+    if (csid == 13) then
         player:addKeyItem(ZEPHYR_FAN);
         player:messageSpecial(KEYITEM_OBTAINED,ZEPHYR_FAN);
-        player:setVar("[ENM]ZephyrFan",os.time(t)+86400*ZEPHYR_FAN_COOLDOWN); -- Current time + 1dayInSeconds*ZEPHYR_FAN_COOLDOWN
+        player:setVar("[ENM]ZephyrFan",os.time(t)+(ENM_COOLDOWN*3600)); -- Current time + (ENM_COOLDOWN*1hr in seconds)
     elseif (csid == 14) then
         if (player:getFreeSlotsCount() == 0) then
             player:messageSpecial(ITEM_CANNOT_BE_OBTAINED, 1779); -- Cotton Pouch
             return;
-        else 
+        else
             player:addItem(1779);
             player:messageSpecial(ITEM_OBTAINED, 1779); -- Cotton Pouch
         end
     end
 end;
-


### PR DESCRIPTION
Fix a script error (#3547), fix bad/missing requires, and consolidate ENM timer global variables. No reason to make a new var for every ENM anyway. Also the setting is now measured in hours.