### PR TITLE
Reworked Dynamis resets and authorization

### DIFF
--- a/scripts/zones/Bastok_Mines/npcs/Trail_Markings.lua
+++ b/scripts/zones/Bastok_Mines/npcs/Trail_Markings.lua
@@ -25,7 +25,7 @@ end;
 
 function onTrigger(player,npc)
     
-    if (player:getVar("Dynamis_Status") == 1) then
+    if bit.band(player:getVar("Dynamis_Status"),1) == 1 then
         player:startEvent(0x00CB); -- cs with Cornelia
     elseif (player:getVar("DynaBastok_Win") == 1) then
         player:startEvent(0x00d7,HYDRA_CORPS_EYEGLASS); -- Win CS
@@ -35,12 +35,12 @@ function onTrigger(player,npc)
         local dynaWaitxDay = player:getVar("dynaWaitxDay");
         
         if (checkFirstDyna(player,2)) then  -- First Dyna-Bastok => CS
-            firstDyna = 1; 
+            firstDyna = 1;
         end
         
         if (player:getMainLvl() < DYNA_LEVEL_MIN) then
             player:messageSpecial(PLAYERS_HAVE_NOT_REACHED_LEVEL,DYNA_LEVEL_MIN);
-        elseif ((dynaWaitxDay + (BETWEEN_2DYNA_WAIT_TIME * 24 * 60 * 60)) < realDay or player:getVar("DynamisID") == GetServerVariable("[DynaBastok]UniqueID")) then
+        elseif dynaWaitxDay + (BETWEEN_2DYNA_WAIT_TIME * 24 * 60 * 60) < realDay then
             player:startEvent(0x00c9,2,firstDyna,0,BETWEEN_2DYNA_WAIT_TIME,64,VIAL_OF_SHROUDED_SAND,4236,4237);
         else
             dayRemaining = math.floor(((dynaWaitxDay + (BETWEEN_2DYNA_WAIT_TIME * 24 * 60 * 60)) - realDay)/3456);
@@ -72,15 +72,14 @@ function onEventFinish(player,csid,option)
     if (csid == 0x00CB) then
         player:addKeyItem(VIAL_OF_SHROUDED_SAND);
         player:messageSpecial(KEYITEM_OBTAINED,VIAL_OF_SHROUDED_SAND);
-        player:setVar("Dynamis_Status",0);
+        player:setVar("Dynamis_Status",bit.band(player:getVar("Dynamis_Status"),bit.bnot(1)));
     elseif (csid == 0x00d7) then
         player:setVar("DynaBastok_Win",0);
     elseif (csid == 0x00c9 and option == 0) then
         if (checkFirstDyna(player,2)) then
-            player:setVar("Dynamis_Status",player:getVar("Dynamis_Status") + 4);
+            player:setVar("Dynamis_Status",bit.bor(player:getVar("Dynamis_Status"),4));
         end
-        
+        player:setVar("enteringDynamis",1);
         player:setPos(116.482,0.994,-72.121,128,0xba);
     end
-    
 end;

--- a/scripts/zones/Beaucedine_Glacier/npcs/Trail_Markings.lua
+++ b/scripts/zones/Beaucedine_Glacier/npcs/Trail_Markings.lua
@@ -34,13 +34,13 @@ function onTrigger(player,npc)
         local realDay = os.time();
         local dynaWaitxDay = player:getVar("dynaWaitxDay");
 
-        if (checkFirstDyna(player,4)) then  -- First Dyna-Bastok => CS
+        if (checkFirstDyna(player,5)) then  -- First Dyna-Beuc => CS
             firstDyna = 1;
         end
 
         if (player:getMainLvl() < DYNA_LEVEL_MIN) then
             player:messageSpecial(PLAYERS_HAVE_NOT_REACHED_LEVEL,DYNA_LEVEL_MIN);
-        elseif ( (dynaWaitxDay + (BETWEEN_2DYNA_WAIT_TIME * 24 * 60 * 60)) < realDay or player:getVar("DynamisID") == GetServerVariable("[DynaBeaucedine]UniqueID")) then
+        elseif dynaWaitxDay + (BETWEEN_2DYNA_WAIT_TIME * 24 * 60 * 60) < realDay then
             player:startEvent(0x0077,5,firstDyna,0,BETWEEN_2DYNA_WAIT_TIME,64,VIAL_OF_SHROUDED_SAND,4236,4237);
         else
             dayRemaining = math.floor(((dynaWaitxDay + (BETWEEN_2DYNA_WAIT_TIME * 24 * 60 * 60)) - realDay)/3456);
@@ -70,9 +70,10 @@ function onEventFinish(player,csid,option)
     if (csid == 0x0086) then
         player:setVar("DynaBeaucedine_Win",0);
     elseif (csid == 0x0077 and option == 0) then
-        if (checkFirstDyna(player,4)) then
-            player:setVar("Dynamis_Status",player:getVar("Dynamis_Status") + 8);
+        if (checkFirstDyna(player,5)) then
+            player:setVar("Dynamis_Status",bit.bor(player:getVar("Dynamis_Status"),32));
         end
+        player:setVar("enteringDynamis",1);
         player:setPos(-284.751,-39.923,-422.948,235,0x86);
     end
 end;

--- a/scripts/zones/Buburimu_Peninsula/npcs/Hieroglyphics.lua
+++ b/scripts/zones/Buburimu_Peninsula/npcs/Hieroglyphics.lua
@@ -1,8 +1,8 @@
 -----------------------------------
 -- Area: Buburimu_Peninsula
 -- NPC:  Hieroglyphics
--- Dynamis Buburimu_Dunes Enter
--- @pos 117 -10 133 172 118
+-- Dynamis Buburimu Enter
+-- @pos 163 0 -174 118
 -----------------------------------
 package.loaded["scripts/zones/Buburimu_Peninsula/TextIDs"] = nil;
 -----------------------------------
@@ -18,7 +18,7 @@ require("scripts/zones/Buburimu_Peninsula/TextIDs");
 -----------------------------------
 
 function onTrade(player,npc,trade)
-end; 
+end;
 
 -----------------------------------
 -- onTrigger Action
@@ -31,22 +31,18 @@ function onTrigger(player,npc)
         local realDay = os.time();
         local dynaWaitxDay = player:getVar("dynaWaitxDay");
         
-        if (checkFirstDyna(player,8)) then 
-             player:startEvent(0x002B);
+        if (checkFirstDyna(player,8)) then
+             player:startEvent(0x0028);
         elseif (player:getMainLvl() < DYNA_LEVEL_MIN) then
             player:messageSpecial(PLAYERS_HAVE_NOT_REACHED_LEVEL,DYNA_LEVEL_MIN);
-        
-        elseif ((dynaWaitxDay + (BETWEEN_2DYNA_WAIT_TIME * 24 * 60 * 60)) < realDay or player:getVar("DynamisID") == GetServerVariable("[DynaBuburimu]UniqueID")) then
-            
+        elseif dynaWaitxDay + (BETWEEN_2DYNA_WAIT_TIME * 24 * 60 * 60) < realDay then
             player:startEvent(0x0016,8,0,0,BETWEEN_2DYNA_WAIT_TIME,32,VIAL_OF_SHROUDED_SAND,4236,4237);
         else
             dayRemaining = math.floor(((dynaWaitxDay + (BETWEEN_2DYNA_WAIT_TIME * 24 * 60 * 60)) - realDay)/3456);
-            --printf("dayRemaining : %u",dayRemaining );
-            
             player:messageSpecial(YOU_CANNOT_ENTER_DYNAMIS,dayRemaining,8);
         end
     else
-        player:messageSpecial(MYSTERIOUS_VOICE); 
+        player:messageSpecial(MYSTERIOUS_VOICE);
     end
     
 end;
@@ -68,12 +64,12 @@ function onEventFinish(player,csid,option)
     -- printf("CSID: %u",csid);
     -- printf("finishRESULT: %u",option);
     
-    if (csid == 0x0021) then
+    if (csid == 0x0028) then
         if (checkFirstDyna(player,8)) then
-            player:setVar("Dynamis_Status",player:getVar("Dynamis_Status") + 256);
+            player:setVar("Dynamis_Status",bit.bor(player:getVar("Dynamis_Status"),256));
         end
     elseif (csid == 0x0016 and option == 0) then
+        player:setVar("enteringDynamis",1);
         player:setPos(155,-1,-169,170,0x28);
     end
-    
 end;

--- a/scripts/zones/Dynamis-Bastok/Zone.lua
+++ b/scripts/zones/Dynamis-Bastok/Zone.lua
@@ -33,37 +33,34 @@ end;
 -----------------------------------
 
 function onZoneIn(player,prevZone)
-    local cs = -1;
+    local cs = 0;
+    local inst = 0;
 
