### PR TITLE
Quests that rewarded OUTLANDS fame now reward NORG or RABAO fame.

### DIFF
--- a/scripts/zones/Eastern_Altepa_Desert/npcs/Lokpix.lua
+++ b/scripts/zones/Eastern_Altepa_Desert/npcs/Lokpix.lua
@@ -59,7 +59,7 @@ function onEventFinish(player,csid,option)
         player:tradeComplete();
         player:addKeyItem(2051);
         player:messageSpecial(KEYITEM_OBTAINED,2051);
-        player:addFame(OUTLANDS,30);
+        player:addFame(RABAO,30);
         player:completeQuest(OUTLANDS,OPEN_SESAME);
     end
     

--- a/scripts/zones/Horlais_Peak/npcs/Hot_springs.lua
+++ b/scripts/zones/Horlais_Peak/npcs/Hot_springs.lua
@@ -55,7 +55,7 @@ function onEventFinish(player,csid,option)
         player:tradeComplete();
         player:addItem(4949); -- Scroll of Jubaku: Ichi
         player:messageSpecial(ITEM_OBTAINED, 4949); 
-        player:addFame(OUTLANDS,75);
+        player:addFame(NORG,75);
         player:addTitle(CRACKER_OF_THE_SECRET_CODE);
         player:completeQuest(OUTLANDS,SECRET_OF_THE_DAMP_SCROLL);
     end

--- a/scripts/zones/Norg/npcs/Heiji.lua
+++ b/scripts/zones/Norg/npcs/Heiji.lua
@@ -84,7 +84,7 @@ function onEventFinish(player,csid,option)
         player:addItem(4955); -- Scroll of Kurayami: Ichi
         player:messageSpecial(ITEM_OBTAINED, 4955); -- Scroll of Kurayami: Ichi
         player:setVar("shiningSubligar_nb",0);
-        player:addFame(OUTLANDS,100);
+        player:addFame(NORG,100);
         player:completeQuest(OUTLANDS,LIKE_A_SHINING_SUBLIGAR);
     end
     

--- a/scripts/zones/Norg/npcs/Heizo.lua
+++ b/scripts/zones/Norg/npcs/Heizo.lua
@@ -81,7 +81,7 @@ function onEventFinish(player,csid,option)
         player:tradeComplete();
         player:addItem(4958); -- Scroll of Dokumori: Ichi
         player:messageSpecial(ITEM_OBTAINED, 4958); -- Scroll of Dokumori: Ichi
-        player:addFame(OUTLANDS,100);
+        player:addFame(NORG,100);
         player:addTitle(LOOKS_GOOD_IN_LEGGINGS);
         player:setVar("shiningLeggings_nb",0);
         player:completeQuest(OUTLANDS,LIKE_A_SHINING_LEGGINGS);

--- a/scripts/zones/Norg/npcs/Jaucribaix.lua
+++ b/scripts/zones/Norg/npcs/Jaucribaix.lua
@@ -162,7 +162,7 @@ function onEventFinish(player,csid,option)
         player:unlockJob(12); -- Samurai Job Unlocked
         player:setVar("ForgeYourDestiny_timer",0);
         player:setVar("ForgeYourDestiny_Event",0);
-        player:addFame(OUTLANDS, 30);
+        player:addFame(NORG, 30);
         player:completeQuest(OUTLANDS, FORGE_YOUR_DESTINY);
     elseif (csid == 0x008b and option == 1) then
         player:addQuest(OUTLANDS,THE_SACRED_KATANA);
@@ -174,7 +174,7 @@ function onEventFinish(player,csid,option)
         player:setVar("Wait1DayForYomiOkuri",VanadielDayOfTheYear());
         player:addItem(17812);
         player:messageSpecial(ITEM_OBTAINED,17812); -- Magoroku
-        player:addFame(OUTLANDS,AF1_FAME);
+        player:addFame(NORG,AF1_FAME);
         player:completeQuest(OUTLANDS,THE_SACRED_KATANA);
     elseif (csid == 0x0092 and option == 1) then
         player:addQuest(OUTLANDS,YOMI_OKURI);
