### PR TITLE
Fixed issue where it would loop you back into MH when trying to zone out

### DIFF
--- a/src/map/utils/charutils.cpp
+++ b/src/map/utils/charutils.cpp
@@ -4754,7 +4754,7 @@ namespace charutils
                 "pos_y = %.3f,"
                 "pos_z = %.3f,"
                 "boundary = %u "
-                "WHERE charid = %u AND pos_zone = %u;";
+                "WHERE charid = %u;";
 
             Sql_Query(SqlHandle, Query,
                 PChar->loc.destination,


### PR DESCRIPTION
Not sure if removing "AND pos_zone = %u" has implications elsewhere but this resolved the MH zoning issue (looped me back into MH when trying to exit).