-    local realDay = os.time();
-    local dynaWaitxDay = player:getVar("dynaWaitxDay");
-
-    if ((dynaWaitxDay + (BETWEEN_2DYNA_WAIT_TIME * 24 * 60 * 60)) < realDay or player:getVar("DynamisID") == GetServerVariable("[DynaBastok]UniqueID")) then
-        if (player:isBcnmsFull() == 1) then
-            if (player:hasStatusEffect(EFFECT_DYNAMIS, 0) == false) then
-                inst = player:addPlayerToDynamis(1280);
-
-                if (inst == 1) then
-                    player:bcnmEnter(1280);
-                else
-                     cs = 0;
-                end
-            else
-                player:bcnmEnter(1280);
-            end
-        else
-            inst = player:bcnmRegister(1280);
-
-            if (inst == 1) then
-                player:bcnmEnter(1280);
-            else
-                cs = 0;
-            end
+    if player:isBcnmsFull() == 1 then
+        -- run currently in progress
+        -- add player to the run if they entered via markings, or if they reconnected to a run they were previously in
+        -- gms will be automatically registered
+        if player:getVar("enteringDynamis") == 1 or player:getVar("DynamisID") == GetServerVariable("[DynaBastok]UniqueID") or player:getGMLevel() > 0 then
+            inst = player:addPlayerToDynamis(1280);
         end
     else
-        cs = 0;
+        -- no run yet in progress
+        -- register run by player if they entered via markings
+        -- gms will be automatically registered
+        if player:getVar("enteringDynamis") == 1 or player:getGMLevel() > 0 then
+            inst = player:bcnmRegister(1280);
+        end
     end
 
+    if inst == 1 then
+        player:bcnmEnter(1280);
+        cs = -1;
+        if ((player:getXPos() == 0) and (player:getYPos() == 0) and (player:getZPos() == 0)) then
+            player:setPos(116.482,0.994,-72.121,128);
+        end
+    end
+
+    player:setVar("enteringDynamis",0);
     return cs;
 end;
 

--- a/scripts/zones/Dynamis-Bastok/bcnms/dynamis_bastok.lua
+++ b/scripts/zones/Dynamis-Bastok/bcnms/dynamis_bastok.lua
@@ -6,7 +6,7 @@
 -- After registering the BCNM via bcnmRegister(bcnmid)
 function onBcnmRegister(player,instance)
     
-    SetServerVariable("[DynaBastok]UniqueID",player:getDynamisUniqueID(1280));
+    SetServerVariable("[DynaBastok]UniqueID",os.time());
     SetServerVariable("[DynaBastok]Boss_Trigger",0);
     SetServerVariable("[DynaBastok]Already_Received",0);
     

--- a/scripts/zones/Dynamis-Beaucedine/Zone.lua
+++ b/scripts/zones/Dynamis-Beaucedine/Zone.lua
@@ -33,40 +33,34 @@ end;
 -----------------------------------
 
 function onZoneIn(player,prevZone)
-    local cs = -1;
+    local cs = 0;
+    local inst = 0;
 
-    local realDay = os.time();
-    local dynaWaitxDay = player:getVar("dynaWaitxDay");
-
-    if ((player:getXPos() == 0) and (player:getYPos() == 0) and (player:getZPos() == 0)) then
-        player:setPos(-284.751,-39.923,-422.948,235);
-    end
-
-    if ((dynaWaitxDay + (BETWEEN_2DYNA_WAIT_TIME * 24 * 60 * 60)) < realDay or player:getVar("DynamisID") == GetServerVariable("[DynaBeaucedine]UniqueID")) then
-        if (player:isBcnmsFull() == 1) then
-            if (player:hasStatusEffect(EFFECT_DYNAMIS, 0) == false) then
-                inst = player:addPlayerToDynamis(1284);
-                if (inst == 1) then
-                    player:bcnmEnter(1284);
-                else
-                     cs = 0;
-                end
-            else
-                player:bcnmEnter(1284);
-            end
-        else
-            inst = player:bcnmRegister(1284);
-
-            if (inst == 1) then
-                player:bcnmEnter(1284);
-            else
-                cs = 0;
-            end
+    if player:isBcnmsFull() == 1 then
+        -- run currently in progress
+        -- add player to the run if they entered via markings, or if they reconnected to a run they were previously in
+        -- gms will be automatically registered
+        if player:getVar("enteringDynamis") == 1 or player:getVar("DynamisID") == GetServerVariable("[DynaBeaucedine]UniqueID") or player:getGMLevel() > 0 then
+            inst = player:addPlayerToDynamis(1284);
         end
     else
-        cs = 0;
+        -- no run yet in progress
+        -- register run by player if they entered via markings
+        -- gms will be automatically registered
+        if player:getVar("enteringDynamis") == 1 or player:getGMLevel() > 0 then
+            inst = player:bcnmRegister(1284);
+        end
     end
 
+    if inst == 1 then
+        player:bcnmEnter(1284);
+        cs = -1;
+        if ((player:getXPos() == 0) and (player:getYPos() == 0) and (player:getZPos() == 0)) then
+            player:setPos(-284.751,-39.923,-422.948,235);
+        end
+    end
+
+    player:setVar("enteringDynamis",0);
     return cs;
 end;
 

--- a/scripts/zones/Dynamis-Beaucedine/bcnms/dynamis_beaucedine.lua
+++ b/scripts/zones/Dynamis-Beaucedine/bcnms/dynamis_beaucedine.lua
@@ -6,7 +6,7 @@
 -- After registering the BCNM via bcnmRegister(bcnmid)
 function onBcnmRegister(player,instance)
     
-    SetServerVariable("[DynaBeaucedine]UniqueID",player:getDynamisUniqueID(1284));
+    SetServerVariable("[DynaBeaucedine]UniqueID",os.time());
     SetServerVariable("[DynaBeaucedine]Already_Received",0);
     
 end;

--- a/scripts/zones/Dynamis-Buburimu/Zone.lua
+++ b/scripts/zones/Dynamis-Buburimu/Zone.lua
@@ -15,9 +15,9 @@ require("scripts/zones/Dynamis-Buburimu/TextIDs");
 function onInitialize(zone)
 end;
 
------------------------------------        
--- onConquestUpdate        
------------------------------------        
+-----------------------------------
+-- onConquestUpdate
+-----------------------------------
 
 function onConquestUpdate(zone, updatetype)
     local players = zone:getPlayers();
@@ -32,45 +32,39 @@ end;
 -----------------------------------
 
 function onZoneIn(player,prevZone)
-    local cs = -1;
-    if ((player:getXPos() == 0) and (player:getYPos() == 0) and (player:getZPos() == 0)) then    
-        player:setPos(143,2 ,-147);
-    end    
-    
-    local realDay = os.time();
-    local dynaWaitxDay = player:getVar("dynaWaitxDay");
-    
-    if ((dynaWaitxDay + (BETWEEN_2DYNA_WAIT_TIME * 24 * 60 * 60)) < realDay or player:getVar("DynamisID") == GetServerVariable("[DynaBuburimu]UniqueID")) then
-        if (player:isBcnmsFull() == 1) then
-            if (player:hasStatusEffect(EFFECT_DYNAMIS, 0) == false) then
-                inst = player:addPlayerToDynamis(1287);
-                
-                if (inst == 1) then
-                    player:bcnmEnter(1287);
-                else
-                     cs = 0x0065;
-                end
-            else
-                player:bcnmEnter(1287);
-            end
-        else
-            inst = player:bcnmRegister(1287);
-            
-            if (inst == 1) then
-                player:bcnmEnter(1287);
-            else
-                cs = 0x0065;
-            end
+    local cs = 0;
+    local inst = 0;
+
+    if player:isBcnmsFull() == 1 then
+        -- run currently in progress
+        -- add player to the run if they entered via markings, or if they reconnected to a run they were previously in
+        -- gms will be automatically registered
+        if player:getVar("enteringDynamis") == 1 or player:getVar("DynamisID") == GetServerVariable("[DynaBuburimu]UniqueID") or player:getGMLevel() > 0 then
+            inst = player:addPlayerToDynamis(1287);
         end
     else
-        cs = 0x0065;
+        -- no run yet in progress
+        -- register run by player if they entered via markings
+        -- gms will be automatically registered
+        if player:getVar("enteringDynamis") == 1 or player:getGMLevel() > 0 then
+            inst = player:bcnmRegister(1287);
+        end
     end
 
+    if inst == 1 then
+        player:bcnmEnter(1287);
+        cs = -1;
+        if ((player:getXPos() == 0) and (player:getYPos() == 0) and (player:getZPos() == 0)) then
+            player:setPos(155,-1,-169,170);
+        end
+    end
+
+    player:setVar("enteringDynamis",0);
     return cs;
 end;
 
 -----------------------------------
--- onRegionEnter          
+-- onRegionEnter
 -----------------------------------
 
 function onRegionEnter(player,region)
