### PR TITLE
LB2 and Windy 7-1 fixes

### DIFF
--- a/scripts/zones/Toraimarai_Canal/npcs/_4pc.lua
+++ b/scripts/zones/Toraimarai_Canal/npcs/_4pc.lua
@@ -2,16 +2,12 @@
 -- Area: Toraimarai Canal
 -- NPC:  Marble Door
 -- Involved In Windurst Mission 7-1
--- @pos 132 12 -19 169 169
------------------------------------
-package.loaded["scripts/zones/Toraimarai_Canal/TextIDs"] = nil;
-require("scripts/zones/Toraimarai_Canal/TextIDs");
+-- @pos 132 12 -19 169
 -----------------------------------
 
-require("scripts/globals/settings");
 require("scripts/globals/keyitems");
-require("scripts/globals/quests");
 require("scripts/globals/missions");
+require("scripts/globals/settings");
 
 -----------------------------------
 -- onTrade Action
@@ -25,22 +21,17 @@ end;
 -----------------------------------
 
 function onTrigger(player,npc)
-local CurrentMission = player:getCurrentMission(WINDURST);
--- NOTE: MobAction is 25(ACTION_SPAWN) when they're dead/despawned and 16(ACTION_ROAMING) when spawned.
---         Not really sure why but this seems to work.
---         print("HingeOil 1 Action: "..GetMobAction(17469666));
-if (CurrentMission == THE_SIXTH_MINISTRY or player:hasCompletedMission(WINDURST,THE_SIXTH_MINISTRY)) then
-    if ((GetMobAction(17469666) == 25) and
-       (GetMobAction(17469667) == 25) and
-       (GetMobAction(17469668) == 25) and
-       (GetMobAction(17469669) == 25)) then
-        player:startEvent(0x0046,0,0,0,2);
+    if player:getCurrentMission(WINDURST) == THE_SIXTH_MINISTRY or player:hasCompletedMission(WINDURST,THE_SIXTH_MINISTRY) then
+        if (GetMobByID(17469666):isDead() and GetMobByID(17469667):isDead() and GetMobByID(17469668):isDead() and GetMobByID(17469669):isDead()) then
+            -- all four hinge oils are dead
+            player:startEvent(0x0046,0,0,0,2);
+        else
+            -- at least one hinge oil is alive
+            player:startEvent(0x0046,0,0,0,1); 
+        end
     else
-        player:startEvent(0x0046,0,0,0,1); 
+        player:startEvent(0x0046);
     end
-else
-    player:startEvent(0x0046);
-end
 end;
 
 -----------------------------------

--- a/scripts/zones/Xarcabard/mobs/Boreal_Coeurl.lua
+++ b/scripts/zones/Xarcabard/mobs/Boreal_Coeurl.lua
@@ -7,6 +7,8 @@
 
 require("scripts/globals/keyitems");
 require("scripts/globals/quests");
+require("scripts/globals/settings");
+require("scripts/zones/Xarcabard/TextIDs");
 
 -----------------------------------
 -- onMobSpawn
@@ -14,9 +16,8 @@ require("scripts/globals/quests");
 
 function onMobSpawn(mob)
     -- Failsafe to make sure NPC is down when NM is up
-    local npc = GetNPCByID(17236309);
-    if (OldSchoolG2 == true) then
-        npc:showNPC(1);
+    if (OldSchoolG2) then
+        GetNPCByID(17236309):showNPC(0);
     end
 end;
 
@@ -25,11 +26,12 @@ end;
 -----------------------------------
 
 function onMobDeath(mob, player, isKiller)
-
-    local npc = GetNPCByID(17236309);
-    if (player:getQuestStatus(JEUNO,ATOP_THE_HIGHEST_MOUNTAINS) == QUEST_ACCEPTED and player:hasKeyItem(SQUARE_FRIGICITE) == false) then
-        player:messageSpecial(BLOCKS_OF_ICE);
+    if (OldSchoolG2) then
+        -- show ??? for desired duration
+        -- notify people on the quest who need the KI
+        GetNPCByID(17236309):showNPC(FrigiciteDuration);
+        if (player:getQuestStatus(JEUNO,ATOP_THE_HIGHEST_MOUNTAINS) == QUEST_ACCEPTED and player:hasKeyItem(SQUARE_FRIGICITE) == false) then
+            player:messageSpecial(BLOCKS_OF_ICE);
+        end
     end
