### PR TITLE
Rampart fix

### DIFF
--- a/scripts/globals/abilities/rampart.lua
+++ b/scripts/globals/abilities/rampart.lua
@@ -23,5 +23,9 @@ end;
 
 function onUseAbility(player,target,ability)
     local duration = 30 + player:getMod(MOD_RAMPART_DURATION);
-    target:addStatusEffect(EFFECT_MAGIC_SHIELD, 1, 0, duration);
+    local vit = player:getStat(MOD_VIT);
+    local subpower = vit*2;
+
+    target:addStatusEffect(EFFECT_MAGIC_SHIELD, 4, 0, duration, subpower);
+
 end;

--- a/scripts/globals/effects/magic_shield.lua
+++ b/scripts/globals/effects/magic_shield.lua
@@ -1,6 +1,7 @@
 -----------------------------------
 --
 -- Magic Shield BLOCKS all magic attacks
+-- Magic Shield from Rampart provides magical stoneskin at vit*2
 --
 -----------------------------------
 
@@ -11,7 +12,9 @@ require("scripts/globals/status");
 -----------------------------------
 
 function onEffectGain(target,effect)
-    if (effect:getPower() == 3) then -- arcane stomp
+    if (effect:getPower() == 4) then
+        target:setMod(MOD_MAGIC_SHIELD, effect:getPower());
+    elseif (effect:getPower() == 3) then -- arcane stomp
         target:addMod(MOD_FIRE_ABSORB, 100);
         target:addMod(MOD_EARTH_ABSORB, 100);
         target:addMod(MOD_WATER_ABSORB, 100);
@@ -20,9 +23,9 @@ function onEffectGain(target,effect)
         target:addMod(MOD_LTNG_ABSORB, 100);
         target:addMod(MOD_LIGHT_ABSORB, 100);
         target:addMod(MOD_DARK_ABSORB, 100);
-    elseif (effect:getPower() < 2) then
+    elseif (effect:getPower() == 1) then
         target:addMod(MOD_UDMGMAGIC, -101);
-    else
+    elseif (effect:getPower() == 0) then
         target:addMod(MOD_MAGIC_ABSORB, 100);
     end;
 end;
@@ -39,7 +42,9 @@ end;
 -----------------------------------
 
 function onEffectLose(target,effect)
-    if (effect:getPower() == 3) then -- arcane stomp
+    if (effect:getPower()== 4) then
+        target:delMod(MOD_MAGIC_SHIELD, 0);
+    elseif (effect:getPower() == 3) then -- arcane stomp
         target:delMod(MOD_FIRE_ABSORB, 100);
         target:delMod(MOD_EARTH_ABSORB, 100);
         target:delMod(MOD_WATER_ABSORB, 100);
@@ -48,9 +53,9 @@ function onEffectLose(target,effect)
         target:delMod(MOD_LTNG_ABSORB, 100);
         target:delMod(MOD_LIGHT_ABSORB, 100);
         target:delMod(MOD_DARK_ABSORB, 100);
-    elseif (effect:getPower() < 2) then
+    elseif (effect:getPower() == 1) then
         target:delMod(MOD_UDMGMAGIC, -101);
-    else
+    elseif (effect:getpower() == 0) then
         target:delMod(MOD_MAGIC_ABSORB, 100);
     end;
 end;

--- a/scripts/globals/effects/magic_shield.lua
+++ b/scripts/globals/effects/magic_shield.lua
@@ -13,7 +13,7 @@ require("scripts/globals/status");
 
 function onEffectGain(target,effect)
     if (effect:getPower() == 4) then
-        target:setMod(MOD_MAGIC_SHIELD, effect:getPower());
+        target:setMod(MOD_MAGIC_SHIELD, effect:getSubpower());
     elseif (effect:getPower() == 3) then -- arcane stomp
         target:addMod(MOD_FIRE_ABSORB, 100);
         target:addMod(MOD_EARTH_ABSORB, 100);