@@ -92,8 +86,7 @@ end;
 function onEventFinish(player,csid,option)
     -- printf("CSID: %u",csid);
     -- printf("RESULT: %u",option);
-    if (csid == 0x0065) then
+    if (csid == 0) then
         player:setPos(154,-1,-170,190, 118);
     end
 end;
-

--- a/scripts/zones/Dynamis-Buburimu/bcnms/dynamis_Buburimu.lua
+++ b/scripts/zones/Dynamis-Buburimu/bcnms/dynamis_Buburimu.lua
@@ -8,7 +8,7 @@
 -- After registering the BCNM via bcnmRegister(bcnmid)
 function onBcnmRegister(player,instance)
     
-    SetServerVariable("[DynaBuburimu]UniqueID",player:getDynamisUniqueID(1287));
+    SetServerVariable("[DynaBuburimu]UniqueID",os.time());
     SetServerVariable("[DynaBuburimu]Boss_Trigger",0);
     SetServerVariable("[DynaBuburimu]Already_Received",0);
     

--- a/scripts/zones/Dynamis-Jeuno/Zone.lua
+++ b/scripts/zones/Dynamis-Jeuno/Zone.lua
@@ -33,37 +33,34 @@ end;
 -----------------------------------
 
 function onZoneIn(player,prevZone)
-    local cs = -1;
+    local cs = 0;
+    local inst = 0;
 
-    local realDay = os.time();
-    local dynaWaitxDay = player:getVar("dynaWaitxDay");
-
-    if ((dynaWaitxDay + (BETWEEN_2DYNA_WAIT_TIME * 24 * 60 * 60)) < realDay or player:getVar("DynamisID") == GetServerVariable("[DynaJeuno]UniqueID")) then
-        if (player:isBcnmsFull() == 1) then
-            if (player:hasStatusEffect(EFFECT_DYNAMIS, 0) == false) then
-                inst = player:addPlayerToDynamis(1283);
-
-                if (inst == 1) then
-                    player:bcnmEnter(1283);
-                else
-                     cs = 0;
-                end
-            else
-                player:bcnmEnter(1283);
-            end
-        else
-            inst = player:bcnmRegister(1283);
-
-            if (inst == 1) then
-                player:bcnmEnter(1283);
-            else
-                cs = 0;
-            end
+    if player:isBcnmsFull() == 1 then
+        -- run currently in progress
+        -- add player to the run if they entered via markings, or if they reconnected to a run they were previously in
+        -- gms will be automatically registered
+        if player:getVar("enteringDynamis") == 1 or player:getVar("DynamisID") == GetServerVariable("[DynaJeuno]UniqueID") or player:getGMLevel() > 0 then
+            inst = player:addPlayerToDynamis(1283);
         end
     else
-        cs = 0;
+        -- no run yet in progress
+        -- register run by player if they entered via markings
+        -- gms will be automatically registered
+        if player:getVar("enteringDynamis") == 1 or player:getGMLevel() > 0 then
+            inst = player:bcnmRegister(1283);
+        end
     end
 
+    if inst == 1 then
+        player:bcnmEnter(1283);
+        cs = -1;
+        if ((player:getXPos() == 0) and (player:getYPos() == 0) and (player:getZPos() == 0)) then
+            player:setPos(48.930,10.002,-71.032,195);
+        end
+    end
+
+    player:setVar("enteringDynamis",0);
     return cs;
 end;
 

--- a/scripts/zones/Dynamis-Jeuno/bcnms/dynamis_jeuno.lua
+++ b/scripts/zones/Dynamis-Jeuno/bcnms/dynamis_jeuno.lua
@@ -6,7 +6,7 @@
 -- After registering the BCNM via bcnmRegister(bcnmid)
 function onBcnmRegister(player,instance)
     
-    SetServerVariable("[DynaJeuno]UniqueID",player:getDynamisUniqueID(1283));
+    SetServerVariable("[DynaJeuno]UniqueID",os.time());
     SetServerVariable("[DynaJeuno]Boss_Trigger",0);
     SetServerVariable("[DynaJeuno]Already_Received",0);
     

--- a/scripts/zones/Dynamis-Qufim/Zone.lua
+++ b/scripts/zones/Dynamis-Qufim/Zone.lua
@@ -15,9 +15,9 @@ require("scripts/zones/Dynamis-Qufim/TextIDs");
 function onInitialize(zone)
 end;
 
------------------------------------        
--- onConquestUpdate        
------------------------------------        
+-----------------------------------
+-- onConquestUpdate
+-----------------------------------
 
 function onConquestUpdate(zone, updatetype)
     local players = zone:getPlayers();
@@ -32,45 +32,39 @@ end;
 -----------------------------------
 
 function onZoneIn(player,prevZone)
-    local cs = -1;
-    if ((player:getXPos() == 0) and (player:getYPos() == 0) and (player:getZPos() == 0)) then    
-        player:setPos(-18,-17,104);
-    end    
-    
-    local realDay = os.time();
-    local dynaWaitxDay = player:getVar("dynaWaitxDay");
-    
-    if ((dynaWaitxDay + (BETWEEN_2DYNA_WAIT_TIME * 24 * 60 * 60)) < realDay or player:getVar("DynamisID") == GetServerVariable("[DynaQufim]UniqueID")) then
-        if (player:isBcnmsFull() == 1) then
-            if (player:hasStatusEffect(EFFECT_DYNAMIS, 0) == false) then
-                inst = player:addPlayerToDynamis(1288);
-                
-                if (inst == 1) then
-                    player:bcnmEnter(1288);
-                else
-                     cs = 0x0065;
-                end
-            else
-                player:bcnmEnter(1288);
-            end
-        else
-            inst = player:bcnmRegister(1288);
-            
-            if (inst == 1) then
-                player:bcnmEnter(1288);
-            else
-                cs = 0x0065;
-            end
+    local cs = 0;
+    local inst = 0;
+
+    if player:isBcnmsFull() == 1 then
+        -- run currently in progress
+        -- add player to the run if they entered via markings, or if they reconnected to a run they were previously in
+        -- gms will be automatically registered
+        if player:getVar("enteringDynamis") == 1 or player:getVar("DynamisID") == GetServerVariable("[DynaQufim]UniqueID") or player:getGMLevel() > 0 then
+            inst = player:addPlayerToDynamis(1288);
         end
     else
-        cs = 0x0065;
+        -- no run yet in progress
+        -- register run by player if they entered via markings
+        -- gms will be automatically registered
+        if player:getVar("enteringDynamis") == 1 or player:getGMLevel() > 0 then
+            inst = player:bcnmRegister(1288);
+        end
     end
 
-  return cs;
+    if inst == 1 then
+        player:bcnmEnter(1288);
+        cs = -1;
+        if ((player:getXPos() == 0) and (player:getYPos() == 0) and (player:getZPos() == 0)) then
+            player:setPos(-19,-17,104,253);
+        end
+    end
+
+    player:setVar("enteringDynamis",0);
+    return cs;
 end;
 
 -----------------------------------
--- onRegionEnter          
+-- onRegionEnter
 -----------------------------------
 
 function onRegionEnter(player,region)
@@ -92,8 +86,7 @@ end;
 function onEventFinish(player,csid,option)
     -- printf("CSID: %u",csid);
     -- printf("RESULT: %u",option);
-    if (csid == 0x0065) then
-            player:setPos(18,-19,162,240, 126);
+    if (csid == 0) then
+        player:setPos(18,-19,162,240, 126);
     end
 end;
-

--- a/scripts/zones/Dynamis-Qufim/bcnms/dynamis_Qufim.lua
+++ b/scripts/zones/Dynamis-Qufim/bcnms/dynamis_Qufim.lua
@@ -8,7 +8,7 @@
 -- After registering the BCNM via bcnmRegister(bcnmid)
 function onBcnmRegister(player,instance)
     
-    SetServerVariable("[DynaQufim]UniqueID",player:getDynamisUniqueID(1288));
+    SetServerVariable("[DynaQufim]UniqueID",os.time());
     SetServerVariable("[DynaQufim]Boss_Trigger",0);
     SetServerVariable("[DynaQufim]Already_Received",0);
     

--- a/scripts/zones/Dynamis-San_dOria/Zone.lua
+++ b/scripts/zones/Dynamis-San_dOria/Zone.lua
@@ -33,37 +33,34 @@ end;
 -----------------------------------
 
 function onZoneIn(player,prevZone)
-    local cs = -1;
+    local cs = 0;
+    local inst = 0;
 
