### PR TITLE
Fixed an issue causing certain 'cannot equip' type armor to not unequip their remove slot when equipped

### DIFF
--- a/src/map/items/item_armor.cpp
+++ b/src/map/items/item_armor.cpp
@@ -61,7 +61,7 @@ uint16 CItemArmor::getEquipSlotId()
 	return m_equipSlotID;
 }
 
-uint8 CItemArmor::getRemoveSlotId()
+uint16 CItemArmor::getRemoveSlotId()
 {
 	return m_removeSlotID;
 }
@@ -111,7 +111,7 @@ void CItemArmor::setEquipSlotId(uint16 equipSlot)
 	m_equipSlotID = equipSlot;
 }
 
-void CItemArmor::setRemoveSlotId(uint8 removSlot)
+void CItemArmor::setRemoveSlotId(uint16 removSlot)
 {
 	m_removeSlotID = removSlot;
 }

--- a/src/map/items/item_armor.h
+++ b/src/map/items/item_armor.h
@@ -63,7 +63,7 @@ public:
 	uint16	getScriptType();
 	uint8	getShieldSize();
 	uint16	getEquipSlotId();
-	uint8	getRemoveSlotId();
+	uint16	getRemoveSlotId();
     uint8   getShieldAbsorption();
 	int16	getModifier(uint16 mod);
     uint8   getSlotType();
@@ -79,7 +79,7 @@ public:
 	void	setShieldSize(uint8 shield);
 	void	setScriptType(uint16 isScripted);
 	void	setEquipSlotId(uint16 equipSlot);
-	void	setRemoveSlotId(uint8 removSlot);
+	void	setRemoveSlotId(uint16 removSlot);
     void    setAugment(uint8 slot, uint16 type, uint8 value);
 	void    setTrialNumber(uint16);
 
@@ -104,7 +104,7 @@ private:
 	uint8	m_shieldSize;
     uint8   m_absorption;
 	uint16	m_equipSlotID;
-	uint8	m_removeSlotID;
+	uint16	m_removeSlotID;
 
     void    SetAugmentMod(uint16 type, uint8 value);
 };


### PR DESCRIPTION
**Re-upload of #3651 with changes suggested by @teschnei** 

Equipping armor with a 'cannot equip footgear' prefix would cause feet to not unequip.
This was due to the item_armor.sql rslot for feet being 256 and the uint8 max being 255.