@@ -200,7 +200,7 @@ function onEventFinish(player,csid,option)
             player:setVar("yomiOkuriCS",0);
             player:needToZone(true);
             player:setVar("Wait1DayForAThiefinNorg_date", os.date("%j")); -- %M for next minute, %j for next day
-            player:addFame(OUTLANDS,AF2_FAME);
+            player:addFame(NORG,AF2_FAME);
             player:completeQuest(OUTLANDS,YOMI_OKURI);
         end
     elseif (csid == 0x009e and option == 1) then
@@ -232,7 +232,7 @@ function onEventFinish(player,csid,option)
             player:addTitle(PARAGON_OF_SAMURAI_EXCELLENCE);
             player:setVar("aThiefinNorgCS",0);
             player:setVar("Wait1DayForAThiefinNorg2_date",0);
-            player:addFame(OUTLANDS,AF3_FAME);
+            player:addFame(NORG,AF3_FAME);
             player:completeQuest(OUTLANDS,A_THIEF_IN_NORG);
         end
     end

--- a/scripts/zones/Norg/npcs/Keal.lua
+++ b/scripts/zones/Norg/npcs/Keal.lua
@@ -133,7 +133,7 @@ function onEventFinish(player,csid,option,npc)
             player:delKeyItem(SEALED_IRON_BOX);
             player:addItem(4961); -- Scroll of Tonko: Ichi
             player:messageSpecial(ITEM_OBTAINED, 4961); 
-            player:addFame(OUTLANDS,50);
+            player:addFame(NORG,50);
             player:completeQuest(OUTLANDS,ITS_NOT_YOUR_VAULT);
         end
     end

--- a/scripts/zones/Norg/npcs/Laisrean.lua
+++ b/scripts/zones/Norg/npcs/Laisrean.lua
@@ -68,7 +68,7 @@ function onEventFinish(player,csid,option)
             player:addItem(4946); -- Scroll of Utsusemi: Ichi
             player:messageSpecial(ITEM_OBTAINED, 4946);
             player:addTitle(TREASUREHOUSE_RANSACKER);
-            player:addFame(OUTLANDS,75);
+            player:addFame(NORG,75);
             player:completeQuest(OUTLANDS,THE_SAHAGINS_STASH);
         end
     end

--- a/scripts/zones/Norg/npcs/Magephaud.lua
+++ b/scripts/zones/Norg/npcs/Magephaud.lua
@@ -58,7 +58,7 @@ function onEventFinish(player,csid,option)
     elseif (csid == 0x0076) then
         player:completeQuest(OUTLANDS,EVERYONES_GRUDGE);
         player:tradeComplete();
-        player:addFame(OUTLANDS,80);
+        player:addFame(NORG,80);
         player:addKeyItem(291);    -- Permanent Tonberry key
         player:messageSpecial(KEYITEM_OBTAINED,291);
         player:setVar("EveryonesGrudgeStarted",0);

--- a/scripts/zones/Norg/npcs/Mamaulabion.lua
+++ b/scripts/zones/Norg/npcs/Mamaulabion.lua
@@ -197,7 +197,7 @@ function onEventFinish(player,csid,option)
         else
             player:addItem(14625); -- Evokers Ring
             player:messageSpecial(ITEM_OBTAINED,14625); -- Evokers Ring
-            player:addFame(OUTLANDS,30); --idk how much fame the quest adds, just left at 30 which the levi quest gave.
+            player:addFame(NORG,30); --idk how much fame the quest adds, just left at 30 which the levi quest gave.
             player:completeQuest(OUTLANDS,MAMA_MIA);
             player:setVar("tradesMamaMia",0)
         end

--- a/scripts/zones/Norg/npcs/Ryoma.lua
+++ b/scripts/zones/Norg/npcs/Ryoma.lua
@@ -95,7 +95,7 @@ function onEventFinish(player,csid,option)
             player:messageSpecial(ITEM_OBTAINED, 17772); -- Zushio
             player:needToZone();
             player:setVar("twentyInPirateYearsCS",0);