-    local realDay = os.time();
-    local dynaWaitxDay = player:getVar("dynaWaitxDay");
-
-    if ((dynaWaitxDay + (BETWEEN_2DYNA_WAIT_TIME * 24 * 60 * 60)) < realDay or player:getVar("DynamisID") == GetServerVariable("[DynaSandoria]UniqueID")) then
-        if (player:isBcnmsFull() == 1) then
-            if (player:hasStatusEffect(EFFECT_DYNAMIS, 0) == false) then
-                inst = player:addPlayerToDynamis(1281);
-
-                if (inst == 1) then
-                    player:bcnmEnter(1281);
-                else
-                     cs = 0;
-                end
-            else
-                player:bcnmEnter(1281);
-            end
-        else
-            inst = player:bcnmRegister(1281);
-
-            if (inst == 1) then
-                player:bcnmEnter(1281);
-            else
-                cs = 0;
-            end
+    if player:isBcnmsFull() == 1 then
+        -- run currently in progress
+        -- add player to the run if they entered via markings, or if they reconnected to a run they were previously in
+        -- gms will be automatically registered
+        if player:getVar("enteringDynamis") == 1 or player:getVar("DynamisID") == GetServerVariable("[DynaSandoria]UniqueID") or player:getGMLevel() > 0 then
+            inst = player:addPlayerToDynamis(1281);
         end
     else
-        cs = 0;
+        -- no run yet in progress
+        -- register run by player if they entered via markings
+        -- gms will be automatically registered
+        if player:getVar("enteringDynamis") == 1 or player:getGMLevel() > 0 then
+            inst = player:bcnmRegister(1281);
+        end
     end
 
+    if inst == 1 then
+        player:bcnmEnter(1281);
+        cs = -1;
+        if ((player:getXPos() == 0) and (player:getYPos() == 0) and (player:getZPos() == 0)) then
+            player:setPos(161.838,-2.000,161.673,93);
+        end
+    end
+
+    player:setVar("enteringDynamis",0);
     return cs;
 end;
 

--- a/scripts/zones/Dynamis-San_dOria/bcnms/dynamis_sandoria.lua
+++ b/scripts/zones/Dynamis-San_dOria/bcnms/dynamis_sandoria.lua
@@ -6,7 +6,7 @@
 -- After registering the BCNM via bcnmRegister(bcnmid)
 function onBcnmRegister(player,instance)
     
-    SetServerVariable("[DynaSandoria]UniqueID",player:getDynamisUniqueID(1281));
+    SetServerVariable("[DynaSandoria]UniqueID",os.time());
     SetServerVariable("[DynaSandoria]Boss_Trigger",0);
     SetServerVariable("[DynaSandoria]Already_Received",0);
     

--- a/scripts/zones/Dynamis-Tavnazia/Zone.lua
+++ b/scripts/zones/Dynamis-Tavnazia/Zone.lua
@@ -15,13 +15,13 @@ require("scripts/zones/Dynamis-Tavnazia/TextIDs");
 function onInitialize(zone)
 end;
 
------------------------------------        
--- onConquestUpdate        
------------------------------------        
+-----------------------------------
+-- onConquestUpdate
+-----------------------------------
 
 function onConquestUpdate(zone, updatetype)
     local players = zone:getPlayers();
-    
+
     for name, player in pairs(players) do
         conquestUpdate(zone, player, updatetype, CONQUEST_BASE);
     end
@@ -32,41 +32,39 @@ end;
 -----------------------------------
 
 function onZoneIn(player,prevZone)
-    local cs = -1;
-    local realDay = os.time();
-    local dynaWaitxDay = player:getVar("dynaWaitxDay");
-    
-    if ((dynaWaitxDay + (BETWEEN_2DYNA_WAIT_TIME * 24 * 60 * 60)) < realDay or player:getVar("DynamisID") == GetServerVariable("[DynaTavnazia]UniqueID")) then
-        if (player:isBcnmsFull() == 1) then
-            if (player:hasStatusEffect(EFFECT_DYNAMIS, 0) == false) then
-                inst = player:addPlayerToDynamis(1289);
-                
-                if (inst == 1) then
-                    player:bcnmEnter(1289);
-                else
-                     cs = 0x0065;
-                end
-            else
-                player:bcnmEnter(1289);
-            end
-        else
-            inst = player:bcnmRegister(1289);
-            
-            if (inst == 1) then
-                player:bcnmEnter(1289);
-            else
-                cs = 0x0065;
-            end
+    local cs = 0;
+    local inst = 0;
+
+    if player:isBcnmsFull() == 1 then
+        -- run currently in progress
+        -- add player to the run if they entered via markings, or if they reconnected to a run they were previously in
+        -- gms will be automatically registered
+        if player:getVar("enteringDynamis") == 1 or player:getVar("DynamisID") == GetServerVariable("[DynaTavnazia]UniqueID") or player:getGMLevel() > 0 then
+            inst = player:addPlayerToDynamis(1289);
         end
     else
-        cs = 0x0065;
+        -- no run yet in progress
+        -- register run by player if they entered via markings
+        -- gms will be automatically registered
+        if player:getVar("enteringDynamis") == 1 or player:getGMLevel() > 0 then
+            inst = player:bcnmRegister(1289);
+        end
     end
 
+    if inst == 1 then
+        player:bcnmEnter(1289);
+        cs = -1;
+        if ((player:getXPos() == 0) and (player:getYPos() == 0) and (player:getZPos() == 0)) then
+            player:setPos(0.1,-7,-21,190);
+        end
+    end
+
+    player:setVar("enteringDynamis",0);
     return cs;
 end;
 
 -----------------------------------
--- onRegionEnter          
+-- onRegionEnter
 -----------------------------------
 
 function onRegionEnter(player,region)
@@ -88,8 +86,7 @@ end;
 function onEventFinish(player,csid,option)
     -- printf("CSID: %u",csid);
     -- printf("RESULT: %u",option);
-    if (csid == 0x0065) then
+    if (csid == 0) then
         player:setPos(0.0,-7,-23,195,26);
     end
 end;
-

--- a/scripts/zones/Dynamis-Tavnazia/bcnms/dynamis_Tavnazia.lua
+++ b/scripts/zones/Dynamis-Tavnazia/bcnms/dynamis_Tavnazia.lua
@@ -8,7 +8,7 @@
 -- After registering the BCNM via bcnmRegister(bcnmid)
 function onBcnmRegister(player,instance)
 
-    SetServerVariable("[DynaTavnazia]UniqueID",player:getDynamisUniqueID(1289));
+    SetServerVariable("[DynaTavnazia]UniqueID",os.time());
     SetServerVariable("[DynaTavnazia]Boss_Trigger",0);
     SetServerVariable("[DynaTavnazia]Already_Received",0);
     

--- a/scripts/zones/Dynamis-Valkurm/Zone.lua
+++ b/scripts/zones/Dynamis-Valkurm/Zone.lua
@@ -16,9 +16,9 @@ require("scripts/zones/Dynamis-Valkurm/TextIDs");
 function onInitialize(zone)
 end;
 
------------------------------------        
--- onConquestUpdate        
------------------------------------        
+-----------------------------------
+-- onConquestUpdate
+-----------------------------------
 
 function onConquestUpdate(zone, updatetype)
     local players = zone:getPlayers();
@@ -33,42 +33,39 @@ end;
 -----------------------------------
 
 function onZoneIn(player,prevZone)
-    local cs = -1;
-    
-    local realDay = os.time();
-    local dynaWaitxDay = player:getVar("dynaWaitxDay");
-    
-    if ((dynaWaitxDay + (BETWEEN_2DYNA_WAIT_TIME * 24 * 60 * 60)) < realDay or player:getVar("DynamisID") == GetServerVariable("[DynaValkurm]UniqueID")) then
-        if (player:isBcnmsFull() == 1) then
-            if (player:hasStatusEffect(EFFECT_DYNAMIS, 0) == false) then
-                inst = player:addPlayerToDynamis(1286);
-                
-                if (inst == 1) then
-                    player:bcnmEnter(1286);
-                else
-                     cs = 0x0065;
-                end
-            else
-                player:bcnmEnter(1286);
-            end
-        else
-            inst = player:bcnmRegister(1286);
-            
-            if (inst == 1) then
-                player:bcnmEnter(1286);
-            else
-                cs = 0x0065;
-            end
+    local cs = 0;
+    local inst = 0;
+
+    if player:isBcnmsFull() == 1 then
+        -- run currently in progress
+        -- add player to the run if they entered via markings, or if they reconnected to a run they were previously in
+        -- gms will be automatically registered
+        if player:getVar("enteringDynamis") == 1 or player:getVar("DynamisID") == GetServerVariable("[DynaValkurm]UniqueID") or player:getGMLevel() > 0 then
+            inst = player:addPlayerToDynamis(1286);
         end
     else
-        cs = 0x0065;
+        -- no run yet in progress
+        -- register run by player if they entered via markings
+        -- gms will be automatically registered
+        if player:getVar("enteringDynamis") == 1 or player:getGMLevel() > 0 then
+            inst = player:bcnmRegister(1286);
+        end
     end
 
