### PR TITLE
Renamed crepe_forestiere to match item_usable

### DIFF
--- a/scripts/globals/items/butter_crepe.lua
+++ b/scripts/globals/items/butter_crepe.lua
@@ -3,8 +3,8 @@
 -- Item: Butter Crepe
 -- Food Effect: 30 Min, All Races
 -----------------------------------------
--- HP +10
--- Magic Accuracy +2
+-- HP +10% (cap 10)
+-- Magic Accuracy +20% (cap 25)
 -- Magic Defense +1
 -----------------------------------------
 
@@ -35,9 +35,11 @@ end;
 -----------------------------------------
 
 function onEffectGain(target,effect)
-    target:addMod(MOD_HP, 10);
-    target:addMod(MOD_MACC, 2);
+    target:addMod(MOD_FOOD_HPP, 10);
+    target:addMod(MOD_FOOD_HP_CAP, 10);
     target:addMod(MOD_MDEF, 1);
+    target:addMod(MOD_FOOD_MACCP, 20);
+    target:addMod(MOD_FOOD_MACC_CAP, 25);
 end;
 
 -----------------------------------------
@@ -45,7 +47,9 @@ end;
 -----------------------------------------
 
 function onEffectLose(target,effect)
-    target:delMod(MOD_HP, 10);
-    target:delMod(MOD_MACC, 2);
+    target:delMod(MOD_FOOD_HPP, 10);
+    target:delMod(MOD_FOOD_HP_CAP, 10);
     target:delMod(MOD_MDEF, 1);
+    target:delMod(MOD_FOOD_MACCP, 20);
+    target:delMod(MOD_FOOD_MACC_CAP, 25);
 end;

--- a/scripts/globals/items/chocolate_crepe.lua
+++ b/scripts/globals/items/chocolate_crepe.lua
@@ -3,9 +3,9 @@
 -- Item: Chocolate Crepe
 -- Food Effect: 30 Min, All Races
 -----------------------------------------
--- HP +15
+-- HP +5% (cap 15)
 -- MP Healing 2
--- Magic Accuracy +4
+-- Magic Accuracy +20% (cap 35)
 -- Magic Defense +1
 -----------------------------------------
 
@@ -36,10 +36,12 @@ end;
 -----------------------------------------
 
 function onEffectGain(target,effect)
-    target:addMod(MOD_HP, 15);
+    target:addMod(MOD_FOOD_HPP, 5);
+    target:addMod(MOD_FOOD_HP_CAP, 15);
     target:addMod(MOD_MPHEAL, 2);
-    target:addMod(MOD_MACC, 4);
     target:addMod(MOD_MDEF, 1);
+    target:addMod(MOD_FOOD_MACCP, 20);
+    target:addMod(MOD_FOOD_MACC_CAP, 35);
 end;
 
 -----------------------------------------
@@ -47,8 +49,10 @@ end;
 -----------------------------------------
 
 function onEffectLose(target,effect)
-    target:delMod(MOD_HP, 15);
+    target:delMod(MOD_FOOD_HPP, 5);
+    target:delMod(MOD_FOOD_HP_CAP, 15);
     target:delMod(MOD_MPHEAL, 2);
-    target:delMod(MOD_MACC, 4);
     target:delMod(MOD_MDEF, 1);
+    target:delMod(MOD_FOOD_MACCP, 20);
+    target:delMod(MOD_FOOD_MACC_CAP, 35);
 end;

--- a/scripts/globals/items/crepe_belle_helene.lua
+++ b/scripts/globals/items/crepe_belle_helene.lua
@@ -1,11 +1,11 @@
 -----------------------------------------
 -- ID: 5778
 -- Item: Crepe Belle Helene
--- Food Effect: 60 Min, All Races
+-- Food Effect: 30 Min, All Races
 -----------------------------------------
 -- Intelligence +2
 -- MP Healing +3
--- Magic Accuracy +6
+-- Magic Accuracy +21% (cap 50)
 -- Magic Defense +1
 -----------------------------------------
 
@@ -28,7 +28,7 @@ end;
 -----------------------------------------
 
 function onItemUse(target)