-            player:addFame(OUTLANDS,30);
+            player:addFame(NORG,30);
             player:completeQuest(OUTLANDS,TWENTY_IN_PIRATE_YEARS);
         end
     elseif (csid == 0x0087) then

--- a/scripts/zones/Norg/npcs/Washu.lua
+++ b/scripts/zones/Norg/npcs/Washu.lua
@@ -93,7 +93,7 @@ function onEventFinish(player,csid,option)
             player:delKeyItem(BARREL_OF_OPOOPO_BREW); --Filled Barrel
             player:addItem(4952); -- Scroll of Hojo: Ichi
             player:messageSpecial(ITEM_OBTAINED,4952); -- Scroll of Hojo: Ichi
-            player:addFame(OUTLANDS,75);
+            player:addFame(NORG,75);
             player:addTitle(APPRENTICE_SOMMELIER);
             player:completeQuest(OUTLANDS,STOP_YOUR_WHINING);
         end

--- a/scripts/zones/Rabao/npcs/Edigey.lua
+++ b/scripts/zones/Rabao/npcs/Edigey.lua
@@ -65,12 +65,12 @@ function onEventFinish(player,csid,option)
         player:addItem(16974); -- Dotanuki
         player:messageSpecial(ITEM_OBTAINED, 16974); 
         player:completeQuest(OUTLANDS,DONT_FORGET_THE_ANTIDOTE);
-        player:addFame(OUTLANDS,60);  
+        player:addFame(RABAO,60);  
     elseif (csid == 0x0004) then --Subsequent completions
         player:tradeComplete();
         player:addGil(GIL_RATE*1800);
         player:messageSpecial(GIL_OBTAINED, 1800);
-        player:addFame(OUTLANDS,30); 
+        player:addFame(RABAO,30); 
     end
 
 end;

--- a/scripts/zones/Rabao/npcs/Irmilant.lua
+++ b/scripts/zones/Rabao/npcs/Irmilant.lua
@@ -73,7 +73,7 @@ function onEventFinish(player,csid,option)
         player:addItem(17386); -- Lu Shang's Fishing Rod
         player:messageSpecial(ITEM_OBTAINED, 17386); 
         player:completeQuest(OUTLANDS,THE_IMMORTAL_LU_SHANG);
-        player:addFame(OUTLANDS,60);  
+        player:addFame(RABAO,60);  
     elseif (csid == 0x0083) then
         player:addQuest(OUTLANDS,201);
     elseif (csid == 0x0084) then
@@ -87,7 +87,7 @@ function onEventFinish(player,csid,option)
             player:addItem(17011); -- Ebisu Fishing Rod
             player:messageSpecial(ITEM_OBTAINED, 17011); 
             player:completeQuest(OUTLANDS,201);
-            player:addFame(OUTLANDS,100);  
+            player:addFame(RABAO,100);  
         end
     end
 end;

--- a/scripts/zones/Rabao/npcs/Leodarion.lua
+++ b/scripts/zones/Rabao/npcs/Leodarion.lua
@@ -101,7 +101,7 @@ function onEventFinish(player,csid,option)
             player:addItem(13782);
             player:messageSpecial(ITEM_OBTAINED,13782); -- Ninja Chainmail
             player:setVar("trueWillCS",0);
-            player:addFame(OUTLANDS,30);
+            player:addFame(NORG,30);
             player:completeQuest(OUTLANDS,TRUE_WILL);
         end
     end

--- a/scripts/zones/Selbina/Zone.lua
+++ b/scripts/zones/Selbina/Zone.lua
@@ -92,7 +92,7 @@ function onEventFinish(player,csid,option)
             player:messageSpecial(ITEM_OBTAINED,14226); -- Ninja Hakama
             player:setVar("Enagakure_Killed",0);
             player:setVar("illTakeTheBigBoxCS",0);
-            player:addFame(OUTLANDS,30);
+            player:addFame(NORG,30);
             player:completeQuest(OUTLANDS,I_LL_TAKE_THE_BIG_BOX);
         end
     end


### PR DESCRIPTION
Fix for Issue #3585 .