+    if inst == 1 then
+        player:bcnmEnter(1286);
+        cs = -1;
+        if ((player:getXPos() == 0) and (player:getYPos() == 0) and (player:getZPos() == 0)) then
+            player:setPos(100,-8,131,47);
+        end
+    end
+
+    player:setVar("enteringDynamis",0);
     return cs;
 end;
 
 -----------------------------------
--- onRegionEnter          
+-- onRegionEnter
 -----------------------------------
 
 function onRegionEnter(player,region)
@@ -91,8 +88,7 @@ end;
 function onEventFinish(player,csid,option)
     -- printf("CSID: %u",csid);
     -- printf("RESULT: %u",option);
-    if (csid == 0x0065) then
+    if (csid == 0) then
         player:setPos(117,-9,132,162,103);
     end
 end;
-

--- a/scripts/zones/Dynamis-Valkurm/bcnms/dynamis_Valkurm.lua
+++ b/scripts/zones/Dynamis-Valkurm/bcnms/dynamis_Valkurm.lua
@@ -8,7 +8,7 @@
 -- After registering the BCNM via bcnmRegister(bcnmid)
 function onBcnmRegister(player,instance)
     
-    SetServerVariable("[DynaValkurm]UniqueID",player:getDynamisUniqueID(1286));
+    SetServerVariable("[DynaValkurm]UniqueID",os.time());
     SetServerVariable("[DynaValkurm]Boss_Trigger",0);
     SetServerVariable("[DynaValkurm]Already_Received",0);
     

--- a/scripts/zones/Dynamis-Windurst/Zone.lua
+++ b/scripts/zones/Dynamis-Windurst/Zone.lua
@@ -33,37 +33,34 @@ end;
 -----------------------------------
 
 function onZoneIn(player,prevZone)
-    local cs = -1;
+    local cs = 0;
+    local inst = 0;
 
-    local realDay = os.time();
-    local dynaWaitxDay = player:getVar("dynaWaitxDay");
-
-    if ((dynaWaitxDay + (BETWEEN_2DYNA_WAIT_TIME * 24 * 60 * 60)) < realDay or player:getVar("DynamisID") == GetServerVariable("[DynaWindurst]UniqueID")) then
-        if (player:isBcnmsFull() == 1) then
-            if (player:hasStatusEffect(EFFECT_DYNAMIS, 0) == false) then
-                inst = player:addPlayerToDynamis(1282);
-
-                if (inst == 1) then
-                    player:bcnmEnter(1282);
-                else
-                     cs = 0;
-                end
-            else
-                player:bcnmEnter(1282);
-            end
-        else
-            inst = player:bcnmRegister(1282);
-
-            if (inst == 1) then
-                player:bcnmEnter(1282);
-            else
-                cs = 0;
-            end
+    if player:isBcnmsFull() == 1 then
+        -- run currently in progress
+        -- add player to the run if they entered via markings, or if they reconnected to a run they were previously in
+        -- gms will be automatically registered
+        if player:getVar("enteringDynamis") == 1 or player:getVar("DynamisID") == GetServerVariable("[DynaWindurst]UniqueID") or player:getGMLevel() > 0 then
+            inst = player:addPlayerToDynamis(1282);
         end
     else
-        cs = 0;
+        -- no run yet in progress
+        -- register run by player if they entered via markings
+        -- gms will be automatically registered
+        if player:getVar("enteringDynamis") == 1 or player:getGMLevel() > 0 then
+            inst = player:bcnmRegister(1282);
+        end
     end
 
+    if inst == 1 then
+        player:bcnmEnter(1282);
+        cs = -1;
+        if ((player:getXPos() == 0) and (player:getYPos() == 0) and (player:getZPos() == 0)) then
+            player:setPos(-221.988,1.000,-120.184,0);
+        end
+    end
+
+    player:setVar("enteringDynamis",0);
     return cs;
 end;
 

--- a/scripts/zones/Dynamis-Windurst/bcnms/dynamis_windurst.lua
+++ b/scripts/zones/Dynamis-Windurst/bcnms/dynamis_windurst.lua
@@ -6,7 +6,7 @@
 -- After registering the BCNM via bcnmRegister(bcnmid)
 function onBcnmRegister(player,instance)
     
-    SetServerVariable("[DynaWindurst]UniqueID",player:getDynamisUniqueID(1282));
+    SetServerVariable("[DynaWindurst]UniqueID",os.time());
     SetServerVariable("[DynaWindurst]Boss_Trigger",0);
     SetServerVariable("[DynaWindurst]Already_Received",0);
     

--- a/scripts/zones/Dynamis-Xarcabard/Zone.lua
+++ b/scripts/zones/Dynamis-Xarcabard/Zone.lua
@@ -33,40 +33,34 @@ end;
 -----------------------------------
 
 function onZoneIn(player,prevZone)
-    local cs = -1;
+    local cs = 0;
+    local inst = 0;
 
-    local realDay = os.time();
-    local dynaWaitxDay = player:getVar("dynaWaitxDay");
-
-    if ((player:getXPos() == 0) and (player:getYPos() == 0) and (player:getZPos() == 0)) then
-        player:setPos(569.600,-0.078,-270.000,90);
-    end
-
-    if ((dynaWaitxDay + (BETWEEN_2DYNA_WAIT_TIME * 24 * 60 * 60)) < realDay or player:getVar("DynamisID") == GetServerVariable("[DynaXarcabard]UniqueID")) then
-        if (player:isBcnmsFull() == 1) then
-            if (player:hasStatusEffect(EFFECT_DYNAMIS, 0) == false) then
-                inst = player:addPlayerToDynamis(1285);
-                if (inst == 1) then
-                    player:bcnmEnter(1285);
-                else
-                     cs = 0;
-                end
-            else
-                player:bcnmEnter(1285);
-            end
-        else
-            inst = player:bcnmRegister(1285);
-
-            if (inst == 1) then
-                player:bcnmEnter(1285);
-            else
-                cs = 0;
-            end
+    if player:isBcnmsFull() == 1 then
+        -- run currently in progress
+        -- add player to the run if they entered via markings, or if they reconnected to a run they were previously in
+        -- gms will be automatically registered
+        if player:getVar("enteringDynamis") == 1 or player:getVar("DynamisID") == GetServerVariable("[DynaXarcabard]UniqueID") or player:getGMLevel() > 0 then
+            inst = player:addPlayerToDynamis(1285);
         end
     else
-        cs = 0;
+        -- no run yet in progress
+        -- register run by player if they entered via markings
+        -- gms will be automatically registered
+        if player:getVar("enteringDynamis") == 1 or player:getGMLevel() > 0 then
+            inst = player:bcnmRegister(1285);
+        end
     end
 
+    if inst == 1 then
+        player:bcnmEnter(1285);
+        cs = -1;
+        if ((player:getXPos() == 0) and (player:getYPos() == 0) and (player:getZPos() == 0)) then
+            player:setPos(569.312,-0.098,-270.158,90);
+        end
+    end
+
+    player:setVar("enteringDynamis",0);
     return cs;
 end;
 

--- a/scripts/zones/Dynamis-Xarcabard/bcnms/dynamis_xarcabard.lua
+++ b/scripts/zones/Dynamis-Xarcabard/bcnms/dynamis_xarcabard.lua
@@ -6,7 +6,7 @@
 -- After registering the BCNM via bcnmRegister(bcnmid)
 function onBcnmRegister(player,instance)
     
-    SetServerVariable("[DynaXarcabard]UniqueID",player:getDynamisUniqueID(1285));
+    SetServerVariable("[DynaXarcabard]UniqueID",os.time());
     SetServerVariable("[DynaXarcabard]TE43_Trigger",0);
     SetServerVariable("[DynaXarcabard]TE60_Trigger",0);
     SetServerVariable("[DynaXarcabard]TE150_Trigger",0);

--- a/scripts/zones/Qufim_Island/npcs/Hieroglyphics.lua
+++ b/scripts/zones/Qufim_Island/npcs/Hieroglyphics.lua
@@ -2,7 +2,7 @@
 -- Area: Qufim_Island
 -- NPC:  Hieroglyphics
 -- Dynamis Qufim Entrance
--- @pos 117 -10 133 172 118
+-- @pos 16 -19 162 126
 -----------------------------------
 package.loaded["scripts/zones/Qufim_Island/TextIDs"] = nil;
 -----------------------------------
@@ -18,7 +18,7 @@ require("scripts/zones/Qufim_Island/TextIDs");
 -----------------------------------
 
 function onTrade(player,npc,trade)
-end; 
+end;
 
 -----------------------------------
 -- onTrigger Action
@@ -30,22 +30,19 @@ function onTrigger(player,npc)
         local firstDyna = 0;
         local realDay = os.time();
         local dynaWaitxDay = player:getVar("dynaWaitxDay");
-        
-    
-        if (player:getMainLvl() < DYNA_LEVEL_MIN) then
+
+        if (checkFirstDyna(player,9)) then
+             player:startEvent(0x0016);
+        elseif (player:getMainLvl() < DYNA_LEVEL_MIN) then
             player:messageSpecial(PLAYERS_HAVE_NOT_REACHED_LEVEL,DYNA_LEVEL_MIN);
