### PR TITLE
Fe'e attack speed tied to its health.

### DIFF
--- a/scripts/zones/Waughroon_Shrine/mobs/Fe_e.lua
+++ b/scripts/zones/Waughroon_Shrine/mobs/Fe_e.lua
@@ -3,12 +3,37 @@
 --  MOB: fe_e
 -----------------------------------
 
-
 -----------------------------------
 -- onMobSpawn Action
 -----------------------------------
 
 function onMobSpawn(mob)
+end;
+
+-----------------------------------
+-- onMobFight Action
+-----------------------------------
+
+function onMobFight(mob,target)
+
+    local hpp = mob:getHPP();
+
+    if hpp < 14 then
+        mob:setDelay(2700);
+    elseif hpp < 28 then
+        mob:setDelay(2350);
+    elseif hpp < 42 then
+        mob:setDelay(2000);
+    elseif hpp < 56 then
+        mob:setDelay(1650);
+    elseif hpp < 70 then
+        mob:setDelay(1300);
+    elseif hpp < 84 then
+        mob:setDelay(950);
+    else
+        mob:setDelay(600);
+    end
+
 end;
 
 -----------------------------------


### PR DESCRIPTION
Fe'e (Up in Arms kraken NM) is supposed to attack really fast at the start of the fight, and slow down as it takes damage.  I eyeballed these delay values from watching YouTube vids of the fight.