@@ -43,7 +43,7 @@ end;
 
 function onEffectLose(target,effect)
     if (effect:getPower()== 4) then
-        target:delMod(MOD_MAGIC_SHIELD, 0);
+        target:setMod(MOD_MAGIC_SHIELD, 0);
     elseif (effect:getPower() == 3) then -- arcane stomp
         target:delMod(MOD_FIRE_ABSORB, 100);
         target:delMod(MOD_EARTH_ABSORB, 100);

--- a/scripts/globals/magic.lua
+++ b/scripts/globals/magic.lua
@@ -367,10 +367,10 @@ end;
 
 function getMagicHitRate(caster, target, skillType, element, percentBonus, bonusAcc)
     -- resist everything if magic shield is active
-    if (target:hasStatusEffect(EFFECT_MAGIC_SHIELD, 0)) then
+    if (target:getMod(MOD_MAGIC_SHIELD) <= 3) then
         return 0;
     end
-
+    
     local magiceva = 0;
 
     if (bonusAcc == nil) then
@@ -619,10 +619,21 @@ end;
     end
 
     dmg = target:magicDmgTaken(dmg);
-
+    
     if (dmg > 0) then
         dmg = dmg - target:getMod(MOD_PHALANX);
         dmg = utils.clamp(dmg, 0, 99999);
+    end
+        
+    --handling magic shield
+    dmg = utils.magicShield(target, dmg);
+    dmg = utils.clamp(dmg, -99999, 99999);
+
+    if (dmg < 0) then
+        dmg = target:addHP(-dmg);
+    else
+        target:delHP(dmg);
+        target:updateEnmityFromDamage(caster,dmg);
     end
 
     --handling stoneskin
@@ -642,6 +653,7 @@ end;
         end
     end
 
+
     return dmg;
  end;
 
@@ -654,10 +666,9 @@ function finalMagicNonSpellAdjustments(caster,target,ele,dmg)
         dmg = dmg - target:getMod(MOD_PHALANX);
         dmg = utils.clamp(dmg, 0, 99999);
     end
-
-    --handling stoneskin
-    dmg = utils.stoneskin(target, dmg);
-
+    
+        --handling magic shield
+    dmg = utils.magicShield(target, dmg);
     dmg = utils.clamp(dmg, -99999, 99999);
 
     if (dmg < 0) then
@@ -665,6 +676,18 @@ function finalMagicNonSpellAdjustments(caster,target,ele,dmg)
     else
         target:delHP(dmg);
     end