-        
-        elseif ((dynaWaitxDay + (BETWEEN_2DYNA_WAIT_TIME * 24 * 60 * 60)) < realDay or player:getVar("DynamisID") == GetServerVariable("[DynaQufim]UniqueID")) then
-            
+        elseif dynaWaitxDay + (BETWEEN_2DYNA_WAIT_TIME * 24 * 60 * 60) < realDay then
             player:startEvent(0x0003,9,0,0,BETWEEN_2DYNA_WAIT_TIME,32,VIAL_OF_SHROUDED_SAND,4236,4237);
         else
             dayRemaining = math.floor(((dynaWaitxDay + (BETWEEN_2DYNA_WAIT_TIME * 24 * 60 * 60)) - realDay)/3456);
-            --printf("dayRemaining : %u",dayRemaining );
-            
             player:messageSpecial(YOU_CANNOT_ENTER_DYNAMIS,dayRemaining,8);
         end
     else
-        player:messageSpecial(MYSTERIOUS_VOICE); 
+        player:messageSpecial(MYSTERIOUS_VOICE);
     end
     
 end;
@@ -67,9 +64,12 @@ function onEventFinish(player,csid,option)
     -- printf("CSID: %u",csid);
     -- printf("finishRESULT: %u",option);
     
-    
-     if (csid == 0x0003 and option == 0) then
+    if (csid == 0x0016) then
+        if (checkFirstDyna(player,9)) then
+            player:setVar("Dynamis_Status",bit.bor(player:getVar("Dynamis_Status"),512));
+        end
+    elseif (csid == 0x0003 and option == 0) then
+        player:setVar("enteringDynamis",1);
         player:setPos(-19,-17,104,253,41);
     end
-    
 end;

--- a/scripts/zones/RuLude_Gardens/npcs/Trail_Markings.lua
+++ b/scripts/zones/RuLude_Gardens/npcs/Trail_Markings.lua
@@ -25,7 +25,7 @@ end;
 
 function onTrigger(player,npc)
     
-    if (player:getVar("Dynamis_Status") == 1) then
+    if bit.band(player:getVar("Dynamis_Status"),1) == 1 then
         player:startEvent(0x2720); -- cs with Cornelia
     elseif (player:getVar("DynaJeuno_Win") == 1) then
         player:startEvent(0x272a,HYDRA_CORPS_TACTICAL_MAP); -- Win CS
@@ -35,12 +35,12 @@ function onTrigger(player,npc)
         local dynaWaitxDay = player:getVar("dynaWaitxDay");
         
         if (checkFirstDyna(player,4)) then  -- First Dyna-Jeuno => CS
-            firstDyna = 1; 
+            firstDyna = 1;
         end
         
         if (player:getMainLvl() < DYNA_LEVEL_MIN) then
             player:messageSpecial(PLAYERS_HAVE_NOT_REACHED_LEVEL,DYNA_LEVEL_MIN);
-        elseif ((dynaWaitxDay + (BETWEEN_2DYNA_WAIT_TIME * 24 * 60 * 60)) < realDay or player:getVar("DynamisID") == GetServerVariable("[DynaJeuno]UniqueID")) then
+        elseif dynaWaitxDay + (BETWEEN_2DYNA_WAIT_TIME * 24 * 60 * 60) < realDay then
             player:startEvent(0x271c,4,firstDyna,0,BETWEEN_2DYNA_WAIT_TIME,64,VIAL_OF_SHROUDED_SAND,4236,4237);
         else
             dayRemaining = math.floor(((dynaWaitxDay + (BETWEEN_2DYNA_WAIT_TIME * 24 * 60 * 60)) - realDay)/3456);
@@ -68,19 +68,18 @@ end;
 function onEventFinish(player,csid,option)
     -- printf("CSID: %u",csid);
     -- printf("finishRESULT: %u",option);
-    
+
     if (csid == 0x2720) then
         player:addKeyItem(VIAL_OF_SHROUDED_SAND);
         player:messageSpecial(KEYITEM_OBTAINED,VIAL_OF_SHROUDED_SAND);
-        player:setVar("Dynamis_Status",0);
+        player:setVar("Dynamis_Status",bit.band(player:getVar("Dynamis_Status"),bit.bnot(1)));
     elseif (csid == 0x272a) then
         player:setVar("DynaJeuno_Win",0);
     elseif (csid == 0x271c and option == 0) then
         if (checkFirstDyna(player,4)) then
-            player:setVar("Dynamis_Status",player:getVar("Dynamis_Status") + 16);
+            player:setVar("Dynamis_Status",bit.bor(player:getVar("Dynamis_Status"),16));
         end
-        
+        player:setVar("enteringDynamis",1);
         player:setPos(48.930,10.002,-71.032,195,0xBC);
     end
-    
 end;

--- a/scripts/zones/Southern_San_dOria/npcs/Trail_Markings.lua
+++ b/scripts/zones/Southern_San_dOria/npcs/Trail_Markings.lua
@@ -24,8 +24,8 @@ end;
 -----------------------------------
 
 function onTrigger(player,npc)
-    
-    if (player:getVar("Dynamis_Status") == 1) then
+
+    if bit.band(player:getVar("Dynamis_Status"),1) == 1 then
         player:startEvent(0x02AE); -- cs with Cornelia
     elseif (player:getVar("DynaSandoria_Win") == 1) then
         player:startEvent(0x02ba,HYDRA_CORPS_COMMAND_SCEPTER); -- Win CS
@@ -35,12 +35,12 @@ function onTrigger(player,npc)
         local dynaWaitxDay = player:getVar("dynaWaitxDay");
         
         if (checkFirstDyna(player,1)) then  -- First Dyna-San d'oria => CS
-            firstDyna = 1; 
+            firstDyna = 1;
         end
         
         if (player:getMainLvl() < DYNA_LEVEL_MIN) then
             player:messageSpecial(PLAYERS_HAVE_NOT_REACHED_LEVEL,DYNA_LEVEL_MIN);
-        elseif ((dynaWaitxDay + (BETWEEN_2DYNA_WAIT_TIME * 24 * 60 * 60)) < realDay or player:getVar("DynamisID") == GetServerVariable("[DynaSandoria]UniqueID")) then
+        elseif dynaWaitxDay + (BETWEEN_2DYNA_WAIT_TIME * 24 * 60 * 60) < realDay then
             player:startEvent(0x02ad,1,firstDyna,0,BETWEEN_2DYNA_WAIT_TIME,64,VIAL_OF_SHROUDED_SAND,4236,4237);
         else
             dayRemaining = math.floor(((dynaWaitxDay + (BETWEEN_2DYNA_WAIT_TIME * 24 * 60 * 60)) - realDay)/3456);
@@ -72,15 +72,14 @@ function onEventFinish(player,csid,option)
     if (csid == 0x02AE) then
         player:addKeyItem(VIAL_OF_SHROUDED_SAND);
         player:messageSpecial(KEYITEM_OBTAINED,VIAL_OF_SHROUDED_SAND);
-        player:setVar("Dynamis_Status",0);
+        player:setVar("Dynamis_Status",bit.band(player:getVar("Dynamis_Status"),bit.bnot(1)));
     elseif (csid == 0x02ba) then
         player:setVar("DynaSandoria_Win",0);
     elseif (csid == 0x02ad and option == 0) then
         if (checkFirstDyna(player,1)) then
-            player:setVar("Dynamis_Status",player:getVar("Dynamis_Status") + 2);
+            player:setVar("Dynamis_Status",bit.bor(player:getVar("Dynamis_Status"),2));
         end
-        
+        player:setVar("enteringDynamis",1);
         player:setPos(161.838,-2.000,161.673,93,0xb9);
     end
-    
 end;

--- a/scripts/zones/Tavnazian_Safehold/npcs/Hieroglyphics.lua
+++ b/scripts/zones/Tavnazian_Safehold/npcs/Hieroglyphics.lua
@@ -24,26 +24,21 @@ end;
 -- onTrigger Action
 -----------------------------------
 
-function onTrigger(player,npc)  
+function onTrigger(player,npc)
 
     if ( (player:hasCompletedMission(COP,DARKNESS_NAMED) or FREE_COP_DYNAMIS == 1) and player:hasKeyItem(DYNAMIS_BUBURIMU_SLIVER ) and player:hasKeyItem(DYNAMIS_QUFIM_SLIVER ) and player:hasKeyItem(DYNAMIS_VALKURM_SLIVER )) then
-    
-    
         local firstDyna = 0;
         local realDay = os.time();
         local dynaWaitxDay = player:getVar("dynaWaitxDay");
-        
     