-    target:addStatusEffect(EFFECT_FOOD,0,0,3600,5778);
+    target:addStatusEffect(EFFECT_FOOD,0,0,1800,5778);
 end;
 
 -----------------------------------------
@@ -38,7 +38,8 @@ end;
 function onEffectGain(target,effect)
     target:addMod(MOD_INT, 2);
     target:addMod(MOD_MPHEAL, 3);
-    target:addMod(MOD_MACC, 6);
+    target:addMod(MOD_FOOD_MACCP, 21);
+    target:addMod(MOD_FOOD_MACC_CAP, 50);
     target:addMod(MOD_MDEF, 1);
 end;
 
@@ -49,6 +50,7 @@ end;
 function onEffectLose(target,effect)
     target:delMod(MOD_INT, 2);
     target:delMod(MOD_MPHEAL, 3);
-    target:delMod(MOD_MACC, 6);
+    target:delMod(MOD_FOOD_MACCP, 21);
+    target:delMod(MOD_FOOD_MACC_CAP, 50);
     target:delMod(MOD_MDEF, 1);
 end;

--- a/scripts/globals/items/crepe_caprice.lua
+++ b/scripts/globals/items/crepe_caprice.lua
@@ -1,11 +1,11 @@
 -----------------------------------------
 -- ID: 5776
 -- Item: Crepe Caprice
--- Food Effect: 60 Min, All Races
+-- Food Effect: 30 Min, All Races
 -----------------------------------------
--- HP +20
+-- HP +5% (cap20)
 -- MP Healing 3
--- Magic Accuracy +5
+-- Magic Accuracy +21% (cap 40)
 -- Magic Defense +2
 -----------------------------------------
 
@@ -28,7 +28,7 @@ end;
 -----------------------------------------
 
 function onItemUse(target)
-    target:addStatusEffect(EFFECT_FOOD,0,0,3600,5776);
+    target:addStatusEffect(EFFECT_FOOD,0,0,1800,5776);
 end;
 
 -----------------------------------------
@@ -36,10 +36,12 @@ end;
 -----------------------------------------
 
 function onEffectGain(target,effect)
-    target:addMod(MOD_HP, 20);
+    target:addMod(MOD_FOOD_HPP, 5);
+    target:addMod(MOD_FOOD_HP_CAP, 20);
     target:addMod(MOD_MPHEAL, 3);
-    target:addMod(MOD_MACC, 5);
     target:addMod(MOD_MDEF, 2);
+    target:addMod(MOD_FOOD_MACCP, 21);
+    target:addMod(MOD_FOOD_MACC_CAP, 40);
 end;
 
 -----------------------------------------
@@ -47,8 +49,10 @@ end;
 -----------------------------------------
 
 function onEffectLose(target,effect)
-    target:delMod(MOD_HP, 20);
+    target:delMod(MOD_FOOD_HPP, 5);
+    target:delMod(MOD_FOOD_HP_CAP, 20);
     target:delMod(MOD_MPHEAL, 3);
-    target:delMod(MOD_MACC, 5);
     target:delMod(MOD_MDEF, 2);
+    target:delMod(MOD_FOOD_MACCP, 21);
+    target:delMod(MOD_FOOD_MACC_CAP, 40);
 end;

--- a/scripts/globals/items/crepe_delice.lua
+++ b/scripts/globals/items/crepe_delice.lua
@@ -1,10 +1,10 @@
 -----------------------------------------
 -- ID: 5767
 -- Item: Crepe Delice
--- Food Effect: 60 Min, All Races
+-- Food Effect: 30 Min, All Races
 -----------------------------------------
--- HP +15
--- Magic Accuracy +3
+-- HP +10% (cap 15)
+-- Magic Accuracy +21% (cap 30)
 -- Magic Defense +2
 -----------------------------------------
 
@@ -27,7 +27,7 @@ end;
 -----------------------------------------
 
 function onItemUse(target)
-    target:addStatusEffect(EFFECT_FOOD,0,0,3600,5767);
+    target:addStatusEffect(EFFECT_FOOD,0,0,1800,5767);
 end;
 
 -----------------------------------------
@@ -35,9 +35,11 @@ end;
 -----------------------------------------
 
 function onEffectGain(target,effect)
