### PR TITLE
Reduce cast range of mobs to match retail.

### DIFF
--- a/src/map/ai/states/magic_state.cpp
+++ b/src/map/ai/states/magic_state.cpp
@@ -182,7 +182,7 @@ bool CMagicState::CanCastSpell(CBattleEntity* PTarget)
     {
         return false;
     }
-    if (distance(m_PEntity->loc.p, PTarget->loc.p) > 40)
+    if (distance(m_PEntity->loc.p, PTarget->loc.p) > 27)
     {
         m_errorMsg = std::make_unique<CMessageBasicPacket>(m_PEntity, PTarget, m_PSpell->getID(), 0, MSGBASIC_TOO_FAR_AWAY);
         return false;


### PR DESCRIPTION
Cast range was previously set to 40. 

Retail is 26.8. Rounded up to 27. http://ffxiclopedia.wikia.com/wiki/Distance

Tested on worms to see if mobs correctly get interrupted if you run past 27.