-        if (player:getMainLvl() < DYNA_LEVEL_MIN) then
+        if (checkFirstDyna(player,10)) then
+             player:startEvent(0x0266);
+        elseif (player:getMainLvl() < DYNA_LEVEL_MIN) then
             player:messageSpecial(PLAYERS_HAVE_NOT_REACHED_LEVEL,DYNA_LEVEL_MIN);
-        
-        elseif ((dynaWaitxDay + (BETWEEN_2DYNA_WAIT_TIME * 24 * 60 * 60)) < realDay or player:getVar("DynamisID") == GetServerVariable("[DynaTavnazia]UniqueID")) then
-            
+        elseif dynaWaitxDay + (BETWEEN_2DYNA_WAIT_TIME * 24 * 60 * 60) < realDay then
             player:startEvent(0x024C,10,0,0,BETWEEN_2DYNA_WAIT_TIME,32,VIAL_OF_SHROUDED_SAND,4236,4237);
         else
             dayRemaining = math.floor(((dynaWaitxDay + (BETWEEN_2DYNA_WAIT_TIME * 24 * 60 * 60)) - realDay)/3456);
-            printf("dayRemaining : %u",dayRemaining );
-            
             player:messageSpecial(YOU_CANNOT_ENTER_DYNAMIS,dayRemaining,10);
         end
     else
@@ -69,9 +64,12 @@ function onEventFinish(player,csid,option)
     -- printf("CSID: %u",csid);
     -- printf("finishRESULT: %u",option);
     
-    
-     if (csid == 0x024C and option == 0) then
-          player:setPos(0.1,-7,-21,190,42);
+    if (csid == 0x0266) then
+        if (checkFirstDyna(player,10)) then
+            player:setVar("Dynamis_Status",bit.bor(player:getVar("Dynamis_Status"),1024));
+        end
+    elseif (csid == 0x024C and option == 0) then
+        player:setVar("enteringDynamis",1);
+        player:setPos(0.1,-7,-21,190,42);
     end
-    
 end;

--- a/scripts/zones/Valkurm_Dunes/npcs/Hieroglyphics.lua
+++ b/scripts/zones/Valkurm_Dunes/npcs/Hieroglyphics.lua
@@ -2,7 +2,7 @@
 -- Area: Valkurm_Dunes
 -- NPC:  Hieroglyphics
 -- Dynamis Valkurm_Dunes Enter
--- @pos 117 -10 133 172 103
+-- @pos 117 -10 133 103
 -----------------------------------
 package.loaded["scripts/zones/Valkurm_Dunes/TextIDs"] = nil;
 -----------------------------------
@@ -18,37 +18,31 @@ require("scripts/zones/Valkurm_Dunes/TextIDs");
 -----------------------------------
 
 function onTrade(player,npc,trade)
-end; 
+end;
 
 -----------------------------------
 -- onTrigger Action
 -----------------------------------
 
 function onTrigger(player,npc)  
-
     if (player:hasCompletedMission(COP,DARKNESS_NAMED) or FREE_COP_DYNAMIS == 1) then
         local firstDyna = 0;
         local realDay = os.time();
         local dynaWaitxDay = player:getVar("dynaWaitxDay");
-        
+
         if (checkFirstDyna(player,7)) then 
              player:startEvent(0x0021);
         elseif (player:getMainLvl() < DYNA_LEVEL_MIN) then
             player:messageSpecial(PLAYERS_HAVE_NOT_REACHED_LEVEL,DYNA_LEVEL_MIN);
-        
-        elseif ((dynaWaitxDay + (BETWEEN_2DYNA_WAIT_TIME * 24 * 60 * 60)) < realDay or player:getVar("DynamisID") == GetServerVariable("[DynaValkurm]UniqueID")) then
-            
+        elseif dynaWaitxDay + (BETWEEN_2DYNA_WAIT_TIME * 24 * 60 * 60) < realDay then
             player:startEvent(0x0010,7,0,0,BETWEEN_2DYNA_WAIT_TIME,32,VIAL_OF_SHROUDED_SAND,4236,4237);
         else
             dayRemaining = math.floor(((dynaWaitxDay + (BETWEEN_2DYNA_WAIT_TIME * 24 * 60 * 60)) - realDay)/3456);
-            printf("dayRemaining : %u",dayRemaining );
-            
             player:messageSpecial(YOU_CANNOT_ENTER_DYNAMIS,dayRemaining,7);
         end
     else
-        player:messageSpecial(MYSTERIOUS_VOICE); 
+        player:messageSpecial(MYSTERIOUS_VOICE);
     end
-    
 end;
 
 -----------------------------------
@@ -70,9 +64,10 @@ function onEventFinish(player,csid,option)
     
     if (csid == 0x0021) then
         if (checkFirstDyna(player,7)) then
-            player:setVar("Dynamis_Status",player:getVar("Dynamis_Status") + 128);
+            player:setVar("Dynamis_Status",bit.bor(player:getVar("Dynamis_Status"),128));
         end
     elseif (csid == 0x0010 and option == 0) then
+        player:setVar("enteringDynamis",1);
         player:setPos(100,-8,131,47,0x27);
     end
     

--- a/scripts/zones/Windurst_Walls/npcs/Trail_Markings.lua
+++ b/scripts/zones/Windurst_Walls/npcs/Trail_Markings.lua
@@ -25,7 +25,7 @@ end;
 
 function onTrigger(player,npc)
     
-    if (player:getVar("Dynamis_Status") == 1) then
+    if bit.band(player:getVar("Dynamis_Status"),1) == 1 then
         player:startEvent(0x01c7); -- cs with Cornelia
     elseif (player:getVar("DynaWindurst_Win") == 1) then
         player:startEvent(0x01d1,HYDRA_CORPS_LANTERN); -- Win CS
@@ -40,7 +40,7 @@ function onTrigger(player,npc)
         
         if (player:getMainLvl() < DYNA_LEVEL_MIN) then
             player:messageSpecial(PLAYERS_HAVE_NOT_REACHED_LEVEL,DYNA_LEVEL_MIN);
-        elseif ((dynaWaitxDay + (BETWEEN_2DYNA_WAIT_TIME * 24 * 60 * 60)) < realDay or player:getVar("DynamisID") == GetServerVariable("[DynaWindurst]UniqueID")) then
+        elseif dynaWaitxDay + (BETWEEN_2DYNA_WAIT_TIME * 24 * 60 * 60) < realDay then
             player:startEvent(0x01c4,3,firstDyna,0,BETWEEN_2DYNA_WAIT_TIME,64,VIAL_OF_SHROUDED_SAND,4236,4237);
         else
             dayRemaining = math.floor(((dynaWaitxDay + (BETWEEN_2DYNA_WAIT_TIME * 24 * 60 * 60)) - realDay)/3456);
@@ -72,15 +72,14 @@ function onEventFinish(player,csid,option)
     if (csid == 0x01c7) then
         player:addKeyItem(VIAL_OF_SHROUDED_SAND);
         player:messageSpecial(KEYITEM_OBTAINED,VIAL_OF_SHROUDED_SAND);
-        player:setVar("Dynamis_Status",0);
+        player:setVar("Dynamis_Status",bit.band(player:getVar("Dynamis_Status"),bit.bnot(1)));
     elseif (csid == 0x01d1) then
         player:setVar("DynaWindurst_Win",0);
     elseif (csid == 0x01c4 and option == 0) then
         if (checkFirstDyna(player,3)) then
-            player:setVar("Dynamis_Status",player:getVar("Dynamis_Status") + 8);
+            player:setVar("Dynamis_Status",bit.bor(player:getVar("Dynamis_Status"),8));
         end
-        
+        player:setVar("enteringDynamis",1);
         player:setPos(-221.988,1.000,-120.184,0,0xbb);
     end
-    
 end;

--- a/scripts/zones/Xarcabard/npcs/Trail_Markings.lua
+++ b/scripts/zones/Xarcabard/npcs/Trail_Markings.lua
@@ -33,12 +33,12 @@ function onTrigger(player,npc)
         local dynaWaitxDay = player:getVar("dynaWaitxDay");
         
         if (checkFirstDyna(player,6)) then  -- First Dyna-Xarcabard => CS
-            firstDyna = 1; 
+            firstDyna = 1;
         end
         
         if (player:getMainLvl() < DYNA_LEVEL_MIN) then
             player:messageSpecial(PLAYERS_HAVE_NOT_REACHED_LEVEL,DYNA_LEVEL_MIN);
-        elseif ((dynaWaitxDay + (BETWEEN_2DYNA_WAIT_TIME * 24 * 60 * 60)) < realDay or player:getVar("DynamisID") == GetServerVariable("[DynaXarcabard]UniqueID")) then
+        elseif dynaWaitxDay + (BETWEEN_2DYNA_WAIT_TIME * 24 * 60 * 60) < realDay then
             player:startEvent(0x0010,6,firstDyna,0,BETWEEN_2DYNA_WAIT_TIME,32,VIAL_OF_SHROUDED_SAND,4236,4237);
         else
             dayRemaining = math.floor(((dynaWaitxDay + (BETWEEN_2DYNA_WAIT_TIME * 24 * 60 * 60)) - realDay)/3456);