+
+    --handling stoneskin
+    dmg = utils.stoneskin(target, dmg);
+    dmg = utils.clamp(dmg, -99999, 99999);
+
+    if (dmg < 0) then
+        dmg = -(target:addHP(-dmg));
+    else
+        target:delHP(dmg);
+    end
+    
+    
     --Not updating enmity from damage, as this is primarily used for additional effects (which don't generate emnity)
     -- in the case that updating enmity is needed, do it manually after calling this
     --target:updateEnmityFromDamage(caster,dmg);

--- a/scripts/globals/status.lua
+++ b/scripts/globals/status.lua
@@ -1172,6 +1172,7 @@ MOD_REGEN_DOWN            = 404 -- poison
 MOD_REFRESH_DOWN          = 405 -- plague, reduce mp
 MOD_REGAIN_DOWN           = 406 -- plague, reduce tp
 MOD_MAGIC_DAMAGE          = 311 --  Magic damage added directly to the spell's base damage
+MOD_MAGIC_SHIELD          = 840 -- Added for Rampart
 
 -- Gear set modifiers
 MOD_DA_DOUBLE_DAMAGE         = 408 -- Double attack's double damage chance %.
@@ -1354,7 +1355,6 @@ MOD_WEAPONSKILL_DAMAGE_BASE = 570 -- See modifier.h for how this is used
 -- MOD_SPARE = 99 -- stuff
 -- MOD_SPARE = 100 -- stuff
 -- 570 - 825 used by WS DMG mods these are not spares.
--- MOD_SPARE = 840 -- stuff
 -- MOD_SPARE = 841 -- stuff
 -- MOD_SPARE = 842 -- stuff
 -- MOD_SPARE = 843 -- stuff

--- a/scripts/globals/utils.lua
+++ b/scripts/globals/utils.lua
@@ -44,6 +44,25 @@ function utils.stoneskin(target, dmg)
     return dmg;
 end;
 
+function utils.magicShield(target, dmg)
+    --handling magic shield
+    if (dmg > 0) then
+        shield = target:getMod(MOD_MAGIC_SHIELD);
+        if (shield > 0) then
+            if (shield > dmg) then --absorb all damage
+                target:delMod(MOD_MAGIC_SHIELD,dmg);
+                return 0;
+            else --absorbs some damage then wear
+                target:delStatusEffect(EFFECT_MAGIC_SHIELD);
+                target:setMod(MOD_MAGIC_SHIELD, 0);
+                return dmg - shield;
+            end
+        end
+    end
+
+    return dmg;
+end;
+
 function utils.takeShadows(target, dmg, shadowbehav)
     if (shadowbehav == nil) then
         shadowbehav = 1;

--- a/src/map/modifier.h
+++ b/src/map/modifier.h
@@ -281,7 +281,7 @@ enum MODIFIER
     MOD_WARCRY_DURATION           = 483, // Warcy duration bonus from gear
 
     // Monk
-	MOD_BOOST_EFFECT              = 97,  // Boost power in tenths
+    MOD_BOOST_EFFECT              = 97,  // Boost power in tenths
     MOD_SUBTLE_BLOW               = 289, // How much TP to reduce.
     MOD_COUNTER                   = 291, // Percent chance to counter
     MOD_KICK_ATTACK               = 292, // Percent chance to kick
@@ -628,7 +628,8 @@ enum MODIFIER
     MOD_RAPTURE_AMOUNT            = 568, // Bonus amount added to Rapture effect
     MOD_EBULLIENCE_AMOUNT         = 569, // Bonus amount added to Ebullience effect
     MOD_AQUAVEIL_COUNT            = 832, // Modifies the amount of hits that Aquaveil absorbs before being removed
-
+    MOD_MAGIC_SHIELD              = 840, // Added for Rampart
+    
     // Crafting food effects
     MOD_SYNTH_SUCCESS             = 851, // Rate of synthesis success
     MOD_SYNTH_SKILL_GAIN          = 852, // Synthesis skill gain rate
@@ -644,7 +645,6 @@ enum MODIFIER
     // MOD_SPARE = 99, // stuff
     // MOD_SPARE = 100, // stuff
     // 570 through 825 used by WS DMG mods these are not spares.
-    // MOD_SPARE = 840, // stuff
     // MOD_SPARE = 841, // stuff
     // MOD_SPARE = 842, // stuff
     // MOD_SPARE = 843, // stuff

--- a/src/map/status_effect.h
+++ b/src/map/status_effect.h
@@ -719,7 +719,7 @@ enum EFFECT
     // EFFECT_PLACEHOLDER             = 1023 // The client dat file seems to have only this many "slots", results of exceeding that are untested.
 };
 
-#define MAX_EFFECTID    802  // 768 real + 32 custom
+#define MAX_EFFECTID    841  // 768 real + 32 custom
 
 /************************************************************************
 *                                                                       *


### PR DESCRIPTION
https://www.bg-wiki.com/bg/Rampart

gedads will check tomorrow to verify if this is a phalanx or stoneskin type of effect, it will give a magic shield effect on the party at the power of vit*2 and magic shield will wear off after magic dmg exceeds or duration expires.

placed a var set and check to make sure it doesn't interfere with how magic shield functions with mobs. tested and working correctly in a party. this does not take into effect the def bonus, someone can add that in later if we can actually verify exactly what levels the def bonus changes at.