-    target:addMod(MOD_HP, 15);
-    target:addMod(MOD_MACC, 3);
+    target:addMod(MOD_FOOD_HPP, 10);
+    target:addMod(MOD_FOOD_HP_CAP, 15);
     target:addMod(MOD_MDEF, 2);
+    target:addMod(MOD_FOOD_MACCP, 21);
+    target:addMod(MOD_FOOD_MACC_CAP, 30);
 end;
 
 -----------------------------------------
@@ -45,7 +47,9 @@ end;
 -----------------------------------------
 
 function onEffectLose(target,effect)
-    target:delMod(MOD_HP, 15);
-    target:delMod(MOD_MACC, 3);
+    target:delMod(MOD_FOOD_HPP, 10);
+    target:delMod(MOD_FOOD_HP_CAP, 15);
     target:delMod(MOD_MDEF, 2);
+    target:delMod(MOD_FOOD_MACCP, 21);
+    target:delMod(MOD_FOOD_MACC_CAP, 30);
 end;

--- a/scripts/globals/items/crepe_forestiere.lua
+++ b/scripts/globals/items/crepe_forestiere.lua
@@ -1,7 +1,7 @@
 -----------------------------------------
 -- ID: 5774
 -- Item: crepe_forestiere
--- Food Effect: 60Min, All Races
+-- Food Effect: 30Min, All Races
 -----------------------------------------
 -- Mind 2
 -- MP % 10 (cap 35)
@@ -28,7 +28,7 @@ end;
 -----------------------------------------
 
 function onItemUse(target)
-    target:addStatusEffect(EFFECT_FOOD,0,0,3600,5774);
+    target:addStatusEffect(EFFECT_FOOD,0,0,1800,5774);
 end;
 
 -----------------------------------------

--- a/scripts/globals/items/crepe_paysanne.lua
+++ b/scripts/globals/items/crepe_paysanne.lua
@@ -1,7 +1,7 @@
 -----------------------------------------
 -- ID: 5772
 -- Item: crepe_paysanne
--- Food Effect: 60 Min, All Races
+-- Food Effect: 30 Min, All Races
 -----------------------------------------
 -- HP +10% (cap 30)
 -- STR +2
@@ -30,7 +30,7 @@ end;
 -----------------------------------------
 
 function onItemUse(target)
-    target:addStatusEffect(EFFECT_FOOD,0,0,3600,5772);
+    target:addStatusEffect(EFFECT_FOOD,0,0,1800,5772);
 end;
 
 -----------------------------------------

--- a/scripts/globals/items/pear_crepe.lua
+++ b/scripts/globals/items/pear_crepe.lua
@@ -5,7 +5,7 @@
 -----------------------------------------
 -- Intelligence +2
 -- MP Healing +2
--- Magic Accuracy +5
+-- Magic Accuracy +20% (cap 45)
 -- Magic Defense +1
 -----------------------------------------
 
@@ -37,9 +37,10 @@ end;
 
 function onEffectGain(target,effect)
     target:addMod(MOD_INT, 2);
-    target:addMod(MOD_MPHEAL, 2);
-    target:addMod(MOD_MACC, 5);
+    target:addMod(MOD_FOOD_MACCP, 20);
+    target:addMod(MOD_FOOD_MACC_CAP, 45);
     target:addMod(MOD_MDEF, 1);
+    target:addMod(MOD_MPHEAL, 2);
 end;
 
 -----------------------------------------
@@ -48,7 +49,8 @@ end;
 
 function onEffectLose(target,effect)
     target:delMod(MOD_INT, 2);
-    target:delMod(MOD_MPHEAL, 2);
-    target:delMod(MOD_MACC, 5);
+    target:delMod(MOD_FOOD_MACCP, 20);
+    target:delMod(MOD_FOOD_MACC_CAP, 45);
     target:delMod(MOD_MDEF, 1);
+    target:delMod(MOD_MPHEAL, 2);
 end;


### PR DESCRIPTION
Some crepes should have the (not yet coded) MOD_FOOD_MACCP rather than a flat MOD_MACC

edit: These mods were added in another PR, so I've updated the files here to account for that.