@@ -66,15 +66,14 @@ end;
 function onEventFinish(player,csid,option)
     -- printf("CSID: %u",csid);
     -- printf("finishRESULT: %u",option);
-    
+
     if (csid == 0x0020) then
         player:setVar("DynaXarcabard_Win",0);
     elseif (csid == 0x0010 and option == 0) then
         if (checkFirstDyna(player,6)) then
-            player:setVar("Dynamis_Status",player:getVar("Dynamis_Status") + 64);
+            player:setVar("Dynamis_Status",bit.bor(player:getVar("Dynamis_Status"),64));
         end
-        
+        player:setVar("enteringDynamis",1);
         player:setPos(569.312,-0.098,-270.158,90,0x87);
     end
-    
 end;

--- a/src/map/battlefield.cpp
+++ b/src/map/battlefield.cpp
@@ -191,7 +191,7 @@ void CBattlefield::capPlayerToBCNM() { //adjust player's level to the appropriat
     }
     uint8 cap = getLevelCap();
     if (cap != 0)
-    {	// Other missions lines and things like dragoon quest battle can be done similarly to CoP_Battle_cap.
+    {   // Other missions lines and things like dragoon quest battle can be done similarly to CoP_Battle_cap.
         // Might be better to add a type flag to the sql to tell bcnm/isnm/which expantions mission than doing by bcnmID like this.
         if ((map_config.CoP_Battle_cap == 0) && (m_BcnmID == 768 || m_BcnmID == 800 || m_BcnmID == 832 || m_BcnmID == 960
             || m_BcnmID == 704 || m_BcnmID == 961 || m_BcnmID == 864 || m_BcnmID == 672 || m_BcnmID == 736 || m_BcnmID == 992 || m_BcnmID == 640))
@@ -527,9 +527,9 @@ void CBattlefield::cleanupDynamis() {
 
     //get all mob of this dyna zone
     const int8* fmtQuery = "SELECT msp.mobid \
-							FROM mob_spawn_points msp \
-							LEFT JOIN mob_groups mg ON mg.groupid = msp.groupid \
-							WHERE zoneid = %u";
+                            FROM mob_spawn_points msp \
+                            LEFT JOIN mob_groups mg ON mg.groupid = msp.groupid \
+                            WHERE zoneid = %u";
 
     int32 ret = Sql_Query(SqlHandle, fmtQuery, this->getZoneId());
 
@@ -542,8 +542,10 @@ void CBattlefield::cleanupDynamis() {
             uint32 mobid = Sql_GetUIntData(SqlHandle, 0);
             CMobEntity* PMob = (CMobEntity*)zoneutils::GetEntity(mobid, TYPE_MOB);
 
-            if (PMob != nullptr)
-                PMob->PAI->Despawn();
+            if (PMob != nullptr) {
+                PMob->FadeOut();
+                PMob->PAI->Internal_Respawn(0s);
+            }
         }
     }
 

--- a/src/map/utils/battlefieldutils.cpp
+++ b/src/map/utils/battlefieldutils.cpp
@@ -44,8 +44,8 @@ namespace battlefieldutils {
     ****************************************************************/
     CBattlefield* loadBattlefield(CBattlefieldHandler* hand, uint16 bcnmid, BATTLEFIELDTYPE type) {
         const int8* fmtQuery = "SELECT name, bcnmId, fastestName, fastestTime, timeLimit, levelCap, lootDropId, rules, partySize, zoneId \
-						    FROM bcnm_info \
-							WHERE bcnmId = %u";
+                            FROM bcnm_info \
+                            WHERE bcnmId = %u";
 
         int32 ret = Sql_Query(SqlHandle, fmtQuery, bcnmid);
 
@@ -83,8 +83,8 @@ namespace battlefieldutils {
 
         //get ids from DB
         const int8* fmtQuery = "SELECT monsterId, conditions \
-						    FROM bcnm_battlefield \
-							WHERE bcnmId = %u AND battlefieldNumber = %u";
+                            FROM bcnm_battlefield \
+                            WHERE bcnmId = %u AND battlefieldNumber = %u";
 
         int32 ret = Sql_Query(SqlHandle, fmtQuery, battlefield->getID(), battlefield->getBattlefieldNumber());
 
@@ -151,8 +151,8 @@ namespace battlefieldutils {
 
         //get ids from DB
         const int8* fmtQuery = "SELECT npcId \
-						    FROM bcnm_treasure_chests \
-							WHERE bcnmId = %u AND battlefieldNumber = %u";
+                            FROM bcnm_treasure_chests \
+                            WHERE bcnmId = %u AND battlefieldNumber = %u";
 
         int32 ret = Sql_Query(SqlHandle, fmtQuery, battlefield->getID(), battlefield->getBattlefieldNumber());
 
@@ -217,9 +217,9 @@ namespace battlefieldutils {
         //check for all dead for 3min (or whatever the rule mask says)
         if (battlefield->getDeadTime() != time_point::min()) {
             if (battlefield->m_RuleMask & RULES_REMOVE_3MIN) {
-                //	if(((tick - battlefield->getDeadTime())/1000) % 20 == 0){
-                //		battlefield->pushMessageToAllInBcnm(200,180 - (tick - battlefield->getDeadTime())/1000);
-                //	}
+                //  if(((tick - battlefield->getDeadTime())/1000) % 20 == 0){
+                //      battlefield->pushMessageToAllInBcnm(200,180 - (tick - battlefield->getDeadTime())/1000);
+                //  }
                 if (tick - battlefield->getDeadTime() > 3min) {
                     ShowDebug("All players from the battlefield %i inst:%i have fallen for 3mins. Removing.\n",
                         battlefield->getID(), battlefield->getBattlefieldNumber());
@@ -287,9 +287,9 @@ namespace battlefieldutils {
 
     uint8 getMaxLootGroups(CBattlefield* battlefield) {
         const int8* fmtQuery = "SELECT MAX(lootGroupId) \
-						FROM bcnm_loot \
-						JOIN bcnm_info ON bcnm_info.LootDropId = bcnm_loot.LootDropId \
-						WHERE bcnm_info.LootDropId = %u LIMIT 1";
+                        FROM bcnm_loot \
+                        JOIN bcnm_info ON bcnm_info.LootDropId = bcnm_loot.LootDropId \
+                        WHERE bcnm_info.LootDropId = %u LIMIT 1";
 
         int32 ret = Sql_Query(SqlHandle, fmtQuery, battlefield->getLootId());
         if (ret == SQL_ERROR || Sql_NumRows(SqlHandle) == 0 || Sql_NextRow(SqlHandle) != SQL_SUCCESS) {
@@ -303,11 +303,11 @@ namespace battlefieldutils {
 
     uint16 getRollsPerGroup(CBattlefield* battlefield, uint8 groupID) {
         const int8* fmtQuery = "SELECT SUM(CASE \
-			WHEN LootDropID = %u \
-			AND lootGroupId = %u \
-			THEN rolls  \
-			ELSE 0 END) \
-			FROM bcnm_loot;";
+            WHEN LootDropID = %u \
+            AND lootGroupId = %u \
+            THEN rolls  \
+            ELSE 0 END) \
+            FROM bcnm_loot;";
 
         int32 ret = Sql_Query(SqlHandle, fmtQuery, battlefield->getLootId(), groupID);
         if (ret == SQL_ERROR || Sql_NumRows(SqlHandle) == 0 || Sql_NextRow(SqlHandle) != SQL_SUCCESS) {
@@ -378,8 +378,8 @@ namespace battlefieldutils {
 
         //get ids from DB
         const int8* fmtQuery = "SELECT monsterId \
-								FROM bcnm_battlefield \
-								WHERE bcnmId = %u AND battlefieldNumber = 2";
+                                FROM bcnm_battlefield \
+                                WHERE bcnmId = %u AND battlefieldNumber = 2";
 
         int32 ret = Sql_Query(SqlHandle, fmtQuery, battlefield->getID());
 


### PR DESCRIPTION
Dynamis fully despawn mobs when all players leave.
Dynamis uniqueIDs are now set to os.time().
Dynamis_Status is now set using bitwise OR to account for old code that set it to incorrect values.
Added/fixed first visit cutscenes for all Dynamis.
Players disconnecting from existing runs will be re-added upon login.
Players soloing or low-manning can no longer force d/c to reset all mobs in Dynamis zones.
GMs who ```@zone``` to Dynamis will now be placed at the entrance.
GMs entering Dynamis zones will always be added to current run, or register new run.

Fixes #3596, #3513, and #1813.

edit: haven't yet found a way to fully reset the mobs other than internal_respawn, so I'm setting the PR back to that for the time being.