### PR TITLE
GoV reward for higher-than-cap regimes adjusts down

### DIFF
--- a/scripts/globals/groundsofvalor.lua
+++ b/scripts/globals/groundsofvalor.lua
@@ -495,6 +495,15 @@ function checkGoVregime(player,mob,rid,index)
                         -- Complete regime
                         player:messageBasic(GOV_MSG_COMPLETED_REGIME);
                         local reward = getGoVregimeReward(rid);
+
+                        -- adjust reward down if regime is higher than mob level cap
+                        -- example: if you have mobs capped at level 80, and the regime is level 100, you will only get 80% of the reward
+                        if NORMAL_MOB_MAX_LEVEL_RANGE_MAX > 0 and fov_info[6] > NORMAL_MOB_MAX_LEVEL_RANGE_MAX then
+                            local avgCapLevel = (NORMAL_MOB_MAX_LEVEL_RANGE_MIN + NORMAL_MOB_MAX_LEVEL_RANGE_MAX)/2;
+                            local avgMobLevel = (fov_info[5] + fov_info[6])/2;
+                            reward = math.floor(reward * avgCapLevel/avgMobLevel);
+                        end
+
                         local RewardCAP = reward * 2;
                         local GoV_clears = 0;
                         local tabs = (math.floor(reward/10)*TABS_RATE);


### PR DESCRIPTION
Example: Player completes regime that's supposed to have level 105-110 mobs.  But your server's settings.lua caps the mobs at 85-90.  Now, regime reward will be multiplied by average cap level over average regime level, or  (87.5/107.5).