-    npc:showNPC(FrigiciteDuration);
-
 end;

--- a/scripts/zones/Xarcabard/mobs/Boreal_Hound.lua
+++ b/scripts/zones/Xarcabard/mobs/Boreal_Hound.lua
@@ -7,6 +7,8 @@
 
 require("scripts/globals/keyitems");
 require("scripts/globals/quests");
+require("scripts/globals/settings");
+require("scripts/zones/Xarcabard/TextIDs");
 
 -----------------------------------
 -- onMobSpawn
@@ -14,9 +16,8 @@ require("scripts/globals/quests");
 
 function onMobSpawn(mob)
     -- Failsafe to make sure NPC is down when NM is up
-    local npc = GetNPCByID(17236310);
-    if (OldSchoolG2 == true) then
-        npc:showNPC(1);
+    if (OldSchoolG2) then
+        GetNPCByID(17236310):showNPC(0);
     end
 end;
 
@@ -25,11 +26,12 @@ end;
 -----------------------------------
 
 function onMobDeath(mob, player, isKiller)
-
-    local npc = GetNPCByID(17236310);
-    if (player:getQuestStatus(JEUNO,ATOP_THE_HIGHEST_MOUNTAINS) == QUEST_ACCEPTED and player:hasKeyItem(TRIANGULAR_FRIGICITE) == false) then
-        player:messageSpecial(BLOCKS_OF_ICE);
+    if (OldSchoolG2) then
+        -- show ??? for desired duration
+        -- notify people on the quest who need the KI
+        GetNPCByID(17236310):showNPC(FrigiciteDuration);
+        if (player:getQuestStatus(JEUNO,ATOP_THE_HIGHEST_MOUNTAINS) == QUEST_ACCEPTED and player:hasKeyItem(TRIANGULAR_FRIGICITE) == false) then
+            player:messageSpecial(BLOCKS_OF_ICE);
+        end
     end
-    npc:showNPC(FrigiciteDuration);
-
 end;

--- a/scripts/zones/Xarcabard/mobs/Boreal_Tiger.lua
+++ b/scripts/zones/Xarcabard/mobs/Boreal_Tiger.lua
@@ -7,6 +7,8 @@
 
 require("scripts/globals/keyitems");
 require("scripts/globals/quests");
+require("scripts/globals/settings");
+require("scripts/zones/Xarcabard/TextIDs");
 
 -----------------------------------
 -- onMobSpawn
@@ -14,9 +16,8 @@ require("scripts/globals/quests");
 
 function onMobSpawn(mob)
     -- Failsafe to make sure NPC is down when NM is up
-    local npc = GetNPCByID(17236308);
-    if (OldSchoolG2 == true) then
-        npc:showNPC(1);
+    if (OldSchoolG2) then
+        GetNPCByID(17236308):showNPC(0);
     end
 end;
 
@@ -25,11 +26,12 @@ end;
 -----------------------------------
 
 function onMobDeath(mob, player, isKiller)
-
-    local npc = GetNPCByID(17236308);
-    if (player:getQuestStatus(JEUNO,ATOP_THE_HIGHEST_MOUNTAINS) == QUEST_ACCEPTED and player:hasKeyItem(ROUND_FRIGICITE) == false) then
-        player:messageSpecial(BLOCKS_OF_ICE);
+    if (OldSchoolG2) then
+        -- show ??? for desired duration
+        -- notify people on the quest who need the KI
+        GetNPCByID(17236308):showNPC(FrigiciteDuration);
+        if (player:getQuestStatus(JEUNO,ATOP_THE_HIGHEST_MOUNTAINS) == QUEST_ACCEPTED and player:hasKeyItem(ROUND_FRIGICITE) == false) then
+            player:messageSpecial(BLOCKS_OF_ICE);
+        end
     end
-    npc:showNPC(FrigiciteDuration);
-
 end;

--- a/scripts/zones/Xarcabard/npcs/qm2.lua
+++ b/scripts/zones/Xarcabard/npcs/qm2.lua
@@ -7,9 +7,10 @@
 package.loaded["scripts/zones/Xarcabard/TextIDs"] = nil;
 -----------------------------------
 
