### PR TITLE
Fix field event areas' Lua scripts' Manual + VW NPC IDs

### DIFF
--- a/scripts/zones/South_Gustaberg/Zone.lua
+++ b/scripts/zones/South_Gustaberg/Zone.lua
@@ -55,10 +55,10 @@ end;
 -----------------------------------
 
 function onInitialize(zone)
-    local manuals = {17216227,17216228};
+    local manuals = {17216186,17216187};
     SetFieldManual(manuals);
 
-    local vwnpc = {17216158,17216157,17216156};
+    local vwnpc = {17216194,17216195,17216196};
     SetVoidwatchNPC(vwnpc);
 
 end;

--- a/scripts/zones/West_Ronfaure/Zone.lua
+++ b/scripts/zones/West_Ronfaure/Zone.lua
@@ -56,10 +56,10 @@ end;
 -----------------------------------
 
 function onInitialize(zone)
-    local manuals = {17187563,17187521};
+    local manuals = {17187549,17187550};
     SetFieldManual(manuals);
 
-    local vwnpc = {17187530,17187563,17187536};
+    local vwnpc = {17187554,17187555,17187556};
     SetVoidwatchNPC(vwnpc);
 
     SetRegionalConquestOverseers(zone:getRegionID())

--- a/scripts/zones/West_Sarutabaruta/Zone.lua
+++ b/scripts/zones/West_Sarutabaruta/Zone.lua
@@ -53,10 +53,10 @@ end;
 -----------------------------------
 
 function onInitialize(zone)
-    local manuals = {17248822,17248834,17248878};
+    local manuals = {17248852,17248853,17248854};
     SetFieldManual(manuals);
 
-    local vwnpc = {17248889,17248906,17248929};
+    local vwnpc = {17248907,17248908,17248909};
     SetVoidwatchNPC(vwnpc);
 
     SetRegionalConquestOverseers(zone:getRegionID())


### PR DESCRIPTION
The IDs listed in the Lua scripts for the zones SE loves to drastically change every other month were pretty off. Batch tool should pick them up from now on.

Addresses #3637