### PR TITLE
make crescent fang fail paralysis if it misses

### DIFF
--- a/scripts/globals/abilities/pets/crescent_fang.lua
+++ b/scripts/globals/abilities/pets/crescent_fang.lua
@@ -20,7 +20,9 @@ function onPetAbility(target, pet, skill)
     local totaldamage = 0;
     local damage = AvatarPhysicalMove(pet,target,skill,numhits,accmod,dmgmod,0,TP_NO_EFFECT,1,2,3);
     totaldamage = AvatarFinalAdjustments(damage.dmg,pet,skill,target,MOBSKILL_PHYSICAL,MOBPARAM_PIERCE,numhits);
+    if (damage.hitslanded > 0) then 
     target:addStatusEffect(EFFECT_PARALYSIS, 22.5, 0, 90);
+    end;
     target:delHP(totaldamage);
     target:updateEnmityFromDamage(pet,totaldamage);
 

--- a/scripts/globals/abilities/pets/crescent_fang.lua
+++ b/scripts/globals/abilities/pets/crescent_fang.lua
@@ -20,9 +20,11 @@ function onPetAbility(target, pet, skill)
     local totaldamage = 0;
     local damage = AvatarPhysicalMove(pet,target,skill,numhits,accmod,dmgmod,0,TP_NO_EFFECT,1,2,3);
     totaldamage = AvatarFinalAdjustments(damage.dmg,pet,skill,target,MOBSKILL_PHYSICAL,MOBPARAM_PIERCE,numhits);
-    if (damage.hitslanded > 0) then 
-    target:addStatusEffect(EFFECT_PARALYSIS, 22.5, 0, 90);
-    end;
+    
+        if (damage.hitslanded > 0) then 
+            target:addStatusEffect(EFFECT_PARALYSIS, 22.5, 0, 90);
+        end;
+    
     target:delHP(totaldamage);
     target:updateEnmityFromDamage(pet,totaldamage);
 

--- a/scripts/globals/abilities/pets/crescent_fang.lua
+++ b/scripts/globals/abilities/pets/crescent_fang.lua
@@ -21,9 +21,9 @@ function onPetAbility(target, pet, skill)
     local damage = AvatarPhysicalMove(pet,target,skill,numhits,accmod,dmgmod,0,TP_NO_EFFECT,1,2,3);
     totaldamage = AvatarFinalAdjustments(damage.dmg,pet,skill,target,MOBSKILL_PHYSICAL,MOBPARAM_PIERCE,numhits);
     
-        if (damage.hitslanded > 0) then 
-            target:addStatusEffect(EFFECT_PARALYSIS, 22.5, 0, 90);
-        end;
+    if (damage.hitslanded > 0) then 
+        target:addStatusEffect(EFFECT_PARALYSIS, 22.5, 0, 90);
+    end;
     
     target:delHP(totaldamage);
     target:updateEnmityFromDamage(pet,totaldamage);

--- a/scripts/globals/abilities/pets/crescent_fang.lua
+++ b/scripts/globals/abilities/pets/crescent_fang.lua
@@ -20,11 +20,11 @@ function onPetAbility(target, pet, skill)
     local totaldamage = 0;
     local damage = AvatarPhysicalMove(pet,target,skill,numhits,accmod,dmgmod,0,TP_NO_EFFECT,1,2,3);
     totaldamage = AvatarFinalAdjustments(damage.dmg,pet,skill,target,MOBSKILL_PHYSICAL,MOBPARAM_PIERCE,numhits);
-    
-    if (damage.hitslanded > 0) then 
+
+    if (damage.hitslanded > 0) then
         target:addStatusEffect(EFFECT_PARALYSIS, 22.5, 0, 90);
     end;
-    
+
     target:delHP(totaldamage);
     target:updateEnmityFromDamage(pet,totaldamage);
 


### PR DESCRIPTION
checked summon.lua global and found that AvatarPhysicalMove() returninfo contains hitslanded, and the current system applies paralysis even during a miss, so this should correct it.