### PR TITLE
Change when player gets credit for curse, during Curse Collector quest

### DIFF
--- a/scripts/zones/Beadeaux/Zone.lua
+++ b/scripts/zones/Beadeaux/Zone.lua
@@ -75,6 +75,9 @@ function onRegionEnter(player,region)
     if (region:GetRegionID() <= 6) then
         if (player:hasStatusEffect(EFFECT_CURSE_I) == false and player:hasStatusEffect(EFFECT_SILENCE) == false) then
             player:addStatusEffect(EFFECT_CURSE_I,50,0,300);
+            if (player:getQuestStatus(BASTOK,THE_CURSE_COLLECTOR) == QUEST_ACCEPTED and player:getVar("cCollectCurse") == 0) then 
+                player:setVar("cCollectCurse",1);
+            end
         end
     end
 end;

--- a/scripts/zones/Beadeaux/npcs/The_Afflictor.lua
+++ b/scripts/zones/Beadeaux/npcs/The_Afflictor.lua
@@ -23,12 +23,8 @@ end;
 -----------------------------------
 
 function onTrigger(player,npc)
-    
-    if (player:getQuestStatus(BASTOK,THE_CURSE_COLLECTOR) == QUEST_ACCEPTED and player:getVar("cCollectCurse") == 0) then 
-        player:setVar("cCollectCurse",1);
-    end
-
 end;
+
 -----------------------------------
 -- onEventUpdate
 -----------------------------------


### PR DESCRIPTION
Currently to progress on this quest, the player must click on the Afflictor.
Instead, the player should get credit when the Afflictor curses them.