### PR TITLE
adjusted drop rate on ix'aern(drg)

### DIFF
--- a/scripts/zones/The_Garden_of_RuHmet/mobs/Ix_aern_drg.lua
+++ b/scripts/zones/The_Garden_of_RuHmet/mobs/Ix_aern_drg.lua
@@ -9,7 +9,7 @@ require("scripts/globals/status");
 -----------------------------------
 
 function onMobSpawn(mob)
-    if (math.random(0,3) == 0) then
+    if (math.random(0,99) < 78) then
         SetDropRate(4396,1870,1000); -- Deed Of Sensib.
         SetDropRate(4396,1903,0);
     else


### PR DESCRIPTION
Ix'Aern(DRG) is supposed to drop the deed more often than the vice, roughly 78% according to [ffxiclopedia](http://ffxiclopedia.wikia.com/wiki/Ix'aern_(Dragoon)).