### PR TITLE
Workaround for antlions that have ambush ability, but are non-aggresi…

### DIFF
--- a/scripts/mixins/families/antlion_ambush_noaggro.lua
+++ b/scripts/mixins/families/antlion_ambush_noaggro.lua
@@ -1,0 +1,24 @@
+-- Antlion family mixin (for ones that ambush and are non-aggressive)
+-- Not hiding upon DISENGAGE event, since mob would be spawned and no longer be accessible
+-- Example: Alastor Antlion has ambush animation when popped [1], but does not burrow when going unclaimed [2]
+-- [1] Alastor Antlion https://www.youtube.com/watch?v=Q3L0SAxiK54
+-- [2] Alastor Antlion duo part 2 of 5 https://www.youtube.com/watch?v=-hAyx56fVnE
+
+require("scripts/globals/mixins")
+
+g_mixins = g_mixins or {}
+g_mixins.families = g_mixins.families or {}
+
+g_mixins.families.antlion_ambush_noaggro = function(mob)
+    mob:addListener("SPAWN", "ANTLION_AMBUSH_NOAGGRO_SPAWN", function(mob)
+        mob:hideName(true);
+        mob:untargetable(true);
+        mob:hideModel(true);
+        mob:AnimationSub(0);
+    end)
+    mob:addListener("ENGAGE", "ANTLION_AMBUSH_NOAGGRO_ENGAGE", function(mob, target)
+        mob:useMobAbility(278); -- Pit Ambush
+    end)
+end
+
+return g_mixins.families.antlion_ambush_noaggro

--- a/scripts/zones/Attohwa_Chasm/mobs/Alastor_Antlion.lua
+++ b/scripts/zones/Attohwa_Chasm/mobs/Alastor_Antlion.lua
@@ -5,7 +5,7 @@
 
 require("scripts/globals/status");
 require("scripts/globals/magic");
-mixins = {require("scripts/mixins/families/antlion_ambush")}
+mixins = {require("scripts/mixins/families/antlion_ambush_noaggro")}
 
 -----------------------------------
 -- onMobInitialize Action

--- a/scripts/zones/Attohwa_Chasm/mobs/Executioner_Antlion.lua
+++ b/scripts/zones/Attohwa_Chasm/mobs/Executioner_Antlion.lua
@@ -4,7 +4,7 @@
 -----------------------------------
 
 require("scripts/globals/status");
-mixins = {require("scripts/mixins/families/antlion_ambush")}
+mixins = {require("scripts/mixins/families/antlion_ambush_noaggro")}
 
 -----------------------------------
 -- onMobInitialize Action

--- a/src/map/ai/controllers/mob_controller.cpp
+++ b/src/map/ai/controllers/mob_controller.cpp
@@ -775,8 +775,14 @@ void CMobController::DoRoamTick(time_point tick)
                     // cast buff
                     CastSpell(PMob->SpellContainer->GetBuffSpell());
                 }
-                else if ((PMob->m_roamFlags & ROAMFLAG_AMBUSH))
+                else if ((PMob->m_roamFlags & ROAMFLAG_AMBUSH) && PMob->m_Aggro)
                 {
+                    // Workaround here until this logic is moved to scripts
+                    // Only applying to aggressive mobs
+                    // Not applying to non-aggresive mobs
+                    // Otherwise non-aggresive mobs get stuck spawned underground until server restart
+                    // For example, Alastor Antlion and Executioner Antlion are non-aggressive
+
                     //#TODO: #AIToScript move to scripts
                     // stay underground
                     PMob->HideName(true);

--- a/src/map/ai/controllers/mob_controller.cpp
+++ b/src/map/ai/controllers/mob_controller.cpp
@@ -758,6 +758,7 @@ void CMobController::DoRoamTick(time_point tick)
             }
             else
             {
+                // No longer including conditional for ROAMFLAG_AMBUSH now that using mixin to handle mob hiding
                 if (PMob->getMobMod(MOBMOD_SPECIAL_SKILL) != 0 &&
                     m_Tick >= m_LastSpecialTime + std::chrono::milliseconds(PMob->getBigMobMod(MOBMOD_SPECIAL_COOL)) &&
                     TrySpecialSkill())
@@ -774,22 +775,6 @@ void CMobController::DoRoamTick(time_point tick)
                 {
                     // cast buff
                     CastSpell(PMob->SpellContainer->GetBuffSpell());
-                }
-                else if ((PMob->m_roamFlags & ROAMFLAG_AMBUSH) && PMob->m_Aggro)
-                {
-                    // Workaround here until this logic is moved to scripts
-                    // Only applying to aggressive mobs
-                    // Not applying to non-aggresive mobs
-                    // Otherwise non-aggresive mobs get stuck spawned underground until server restart
-                    // For example, Alastor Antlion and Executioner Antlion are non-aggressive
-
-                    //#TODO: #AIToScript move to scripts
-                    // stay underground
-                    PMob->HideName(true);
-                    PMob->HideModel(true);
-                    PMob->animationsub = 0;
-
-                    PMob->updatemask |= UPDATE_HP;
                 }
                 else if ((PMob->m_roamFlags & ROAMFLAG_STEALTH))
                 {


### PR DESCRIPTION
…ve, getting stuck underground after disengage, and upon roaming after returning to spawn point. This is especially for Alastor Antlion and Executioner Antlion.

Alastor Antlion and Executioner Antlion are the only antlions with ambush that are non-aggressive in mob_pools.

Alastor Antlion has ambush animation when popped [1], but does not burrow when going unclaimed [2]
[1] Alastor Antlion https://www.youtube.com/watch?v=Q3L0SAxiK54
[2] Alastor Antlion duo part 2 of 5 https://www.youtube.com/watch?v=-hAyx56fVnE