-require("scripts/globals/settings");
 require("scripts/globals/keyitems");
 require("scripts/globals/quests");
+require("scripts/globals/settings");
+require("scripts/globals/status");
 require("scripts/zones/Xarcabard/TextIDs");
 
 -----------------------------------
@@ -24,8 +25,7 @@ end;
 -----------------------------------
 
 function onTrigger(player,npc)
-    local BorealTiger = GetMobAction(17236204);
-    if ((OldSchoolG2 == false) or (BorealTiger == ACTION_NONE or BorealTiger == ACTION_SPAWN)) then
+    if (OldSchoolG2 == false or GetMobByID(17236204):isDead()) then
         if (player:getQuestStatus(JEUNO,ATOP_THE_HIGHEST_MOUNTAINS) == QUEST_ACCEPTED and player:hasKeyItem(ROUND_FRIGICITE) == false) then
             player:addKeyItem(ROUND_FRIGICITE);
             player:messageSpecial(KEYITEM_OBTAINED, ROUND_FRIGICITE);

--- a/scripts/zones/Xarcabard/npcs/qm3.lua
+++ b/scripts/zones/Xarcabard/npcs/qm3.lua
@@ -7,9 +7,10 @@
 package.loaded["scripts/zones/Xarcabard/TextIDs"] = nil;
 -----------------------------------
 
-require("scripts/globals/settings");
 require("scripts/globals/keyitems");
 require("scripts/globals/quests");
+require("scripts/globals/settings");
+require("scripts/globals/status");
 require("scripts/zones/Xarcabard/TextIDs");
 
 -----------------------------------
@@ -24,8 +25,7 @@ end;
 -----------------------------------
 
 function onTrigger(player,npc)
-    local BorealCoeurl = GetMobAction(17236203);
-    if ((OldSchoolG2 == false) or (BorealCoeurl == ACTION_NONE or BorealCoeurl == ACTION_SPAWN)) then
+    if (OldSchoolG2 == false or GetMobByID(17236203):isDead()) then
         if (player:getQuestStatus(JEUNO,ATOP_THE_HIGHEST_MOUNTAINS) == QUEST_ACCEPTED and player:hasKeyItem(SQUARE_FRIGICITE) == false) then
             player:addKeyItem(SQUARE_FRIGICITE);
             player:messageSpecial(KEYITEM_OBTAINED, SQUARE_FRIGICITE);

--- a/scripts/zones/Xarcabard/npcs/qm4.lua
+++ b/scripts/zones/Xarcabard/npcs/qm4.lua
@@ -1,15 +1,16 @@
 -----------------------------------
 -- Area: Xarcabard
 -- NPC:  qm4 (???)
--- Involved in Quests: Atop the Highest Mountains
+-- Involved in Quests: Atop the Highest Mountains (for Boreal Hound)
 -- @pos -21 -25 -490 112
 -----------------------------------
 package.loaded["scripts/zones/Xarcabard/TextIDs"] = nil;
 -----------------------------------
 
-require("scripts/globals/settings");
 require("scripts/globals/keyitems");
 require("scripts/globals/quests");
+require("scripts/globals/settings");
+require("scripts/globals/status");
 require("scripts/zones/Xarcabard/TextIDs");
 
 -----------------------------------
@@ -24,8 +25,7 @@ end;
 -----------------------------------
 
 function onTrigger(player,npc)
-    local BorealHound = GetMobAction(17236202);
-    if ((OldSchoolG2 == false) or (BorealHound == ACTION_NONE or BorealHound == ACTION_SPAWN)) then
+    if (OldSchoolG2 == false or GetMobByID(17236202):isDead()) then
         if (player:getQuestStatus(JEUNO,ATOP_THE_HIGHEST_MOUNTAINS) == QUEST_ACCEPTED and player:hasKeyItem(TRIANGULAR_FRIGICITE) == false) then
             player:addKeyItem(TRIANGULAR_FRIGICITE);
             player:messageSpecial(KEYITEM_OBTAINED, TRIANGULAR_FRIGICITE);


### PR DESCRIPTION
Oldschool G2 ???s are now clickable immediately after mob dies, rather than having to wait for fade-out
Marble Door for Windurst 7-1 now opens when all four hinge oils are dead or dying