### PR TITLE
Zvahl Treasure Chest Fix

### DIFF
--- a/scripts/zones/Castle_Zvahl_Baileys/npcs/Treasure_Chest.lua
+++ b/scripts/zones/Castle_Zvahl_Baileys/npcs/Treasure_Chest.lua
@@ -21,14 +21,14 @@ local TreasureMinLvL = 43;
 -----------------------------------
 
 function onTrade(player,npc,trade)
-    -- trade:hasItemQty(1048,1);             -- Treasure Key
+    -- trade:hasItemQty(1038,1);             -- Treasure Key
     -- trade:hasItemQty(1115,1);            -- Skeleton Key
     -- trade:hasItemQty(1023,1);            -- Living Key
     -- trade:hasItemQty(1022,1);            -- Thief's Tools
     local questItemNeeded = 0;
     
     -- Player traded a key.
-    if ((trade:hasItemQty(1048,1) or trade:hasItemQty(1115,1) or trade:hasItemQty(1023,1) or trade:hasItemQty(1022,1)) and trade:getItemCount() == 1) then 
+    if ((trade:hasItemQty(1038,1) or trade:hasItemQty(1115,1) or trade:hasItemQty(1023,1) or trade:hasItemQty(1022,1)) and trade:getItemCount() == 1) then 
         local zone = player:getZoneID();
         -- IMPORTANT ITEM: keyitem -----------
         if (player:getQuestStatus(BASTOK,A_TEST_OF_TRUE_LOVE) == QUEST_ACCEPTED and player:hasKeyItem(UN_MOMENT) == false) then 
@@ -85,7 +85,7 @@ end;
 -----------------------------------
 
 function onTrigger(player,npc)
-    player:messageSpecial(CHEST_LOCKED,1048);
+    player:messageSpecial(CHEST_LOCKED,1038);
 end; 
 
 -----------------------------------


### PR DESCRIPTION
Issue where item id for the chest key was the same as the item id for the coffer key.