### PR TITLE
Version update 2017/02/10 (client: 30170204_1)

### DIFF
--- a/scripts/zones/Abdhaljs_Isle-Purgonorgo/TextIDs.lua
+++ b/scripts/zones/Abdhaljs_Isle-Purgonorgo/TextIDs.lua
@@ -2,7 +2,7 @@
 
 -- General Texts
 ITEM_CANNOT_BE_OBTAINED = 6379; -- You cannot obtain the item <item> come back again after sorting your inventory
-          ITEM_OBTAINED = 6384; -- Obtained: <item>
-           GIL_OBTAINED = 6385; -- Obtained <number> gil
-       KEYITEM_OBTAINED = 6387; -- Obtained key item: <keyitem>
- FISHING_MESSAGE_OFFSET = 7045; -- You can't fish here
+          ITEM_OBTAINED = 6385; -- Obtained: <item>
+           GIL_OBTAINED = 6386; -- Obtained <number> gil
+       KEYITEM_OBTAINED = 6388; -- Obtained key item: <keyitem>
+ FISHING_MESSAGE_OFFSET = 7046; -- You can't fish here

--- a/scripts/zones/Abyssea-Altepa/TextIDs.lua
+++ b/scripts/zones/Abyssea-Altepa/TextIDs.lua
@@ -2,9 +2,9 @@
 
 -- General Texts
 ITEM_CANNOT_BE_OBTAINED = 6379; -- You cannot obtain the item <item> come back again after sorting your inventory
-          ITEM_OBTAINED = 6384; -- Obtained: <item>
-           GIL_OBTAINED = 6385; -- Obtained <number> gil
-       KEYITEM_OBTAINED = 6387; -- Obtained key item: <keyitem>
-         CRUOR_OBTAINED = 7491; -- <Possible Special Code: 1F>y<Player Name> obtained <Numeric Parameter 0> cruor.
-            CRUOR_TOTAL = 6982; -- Obtained <Numeric Parameter 0> cruor. (Total: <Numeric Parameter 1>)<Prompt>
+          ITEM_OBTAINED = 6385; -- Obtained: <item>
+           GIL_OBTAINED = 6386; -- Obtained <number> gil
+       KEYITEM_OBTAINED = 6388; -- Obtained key item: <keyitem>
+         CRUOR_OBTAINED = 7492; -- <Possible Special Code: 1F>y<Player Name> obtained <Numeric Parameter 0> cruor.
+            CRUOR_TOTAL = 6983; -- Obtained <Numeric Parameter 0> cruor. (Total: <Numeric Parameter 1>)<Prompt>
 

--- a/scripts/zones/Abyssea-Attohwa/TextIDs.lua
+++ b/scripts/zones/Abyssea-Attohwa/TextIDs.lua
@@ -2,8 +2,8 @@
 
 -- General Texts
 ITEM_CANNOT_BE_OBTAINED = 6383; -- You cannot obtain the #. Try trading again after sorting your inventory.
-          ITEM_OBTAINED = 6384; -- Obtained: <item>
-           GIL_OBTAINED = 6385; -- Obtained <number> gil
-       KEYITEM_OBTAINED = 6387; -- Obtained key item: <keyitem>
-         CRUOR_OBTAINED = 7391; -- <Possible Special Code: 1F>y<Player Name> obtains <Numeric Parameter 0> cruor.
-            CRUOR_TOTAL = 6982; -- Obtained <Numeric Parameter 0> cruor. (Total: <Numeric Parameter 1>)<Prompt>
+          ITEM_OBTAINED = 6385; -- Obtained: <item>
+           GIL_OBTAINED = 6386; -- Obtained <number> gil
+       KEYITEM_OBTAINED = 6388; -- Obtained key item: <keyitem>
+         CRUOR_OBTAINED = 7392; -- <Possible Special Code: 1F>y<Player Name> obtains <Numeric Parameter 0> cruor.
+            CRUOR_TOTAL = 6983; -- Obtained <Numeric Parameter 0> cruor. (Total: <Numeric Parameter 1>)<Prompt>

--- a/scripts/zones/Abyssea-Empyreal_Paradox/TextIDs.lua
+++ b/scripts/zones/Abyssea-Empyreal_Paradox/TextIDs.lua
@@ -2,8 +2,8 @@
 
 -- General Texts
 ITEM_CANNOT_BE_OBTAINED = 6379; -- You cannot obtain the item <item> come back again after sorting your inventory
-          ITEM_OBTAINED = 6384; -- Obtained: <item>
-           GIL_OBTAINED = 6385; -- Obtained <number> gil
-       KEYITEM_OBTAINED = 6387; -- Obtained key item: <keyitem>
-         CRUOR_OBTAINED = 7391; -- <Possible Special Code: 1F>y<Player Name> obtains <Numeric Parameter 0> cruor.
-            CRUOR_TOTAL = 6982; -- Obtained <Numeric Parameter 0> cruor. (Total: <Numeric Parameter 1>)<Prompt>
+          ITEM_OBTAINED = 6385; -- Obtained: <item>
+           GIL_OBTAINED = 6386; -- Obtained <number> gil
+       KEYITEM_OBTAINED = 6388; -- Obtained key item: <keyitem>
+         CRUOR_OBTAINED = 7392; -- <Possible Special Code: 1F>y<Player Name> obtains <Numeric Parameter 0> cruor.
+            CRUOR_TOTAL = 6983; -- Obtained <Numeric Parameter 0> cruor. (Total: <Numeric Parameter 1>)<Prompt>

--- a/scripts/zones/Abyssea-Grauberg/TextIDs.lua
+++ b/scripts/zones/Abyssea-Grauberg/TextIDs.lua
@@ -2,8 +2,8 @@
 
 -- General Texts
 ITEM_CANNOT_BE_OBTAINED = 6379; -- You cannot obtain the item <item> come back again after sorting your inventory
-          ITEM_OBTAINED = 6384; -- Obtained: <item>
-           GIL_OBTAINED = 6385; -- Obtained <number> gil
-       KEYITEM_OBTAINED = 6387; -- Obtained key item: <keyitem>
-         CRUOR_OBTAINED = 7491; -- <Possible Special Code: 1F>y<Player Name> obtains <Numeric Parameter 0> cruor.
-            CRUOR_TOTAL = 6982; -- Obtained <Numeric Parameter 0> cruor. (Total: <Numeric Parameter 1>)<Prompt>
+          ITEM_OBTAINED = 6385; -- Obtained: <item>
+           GIL_OBTAINED = 6386; -- Obtained <number> gil
+       KEYITEM_OBTAINED = 6388; -- Obtained key item: <keyitem>
+         CRUOR_OBTAINED = 7492; -- <Possible Special Code: 1F>y<Player Name> obtains <Numeric Parameter 0> cruor.
+            CRUOR_TOTAL = 6983; -- Obtained <Numeric Parameter 0> cruor. (Total: <Numeric Parameter 1>)<Prompt>

--- a/scripts/zones/Abyssea-Konschtat/TextIDs.lua
+++ b/scripts/zones/Abyssea-Konschtat/TextIDs.lua
@@ -2,37 +2,37 @@
 
 -- General Texts
 ITEM_CANNOT_BE_OBTAINED = 6379; -- You cannot obtain the item <item> come back again after sorting your inventory
-          ITEM_OBTAINED = 6384; -- Obtained: <item>
-           GIL_OBTAINED = 6385; -- Obtained <number> gil
-       KEYITEM_OBTAINED = 6387; -- Obtained key item: <keyitem>
-         CRUOR_OBTAINED = 7491; -- <Possible Special Code: 1F>y<Player Name> obtains <Numeric Parameter 0> cruor.
-            CRUOR_TOTAL = 6982; -- Obtained <Numeric Parameter 0> cruor. (Total: <Numeric Parameter 1>)<Prompt>
+          ITEM_OBTAINED = 6385; -- Obtained: <item>
+           GIL_OBTAINED = 6386; -- Obtained <number> gil
+       KEYITEM_OBTAINED = 6388; -- Obtained key item: <keyitem>
+         CRUOR_OBTAINED = 7492; -- <Possible Special Code: 1F>y<Player Name> obtains <Numeric Parameter 0> cruor.
+            CRUOR_TOTAL = 6983; -- Obtained <Numeric Parameter 0> cruor. (Total: <Numeric Parameter 1>)<Prompt>
 
 -- Abyssea Weakness Targeting
-               STAGGERED = 7312; -- ?Player/Chocobo Parameter 0?'s attack staggers the fiend!
-          YELLOW_STAGGER = 7313; -- The fiend is unable to cast magic.
-            BLUE_STAGGER = 7314; -- The fiend is unable to use special attacks.
-             RED_STAGGER = 7315; -- The fiend is frozen in its tracks.
-         YELLOW_WEAKNESS = 7316; -- The fiend appears vulnerable to Multiple Choice (Parameter 0)[/fire/ice/wind/earth/lightning/water/light/darkness] elemental magic
-           BLUE_WEAKNESS = 7317; -- The fiend appears vulnerable to Multiple Choice (Parameter 0)[/hand-to-hand/dagger/sword/great sword/axe/great axe/scythe/polearm/katana/great katana/club/staff/archery/marksmanship] weapon skills
-            RED_WEAKNESS = 7318; -- The fiend appears vulnerable to Multiple Choice (Parameter 0)[/fire/ice/wind/earth/lightning/water/light/darkness] elemental weapon skills
+               STAGGERED = 7313; -- ?Player/Chocobo Parameter 0?'s attack staggers the fiend!
+          YELLOW_STAGGER = 7314; -- The fiend is unable to cast magic.
+            BLUE_STAGGER = 7315; -- The fiend is unable to use special attacks.
+             RED_STAGGER = 7316; -- The fiend is frozen in its tracks.
+         YELLOW_WEAKNESS = 7317; -- The fiend appears vulnerable to Multiple Choice (Parameter 0)[/fire/ice/wind/earth/lightning/water/light/darkness] elemental magic
+           BLUE_WEAKNESS = 7318; -- The fiend appears vulnerable to Multiple Choice (Parameter 0)[/hand-to-hand/dagger/sword/great sword/axe/great axe/scythe/polearm/katana/great katana/club/staff/archery/marksmanship] weapon skills
+            RED_WEAKNESS = 7319; -- The fiend appears vulnerable to Multiple Choice (Parameter 0)[/fire/ice/wind/earth/lightning/water/light/darkness] elemental weapon skills
 
 -- Visitant Related Messages
-    EXACT_TIME_REMAINING = 7319; -- Your visitant status will wear off inMultiple Choice (Parameter 1)[second/minute]
-          TIME_REMAINING = 7320; -- Your visitant status will wear off inMultiple Choice (Parameter 1)[seconds/minutes]
-    LOST_VISITANT_STATUS = 7321; -- Your visitant status has worn off
-       VISITANT_EXTENDED = 7322; -- Your visitant status has been extended bySingular/Plural Choice (Parameter 0)[minute/minutes]
-          EXIT_WARNING_1 = 7323; -- Exiting inSingular/Plural Choice (Parameter 0)[minute/minutes]
-          EXIT_WARNING_2 = 7324; -- Those without visitant status will be ejected from the area inSingular/Plural Choice (Parameter 0)[minute/minutes]. To learn about this status, please consult a Conflux Surveyor
-          EXIT_WARNING_3 = 7325; -- Exiting inMultiple Choice (Parameter 1)[second/minute]
-          EXIT_WARNING_4 = 7326; -- Exiting inMultiple Choice (Parameter 1)[seconds/minutes]
-             EXITING_NOW = 7327; -- Exiting now.
-          WARD_WARNING_1 = 7328; -- Returning to the Searing Ward inSingular/Plural Choice (Parameter 0)[second/seconds]
-          WARD_WARNING_2 = 7329; -- You do not have visitant status. Returning to the Searing Ward inSingular/Plural Choice (Parameter 0)[second/seconds]
-          WARD_WARNING_3 = 7328; -- Returning to the Searing Ward inSingular/Plural Choice (Parameter 0)[second/seconds]
-       SEARING_WARD_TELE = 7331; -- Returning to the Searing Ward now.
+    EXACT_TIME_REMAINING = 7320; -- Your visitant status will wear off inMultiple Choice (Parameter 1)[second/minute]
+          TIME_REMAINING = 7321; -- Your visitant status will wear off inMultiple Choice (Parameter 1)[seconds/minutes]
+    LOST_VISITANT_STATUS = 7322; -- Your visitant status has worn off
+       VISITANT_EXTENDED = 7323; -- Your visitant status has been extended bySingular/Plural Choice (Parameter 0)[minute/minutes]
+          EXIT_WARNING_1 = 7324; -- Exiting inSingular/Plural Choice (Parameter 0)[minute/minutes]
+          EXIT_WARNING_2 = 7325; -- Those without visitant status will be ejected from the area inSingular/Plural Choice (Parameter 0)[minute/minutes]. To learn about this status, please consult a Conflux Surveyor
+          EXIT_WARNING_3 = 7326; -- Exiting inMultiple Choice (Parameter 1)[second/minute]
+          EXIT_WARNING_4 = 7327; -- Exiting inMultiple Choice (Parameter 1)[seconds/minutes]
+             EXITING_NOW = 7328; -- Exiting now.
+          WARD_WARNING_1 = 7329; -- Returning to the Searing Ward inSingular/Plural Choice (Parameter 0)[second/seconds]
+          WARD_WARNING_2 = 7330; -- You do not have visitant status. Returning to the Searing Ward inSingular/Plural Choice (Parameter 0)[second/seconds]
+          WARD_WARNING_3 = 7329; -- Returning to the Searing Ward inSingular/Plural Choice (Parameter 0)[second/seconds]
+       SEARING_WARD_TELE = 7332; -- Returning to the Searing Ward now.
 
 -- Abyssea ??? Targets
-          BOUNDLESS_RAGE = 7568; -- You sense an aura of boundless rage...
-                 INFO_KI = 7569; -- Your keen senses tell you that something may happen if only you had Multiple Choice (Parameter 0)[this item/these items]
-                  USE_KI = 7572; -- Use the Multiple Choice (Parameter 0)[key item/key items]
+          BOUNDLESS_RAGE = 7569; -- You sense an aura of boundless rage...
+                 INFO_KI = 7570; -- Your keen senses tell you that something may happen if only you had Multiple Choice (Parameter 0)[this item/these items]
+                  USE_KI = 7573; -- Use the Multiple Choice (Parameter 0)[key item/key items]

--- a/scripts/zones/Abyssea-La_Theine/TextIDs.lua
+++ b/scripts/zones/Abyssea-La_Theine/TextIDs.lua
@@ -2,9 +2,9 @@
 
 -- General Texts
 ITEM_CANNOT_BE_OBTAINED = 6379; -- You cannot obtain the item <item> come back again after sorting your inventory
-          ITEM_OBTAINED = 6384; -- Obtained: <item>
-           GIL_OBTAINED = 6385; -- Obtained <number> gil
-       KEYITEM_OBTAINED = 6387; -- Obtained key item: <keyitem>
- FISHING_MESSAGE_OFFSET = 7045; -- You can't fish here
-         CRUOR_OBTAINED = 7491; -- <Possible Special Code: 1F>y<Player Name> obtains <Numeric Parameter 0> cruor.
-            CRUOR_TOTAL = 6982; -- Obtained <Numeric Parameter 0> cruor. (Total: <Numeric Parameter 1>)<Prompt>
+          ITEM_OBTAINED = 6385; -- Obtained: <item>
+           GIL_OBTAINED = 6386; -- Obtained <number> gil
+       KEYITEM_OBTAINED = 6388; -- Obtained key item: <keyitem>
+ FISHING_MESSAGE_OFFSET = 7046; -- You can't fish here
+         CRUOR_OBTAINED = 7492; -- <Possible Special Code: 1F>y<Player Name> obtains <Numeric Parameter 0> cruor.
+            CRUOR_TOTAL = 6983; -- Obtained <Numeric Parameter 0> cruor. (Total: <Numeric Parameter 1>)<Prompt>

--- a/scripts/zones/Abyssea-Misareaux/TextIDs.lua
+++ b/scripts/zones/Abyssea-Misareaux/TextIDs.lua
@@ -2,9 +2,9 @@
 
 -- General Texts
 ITEM_CANNOT_BE_OBTAINED = 6379; -- You cannot obtain the item <item> come back again after sorting your inventory
-          ITEM_OBTAINED = 6384; -- Obtained: <item>
-           GIL_OBTAINED = 6385; -- Obtained <number> gil
-       KEYITEM_OBTAINED = 6387; -- Obtained key item: <keyitem>
- FISHING_MESSAGE_OFFSET = 7045; -- You can't fish here
-         CRUOR_OBTAINED = 7491; -- <Possible Special Code: 1F>y<Player Name> obtains <Numeric Parameter 0> cruor.
-            CRUOR_TOTAL = 6982; -- Obtained <Numeric Parameter 0> cruor. (Total: <Numeric Parameter 1>)<Prompt>
+          ITEM_OBTAINED = 6385; -- Obtained: <item>
+           GIL_OBTAINED = 6386; -- Obtained <number> gil
+       KEYITEM_OBTAINED = 6388; -- Obtained key item: <keyitem>
+ FISHING_MESSAGE_OFFSET = 7046; -- You can't fish here
+         CRUOR_OBTAINED = 7492; -- <Possible Special Code: 1F>y<Player Name> obtains <Numeric Parameter 0> cruor.
+            CRUOR_TOTAL = 6983; -- Obtained <Numeric Parameter 0> cruor. (Total: <Numeric Parameter 1>)<Prompt>

--- a/scripts/zones/Abyssea-Tahrongi/TextIDs.lua
+++ b/scripts/zones/Abyssea-Tahrongi/TextIDs.lua
@@ -2,8 +2,8 @@
 
 -- General Texts
 ITEM_CANNOT_BE_OBTAINED = 6379; -- You cannot obtain the item <item> come back again after sorting your inventory
-          ITEM_OBTAINED = 6384; -- Obtained: <item>
-           GIL_OBTAINED = 6385; -- Obtained <number> gil
-       KEYITEM_OBTAINED = 6387; -- Obtained key item: <keyitem>
-         CRUOR_OBTAINED = 7491; -- <Possible Special Code: 1F>y<Player Name> obtains <Numeric Parameter 0> cruor.
-            CRUOR_TOTAL = 6982; -- Obtained <Numeric Parameter 0> cruor. (Total: <Numeric Parameter 1>)<Prompt>
+          ITEM_OBTAINED = 6385; -- Obtained: <item>
+           GIL_OBTAINED = 6386; -- Obtained <number> gil
+       KEYITEM_OBTAINED = 6388; -- Obtained key item: <keyitem>
+         CRUOR_OBTAINED = 7492; -- <Possible Special Code: 1F>y<Player Name> obtains <Numeric Parameter 0> cruor.
+            CRUOR_TOTAL = 6983; -- Obtained <Numeric Parameter 0> cruor. (Total: <Numeric Parameter 1>)<Prompt>

--- a/scripts/zones/Abyssea-Uleguerand/TextIDs.lua
+++ b/scripts/zones/Abyssea-Uleguerand/TextIDs.lua
@@ -2,8 +2,8 @@
 
 -- General Texts
 ITEM_CANNOT_BE_OBTAINED = 6379; -- You cannot obtain the item <item> come back again after sorting your inventory
-          ITEM_OBTAINED = 6384; -- Obtained: <item>
-           GIL_OBTAINED = 6385; -- Obtained <number> gil
-       KEYITEM_OBTAINED = 6387; -- Obtained key item: <keyitem>
-         CRUOR_OBTAINED = 7391; -- <Possible Special Code: 1F>y<Player Name> obtains <Numeric Parameter 0> cruor.
-            CRUOR_TOTAL = 6982; -- Obtained <Numeric Parameter 0> cruor. (Total: <Numeric Parameter 1>)<Prompt>
+          ITEM_OBTAINED = 6385; -- Obtained: <item>
+           GIL_OBTAINED = 6386; -- Obtained <number> gil
+       KEYITEM_OBTAINED = 6388; -- Obtained key item: <keyitem>
+         CRUOR_OBTAINED = 7392; -- <Possible Special Code: 1F>y<Player Name> obtains <Numeric Parameter 0> cruor.
+            CRUOR_TOTAL = 6983; -- Obtained <Numeric Parameter 0> cruor. (Total: <Numeric Parameter 1>)<Prompt>

--- a/scripts/zones/Abyssea-Vunkerl/TextIDs.lua
+++ b/scripts/zones/Abyssea-Vunkerl/TextIDs.lua
@@ -2,9 +2,9 @@
 
 -- General Texts
 ITEM_CANNOT_BE_OBTAINED = 6379; -- You cannot obtain the item <item> come back again after sorting your inventory
-          ITEM_OBTAINED = 6384; -- Obtained: <item>
-           GIL_OBTAINED = 6385; -- Obtained <number> gil
-       KEYITEM_OBTAINED = 6387; -- Obtained key item: <keyitem>
- FISHING_MESSAGE_OFFSET = 7045; -- You can't fish here
-         CRUOR_OBTAINED = 7491; -- <Possible Special Code: 1F>y<Player Name> obtains <Numeric Parameter 0> cruor.
-            CRUOR_TOTAL = 6982; -- Obtained <Numeric Parameter 0> cruor. (Total: <Numeric Parameter 1>)<Prompt>
+          ITEM_OBTAINED = 6385; -- Obtained: <item>
+           GIL_OBTAINED = 6386; -- Obtained <number> gil
+       KEYITEM_OBTAINED = 6388; -- Obtained key item: <keyitem>
+ FISHING_MESSAGE_OFFSET = 7046; -- You can't fish here
+         CRUOR_OBTAINED = 7492; -- <Possible Special Code: 1F>y<Player Name> obtains <Numeric Parameter 0> cruor.
+            CRUOR_TOTAL = 6983; -- Obtained <Numeric Parameter 0> cruor. (Total: <Numeric Parameter 1>)<Prompt>

--- a/scripts/zones/Aht_Urhgan_Whitegate/TextIDs.lua
+++ b/scripts/zones/Aht_Urhgan_Whitegate/TextIDs.lua
@@ -3,60 +3,60 @@
 -- General Texts
 ITEM_CANNOT_BE_OBTAINED = 218; -- You cannot obtain the item. Come back after sorting your inventory.?Prompt?
 ITEM_CANNOT_BE_OBTAINEDX = 220; -- You cannot obtain the ?Possible Special Code: 01??Possible Special Code: 05?#?BAD CHAR: 8280??BAD CHAR: 80??BAD CHAR: 80?. Try trading again after sorting your inventory.?Prompt?
-          ITEM_OBTAINED = 221; -- Obtained: <item>
-         ITEM_OBTAINEDX = 230; -- You obtain ?Numeric Parameter 1? ?Possible Special Code: 01??Speaker Name?)??BAD CHAR: 80??BAD CHAR: 80??BAD CHAR: 8280??BAD CHAR: 80??BAD CHAR: 80?!?Prompt?
-           GIL_OBTAINED = 222; -- Obtained <number> gil
-       KEYITEM_OBTAINED = 224; -- Obtained key item: <keyitem>
-    NOT_HAVE_ENOUGH_GIL = 226; -- You do not have enough gil
- FISHING_MESSAGE_OFFSET = 882; -- You can't fish here
-          HOMEPOINT_SET = 1360; -- Home point set!
-          IMAGE_SUPPORT = 1401; -- Your ?Multiple Choice (Parameter 1)?[fishing/woodworking/smithing/goldsmithing/clothcraft/leatherworking/bonecraft/alchemy/cooking] skills went up ?Multiple Choice (Parameter 2)?[a little/ever so slightly/ever so slightly].?Prompt?
+          ITEM_OBTAINED = 222; -- Obtained: <item>
+         ITEM_OBTAINEDX = 231; -- You obtain ?Numeric Parameter 1? ?Possible Special Code: 01??Speaker Name?)??BAD CHAR: 80??BAD CHAR: 80??BAD CHAR: 8280??BAD CHAR: 80??BAD CHAR: 80?!?Prompt?
+           GIL_OBTAINED = 223; -- Obtained <number> gil
+       KEYITEM_OBTAINED = 225; -- Obtained key item: <keyitem>
+    NOT_HAVE_ENOUGH_GIL = 227; -- You do not have enough gil
+ FISHING_MESSAGE_OFFSET = 883; -- You can't fish here
+          HOMEPOINT_SET = 1361; -- Home point set!
+          IMAGE_SUPPORT = 1402; -- Your ?Multiple Choice (Parameter 1)?[fishing/woodworking/smithing/goldsmithing/clothcraft/leatherworking/bonecraft/alchemy/cooking] skills went up ?Multiple Choice (Parameter 2)?[a little/ever so slightly/ever so slightly].?Prompt?
 
 -- Conquest system
-SANCTION = 9795; -- You have received the Empire's Sanction.
+SANCTION = 9796; -- You have received the Empire's Sanction.
 
 -- Quest dialogs
- ZASSHAL_DIALOG = 10989; -- 'ang about. Looks like the permit you got was the last one I 'ad, so it might take me a bit o' time to scrounge up some more. 'ere, don't gimme that look. I'll be restocked before you know it.
-MUSHAYRA_DIALOG = 4958; -- Sorry for all the trouble. Please ignore Hadahda the next time he asks you to do something.
- HADAHDA_DIALOG = 4909; -- Hey, think you could help me out?
+ ZASSHAL_DIALOG = 10990; -- 'ang about. Looks like the permit you got was the last one I 'ad, so it might take me a bit o' time to scrounge up some more. 'ere, don't gimme that look. I'll be restocked before you know it.
+MUSHAYRA_DIALOG = 4959; -- Sorry for all the trouble. Please ignore Hadahda the next time he asks you to do something.
+ HADAHDA_DIALOG = 4910; -- Hey, think you could help me out?
 
  -- Other Dialogs
-ITEM_DELIVERY_DIALOG = 9345; -- You have something you want delivered?
-        RUNIC_PORTAL = 4578; -- You cannot use the runic portal without the Empire's authorization.
-IMAGE_SUPPORT_ACTIVE = 1399; -- You have to wait a bit longer before asking for synthesis image support again.
+ITEM_DELIVERY_DIALOG = 9346; -- You have something you want delivered?
+        RUNIC_PORTAL = 4579; -- You cannot use the runic portal without the Empire's authorization.
+IMAGE_SUPPORT_ACTIVE = 1400; -- You have to wait a bit longer before asking for synthesis image support again.
 
 -- Shop Texts
-UGRIHD_PURCHASE_DIALOGUE = 4639; -- Salaheem's Sentinels values your contribution to the success of the company. Please come again!
+UGRIHD_PURCHASE_DIALOGUE = 4640; -- Salaheem's Sentinels values your contribution to the success of the company. Please come again!
 
-      GAVRIE_SHOP_DIALOG = 9259; -- Remember to take your medicine in small doses... Sometimes you can get a little too much of a good thing!
-      MALFUD_SHOP_DIALOG = 9260; -- Welcome, welcome! Flavor your meals with Malfud's ingredients!
-     RUBAHAH_SHOP_DIALOG = 9261; -- Flour! Flooour! Corn! Rice and beans! Get your rice and beans here! If you're looking for grain, you've come to the right place!
-     MULNITH_SHOP_DIALOG = 9262; -- Drawn in by my shop's irresistible aroma, were you? How would you like some of the Near East's famous skewers to enjoy during your journeys?
-     SALUHWA_SHOP_DIALOG = 9263; -- Looking for undentable shields? This shop's got the best of 'em! These are absolute must-haves for a mercenary's dangerous work!
-       DWAGO_SHOP_DIALOG = 9264; -- Buy your goods here...or you'll regret it!
- KULHAMARIYO_SHOP_DIALOG = 9265; -- Some fish to savorrr while you enjoy the sights of Aht Urhgan?
- KHAFJHIFANM_SHOP_DIALOG = 9266; -- How about a souvenir for back home? There's nothing like dried dates to remind you of good times in Al Zahbi!
-    HAGAKOFF_SHOP_DIALOG = 9267; -- Welcome! Fill all your destructive needs with my superb weaponry! No good mercenary goes without a good weapon!
-      BAJAHB_SHOP_DIALOG = 9268; -- Good day! If you want to live long, you'll buy your armor here.
-     MAZWEEN_SHOP_DIALOG = 9269; -- Magic scrolls! Get your magic scrolls here!
-    FAYEEWAH_SHOP_DIALOG = 9270; -- Why not sit back a spell and enjoy the rich aroma and taste of a cup of chai?
-      YAFAAF_SHOP_DIALOG = 9271; -- There's nothing like the mature taste and luxurious aroma of coffee... Would you like a cup
+      GAVRIE_SHOP_DIALOG = 9260; -- Remember to take your medicine in small doses... Sometimes you can get a little too much of a good thing!
+      MALFUD_SHOP_DIALOG = 9261; -- Welcome, welcome! Flavor your meals with Malfud's ingredients!
+     RUBAHAH_SHOP_DIALOG = 9262; -- Flour! Flooour! Corn! Rice and beans! Get your rice and beans here! If you're looking for grain, you've come to the right place!
+     MULNITH_SHOP_DIALOG = 9263; -- Drawn in by my shop's irresistible aroma, were you? How would you like some of the Near East's famous skewers to enjoy during your journeys?
+     SALUHWA_SHOP_DIALOG = 9264; -- Looking for undentable shields? This shop's got the best of 'em! These are absolute must-haves for a mercenary's dangerous work!
+       DWAGO_SHOP_DIALOG = 9265; -- Buy your goods here...or you'll regret it!
+ KULHAMARIYO_SHOP_DIALOG = 9266; -- Some fish to savorrr while you enjoy the sights of Aht Urhgan?
+ KHAFJHIFANM_SHOP_DIALOG = 9267; -- How about a souvenir for back home? There's nothing like dried dates to remind you of good times in Al Zahbi!
+    HAGAKOFF_SHOP_DIALOG = 9268; -- Welcome! Fill all your destructive needs with my superb weaponry! No good mercenary goes without a good weapon!
+      BAJAHB_SHOP_DIALOG = 9269; -- Good day! If you want to live long, you'll buy your armor here.
+     MAZWEEN_SHOP_DIALOG = 9270; -- Magic scrolls! Get your magic scrolls here!
+    FAYEEWAH_SHOP_DIALOG = 9271; -- Why not sit back a spell and enjoy the rich aroma and taste of a cup of chai?
+      YAFAAF_SHOP_DIALOG = 9272; -- There's nothing like the mature taste and luxurious aroma of coffee... Would you like a cup
 
-      WAHNID_SHOP_DIALOG = 9272; -- All the fishing gear you'll ever need, here in one place!
-     WAHRAGA_SHOP_DIALOG = 9273; -- Welcome to the Alchemists' Guild.
+      WAHNID_SHOP_DIALOG = 9273; -- All the fishing gear you'll ever need, here in one place!
+     WAHRAGA_SHOP_DIALOG = 9274; -- Welcome to the Alchemists' Guild.
 
 -- Automaton
-      AUTOMATON_RENAME = 5824; -- Your automaton has a new name.
-      AUTOMATON_VALOREDGE_UNLOCK = 9583; -- You obtain the Valoredge X-900 head and frame!
-      AUTOMATON_SHARPSHOT_UNLOCK = 9588; -- You obtain the Sharpshot Z-500 head and frame!
-      AUTOMATON_STORMWAKER_UNLOCK = 9593; -- You obtain the Stormwaker Y-700 head and frame!
-      AUTOMATON_SOULSOOTHER_UNLOCK = 9625; -- You obtain the Soulsoother C-1000 head!
-      AUTOMATON_SPIRITREAVER_UNLOCK = 9626; -- You obtain the Spiritreaver M-400 head!
-      AUTOMATON_ATTACHMENT_UNLOCK = 9642; -- You can now equip your automaton with
+      AUTOMATON_RENAME = 5825; -- Your automaton has a new name.
+      AUTOMATON_VALOREDGE_UNLOCK = 9584; -- You obtain the Valoredge X-900 head and frame!
+      AUTOMATON_SHARPSHOT_UNLOCK = 9589; -- You obtain the Sharpshot Z-500 head and frame!
+      AUTOMATON_STORMWAKER_UNLOCK = 9594; -- You obtain the Stormwaker Y-700 head and frame!
+      AUTOMATON_SOULSOOTHER_UNLOCK = 9626; -- You obtain the Soulsoother C-1000 head!
+      AUTOMATON_SPIRITREAVER_UNLOCK = 9627; -- You obtain the Spiritreaver M-400 head!
+      AUTOMATON_ATTACHMENT_UNLOCK = 9643; -- You can now equip your automaton with
 
 -- Assault
-    RYTAAL_MISSION_COMPLETE = 5646; -- Congratulations. You have been awarded Assault Points for the successful completion of your mission.
-    RYTAAL_MISSION_FAILED = 5647; -- Your mission was not successful; however, the Empire recognizes your contribution and has awarded you Assault Points.
+    RYTAAL_MISSION_COMPLETE = 5647; -- Congratulations. You have been awarded Assault Points for the successful completion of your mission.
+    RYTAAL_MISSION_FAILED = 5648; -- Your mission was not successful; however, the Empire recognizes your contribution and has awarded you Assault Points.
 
 -- Porter Moogle
-    RETRIEVE_DIALOG_ID = 13508; -- You retrieve$ from the porter moogle's care.
+    RETRIEVE_DIALOG_ID = 13509; -- You retrieve$ from the porter moogle's care.

--- a/scripts/zones/AlTaieu/TextIDs.lua
+++ b/scripts/zones/AlTaieu/TextIDs.lua
@@ -2,18 +2,18 @@
 
 -- General Texts
 ITEM_CANNOT_BE_OBTAINED = 6379; -- You cannot obtain the item <item> come back again after sorting your inventory
-          ITEM_OBTAINED = 6384; -- Obtained: <item>
-           GIL_OBTAINED = 6385; -- Obtained <number> gil
-       KEYITEM_OBTAINED = 6387; -- Obtained key item: <keyitem>
-            HOMEPOINT_SET = 7560; -- Home point set!
+          ITEM_OBTAINED = 6385; -- Obtained: <item>
+           GIL_OBTAINED = 6386; -- Obtained <number> gil
+       KEYITEM_OBTAINED = 6388; -- Obtained key item: <keyitem>
+            HOMEPOINT_SET = 7561; -- Home point set!
 
 -- Quasilumin Texts
-QUASILUMIN_01 = 7361; -- This is Al'Taieu. The celestial capital overflowing with the blessings of Altana.
+QUASILUMIN_01 = 7362; -- This is Al'Taieu. The celestial capital overflowing with the blessings of Altana.
 
 -- Other
-    NOTHING_OF_INTEREST = 7471; -- There is nothing of interest here.
-         OMINOUS_SHADOW = 7472; -- An ominous shadow falls over you...
-NOTHING_OUT_OF_ORDINARY = 7474; --There is nothing out of the ordinary here.
+    NOTHING_OF_INTEREST = 7472; -- There is nothing of interest here.
+         OMINOUS_SHADOW = 7473; -- An ominous shadow falls over you...
+NOTHING_OUT_OF_ORDINARY = 7475; --There is nothing out of the ordinary here.
 
 -- conquest Base
-CONQUEST_BASE = 7145; -- Tallying conquest results...
+CONQUEST_BASE = 7146; -- Tallying conquest results...

--- a/scripts/zones/Al_Zahbi/TextIDs.lua
+++ b/scripts/zones/Al_Zahbi/TextIDs.lua
@@ -2,28 +2,28 @@
 
 -- General Texts
 ITEM_CANNOT_BE_OBTAINED = 6379; -- You cannot obtain the item <item> come back again after sorting your inventory
-          ITEM_OBTAINED = 6384; -- Obtained: <item>
-           GIL_OBTAINED = 6385; -- Obtained <number> gil
-       KEYITEM_OBTAINED = 6387; -- Obtained key item: <keyitem>
- FISHING_MESSAGE_OFFSET = 7045; -- You can't fish here
-          HOMEPOINT_SET = 7523; -- Home point set!
-   IMAGE_SUPPORT_ACTIVE = 7546; -- You have to wait a bit longer before asking for synthesis image support again.
-          IMAGE_SUPPORT = 7548; -- Your ?Multiple Choice (Parameter 1)?[fishing/woodworking/smithing/goldsmithing/clothcraft/leatherworking/bonecraft/alchemy/cooking] skills went up ...
-               SANCTION = 7967; -- You have received the Empire's Sanction.
+          ITEM_OBTAINED = 6385; -- Obtained: <item>
+           GIL_OBTAINED = 6386; -- Obtained <number> gil
+       KEYITEM_OBTAINED = 6388; -- Obtained key item: <keyitem>
+ FISHING_MESSAGE_OFFSET = 7046; -- You can't fish here
+          HOMEPOINT_SET = 7524; -- Home point set!
+   IMAGE_SUPPORT_ACTIVE = 7547; -- You have to wait a bit longer before asking for synthesis image support again.
+          IMAGE_SUPPORT = 7549; -- Your ?Multiple Choice (Parameter 1)?[fishing/woodworking/smithing/goldsmithing/clothcraft/leatherworking/bonecraft/alchemy/cooking] skills went up ...
+               SANCTION = 7968; -- You have received the Empire's Sanction.
 
  --Other Texts
-   ITEM_DELIVERY_DIALOG = 7829; -- No need to wrap your goods. Just hand them over and they're as good as delivered! (I've got to be nice as long as the manager's got his eye on me...)
+   ITEM_DELIVERY_DIALOG = 7830; -- No need to wrap your goods. Just hand them over and they're as good as delivered! (I've got to be nice as long as the manager's got his eye on me...)
 
 -- Shop Texts
-       ALLARD_SHOP_DIALOG = 7613; -- Hey, how ya doin'? Welcome to the armor shop of the Ulthalam Parade's leading star--Allard, in the flesh!
-      CHAYAYA_SHOP_DIALOG = 7625; -- Chayaya's Projectiles! Get your darts and more at Chayaya's Projectiles! Just don't touch the stuff in the high drawers, okay
-KAHAHHOBICHAI_SHOP_DIALOG = 7607; -- Step rrright up to Kahah Hobichai's Blades! We've got everything your battle-thirrrsty heart desires!
-        ZAFIF_SHOP_DIALOG = 7619; -- Welcome... I'm Zafif, and this is my magic shop... I hope you can find something of use here.
+       ALLARD_SHOP_DIALOG = 7614; -- Hey, how ya doin'? Welcome to the armor shop of the Ulthalam Parade's leading star--Allard, in the flesh!
+      CHAYAYA_SHOP_DIALOG = 7626; -- Chayaya's Projectiles! Get your darts and more at Chayaya's Projectiles! Just don't touch the stuff in the high drawers, okay
+KAHAHHOBICHAI_SHOP_DIALOG = 7608; -- Step rrright up to Kahah Hobichai's Blades! We've got everything your battle-thirrrsty heart desires!
+        ZAFIF_SHOP_DIALOG = 7620; -- Welcome... I'm Zafif, and this is my magic shop... I hope you can find something of use here.
 
-DEHBI_MOSHAL_SHOP_DIALOG = 7833; -- Welcome to the Carpenters' Guild!
-       NDEGO_SHOP_DIALOG = 7835; -- The Blacksmiths' Guild thanks you for your business!
-     BORNAHN_SHOP_DIALOG = 7837; -- Welcome! We have all your goldsmithing needs right here!
-TATEN_BILTEN_SHOP_DIALOG = 7839; -- Weave something beautiful with the materials you buy here, okay?
+DEHBI_MOSHAL_SHOP_DIALOG = 7834; -- Welcome to the Carpenters' Guild!
+       NDEGO_SHOP_DIALOG = 7836; -- The Blacksmiths' Guild thanks you for your business!
+     BORNAHN_SHOP_DIALOG = 7838; -- Welcome! We have all your goldsmithing needs right here!
+TATEN_BILTEN_SHOP_DIALOG = 7840; -- Weave something beautiful with the materials you buy here, okay?
 
 -- NPC Texts
-CHOCOBO_HAPPY = 7842; -- The chocobo appears to be extremely happy.
+CHOCOBO_HAPPY = 7843; -- The chocobo appears to be extremely happy.

--- a/scripts/zones/Altar_Room/TextIDs.lua
+++ b/scripts/zones/Altar_Room/TextIDs.lua
@@ -2,12 +2,12 @@
 
 -- General Texts
 ITEM_CANNOT_BE_OBTAINED = 6379; -- You cannot obtain the item <item>. Come back after sorting your inventory.
-          ITEM_OBTAINED = 6384; -- Obtained: <item>.
-           GIL_OBTAINED = 6385; -- Obtained <number> gil.
-       KEYITEM_OBTAINED = 6387; -- Obtained key item: <keyitem>.
+          ITEM_OBTAINED = 6385; -- Obtained: <item>.
+           GIL_OBTAINED = 6386; -- Obtained <number> gil.
+       KEYITEM_OBTAINED = 6388; -- Obtained key item: <keyitem>.
 
 -- Other dialog
-THE_MAGICITE_GLOWS_OMINOUSLY = 7098; -- The magicite glows ominously.
+THE_MAGICITE_GLOWS_OMINOUSLY = 7099; -- The magicite glows ominously.
 
 -- conquest Base
-CONQUEST_BASE = 7099; -- Tallying conquest results...
+CONQUEST_BASE = 7100; -- Tallying conquest results...

--- a/scripts/zones/Alzadaal_Undersea_Ruins/TextIDs.lua
+++ b/scripts/zones/Alzadaal_Undersea_Ruins/TextIDs.lua
@@ -2,20 +2,20 @@
 
 -- General Texts
 ITEM_CANNOT_BE_OBTAINED = 6379; -- You cannot obtain the item <item> come back again after sorting your inventory
-          ITEM_OBTAINED = 6384; -- Obtained: <item>
-           GIL_OBTAINED = 6385; -- Obtained <number> gil
-       KEYITEM_OBTAINED = 6387; -- Obtained key item: <keyitem>
+          ITEM_OBTAINED = 6385; -- Obtained: <item>
+           GIL_OBTAINED = 6386; -- Obtained <number> gil
+       KEYITEM_OBTAINED = 6388; -- Obtained key item: <keyitem>
 
 -- Assault / Salvage
-CANNOT_ENTER = 7437; -- You cannot enter at this time.  Please wait a while before trying again.
-AREA_FULL = 7438; -- This area is fully occupied. You were unable to enter.
-MEMBER_NO_REQS = 7442; -- Not all of your party members meet the requirements for this objective.  Unable to enter area.
-MEMBER_TOO_FAR = 7446; -- One or more party members are too far away from the entrance.  Unable to enter area.
-MEMBER_IMBUED_ITEM = 7447; -- One or more party members are carrying imbued items. Unable to enter area
-IMBUED_ITEM = 7448; -- You are carrying imbued items. Unable to enter area
-MYTHIC_REQUIRED = 7450; -- You do not have the appropriate mythic weapon equipped. Unable to enter area.
+CANNOT_ENTER = 7438; -- You cannot enter at this time.  Please wait a while before trying again.
+AREA_FULL = 7439; -- This area is fully occupied. You were unable to enter.
+MEMBER_NO_REQS = 7443; -- Not all of your party members meet the requirements for this objective.  Unable to enter area.
+MEMBER_TOO_FAR = 7447; -- One or more party members are too far away from the entrance.  Unable to enter area.
+MEMBER_IMBUED_ITEM = 7448; -- One or more party members are carrying imbued items. Unable to enter area
+IMBUED_ITEM = 7449; -- You are carrying imbued items. Unable to enter area
+MYTHIC_REQUIRED = 7451; -- You do not have the appropriate mythic weapon equipped. Unable to enter area.
        
 -- Other Texts
       NOTHING_HAPPENS = 119; -- Nothing happens...
-             RESPONSE = 7225; -- There is no response...
-DEVICE_MALFUNCTIONING = 7241; -- The device appears to be malfunctioning...
+             RESPONSE = 7226; -- There is no response...
+DEVICE_MALFUNCTIONING = 7242; -- The device appears to be malfunctioning...

--- a/scripts/zones/Apollyon/TextIDs.lua
+++ b/scripts/zones/Apollyon/TextIDs.lua
@@ -2,15 +2,15 @@
 
 -- General Texts
 ITEM_CANNOT_BE_OBTAINED = 6379; -- You cannot obtain the item <item> come back again after sorting your inventory
-          ITEM_OBTAINED = 6384; -- Obtained: <item>
-           GIL_OBTAINED = 6385; -- Obtained <number> gil
-       KEYITEM_OBTAINED = 6387; -- Obtained key item: <keyitem>
+          ITEM_OBTAINED = 6385; -- Obtained: <item>
+           GIL_OBTAINED = 6386; -- Obtained <number> gil
+       KEYITEM_OBTAINED = 6388; -- Obtained key item: <keyitem>
 
-CONDITION_FOR_LIMBUS = 7051;    -- You have clearance to enter Limbus, but cannot enter while you or a party member is engaged in battle.
+CONDITION_FOR_LIMBUS = 7052;    -- You have clearance to enter Limbus, but cannot enter while you or a party member is engaged in battle.
 CHIP_TRADE = 7022;              --
 
 -- Cannot find correct TextID for CHIP_TRADE
 
 -- conquest Base
-CONQUEST_BASE = 7362; -- Tallying conquest results...
+CONQUEST_BASE = 7363; -- Tallying conquest results...
 

--- a/scripts/zones/Arrapago_Reef/TextIDs.lua
+++ b/scripts/zones/Arrapago_Reef/TextIDs.lua
@@ -2,22 +2,22 @@
 
 -- General Texts
 ITEM_CANNOT_BE_OBTAINED = 6379; -- You cannot obtain the item <item> come back again after sorting your inventory
-          ITEM_OBTAINED = 6384; -- Obtained: <item>
-           GIL_OBTAINED = 6385; -- Obtained <number> gil
-       KEYITEM_OBTAINED = 6387; -- Obtained key item: <keyitem>
- FISHING_MESSAGE_OFFSET = 7045; -- You can't fish here
+          ITEM_OBTAINED = 6385; -- Obtained: <item>
+           GIL_OBTAINED = 6386; -- Obtained <number> gil
+       KEYITEM_OBTAINED = 6388; -- Obtained key item: <keyitem>
+ FISHING_MESSAGE_OFFSET = 7046; -- You can't fish here
 
 -- Assault
-CANNOT_ENTER = 8441; -- You cannot enter at this time.  Please wait a while before trying again.
-AREA_FULL = 8442; -- This area is fully occupied. You were unable to enter.
-MEMBER_NO_REQS = 8446; -- Not all of your party members meet the requirements for this objective.  Unable to enter area.
-MEMBER_TOO_FAR = 8450; -- One or more party members are too far away from the entrance.  Unable to enter area.
+CANNOT_ENTER = 8442; -- You cannot enter at this time.  Please wait a while before trying again.
+AREA_FULL = 8443; -- This area is fully occupied. You were unable to enter.
+MEMBER_NO_REQS = 8447; -- Not all of your party members meet the requirements for this objective.  Unable to enter area.
+MEMBER_TOO_FAR = 8451; -- One or more party members are too far away from the entrance.  Unable to enter area.
 
 -- Other Texts
-   YOU_NO_REQS = 7580; -- You do not meet the requirements to enter the battlefield
+   YOU_NO_REQS = 7581; -- You do not meet the requirements to enter the battlefield
 NOTHING_HAPPENS = 119; -- Nothing happens...
-       RESPONSE = 7325; -- There is no response...
+       RESPONSE = 7326; -- There is no response...
 
 -- Medusa
-MEDUSA_ENGAGE = 8552; -- Foolish two-legs... Have you forgotten the terrible power of the gorgons you created? It is time you were reminded...
-MEDUSA_DEATH  = 8553; -- No... I cannot leave my sisters...
+MEDUSA_ENGAGE = 8553; -- Foolish two-legs... Have you forgotten the terrible power of the gorgons you created? It is time you were reminded...
+MEDUSA_DEATH  = 8554; -- No... I cannot leave my sisters...

--- a/scripts/zones/Attohwa_Chasm/TextIDs.lua
+++ b/scripts/zones/Attohwa_Chasm/TextIDs.lua
@@ -2,19 +2,19 @@
 
 -- General Texts
 ITEM_CANNOT_BE_OBTAINED = 6379; -- You cannot obtain the item <item> come back again after sorting your inventory.
-          ITEM_OBTAINED = 6384; -- Obtained: <item>.
-           GIL_OBTAINED = 6385; -- Obtained <number> gil.
-       KEYITEM_OBTAINED = 6387; -- Obtained key item: <keyitem>.
-           KEYITEM_LOST = 6388; -- Lost key item:
-NOTHING_OUT_OF_ORDINARY = 6398; -- There is nothing out of the ordinary here.
-            HOMEPOINT_SET = 8226; -- Home point set!
+          ITEM_OBTAINED = 6385; -- Obtained: <item>.
+           GIL_OBTAINED = 6386; -- Obtained <number> gil.
+       KEYITEM_OBTAINED = 6388; -- Obtained key item: <keyitem>.
+           KEYITEM_LOST = 6389; -- Lost key item:
+NOTHING_OUT_OF_ORDINARY = 6399; -- There is nothing out of the ordinary here.
+            HOMEPOINT_SET = 8227; -- Home point set!
 
 -- Mining
-MINING_IS_POSSIBLE_HERE = 7204; -- Mining is possible here if you have
+MINING_IS_POSSIBLE_HERE = 7205; -- Mining is possible here if you have
 
 -- Other
- GASPONIA_POISON = 7324; -- The poison of the Gasponia has begun to spread through your body.
-OCCASIONAL_LUMPS = 7339; -- Occasionally lumps arise in the ground here, then settle down again. It seems that there is something beneath the earth.
+ GASPONIA_POISON = 7325; -- The poison of the Gasponia has begun to spread through your body.
+OCCASIONAL_LUMPS = 7340; -- Occasionally lumps arise in the ground here, then settle down again. It seems that there is something beneath the earth.
 
 -- conquest Base
-CONQUEST_BASE = 7045; -- Tallying conquest results...
+CONQUEST_BASE = 7046; -- Tallying conquest results...

--- a/scripts/zones/Aydeewa_Subterrane/TextIDs.lua
+++ b/scripts/zones/Aydeewa_Subterrane/TextIDs.lua
@@ -2,11 +2,11 @@
 
 -- General Texts
 ITEM_CANNOT_BE_OBTAINED = 6379; -- You cannot obtain the item <item>. Come back after sorting your inventory.
-          ITEM_OBTAINED = 6384; -- Obtained: <item>.
-           GIL_OBTAINED = 6385; -- Obtained <number> gil.
-       KEYITEM_OBTAINED = 6387; -- Obtained key item: <keyitem>.
- FISHING_MESSAGE_OFFSET = 7045; -- You can't fish here.
+          ITEM_OBTAINED = 6385; -- Obtained: <item>.
+           GIL_OBTAINED = 6386; -- Obtained <number> gil.
+       KEYITEM_OBTAINED = 6388; -- Obtained key item: <keyitem>.
+ FISHING_MESSAGE_OFFSET = 7046; -- You can't fish here.
 
 -- Other Texts
-MINING_IS_POSSIBLE_HERE = 7316; -- Mining is possible here if you have
+MINING_IS_POSSIBLE_HERE = 7317; -- Mining is possible here if you have
         NOTHING_HAPPENS = 119; -- Nothing happens...

--- a/scripts/zones/Balgas_Dais/TextIDs.lua
+++ b/scripts/zones/Balgas_Dais/TextIDs.lua
@@ -2,17 +2,17 @@
 
 -- General Texts
 ITEM_CANNOT_BE_OBTAINED = 6379; -- You cannot obtain the item <item>. Come back after sorting your inventory.
-          ITEM_OBTAINED = 6384; -- Obtained: <item>.
-           GIL_OBTAINED = 6385; -- Obtained <number> gil.
-       KEYITEM_OBTAINED = 6387; -- Obtained key item: <keyitem>.
+          ITEM_OBTAINED = 6385; -- Obtained: <item>.
+           GIL_OBTAINED = 6386; -- Obtained <number> gil.
+       KEYITEM_OBTAINED = 6388; -- Obtained key item: <keyitem>.
 
 -- Maat dialog
-      YOU_DECIDED_TO_SHOW_UP = 7625; -- So, you decided to show up.
- LOOKS_LIKE_YOU_WERENT_READY = 7626; -- Looks like you weren't ready for me, were you?
-       YOUVE_COME_A_LONG_WAY = 7627; -- Hm. That was a mighty fine display of skill there, Player Name. You've come a long way...
- TEACH_YOU_TO_RESPECT_ELDERS = 7628; -- I'll teach you to respect your elders!
-TAKE_THAT_YOU_WHIPPERSNAPPER = 7629; -- Take that, you whippersnapper!
- THAT_LL_HURT_IN_THE_MORNING = 7631; -- Ungh... That'll hurt in the morning...
+      YOU_DECIDED_TO_SHOW_UP = 7626; -- So, you decided to show up.
+ LOOKS_LIKE_YOU_WERENT_READY = 7627; -- Looks like you weren't ready for me, were you?
+       YOUVE_COME_A_LONG_WAY = 7628; -- Hm. That was a mighty fine display of skill there, Player Name. You've come a long way...
+ TEACH_YOU_TO_RESPECT_ELDERS = 7629; -- I'll teach you to respect your elders!
+TAKE_THAT_YOU_WHIPPERSNAPPER = 7630; -- Take that, you whippersnapper!
+ THAT_LL_HURT_IN_THE_MORNING = 7632; -- Ungh... That'll hurt in the morning...
 
 -- conquest Base
-CONQUEST_BASE = 7045; -- Tallying conquest results...
+CONQUEST_BASE = 7046; -- Tallying conquest results...

--- a/scripts/zones/Bastok-Jeuno_Airship/TextIDs.lua
+++ b/scripts/zones/Bastok-Jeuno_Airship/TextIDs.lua
@@ -2,13 +2,13 @@
 
 -- General Texts
 ITEM_CANNOT_BE_OBTAINED = 6379; -- You cannot obtain the item <item> come back again after sorting your inventory
-          ITEM_OBTAINED = 6384; -- Obtained: <item>
-           GIL_OBTAINED = 6385; -- Obtained <number> gil
-       KEYITEM_OBTAINED = 6387; -- Obtained key item: <keyitem>
+          ITEM_OBTAINED = 6385; -- Obtained: <item>
+           GIL_OBTAINED = 6386; -- Obtained <number> gil
+       KEYITEM_OBTAINED = 6388; -- Obtained key item: <keyitem>
 
 -- Other
 
-       WILL_REACH_JEUNO = 7204; -- The airship will reach Jeuno in Multiple Choice (Parameter 1)[less than an hour/about 1 hour/about 2 hours/about 3 hours/about 4 hours/about 5 hours/about 6 hours/about 7 hours] ( Singular/Plural Choice (Parameter 0)[minute/minutes] in Earth time). 
-      WILL_REACH_BASTOK = 7205; -- The airship will reach Bastok in Multiple Choice (Parameter 1)[less than an hour/about 1 hour/about 2 hours/about 3 hours/about 4 hours/about 5 hours/about 6 hours/about 7 hours] ( Singular/Plural Choice (Parameter 0)[minute/minutes] in Earth time). 
-   IN_JEUNO_MOMENTARILY = 7206; -- We will be arriving in Jeuno momentarily.
-  IN_BASTOK_MOMENTARILY = 7207; -- We will be arriving in Bastok momentarily.
+       WILL_REACH_JEUNO = 7205; -- The airship will reach Jeuno in Multiple Choice (Parameter 1)[less than an hour/about 1 hour/about 2 hours/about 3 hours/about 4 hours/about 5 hours/about 6 hours/about 7 hours] ( Singular/Plural Choice (Parameter 0)[minute/minutes] in Earth time). 
+      WILL_REACH_BASTOK = 7206; -- The airship will reach Bastok in Multiple Choice (Parameter 1)[less than an hour/about 1 hour/about 2 hours/about 3 hours/about 4 hours/about 5 hours/about 6 hours/about 7 hours] ( Singular/Plural Choice (Parameter 0)[minute/minutes] in Earth time). 
+   IN_JEUNO_MOMENTARILY = 7207; -- We will be arriving in Jeuno momentarily.
+  IN_BASTOK_MOMENTARILY = 7208; -- We will be arriving in Bastok momentarily.

--- a/scripts/zones/Bastok_Markets/TextIDs.lua
+++ b/scripts/zones/Bastok_Markets/TextIDs.lua
@@ -3,67 +3,67 @@
 -- General Texts
    ITEM_CANNOT_BE_OBTAINED =  6379; --Come back after sorting your inventory.
 FULL_INVENTORY_AFTER_TRADE =  6383; --Try trading again after sorting your inventory.
-             ITEM_OBTAINED =  6384; --Obtained: <<<Unknown Parameter (Type: 80) 1>>><<<Possible Special Code: 01>>><<<Possible Special Code: 05>>>
-              GIL_OBTAINED =  6385; --Obtained <<<Numeric Parameter 0>>> gil.
-          KEYITEM_OBTAINED =  6387; --Obtained key item: <<<Unknown Parameter (Type: 80) 1>>>
-       NOT_HAVE_ENOUGH_GIL =  6389; --You do not have enough gil.
-            ITEMS_OBTAINED =  6393; --You obtain ?Numeric Parameter 1? ?Possible Special Code: 01??Speaker Name?)??BAD CHAR: 80??BAD CHAR: 80??BAD CHAR: 8280??BAD CHAR: 80??BAD CHAR: 80?!?Prompt?
-             HOMEPOINT_SET =  6475; --Home point set!
-      GOLDSMITHING_SUPPORT =  7069; --Your ?Multiple Choice (Parameter 1)?[fishing/woodworking/smithing/goldsmithing/clothcraft/leatherworking/bonecraft/alchemy/cooking] skills went up ...
-  GUILD_TERMINATE_CONTRACT =  7083; --You have terminated your trading contract with the Multiple Choice (Parameter 1)[Fishermen's/Carpenters'/Blacksmiths'/Goldsmiths'/Weavers'/Tanners'/Boneworkers'/Alchemists'/Culinarians'] Guild and formed a new one with the Multiple Choice (Parameter 0)[Fishermen's/Carpenters'/Blacksmiths'/Goldsmiths'/Weavers'/Tanners'/Boneworkers'/Alchemists'/Culinarians'] Guild
+             ITEM_OBTAINED =  6385; --Obtained: <<<Unknown Parameter (Type: 80) 1>>><<<Possible Special Code: 01>>><<<Possible Special Code: 05>>>
+              GIL_OBTAINED =  6386; --Obtained <<<Numeric Parameter 0>>> gil.
+          KEYITEM_OBTAINED =  6388; --Obtained key item: <<<Unknown Parameter (Type: 80) 1>>>
+       NOT_HAVE_ENOUGH_GIL =  6390; --You do not have enough gil.
+            ITEMS_OBTAINED =  6394; --You obtain ?Numeric Parameter 1? ?Possible Special Code: 01??Speaker Name?)??BAD CHAR: 80??BAD CHAR: 80??BAD CHAR: 8280??BAD CHAR: 80??BAD CHAR: 80?!?Prompt?
+             HOMEPOINT_SET =  6476; --Home point set!
+      GOLDSMITHING_SUPPORT =  7070; --Your ?Multiple Choice (Parameter 1)?[fishing/woodworking/smithing/goldsmithing/clothcraft/leatherworking/bonecraft/alchemy/cooking] skills went up ...
+  GUILD_TERMINATE_CONTRACT =  7084; --You have terminated your trading contract with the Multiple Choice (Parameter 1)[Fishermen's/Carpenters'/Blacksmiths'/Goldsmiths'/Weavers'/Tanners'/Boneworkers'/Alchemists'/Culinarians'] Guild and formed a new one with the Multiple Choice (Parameter 0)[Fishermen's/Carpenters'/Blacksmiths'/Goldsmiths'/Weavers'/Tanners'/Boneworkers'/Alchemists'/Culinarians'] Guild
 
-        GUILD_NEW_CONTRACT =  7091; --You have formed a new trading contract with the Multiple Choice (Parameter 0)[Fishermen's/Carpenters'/Blacksmiths'/Goldsmiths'/Weavers'/Tanners'/Boneworkers'/Alchemists'/Culinarians'] Guild
+        GUILD_NEW_CONTRACT =  7092; --You have formed a new trading contract with the Multiple Choice (Parameter 0)[Fishermen's/Carpenters'/Blacksmiths'/Goldsmiths'/Weavers'/Tanners'/Boneworkers'/Alchemists'/Culinarians'] Guild
 
-       NO_MORE_GP_ELIGIBLE =  7098; --You are not eligible to receive guild points at this time.
-               GP_OBTAINED =  7103; --Obtained: ?Numeric Parameter 0? guild points.
-        NOT_HAVE_ENOUGH_GP =  7104; --You do not have enough guild points.
-    FISHING_MESSAGE_OFFSET =  7198; --You can't fish here.
+       NO_MORE_GP_ELIGIBLE =  7099; --You are not eligible to receive guild points at this time.
+               GP_OBTAINED =  7104; --Obtained: ?Numeric Parameter 0? guild points.
+        NOT_HAVE_ENOUGH_GP =  7105; --You do not have enough guild points.
+    FISHING_MESSAGE_OFFSET =  7200; --You can't fish here.
 
 -- Conquest System
-CONQUEST =  7776; --You've earned conquest points!
+CONQUEST =  7778; --You've earned conquest points!
 
 -- Mission Dialogs
-    YOU_ACCEPT_THE_MISSION =  6504; --You have accepted the mission.
-   ORIGINAL_MISSION_OFFSET =  6509; -- You can consult the ission section of the main menu to review your objectives. Speed and efficiency are your priorities. Dismissed. 
-   EXTENDED_MISSION_OFFSET =  8138; --Go to Ore Street and talk to Medicine Eagle. He says he was there when the commotion started.
+    YOU_ACCEPT_THE_MISSION =  6505; --You have accepted the mission.
+   ORIGINAL_MISSION_OFFSET =  6510; -- You can consult the ission section of the main menu to review your objectives. Speed and efficiency are your priorities. Dismissed. 
+   EXTENDED_MISSION_OFFSET =  8140; --Go to Ore Street and talk to Medicine Eagle. He says he was there when the commotion started.
 
 -- Other Dialogs
-ITEM_DELIVERY_DIALOG =  7653; --Need something sent to a friend's house? Sending items to your own room? You've come to the right place
+ITEM_DELIVERY_DIALOG =  7655; --Need something sent to a friend's house? Sending items to your own room? You've come to the right place
 
 -- Harvest Festival
-      TRICK_OR_TREAT =  8261; --Trick or treat...
-     THANK_YOU_TREAT =  8262; --And now for your treat...
-      HERE_TAKE_THIS =  8263; --Here, take this...
-    IF_YOU_WEAR_THIS =  8264; --If you put this on and walk around, something...unexpected might happen...
-           THANK_YOU =  8262; --Thank you...
+      TRICK_OR_TREAT =  8263; --Trick or treat...
+     THANK_YOU_TREAT =  8264; --And now for your treat...
+      HERE_TAKE_THIS =  8265; --Here, take this...
+    IF_YOU_WEAR_THIS =  8266; --If you put this on and walk around, something...unexpected might happen...
+           THANK_YOU =  8264; --Thank you...
 
 -- Shop Texts
-    SOMNPAEMN_CLOSED_DIALOG =  7564; --I'm trying to start a business selling goods from Sarutabaruta,
-       YAFAFA_CLOSED_DIALOG =  7565; --I'm trying to start a business selling goods from Kolshushu,
-     OGGODETT_CLOSED_DIALOG =  7566; --I'm trying to start a business selling goods from Aragoneu,
+    SOMNPAEMN_CLOSED_DIALOG =  7566; --I'm trying to start a business selling goods from Sarutabaruta,
+       YAFAFA_CLOSED_DIALOG =  7567; --I'm trying to start a business selling goods from Kolshushu,
+     OGGODETT_CLOSED_DIALOG =  7568; --I'm trying to start a business selling goods from Aragoneu,
 
-         TEERTH_SHOP_DIALOG =  7667; --Welcome to the Goldsmiths' Guild shop. What can I do for you?
-         VISALA_SHOP_DIALOG =  7668; --Welcome to the Goldsmiths' Guild shop. How may I help you?
-        ZHIKKOM_SHOP_DIALOG =  7669; --Welcome to the only weaponry store in Bastok, the Dragon's Claws!
-         CIQALA_SHOP_DIALOG =  7670; --A weapon is the most precious thing to an adventurer! Well, after his life, of course.
-      PERITRAGE_SHOP_DIALOG =  7671; --Hey! I've got just the thing for you!
-      BRUNHILDE_SHOP_DIALOG =  7672; --Welcome to my store! You want armor, you want shields? I've got them all!
-CHARGINGCHOKOBO_SHOP_DIALOG =  7673; --Hello. What piece of armor are you missing?
-      BALTHILDA_SHOP_DIALOG =  7674; --Feeling defenseless of late? Brunhilde's Armory has got you covered!
-          MJOLL_SHOP_DIALOG =  7675; --Welcome. Have a look and compare! You'll never find better wares anywhere.
-          OLWYN_SHOP_DIALOG =  7676; --Welcome to Mjoll's Goods! What can I do for you?
-          ZAIRA_SHOP_DIALOG =  7677; --Greetings. What spell are you looking for?
-         SORORO_SHOP_DIALOG =  7678; --Hello-mellow, welcome to Sororo's Scribe and Notary!
-      HARMODIOS_SHOP_DIALOG =  7679; --Add music to your adventuring life! Welcome to Harmodios's.
-      CARMELIDE_SHOP_DIALOG =  7680; --Ah, welcome, welcome! What might I interest you in?
-          RAGHD_SHOP_DIALOG =  7681; --Give a smile to that special someone! Welcome to Carmelide's.
-       HORTENSE_SHOP_DIALOG =  7682; --Hello there! We have instruments and music sheets at Harmodios's!
-       OGGODETT_OPEN_DIALOG =  7683; --Hello there! Might I interest you in some specialty goods from Aragoneu?
-         YAFAFA_OPEN_DIALOG =  7684; --Hello! I've got some goods from Kolshushu--interested?
-      SOMNPAEMN_OPEN_DIALOG =  7685; --Welcome! I have goods straight from Sarutabaruta! What say you?
+         TEERTH_SHOP_DIALOG =  7669; --Welcome to the Goldsmiths' Guild shop. What can I do for you?
+         VISALA_SHOP_DIALOG =  7670; --Welcome to the Goldsmiths' Guild shop. How may I help you?
+        ZHIKKOM_SHOP_DIALOG =  7671; --Welcome to the only weaponry store in Bastok, the Dragon's Claws!
+         CIQALA_SHOP_DIALOG =  7672; --A weapon is the most precious thing to an adventurer! Well, after his life, of course.
+      PERITRAGE_SHOP_DIALOG =  7673; --Hey! I've got just the thing for you!
+      BRUNHILDE_SHOP_DIALOG =  7674; --Welcome to my store! You want armor, you want shields? I've got them all!
+CHARGINGCHOKOBO_SHOP_DIALOG =  7675; --Hello. What piece of armor are you missing?
+      BALTHILDA_SHOP_DIALOG =  7676; --Feeling defenseless of late? Brunhilde's Armory has got you covered!
+          MJOLL_SHOP_DIALOG =  7677; --Welcome. Have a look and compare! You'll never find better wares anywhere.
+          OLWYN_SHOP_DIALOG =  7678; --Welcome to Mjoll's Goods! What can I do for you?
+          ZAIRA_SHOP_DIALOG =  7679; --Greetings. What spell are you looking for?
+         SORORO_SHOP_DIALOG =  7680; --Hello-mellow, welcome to Sororo's Scribe and Notary!
+      HARMODIOS_SHOP_DIALOG =  7681; --Add music to your adventuring life! Welcome to Harmodios's.
+      CARMELIDE_SHOP_DIALOG =  7682; --Ah, welcome, welcome! What might I interest you in?
+          RAGHD_SHOP_DIALOG =  7683; --Give a smile to that special someone! Welcome to Carmelide's.
+       HORTENSE_SHOP_DIALOG =  7684; --Hello there! We have instruments and music sheets at Harmodios's!
+       OGGODETT_OPEN_DIALOG =  7685; --Hello there! Might I interest you in some specialty goods from Aragoneu?
+         YAFAFA_OPEN_DIALOG =  7686; --Hello! I've got some goods from Kolshushu--interested?
+      SOMNPAEMN_OPEN_DIALOG =  7687; --Welcome! I have goods straight from Sarutabaruta! What say you?
 
 -- conquest Base
-              CONQUEST_BASE = 6577; -- Tallying conquest results...
+              CONQUEST_BASE = 6578; -- Tallying conquest results...
 
 -- Porter Moogle
-         RETRIEVE_DIALOG_ID = 12866; -- You retrieve$ from the porter moogle's care.
+         RETRIEVE_DIALOG_ID = 12868; -- You retrieve$ from the porter moogle's care.

--- a/scripts/zones/Bastok_Markets_[S]/TextIDs.lua
+++ b/scripts/zones/Bastok_Markets_[S]/TextIDs.lua
@@ -1,19 +1,19 @@
 -- Variable TextID   Description text
 
 -- General Texts
-ITEM_CANNOT_BE_OBTAINED = 11215; -- You cannot obtain the item <item> come back again after sorting your inventory
-          ITEM_OBTAINED = 6384; -- Obtained: <item>
-           GIL_OBTAINED = 6385; -- Obtained <number> gil
-       KEYITEM_OBTAINED = 6387; -- Obtained key item: <keyitem>
- FISHING_MESSAGE_OFFSET = 7045; -- You can't fish here
+ITEM_CANNOT_BE_OBTAINED = 11216; -- You cannot obtain the item <item> come back again after sorting your inventory
+          ITEM_OBTAINED = 6385; -- Obtained: <item>
+           GIL_OBTAINED = 6386; -- Obtained <number> gil
+       KEYITEM_OBTAINED = 6388; -- Obtained key item: <keyitem>
+ FISHING_MESSAGE_OFFSET = 7046; -- You can't fish here
 
 -- Other Texts
-KARLOTTE_DELIVERY_DIALOG = 10855; -- I am here to help with all your parcel delivery needs.
-  WELDON_DELIVERY_DIALOG = 10856; -- Do you have something you wish to send?
+KARLOTTE_DELIVERY_DIALOG = 10856; -- I am here to help with all your parcel delivery needs.
+  WELDON_DELIVERY_DIALOG = 10857; -- Do you have something you wish to send?
 
 -- Shop Texts
-   BLINGBRIX_SHOP_DIALOG = 7195; -- Blingbrix good Gobbie from Boodlix's! Boodlix's Emporium help fighting fighters and maging mages. Gil okay, okay
-       SILKE_SHOP_DIALOG = 12796; -- You wouldn't happen to be a fellow scholar, by any chance? The contents of these pages are beyond me, but perhaps you might glean something from them. They could be yours...for a nominal fee.
+   BLINGBRIX_SHOP_DIALOG = 7196; -- Blingbrix good Gobbie from Boodlix's! Boodlix's Emporium help fighting fighters and maging mages. Gil okay, okay
+       SILKE_SHOP_DIALOG = 12797; -- You wouldn't happen to be a fellow scholar, by any chance? The contents of these pages are beyond me, but perhaps you might glean something from them. They could be yours...for a nominal fee.
 
 -- Porter Moogle
-      RETRIEVE_DIALOG_ID = 14708; -- You retrieve$ from the porter moogle's care.
+      RETRIEVE_DIALOG_ID = 14709; -- You retrieve$ from the porter moogle's care.

--- a/scripts/zones/Bastok_Mines/TextIDs.lua
+++ b/scripts/zones/Bastok_Mines/TextIDs.lua
@@ -3,83 +3,83 @@
 -- General Texts
        ITEM_CANNOT_BE_OBTAINED =  6379; -- Come back after sorting your inventory.
     FULL_INVENTORY_AFTER_TRADE =  6383; -- Try trading again after sorting your inventory.
-                 ITEM_OBTAINED =  6384; -- Obtained: <<<Unknown Parameter (Type: 80) 1>>><<<Possible Special Code: 01>>><<<Possible Special Code: 05>>>
-                  GIL_OBTAINED =  6385; -- Obtained <<<Numeric Parameter 0>>> gil.
-           NOT_HAVE_ENOUGH_GIL =  6389; -- You do not have enough gil.
-              KEYITEM_OBTAINED =  6387; -- Obtained key item: <<<Unknown Parameter (Type: 80) 1>>>
-                 HOMEPOINT_SET =  6475; -- Home point set!
-               ALCHEMY_SUPPORT =  7047; -- Your Multiple Choice (Parameter 1)[fishing/woodworking/smithing/goldsmithing/clothcraft/leatherworking/bonecraft/alchemy/cooking] skills went up
-      GUILD_TERMINATE_CONTRACT =  7061; -- You have terminated your trading contract with the Multiple Choice (Parameter 1)[Fishermen's/Carpenters'/Blacksmiths'/Goldsmiths'/Weavers'/Tanners'/Boneworkers'/Alchemists'/Culinarians'] Guild and formed a new one with the Multiple Choice (Parameter 0)[Fishermen's/Carpenters'/Blacksmiths'/Goldsmiths'/Weavers'/Tanners'/Boneworkers'/Alchemists'/Culinarians'] Guild
-            GUILD_NEW_CONTRACT =  7069; -- You have formed a new trading contract with the Multiple Choice (Parameter 0)[Fishermen's/Carpenters'/Blacksmiths'/Goldsmiths'/Weavers'/Tanners'/Boneworkers'/Alchemists'/Culinarians'] Guild
-           NO_MORE_GP_ELIGIBLE =  7076; -- You are not eligible to receive guild points at this time.
-                   GP_OBTAINED =  7081; -- Obtained: ?Numeric Parameter 0? guild points.
-            NOT_HAVE_ENOUGH_GP =  7082; -- You do not have enough guild points.
-        FISHING_MESSAGE_OFFSET = 10792; -- You can't fish here.
+                 ITEM_OBTAINED =  6385; -- Obtained: <<<Unknown Parameter (Type: 80) 1>>><<<Possible Special Code: 01>>><<<Possible Special Code: 05>>>
+                  GIL_OBTAINED =  6386; -- Obtained <<<Numeric Parameter 0>>> gil.
+           NOT_HAVE_ENOUGH_GIL =  6390; -- You do not have enough gil.
+              KEYITEM_OBTAINED =  6388; -- Obtained key item: <<<Unknown Parameter (Type: 80) 1>>>
+                 HOMEPOINT_SET =  6476; -- Home point set!
+               ALCHEMY_SUPPORT =  7048; -- Your Multiple Choice (Parameter 1)[fishing/woodworking/smithing/goldsmithing/clothcraft/leatherworking/bonecraft/alchemy/cooking] skills went up
+      GUILD_TERMINATE_CONTRACT =  7062; -- You have terminated your trading contract with the Multiple Choice (Parameter 1)[Fishermen's/Carpenters'/Blacksmiths'/Goldsmiths'/Weavers'/Tanners'/Boneworkers'/Alchemists'/Culinarians'] Guild and formed a new one with the Multiple Choice (Parameter 0)[Fishermen's/Carpenters'/Blacksmiths'/Goldsmiths'/Weavers'/Tanners'/Boneworkers'/Alchemists'/Culinarians'] Guild
+            GUILD_NEW_CONTRACT =  7070; -- You have formed a new trading contract with the Multiple Choice (Parameter 0)[Fishermen's/Carpenters'/Blacksmiths'/Goldsmiths'/Weavers'/Tanners'/Boneworkers'/Alchemists'/Culinarians'] Guild
+           NO_MORE_GP_ELIGIBLE =  7077; -- You are not eligible to receive guild points at this time.
+                   GP_OBTAINED =  7082; -- Obtained: ?Numeric Parameter 0? guild points.
+            NOT_HAVE_ENOUGH_GP =  7083; -- You do not have enough guild points.
+        FISHING_MESSAGE_OFFSET = 10794; -- You can't fish here.
 
 -- Conquest System
-CONQUEST = 11103; --You've earned conquest points!
+CONQUEST = 11105; --You've earned conquest points!
 
 -- Mission Dialogs
-      YOU_ACCEPT_THE_MISSION =  6504; -- You have accepted the mission.
-       ORIGINAL_MISSION_OFFSET =  6509; -- You can consult the ission section of the main menu to review your objectives. Speed and efficiency are your priorities. Dismissed. 
-   EXTENDED_MISSION_OFFSET = 11606; -- Go to Ore Street and talk to Medicine Eagle. He says he was there when the commotion started.
+      YOU_ACCEPT_THE_MISSION =  6505; -- You have accepted the mission.
+       ORIGINAL_MISSION_OFFSET =  6510; -- You can consult the ission section of the main menu to review your objectives. Speed and efficiency are your priorities. Dismissed. 
+   EXTENDED_MISSION_OFFSET = 11608; -- Go to Ore Street and talk to Medicine Eagle. He says he was there when the commotion started.
 
 -- Dynamis dialogs
-      YOU_CANNOT_ENTER_DYNAMIS = 11716; -- You cannot enter Dynamis
-PLAYERS_HAVE_NOT_REACHED_LEVEL = 11718; -- Players who have not reached levelare prohibited from entering Dynamis.
-   UNUSUAL_ARRANGEMENT_PEBBLES = 11729; -- There is an unusual arrangement of pebbles here.
+      YOU_CANNOT_ENTER_DYNAMIS = 11718; -- You cannot enter Dynamis
+PLAYERS_HAVE_NOT_REACHED_LEVEL = 11720; -- Players who have not reached levelare prohibited from entering Dynamis.
+   UNUSUAL_ARRANGEMENT_PEBBLES = 11731; -- There is an unusual arrangement of pebbles here.
 
 -- Dialog Texts
-   HEMEWMEW_DIALOG =  7054; -- I have been appointed by the Guildworkers' Union to manage the trading of manufactured crafts and the exchange of guild points.
-  VIRNAGE_DIALOG_1 = 10974; -- They stayed in a citadel on the Sauromugue Champaign. The paint may be there still!
-  VIRNAGE_DIALOG_2 = 10980; -- Hand my letter to Eperdur in the San d'Oria Cathedral to claim your reward.
-THE_GATE_IS_LOCKED = 12151; -- The gate is locked.
+   HEMEWMEW_DIALOG =  7055; -- I have been appointed by the Guildworkers' Union to manage the trading of manufactured crafts and the exchange of guild points.
+  VIRNAGE_DIALOG_1 = 10976; -- They stayed in a citadel on the Sauromugue Champaign. The paint may be there still!
+  VIRNAGE_DIALOG_2 = 10982; -- Hand my letter to Eperdur in the San d'Oria Cathedral to claim your reward.
+THE_GATE_IS_LOCKED = 12153; -- The gate is locked.
 
 -- Harvest Festival
-      TRICK_OR_TREAT = 11678; -- Trick or treat...
-     THANK_YOU_TREAT = 11679; -- And now for your treat...
-      HERE_TAKE_THIS = 11680; -- Here, take this...
-    IF_YOU_WEAR_THIS = 11681; -- If you put this on and walk around, something...unexpected might happen...
-           THANK_YOU = 11679; -- Thank you...
+      TRICK_OR_TREAT = 11680; -- Trick or treat...
+     THANK_YOU_TREAT = 11681; -- And now for your treat...
+      HERE_TAKE_THIS = 11682; -- Here, take this...
+    IF_YOU_WEAR_THIS = 11683; -- If you put this on and walk around, something...unexpected might happen...
+           THANK_YOU = 11681; -- Thank you...
 
 -- Shop Texts
-         FAUSTIN_CLOSED_DIALOG = 10771; -- I'm trying to start a business selling goods from Ronfaure,
-      RODELLIEUX_CLOSED_DIALOG = 10772; -- I'm trying to start a business selling goods from Fauregandi,
-           MILLE_CLOSED_DIALOG = 10773; -- I'm trying to start a business selling goods from Norvallen,
-         TIBELDA_CLOSED_DIALOG = 10774; -- I'm trying to start a business selling goods from Valdeaunia,
-          GALDEO_CLOSED_DIALOG = 10775; -- I'm trying to start a business selling goods from Li'Telor,
+         FAUSTIN_CLOSED_DIALOG = 10773; -- I'm trying to start a business selling goods from Ronfaure,
+      RODELLIEUX_CLOSED_DIALOG = 10774; -- I'm trying to start a business selling goods from Fauregandi,
+           MILLE_CLOSED_DIALOG = 10775; -- I'm trying to start a business selling goods from Norvallen,
+         TIBELDA_CLOSED_DIALOG = 10776; -- I'm trying to start a business selling goods from Valdeaunia,
+          GALDEO_CLOSED_DIALOG = 10777; -- I'm trying to start a business selling goods from Li'Telor,
 
-            DEEGIS_SHOP_DIALOG = 10892; -- The only things an adventurer needs are courage and a good suit of armor! Welcome to Deegis's Armour!
-          ZEMEDARS_SHOP_DIALOG = 10893; -- Everything in our store is top-grade and Galka-made! What're you lookin' for?
-             BOYTZ_SHOP_DIALOG = 10894; -- Welcome to Boytz's Knickknacks.
-          GELZERIO_SHOP_DIALOG = 10895; -- ...Yes?
-          GRISELDA_SHOP_DIALOG = 10896; -- Good of you to drop by the Bat's Lair Inn! Why don't you try some of our specialty plates?
-        NEIGEPANCE_SHOP_DIALOG = 10897; -- Hello there. A well-fed chocobo is a happy chocobo!
+            DEEGIS_SHOP_DIALOG = 10894; -- The only things an adventurer needs are courage and a good suit of armor! Welcome to Deegis's Armour!
+          ZEMEDARS_SHOP_DIALOG = 10895; -- Everything in our store is top-grade and Galka-made! What're you lookin' for?
+             BOYTZ_SHOP_DIALOG = 10896; -- Welcome to Boytz's Knickknacks.
+          GELZERIO_SHOP_DIALOG = 10897; -- ...Yes?
+          GRISELDA_SHOP_DIALOG = 10898; -- Good of you to drop by the Bat's Lair Inn! Why don't you try some of our specialty plates?
+        NEIGEPANCE_SHOP_DIALOG = 10899; -- Hello there. A well-fed chocobo is a happy chocobo!
 
-           FAUSTIN_OPEN_DIALOG = 10898; -- Hello there! Might I interest you specialty goods from Ronfaure?
-             MILLE_OPEN_DIALOG = 10899; -- Hello there! Might I interest you specialty goods from Norvallen?
-        RODELLIEUX_OPEN_DIALOG = 10900; -- Hello there! Might I interest you specialty goods from Fauregandi?
-           TIBELDA_OPEN_DIALOG = 10901; -- Goods of all varieties, imported directly from the northern land of Valdeaunia!
-          MAYMUNAH_SHOP_DIALOG = 10902; -- Welcome to the Alchemists' Guild! Looking for something specific?
-             ODOBA_SHOP_DIALOG = 10903; -- Welcome to the Alchemists' Guild. How may I help you?
+           FAUSTIN_OPEN_DIALOG = 10900; -- Hello there! Might I interest you specialty goods from Ronfaure?
+             MILLE_OPEN_DIALOG = 10901; -- Hello there! Might I interest you specialty goods from Norvallen?
+        RODELLIEUX_OPEN_DIALOG = 10902; -- Hello there! Might I interest you specialty goods from Fauregandi?
+           TIBELDA_OPEN_DIALOG = 10903; -- Goods of all varieties, imported directly from the northern land of Valdeaunia!
+          MAYMUNAH_SHOP_DIALOG = 10904; -- Welcome to the Alchemists' Guild! Looking for something specific?
+             ODOBA_SHOP_DIALOG = 10905; -- Welcome to the Alchemists' Guild. How may I help you?
 
-            GALDEO_OPEN_DIALOG = 11463; -- Come! Take a look at all the wonderful goods from Li'Telor.
+            GALDEO_OPEN_DIALOG = 11465; -- Come! Take a look at all the wonderful goods from Li'Telor.
 
-           AULAVIA_OPEN_DIALOG = 11464; -- May I interest you in some specialty goods from Vollbow?
-         AULAVIA_CLOSED_DIALOG = 11465; -- I'm trying to start a business selling goods from Vollbow,
+           AULAVIA_OPEN_DIALOG = 11466; -- May I interest you in some specialty goods from Vollbow?
+         AULAVIA_CLOSED_DIALOG = 11467; -- I'm trying to start a business selling goods from Vollbow,
 
-        PROUDBEARD_SHOP_DIALOG = 11634; -- Would you be interested in a nice suit of adventurer-issue armor? Be careful when you buy, though. We offer no refunds.
+        PROUDBEARD_SHOP_DIALOG = 11636; -- Would you be interested in a nice suit of adventurer-issue armor? Be careful when you buy, though. We offer no refunds.
 
-EMALIVEULAUX_COP_NOT_COMPLETED = 12232; -- I'd like to start my own business someday, but I just haven't found anything that truly interests me.
-      EMALIVEULAUX_OPEN_DIALOG = 12233; -- Rare Tavnazian imports! Get them before they're gone!
-    EMALIVEULAUX_CLOSED_DIALOG = 12234; -- I'd love to sell you goods imported from the island of Tavnazia, but with the area under foreign control, I can't secure my trade routes...
+EMALIVEULAUX_COP_NOT_COMPLETED = 12234; -- I'd like to start my own business someday, but I just haven't found anything that truly interests me.
+      EMALIVEULAUX_OPEN_DIALOG = 12235; -- Rare Tavnazian imports! Get them before they're gone!
+    EMALIVEULAUX_CLOSED_DIALOG = 12236; -- I'd love to sell you goods imported from the island of Tavnazia, but with the area under foreign control, I can't secure my trade routes...
 
 -- Weather Dialog
-MARIADOK_DIALOG = 6736; -- Your fate rides on the changing winds of Vana'diel. I can give you insight on the local weather.
+MARIADOK_DIALOG = 6737; -- Your fate rides on the changing winds of Vana'diel. I can give you insight on the local weather.
 
 -- Standard NPC Dialog
-ITEM_DELIVERY_DIALOG = 10427; -- Need something sent to a friend's house? Sending items to your own house? You've come to the right place!
+ITEM_DELIVERY_DIALOG = 10429; -- Need something sent to a friend's house? Sending items to your own house? You've come to the right place!
 
 -- conquest Base
-CONQUEST_BASE = 6577; -- Tallying conquest results...
+CONQUEST_BASE = 6578; -- Tallying conquest results...
 

--- a/scripts/zones/Batallia_Downs/TextIDs.lua
+++ b/scripts/zones/Batallia_Downs/TextIDs.lua
@@ -2,17 +2,17 @@
 
 -- General Texts
 ITEM_CANNOT_BE_OBTAINED = 6401; -- You cannot obtain the item <item>. Come back after sorting your inventory.
-          ITEM_OBTAINED = 6406; -- Obtained: <item>.
-           GIL_OBTAINED = 6407; -- Obtained <number> gil.
-       KEYITEM_OBTAINED = 6409; -- Obtained key item: <keyitem>.
- FISHING_MESSAGE_OFFSET = 7226; -- You can't fish here.
+          ITEM_OBTAINED = 6407; -- Obtained: <item>.
+           GIL_OBTAINED = 6408; -- Obtained <number> gil.
+       KEYITEM_OBTAINED = 6410; -- Obtained key item: <keyitem>.
+ FISHING_MESSAGE_OFFSET = 7227; -- You can't fish here.
 
 -- Other Dialog
-NOTHING_HAPPENS = 7326; -- Nothing happens...
+NOTHING_HAPPENS = 7327; -- Nothing happens...
 
 -- conquest Base
-CONQUEST_BASE = 7067; -- Tallying conquest results...
+CONQUEST_BASE = 7068; -- Tallying conquest results...
 
 --chocobo digging
-DIG_THROW_AWAY = 7239; -- You dig up$, but your inventory is full. You regretfully throw the # away.
-FIND_NOTHING = 7241; -- You dig and you dig, but find nothing.
+DIG_THROW_AWAY = 7240; -- You dig up$, but your inventory is full. You regretfully throw the # away.
+FIND_NOTHING = 7242; -- You dig and you dig, but find nothing.

--- a/scripts/zones/Batallia_Downs_[S]/TextIDs.lua
+++ b/scripts/zones/Batallia_Downs_[S]/TextIDs.lua
@@ -2,7 +2,7 @@
 
 -- General Texts
 ITEM_CANNOT_BE_OBTAINED = 6379; -- You cannot obtain the item <item> come back again after sorting your inventory
-          ITEM_OBTAINED = 6384; -- Obtained: <item>
-           GIL_OBTAINED = 6385; -- Obtained <number> gil
-       KEYITEM_OBTAINED = 6387; -- Obtained key item: <keyitem>
- FISHING_MESSAGE_OFFSET = 7065; -- You can't fish here
+          ITEM_OBTAINED = 6385; -- Obtained: <item>
+           GIL_OBTAINED = 6386; -- Obtained <number> gil
+       KEYITEM_OBTAINED = 6388; -- Obtained key item: <keyitem>
+ FISHING_MESSAGE_OFFSET = 7066; -- You can't fish here

--- a/scripts/zones/Beadeaux/TextIDs.lua
+++ b/scripts/zones/Beadeaux/TextIDs.lua
@@ -2,26 +2,26 @@
 
 -- General Texts
 ITEM_CANNOT_BE_OBTAINED = 6379; -- You cannot obtain the item <item>. Come back after sorting your inventory.
-          ITEM_OBTAINED = 6384; -- Obtained: <item>.
-           GIL_OBTAINED = 6385; -- Obtained <number> gil.
-       KEYITEM_OBTAINED = 6387; -- Obtained key item: <keyitem>.
-         ITEMS_OBTAINED = 6390; -- You obtain <param2 number> <param1 item>!
+          ITEM_OBTAINED = 6385; -- Obtained: <item>.
+           GIL_OBTAINED = 6386; -- Obtained <number> gil.
+       KEYITEM_OBTAINED = 6388; -- Obtained key item: <keyitem>.
+         ITEMS_OBTAINED = 6391; -- You obtain <param2 number> <param1 item>!
 
 -- Treasure Coffer/Chest Dialog
-    CHEST_UNLOCKED = 7355; -- You unlock the chest!
-        CHEST_FAIL = 7356; -- Fails to open the chest.
-        CHEST_TRAP = 7357; -- The chest was trapped!
-        CHEST_WEAK = 7358; -- You cannot open the chest when you are in a weakened state.
-       CHEST_MIMIC = 7359; -- The chest was a mimic!
-      CHEST_MOOGLE = 7360; -- You cannot open the chest while participating in the moogle event.
-    CHEST_ILLUSION = 7361; -- The chest was but an illusion...
-      CHEST_LOCKED = 7362; -- The chest appears to be locked.
+    CHEST_UNLOCKED = 7356; -- You unlock the chest!
+        CHEST_FAIL = 7357; -- Fails to open the chest.
+        CHEST_TRAP = 7358; -- The chest was trapped!
+        CHEST_WEAK = 7359; -- You cannot open the chest when you are in a weakened state.
+       CHEST_MIMIC = 7360; -- The chest was a mimic!
+      CHEST_MOOGLE = 7361; -- You cannot open the chest while participating in the moogle event.
+    CHEST_ILLUSION = 7362; -- The chest was but an illusion...
+      CHEST_LOCKED = 7363; -- The chest appears to be locked.
 
 -- Quest Dialog
-      LOCKED_DOOR_QUADAV_HAS_KEY = 7208; -- It is locked tight, but has what looks like a keyhole. Maybe one of the Quadav here has the key.
-         NOTHING_OUT_OF_ORDINARY = 7693; -- There is nothing out of the ordinary here.
-YOU_CAN_NOW_BECOME_A_DARK_KNIGHT = 7345; -- You can now become a dark knight!
+      LOCKED_DOOR_QUADAV_HAS_KEY = 7209; -- It is locked tight, but has what looks like a keyhole. Maybe one of the Quadav here has the key.
+         NOTHING_OUT_OF_ORDINARY = 7694; -- There is nothing out of the ordinary here.
+YOU_CAN_NOW_BECOME_A_DARK_KNIGHT = 7346; -- You can now become a dark knight!
 
 -- conquest Base
-CONQUEST_BASE = 7045; -- Tallying conquest results...
+CONQUEST_BASE = 7046; -- Tallying conquest results...
 

--- a/scripts/zones/Beadeaux_[S]/TextIDs.lua
+++ b/scripts/zones/Beadeaux_[S]/TextIDs.lua
@@ -2,6 +2,6 @@
 
 -- General Texts
 ITEM_CANNOT_BE_OBTAINED = 6379; -- You cannot obtain the item <item> come back again after sorting your inventory
-          ITEM_OBTAINED = 6384; -- Obtained: <item>
-           GIL_OBTAINED = 6385; -- Obtained <number> gil
-       KEYITEM_OBTAINED = 6387; -- Obtained key item: <keyitem>
+          ITEM_OBTAINED = 6385; -- Obtained: <item>
+           GIL_OBTAINED = 6386; -- Obtained <number> gil
+       KEYITEM_OBTAINED = 6388; -- Obtained key item: <keyitem>

--- a/scripts/zones/Bearclaw_Pinnacle/TextIDs.lua
+++ b/scripts/zones/Bearclaw_Pinnacle/TextIDs.lua
@@ -2,9 +2,9 @@
 
 -- General Texts
 ITEM_CANNOT_BE_OBTAINED = 6379; -- You cannot obtain the item <item>. Come back after sorting your inventory.
-          ITEM_OBTAINED = 6384; -- Obtained: <item>.
-           GIL_OBTAINED = 6385; -- Obtained <number> gil.
-       KEYITEM_OBTAINED = 6387; -- Obtained key item: <keyitem>.
+          ITEM_OBTAINED = 6385; -- Obtained: <item>.
+           GIL_OBTAINED = 6386; -- Obtained <number> gil.
+       KEYITEM_OBTAINED = 6388; -- Obtained key item: <keyitem>.
 
 -- conquest Base
-CONQUEST_BASE = 7416; -- Tallying conquest results...
+CONQUEST_BASE = 7417; -- Tallying conquest results...

--- a/scripts/zones/Beaucedine_Glacier/TextIDs.lua
+++ b/scripts/zones/Beaucedine_Glacier/TextIDs.lua
@@ -3,23 +3,23 @@
 -- General Texts
    ITEM_CANNOT_BE_OBTAINED = 6562; -- You cannot obtain the item. Come back after sorting your inventory.
 FULL_INVENTORY_AFTER_TRADE = 6564; -- You cannot obtain the #. Try trading again after sorting your inventory.
-             ITEM_OBTAINED = 6565; -- Obtained: <item>.
-              GIL_OBTAINED = 6566; -- Obtained <number> gil.
-          KEYITEM_OBTAINED = 6568; -- Obtained key item: <keyitem>.
-            ITEMS_OBTAINED = 6571; -- You obtain
+             ITEM_OBTAINED = 6566; -- Obtained: <item>.
+              GIL_OBTAINED = 6567; -- Obtained <number> gil.
+          KEYITEM_OBTAINED = 6569; -- Obtained key item: <keyitem>.
+            ITEMS_OBTAINED = 6572; -- You obtain
            BEASTMEN_BANNER = 81; -- There is a beastmen's banner.
-    FISHING_MESSAGE_OFFSET = 7226; -- You can't fish here.
+    FISHING_MESSAGE_OFFSET = 7227; -- You can't fish here.
 
 -- Conquest
-CONQUEST = 7479; -- You've earned conquest points!
+CONQUEST = 7480; -- You've earned conquest points!
 
 -- Other dialog
-NOTHING_OUT_OF_ORDINARY = 6579; -- There is nothing out of the ordinary here.
+NOTHING_OUT_OF_ORDINARY = 6580; -- There is nothing out of the ordinary here.
 
 -- Dynamis dialogs
-       YOU_CANNOT_ENTER_DYNAMIS = 7859; -- You cannot enter Dynamis
- PLAYERS_HAVE_NOT_REACHED_LEVEL = 7861; -- Players who have not reached levelare prohibited from entering Dynamis.
-UNUSUAL_ARRANGEMENT_OF_BRANCHES = 7871; -- There is an unusual arrangement of branches here.
+       YOU_CANNOT_ENTER_DYNAMIS = 7860; -- You cannot enter Dynamis
+ PLAYERS_HAVE_NOT_REACHED_LEVEL = 7862; -- Players who have not reached levelare prohibited from entering Dynamis.
+UNUSUAL_ARRANGEMENT_OF_BRANCHES = 7872; -- There is an unusual arrangement of branches here.
 
 -- conquest Base
 CONQUEST_BASE = 0;

--- a/scripts/zones/Beaucedine_Glacier_[S]/TextIDs.lua
+++ b/scripts/zones/Beaucedine_Glacier_[S]/TextIDs.lua
@@ -2,6 +2,6 @@
 
 -- General Texts
 ITEM_CANNOT_BE_OBTAINED = 6379; -- You cannot obtain the item <item> come back again after sorting your inventory
-          ITEM_OBTAINED = 6384; -- Obtained: <item>
-           GIL_OBTAINED = 6385; -- Obtained <number> gil
-       KEYITEM_OBTAINED = 6387; -- Obtained key item: <keyitem>
+          ITEM_OBTAINED = 6385; -- Obtained: <item>
+           GIL_OBTAINED = 6386; -- Obtained <number> gil
+       KEYITEM_OBTAINED = 6388; -- Obtained key item: <keyitem>

--- a/scripts/zones/Behemoths_Dominion/TextIDs.lua
+++ b/scripts/zones/Behemoths_Dominion/TextIDs.lua
@@ -2,19 +2,19 @@
 
 -- General Texts
 ITEM_CANNOT_BE_OBTAINED = 6379; -- You cannot obtain the item <item>. Come back after sorting your inventory.
-          ITEM_OBTAINED = 6384; -- Obtained: <item>.
-           GIL_OBTAINED = 6385; -- Obtained <number> gil.
-       KEYITEM_OBTAINED = 6387; -- Obtained key item: <keyitem>.
+          ITEM_OBTAINED = 6385; -- Obtained: <item>.
+           GIL_OBTAINED = 6386; -- Obtained <number> gil.
+       KEYITEM_OBTAINED = 6388; -- Obtained key item: <keyitem>.
 
-    SENSE_OF_FOREBODING = 6399; -- You are suddenly overcome with a sense of foreboding...
-NOTHING_OUT_OF_ORDINARY = 6398; -- There is nothing out of the ordinary here.
-    IRREPRESSIBLE_MIGHT = 6402; -- An aura of irrepressible might threatens to overwhelm you...
+    SENSE_OF_FOREBODING = 6400; -- You are suddenly overcome with a sense of foreboding...
+NOTHING_OUT_OF_ORDINARY = 6399; -- There is nothing out of the ordinary here.
+    IRREPRESSIBLE_MIGHT = 6403; -- An aura of irrepressible might threatens to overwhelm you...
 
 -- ZM4 Dialog
-      ZILART_MONUMENT = 7318; -- It is an ancient Zilart monument.?Prompt?
-ALREADY_OBTAINED_FRAG = 7315; -- You have already obtained this monument's
-      FOUND_ALL_FRAGS = 7317; -- You have obtained ! You now have all 8 fragments of light!
-   CANNOT_REMOVE_FRAG = 7314; -- It is an oddly shaped stone monument. A shining stone is embedded in it, but cannot be removed...?Prompt?
+      ZILART_MONUMENT = 7319; -- It is an ancient Zilart monument.?Prompt?
+ALREADY_OBTAINED_FRAG = 7316; -- You have already obtained this monument's
+      FOUND_ALL_FRAGS = 7318; -- You have obtained ! You now have all 8 fragments of light!
+   CANNOT_REMOVE_FRAG = 7315; -- It is an oddly shaped stone monument. A shining stone is embedded in it, but cannot be removed...?Prompt?
 
 -- conquest Base
-CONQUEST_BASE = 7045; -- Tallying conquest results...
+CONQUEST_BASE = 7046; -- Tallying conquest results...

--- a/scripts/zones/Bhaflau_Remnants/TextIDs.lua
+++ b/scripts/zones/Bhaflau_Remnants/TextIDs.lua
@@ -2,6 +2,6 @@
 
 -- General Texts
 ITEM_CANNOT_BE_OBTAINED = 6379; -- You cannot obtain the item <item> come back again after sorting your inventory
-          ITEM_OBTAINED = 6384; -- Obtained: <item>
-           GIL_OBTAINED = 6385; -- Obtained <number> gil
-       KEYITEM_OBTAINED = 6387; -- Obtained key item: <keyitem>
+          ITEM_OBTAINED = 6385; -- Obtained: <item>
+           GIL_OBTAINED = 6386; -- Obtained <number> gil
+       KEYITEM_OBTAINED = 6388; -- Obtained key item: <keyitem>

--- a/scripts/zones/Bhaflau_Thickets/TextIDs.lua
+++ b/scripts/zones/Bhaflau_Thickets/TextIDs.lua
@@ -2,22 +2,22 @@
 
 -- General Texts
 ITEM_CANNOT_BE_OBTAINED = 6379; -- You cannot obtain the item <item>. Come back after sorting your inventory.
-          ITEM_OBTAINED = 6384; -- Obtained: <item>.
-           GIL_OBTAINED = 6385; -- Obtained <number> gil.
-       KEYITEM_OBTAINED = 6387; -- Obtained key item: <keyitem>.
- FISHING_MESSAGE_OFFSET = 7045; -- You can't fish here.
-            HOMEPOINT_SET = 7688; -- Home point set!
+          ITEM_OBTAINED = 6385; -- Obtained: <item>.
+           GIL_OBTAINED = 6386; -- Obtained <number> gil.
+       KEYITEM_OBTAINED = 6388; -- Obtained key item: <keyitem>.
+ FISHING_MESSAGE_OFFSET = 7046; -- You can't fish here.
+            HOMEPOINT_SET = 7689; -- Home point set!
 
 -- Assault
-CANNOT_ENTER = 7580; -- You cannot enter at this time.  Please wait a while before trying again.
-AREA_FULL = 7581; -- This area is fully occupied. You were unable to enter.
-MEMBER_NO_REQS = 7585; -- Not all of your party members meet the requirements for this objective.  Unable to enter area.
-MEMBER_TOO_FAR = 7589; -- One or more party members are too far away from the entrance.  Unable to enter area.
+CANNOT_ENTER = 7581; -- You cannot enter at this time.  Please wait a while before trying again.
+AREA_FULL = 7582; -- This area is fully occupied. You were unable to enter.
+MEMBER_NO_REQS = 7586; -- Not all of your party members meet the requirements for this objective.  Unable to enter area.
+MEMBER_TOO_FAR = 7590; -- One or more party members are too far away from the entrance.  Unable to enter area.
  
 -- Other Texts
-NOTHING_HAPPENS = 7566; -- Nothing happens...
-RESPONSE = 7325; -- There is no response...
+NOTHING_HAPPENS = 7567; -- Nothing happens...
+RESPONSE = 7326; -- There is no response...
 
 --chocobo digging
-DIG_THROW_AWAY = 7058; -- You dig up$, but your inventory is full. You regretfully throw the # away.
-FIND_NOTHING = 7060; -- You dig and you dig, but find nothing.
+DIG_THROW_AWAY = 7059; -- You dig up$, but your inventory is full. You regretfully throw the # away.
+FIND_NOTHING = 7061; -- You dig and you dig, but find nothing.

--- a/scripts/zones/Bibiki_Bay/TextIDs.lua
+++ b/scripts/zones/Bibiki_Bay/TextIDs.lua
@@ -2,41 +2,41 @@
 
 -- General Texts
 ITEM_CANNOT_BE_OBTAINED = 6379; -- You cannot obtain the item <item> come back again after sorting your inventory.
-          ITEM_OBTAINED = 6384; -- Obtained: <item>.
-           GIL_OBTAINED = 6385; -- Obtained <number> gil.
-       KEYITEM_OBTAINED = 6387; -- Obtained key item: <keyitem>.
- FISHING_MESSAGE_OFFSET = 7260; -- You can't fish here.
+          ITEM_OBTAINED = 6385; -- Obtained: <item>.
+           GIL_OBTAINED = 6386; -- Obtained <number> gil.
+       KEYITEM_OBTAINED = 6388; -- Obtained key item: <keyitem>.
+ FISHING_MESSAGE_OFFSET = 7261; -- You can't fish here.
 
 -- Dialogs
- MEP_NHAPOPOLUKO_DIALOG = 7218; -- Welcome! Fishermen's Guild representative, at your service!?Prompt?
-NOTHING_OUT_OF_ORDINARY = 6398; -- There is nothing out of the ordinary here.
+ MEP_NHAPOPOLUKO_DIALOG = 7219; -- Welcome! Fishermen's Guild representative, at your service!?Prompt?
+NOTHING_OUT_OF_ORDINARY = 6399; -- There is nothing out of the ordinary here.
 
 -- Manaclipper
-  NO_BILLET = 7477; -- You were refused passage for failing to present
-HAVE_BILLET = 7482; -- You cannot buy morrre than one . Use the one you have now to ride the next ship.
-LEFT_BILLET = 7487; -- You use your
- END_BILLET = 7488; -- You use up your
-NEWS_BILLET = 7489; -- added to your
+  NO_BILLET = 7478; -- You were refused passage for failing to present
+HAVE_BILLET = 7483; -- You cannot buy morrre than one . Use the one you have now to ride the next ship.
+LEFT_BILLET = 7488; -- You use your
+ END_BILLET = 7489; -- You use up your
+NEWS_BILLET = 7490; -- added to your
 
 -- Conquest Base
-CONQUEST_BASE = 7045; -- Tallying conquest results...
+CONQUEST_BASE = 7046; -- Tallying conquest results...
 
 -- Shop Texts
-POHKA_SHOP_DIALOG = 7216; --Hey buddy, need a rod? I've got loads of state-of-the-art, top-of-the-line, high quality rods right here waitin' fer ya! Whaddya say?
+POHKA_SHOP_DIALOG = 7217; --Hey buddy, need a rod? I've got loads of state-of-the-art, top-of-the-line, high quality rods right here waitin' fer ya! Whaddya say?
 
 -- Clamming
-            YOU_OBTAIN = 6390; -- You obtain
-      WHOA_HOLD_ON_NOW = 7234; -- Whoa, hold on now. Ain't look like you got 'nuff room in that spiffy bag o' yours to carrrry all these darn clams.
- YOU_GIT_YER_BAG_READY = 7235; -- You git yer bag ready, pardner? Well alrighty then. Here'rrre yer clams.
-        YOU_RETURN_THE = 7242; -- You return the
-      AREA_IS_LITTERED = 7243; -- The area is littered with pieces of broken seashells.
-         YOU_FIND_ITEM = 7245; -- You find$ and toss it into your bucket
-THE_WEIGHT_IS_TOO_MUCH = 7246; -- You find$ and toss it into your bucket... But the weight is too much for the bucket and its bottom breaks! All your shellfish are washed back into the sea...
-    YOU_CANNOT_COLLECT = 7247; -- You cannot collect any clams with a broken bucket!
- IT_LOOKS_LIKE_SOMEONE = 7248; -- It looks like someone has been digging here.
-YOUR_CLAMMING_CAPACITY = 7256; -- Your clamming capacity has increased toponzes! Now you may be able to dig up a...
-  SOMETHING_JUMPS_INTO = 7259; -- Something jumps into your bucket and breaks through the bottom! All your shellfish are washed back into the sea...
+            YOU_OBTAIN = 6391; -- You obtain
+      WHOA_HOLD_ON_NOW = 7235; -- Whoa, hold on now. Ain't look like you got 'nuff room in that spiffy bag o' yours to carrrry all these darn clams.
+ YOU_GIT_YER_BAG_READY = 7236; -- You git yer bag ready, pardner? Well alrighty then. Here'rrre yer clams.
+        YOU_RETURN_THE = 7243; -- You return the
+      AREA_IS_LITTERED = 7244; -- The area is littered with pieces of broken seashells.
+         YOU_FIND_ITEM = 7246; -- You find$ and toss it into your bucket
+THE_WEIGHT_IS_TOO_MUCH = 7247; -- You find$ and toss it into your bucket... But the weight is too much for the bucket and its bottom breaks! All your shellfish are washed back into the sea...
+    YOU_CANNOT_COLLECT = 7248; -- You cannot collect any clams with a broken bucket!
+ IT_LOOKS_LIKE_SOMEONE = 7249; -- It looks like someone has been digging here.
+YOUR_CLAMMING_CAPACITY = 7257; -- Your clamming capacity has increased toponzes! Now you may be able to dig up a...
+  SOMETHING_JUMPS_INTO = 7260; -- Something jumps into your bucket and breaks through the bottom! All your shellfish are washed back into the sea...
   
 --chocobo digging
-DIG_THROW_AWAY = 7273; -- You dig up$, but your inventory is full. You regretfully throw the # away.
-FIND_NOTHING = 7275; -- You dig and you dig, but find nothing.
+DIG_THROW_AWAY = 7274; -- You dig up$, but your inventory is full. You regretfully throw the # away.
+FIND_NOTHING = 7276; -- You dig and you dig, but find nothing.

--- a/scripts/zones/Boneyard_Gully/TextIDs.lua
+++ b/scripts/zones/Boneyard_Gully/TextIDs.lua
@@ -2,9 +2,9 @@
 
 -- General Texts
 ITEM_CANNOT_BE_OBTAINED = 6379; -- You cannot obtain the item <item>. Come back after sorting your inventory.
-          ITEM_OBTAINED = 6384; -- Obtained: <item>.
-           GIL_OBTAINED = 6385; -- Obtained <number> gil.
-       KEYITEM_OBTAINED = 6387; -- Obtained key item: <keyitem>.
+          ITEM_OBTAINED = 6385; -- Obtained: <item>.
+           GIL_OBTAINED = 6386; -- Obtained <number> gil.
+       KEYITEM_OBTAINED = 6388; -- Obtained key item: <keyitem>.
 
 -- conquest Base
-CONQUEST_BASE = 7416; -- Tallying conquest results...
+CONQUEST_BASE = 7417; -- Tallying conquest results...

--- a/scripts/zones/Bostaunieux_Oubliette/TextIDs.lua
+++ b/scripts/zones/Bostaunieux_Oubliette/TextIDs.lua
@@ -3,14 +3,14 @@
 -- General Texts
           CONQUEST_BASE = 0;
 ITEM_CANNOT_BE_OBTAINED = 6538; -- You cannot obtain the item <item>. Come back after sorting your inventory.
-          ITEM_OBTAINED = 6543; -- Obtained: <item>.
-           GIL_OBTAINED = 6544; -- Obtained <number> gil.
-       KEYITEM_OBTAINED = 6546; -- Obtained key item: <keyitem>.
- FISHING_MESSAGE_OFFSET = 7204; -- You can't fish here.
+          ITEM_OBTAINED = 6544; -- Obtained: <item>.
+           GIL_OBTAINED = 6545; -- Obtained <number> gil.
+       KEYITEM_OBTAINED = 6547; -- Obtained key item: <keyitem>.
+ FISHING_MESSAGE_OFFSET = 7205; -- You can't fish here.
 
 -- General Dialog
-CHUMIA_DIALOG = 7304; -- Welcome to Bostaunieux Oubliette...
- SEEMS_LOCKED = 7306; -- It seems to be locked.
+CHUMIA_DIALOG = 7305; -- Welcome to Bostaunieux Oubliette...
+ SEEMS_LOCKED = 7307; -- It seems to be locked.
 
 -- conquest Base
 CONQUEST_BASE = 0;

--- a/scripts/zones/Buburimu_Peninsula/TextIDs.lua
+++ b/scripts/zones/Buburimu_Peninsula/TextIDs.lua
@@ -2,34 +2,34 @@
 
 -- General Texts
 ITEM_CANNOT_BE_OBTAINED = 6414; -- You cannot obtain the item <item>. Come back after sorting your inventory.
-          ITEM_OBTAINED = 6419; -- Obtained: <item>.
-           GIL_OBTAINED = 6420; -- Obtained <number> gil.
-       KEYITEM_OBTAINED = 6422; -- Obtained key item: <keyitem>.
-        BEASTMEN_BANNER = 7161; -- There is a beastmen's banner.
- FISHING_MESSAGE_OFFSET = 7245; -- You can't fish here.
+          ITEM_OBTAINED = 6420; -- Obtained: <item>.
+           GIL_OBTAINED = 6421; -- Obtained <number> gil.
+       KEYITEM_OBTAINED = 6423; -- Obtained key item: <keyitem>.
+        BEASTMEN_BANNER = 7162; -- There is a beastmen's banner.
+ FISHING_MESSAGE_OFFSET = 7246; -- You can't fish here.
 
 -- Conquest
-CONQUEST = 7408; -- You've earned conquest points!
+CONQUEST = 7409; -- You've earned conquest points!
 
 -- Logging
-LOGGING_IS_POSSIBLE_HERE = 7392; -- Logging is possible here if you have
+LOGGING_IS_POSSIBLE_HERE = 7393; -- Logging is possible here if you have
 
 -- Dialog Texts
-           FIVEOFSPADES_DIALOG = 7239; -- GiMmeIvE! FiVe is cArdIanF WiN-DuRst! FIvES OnA-tRol!
-      YOU_CANNOT_ENTER_DYNAMIS = 7884; -- You cannot enter Dynamis
-              MYSTERIOUS_VOICE = 7885; -- You hear a mysterious, floating voice: The guiding aura has not yet faded... Bring forth the
-PLAYERS_HAVE_NOT_REACHED_LEVEL = 7886; -- Players who have not reached levelare prohibited from entering Dynamis.
+           FIVEOFSPADES_DIALOG = 7240; -- GiMmeIvE! FiVe is cArdIanF WiN-DuRst! FIvES OnA-tRol!
+      YOU_CANNOT_ENTER_DYNAMIS = 7885; -- You cannot enter Dynamis
+              MYSTERIOUS_VOICE = 7886; -- You hear a mysterious, floating voice: The guiding aura has not yet faded... Bring forth the
+PLAYERS_HAVE_NOT_REACHED_LEVEL = 7887; -- Players who have not reached levelare prohibited from entering Dynamis.
 
 -- Signs
-SIGN_1 = 7387; -- West: Tahrongi Canyon Southeast: Mhaura
-SIGN_2 = 7388; -- West: Tahrongi Canyon South: Mhaura
-SIGN_3 = 7389; -- West: Tahrongi Canyon Southwest: Mhaura
-SIGN_4 = 7390; -- West: Mhaura and Tahrongi Canyon
-SIGN_5 = 7391; -- West: Mhaura Northwest: Tahrongi Canyon
+SIGN_1 = 7388; -- West: Tahrongi Canyon Southeast: Mhaura
+SIGN_2 = 7389; -- West: Tahrongi Canyon South: Mhaura
+SIGN_3 = 7390; -- West: Tahrongi Canyon Southwest: Mhaura
+SIGN_4 = 7391; -- West: Mhaura and Tahrongi Canyon
+SIGN_5 = 7392; -- West: Mhaura Northwest: Tahrongi Canyon
 
 -- conquest Base
-CONQUEST_BASE = 7080; -- Tallying conquest results...
+CONQUEST_BASE = 7081; -- Tallying conquest results...
 
 --chocobo digging
-DIG_THROW_AWAY = 7258; -- You dig up$, but your inventory is full. You regretfully throw the # away.
-FIND_NOTHING = 7260; -- You dig and you dig, but find nothing.
+DIG_THROW_AWAY = 7259; -- You dig up$, but your inventory is full. You regretfully throw the # away.
+FIND_NOTHING = 7261; -- You dig and you dig, but find nothing.

--- a/scripts/zones/Caedarva_Mire/TextIDs.lua
+++ b/scripts/zones/Caedarva_Mire/TextIDs.lua
@@ -2,25 +2,25 @@
 
 -- General Texts
 ITEM_CANNOT_BE_OBTAINED = 6379; -- You cannot obtain the item <item>. Come back after sorting your inventory.
-          ITEM_OBTAINED = 6384; -- Obtained: <item>.
-           GIL_OBTAINED = 6385; -- Obtained <number> gil.
-       KEYITEM_OBTAINED = 6387; -- Obtained key item: <keyitem>.
- FISHING_MESSAGE_OFFSET = 7045; -- You can't fish here.
-            HOMEPOINT_SET = 8970; -- Home point set!
+          ITEM_OBTAINED = 6385; -- Obtained: <item>.
+           GIL_OBTAINED = 6386; -- Obtained <number> gil.
+       KEYITEM_OBTAINED = 6388; -- Obtained key item: <keyitem>.
+ FISHING_MESSAGE_OFFSET = 7046; -- You can't fish here.
+            HOMEPOINT_SET = 8971; -- Home point set!
 
 -- Logging
-LOGGING_IS_POSSIBLE_HERE = 7339; -- Logging is possible here if you have
+LOGGING_IS_POSSIBLE_HERE = 7340; -- Logging is possible here if you have
 
 -- Assault
-CANNOT_ENTER = 7459; -- You cannot enter at this time.  Please wait a while before trying again.
-AREA_FULL = 7460; -- This area is fully occupied. You were unable to enter.
-MEMBER_NO_REQS = 7464; -- Not all of your party members meet the requirements for this objective.  Unable to enter area.
-MEMBER_TOO_FAR = 7468; -- One or more party members are too far away from the entrance.  Unable to enter area.
+CANNOT_ENTER = 7460; -- You cannot enter at this time.  Please wait a while before trying again.
+AREA_FULL = 7461; -- This area is fully occupied. You were unable to enter.
+MEMBER_NO_REQS = 7465; -- Not all of your party members meet the requirements for this objective.  Unable to enter area.
+MEMBER_TOO_FAR = 7469; -- One or more party members are too far away from the entrance.  Unable to enter area.
 
 -- Other Texts
-               RESPONSE = 7325; -- There is no response...
-NOTHING_OUT_OF_ORDINARY = 7377; --There is nothing out of the ordinary here.
-        NOTHING_HAPPENS = 7445; -- Nothing happens...
+               RESPONSE = 7326; -- There is no response...
+NOTHING_OUT_OF_ORDINARY = 7378; --There is nothing out of the ordinary here.
+        NOTHING_HAPPENS = 7446; -- Nothing happens...
 
- JAZARAATS_HEADSTONE = 7520; -- The name ir Jazaraatis engraved on the headstone...
-SEAPRINCES_TOMBSTONE = 8044; -- It appears to be the grave of a great soul to an age long past.
+ JAZARAATS_HEADSTONE = 7521; -- The name ir Jazaraatis engraved on the headstone...
+SEAPRINCES_TOMBSTONE = 8045; -- It appears to be the grave of a great soul to an age long past.

--- a/scripts/zones/Cape_Teriggan/TextIDs.lua
+++ b/scripts/zones/Cape_Teriggan/TextIDs.lua
@@ -3,28 +3,28 @@
 -- General Texts
    ITEM_CANNOT_BE_OBTAINED = 6379; -- You cannot obtain the item <item> come back again after sorting your inventory.
 FULL_INVENTORY_AFTER_TRADE = 6383; -- You cannot obtain the #. Try trading again after sorting your inventory.
-             ITEM_OBTAINED = 6384; -- Obtained: <item>.
-              GIL_OBTAINED = 6385; -- Obtained <number> gil.
-          KEYITEM_OBTAINED = 6387; -- Obtained key item: <keyitem>.
-            ITEMS_OBTAINED = 6393; -- You obtain
-           BEASTMEN_BANNER = 7126; -- There is a beastmen's banner.
-    FISHING_MESSAGE_OFFSET = 7546; -- You can't fish here.
-            HOMEPOINT_SET = 11249; -- Home point set!
+             ITEM_OBTAINED = 6385; -- Obtained: <item>.
+              GIL_OBTAINED = 6386; -- Obtained <number> gil.
+          KEYITEM_OBTAINED = 6388; -- Obtained key item: <keyitem>.
+            ITEMS_OBTAINED = 6394; -- You obtain
+           BEASTMEN_BANNER = 7127; -- There is a beastmen's banner.
+    FISHING_MESSAGE_OFFSET = 7547; -- You can't fish here.
+            HOMEPOINT_SET = 11250; -- Home point set!
 
 -- Other dialog
-NOTHING_OUT_OF_ORDINARY = 6398; -- There is nothing out of the ordinary here.
+NOTHING_OUT_OF_ORDINARY = 6399; -- There is nothing out of the ordinary here.
 
 -- Conquest
-CONQUEST = 7213; -- You've earned conquest points!
+CONQUEST = 7214; -- You've earned conquest points!
 
 -- ZM4 Dialog
-   CANNOT_REMOVE_FRAG = 7661; -- It is an oddly shaped stone monument. A shining stone is embedded in it, but cannot be removed...
-ALREADY_OBTAINED_FRAG = 7662; -- You have already obtained this monument's . Try searching for another.
-      FOUND_ALL_FRAGS = 7663; -- You have obtained all of the fragments. You must hurry to the ruins of the ancient shrine!
-      ZILART_MONUMENT = 7665; -- It is an ancient Zilart monument.
+   CANNOT_REMOVE_FRAG = 7662; -- It is an oddly shaped stone monument. A shining stone is embedded in it, but cannot be removed...
+ALREADY_OBTAINED_FRAG = 7663; -- You have already obtained this monument's . Try searching for another.
+      FOUND_ALL_FRAGS = 7664; -- You have obtained all of the fragments. You must hurry to the ruins of the ancient shrine!
+      ZILART_MONUMENT = 7666; -- It is an ancient Zilart monument.
 
 -- Other
 NOTHING_HAPPENS = 119; -- Nothing happens...?Possible Special Code: 00?
 
 -- conquest Base
-CONQUEST_BASE = 7045; -- Tallying conquest results...
+CONQUEST_BASE = 7046; -- Tallying conquest results...

--- a/scripts/zones/Carpenters_Landing/TextIDs.lua
+++ b/scripts/zones/Carpenters_Landing/TextIDs.lua
@@ -3,20 +3,20 @@
 -- General Texts
    ITEM_CANNOT_BE_OBTAINED = 6379; -- You cannot obtain the item <item>. Come back again after sorting your inventory.
 FULL_INVENTORY_AFTER_TRADE = 6383; -- You cannot obtain the #. Try trading again after sorting your inventory.
-             ITEM_OBTAINED = 6384; -- Obtained: <item>.
-              GIL_OBTAINED = 6385; -- Obtained <number> gil.
-          KEYITEM_OBTAINED = 6387; -- Obtained key item: <keyitem>.
-            ITEMS_OBTAINED = 6393; -- You obtain
-    FISHING_MESSAGE_OFFSET = 7266; -- You can't fish here.
+             ITEM_OBTAINED = 6385; -- Obtained: <item>.
+              GIL_OBTAINED = 6386; -- Obtained <number> gil.
+          KEYITEM_OBTAINED = 6388; -- Obtained key item: <keyitem>.
+            ITEMS_OBTAINED = 6394; -- You obtain
+    FISHING_MESSAGE_OFFSET = 7267; -- You can't fish here.
 
 -- Other dialog
-NOTHING_OUT_OF_ORDINARY = 6398; -- There is nothing out of the ordinary here.
+NOTHING_OUT_OF_ORDINARY = 6399; -- There is nothing out of the ordinary here.
 
 -- Logging
-LOGGING_IS_POSSIBLE_HERE = 7383; -- Logging is possible here if you have
+LOGGING_IS_POSSIBLE_HERE = 7384; -- Logging is possible here if you have
 
 -- Shop Texts
-BEUGUNGEL_SHOP_DIALOG = 7415; -- I'm selling goods direct from the Carpenters' Guild.
+BEUGUNGEL_SHOP_DIALOG = 7416; -- I'm selling goods direct from the Carpenters' Guild.
 
 -- conquest Base
-CONQUEST_BASE = 7045; -- Tallying conquest results...
+CONQUEST_BASE = 7046; -- Tallying conquest results...

--- a/scripts/zones/Castle_Oztroja/TextIDs.lua
+++ b/scripts/zones/Castle_Oztroja/TextIDs.lua
@@ -3,33 +3,33 @@
 -- General Texts
    ITEM_CANNOT_BE_OBTAINED = 6564; -- You cannot obtain the item <item>. Come back after sorting your inventory.
 FULL_INVENTORY_AFTER_TRADE = 6568; -- You cannot obtain the #. Try trading again after sorting your inventory.
-             ITEM_OBTAINED = 6569; -- Obtained: <item>.
-              GIL_OBTAINED = 6570; -- Obtained <number> gil.
-          KEYITEM_OBTAINED = 6572; -- Obtained key item: <keyitem>.
-            ITEMS_OBTAINED = 6575; -- You obtain
-    FISHING_MESSAGE_OFFSET = 7249; -- You can't fish here.
+             ITEM_OBTAINED = 6570; -- Obtained: <item>.
+              GIL_OBTAINED = 6571; -- Obtained <number> gil.
+          KEYITEM_OBTAINED = 6573; -- Obtained key item: <keyitem>.
+            ITEMS_OBTAINED = 6576; -- You obtain
+    FISHING_MESSAGE_OFFSET = 7250; -- You can't fish here.
 
 -- Other dialog
-               SENSE_OF_FOREBODING = 6584; -- You are suddenly overcome with a sense of foreboding...
-           NOTHING_OUT_OF_ORDINARY = 7762; -- There is nothing out of the ordinary here.
+               SENSE_OF_FOREBODING = 6585; -- You are suddenly overcome with a sense of foreboding...
+           NOTHING_OUT_OF_ORDINARY = 7763; -- There is nothing out of the ordinary here.
                         ITS_LOCKED = 1; -- It's locked.
 PROBABLY_WORKS_WITH_SOMETHING_ELSE = 3; -- It probably works with something else.
                          TORCH_LIT = 5; -- The torch is lit.
 
 -- Treasure Coffer/Chest Dialog
-CHEST_UNLOCKED = 7419; -- You unlock the chest!
-    CHEST_FAIL = 7420; -- Fails to open the chest.
-    CHEST_TRAP = 7421; -- The chest was trapped!
-    CHEST_WEAK = 7422; -- You cannot open the chest when you are in a weakened state.
-   CHEST_MIMIC = 7423; -- The chest was a mimic!
-  CHEST_MOOGLE = 7424; -- You cannot open the chest while participating in the moogle event.
-CHEST_ILLUSION = 7425; -- The chest was but an illusion...
-  CHEST_LOCKED = 7426; -- The chest appears to be locked.
+CHEST_UNLOCKED = 7420; -- You unlock the chest!
+    CHEST_FAIL = 7421; -- Fails to open the chest.
+    CHEST_TRAP = 7422; -- The chest was trapped!
+    CHEST_WEAK = 7423; -- You cannot open the chest when you are in a weakened state.
+   CHEST_MIMIC = 7424; -- The chest was a mimic!
+  CHEST_MOOGLE = 7425; -- You cannot open the chest while participating in the moogle event.
+CHEST_ILLUSION = 7426; -- The chest was but an illusion...
+  CHEST_LOCKED = 7427; -- The chest appears to be locked.
 
-YAGUDO_AVATAR_ENGAGE = 7440; -- Kahk-ka-ka... You filthy, dim-witted heretics! You have damned yourselves by coming here.
- YAGUDO_AVATAR_DEATH = 7441; -- Our lord, Tzee Xicu the Manifest!Even should our bodies be crushed and broken, may our souls endure into eternity...
-  YAGUDO_KING_ENGAGE = 7442; -- You are not here as sacrifices, are you? Could you possibly be committing this affront in the face of a deity?Very well, I will personally mete out your divine punishment, kyah!
-   YAGUDO_KING_DEATH = 7443; -- You have...bested me... However, I...am...a god... I will never die...never rot...never fade...never...
+YAGUDO_AVATAR_ENGAGE = 7441; -- Kahk-ka-ka... You filthy, dim-witted heretics! You have damned yourselves by coming here.
+ YAGUDO_AVATAR_DEATH = 7442; -- Our lord, Tzee Xicu the Manifest!Even should our bodies be crushed and broken, may our souls endure into eternity...
+  YAGUDO_KING_ENGAGE = 7443; -- You are not here as sacrifices, are you? Could you possibly be committing this affront in the face of a deity?Very well, I will personally mete out your divine punishment, kyah!
+   YAGUDO_KING_DEATH = 7444; -- You have...bested me... However, I...am...a god... I will never die...never rot...never fade...never...
 
 -- conquest Base
 CONQUEST_BASE = 26;

--- a/scripts/zones/Castle_Oztroja_[S]/TextIDs.lua
+++ b/scripts/zones/Castle_Oztroja_[S]/TextIDs.lua
@@ -2,7 +2,7 @@
 
 -- General Texts
 ITEM_CANNOT_BE_OBTAINED = 6379; -- You cannot obtain the item <item> come back again after sorting your inventory
-          ITEM_OBTAINED = 6384; -- Obtained: <item>
-           GIL_OBTAINED = 6385; -- Obtained <number> gil
-       KEYITEM_OBTAINED = 6387; -- Obtained key item: <keyitem>
- FISHING_MESSAGE_OFFSET = 7045; -- You can't fish here
+          ITEM_OBTAINED = 6385; -- Obtained: <item>
+           GIL_OBTAINED = 6386; -- Obtained <number> gil
+       KEYITEM_OBTAINED = 6388; -- Obtained key item: <keyitem>
+ FISHING_MESSAGE_OFFSET = 7046; -- You can't fish here

--- a/scripts/zones/Castle_Zvahl_Baileys/TextIDs.lua
+++ b/scripts/zones/Castle_Zvahl_Baileys/TextIDs.lua
@@ -2,23 +2,23 @@
 
 -- General Texts
 ITEM_CANNOT_BE_OBTAINED = 6538; -- You cannot obtain the item <item>. come back after sorting your inventory.
-          ITEM_OBTAINED = 6543; -- Obtained: <item>.
-           GIL_OBTAINED = 6544; -- Obtained <number> gil.
-       KEYITEM_OBTAINED = 6546; -- Obtained key item: <keyitem>.
+          ITEM_OBTAINED = 6544; -- Obtained: <item>.
+           GIL_OBTAINED = 6545; -- Obtained <number> gil.
+       KEYITEM_OBTAINED = 6547; -- Obtained key item: <keyitem>.
 
 -- Treasure Coffer/Chest Dialog
-CHEST_UNLOCKED = 7218; -- You unlock the chest!
-    CHEST_FAIL = 7219; -- Fails to open the chest.
-    CHEST_TRAP = 7220; -- The chest was trapped!
-    CHEST_WEAK = 7221; -- You cannot open the chest when you are in a weakened state.
-   CHEST_MIMIC = 7222; -- The chest was a mimic!
-  CHEST_MOOGLE = 7223; -- You cannot open the chest while participating in the moogle event.
-CHEST_ILLUSION = 7224; -- The chest was but an illusion...
-  CHEST_LOCKED = 7225; -- The chest appears to be locked.
+CHEST_UNLOCKED = 7219; -- You unlock the chest!
+    CHEST_FAIL = 7220; -- Fails to open the chest.
+    CHEST_TRAP = 7221; -- The chest was trapped!
+    CHEST_WEAK = 7222; -- You cannot open the chest when you are in a weakened state.
+   CHEST_MIMIC = 7223; -- The chest was a mimic!
+  CHEST_MOOGLE = 7224; -- You cannot open the chest while participating in the moogle event.
+CHEST_ILLUSION = 7225; -- The chest was but an illusion...
+  CHEST_LOCKED = 7226; -- The chest appears to be locked.
 
 -- Quest dialog
-    SENSE_OF_FOREBODING = 6558; -- You are suddenly overcome with a sense of foreboding...
-NOTHING_OUT_OF_ORDINARY = 7548; -- There is nothing out of the ordinary here.
+    SENSE_OF_FOREBODING = 6559; -- You are suddenly overcome with a sense of foreboding...
+NOTHING_OUT_OF_ORDINARY = 7549; -- There is nothing out of the ordinary here.
 
 -- conquest Base
 CONQUEST_BASE = 0;

--- a/scripts/zones/Castle_Zvahl_Baileys_[S]/TextIDs.lua
+++ b/scripts/zones/Castle_Zvahl_Baileys_[S]/TextIDs.lua
@@ -2,6 +2,6 @@
 
 -- General Texts
 ITEM_CANNOT_BE_OBTAINED = 6379; -- You cannot obtain the item <item> come back again after sorting your inventory
-          ITEM_OBTAINED = 6384; -- Obtained: <item>
-           GIL_OBTAINED = 6385; -- Obtained <number> gil
-       KEYITEM_OBTAINED = 6387; -- Obtained key item: <keyitem>
+          ITEM_OBTAINED = 6385; -- Obtained: <item>
+           GIL_OBTAINED = 6386; -- Obtained <number> gil
+       KEYITEM_OBTAINED = 6388; -- Obtained key item: <keyitem>

--- a/scripts/zones/Castle_Zvahl_Keep/TextIDs.lua
+++ b/scripts/zones/Castle_Zvahl_Keep/TextIDs.lua
@@ -2,20 +2,20 @@
 
 -- General Texts
 ITEM_CANNOT_BE_OBTAINED = 6538; -- You cannot obtain the item <item>. Come back after sorting your inventory.
-          ITEM_OBTAINED = 6543; -- Obtained: <item>.
-           GIL_OBTAINED = 6544; -- Obtained <number> gil.
-       KEYITEM_OBTAINED = 6546; -- Obtained key item: <keyitem>.
-            HOMEPOINT_SET = 7276; -- Home point set!
+          ITEM_OBTAINED = 6544; -- Obtained: <item>.
+           GIL_OBTAINED = 6545; -- Obtained <number> gil.
+       KEYITEM_OBTAINED = 6547; -- Obtained key item: <keyitem>.
+            HOMEPOINT_SET = 7277; -- Home point set!
 
 -- Treasure Coffer/Chest Dialog
-CHEST_UNLOCKED = 7218; -- You unlock the chest!
-    CHEST_FAIL = 7219; -- Fails to open the chest.
-    CHEST_TRAP = 7220; -- The chest was trapped!
-    CHEST_WEAK = 7221; -- You cannot open the chest when you are in a weakened state.
-   CHEST_MIMIC = 7222; -- The chest was a mimic!
-  CHEST_MOOGLE = 7223; -- You cannot open the chest while participating in the moogle event.
-CHEST_ILLUSION = 7224; -- The chest was but an illusion...
-  CHEST_LOCKED = 7225; -- The chest appears to be locked.
+CHEST_UNLOCKED = 7219; -- You unlock the chest!
+    CHEST_FAIL = 7220; -- Fails to open the chest.
+    CHEST_TRAP = 7221; -- The chest was trapped!
+    CHEST_WEAK = 7222; -- You cannot open the chest when you are in a weakened state.
+   CHEST_MIMIC = 7223; -- The chest was a mimic!
+  CHEST_MOOGLE = 7224; -- You cannot open the chest while participating in the moogle event.
+CHEST_ILLUSION = 7225; -- The chest was but an illusion...
+  CHEST_LOCKED = 7226; -- The chest appears to be locked.
 
 -- conquest Base
 CONQUEST_BASE = 0;

--- a/scripts/zones/Castle_Zvahl_Keep_[S]/TextIDs.lua
+++ b/scripts/zones/Castle_Zvahl_Keep_[S]/TextIDs.lua
@@ -2,7 +2,7 @@
 
 -- General Texts
 ITEM_CANNOT_BE_OBTAINED = 6379; -- You cannot obtain the item <item> come back again after sorting your inventory
-          ITEM_OBTAINED = 6384; -- Obtained: <item>
-           GIL_OBTAINED = 6385; -- Obtained <number> gil
-       KEYITEM_OBTAINED = 6387; -- Obtained key item: <keyitem>
-            HOMEPOINT_SET = 7858; -- Home point set!
+          ITEM_OBTAINED = 6385; -- Obtained: <item>
+           GIL_OBTAINED = 6386; -- Obtained <number> gil
+       KEYITEM_OBTAINED = 6388; -- Obtained key item: <keyitem>
+            HOMEPOINT_SET = 7859; -- Home point set!

--- a/scripts/zones/Ceizak_Battlegrounds/TextIDs.lua
+++ b/scripts/zones/Ceizak_Battlegrounds/TextIDs.lua
@@ -2,7 +2,7 @@
 
 -- General Texts
 ITEM_CANNOT_BE_OBTAINED = 6379; -- You cannot obtain the item <item> come back again after sorting your inventory
-          ITEM_OBTAINED = 6384; -- Obtained: <item>
-           GIL_OBTAINED = 6385; -- Obtained <number> gil
-       KEYITEM_OBTAINED = 6387; -- Obtained key item: <keyitem>
-            HOMEPOINT_SET = 7779; -- Home point set!
+          ITEM_OBTAINED = 6385; -- Obtained: <item>
+           GIL_OBTAINED = 6386; -- Obtained <number> gil
+       KEYITEM_OBTAINED = 6388; -- Obtained key item: <keyitem>
+            HOMEPOINT_SET = 7780; -- Home point set!

--- a/scripts/zones/Celennia_Memorial_Library/TextIDs.lua
+++ b/scripts/zones/Celennia_Memorial_Library/TextIDs.lua
@@ -2,6 +2,6 @@
 
 -- General Texts
 ITEM_CANNOT_BE_OBTAINED = 6379; -- You cannot obtain the item <item> come back again after sorting your inventory
-          ITEM_OBTAINED = 6384; -- Obtained: <item>
-           GIL_OBTAINED = 6385; -- Obtained <number> gil
-       KEYITEM_OBTAINED = 6387; -- Obtained key item: <keyitem>
+          ITEM_OBTAINED = 6385; -- Obtained: <item>
+           GIL_OBTAINED = 6386; -- Obtained <number> gil
+       KEYITEM_OBTAINED = 6388; -- Obtained key item: <keyitem>

--- a/scripts/zones/Chamber_of_Oracles/TextIDs.lua
+++ b/scripts/zones/Chamber_of_Oracles/TextIDs.lua
@@ -2,26 +2,26 @@
 
 -- General Texts
 ITEM_CANNOT_BE_OBTAINED = 6379; -- You cannot obtain the item <item> come back again after sorting your inventory
-          ITEM_OBTAINED = 6384; -- Obtained: <item>
-           GIL_OBTAINED = 6385; -- Obtained <number> gil
-       KEYITEM_OBTAINED = 6387; -- Obtained key item: <keyitem>
+          ITEM_OBTAINED = 6385; -- Obtained: <item>
+           GIL_OBTAINED = 6386; -- Obtained <number> gil
+       KEYITEM_OBTAINED = 6388; -- Obtained key item: <keyitem>
 
 -- Other Texts
-YOU_CANNOT_ENTER_THE_BATTLEFIELD = 7206; -- You cannot enter the battlefield at present. Please wait a little longer.
+YOU_CANNOT_ENTER_THE_BATTLEFIELD = 7207; -- You cannot enter the battlefield at present. Please wait a little longer.
 
 -- Mission Texts
-PLACED_INTO_THE_PEDESTAL = 7613; -- It appears that something should be placed into this pedestal.
-           YOU_PLACE_THE = 7614; -- You place theinto the pedestal.
-  IS_SET_IN_THE_PEDESTAL = 7615; -- Theis set in the pedestal.
-      HAS_LOST_ITS_POWER = 7616; -- Thehas lost its power.
+PLACED_INTO_THE_PEDESTAL = 7614; -- It appears that something should be placed into this pedestal.
+           YOU_PLACE_THE = 7615; -- You place theinto the pedestal.
+  IS_SET_IN_THE_PEDESTAL = 7616; -- Theis set in the pedestal.
+      HAS_LOST_ITS_POWER = 7617; -- Thehas lost its power.
 
 -- Maat dialog
-      YOU_DECIDED_TO_SHOW_UP = 7635; -- So, you decided to show up.
- LOOKS_LIKE_YOU_WERENT_READY = 7636; -- Looks like you weren't ready for me, were you?
-       YOUVE_COME_A_LONG_WAY = 7637; -- Hm. That was a mighty fine display of skill there, Player Name. You've come a long way...
- TEACH_YOU_TO_RESPECT_ELDERS = 7638; -- I'll teach you to respect your elders!
-TAKE_THAT_YOU_WHIPPERSNAPPER = 7639; -- Take that, you whippersnapper!
- THAT_LL_HURT_IN_THE_MORNING = 7641; -- Ungh... That'll hurt in the morning...
+      YOU_DECIDED_TO_SHOW_UP = 7636; -- So, you decided to show up.
+ LOOKS_LIKE_YOU_WERENT_READY = 7637; -- Looks like you weren't ready for me, were you?
+       YOUVE_COME_A_LONG_WAY = 7638; -- Hm. That was a mighty fine display of skill there, Player Name. You've come a long way...
+ TEACH_YOU_TO_RESPECT_ELDERS = 7639; -- I'll teach you to respect your elders!
+TAKE_THAT_YOU_WHIPPERSNAPPER = 7640; -- Take that, you whippersnapper!
+ THAT_LL_HURT_IN_THE_MORNING = 7642; -- Ungh... That'll hurt in the morning...
 
 -- conquest Base
-CONQUEST_BASE = 7045; -- Tallying conquest results...
+CONQUEST_BASE = 7046; -- Tallying conquest results...

--- a/scripts/zones/Chateau_dOraguille/TextIDs.lua
+++ b/scripts/zones/Chateau_dOraguille/TextIDs.lua
@@ -2,17 +2,17 @@
 
 -- General Texts
    ITEM_CANNOT_BE_OBTAINED = 6587; -- Come back after sorting your inventory.
-             ITEM_OBTAINED = 6592; -- Obtained:
-              GIL_OBTAINED = 6593; -- Obtainedgil.
-          KEYITEM_OBTAINED = 6595; -- Obtained key item: <<<Unknown Parameter (Type: 80) 1>>>.
-              KEYITEM_LOST = 6596; -- Lost key item:
+             ITEM_OBTAINED = 6593; -- Obtained:
+              GIL_OBTAINED = 6594; -- Obtainedgil.
+          KEYITEM_OBTAINED = 6596; -- Obtained key item: <<<Unknown Parameter (Type: 80) 1>>>.
+              KEYITEM_LOST = 6597; -- Lost key item:
 
 -- Other Dialog
-TOMBSTONE = 7168; -- Here lies the beloved Queen Leaute. May Her Majesty's soul find Paradise.
+TOMBSTONE = 7169; -- Here lies the beloved Queen Leaute. May Her Majesty's soul find Paradise.
 
 -- Mission dialog
-HALVER_OFFSET = 6789; -- The princess is always speaking of your deeds for the Kingdom. Everyone here is counting on you,
+HALVER_OFFSET = 6790; -- The princess is always speaking of your deeds for the Kingdom. Everyone here is counting on you,
 
 -- Conquest Base
 
-CONQUEST_BASE = 6875; -- Tallying conquest results...
+CONQUEST_BASE = 6876; -- Tallying conquest results...

--- a/scripts/zones/Chocobo_Circuit/TextIDs.lua
+++ b/scripts/zones/Chocobo_Circuit/TextIDs.lua
@@ -2,6 +2,6 @@
 
 -- General Texts
 ITEM_CANNOT_BE_OBTAINED = 6379; -- You cannot obtain the item <item> come back again after sorting your inventory
-          ITEM_OBTAINED = 6384; -- Obtained: <item>
-           GIL_OBTAINED = 6385; -- Obtained <number> gil
-       KEYITEM_OBTAINED = 6387; -- Obtained key item: <keyitem>
+          ITEM_OBTAINED = 6385; -- Obtained: <item>
+           GIL_OBTAINED = 6386; -- Obtained <number> gil
+       KEYITEM_OBTAINED = 6388; -- Obtained key item: <keyitem>

--- a/scripts/zones/Cirdas_Caverns/TextIDs.lua
+++ b/scripts/zones/Cirdas_Caverns/TextIDs.lua
@@ -2,6 +2,6 @@
 
 -- General Texts
 ITEM_CANNOT_BE_OBTAINED = 6379; -- You cannot obtain the item <item> come back again after sorting your inventory
-          ITEM_OBTAINED = 6384; -- Obtained: <item>
-           GIL_OBTAINED = 6385; -- Obtained <number> gil
-       KEYITEM_OBTAINED = 6387; -- Obtained key item: <keyitem>
+          ITEM_OBTAINED = 6385; -- Obtained: <item>
+           GIL_OBTAINED = 6386; -- Obtained <number> gil
+       KEYITEM_OBTAINED = 6388; -- Obtained key item: <keyitem>

--- a/scripts/zones/Cirdas_Caverns_U/TextIDs.lua
+++ b/scripts/zones/Cirdas_Caverns_U/TextIDs.lua
@@ -2,6 +2,6 @@
 
 -- General Texts
 ITEM_CANNOT_BE_OBTAINED = 6379; -- You cannot obtain the item <item> come back again after sorting your inventory
-          ITEM_OBTAINED = 6384; -- Obtained: <item>
-           GIL_OBTAINED = 6385; -- Obtained <number> gil
-       KEYITEM_OBTAINED = 6387; -- Obtained key item: <keyitem>
+          ITEM_OBTAINED = 6385; -- Obtained: <item>
+           GIL_OBTAINED = 6386; -- Obtained <number> gil
+       KEYITEM_OBTAINED = 6388; -- Obtained key item: <keyitem>

--- a/scripts/zones/Cloister_of_Flames/TextIDs.lua
+++ b/scripts/zones/Cloister_of_Flames/TextIDs.lua
@@ -2,16 +2,16 @@
 
 -- General Texts
 ITEM_CANNOT_BE_OBTAINED = 6379; -- You cannot obtain the item <item> come back again after sorting your inventory
-          ITEM_OBTAINED = 6384; -- Obtained: <item>
-           GIL_OBTAINED = 6385; -- Obtained <number> gil
-       KEYITEM_OBTAINED = 6387; -- Obtained key item: <keyitem>
+          ITEM_OBTAINED = 6385; -- Obtained: <item>
+           GIL_OBTAINED = 6386; -- Obtained <number> gil
+       KEYITEM_OBTAINED = 6388; -- Obtained key item: <keyitem>
 
 -- Quest dialog
-YOU_CANNOT_ENTER_THE_BATTLEFIELD = 7206; -- You cannot enter the battlefield at present.
-          IFRIT_UNLOCKED = 7564; -- You are now able to summon
+YOU_CANNOT_ENTER_THE_BATTLEFIELD = 7207; -- You cannot enter the battlefield at present.
+          IFRIT_UNLOCKED = 7565; -- You are now able to summon
 
 -- Other
-PROTOCRYSTAL = 7230; -- It is a giant crystal.
+PROTOCRYSTAL = 7231; -- It is a giant crystal.
 
 -- conquest Base
-CONQUEST_BASE = 7045; -- Tallying conquest results...
+CONQUEST_BASE = 7046; -- Tallying conquest results...

--- a/scripts/zones/Cloister_of_Frost/TextIDs.lua
+++ b/scripts/zones/Cloister_of_Frost/TextIDs.lua
@@ -2,23 +2,23 @@
 
 -- General Texts
 ITEM_CANNOT_BE_OBTAINED = 6379; -- You cannot obtain the item <item> come back again after sorting your inventory
-          ITEM_OBTAINED = 6384; -- Obtained: <item>
-           GIL_OBTAINED = 6385; -- Obtained <number> gil
-       KEYITEM_OBTAINED = 6387; -- Obtained key item: <keyitem>
+          ITEM_OBTAINED = 6385; -- Obtained: <item>
+           GIL_OBTAINED = 6386; -- Obtained <number> gil
+       KEYITEM_OBTAINED = 6388; -- Obtained key item: <keyitem>
 
 -- Quest dialog
-YOU_CANNOT_ENTER_THE_BATTLEFIELD = 7206; -- You cannot enter the battlefield at present.
-                  SHIVA_UNLOCKED = 7564; -- You are now able to summon
+YOU_CANNOT_ENTER_THE_BATTLEFIELD = 7207; -- You cannot enter the battlefield at present.
+                  SHIVA_UNLOCKED = 7565; -- You are now able to summon
 
 -- ZM4 Dialog
-    CANNOT_REMOVE_FRAG = 7657; -- It is an oddly shaped stone monument
- ALREADY_OBTAINED_FRAG = 7658; -- You have already obtained this monument
-ALREADY_HAVE_ALL_FRAGS = 7659; -- You have obtained all of the fragments
-       FOUND_ALL_FRAGS = 7660; -- You have obtained ! You now have all 8 fragments of light!
-       ZILART_MONUMENT = 7661; -- It is an ancient Zilart monument
+    CANNOT_REMOVE_FRAG = 7658; -- It is an oddly shaped stone monument
+ ALREADY_OBTAINED_FRAG = 7659; -- You have already obtained this monument
+ALREADY_HAVE_ALL_FRAGS = 7660; -- You have obtained all of the fragments
+       FOUND_ALL_FRAGS = 7661; -- You have obtained ! You now have all 8 fragments of light!
+       ZILART_MONUMENT = 7662; -- It is an ancient Zilart monument
 
 -- Other
-PROTOCRYSTAL = 7230; -- It is a giant crystal.
+PROTOCRYSTAL = 7231; -- It is a giant crystal.
 
 -- conquest Base
-CONQUEST_BASE = 7045; -- Tallying conquest results...
+CONQUEST_BASE = 7046; -- Tallying conquest results...

--- a/scripts/zones/Cloister_of_Gales/TextIDs.lua
+++ b/scripts/zones/Cloister_of_Gales/TextIDs.lua
@@ -2,16 +2,16 @@
 
 -- General Texts
 ITEM_CANNOT_BE_OBTAINED = 6379; -- You cannot obtain the item <item> come back again after sorting your inventory
-          ITEM_OBTAINED = 6384; -- Obtained: <item>
-           GIL_OBTAINED = 6385; -- Obtained <number> gil
-       KEYITEM_OBTAINED = 6387; -- Obtained key item: <keyitem>
+          ITEM_OBTAINED = 6385; -- Obtained: <item>
+           GIL_OBTAINED = 6386; -- Obtained <number> gil
+       KEYITEM_OBTAINED = 6388; -- Obtained key item: <keyitem>
 
 -- Quest dialog
-YOU_CANNOT_ENTER_THE_BATTLEFIELD = 7206; -- You cannot enter the battlefield at present.
-         GARUDA_UNLOCKED = 7564; -- You are now able to summon
+YOU_CANNOT_ENTER_THE_BATTLEFIELD = 7207; -- You cannot enter the battlefield at present.
+         GARUDA_UNLOCKED = 7565; -- You are now able to summon
 
 -- Other
-PROTOCRYSTAL = 7230; -- It is a giant crystal.
+PROTOCRYSTAL = 7231; -- It is a giant crystal.
 
 -- conquest Base
-CONQUEST_BASE = 7045; -- Tallying conquest results...
+CONQUEST_BASE = 7046; -- Tallying conquest results...

--- a/scripts/zones/Cloister_of_Storms/TextIDs.lua
+++ b/scripts/zones/Cloister_of_Storms/TextIDs.lua
@@ -2,16 +2,16 @@
 
 -- General Texts
 ITEM_CANNOT_BE_OBTAINED = 6379; -- You cannot obtain the item <item> come back again after sorting your inventory
-          ITEM_OBTAINED = 6384; -- Obtained: <item>
-           GIL_OBTAINED = 6385; -- Obtained <number> gil
-       KEYITEM_OBTAINED = 6387; -- Obtained key item: <keyitem>
+          ITEM_OBTAINED = 6385; -- Obtained: <item>
+           GIL_OBTAINED = 6386; -- Obtained <number> gil
+       KEYITEM_OBTAINED = 6388; -- Obtained key item: <keyitem>
 
 -- Quest dialog
-YOU_CANNOT_ENTER_THE_BATTLEFIELD = 7206; -- You cannot enter the battlefield at present.
-          RAMUH_UNLOCKED = 7564; -- You are now able to summon
+YOU_CANNOT_ENTER_THE_BATTLEFIELD = 7207; -- You cannot enter the battlefield at present.
+          RAMUH_UNLOCKED = 7565; -- You are now able to summon
 
 -- Other
-PROTOCRYSTAL = 7230; -- It is a giant crystal.
+PROTOCRYSTAL = 7231; -- It is a giant crystal.
 
 -- conquest Base
-CONQUEST_BASE = 7045; -- Tallying conquest results...
+CONQUEST_BASE = 7046; -- Tallying conquest results...

--- a/scripts/zones/Cloister_of_Tides/TextIDs.lua
+++ b/scripts/zones/Cloister_of_Tides/TextIDs.lua
@@ -2,16 +2,16 @@
 
 -- General Texts
 ITEM_CANNOT_BE_OBTAINED = 6379; -- You cannot obtain the item <item> come back again after sorting your inventory
-          ITEM_OBTAINED = 6384; -- Obtained: <item>
-           GIL_OBTAINED = 6385; -- Obtained <number> gil
-       KEYITEM_OBTAINED = 6387; -- Obtained key item: <keyitem>
+          ITEM_OBTAINED = 6385; -- Obtained: <item>
+           GIL_OBTAINED = 6386; -- Obtained <number> gil
+       KEYITEM_OBTAINED = 6388; -- Obtained key item: <keyitem>
 
 -- Quest dialog
-YOU_CANNOT_ENTER_THE_BATTLEFIELD = 7206; -- You cannot enter the battlefield at present. Please wait a little longer.
-              LEVIATHAN_UNLOCKED = 7564; -- You are now able to summon
+YOU_CANNOT_ENTER_THE_BATTLEFIELD = 7207; -- You cannot enter the battlefield at present. Please wait a little longer.
+              LEVIATHAN_UNLOCKED = 7565; -- You are now able to summon
 
 -- Other
-PROTOCRYSTAL = 7230; -- It is a giant crystal.
+PROTOCRYSTAL = 7231; -- It is a giant crystal.
 
 -- conquest Base
-CONQUEST_BASE = 7045; -- Tallying conquest results...
+CONQUEST_BASE = 7046; -- Tallying conquest results...

--- a/scripts/zones/Cloister_of_Tremors/TextIDs.lua
+++ b/scripts/zones/Cloister_of_Tremors/TextIDs.lua
@@ -2,17 +2,17 @@
 
 -- General Texts
 ITEM_CANNOT_BE_OBTAINED = 6379; -- You cannot obtain the item <item> come back again after sorting your inventory
-          ITEM_OBTAINED = 6384; -- Obtained: <item>
-           GIL_OBTAINED = 6385; -- Obtained <number> gil
-       KEYITEM_OBTAINED = 6387; -- Obtained key item: <keyitem>
+          ITEM_OBTAINED = 6385; -- Obtained: <item>
+           GIL_OBTAINED = 6386; -- Obtained <number> gil
+       KEYITEM_OBTAINED = 6388; -- Obtained key item: <keyitem>
 
 -- Quest dialog
-YOU_CANNOT_ENTER_THE_BATTLEFIELD = 7206; -- You cannot enter the battlefield at present.
-          TITAN_UNLOCKED = 7564; -- You are now able to summon
+YOU_CANNOT_ENTER_THE_BATTLEFIELD = 7207; -- You cannot enter the battlefield at present.
+          TITAN_UNLOCKED = 7565; -- You are now able to summon
 
 -- Other
-NOTHING_OUT_OF_THE_ORDINARY = 6398; -- There is nothing out of the ordinary here.
-               PROTOCRYSTAL = 7230; -- It is a giant crystal.
+NOTHING_OUT_OF_THE_ORDINARY = 6399; -- There is nothing out of the ordinary here.
+               PROTOCRYSTAL = 7231; -- It is a giant crystal.
 
 -- conquest Base
-CONQUEST_BASE = 7045; -- Tallying conquest results...
+CONQUEST_BASE = 7046; -- Tallying conquest results...

--- a/scripts/zones/Crawlers_Nest/TextIDs.lua
+++ b/scripts/zones/Crawlers_Nest/TextIDs.lua
@@ -2,28 +2,28 @@
 
 -- General Texts
 ITEM_CANNOT_BE_OBTAINED = 6569; -- You cannot obtain the item <item>. Come back after sorting your inventory.
-          ITEM_OBTAINED = 6574; -- Obtained: <item>.
-           GIL_OBTAINED = 6575; -- Obtained <number> gil.
-       KEYITEM_OBTAINED = 6577; -- Obtained key item: <keyitem>.
+          ITEM_OBTAINED = 6575; -- Obtained: <item>.
+           GIL_OBTAINED = 6576; -- Obtained <number> gil.
+       KEYITEM_OBTAINED = 6578; -- Obtained key item: <keyitem>.
 
 -- Treasure Coffer/Chest Dialog
-CHEST_UNLOCKED = 7247; -- You unlock the chest!
-    CHEST_FAIL = 7248; -- Fails to open the chest.
-    CHEST_TRAP = 7249; -- The chest was trapped!
-    CHEST_WEAK = 7250; -- You cannot open the chest when you are in a weakened state.
-   CHEST_MIMIC = 7251; -- The chest was a mimic!
-  CHEST_MOOGLE = 7252; -- You cannot open the chest while participating in the moogle event.
-CHEST_ILLUSION = 7253; -- The chest was but an illusion...
-  CHEST_LOCKED = 7254; -- The chest appears to be locked.
+CHEST_UNLOCKED = 7248; -- You unlock the chest!
+    CHEST_FAIL = 7249; -- Fails to open the chest.
+    CHEST_TRAP = 7250; -- The chest was trapped!
+    CHEST_WEAK = 7251; -- You cannot open the chest when you are in a weakened state.
+   CHEST_MIMIC = 7252; -- The chest was a mimic!
+  CHEST_MOOGLE = 7253; -- You cannot open the chest while participating in the moogle event.
+CHEST_ILLUSION = 7254; -- The chest was but an illusion...
+  CHEST_LOCKED = 7255; -- The chest appears to be locked.
 
 -- Quest Dialog
-          SENSE_OF_FOREBODING = 6589; -- You are suddenly overcome with a sense of foreboding...
-      NOTHING_WILL_HAPPEN_YET = 7261; -- It seems that nothing will happen yet.
-      NOTHING_SEEMS_TO_HAPPEN = 7262; -- Nothing seems to happen.
+          SENSE_OF_FOREBODING = 6590; -- You are suddenly overcome with a sense of foreboding...
+      NOTHING_WILL_HAPPEN_YET = 7262; -- It seems that nothing will happen yet.
+      NOTHING_SEEMS_TO_HAPPEN = 7263; -- Nothing seems to happen.
 
-SOMEONE_HAS_BEEN_DIGGING_HERE = 7255; -- Someone has been digging here.
-EQUIPMENT_COMPLETELY_PURIFIED = 7256; -- Your equipment has not been completely purified.
-                 YOU_BURY_THE = 7258; -- You bury the
+SOMEONE_HAS_BEEN_DIGGING_HERE = 7256; -- Someone has been digging here.
+EQUIPMENT_COMPLETELY_PURIFIED = 7257; -- Your equipment has not been completely purified.
+                 YOU_BURY_THE = 7259; -- You bury the
 
 
 -- conquest Base

--- a/scripts/zones/Crawlers_Nest_[S]/TextIDs.lua
+++ b/scripts/zones/Crawlers_Nest_[S]/TextIDs.lua
@@ -2,10 +2,10 @@
 
 -- General Texts
 ITEM_CANNOT_BE_OBTAINED = 6903; -- You cannot obtain the item
-          ITEM_OBTAINED = 7504; -- Obtained: <item>
-           GIL_OBTAINED = 8641; -- Obtained <number> gil
-       KEYITEM_OBTAINED = 6909; -- Obtained key item:
+          ITEM_OBTAINED = 7505; -- Obtained: <item>
+           GIL_OBTAINED = 8642; -- Obtained <number> gil
+       KEYITEM_OBTAINED = 6910; -- Obtained key item:
 
 
 -- Other Texts
-ITEM_DELIVERY_DIALOG = 7673; -- Hello! Any packages to sendy-wend
+ITEM_DELIVERY_DIALOG = 7674; -- Hello! Any packages to sendy-wend

--- a/scripts/zones/Dangruf_Wadi/TextIDs.lua
+++ b/scripts/zones/Dangruf_Wadi/TextIDs.lua
@@ -2,29 +2,29 @@
 
 -- General Texts
 ITEM_CANNOT_BE_OBTAINED = 6538; -- You cannot obtain the item <item>. Come back after sorting your inventory.
-          ITEM_OBTAINED = 6543; -- Obtained: <item>.
-           GIL_OBTAINED = 6544; -- Obtained <number> gil.
-       KEYITEM_OBTAINED = 6546; -- Obtained key item: <keyitem>.
- FISHING_MESSAGE_OFFSET = 7204; -- You can't fish here.
+          ITEM_OBTAINED = 6544; -- Obtained: <item>.
+           GIL_OBTAINED = 6545; -- Obtained <number> gil.
+       KEYITEM_OBTAINED = 6547; -- Obtained key item: <keyitem>.
+ FISHING_MESSAGE_OFFSET = 7205; -- You can't fish here.
 
 -- Treasure Coffer/Chest Dialog
-CHEST_UNLOCKED = 7429; -- You unlock the chest!
-    CHEST_FAIL = 7430; -- fails to open the chest.
-    CHEST_TRAP = 7431; -- The chest was trapped!
-    CHEST_WEAK = 7432; -- You cannot open the chest when you are in a weakened state.
-   CHEST_MIMIC = 7433; -- The chest was a mimic!
-  CHEST_MOOGLE = 7434; -- You cannot open the chest while participating in the moogle event.
-CHEST_ILLUSION = 7435; -- The chest was but an illusion...
-  CHEST_LOCKED = 7436; -- The chest appears to be locked.
+CHEST_UNLOCKED = 7430; -- You unlock the chest!
+    CHEST_FAIL = 7431; -- fails to open the chest.
+    CHEST_TRAP = 7432; -- The chest was trapped!
+    CHEST_WEAK = 7433; -- You cannot open the chest when you are in a weakened state.
+   CHEST_MIMIC = 7434; -- The chest was a mimic!
+  CHEST_MOOGLE = 7435; -- You cannot open the chest while participating in the moogle event.
+CHEST_ILLUSION = 7436; -- The chest was but an illusion...
+  CHEST_LOCKED = 7437; -- The chest appears to be locked.
 
 -- Other Text
-GEOMAGNETIC_FOUNT = 7166; -- A faint energy wafts up from the ground.
-       SMALL_HOLE = 7483; -- There is a small hole here.
+GEOMAGNETIC_FOUNT = 7167; -- A faint energy wafts up from the ground.
+       SMALL_HOLE = 7484; -- There is a small hole here.
 
 -- conquest Base
 CONQUEST_BASE = 0;
 
 -- Strange Apparatus
-DEVICE_NOT_WORKING = 7318; -- The device is not working.
-      SYS_OVERLOAD = 7327; -- arning! Sys...verload! Enterin...fety mode. ID eras...d 
-      YOU_LOST_THE = 7332; -- You lost the #. 
+DEVICE_NOT_WORKING = 7319; -- The device is not working.
+      SYS_OVERLOAD = 7328; -- arning! Sys...verload! Enterin...fety mode. ID eras...d 
+      YOU_LOST_THE = 7333; -- You lost the #. 

--- a/scripts/zones/Davoi/TextIDs.lua
+++ b/scripts/zones/Davoi/TextIDs.lua
@@ -2,30 +2,30 @@
 
 -- General Texts
 ITEM_CANNOT_BE_OBTAINED = 6379; -- You cannot obtain the item <item>. Come back after sorting your inventory.
-          ITEM_OBTAINED = 6384; -- Obtained: <item>.
-           GIL_OBTAINED = 6385; -- Obtained <number> gil.
-       KEYITEM_OBTAINED = 6387; -- Obtained key item: <keyitem>.
-         ITEMS_OBTAINED = 6390; -- You obtain
- FISHING_MESSAGE_OFFSET = 7204; -- You can't fish here.
+          ITEM_OBTAINED = 6385; -- Obtained: <item>.
+           GIL_OBTAINED = 6386; -- Obtained <number> gil.
+       KEYITEM_OBTAINED = 6388; -- Obtained key item: <keyitem>.
+         ITEMS_OBTAINED = 6391; -- You obtain
+ FISHING_MESSAGE_OFFSET = 7205; -- You can't fish here.
 
-   CAVE_HAS_BEEN_SEALED_OFF = 7348; -- The cave has been sealed off by some sort of barrier.
-   MAY_BE_SOME_WAY_TO_BREAK = 7349; -- There may be some way to break through.
-POWER_OF_THE_ORB_ALLOW_PASS = 7351; -- The disruptive power of the orb allows passage through the barrier.
-         QUEMARICOND_DIALOG = 7370; -- I can't believe I've lost my way!
-            YOU_SEE_NOTHING = 7404; -- There is nothing here.
-     AN_ORCISH_STORAGE_HOLE = 7446; -- An Orcish storage hole. There is something inside, but you cannot open it without a key.
-                     A_WELL = 7448; -- A well, presumably dug by Orcs.
+   CAVE_HAS_BEEN_SEALED_OFF = 7349; -- The cave has been sealed off by some sort of barrier.
+   MAY_BE_SOME_WAY_TO_BREAK = 7350; -- There may be some way to break through.
+POWER_OF_THE_ORB_ALLOW_PASS = 7352; -- The disruptive power of the orb allows passage through the barrier.
+         QUEMARICOND_DIALOG = 7371; -- I can't believe I've lost my way!
+            YOU_SEE_NOTHING = 7405; -- There is nothing here.
+     AN_ORCISH_STORAGE_HOLE = 7447; -- An Orcish storage hole. There is something inside, but you cannot open it without a key.
+                     A_WELL = 7449; -- A well, presumably dug by Orcs.
 
 -- Treasure Coffer/Chest Dialog
-CHEST_UNLOCKED = 7466; -- You unlock the chest!
-    CHEST_FAIL = 7467; -- Fails to open the chest.
-    CHEST_TRAP = 7468; -- The chest was trapped!
-    CHEST_WEAK = 7469; -- You cannot open the chest when you are in a weakened state.
-   CHEST_MIMIC = 7470; -- The chest was a mimic!
-  CHEST_MOOGLE = 7471; -- You cannot open the chest while participating in the moogle event.
-CHEST_ILLUSION = 7472; -- The chest was but an illusion...
-  CHEST_LOCKED = 7473; -- The chest appears to be locked.
+CHEST_UNLOCKED = 7467; -- You unlock the chest!
+    CHEST_FAIL = 7468; -- Fails to open the chest.
+    CHEST_TRAP = 7469; -- The chest was trapped!
+    CHEST_WEAK = 7470; -- You cannot open the chest when you are in a weakened state.
+   CHEST_MIMIC = 7471; -- The chest was a mimic!
+  CHEST_MOOGLE = 7472; -- You cannot open the chest while participating in the moogle event.
+CHEST_ILLUSION = 7473; -- The chest was but an illusion...
+  CHEST_LOCKED = 7474; -- The chest appears to be locked.
 
 -- conquest Base
-CONQUEST_BASE = 7045; -- Tallying conquest results...
+CONQUEST_BASE = 7046; -- Tallying conquest results...
 

--- a/scripts/zones/Den_of_Rancor/TextIDs.lua
+++ b/scripts/zones/Den_of_Rancor/TextIDs.lua
@@ -2,24 +2,24 @@
 
 -- General Texts
 ITEM_CANNOT_BE_OBTAINED = 6379; -- You cannot obtain the item <item> come back again after sorting your inventory
-          ITEM_OBTAINED = 6384; -- Obtained: <item>
-           GIL_OBTAINED = 6385; -- Obtained <number> gil
-       KEYITEM_OBTAINED = 6387; -- Obtained key item: <keyitem>
- FISHING_MESSAGE_OFFSET = 7232; -- You can't fish here
-            HOMEPOINT_SET = 10532; -- Home point set!
+          ITEM_OBTAINED = 6385; -- Obtained: <item>
+           GIL_OBTAINED = 6386; -- Obtained <number> gil
+       KEYITEM_OBTAINED = 6388; -- Obtained key item: <keyitem>
+ FISHING_MESSAGE_OFFSET = 7233; -- You can't fish here
+            HOMEPOINT_SET = 10533; -- Home point set!
 
 -- Treasure Coffer/Chest Dialog
-CHEST_UNLOCKED = 7339; -- You unlock the chest!
-    CHEST_FAIL = 7340; -- Fails to open the chest.
-    CHEST_TRAP = 7341; -- The chest was trapped!
-    CHEST_WEAK = 7342; -- You cannot open the chest when you are in a weakened state.
-   CHEST_MIMIC = 7343; -- The chest was a mimic!
-  CHEST_MOOGLE = 7344; -- You cannot open the chest while participating in the moogle event.
-CHEST_ILLUSION = 7345; -- The chest was but an illusion...
-  CHEST_LOCKED = 7346; -- The chest appears to be locked.
+CHEST_UNLOCKED = 7340; -- You unlock the chest!
+    CHEST_FAIL = 7341; -- Fails to open the chest.
+    CHEST_TRAP = 7342; -- The chest was trapped!
+    CHEST_WEAK = 7343; -- You cannot open the chest when you are in a weakened state.
+   CHEST_MIMIC = 7344; -- The chest was a mimic!
+  CHEST_MOOGLE = 7345; -- You cannot open the chest while participating in the moogle event.
+CHEST_ILLUSION = 7346; -- The chest was but an illusion...
+  CHEST_LOCKED = 7347; -- The chest appears to be locked.
 
 -- Other dialog
-LANTERN_OFFSET = 7204; -- The grating will not budge.
+LANTERN_OFFSET = 7205; -- The grating will not budge.
 
 -- conquest Base
-CONQUEST_BASE = 7045; -- Tallying conquest results...
+CONQUEST_BASE = 7046; -- Tallying conquest results...

--- a/scripts/zones/Dho_Gates/TextIDs.lua
+++ b/scripts/zones/Dho_Gates/TextIDs.lua
@@ -2,6 +2,6 @@
 
 -- General Texts
 ITEM_CANNOT_BE_OBTAINED = 6379; -- You cannot obtain the item <item> come back again after sorting your inventory
-          ITEM_OBTAINED = 6384; -- Obtained: <item>
-           GIL_OBTAINED = 6385; -- Obtained <number> gil
-       KEYITEM_OBTAINED = 6387; -- Obtained key item: <keyitem>
+          ITEM_OBTAINED = 6385; -- Obtained: <item>
+           GIL_OBTAINED = 6386; -- Obtained <number> gil
+       KEYITEM_OBTAINED = 6388; -- Obtained key item: <keyitem>

--- a/scripts/zones/Diorama_Abdhaljs-Ghelsba/TextIDs.lua
+++ b/scripts/zones/Diorama_Abdhaljs-Ghelsba/TextIDs.lua
@@ -2,6 +2,6 @@
 
 -- General Texts
 ITEM_CANNOT_BE_OBTAINED = 6379; -- You cannot obtain the item <item> come back again after sorting your inventory
-          ITEM_OBTAINED = 6384; -- Obtained: <item>
-           GIL_OBTAINED = 6385; -- Obtained <number> gil
-       KEYITEM_OBTAINED = 6387; -- Obtained key item: <keyitem>
+          ITEM_OBTAINED = 6385; -- Obtained: <item>
+           GIL_OBTAINED = 6386; -- Obtained <number> gil
+       KEYITEM_OBTAINED = 6388; -- Obtained key item: <keyitem>

--- a/scripts/zones/Dragons_Aery/TextIDs.lua
+++ b/scripts/zones/Dragons_Aery/TextIDs.lua
@@ -3,14 +3,14 @@
 -- General Texts
    ITEM_CANNOT_BE_OBTAINED = 6379; -- You cannot obtain the item <item>. Come back after sorting your inventory.
 FULL_INVENTORY_AFTER_TRADE = 6383; -- You cannot obtain the #. Try trading again after sorting your inventory.
-             ITEM_OBTAINED = 6384; -- Obtained: <item>.
-              GIL_OBTAINED = 6385; -- Obtained <number> gil.
-          KEYITEM_OBTAINED = 6387; -- Obtained key item: <keyitem>.
-            ITEMS_OBTAINED = 6390; -- You obtain
-    FISHING_MESSAGE_OFFSET = 7045; -- You can't fish here.
+             ITEM_OBTAINED = 6385; -- Obtained: <item>.
+              GIL_OBTAINED = 6386; -- Obtained <number> gil.
+          KEYITEM_OBTAINED = 6388; -- Obtained key item: <keyitem>.
+            ITEMS_OBTAINED = 6391; -- You obtain
+    FISHING_MESSAGE_OFFSET = 7046; -- You can't fish here.
 
 -- Other dialog
-   NOTHING_OUT_OF_ORDINARY = 6398; -- There is nothing out of the ordinary here.
+   NOTHING_OUT_OF_ORDINARY = 6399; -- There is nothing out of the ordinary here.
 
 -- conquest Base
-CONQUEST_BASE = 7147; -- Tallying conquest results...
+CONQUEST_BASE = 7148; -- Tallying conquest results...

--- a/scripts/zones/Dynamis-Bastok/TextIDs.lua
+++ b/scripts/zones/Dynamis-Bastok/TextIDs.lua
@@ -2,11 +2,11 @@
 
 -- General Texts
 ITEM_CANNOT_BE_OBTAINED = 6379; -- You cannot obtain the item <item> come back again after sorting your inventory
-          ITEM_OBTAINED = 6384; -- Obtained: <item>
-           GIL_OBTAINED = 6385; -- Obtained <number> gil
-       KEYITEM_OBTAINED = 6387; -- Obtained key item: <keyitem>
+          ITEM_OBTAINED = 6385; -- Obtained: <item>
+           GIL_OBTAINED = 6386; -- Obtained <number> gil
+       KEYITEM_OBTAINED = 6388; -- Obtained key item: <keyitem>
 
-NOTHING_OUT_OF_ORDINARY = 6398; -- There is nothing out of the ordinary here.
+NOTHING_OUT_OF_ORDINARY = 6399; -- There is nothing out of the ordinary here.
 
 -- conquest Base
-CONQUEST_BASE = 7151; -- Tallying conquest results...
+CONQUEST_BASE = 7152; -- Tallying conquest results...

--- a/scripts/zones/Dynamis-Beaucedine/TextIDs.lua
+++ b/scripts/zones/Dynamis-Beaucedine/TextIDs.lua
@@ -2,10 +2,10 @@
 
 -- General Texts
 ITEM_CANNOT_BE_OBTAINED = 6379; -- You cannot obtain the item <item> come back again after sorting your inventory
-          ITEM_OBTAINED = 6384; -- Obtained: <item>
-           GIL_OBTAINED = 6385; -- Obtained <number> gil
-       KEYITEM_OBTAINED = 6387; -- Obtained key item: <keyitem>
+          ITEM_OBTAINED = 6385; -- Obtained: <item>
+           GIL_OBTAINED = 6386; -- Obtained <number> gil
+       KEYITEM_OBTAINED = 6388; -- Obtained key item: <keyitem>
 
 
 -- conquest Base
-CONQUEST_BASE = 7151; -- Tallying conquest results...
+CONQUEST_BASE = 7152; -- Tallying conquest results...

--- a/scripts/zones/Dynamis-Buburimu/TextIDs.lua
+++ b/scripts/zones/Dynamis-Buburimu/TextIDs.lua
@@ -2,9 +2,9 @@
 
 -- General Texts
 ITEM_CANNOT_BE_OBTAINED = 6379; -- You cannot obtain the item <item> come back again after sorting your inventory
-          ITEM_OBTAINED = 6384; -- Obtained: <item>
-           GIL_OBTAINED = 6385; -- Obtained <number> gil
-       KEYITEM_OBTAINED = 6387; -- Obtained key item: <keyitem>
+          ITEM_OBTAINED = 6385; -- Obtained: <item>
+           GIL_OBTAINED = 6386; -- Obtained <number> gil
+       KEYITEM_OBTAINED = 6388; -- Obtained key item: <keyitem>
 
 -- conquest Base
-CONQUEST_BASE = 7145; -- Tallying conquest results...
+CONQUEST_BASE = 7146; -- Tallying conquest results...

--- a/scripts/zones/Dynamis-Jeuno/TextIDs.lua
+++ b/scripts/zones/Dynamis-Jeuno/TextIDs.lua
@@ -2,9 +2,9 @@
 
 -- General Texts
 ITEM_CANNOT_BE_OBTAINED = 6379; -- You cannot obtain the item <item> come back again after sorting your inventory
-          ITEM_OBTAINED = 6384; -- Obtained: <item>
-           GIL_OBTAINED = 6385; -- Obtained <number> gil
-       KEYITEM_OBTAINED = 6387; -- Obtained key item: <keyitem>
+          ITEM_OBTAINED = 6385; -- Obtained: <item>
+           GIL_OBTAINED = 6386; -- Obtained <number> gil
+       KEYITEM_OBTAINED = 6388; -- Obtained key item: <keyitem>
 
 -- conquest Base
-CONQUEST_BASE = 7051; -- Tallying conquest results...
+CONQUEST_BASE = 7052; -- Tallying conquest results...

--- a/scripts/zones/Dynamis-Qufim/TextIDs.lua
+++ b/scripts/zones/Dynamis-Qufim/TextIDs.lua
@@ -2,9 +2,9 @@
 
 -- General Texts
 ITEM_CANNOT_BE_OBTAINED = 6379; -- You cannot obtain the item <item> come back again after sorting your inventory
-          ITEM_OBTAINED = 6384; -- Obtained: <item>
-           GIL_OBTAINED = 6385; -- Obtained <number> gil
-       KEYITEM_OBTAINED = 6387; -- Obtained key item: <keyitem>
+          ITEM_OBTAINED = 6385; -- Obtained: <item>
+           GIL_OBTAINED = 6386; -- Obtained <number> gil
+       KEYITEM_OBTAINED = 6388; -- Obtained key item: <keyitem>
 
 -- conquest Base
-CONQUEST_BASE = 7145; -- Tallying conquest results...
+CONQUEST_BASE = 7146; -- Tallying conquest results...

--- a/scripts/zones/Dynamis-San_dOria/TextIDs.lua
+++ b/scripts/zones/Dynamis-San_dOria/TextIDs.lua
@@ -2,11 +2,11 @@
 
 -- General Texts
 ITEM_CANNOT_BE_OBTAINED = 6379; -- You cannot obtain the item <item> come back again after sorting your inventory
-          ITEM_OBTAINED = 6384; -- Obtained: <item>
-           GIL_OBTAINED = 6385; -- Obtained <number> gil
-       KEYITEM_OBTAINED = 6387; -- Obtained key item: <keyitem>
+          ITEM_OBTAINED = 6385; -- Obtained: <item>
+           GIL_OBTAINED = 6386; -- Obtained <number> gil
+       KEYITEM_OBTAINED = 6388; -- Obtained key item: <keyitem>
 
-NOTHING_OUT_OF_ORDINARY = 6398; -- There is nothing out of the ordinary here.
+NOTHING_OUT_OF_ORDINARY = 6399; -- There is nothing out of the ordinary here.
 
 -- conquest Base
-CONQUEST_BASE = 7051; -- Tallying conquest results...
+CONQUEST_BASE = 7052; -- Tallying conquest results...

--- a/scripts/zones/Dynamis-Tavnazia/TextIDs.lua
+++ b/scripts/zones/Dynamis-Tavnazia/TextIDs.lua
@@ -2,12 +2,12 @@
 
 -- General Texts
 ITEM_CANNOT_BE_OBTAINED = 6379; -- You cannot obtain the item <item> come back again after sorting your inventory
-          ITEM_OBTAINED = 6384; -- Obtained: <item>
-           GIL_OBTAINED = 6385; -- Obtained <number> gil
-       KEYITEM_OBTAINED = 6387; -- Obtained key item: <keyitem>
+          ITEM_OBTAINED = 6385; -- Obtained: <item>
+           GIL_OBTAINED = 6386; -- Obtained <number> gil
+       KEYITEM_OBTAINED = 6388; -- Obtained key item: <keyitem>
 
 
 
 DIABOLOS = 7278; -- ??? message
 -- conquest Base
-CONQUEST_BASE = 7145; -- Tallying conquest results...
+CONQUEST_BASE = 7146; -- Tallying conquest results...

--- a/scripts/zones/Dynamis-Valkurm/TextIDs.lua
+++ b/scripts/zones/Dynamis-Valkurm/TextIDs.lua
@@ -2,9 +2,9 @@
 
 -- General Texts
 ITEM_CANNOT_BE_OBTAINED = 6379; -- You cannot obtain the item <item> come back again after sorting your inventory
-          ITEM_OBTAINED = 6384; -- Obtained: <item>
-           GIL_OBTAINED = 6385; -- Obtained <number> gil
-       KEYITEM_OBTAINED = 6387; -- Obtained key item: <keyitem>
+          ITEM_OBTAINED = 6385; -- Obtained: <item>
+           GIL_OBTAINED = 6386; -- Obtained <number> gil
+       KEYITEM_OBTAINED = 6388; -- Obtained key item: <keyitem>
 
 -- conquest Base
-CONQUEST_BASE = 7145; -- Tallying conquest results...
+CONQUEST_BASE = 7146; -- Tallying conquest results...

--- a/scripts/zones/Dynamis-Windurst/TextIDs.lua
+++ b/scripts/zones/Dynamis-Windurst/TextIDs.lua
@@ -2,11 +2,11 @@
 
 -- General Texts
 ITEM_CANNOT_BE_OBTAINED = 6379; -- You cannot obtain the item <item> come back again after sorting your inventory
-          ITEM_OBTAINED = 6384; -- Obtained: <item>
-           GIL_OBTAINED = 6385; -- Obtained <number> gil
-       KEYITEM_OBTAINED = 6387; -- Obtained key item: <keyitem>
+          ITEM_OBTAINED = 6385; -- Obtained: <item>
+           GIL_OBTAINED = 6386; -- Obtained <number> gil
+       KEYITEM_OBTAINED = 6388; -- Obtained key item: <keyitem>
 
-NOTHING_OUT_OF_ORDINARY = 6398; -- There is nothing out of the ordinary here.
+NOTHING_OUT_OF_ORDINARY = 6399; -- There is nothing out of the ordinary here.
 
 -- conquest Base
-CONQUEST_BASE = 7151; -- Tallying conquest results...
+CONQUEST_BASE = 7152; -- Tallying conquest results...

--- a/scripts/zones/Dynamis-Xarcabard/TextIDs.lua
+++ b/scripts/zones/Dynamis-Xarcabard/TextIDs.lua
@@ -2,28 +2,28 @@
 
 -- General Texts
 ITEM_CANNOT_BE_OBTAINED = 6379; -- You cannot obtain the item <item> come back again after sorting your inventory
-          ITEM_OBTAINED = 6384; -- Obtained: <item>
-           GIL_OBTAINED = 6385; -- Obtained <number> gil
-       KEYITEM_OBTAINED = 6387; -- Obtained key item: <keyitem>
+          ITEM_OBTAINED = 6385; -- Obtained: <item>
+           GIL_OBTAINED = 6386; -- Obtained <number> gil
+       KEYITEM_OBTAINED = 6388; -- Obtained key item: <keyitem>
 
-    ANIMATED_KNUCKLES_DIALOG = 7293; -- I am known as the Fists of Mystics. Come, show me your fighting spirit.
-      ANIMATED_DAGGER_DIALOG = 7325; -- I am called the Ornate Blade. Now, show me your strength.
-   ANIMATED_LONGSWORD_DIALOG = 7357; -- People have named me the Holy Blade. I will try thy resolution.
-    ANIMATED_CLAYMORE_DIALOG = 7389; -- I am the Intricate Blade. Show me the depths of your fury!
-       ANIMATED_TABAR_DIALOG = 7421; -- Me, axe. Runaeic, Axe. You, die
-    ANIMATED_GREATAXE_DIALOG = 7453; -- I have been given the title of Seraphic Axe. Will you attempt to survive my love?
-       ANIMATED_SPEAR_DIALOG = 7485; -- I am the Stellar Spear. It is time to test your courage.
-      ANIMATED_SCYTHE_DIALOG = 7517; -- I am known as the Tenebrous Scythe. Overwhelm me with your greed for power.
-       ANIMATED_KUNAI_DIALOG = 7549; -- I am called the Demoniac Blade. Allow me to witness your technique.
-       ANIMATED_TACHI_DIALOG = 7581; -- I am the Divine Blade. I demand a test of your will.
-      ANIMATED_HAMMER_DIALOG = 7613; -- People have named me the Heavenly Hammer. I will test your might to its very limits.
-       ANIMATED_STAFF_DIALOG = 7645; -- I am called the Celestial Staff. I will glimpse into your mind's eye...
-     ANIMATED_LONGBOW_DIALOG = 7677; -- I am known as the Snarled Bow. I will measure the limits of your determination.
-         ANIMATED_GUN_DIALOG = 7709; -- I am known as the Ethereal Rifle. Do you realize my incredible value?
-        ANIMATED_HORN_DIALOG = 7741; -- I am called the Mysterial Horn. Show me your true intentions.
-      ANIMATED_SHIELD_DIALOG = 7773; -- I am Aegis, the impervious shield of everlasting.
-PRISON_OF_SOULS_HAS_SET_FREE = 7805; -- prison of souls has set free its captive spirits!?Prompt?
+    ANIMATED_KNUCKLES_DIALOG = 7294; -- I am known as the Fists of Mystics. Come, show me your fighting spirit.
+      ANIMATED_DAGGER_DIALOG = 7326; -- I am called the Ornate Blade. Now, show me your strength.
+   ANIMATED_LONGSWORD_DIALOG = 7358; -- People have named me the Holy Blade. I will try thy resolution.
+    ANIMATED_CLAYMORE_DIALOG = 7390; -- I am the Intricate Blade. Show me the depths of your fury!
+       ANIMATED_TABAR_DIALOG = 7422; -- Me, axe. Runaeic, Axe. You, die
+    ANIMATED_GREATAXE_DIALOG = 7454; -- I have been given the title of Seraphic Axe. Will you attempt to survive my love?
+       ANIMATED_SPEAR_DIALOG = 7486; -- I am the Stellar Spear. It is time to test your courage.
+      ANIMATED_SCYTHE_DIALOG = 7518; -- I am known as the Tenebrous Scythe. Overwhelm me with your greed for power.
+       ANIMATED_KUNAI_DIALOG = 7550; -- I am called the Demoniac Blade. Allow me to witness your technique.
+       ANIMATED_TACHI_DIALOG = 7582; -- I am the Divine Blade. I demand a test of your will.
+      ANIMATED_HAMMER_DIALOG = 7614; -- People have named me the Heavenly Hammer. I will test your might to its very limits.
+       ANIMATED_STAFF_DIALOG = 7646; -- I am called the Celestial Staff. I will glimpse into your mind's eye...
+     ANIMATED_LONGBOW_DIALOG = 7678; -- I am known as the Snarled Bow. I will measure the limits of your determination.
+         ANIMATED_GUN_DIALOG = 7710; -- I am known as the Ethereal Rifle. Do you realize my incredible value?
+        ANIMATED_HORN_DIALOG = 7742; -- I am called the Mysterial Horn. Show me your true intentions.
+      ANIMATED_SHIELD_DIALOG = 7774; -- I am Aegis, the impervious shield of everlasting.
+PRISON_OF_SOULS_HAS_SET_FREE = 7806; -- prison of souls has set free its captive spirits!?Prompt?
 
 
 -- conquest Base
-CONQUEST_BASE = 7051; -- Tallying conquest results...
+CONQUEST_BASE = 7052; -- Tallying conquest results...

--- a/scripts/zones/East_Ronfaure/TextIDs.lua
+++ b/scripts/zones/East_Ronfaure/TextIDs.lua
@@ -2,26 +2,26 @@
 
 -- General Texts
 ITEM_CANNOT_BE_OBTAINED = 6401; -- You cannot obtain the item <item> come back again after sorting your inventory.
-          ITEM_OBTAINED = 6406; -- Obtained: <item>.
-           GIL_OBTAINED = 6407; -- Obtained <number> gil.
-       KEYITEM_OBTAINED = 6409; -- Obtained key item: <keyitem>.
- FISHING_MESSAGE_OFFSET = 7226; -- You can't fish here.
+          ITEM_OBTAINED = 6407; -- Obtained: <item>.
+           GIL_OBTAINED = 6408; -- Obtained <number> gil.
+       KEYITEM_OBTAINED = 6410; -- Obtained key item: <keyitem>.
+ FISHING_MESSAGE_OFFSET = 7227; -- You can't fish here.
 
 -- Logging
-LOGGING_IS_POSSIBLE_HERE = 7482; -- Logging is possible here if you have
+LOGGING_IS_POSSIBLE_HERE = 7483; -- Logging is possible here if you have
 
 -- General Dialog
-     RAYOCHINDOT_DIALOG = 7406; -- If you are outmatched, run to the city as quickly as you can.
-     CROTEILLARD_DIALOG = 7407; -- Sorry, no chatting while I'm on duty.
-      BLESSED_WATERSKIN = 7451; -- To get water, radethe waterskin you hold with the river.
-     CHEVAL_RIVER_WATER = 7432; -- You fill your waterskin with water from the river. You now have
-NOTHING_OUT_OF_ORDINARY = 6420; -- There is nothing out of the ordinary here.
+     RAYOCHINDOT_DIALOG = 7407; -- If you are outmatched, run to the city as quickly as you can.
+     CROTEILLARD_DIALOG = 7408; -- Sorry, no chatting while I'm on duty.
+      BLESSED_WATERSKIN = 7452; -- To get water, radethe waterskin you hold with the river.
+     CHEVAL_RIVER_WATER = 7433; -- You fill your waterskin with water from the river. You now have
+NOTHING_OUT_OF_ORDINARY = 6421; -- There is nothing out of the ordinary here.
 
 -- Other Dialog
-NOTHING_HAPPENS = 7326; -- Nothing happens...
+NOTHING_HAPPENS = 7327; -- Nothing happens...
 -- conquest Base
-CONQUEST_BASE = 7067; -- Tallying conquest results...
+CONQUEST_BASE = 7068; -- Tallying conquest results...
 
 -- chocobo digging
-DIG_THROW_AWAY = 7239; -- You dig up ?Possible Special Code: 01??Possible Special Code: 01??Possible Special Code: 01? ?Possible Special Code: 01??Possible Special Code: 05?$?BAD CHAR: 8280??BAD CHAR: 80??BAD CHAR: 80?, but your inventory is full.
-FIND_NOTHING = 7241; -- You dig and you dig, but find nothing.
+DIG_THROW_AWAY = 7240; -- You dig up ?Possible Special Code: 01??Possible Special Code: 01??Possible Special Code: 01? ?Possible Special Code: 01??Possible Special Code: 05?$?BAD CHAR: 8280??BAD CHAR: 80??BAD CHAR: 80?, but your inventory is full.
+FIND_NOTHING = 7242; -- You dig and you dig, but find nothing.

--- a/scripts/zones/East_Ronfaure_[S]/TextIDs.lua
+++ b/scripts/zones/East_Ronfaure_[S]/TextIDs.lua
@@ -2,11 +2,11 @@
 
 -- General Texts
 ITEM_CANNOT_BE_OBTAINED = 6379; -- You cannot obtain the item <item>. Come back after sorting your inventory.
-          ITEM_OBTAINED = 6384; -- Obtained: <item>.
-           GIL_OBTAINED = 6385; -- Obtained <number> gil.
-       KEYITEM_OBTAINED = 6387; -- Obtained key item: <keyitem>.
-NOTHING_OUT_OF_ORDINARY = 6398; -- There is nothing out of the ordinary here.
- FISHING_MESSAGE_OFFSET = 7726; -- You can't fish here.
+          ITEM_OBTAINED = 6385; -- Obtained: <item>.
+           GIL_OBTAINED = 6386; -- Obtained <number> gil.
+       KEYITEM_OBTAINED = 6388; -- Obtained key item: <keyitem>.
+NOTHING_OUT_OF_ORDINARY = 6399; -- There is nothing out of the ordinary here.
+ FISHING_MESSAGE_OFFSET = 7727; -- You can't fish here.
 
 -- Logging
-LOGGING_IS_POSSIBLE_HERE = 7142; -- Logging is possible here if you have
+LOGGING_IS_POSSIBLE_HERE = 7143; -- Logging is possible here if you have

--- a/scripts/zones/East_Sarutabaruta/TextIDs.lua
+++ b/scripts/zones/East_Sarutabaruta/TextIDs.lua
@@ -2,23 +2,23 @@
 
 -- General Texts
 ITEM_CANNOT_BE_OBTAINED = 6379; -- You cannot obtain the item <item> come back again after sorting your inventory
-          ITEM_OBTAINED = 6384; -- Obtained: <item>
-           GIL_OBTAINED = 6385; -- Obtained <number> gil
-       KEYITEM_OBTAINED = 6387; -- Obtained key item: <keyitem>
- FISHING_MESSAGE_OFFSET = 7204; -- You can't fish here
+          ITEM_OBTAINED = 6385; -- Obtained: <item>
+           GIL_OBTAINED = 6386; -- Obtained <number> gil
+       KEYITEM_OBTAINED = 6388; -- Obtained key item: <keyitem>
+ FISHING_MESSAGE_OFFSET = 7205; -- You can't fish here
 
 -- Dialog Texts
-  TABY_CANATAHEY_DIALOG = 7384; -- This is the entrrrance to Windurst. Please maintain orderrrly conduct while you'rrre in town.
-   HEIH_PORHIAAP_DIALOG = 7385; -- These grrrasslands make up East Sarutabaruta. Lately the number of monsters has drrramatically increased, causing us all sorts of trrrouble.
- SAMA_GOHJIMA_PREDIALOG = 7387; -- The ministerrr of the Orastery is in the laborrratory beneath here. To get there, you should check the walls verrry carrrefully.
-SAMA_GOHJIMA_POSTDIALOG = 7388; -- Were you able to find the laborrratory? There are many such hidden passages in the Horutoto Ruins.
+  TABY_CANATAHEY_DIALOG = 7385; -- This is the entrrrance to Windurst. Please maintain orderrrly conduct while you'rrre in town.
+   HEIH_PORHIAAP_DIALOG = 7386; -- These grrrasslands make up East Sarutabaruta. Lately the number of monsters has drrramatically increased, causing us all sorts of trrrouble.
+ SAMA_GOHJIMA_PREDIALOG = 7388; -- The ministerrr of the Orastery is in the laborrratory beneath here. To get there, you should check the walls verrry carrrefully.
+SAMA_GOHJIMA_POSTDIALOG = 7389; -- Were you able to find the laborrratory? There are many such hidden passages in the Horutoto Ruins.
 
 -- Signs
-SIGNPOST_OFFSET = 7374; -- Southeast: South Tower, Horutoto Ruins Southwest: Windurst Woods
+SIGNPOST_OFFSET = 7375; -- Southeast: South Tower, Horutoto Ruins Southwest: Windurst Woods
 
 -- conquest Base
-CONQUEST_BASE = 7045; -- Tallying conquest results...
+CONQUEST_BASE = 7046; -- Tallying conquest results...
 
 -- chocobo digging
-DIG_THROW_AWAY = 7217; -- You dig up ?Possible Special Code: 01??Possible Special Code: 01??Possible Special Code: 01? ?Possible Special Code: 01??Possible Special Code: 05?$?BAD CHAR: 8280??BAD CHAR: 80??BAD CHAR: 80?, but your inventory is full.
-FIND_NOTHING = 7219; -- You dig and you dig, but find nothing.
+DIG_THROW_AWAY = 7218; -- You dig up ?Possible Special Code: 01??Possible Special Code: 01??Possible Special Code: 01? ?Possible Special Code: 01??Possible Special Code: 05?$?BAD CHAR: 8280??BAD CHAR: 80??BAD CHAR: 80?, but your inventory is full.
+FIND_NOTHING = 7220; -- You dig and you dig, but find nothing.

--- a/scripts/zones/Eastern_Adoulin/TextIDs.lua
+++ b/scripts/zones/Eastern_Adoulin/TextIDs.lua
@@ -2,7 +2,7 @@
 
 -- General Texts
 ITEM_CANNOT_BE_OBTAINED = 6379; -- You cannot obtain the item <item> come back again after sorting your inventory
-          ITEM_OBTAINED = 6384; -- Obtained: <item>
-           GIL_OBTAINED = 6385; -- Obtained <number> gil
-       KEYITEM_OBTAINED = 6387; -- Obtained key item: <keyitem>
-          HOMEPOINT_SET = 8279; -- Home point set!
+          ITEM_OBTAINED = 6385; -- Obtained: <item>
+           GIL_OBTAINED = 6386; -- Obtained <number> gil
+       KEYITEM_OBTAINED = 6388; -- Obtained key item: <keyitem>
+          HOMEPOINT_SET = 8280; -- Home point set!

--- a/scripts/zones/Eastern_Altepa_Desert/TextIDs.lua
+++ b/scripts/zones/Eastern_Altepa_Desert/TextIDs.lua
@@ -2,23 +2,23 @@
 
 -- General Texts
 ITEM_CANNOT_BE_OBTAINED = 6379; -- You cannot obtain the item <item>. Come back after sorting your inventory.
-          ITEM_OBTAINED = 6384; -- Obtained: <item>.
-           GIL_OBTAINED = 6385; -- Obtained <number> gil.
-       KEYITEM_OBTAINED = 6387; -- Obtained key item: <keyitem>.
-        BEASTMEN_BANNER = 7126; -- There is a beastmen's banner.
- FISHING_MESSAGE_OFFSET = 7546; -- You can't fish here.
-  ALREADY_OBTAINED_TELE = 7655; -- You already possess the gate crystal for this telepoint.
+          ITEM_OBTAINED = 6385; -- Obtained: <item>.
+           GIL_OBTAINED = 6386; -- Obtained <number> gil.
+       KEYITEM_OBTAINED = 6388; -- Obtained key item: <keyitem>.
+        BEASTMEN_BANNER = 7127; -- There is a beastmen's banner.
+ FISHING_MESSAGE_OFFSET = 7547; -- You can't fish here.
+  ALREADY_OBTAINED_TELE = 7656; -- You already possess the gate crystal for this telepoint.
 
 -- Conquest
-CONQUEST = 7213; -- You've earned conquest points!
+CONQUEST = 7214; -- You've earned conquest points!
 
 -- Quest Dialog
-    SENSE_OF_FOREBODING = 6399; -- You are suddenly overcome with a sense of foreboding...
-NOTHING_OUT_OF_ORDINARY = 7661; -- There is nothing out of the ordinary here.
+    SENSE_OF_FOREBODING = 6400; -- You are suddenly overcome with a sense of foreboding...
+NOTHING_OUT_OF_ORDINARY = 7662; -- There is nothing out of the ordinary here.
 
 -- conquest Base
-CONQUEST_BASE = 7045; -- Tallying conquest results...
+CONQUEST_BASE = 7046; -- Tallying conquest results...
 
 --chocobo digging
-DIG_THROW_AWAY = 7559; -- You dig up$, but your inventory is full. You regretfully throw the # away.
-FIND_NOTHING = 7561; -- You dig and you dig, but find nothing.
+DIG_THROW_AWAY = 7560; -- You dig up$, but your inventory is full. You regretfully throw the # away.
+FIND_NOTHING = 7562; -- You dig and you dig, but find nothing.

--- a/scripts/zones/Empyreal_Paradox/TextIDs.lua
+++ b/scripts/zones/Empyreal_Paradox/TextIDs.lua
@@ -2,14 +2,14 @@
 
 -- General Texts
 ITEM_CANNOT_BE_OBTAINED = 6379; -- You cannot obtain the item <item> come back again after sorting your inventory
-          ITEM_OBTAINED = 6384; -- Obtained: <item>
-           GIL_OBTAINED = 6385; -- Obtained <number> gil
-       KEYITEM_OBTAINED = 6387; -- Obtained key item: <keyitem>
+          ITEM_OBTAINED = 6385; -- Obtained: <item>
+           GIL_OBTAINED = 6386; -- Obtained <number> gil
+       KEYITEM_OBTAINED = 6388; -- Obtained key item: <keyitem>
 
-            PRISHE_TEXT =  7680; -- You're about to learn how strong the will to live makes us!
-          SELHTEUS_TEXT = 7693; -- The...Emptiness... Is this...how it was meant...to be...?
-         PROMATHIA_TEXT = 7696; -- Give thyself to the apathy within...
+            PRISHE_TEXT =  7681; -- You're about to learn how strong the will to live makes us!
+          SELHTEUS_TEXT = 7694; -- The...Emptiness... Is this...how it was meant...to be...?
+         PROMATHIA_TEXT = 7697; -- Give thyself to the apathy within...
 
 
 -- conquest Base
-CONQUEST_BASE = 7415; -- Tallying conquest results...
+CONQUEST_BASE = 7416; -- Tallying conquest results...

--- a/scripts/zones/Escha_ZiTah/TextIDs.lua
+++ b/scripts/zones/Escha_ZiTah/TextIDs.lua
@@ -2,7 +2,7 @@
 
 -- General Texts
 ITEM_CANNOT_BE_OBTAINED = 6379; -- You cannot obtain the item <item>. Come back after sorting your inventory.
-          ITEM_OBTAINED = 6384; -- Obtained: <item>.
-           GIL_OBTAINED = 6385; -- Obtained <number> gil.
-       KEYITEM_OBTAINED = 6387; -- Obtained key item: <keyitem>.
-         ITEMS_OBTAINED = 6390; -- You obtain <param2 number> <param1 item>!
+          ITEM_OBTAINED = 6385; -- Obtained: <item>.
+           GIL_OBTAINED = 6386; -- Obtained <number> gil.
+       KEYITEM_OBTAINED = 6388; -- Obtained key item: <keyitem>.
+         ITEMS_OBTAINED = 6391; -- You obtain <param2 number> <param1 item>!

--- a/scripts/zones/Everbloom_Hollow/TextIDs.lua
+++ b/scripts/zones/Everbloom_Hollow/TextIDs.lua
@@ -2,6 +2,6 @@
 
 -- General Texts
 ITEM_CANNOT_BE_OBTAINED = 6379; -- You cannot obtain the item <item> come back again after sorting your inventory
-          ITEM_OBTAINED = 6384; -- Obtained: <item>
-           GIL_OBTAINED = 6385; -- Obtained <number> gil
-       KEYITEM_OBTAINED = 6387; -- Obtained key item: <keyitem>
+          ITEM_OBTAINED = 6385; -- Obtained: <item>
+           GIL_OBTAINED = 6386; -- Obtained <number> gil
+       KEYITEM_OBTAINED = 6388; -- Obtained key item: <keyitem>

--- a/scripts/zones/FeiYin/TextIDs.lua
+++ b/scripts/zones/FeiYin/TextIDs.lua
@@ -2,37 +2,37 @@
 
 -- General Texts
 ITEM_CANNOT_BE_OBTAINED = 6558; -- You cannot obtain the item <item> come back again after sorting your inventory
-          ITEM_OBTAINED = 6563; -- Obtained: <item>
-           GIL_OBTAINED = 6564; -- Obtained <number> gil
-       KEYITEM_OBTAINED = 6566; -- Obtained key item: <keyitem>
- FISHING_MESSAGE_OFFSET = 7224; -- You can't fish here
-            HOMEPOINT_SET = 10684; -- Home point set!
+          ITEM_OBTAINED = 6564; -- Obtained: <item>
+           GIL_OBTAINED = 6565; -- Obtained <number> gil
+       KEYITEM_OBTAINED = 6567; -- Obtained key item: <keyitem>
+ FISHING_MESSAGE_OFFSET = 7225; -- You can't fish here
+            HOMEPOINT_SET = 10685; -- Home point set!
 
 -- Treasure Coffer/Chest Dialog
-CHEST_UNLOCKED = 7354; -- You unlock the chest!
-    CHEST_FAIL = 7355; -- Fails to open the chest.
-    CHEST_TRAP = 7356; -- The chest was trapped!
-    CHEST_WEAK = 7357; -- You cannot open the chest when you are in a weakened state.
-   CHEST_MIMIC = 7358; -- The chest was a mimic!
-  CHEST_MOOGLE = 7359; -- You cannot open the chest while participating in the moogle event.
-CHEST_ILLUSION = 7360; -- The chest was but an illusion...
-  CHEST_LOCKED = 7361; -- The chest appears to be locked.
+CHEST_UNLOCKED = 7355; -- You unlock the chest!
+    CHEST_FAIL = 7356; -- Fails to open the chest.
+    CHEST_TRAP = 7357; -- The chest was trapped!
+    CHEST_WEAK = 7358; -- You cannot open the chest when you are in a weakened state.
+   CHEST_MIMIC = 7359; -- The chest was a mimic!
+  CHEST_MOOGLE = 7360; -- You cannot open the chest while participating in the moogle event.
+CHEST_ILLUSION = 7361; -- The chest was but an illusion...
+  CHEST_LOCKED = 7362; -- The chest appears to be locked.
 
 -- Other Dialog
-    SENSE_OF_FOREBODING = 6578; -- You are suddenly overcome with a sense of foreboding...
-NOTHING_OUT_OF_ORDINARY = 6577; -- There is nothing out of the ordinary here.
+    SENSE_OF_FOREBODING = 6579; -- You are suddenly overcome with a sense of foreboding...
+NOTHING_OUT_OF_ORDINARY = 6578; -- There is nothing out of the ordinary here.
 
 -- ACP mission
-         MARK_OF_SEED_HAS_VANISHED = 7497; -- The Mark of Seed has vanished without a trace...
-MARK_OF_SEED_IS_ABOUT_TO_DISSIPATE = 7496; -- The Mark of Seed is about to dissipate entirely! Only a faint outline remains...
-        MARK_OF_SEED_GROWS_FAINTER = 7495; -- The Mark of Seed grows fainter still. Before long, it will fade away entirely...
-             MARK_OF_SEED_FLICKERS = 7494; -- The glow of the Mark of Seed flickers and dims ever so slightly...
-      SCINTILLATING_BURST_OF_LIGHT = 7485; -- As you extend your hand, there is a scintillating burst of light!
-           YOU_REACH_FOR_THE_LIGHT = 7484; -- You reach for the light, but there is no discernable effect...
-            EVEN_GREATER_INTENSITY = 7483; -- The emblem on your hand glows with even greater intensity!
-                THE_LIGHT_DWINDLES = 7482; -- However, the light dwindles and grows dim almost at once...
-        YOU_REACH_OUT_TO_THE_LIGHT = 7481; -- You reach out to the light, and one facet of a curious seed-shaped emblem materializes on the back of your hand.
-           SOFTLY_SHIMMERING_LIGHT = 7480; -- You see a softly shimmering light...
+         MARK_OF_SEED_HAS_VANISHED = 7498; -- The Mark of Seed has vanished without a trace...
+MARK_OF_SEED_IS_ABOUT_TO_DISSIPATE = 7497; -- The Mark of Seed is about to dissipate entirely! Only a faint outline remains...
+        MARK_OF_SEED_GROWS_FAINTER = 7496; -- The Mark of Seed grows fainter still. Before long, it will fade away entirely...
+             MARK_OF_SEED_FLICKERS = 7495; -- The glow of the Mark of Seed flickers and dims ever so slightly...
+      SCINTILLATING_BURST_OF_LIGHT = 7486; -- As you extend your hand, there is a scintillating burst of light!
+           YOU_REACH_FOR_THE_LIGHT = 7485; -- You reach for the light, but there is no discernable effect...
+            EVEN_GREATER_INTENSITY = 7484; -- The emblem on your hand glows with even greater intensity!
+                THE_LIGHT_DWINDLES = 7483; -- However, the light dwindles and grows dim almost at once...
+        YOU_REACH_OUT_TO_THE_LIGHT = 7482; -- You reach out to the light, and one facet of a curious seed-shaped emblem materializes on the back of your hand.
+           SOFTLY_SHIMMERING_LIGHT = 7481; -- You see a softly shimmering light...
 
 -- conquest Base
 CONQUEST_BASE = 3;

--- a/scripts/zones/Feretory/TextIDs.lua
+++ b/scripts/zones/Feretory/TextIDs.lua
@@ -2,6 +2,6 @@
 
 -- General Texts
 ITEM_CANNOT_BE_OBTAINED = 6379; -- You cannot obtain the item <item> come back again after sorting your inventory
-          ITEM_OBTAINED = 6384; -- Obtained: <item>
-           GIL_OBTAINED = 6385; -- Obtained <number> gil
-       KEYITEM_OBTAINED = 6387; -- Obtained key item: <keyitem>
+          ITEM_OBTAINED = 6385; -- Obtained: <item>
+           GIL_OBTAINED = 6386; -- Obtained <number> gil
+       KEYITEM_OBTAINED = 6388; -- Obtained key item: <keyitem>

--- a/scripts/zones/Foret_de_Hennetiel/TextIDs.lua
+++ b/scripts/zones/Foret_de_Hennetiel/TextIDs.lua
@@ -2,7 +2,7 @@
 
 -- General Texts
 ITEM_CANNOT_BE_OBTAINED = 6379; -- You cannot obtain the item <item> come back again after sorting your inventory
-          ITEM_OBTAINED = 6384; -- Obtained: <item>
-           GIL_OBTAINED = 6385; -- Obtained <number> gil
-       KEYITEM_OBTAINED = 6387; -- Obtained key item: <keyitem>
-            HOMEPOINT_SET = 7986; -- Home point set!
+          ITEM_OBTAINED = 6385; -- Obtained: <item>
+           GIL_OBTAINED = 6386; -- Obtained <number> gil
+       KEYITEM_OBTAINED = 6388; -- Obtained key item: <keyitem>
+            HOMEPOINT_SET = 7987; -- Home point set!

--- a/scripts/zones/Fort_Ghelsba/TextIDs.lua
+++ b/scripts/zones/Fort_Ghelsba/TextIDs.lua
@@ -2,19 +2,19 @@
 
 -- General Texts
 ITEM_CANNOT_BE_OBTAINED = 6538; -- You cannot obtain the item <item>. Come back after sorting your inventory.
-          ITEM_OBTAINED = 6543; -- Obtained: <item>.
-           GIL_OBTAINED = 6544; -- Obtained <number> gil.
-       KEYITEM_OBTAINED = 6546; -- Obtained key item: <keyitem>.
+          ITEM_OBTAINED = 6544; -- Obtained: <item>.
+           GIL_OBTAINED = 6545; -- Obtained <number> gil.
+       KEYITEM_OBTAINED = 6547; -- Obtained key item: <keyitem>.
 
 -- Treasure Coffer/Chest Dialog
-CHEST_UNLOCKED = 7350; -- You unlock the chest!
-    CHEST_FAIL = 7351; -- Fails to open the chest.
-    CHEST_TRAP = 7352; -- The chest was trapped!
-    CHEST_WEAK = 7353; -- You cannot open the chest when you are in a weakened state.
-   CHEST_MIMIC = 7354; -- The chest was a mimic!
-  CHEST_MOOGLE = 7355; -- You cannot open the chest while participating in the moogle event.
-CHEST_ILLUSION = 7356; -- The chest was but an illusion...
-  CHEST_LOCKED = 7357; -- The chest appears to be locked.
+CHEST_UNLOCKED = 7351; -- You unlock the chest!
+    CHEST_FAIL = 7352; -- Fails to open the chest.
+    CHEST_TRAP = 7353; -- The chest was trapped!
+    CHEST_WEAK = 7354; -- You cannot open the chest when you are in a weakened state.
+   CHEST_MIMIC = 7355; -- The chest was a mimic!
+  CHEST_MOOGLE = 7356; -- You cannot open the chest while participating in the moogle event.
+CHEST_ILLUSION = 7357; -- The chest was but an illusion...
+  CHEST_LOCKED = 7358; -- The chest appears to be locked.
 
 -- conquest Base
 CONQUEST_BASE = 0;

--- a/scripts/zones/Fort_Karugo-Narugo_[S]/TextIDs.lua
+++ b/scripts/zones/Fort_Karugo-Narugo_[S]/TextIDs.lua
@@ -2,16 +2,16 @@
 
 -- General Texts
 ITEM_CANNOT_BE_OBTAINED = 6379; -- You cannot obtain the item <item>. Come back after sorting your inventory.
-          ITEM_OBTAINED = 6384; -- Obtained: <item>.
-           GIL_OBTAINED = 6385; -- Obtained <number> gil.
-       KEYITEM_OBTAINED = 6387; -- Obtained key item: <keyitem>.
-NOTHING_OUT_OF_ORDINARY = 6398; -- There is nothing out of the ordinary here.
+          ITEM_OBTAINED = 6385; -- Obtained: <item>.
+           GIL_OBTAINED = 6386; -- Obtained <number> gil.
+       KEYITEM_OBTAINED = 6388; -- Obtained key item: <keyitem>.
+NOTHING_OUT_OF_ORDINARY = 6399; -- There is nothing out of the ordinary here.
 
 -- Shop Dialogues
-SPONDULIX_SHOP_DIALOG = 7200; -- Spondulix comes all the way from Boodlix's Emporium to help Tarutaru and Mithra. I can help you, too! You have gil, no?
+SPONDULIX_SHOP_DIALOG = 7201; -- Spondulix comes all the way from Boodlix's Emporium to help Tarutaru and Mithra. I can help you, too! You have gil, no?
 
 -- Logging
-LOGGING_IS_POSSIBLE_HERE = 7667; -- Logging is possible here if you have
+LOGGING_IS_POSSIBLE_HERE = 7668; -- Logging is possible here if you have
 
 -- Other Texts
-ITEM_DELIVERY_DIALOG = 8106; -- Deliveries! We're open for business!
+ITEM_DELIVERY_DIALOG = 8107; -- Deliveries! We're open for business!

--- a/scripts/zones/Full_Moon_Fountain/TextIDs.lua
+++ b/scripts/zones/Full_Moon_Fountain/TextIDs.lua
@@ -2,10 +2,10 @@
 
 -- General Texts
 ITEM_CANNOT_BE_OBTAINED = 6379; -- You cannot obtain the item <item>. Come back after sorting your inventory.
-          ITEM_OBTAINED = 6384; -- Obtained: <item>.
-           GIL_OBTAINED = 6385; -- Obtained <number> gil.
-       KEYITEM_OBTAINED = 6387; -- Obtained key item: <keyitem>.
+          ITEM_OBTAINED = 6385; -- Obtained: <item>.
+           GIL_OBTAINED = 6386; -- Obtained <number> gil.
+       KEYITEM_OBTAINED = 6388; -- Obtained key item: <keyitem>.
 
 
 -- conquest Base
-CONQUEST_BASE = 7045; -- Tallying conquest results...
+CONQUEST_BASE = 7046; -- Tallying conquest results...

--- a/scripts/zones/GM_Home/TextIDs.lua
+++ b/scripts/zones/GM_Home/TextIDs.lua
@@ -2,6 +2,6 @@
 
 -- General Texts
 ITEM_CANNOT_BE_OBTAINED = 6379; -- You cannot obtain the item <item>. Come back after sorting your inventory.
-          ITEM_OBTAINED = 6384; -- Obtained: <item>.
-           GIL_OBTAINED = 6385; -- Obtained <number> gil.
-       KEYITEM_OBTAINED = 6387; -- Obtained key item: <keyitem>.
+          ITEM_OBTAINED = 6385; -- Obtained: <item>.
+           GIL_OBTAINED = 6386; -- Obtained <number> gil.
+       KEYITEM_OBTAINED = 6388; -- Obtained key item: <keyitem>.

--- a/scripts/zones/Garlaige_Citadel/TextIDs.lua
+++ b/scripts/zones/Garlaige_Citadel/TextIDs.lua
@@ -2,39 +2,39 @@
 
 -- General Texts
 ITEM_CANNOT_BE_OBTAINED = 6538; -- You cannot obtain the item <item>. Come back after sorting your inventory.
-          ITEM_OBTAINED = 6543; -- Obtained: <item>.
-           GIL_OBTAINED = 6544; -- Obtained <number> gil.
-       KEYITEM_OBTAINED = 6546; -- Obtained key item: <keyitem>.
+          ITEM_OBTAINED = 6544; -- Obtained: <item>.
+           GIL_OBTAINED = 6545; -- Obtained <number> gil.
+       KEYITEM_OBTAINED = 6547; -- Obtained key item: <keyitem>.
 
 -- Treasure Coffer/Chest Dialog
-CHEST_UNLOCKED = 7321; -- You unlock the chest!
-    CHEST_FAIL = 7322; -- Fails to open the chest.
-    CHEST_TRAP = 7323; -- The chest was trapped!
-    CHEST_WEAK = 7324; -- You cannot open the chest when you are in a weakened state.
-   CHEST_MIMIC = 7325; -- The chest was a mimic!
-  CHEST_MOOGLE = 7326; -- You cannot open the chest while participating in the moogle event.
-CHEST_ILLUSION = 7327; -- The chest was but an illusion...
-  CHEST_LOCKED = 7328; -- The chest appears to be locked.
+CHEST_UNLOCKED = 7322; -- You unlock the chest!
+    CHEST_FAIL = 7323; -- Fails to open the chest.
+    CHEST_TRAP = 7324; -- The chest was trapped!
+    CHEST_WEAK = 7325; -- You cannot open the chest when you are in a weakened state.
+   CHEST_MIMIC = 7326; -- The chest was a mimic!
+  CHEST_MOOGLE = 7327; -- You cannot open the chest while participating in the moogle event.
+CHEST_ILLUSION = 7328; -- The chest was but an illusion...
+  CHEST_LOCKED = 7329; -- The chest appears to be locked.
 
 -- Dialog Texts
-     SENSE_OF_FOREBODING = 6558; -- You are suddenly overcome with a sense of foreboding...
-        YOU_FIND_NOTHING = 7289; -- You find nothing special.
-   PRESENCE_FROM_CEILING = 7291; -- You sense a presence from in the ceiling.?Prompt?
-       HEAT_FROM_CEILING = 7292; -- You feel a terrible heat from the ceiling.
+     SENSE_OF_FOREBODING = 6559; -- You are suddenly overcome with a sense of foreboding...
+        YOU_FIND_NOTHING = 7290; -- You find nothing special.
+   PRESENCE_FROM_CEILING = 7292; -- You sense a presence from in the ceiling.?Prompt?
+       HEAT_FROM_CEILING = 7293; -- You feel a terrible heat from the ceiling.
 
 -- Door dialog
- A_GATE_OF_STURDY_STEEL = 7267; -- A gate of sturdy steel.
-OPEN_WITH_THE_RIGHT_KEY = 7273; -- You might be able to open it with the right key.
-        BANISHING_GATES = 7282; -- The first banishing gate begins to open...
-BANISHING_GATES_CLOSING = 7285; -- The first banishing gate starts to close.
+ A_GATE_OF_STURDY_STEEL = 7268; -- A gate of sturdy steel.
+OPEN_WITH_THE_RIGHT_KEY = 7274; -- You might be able to open it with the right key.
+        BANISHING_GATES = 7283; -- The first banishing gate begins to open...
+BANISHING_GATES_CLOSING = 7286; -- The first banishing gate starts to close.
 
 -- Other
-NOTHING_OUT_OF_THE_ORDINARY = 6557; -- There is nothing out of the ordinary here.
+NOTHING_OUT_OF_THE_ORDINARY = 6558; -- There is nothing out of the ordinary here.
 
 -- conquest Base
 CONQUEST_BASE = 0;
 
 -- Strange Apparatus
-DEVICE_NOT_WORKING = 7229; -- The device is not working.
-      SYS_OVERLOAD = 7238; -- arning! Sys...verload! Enterin...fety mode. ID eras...d 
-      YOU_LOST_THE = 7243; -- You lost the #. 
+DEVICE_NOT_WORKING = 7230; -- The device is not working.
+      SYS_OVERLOAD = 7239; -- arning! Sys...verload! Enterin...fety mode. ID eras...d 
+      YOU_LOST_THE = 7244; -- You lost the #. 

--- a/scripts/zones/Garlaige_Citadel_[S]/TextIDs.lua
+++ b/scripts/zones/Garlaige_Citadel_[S]/TextIDs.lua
@@ -2,6 +2,6 @@
 
 -- General Texts
 ITEM_CANNOT_BE_OBTAINED = 6379; -- You cannot obtain the item <item> come back again after sorting your inventory
-          ITEM_OBTAINED = 6384; -- Obtained: <item>
-           GIL_OBTAINED = 6385; -- Obtained <number> gil
-       KEYITEM_OBTAINED = 6387; -- Obtained key item: <keyitem>
+          ITEM_OBTAINED = 6385; -- Obtained: <item>
+           GIL_OBTAINED = 6386; -- Obtained <number> gil
+       KEYITEM_OBTAINED = 6388; -- Obtained key item: <keyitem>

--- a/scripts/zones/Ghelsba_Outpost/TextIDs.lua
+++ b/scripts/zones/Ghelsba_Outpost/TextIDs.lua
@@ -2,17 +2,17 @@
 
 -- General Texts
 ITEM_CANNOT_BE_OBTAINED = 6908; -- You cannot obtain the item <item>. Come back after sorting your inventory.
-          ITEM_OBTAINED = 6913; -- Obtained: <item>.
-           GIL_OBTAINED = 6914; -- Obtained <number> gil.
-       KEYITEM_OBTAINED = 6916; -- Obtained key item: <keyitem>.
- FISHING_MESSAGE_OFFSET = 7574; -- You can't fish here.
+          ITEM_OBTAINED = 6914; -- Obtained: <item>.
+           GIL_OBTAINED = 6915; -- Obtained <number> gil.
+       KEYITEM_OBTAINED = 6917; -- Obtained key item: <keyitem>.
+ FISHING_MESSAGE_OFFSET = 7575; -- You can't fish here.
 
 -- Logging
-LOGGING_IS_POSSIBLE_HERE = 7735; -- Logging is possible here if you have
+LOGGING_IS_POSSIBLE_HERE = 7736; -- Logging is possible here if you have
 
 -- Quest Dialogs
 YOU_CANNOT_ENTER_THE_BATTLEFIELD = 162; -- You cannot enter the battlefield at present. Please wait a little longer.
-    YOU_CAN_NOW_BECOME_A_DRAGOON = 7775; -- You can now become a dragoon!
+    YOU_CAN_NOW_BECOME_A_DRAGOON = 7776; -- You can now become a dragoon!
 
 -- conquest Base
 CONQUEST_BASE = 0;

--- a/scripts/zones/Ghoyus_Reverie/TextIDs.lua
+++ b/scripts/zones/Ghoyus_Reverie/TextIDs.lua
@@ -2,6 +2,6 @@
 
 -- General Texts
 ITEM_CANNOT_BE_OBTAINED = 6379; -- You cannot obtain the item <item> come back again after sorting your inventory
-          ITEM_OBTAINED = 6384; -- Obtained: <item>
-           GIL_OBTAINED = 6385; -- Obtained <number> gil
-       KEYITEM_OBTAINED = 6387; -- Obtained key item: <keyitem>
+          ITEM_OBTAINED = 6385; -- Obtained: <item>
+           GIL_OBTAINED = 6386; -- Obtained <number> gil
+       KEYITEM_OBTAINED = 6388; -- Obtained key item: <keyitem>

--- a/scripts/zones/Giddeus/TextIDs.lua
+++ b/scripts/zones/Giddeus/TextIDs.lua
@@ -2,31 +2,31 @@
 
 -- General Texts
 ITEM_CANNOT_BE_OBTAINED = 6379; -- You cannot obtain the item <item>. Come back after sorting your inventory.
-          ITEM_OBTAINED = 6384; -- Obtained: <item>.
-           GIL_OBTAINED = 6385; -- Obtained <number> gil.
-       KEYITEM_OBTAINED = 6387; -- Obtained key item: <keyitem>.
- FISHING_MESSAGE_OFFSET = 7204; -- You can't fish here.
-            HOMEPOINT_SET = 7419; -- Home point set!
+          ITEM_OBTAINED = 6385; -- Obtained: <item>.
+           GIL_OBTAINED = 6386; -- Obtained <number> gil.
+       KEYITEM_OBTAINED = 6388; -- Obtained key item: <keyitem>.
+ FISHING_MESSAGE_OFFSET = 7205; -- You can't fish here.
+            HOMEPOINT_SET = 7420; -- Home point set!
 
 -- Harvesting
-HARVESTING_IS_POSSIBLE_HERE = 7391; -- Harvesting is possible here if you have
+HARVESTING_IS_POSSIBLE_HERE = 7392; -- Harvesting is possible here if you have
 
 -- Quest Dialog
-    SENSE_OF_FOREBODING = 6399; -- You are suddenly overcome with a sense of foreboding...
-NOTHING_OUT_OF_ORDINARY = 7304; -- There is nothing out of the ordinary here.
-         SPRING_FILL_UP = 7350; -- You fill your flask with water.
-         SPRING_DEFAULT = 7351; -- Sparkling clear water bubbles up from the ground. If you have a container, you can fill it here.
+    SENSE_OF_FOREBODING = 6400; -- You are suddenly overcome with a sense of foreboding...
+NOTHING_OUT_OF_ORDINARY = 7305; -- There is nothing out of the ordinary here.
+         SPRING_FILL_UP = 7351; -- You fill your flask with water.
+         SPRING_DEFAULT = 7352; -- Sparkling clear water bubbles up from the ground. If you have a container, you can fill it here.
 
 -- Treasure Coffer/Chest Dialog
-CHEST_UNLOCKED = 7383; -- You unlock the chest!
-    CHEST_FAIL = 7384; -- Fails to open the chest.
-    CHEST_TRAP = 7385; -- The chest was trapped!
-    CHEST_WEAK = 7386; -- You cannot open the chest when you are in a weakened state.
-   CHEST_MIMIC = 7387; -- The chest was a mimic!
-  CHEST_MOOGLE = 7388; -- You cannot open the chest while participating in the moogle event.
-CHEST_ILLUSION = 7389; -- The chest was but an illusion...
-  CHEST_LOCKED = 7390; -- The chest appears to be locked.
+CHEST_UNLOCKED = 7384; -- You unlock the chest!
+    CHEST_FAIL = 7385; -- Fails to open the chest.
+    CHEST_TRAP = 7386; -- The chest was trapped!
+    CHEST_WEAK = 7387; -- You cannot open the chest when you are in a weakened state.
+   CHEST_MIMIC = 7388; -- The chest was a mimic!
+  CHEST_MOOGLE = 7389; -- You cannot open the chest while participating in the moogle event.
+CHEST_ILLUSION = 7390; -- The chest was but an illusion...
+  CHEST_LOCKED = 7391; -- The chest appears to be locked.
 
 -- conquest Base
-CONQUEST_BASE = 7045; -- Tallying conquest results...
+CONQUEST_BASE = 7046; -- Tallying conquest results...
 

--- a/scripts/zones/Grand_Palace_of_HuXzoi/TextIDs.lua
+++ b/scripts/zones/Grand_Palace_of_HuXzoi/TextIDs.lua
@@ -2,10 +2,10 @@
 
 -- General Texts
 ITEM_CANNOT_BE_OBTAINED = 6379; -- You cannot obtain the item <item> come back again after sorting your inventory
-          ITEM_OBTAINED = 6384; -- Obtained: <item>
-           GIL_OBTAINED = 6385; -- Obtained <number> gil
-       KEYITEM_OBTAINED = 6387; -- Obtained key item: <keyitem>
-            HOMEPOINT_SET = 7449; -- Home point set!
+          ITEM_OBTAINED = 6385; -- Obtained: <item>
+           GIL_OBTAINED = 6386; -- Obtained <number> gil
+       KEYITEM_OBTAINED = 6388; -- Obtained key item: <keyitem>
+            HOMEPOINT_SET = 7450; -- Home point set!
 
 -- conquest Base
-CONQUEST_BASE = 7067; -- Tallying conquest results...
+CONQUEST_BASE = 7068; -- Tallying conquest results...

--- a/scripts/zones/Grauberg_[S]/TextIDs.lua
+++ b/scripts/zones/Grauberg_[S]/TextIDs.lua
@@ -2,11 +2,11 @@
 
 -- General Texts
 ITEM_CANNOT_BE_OBTAINED = 6379; -- You cannot obtain the item <item>. Come back after sorting your inventory.
-          ITEM_OBTAINED = 6384; -- Obtained: <item>.
-           GIL_OBTAINED = 6385; -- Obtained <number> gil.
-       KEYITEM_OBTAINED = 6387; -- Obtained key item: <keyitem>.
- FISHING_MESSAGE_OFFSET = 7045; -- You can't fish here.
-NOTHING_OUT_OF_ORDINARY = 7696; -- There is nothing out of the ordinary here.
+          ITEM_OBTAINED = 6385; -- Obtained: <item>.
+           GIL_OBTAINED = 6386; -- Obtained <number> gil.
+       KEYITEM_OBTAINED = 6388; -- Obtained key item: <keyitem>.
+ FISHING_MESSAGE_OFFSET = 7046; -- You can't fish here.
+NOTHING_OUT_OF_ORDINARY = 7697; -- There is nothing out of the ordinary here.
 
 -- Harvesting
-HARVESTING_IS_POSSIBLE_HERE = 7683; -- Harvesting is possible here if you have
+HARVESTING_IS_POSSIBLE_HERE = 7684; -- Harvesting is possible here if you have

--- a/scripts/zones/Gusgen_Mines/TextIDs.lua
+++ b/scripts/zones/Gusgen_Mines/TextIDs.lua
@@ -2,37 +2,37 @@
 
 -- General Texts
 ITEM_CANNOT_BE_OBTAINED = 6379; -- You cannot obtain the item <item>. Come back after sorting your inventory.
-          ITEM_OBTAINED = 6384; -- Obtained: <item>.
-           GIL_OBTAINED = 6385; -- Obtained <number> gil.
-       KEYITEM_OBTAINED = 6387; -- Obtained key item: <keyitem>.
- FISHING_MESSAGE_OFFSET = 7204; -- You can't fish here.
+          ITEM_OBTAINED = 6385; -- Obtained: <item>.
+           GIL_OBTAINED = 6386; -- Obtained <number> gil.
+       KEYITEM_OBTAINED = 6388; -- Obtained key item: <keyitem>.
+ FISHING_MESSAGE_OFFSET = 7205; -- You can't fish here.
 
 -- Mining
-MINING_IS_POSSIBLE_HERE = 7355; -- Mining is possible here if you have
+MINING_IS_POSSIBLE_HERE = 7356; -- Mining is possible here if you have
 
 -- Treasure Coffer/Chest Dialog
-CHEST_UNLOCKED = 7369; -- You unlock the chest!
-    CHEST_FAIL = 7370; -- Fails to open the chest.
-    CHEST_TRAP = 7371; -- The chest was trapped!
-    CHEST_WEAK = 7372; -- You cannot open the chest when you are in a weakened state.
-   CHEST_MIMIC = 7373; -- The chest was a mimic!
-  CHEST_MOOGLE = 7374; -- You cannot open the chest while participating in the moogle event.
-CHEST_ILLUSION = 7375; -- The chest was but an illusion...
-  CHEST_LOCKED = 7376; -- The chest appears to be locked.
+CHEST_UNLOCKED = 7370; -- You unlock the chest!
+    CHEST_FAIL = 7371; -- Fails to open the chest.
+    CHEST_TRAP = 7372; -- The chest was trapped!
+    CHEST_WEAK = 7373; -- You cannot open the chest when you are in a weakened state.
+   CHEST_MIMIC = 7374; -- The chest was a mimic!
+  CHEST_MOOGLE = 7375; -- You cannot open the chest while participating in the moogle event.
+CHEST_ILLUSION = 7376; -- The chest was but an illusion...
+  CHEST_LOCKED = 7377; -- The chest appears to be locked.
 
 -- Dialog Texts
-LETTERS_IS_WRITTEN_HERE = 7377; -- Something resembling letters is written here.
-    FOUND_LOCATION_SEAL = 7378; -- You have found the location of the seal. You placeon it.
-        IS_ON_THIS_SEAL = 7379; -- is on this seal.
-NOTHING_OUT_OF_ORDINARY = 7399; -- There is nothing out of the ordinary here.
+LETTERS_IS_WRITTEN_HERE = 7378; -- Something resembling letters is written here.
+    FOUND_LOCATION_SEAL = 7379; -- You have found the location of the seal. You placeon it.
+        IS_ON_THIS_SEAL = 7380; -- is on this seal.
+NOTHING_OUT_OF_ORDINARY = 7400; -- There is nothing out of the ordinary here.
 
 -- Other
-LOCK_OTHER_DEVICE = 7335; -- This entrance's lock is connected to some other device.
+LOCK_OTHER_DEVICE = 7336; -- This entrance's lock is connected to some other device.
 
 -- conquest Base
-CONQUEST_BASE = 7045; -- Tallying conquest results...
+CONQUEST_BASE = 7046; -- Tallying conquest results...
 
 -- Strange Apparatus
-DEVICE_NOT_WORKING = 7318; -- The device is not working.
-      SYS_OVERLOAD = 7327; -- arning! Sys...verload! Enterin...fety mode. ID eras...d 
-      YOU_LOST_THE = 7332; -- You lost the #. 
+DEVICE_NOT_WORKING = 7319; -- The device is not working.
+      SYS_OVERLOAD = 7328; -- arning! Sys...verload! Enterin...fety mode. ID eras...d 
+      YOU_LOST_THE = 7333; -- You lost the #. 

--- a/scripts/zones/Gustav_Tunnel/TextIDs.lua
+++ b/scripts/zones/Gustav_Tunnel/TextIDs.lua
@@ -2,12 +2,12 @@
 
 -- General Texts
 ITEM_CANNOT_BE_OBTAINED = 6379; -- You cannot obtain the item <item> come back again after sorting your inventory
-          ITEM_OBTAINED = 6384; -- Obtained: <item>
-           GIL_OBTAINED = 6385; -- Obtained <number> gil
-       KEYITEM_OBTAINED = 6387; -- Obtained key item: <keyitem>
- FISHING_MESSAGE_OFFSET = 7204; -- You can't fish here.
+          ITEM_OBTAINED = 6385; -- Obtained: <item>
+           GIL_OBTAINED = 6386; -- Obtained <number> gil
+       KEYITEM_OBTAINED = 6388; -- Obtained key item: <keyitem>
+ FISHING_MESSAGE_OFFSET = 7205; -- You can't fish here.
 
 -- conquest Base
-CONQUEST_BASE = 7045; -- Tallying conquest results...
+CONQUEST_BASE = 7046; -- Tallying conquest results...
 
-NOTHING_OUT_OF_ORDINARY = 6398; -- There is nothing out of the ordinary here
+NOTHING_OUT_OF_ORDINARY = 6399; -- There is nothing out of the ordinary here

--- a/scripts/zones/Hall_of_Transference/TextIDs.lua
+++ b/scripts/zones/Hall_of_Transference/TextIDs.lua
@@ -2,9 +2,9 @@
 
 -- General Texts
 ITEM_CANNOT_BE_OBTAINED = 6379; -- You cannot obtain the item <item> come back again after sorting your inventory
-          ITEM_OBTAINED = 6384; -- Obtained: <item>
-           GIL_OBTAINED = 6385; -- Obtained <number> gil
-       KEYITEM_OBTAINED = 6387; -- Obtained key item: <keyitem>
+          ITEM_OBTAINED = 6385; -- Obtained: <item>
+           GIL_OBTAINED = 6386; -- Obtained <number> gil
+       KEYITEM_OBTAINED = 6388; -- Obtained key item: <keyitem>
 
 -- Other Texts
-NO_RESPONSE_OFFSET = 7240; -- There is no response.
+NO_RESPONSE_OFFSET = 7241; -- There is no response.

--- a/scripts/zones/Hall_of_the_Gods/TextIDs.lua
+++ b/scripts/zones/Hall_of_the_Gods/TextIDs.lua
@@ -2,10 +2,10 @@
 
 -- General Texts
 ITEM_CANNOT_BE_OBTAINED = 6379; -- You cannot obtain the item <item>. Come back after sorting your inventory.
-          ITEM_OBTAINED = 6384; -- Obtained: <item>.
-           GIL_OBTAINED = 6385; -- Obtained <number> gil.
-       KEYITEM_OBTAINED = 6387; -- Obtained key item: <keyitem>.
-NOTHING_OUT_OF_ORDINARY = 6398; -- There is nothing out of the ordinary here.
+          ITEM_OBTAINED = 6385; -- Obtained: <item>.
+           GIL_OBTAINED = 6386; -- Obtained <number> gil.
+       KEYITEM_OBTAINED = 6388; -- Obtained key item: <keyitem>.
+NOTHING_OUT_OF_ORDINARY = 6399; -- There is nothing out of the ordinary here.
 
 -- conquest Base
-CONQUEST_BASE = 7189; -- Tallying conquest results...
+CONQUEST_BASE = 7190; -- Tallying conquest results...

--- a/scripts/zones/Halvung/TextIDs.lua
+++ b/scripts/zones/Halvung/TextIDs.lua
@@ -2,13 +2,13 @@
 
 -- General Texts
 ITEM_CANNOT_BE_OBTAINED = 6379; -- You cannot obtain the item <item> come back again after sorting your inventory
-          ITEM_OBTAINED = 6384; -- Obtained: <item>
-           GIL_OBTAINED = 6385; -- Obtained <number> gil
-       KEYITEM_OBTAINED = 6387; -- Obtained key item: <keyitem>
+          ITEM_OBTAINED = 6385; -- Obtained: <item>
+           GIL_OBTAINED = 6386; -- Obtained <number> gil
+       KEYITEM_OBTAINED = 6388; -- Obtained key item: <keyitem>
 
 -- Mining
-MINING_IS_POSSIBLE_HERE = 7919; -- Mining is possible here if you have
+MINING_IS_POSSIBLE_HERE = 7920; -- Mining is possible here if you have
 
 -- Other Texts
-NOTHING_HAPPENS = 7379; -- Nothing happens...
-    BLUE_FLAMES = 7958; -- You can see blue flames flickering from a hole in the ground here...
+NOTHING_HAPPENS = 7380; -- Nothing happens...
+    BLUE_FLAMES = 7959; -- You can see blue flames flickering from a hole in the ground here...

--- a/scripts/zones/Hazhalm_Testing_Grounds/TextIDs.lua
+++ b/scripts/zones/Hazhalm_Testing_Grounds/TextIDs.lua
@@ -2,6 +2,6 @@
 
 -- General Texts
 ITEM_CANNOT_BE_OBTAINED = 6379; -- You cannot obtain the item <item> come back again after sorting your inventory
-          ITEM_OBTAINED = 6384; -- Obtained: <item>
-           GIL_OBTAINED = 6385; -- Obtained <number> gil
-       KEYITEM_OBTAINED = 6387; -- Obtained key item: <keyitem>
+          ITEM_OBTAINED = 6385; -- Obtained: <item>
+           GIL_OBTAINED = 6386; -- Obtained <number> gil
+       KEYITEM_OBTAINED = 6388; -- Obtained key item: <keyitem>

--- a/scripts/zones/Heavens_Tower/TextIDs.lua
+++ b/scripts/zones/Heavens_Tower/TextIDs.lua
@@ -2,10 +2,10 @@
 
 -- General Texts
    ITEM_CANNOT_BE_OBTAINED = 7120; -- Come back after sorting your inventory.
-             ITEM_OBTAINED = 7125; -- Obtained:
-              GIL_OBTAINED = 7126; -- Obtained <<<Numeric Parameter 0>>> gil.
-          KEYITEM_OBTAINED = 7128; -- Obtained key item: <<<Unknown Parameter (Type: 80) 1>>>.
-    FISHING_MESSAGE_OFFSET = 7362; -- You can't fish here.
+             ITEM_OBTAINED = 7126; -- Obtained:
+              GIL_OBTAINED = 7127; -- Obtained <<<Numeric Parameter 0>>> gil.
+          KEYITEM_OBTAINED = 7129; -- Obtained key item: <<<Unknown Parameter (Type: 80) 1>>>.
+    FISHING_MESSAGE_OFFSET = 7363; -- You can't fish here.
 
 -- Other dialog
        STAIRWAY_LOCKED = 554; -- The door to the Starway Stairway is locked tight.

--- a/scripts/zones/Horlais_Peak/TextIDs.lua
+++ b/scripts/zones/Horlais_Peak/TextIDs.lua
@@ -3,21 +3,21 @@
 -- General Texts
    ITEM_CANNOT_BE_OBTAINED = 6379; -- You cannot obtain the item <item>. Come back after sorting your inventory.
 FULL_INVENTORY_AFTER_TRADE = 6383; -- You cannot obtain the #. Try trading again after sorting your inventory.
-             ITEM_OBTAINED = 6384; -- Obtained: <item>.
-              GIL_OBTAINED = 6385; -- Obtained <number> gil.
-          KEYITEM_OBTAINED = 6387; -- Obtained key item: <keyitem>.
-            ITEMS_OBTAINED = 6393; -- You obtain
+             ITEM_OBTAINED = 6385; -- Obtained: <item>.
+              GIL_OBTAINED = 6386; -- Obtained <number> gil.
+          KEYITEM_OBTAINED = 6388; -- Obtained key item: <keyitem>.
+            ITEMS_OBTAINED = 6394; -- You obtain
 
-   NOTHING_OUT_OF_ORDINARY = 6398; -- There is nothing out of the ordinary here.
+   NOTHING_OUT_OF_ORDINARY = 6399; -- There is nothing out of the ordinary here.
 
 -- Maat dialog
-      YOU_DECIDED_TO_SHOW_UP = 7737; -- So, you decided to show up.
- LOOKS_LIKE_YOU_WERENT_READY = 7738; -- Looks like you weren't ready for me, were you?
-       YOUVE_COME_A_LONG_WAY = 7739; -- Hm. That was a mighty fine display of skill there, Player Name. You've come a long way...
- TEACH_YOU_TO_RESPECT_ELDERS = 7740; -- I'll teach you to respect your elders!
-TAKE_THAT_YOU_WHIPPERSNAPPER = 7741; -- Take that, you whippersnapper!
- THAT_LL_HURT_IN_THE_MORNING = 7743; -- Ungh... That'll hurt in the morning...
+      YOU_DECIDED_TO_SHOW_UP = 7738; -- So, you decided to show up.
+ LOOKS_LIKE_YOU_WERENT_READY = 7739; -- Looks like you weren't ready for me, were you?
+       YOUVE_COME_A_LONG_WAY = 7740; -- Hm. That was a mighty fine display of skill there, Player Name. You've come a long way...
+ TEACH_YOU_TO_RESPECT_ELDERS = 7741; -- I'll teach you to respect your elders!
+TAKE_THAT_YOU_WHIPPERSNAPPER = 7742; -- Take that, you whippersnapper!
+ THAT_LL_HURT_IN_THE_MORNING = 7744; -- Ungh... That'll hurt in the morning...
 
 -- conquest Base
-CONQUEST_BASE = 7045; -- Tallying conquest results...
+CONQUEST_BASE = 7046; -- Tallying conquest results...
 

--- a/scripts/zones/Ifrits_Cauldron/TextIDs.lua
+++ b/scripts/zones/Ifrits_Cauldron/TextIDs.lua
@@ -3,35 +3,35 @@
 -- General Texts
    ITEM_CANNOT_BE_OBTAINED = 6379; -- You cannot obtain the item <item>. Come back after sorting your inventory.
 FULL_INVENTORY_AFTER_TRADE = 6383; -- You cannot obtain the #. Try trading again after sorting your inventory.
-             ITEM_OBTAINED = 6384; -- Obtained: <item>.
-              GIL_OBTAINED = 6385; -- Obtained <number> gil.
-          KEYITEM_OBTAINED = 6387; -- Obtained key item: <keyitem>.
-            ITEMS_OBTAINED = 6393; -- You obtain
-            HOMEPOINT_SET = 11503; -- Home point set!
+             ITEM_OBTAINED = 6385; -- Obtained: <item>.
+              GIL_OBTAINED = 6386; -- Obtained <number> gil.
+          KEYITEM_OBTAINED = 6388; -- Obtained key item: <keyitem>.
+            ITEMS_OBTAINED = 6394; -- You obtain
+            HOMEPOINT_SET = 11504; -- Home point set!
 
 -- Other dialog
-NOTHING_OUT_OF_ORDINARY = 6398; -- There is nothing out of the ordinary here.
-EGGSHELLS_LIE_SCATTERED = 7262; -- Eggshells lie scattered around the place...
+NOTHING_OUT_OF_ORDINARY = 6399; -- There is nothing out of the ordinary here.
+EGGSHELLS_LIE_SCATTERED = 7263; -- Eggshells lie scattered around the place...
 
 -- Altar of Ashes Dialog (unable to find csid)
-ALTAR_COMPLETED = 7234; -- You have already made an offering today.
-  ALTAR_INSPECT = 7235; -- This looks like the altar where offerings are to be placed.
- ALTAR_OFFERING = 7236; -- You place your offering of
- ALTAR_STANDARD = 7237; -- It is an altar for offerings.
+ALTAR_COMPLETED = 7235; -- You have already made an offering today.
+  ALTAR_INSPECT = 7236; -- This looks like the altar where offerings are to be placed.
+ ALTAR_OFFERING = 7237; -- You place your offering of
+ ALTAR_STANDARD = 7238; -- It is an altar for offerings.
 
 -- Treasure Coffer/Chest Dialog
-CHEST_UNLOCKED = 7245; -- You unlock the chest!
-    CHEST_FAIL = 7246; -- Fails to open the chest.
-    CHEST_TRAP = 7247; -- The chest was trapped!
-    CHEST_WEAK = 7248; -- You cannot open the chest when you are in a weakened state.
-   CHEST_MIMIC = 7249; -- The chest was a mimic!
-  CHEST_MOOGLE = 7250; -- You cannot open the chest while participating in the moogle event.
-CHEST_ILLUSION = 7251; -- The chest was but an illusion...
-  CHEST_LOCKED = 7252; -- The chest appears to be locked.
+CHEST_UNLOCKED = 7246; -- You unlock the chest!
+    CHEST_FAIL = 7247; -- Fails to open the chest.
+    CHEST_TRAP = 7248; -- The chest was trapped!
+    CHEST_WEAK = 7249; -- You cannot open the chest when you are in a weakened state.
+   CHEST_MIMIC = 7250; -- The chest was a mimic!
+  CHEST_MOOGLE = 7251; -- You cannot open the chest while participating in the moogle event.
+CHEST_ILLUSION = 7252; -- The chest was but an illusion...
+  CHEST_LOCKED = 7253; -- The chest appears to be locked.
 
 -- Mining
-MINING_IS_POSSIBLE_HERE = 7253; -- Mining is possible here if you have
+MINING_IS_POSSIBLE_HERE = 7254; -- Mining is possible here if you have
 
 -- conquest Base
-CONQUEST_BASE = 7045; -- Tallying conquest results...
+CONQUEST_BASE = 7046; -- Tallying conquest results...
 

--- a/scripts/zones/Ilrusi_Atoll/TextIDs.lua
+++ b/scripts/zones/Ilrusi_Atoll/TextIDs.lua
@@ -2,10 +2,10 @@
 
 -- General Texts
 ITEM_CANNOT_BE_OBTAINED = 6379; -- You cannot obtain the item <item> come back again after sorting your inventory
-          ITEM_OBTAINED = 6384; -- Obtained: <item>
-           GIL_OBTAINED = 6385; -- Obtained <number> gil
-       KEYITEM_OBTAINED = 6387; -- Obtained key item: <keyitem>
+          ITEM_OBTAINED = 6385; -- Obtained: <item>
+           GIL_OBTAINED = 6386; -- Obtained <number> gil
+       KEYITEM_OBTAINED = 6388; -- Obtained key item: <keyitem>
 
        --golden salvage
-                  CHEST = 7521;--The chest contains...
-                 GOLDEN = 7522; --..a golden figurehead!
+                  CHEST = 7522;--The chest contains...
+                 GOLDEN = 7523; --..a golden figurehead!

--- a/scripts/zones/Inner_Horutoto_Ruins/TextIDs.lua
+++ b/scripts/zones/Inner_Horutoto_Ruins/TextIDs.lua
@@ -2,22 +2,22 @@
 
 -- General Texts
 ITEM_CANNOT_BE_OBTAINED = 6548; -- You cannot obtain the item <item>. Come back after sorting your inventory.
-          ITEM_OBTAINED = 6553; -- Obtained: <item>.
-           GIL_OBTAINED = 6554; -- Obtained <number> gil.
-       KEYITEM_OBTAINED = 6556; -- Obtained key item: <keyitem>.
-         NOT_BROKEN_ORB = 7230; -- The Mana Orb in this receptacle is not broken.
-    EXAMINED_RECEPTACLE = 7231; -- You have already examined this receptacle.
-     DOOR_FIRMLY_CLOSED = 7258; -- The door is firmly closed.
+          ITEM_OBTAINED = 6554; -- Obtained: <item>.
+           GIL_OBTAINED = 6555; -- Obtained <number> gil.
+       KEYITEM_OBTAINED = 6557; -- Obtained key item: <keyitem>.
+         NOT_BROKEN_ORB = 7231; -- The Mana Orb in this receptacle is not broken.
+    EXAMINED_RECEPTACLE = 7232; -- You have already examined this receptacle.
+     DOOR_FIRMLY_CLOSED = 7259; -- The door is firmly closed.
 
 -- Treasure Coffer/Chest Dialog
-CHEST_UNLOCKED = 7333; -- You unlock the chest!
-    CHEST_FAIL = 7334; -- Fails to open the chest.
-    CHEST_TRAP = 7335; -- The chest was trapped!
-    CHEST_WEAK = 7336; -- You cannot open the chest when you are in a weakened state.
-   CHEST_MIMIC = 7337; -- The chest was a mimic!
-  CHEST_MOOGLE = 7338; -- You cannot open the chest while participating in the moogle event.
-CHEST_ILLUSION = 7339; -- The chest was but an illusion...
-  CHEST_LOCKED = 7340; -- The chest appears to be locked.
+CHEST_UNLOCKED = 7334; -- You unlock the chest!
+    CHEST_FAIL = 7335; -- Fails to open the chest.
+    CHEST_TRAP = 7336; -- The chest was trapped!
+    CHEST_WEAK = 7337; -- You cannot open the chest when you are in a weakened state.
+   CHEST_MIMIC = 7338; -- The chest was a mimic!
+  CHEST_MOOGLE = 7339; -- You cannot open the chest while participating in the moogle event.
+CHEST_ILLUSION = 7340; -- The chest was but an illusion...
+  CHEST_LOCKED = 7341; -- The chest appears to be locked.
 
 -- Other texts
  PORTAL_SEALED_BY_3_MAGIC = 8; -- The Sealed Portal is sealed by three kinds of magic.

--- a/scripts/zones/Jade_Sepulcher/TextIDs.lua
+++ b/scripts/zones/Jade_Sepulcher/TextIDs.lua
@@ -2,6 +2,6 @@
 
 -- General Texts
 ITEM_CANNOT_BE_OBTAINED = 6379; -- You cannot obtain the item <item> come back again after sorting your inventory
-          ITEM_OBTAINED = 6384; -- Obtained: <item>
-           GIL_OBTAINED = 6385; -- Obtained <number> gil
-       KEYITEM_OBTAINED = 6387; -- Obtained key item: <keyitem>
+          ITEM_OBTAINED = 6385; -- Obtained: <item>
+           GIL_OBTAINED = 6386; -- Obtained <number> gil
+       KEYITEM_OBTAINED = 6388; -- Obtained key item: <keyitem>

--- a/scripts/zones/Jugner_Forest/TextIDs.lua
+++ b/scripts/zones/Jugner_Forest/TextIDs.lua
@@ -2,25 +2,25 @@
 
 -- General Texts
 ITEM_CANNOT_BE_OBTAINED = 6401; -- You cannot obtain the item <item>. Come back after sorting your inventory.
-          ITEM_OBTAINED = 6406; -- Obtained: <item>.
-           GIL_OBTAINED = 6407; -- Obtained <number> gil.
-       KEYITEM_OBTAINED = 6409; -- Obtained key item: <keyitem>.
-        BEASTMEN_BANNER = 7148; -- There is a beastmen's banner.
- FISHING_MESSAGE_OFFSET = 7700; -- You can't fish here.
+          ITEM_OBTAINED = 6407; -- Obtained: <item>.
+           GIL_OBTAINED = 6408; -- Obtained <number> gil.
+       KEYITEM_OBTAINED = 6410; -- Obtained key item: <keyitem>.
+        BEASTMEN_BANNER = 7149; -- There is a beastmen's banner.
+ FISHING_MESSAGE_OFFSET = 7701; -- You can't fish here.
 
 -- Conquest
-CONQUEST = 8044; -- You've earned conquest points!
+CONQUEST = 8045; -- You've earned conquest points!
 
 -- Logging
-LOGGING_IS_POSSIBLE_HERE = 7893; -- Logging is possible here if you have
+LOGGING_IS_POSSIBLE_HERE = 7894; -- Logging is possible here if you have
 
 -- Other Dialog
 NOTHING_HAPPENS = 141; -- Nothing happens...
 
 
 -- conquest Base
-CONQUEST_BASE = 7067; -- Tallying conquest results...
+CONQUEST_BASE = 7068; -- Tallying conquest results...
 
 --chocobo digging
-DIG_THROW_AWAY = 7713; -- You dig up$, but your inventory is full. You regretfully throw the # away.
-FIND_NOTHING = 7715; -- You dig and you dig, but find nothing.
+DIG_THROW_AWAY = 7714; -- You dig up$, but your inventory is full. You regretfully throw the # away.
+FIND_NOTHING = 7716; -- You dig and you dig, but find nothing.

--- a/scripts/zones/Jugner_Forest_[S]/TextIDs.lua
+++ b/scripts/zones/Jugner_Forest_[S]/TextIDs.lua
@@ -2,15 +2,15 @@
 
 -- General Texts
 ITEM_CANNOT_BE_OBTAINED = 6379; -- You cannot obtain the item <item>. Come back after sorting your inventory.
-          ITEM_OBTAINED = 6384; -- Obtained: <item>.
-           GIL_OBTAINED = 6385; -- Obtained <number> gil.
-       KEYITEM_OBTAINED = 6387; -- Obtained key item: <keyitem>.
-NOTHING_OUT_OF_ORDINARY = 6398; -- There is nothing out of the ordinary here.
- FISHING_MESSAGE_OFFSET = 7358; -- You can't fish here.
+          ITEM_OBTAINED = 6385; -- Obtained: <item>.
+           GIL_OBTAINED = 6386; -- Obtained <number> gil.
+       KEYITEM_OBTAINED = 6388; -- Obtained key item: <keyitem>.
+NOTHING_OUT_OF_ORDINARY = 6399; -- There is nothing out of the ordinary here.
+ FISHING_MESSAGE_OFFSET = 7359; -- You can't fish here.
 
 -- Logging
-LOGGING_IS_POSSIBLE_HERE = 7065; -- Logging is possible here if you have
+LOGGING_IS_POSSIBLE_HERE = 7066; -- Logging is possible here if you have
 
 -- Other Texts
       NOTHING_HAPPENS = 119; -- Nothing happens.
-ALREADY_OBTAINED_TELE = 7694; -- You already possess the gate crystal for this telepoint.
+ALREADY_OBTAINED_TELE = 7695; -- You already possess the gate crystal for this telepoint.

--- a/scripts/zones/Kamihr_Drifts/TextIDs.lua
+++ b/scripts/zones/Kamihr_Drifts/TextIDs.lua
@@ -2,7 +2,7 @@
 
 -- General Texts
 ITEM_CANNOT_BE_OBTAINED = 6379; -- You cannot obtain the item <item> come back again after sorting your inventory
-          ITEM_OBTAINED = 6384; -- Obtained: <item>
-           GIL_OBTAINED = 6385; -- Obtained <number> gil
-       KEYITEM_OBTAINED = 6387; -- Obtained key item: <keyitem>
-            HOMEPOINT_SET = 7951; -- Home point set!
+          ITEM_OBTAINED = 6385; -- Obtained: <item>
+           GIL_OBTAINED = 6386; -- Obtained <number> gil
+       KEYITEM_OBTAINED = 6388; -- Obtained key item: <keyitem>
+            HOMEPOINT_SET = 7952; -- Home point set!

--- a/scripts/zones/Kazham-Jeuno_Airship/TextIDs.lua
+++ b/scripts/zones/Kazham-Jeuno_Airship/TextIDs.lua
@@ -2,13 +2,13 @@
 
 -- General Texts
 ITEM_CANNOT_BE_OBTAINED = 6379; -- You cannot obtain the item <item> come back again after sorting your inventory
-          ITEM_OBTAINED = 6384; -- Obtained: <item>
-           GIL_OBTAINED = 6385; -- Obtained <number> gil
-       KEYITEM_OBTAINED = 6387; -- Obtained key item: <keyitem>
+          ITEM_OBTAINED = 6385; -- Obtained: <item>
+           GIL_OBTAINED = 6386; -- Obtained <number> gil
+       KEYITEM_OBTAINED = 6388; -- Obtained key item: <keyitem>
 
 -- Other
 
-     WILL_REACH_JEUNO = 7045; -- The airship will reach Jeuno in Multiple Choice (Parameter 1)[less than an hour/about 1 hour/about 2 hours/about 3 hours/about 4 hours/about 5 hours/about 6 hours/about 7 hours] ( Singular/Plural Choice (Parameter 0)[minute/minutes] in Earth time). 
-    WILL_REACH_KAZHAM = 7046; -- The airship will reach Kazham in Multiple Choice (Parameter 1)[less than an hour/about 1 hour/about 2 hours/about 3 hours/about 4 hours/about 5 hours/about 6 hours/about 7 hours] ( Singular/Plural Choice (Parameter 0)[minute/minutes] in Earth time). 
-  N_JEUNO_MOMENTARILY = 7047; -- We will be arriving in Jeuno momentarily.
-IN_KAZHAM_MOMENTARILY = 7048; -- We will be arriving in Kazham momentarily.
+     WILL_REACH_JEUNO = 7046; -- The airship will reach Jeuno in Multiple Choice (Parameter 1)[less than an hour/about 1 hour/about 2 hours/about 3 hours/about 4 hours/about 5 hours/about 6 hours/about 7 hours] ( Singular/Plural Choice (Parameter 0)[minute/minutes] in Earth time). 
+    WILL_REACH_KAZHAM = 7047; -- The airship will reach Kazham in Multiple Choice (Parameter 1)[less than an hour/about 1 hour/about 2 hours/about 3 hours/about 4 hours/about 5 hours/about 6 hours/about 7 hours] ( Singular/Plural Choice (Parameter 0)[minute/minutes] in Earth time). 
+  N_JEUNO_MOMENTARILY = 7048; -- We will be arriving in Jeuno momentarily.
+IN_KAZHAM_MOMENTARILY = 7049; -- We will be arriving in Kazham momentarily.

--- a/scripts/zones/Kazham/TextIDs.lua
+++ b/scripts/zones/Kazham/TextIDs.lua
@@ -2,30 +2,30 @@
 
 -- General Texts
 ITEM_CANNOT_BE_OBTAINED = 6379; -- You cannot obtain the item <item>. Come back after sorting your inventory.
-          ITEM_OBTAINED = 6384;  -- Obtained: <item>.
-           GIL_OBTAINED = 6385;  -- Obtained <number> gil.
-       KEYITEM_OBTAINED = 6387;  -- Obtained key item: <keyitem>.
-          HOMEPOINT_SET = 6475;  -- Home point set!
- FISHING_MESSAGE_OFFSET = 6654;  -- You can't fish here.
+          ITEM_OBTAINED = 6385;  -- Obtained: <item>.
+           GIL_OBTAINED = 6386;  -- Obtained <number> gil.
+       KEYITEM_OBTAINED = 6388;  -- Obtained key item: <keyitem>.
+          HOMEPOINT_SET = 6476;  -- Home point set!
+ FISHING_MESSAGE_OFFSET = 6655;  -- You can't fish here.
 
 -- Other Texts
-ITEM_DELIVERY_DIALOG = 9954; -- We can deliver packages to Mog Houses anywhere in Vana'diel.
+ITEM_DELIVERY_DIALOG = 9955; -- We can deliver packages to Mog Houses anywhere in Vana'diel.
 
 -- Quest Dialog
-     IFRIT_UNLOCKED = 10513; -- You are now able to summon
-NOMAD_MOOGLE_DIALOG = 10581; -- I'm a traveling moogle, kupo. I help adventurers in the Outlands access items they have stored in a Mog House elsewhere, kupo.
+     IFRIT_UNLOCKED = 10514; -- You are now able to summon
+NOMAD_MOOGLE_DIALOG = 10582; -- I'm a traveling moogle, kupo. I help adventurers in the Outlands access items they have stored in a Mog House elsewhere, kupo.
 
 -- Shop Texts
- TOJIMUMOSULAH_SHOP_DIALOG = 10018; -- Things meant to live will live. Things meant to die will die when their time has come. However, this does not mean you should cease your strrruggle for life.
-GHEMISENTERILO_SHOP_DIALOG = 10040; -- Can you really get everything that you want on the mainland?
-  NUHCELODENKI_SHOP_DIALOG = 10042; -- When you die, you can't take anything with you, but what fun is life if you don't have anything to live it up with?
- KHIFORYUHKOWA_SHOP_DIALOG = 10043; -- Sometimes a strrrange Hume comes from the south to buy stuff. I wonder what he's doing down there...
-    TAHNPOSBEI_SHOP_DIALOG = 10044; -- You don't want to get whipped by those Tonberries, do you? Well, have I got the equipment forrr you!
- PAHYALOLOHOIV_SHOP_DIALOG = 10326; -- Nothing in this world is crrreated good or evil. However, evil can arrrise when something exists in a place where it did not originally belong.
-       MAMERIE_SHOP_DIALOG = 10605; -- Is there something you require?
+ TOJIMUMOSULAH_SHOP_DIALOG = 10019; -- Things meant to live will live. Things meant to die will die when their time has come. However, this does not mean you should cease your strrruggle for life.
+GHEMISENTERILO_SHOP_DIALOG = 10041; -- Can you really get everything that you want on the mainland?
+  NUHCELODENKI_SHOP_DIALOG = 10043; -- When you die, you can't take anything with you, but what fun is life if you don't have anything to live it up with?
+ KHIFORYUHKOWA_SHOP_DIALOG = 10044; -- Sometimes a strrrange Hume comes from the south to buy stuff. I wonder what he's doing down there...
+    TAHNPOSBEI_SHOP_DIALOG = 10045; -- You don't want to get whipped by those Tonberries, do you? Well, have I got the equipment forrr you!
+ PAHYALOLOHOIV_SHOP_DIALOG = 10327; -- Nothing in this world is crrreated good or evil. However, evil can arrrise when something exists in a place where it did not originally belong.
+       MAMERIE_SHOP_DIALOG = 10606; -- Is there something you require?
 
 -- conquest Base
-CONQUEST_BASE = 6495; -- Tallying conquest results...
+CONQUEST_BASE = 6496; -- Tallying conquest results...
 
 -- Porter Moogle
-        RETRIEVE_DIALOG_ID = 10992; -- You retrieve$ from the porter moogle's care.
+        RETRIEVE_DIALOG_ID = 10993; -- You retrieve$ from the porter moogle's care.

--- a/scripts/zones/King_Ranperres_Tomb/TextIDs.lua
+++ b/scripts/zones/King_Ranperres_Tomb/TextIDs.lua
@@ -2,22 +2,22 @@
 
 -- General Texts
 ITEM_CANNOT_BE_OBTAINED = 6538; -- You cannot obtain the item <item>. Come back after sorting your inventory.
-          ITEM_OBTAINED = 6543; -- Obtained: <item>.
-           GIL_OBTAINED = 6544; -- Obtained <number> gil.
-       KEYITEM_OBTAINED = 6546; -- Obtained key item: <keyitem>.
+          ITEM_OBTAINED = 6544; -- Obtained: <item>.
+           GIL_OBTAINED = 6545; -- Obtained <number> gil.
+       KEYITEM_OBTAINED = 6547; -- Obtained key item: <keyitem>.
 
 -- Treasure Coffer/Chest Dialog
-CHEST_UNLOCKED = 7274; -- You unlock the chest!
-    CHEST_FAIL = 7275; -- Fails to open the chest.
-    CHEST_TRAP = 7276; -- The chest was trapped!
-    CHEST_WEAK = 7277; -- You cannot open the chest when you are in a weakened state.
-   CHEST_MIMIC = 7278; -- The chest was a mimic!
-  CHEST_MOOGLE = 7279; -- You cannot open the chest while participating in the moogle event.
-CHEST_ILLUSION = 7280; -- The chest was but an illusion...
-  CHEST_LOCKED = 7281; -- The chest appears to be locked.
+CHEST_UNLOCKED = 7275; -- You unlock the chest!
+    CHEST_FAIL = 7276; -- Fails to open the chest.
+    CHEST_TRAP = 7277; -- The chest was trapped!
+    CHEST_WEAK = 7278; -- You cannot open the chest when you are in a weakened state.
+   CHEST_MIMIC = 7279; -- The chest was a mimic!
+  CHEST_MOOGLE = 7280; -- You cannot open the chest while participating in the moogle event.
+CHEST_ILLUSION = 7281; -- The chest was but an illusion...
+  CHEST_LOCKED = 7282; -- The chest appears to be locked.
 
 -- Other
-HEAVY_DOOR = 7302; -- It is a solid stone door.
+HEAVY_DOOR = 7303; -- It is a solid stone door.
 
 -- conquest Base
 CONQUEST_BASE = 0;

--- a/scripts/zones/Konschtat_Highlands/TextIDs.lua
+++ b/scripts/zones/Konschtat_Highlands/TextIDs.lua
@@ -2,27 +2,27 @@
 
 -- General Texts
 ITEM_CANNOT_BE_OBTAINED = 6379; -- You cannot obtain the item <item>. Come back after sorting your inventory.
-          ITEM_OBTAINED = 6384; -- Obtained: <item>.
-           GIL_OBTAINED = 6385; -- Obtained <number> gil.
-       KEYITEM_OBTAINED = 6387; -- Obtained key item: <keyitem>.
-  ALREADY_OBTAINED_TELE = 7204; -- You already possess the gate crystal for this telepoint.
+          ITEM_OBTAINED = 6385; -- Obtained: <item>.
+           GIL_OBTAINED = 6386; -- Obtained <number> gil.
+       KEYITEM_OBTAINED = 6388; -- Obtained key item: <keyitem>.
+  ALREADY_OBTAINED_TELE = 7205; -- You already possess the gate crystal for this telepoint.
 
 -- Other texts
-        SIGNPOST3 = 7379; -- North: Valkurm Dunes South: North Gustaberg East: Gusgen Mines, Pashhow Marshlands
-        SIGNPOST2 = 7380; -- North: Pashhow Marshlands West: Valkurm Dunes, North Gustaberg Southeast: Gusgen Mines
-    SIGNPOST_DIALOG_1 = 7381; -- North: Valkurm Dunes South: To Gustaberg
-    SIGNPOST_DIALOG_2 = 7382; -- You see something stuck behind the signpost.
-SOMETHING_BURIED_HERE = 7383; -- Something has been buried here.
-         FIND_NOTHING = 7384; -- You thought you saw something, but find nothing.
+        SIGNPOST3 = 7380; -- North: Valkurm Dunes South: North Gustaberg East: Gusgen Mines, Pashhow Marshlands
+        SIGNPOST2 = 7381; -- North: Pashhow Marshlands West: Valkurm Dunes, North Gustaberg Southeast: Gusgen Mines
+    SIGNPOST_DIALOG_1 = 7382; -- North: Valkurm Dunes South: To Gustaberg
+    SIGNPOST_DIALOG_2 = 7383; -- You see something stuck behind the signpost.
+SOMETHING_BURIED_HERE = 7384; -- Something has been buried here.
+         FIND_NOTHING = 7385; -- You thought you saw something, but find nothing.
 
       NOTHING_HAPPENS = 119;  -- Nothing happens...
 
-     NOTHING_OUT_OF_ORDINARY = 6398; -- There is nothing out of the ordinary here.
-TELEPOINT_HAS_BEEN_SHATTERED = 7472; -- The telepoint has been shattered into a thousand pieces...
+     NOTHING_OUT_OF_ORDINARY = 6399; -- There is nothing out of the ordinary here.
+TELEPOINT_HAS_BEEN_SHATTERED = 7473; -- The telepoint has been shattered into a thousand pieces...
 
 -- conquest Base
-CONQUEST_BASE = 7045; -- Tallying conquest results...
+CONQUEST_BASE = 7046; -- Tallying conquest results...
 
 --chocobo digging
-DIG_THROW_AWAY = 7221; -- You dig up$, but your inventory is full. You regretfully throw the # away.
-FIND_NOTHING = 7223; -- You dig and you dig, but find nothing.
+DIG_THROW_AWAY = 7222; -- You dig up$, but your inventory is full. You regretfully throw the # away.
+FIND_NOTHING = 7224; -- You dig and you dig, but find nothing.

--- a/scripts/zones/Korroloka_Tunnel/TextIDs.lua
+++ b/scripts/zones/Korroloka_Tunnel/TextIDs.lua
@@ -2,24 +2,24 @@
 
 -- General Texts
 ITEM_CANNOT_BE_OBTAINED = 6379; -- You cannot obtain the item <item> come back again after sorting your inventory.
-          ITEM_OBTAINED = 6384; -- Obtained: <item>.
-           GIL_OBTAINED = 6385; -- Obtained <number> gil.
-       KEYITEM_OBTAINED = 6387; -- Obtained key item: <keyitem>.
- FISHING_MESSAGE_OFFSET = 7045; -- You can't fish here.
+          ITEM_OBTAINED = 6385; -- Obtained: <item>.
+           GIL_OBTAINED = 6386; -- Obtained <number> gil.
+       KEYITEM_OBTAINED = 6388; -- Obtained key item: <keyitem>.
+ FISHING_MESSAGE_OFFSET = 7046; -- You can't fish here.
 
 -- Mining
-MINING_IS_POSSIBLE_HERE = 7304; -- Mining is possible here if you have
+MINING_IS_POSSIBLE_HERE = 7305; -- Mining is possible here if you have
 
 -- Quest dialog
-NOTHING_OUT_OF_ORDINARY = 6398; -- There is nothing out of the ordinary here.
-    SENSE_OF_BOREBODING = 6399; -- You are suddenly overcome with a sense of foreboding...
+NOTHING_OUT_OF_ORDINARY = 6399; -- There is nothing out of the ordinary here.
+    SENSE_OF_BOREBODING = 6400; -- You are suddenly overcome with a sense of foreboding...
 
 -- Other
-      MORION_WORM_1 = 7325; -- It appears to be a hole made by some kind of animal. Fragments of iron ore are scattered around the area...
-     ENTERED_SPRING = 7320; -- The water in this spring is pleasant and tepid. This looks like a nice place to warm yourself up.
-  LEFT_SPRING_EARLY = 7321; -- You are not warm enough yet. You will need to spend more time than that in the spring to get your body heated up.
-  LEFT_SPRING_CLEAN = 7322; -- Your whole body is piping hot, and the smell of the Rafflesia pollen is gone!
+      MORION_WORM_1 = 7326; -- It appears to be a hole made by some kind of animal. Fragments of iron ore are scattered around the area...
+     ENTERED_SPRING = 7321; -- The water in this spring is pleasant and tepid. This looks like a nice place to warm yourself up.
+  LEFT_SPRING_EARLY = 7322; -- You are not warm enough yet. You will need to spend more time than that in the spring to get your body heated up.
+  LEFT_SPRING_CLEAN = 7323; -- Your whole body is piping hot, and the smell of the Rafflesia pollen is gone!
 
 -- conquest Base
-CONQUEST_BASE = 7145; -- Tallying conquest results...
+CONQUEST_BASE = 7146; -- Tallying conquest results...
 

--- a/scripts/zones/Kuftal_Tunnel/TextIDs.lua
+++ b/scripts/zones/Kuftal_Tunnel/TextIDs.lua
@@ -2,28 +2,28 @@
 
 -- General Texts
 ITEM_CANNOT_BE_OBTAINED = 6379; -- You cannot obtain the item <item> come back again after sorting your inventory
-          ITEM_OBTAINED = 6384; -- Obtained: <item>
-           GIL_OBTAINED = 6385; -- Obtained <number> gil
-       KEYITEM_OBTAINED = 6387; -- Obtained key item: <keyitem>
- FISHING_MESSAGE_OFFSET = 7204; -- You can't fish here
-  NOTHING_OUT_OF_ORDINARY = 6398;  -- There is nothing out of the ordinary here.
+          ITEM_OBTAINED = 6385; -- Obtained: <item>
+           GIL_OBTAINED = 6386; -- Obtained <number> gil
+       KEYITEM_OBTAINED = 6388; -- Obtained key item: <keyitem>
+ FISHING_MESSAGE_OFFSET = 7205; -- You can't fish here
+  NOTHING_OUT_OF_ORDINARY = 6399;  -- There is nothing out of the ordinary here.
   
   
 -- Treasure Coffer/Chest Dialog
-CHEST_UNLOCKED = 7311; -- You unlock the chest!
-    CHEST_FAIL = 7312; -- Fails to open the chest.
-    CHEST_TRAP = 7313; -- The chest was trapped!
-    CHEST_WEAK = 7314; -- You cannot open the chest when you are in a weakened state.
-   CHEST_MIMIC = 7315; -- The chest was a mimic!
-  CHEST_MOOGLE = 7316; -- You cannot open the chest while participating in the moogle event.
-CHEST_ILLUSION = 7317; -- The chest was but an illusion...
-  CHEST_LOCKED = 7318; -- The chest appears to be locked.
+CHEST_UNLOCKED = 7312; -- You unlock the chest!
+    CHEST_FAIL = 7313; -- Fails to open the chest.
+    CHEST_TRAP = 7314; -- The chest was trapped!
+    CHEST_WEAK = 7315; -- You cannot open the chest when you are in a weakened state.
+   CHEST_MIMIC = 7316; -- The chest was a mimic!
+  CHEST_MOOGLE = 7317; -- You cannot open the chest while participating in the moogle event.
+CHEST_ILLUSION = 7318; -- The chest was but an illusion...
+  CHEST_LOCKED = 7319; -- The chest appears to be locked.
 
 
 -- Other Dialog
-FELL = 7329; -- The piece of wood fell off the cliff!
-EVIL = 7330; -- You sense an evil presence...
-FISHBONES = 7344; -- Fish bones lie scattered about the area...
+FELL = 7330; -- The piece of wood fell off the cliff!
+EVIL = 7331; -- You sense an evil presence...
+FISHBONES = 7345; -- Fish bones lie scattered about the area...
 
 -- conquest Base
-CONQUEST_BASE = 7045; -- Tallying conquest results...
+CONQUEST_BASE = 7046; -- Tallying conquest results...

--- a/scripts/zones/LaLoff_Amphitheater/TextIDs.lua
+++ b/scripts/zones/LaLoff_Amphitheater/TextIDs.lua
@@ -2,9 +2,9 @@
 
 -- General Texts
 ITEM_CANNOT_BE_OBTAINED = 6379; -- You cannot obtain the item <item> come back again after sorting your inventory
-          ITEM_OBTAINED = 6384; -- Obtained: <item>
-           GIL_OBTAINED = 6385; -- Obtained <number> gil
-       KEYITEM_OBTAINED = 6387; -- Obtained key item: <keyitem>
+          ITEM_OBTAINED = 6385; -- Obtained: <item>
+           GIL_OBTAINED = 6386; -- Obtained <number> gil
+       KEYITEM_OBTAINED = 6388; -- Obtained key item: <keyitem>
 
 -- conquest Base
-CONQUEST_BASE = 7045; -- Tallying conquest results...
+CONQUEST_BASE = 7046; -- Tallying conquest results...

--- a/scripts/zones/La_Theine_Plateau/TextIDs.lua
+++ b/scripts/zones/La_Theine_Plateau/TextIDs.lua
@@ -2,43 +2,43 @@
 
 -- General Texts
 ITEM_CANNOT_BE_OBTAINED = 6379; -- You cannot obtain the item <item>. Come back after sorting your inventory.
-          ITEM_OBTAINED = 6384; -- Obtained: <item>.
-           GIL_OBTAINED = 6385; -- Obtained <number> gil.
-       KEYITEM_OBTAINED = 6387; -- Obtained key item: <keyitem>.
- FISHING_MESSAGE_OFFSET = 7208; -- You can't fish here.
+          ITEM_OBTAINED = 6385; -- Obtained: <item>.
+           GIL_OBTAINED = 6386; -- Obtained <number> gil.
+       KEYITEM_OBTAINED = 6388; -- Obtained key item: <keyitem>.
+ FISHING_MESSAGE_OFFSET = 7209; -- You can't fish here.
         NOTHING_HAPPENS = 119; -- Nothing happens...
 
 -- Other Texts
-       ALREADY_OBTAINED_TELE = 7204; -- You already possess the gate crystal for this telepoint.
-TELEPOINT_HAS_BEEN_SHATTERED = 7744; -- The telepoint has been shattered into a thousand pieces...
-              CHOCOBO_TRACKS = 7876; -- There are chocobo tracks on the ground here.
+       ALREADY_OBTAINED_TELE = 7205; -- You already possess the gate crystal for this telepoint.
+TELEPOINT_HAS_BEEN_SHATTERED = 7745; -- The telepoint has been shattered into a thousand pieces...
+              CHOCOBO_TRACKS = 7877; -- There are chocobo tracks on the ground here.
 
 -- Quest Dialogs
- UNLOCK_SUMMONER = 7564; -- You can now become a summoner.
-UNLOCK_CARBUNCLE = 7565; -- You can now summon Carbuncle.
+ UNLOCK_SUMMONER = 7565; -- You can now become a summoner.
+UNLOCK_CARBUNCLE = 7566; -- You can now summon Carbuncle.
 
 -- Mission Dialogs
-RESCUE_DRILL = 7380; -- Rescue drills in progress. Try to stay out of the way.
+RESCUE_DRILL = 7381; -- Rescue drills in progress. Try to stay out of the way.
 
 -- General Dialogs
-FAURBELLANT_1 = 7420; -- Greetings. traveler. Sorry, I've little time to chat. I must focus on my prayer.
-FAURBELLANT_2 = 7421; -- Thank you for making such a long journey to bring this! May the Gates of Paradise open to all.
-FAURBELLANT_3 = 7422; -- Please deliver thatto the high priest in the San d'Oria Cathedral.
-FAURBELLANT_4 = 7423; -- My thanks again for your services. May the Gates of Paradise open to all.
+FAURBELLANT_1 = 7421; -- Greetings. traveler. Sorry, I've little time to chat. I must focus on my prayer.
+FAURBELLANT_2 = 7422; -- Thank you for making such a long journey to bring this! May the Gates of Paradise open to all.
+FAURBELLANT_3 = 7423; -- Please deliver thatto the high priest in the San d'Oria Cathedral.
+FAURBELLANT_4 = 7424; -- My thanks again for your services. May the Gates of Paradise open to all.
 
 -- ZM4 Dialog
-    CANNOT_REMOVE_FRAG = 7579; -- It is an oddly shaped stone monument. A shining stone is embedded in it, but cannot be removed...
- ALREADY_OBTAINED_FRAG = 7580; -- You have already obtained this monument's . Try searching for another.
-ALREADY_HAVE_ALL_FRAGS = 7581; -- You have obtained all of the fragments. You must hurry to the ruins of the ancient shrine!
-       FOUND_ALL_FRAGS = 7582; -- You have obtained ! You now have all 8 fragments of light!
-       ZILART_MONUMENT = 7583; -- It is an ancient Zilart monument.
+    CANNOT_REMOVE_FRAG = 7580; -- It is an oddly shaped stone monument. A shining stone is embedded in it, but cannot be removed...
+ ALREADY_OBTAINED_FRAG = 7581; -- You have already obtained this monument's . Try searching for another.
+ALREADY_HAVE_ALL_FRAGS = 7582; -- You have obtained all of the fragments. You must hurry to the ruins of the ancient shrine!
+       FOUND_ALL_FRAGS = 7583; -- You have obtained ! You now have all 8 fragments of light!
+       ZILART_MONUMENT = 7584; -- It is an ancient Zilart monument.
 
 -- conquest Base
-CONQUEST_BASE = 7045; -- Tallying conquest results...
+CONQUEST_BASE = 7046; -- Tallying conquest results...
 
 --chocobo digging
-DIG_THROW_AWAY = 7221; -- You dig up$, but your inventory is full. You regretfully throw the # away.
-FIND_NOTHING =  7223; -- You dig and you dig, but find nothing.
+DIG_THROW_AWAY = 7222; -- You dig up$, but your inventory is full. You regretfully throw the # away.
+FIND_NOTHING =  7224; -- You dig and you dig, but find nothing.
 
 -- FallenEgg
-BROKEN_EGG = 7815; -- There is a broken egg on the ground here. Perhaps there is a nest in the boughs of this tree.
+BROKEN_EGG = 7816; -- There is a broken egg on the ground here. Perhaps there is a nest in the boughs of this tree.

--- a/scripts/zones/La_Vaule_[S]/TextIDs.lua
+++ b/scripts/zones/La_Vaule_[S]/TextIDs.lua
@@ -2,7 +2,7 @@
 
 -- General Texts
 ITEM_CANNOT_BE_OBTAINED = 6379; -- You cannot obtain the item <item> come back again after sorting your inventory
-          ITEM_OBTAINED = 6384; -- Obtained: <item>
-           GIL_OBTAINED = 6385; -- Obtained <number> gil
-       KEYITEM_OBTAINED = 6387; -- Obtained key item: <keyitem>
- FISHING_MESSAGE_OFFSET = 7045; -- You can't fish here.
+          ITEM_OBTAINED = 6385; -- Obtained: <item>
+           GIL_OBTAINED = 6386; -- Obtained <number> gil
+       KEYITEM_OBTAINED = 6388; -- Obtained key item: <keyitem>
+ FISHING_MESSAGE_OFFSET = 7046; -- You can't fish here.

--- a/scripts/zones/Labyrinth_of_Onzozo/TextIDs.lua
+++ b/scripts/zones/Labyrinth_of_Onzozo/TextIDs.lua
@@ -2,23 +2,23 @@
 
 -- General Texts
 ITEM_CANNOT_BE_OBTAINED = 6379; -- You cannot obtain the item <item>. Come back after sorting your inventory.
-          ITEM_OBTAINED = 6384; -- Obtained: <item>.
-           GIL_OBTAINED = 6385; -- Obtained <number> gil.
-       KEYITEM_OBTAINED = 6387; -- Obtained key item: <keyitem>.
- FISHING_MESSAGE_OFFSET = 7204; -- You can't fish here.
+          ITEM_OBTAINED = 6385; -- Obtained: <item>.
+           GIL_OBTAINED = 6386; -- Obtained <number> gil.
+       KEYITEM_OBTAINED = 6388; -- Obtained key item: <keyitem>.
+ FISHING_MESSAGE_OFFSET = 7205; -- You can't fish here.
 
 -- Treasure Coffer/Chest Dialog
-CHEST_UNLOCKED = 7311; -- You unlock the chest!
-    CHEST_FAIL = 7312; -- Fails to open the chest.
-    CHEST_TRAP = 7313; -- The chest was trapped!
-    CHEST_WEAK = 7314; -- You cannot open the chest when you are in a weakened state.
-   CHEST_MIMIC = 7315; -- The chest was a mimic!
-  CHEST_MOOGLE = 7316; -- You cannot open the chest while participating in the moogle event.
-CHEST_ILLUSION = 7317; -- The chest was but an illusion...
-  CHEST_LOCKED = 7318; -- The chest appears to be locked.
+CHEST_UNLOCKED = 7312; -- You unlock the chest!
+    CHEST_FAIL = 7313; -- Fails to open the chest.
+    CHEST_TRAP = 7314; -- The chest was trapped!
+    CHEST_WEAK = 7315; -- You cannot open the chest when you are in a weakened state.
+   CHEST_MIMIC = 7316; -- The chest was a mimic!
+  CHEST_MOOGLE = 7317; -- You cannot open the chest while participating in the moogle event.
+CHEST_ILLUSION = 7318; -- The chest was but an illusion...
+  CHEST_LOCKED = 7319; -- The chest appears to be locked.
 
 -- Other Dialogs
-NOTHING_OUT_OF_ORDINARY = 6398; -- There is nothing out of the ordinary here.
+NOTHING_OUT_OF_ORDINARY = 6399; -- There is nothing out of the ordinary here.
 
 -- conquest Base
-CONQUEST_BASE = 7045; -- Tallying conquest results...
+CONQUEST_BASE = 7046; -- Tallying conquest results...

--- a/scripts/zones/Lower_Delkfutts_Tower/TextIDs.lua
+++ b/scripts/zones/Lower_Delkfutts_Tower/TextIDs.lua
@@ -2,10 +2,10 @@
 
 -- General Texts
 ITEM_CANNOT_BE_OBTAINED = 6568; -- You cannot obtain the item <item>. Come back after sorting your inventory.
-          ITEM_OBTAINED = 6573; -- Obtained: <item>.
-           GIL_OBTAINED = 6574; -- Obtained <number> gil.
-       KEYITEM_OBTAINED = 6576; -- Obtained key item: <keyitem>.
- FISHING_MESSAGE_OFFSET = 7234; -- You can't fish here.
+          ITEM_OBTAINED = 6574; -- Obtained: <item>.
+           GIL_OBTAINED = 6575; -- Obtained <number> gil.
+       KEYITEM_OBTAINED = 6577; -- Obtained key item: <keyitem>.
+ FISHING_MESSAGE_OFFSET = 7235; -- You can't fish here.
 
 -- Other dialog
 THE_DOOR_IS_FIRMLY_SHUT_OPEN_KEY = 159; -- The door is firmly shut. You might be able to open it if you had the key.

--- a/scripts/zones/Lower_Jeuno/TextIDs.lua
+++ b/scripts/zones/Lower_Jeuno/TextIDs.lua
@@ -2,66 +2,66 @@
 
 -- General Texts
 ITEM_CANNOT_BE_OBTAINED = 6379; -- You cannot obtain the item <item>. Come back after sorting your inventory.
-          ITEM_OBTAINED = 6384; -- Obtained: <item>.
-           GIL_OBTAINED = 6385; -- Obtained <number> gil.
-       KEYITEM_OBTAINED = 6387; -- Obtained key item: <keyitem>.
-    NOT_HAVE_ENOUGH_GIL = 6391; -- You do not have enough gil.
-          HOMEPOINT_SET = 6513; -- Home point set!
- FISHING_MESSAGE_OFFSET = 6915; -- You can't fish here.
-    INVENTORY_INCREASED = 7773; -- Your inventory capacity has increased.
-             ITS_LOCKED = 7578; -- It's locked.
+          ITEM_OBTAINED = 6385; -- Obtained: <item>.
+           GIL_OBTAINED = 6386; -- Obtained <number> gil.
+       KEYITEM_OBTAINED = 6388; -- Obtained key item: <keyitem>.
+    NOT_HAVE_ENOUGH_GIL = 6392; -- You do not have enough gil.
+          HOMEPOINT_SET = 6514; -- Home point set!
+ FISHING_MESSAGE_OFFSET = 6916; -- You can't fish here.
+    INVENTORY_INCREASED = 7774; -- Your inventory capacity has increased.
+             ITS_LOCKED = 7579; -- It's locked.
 
 -- Other Texts
-ITEM_DELIVERY_DIALOG = 7774; -- Now offering quick and easy delivery of packages to residences everywhere!
+ITEM_DELIVERY_DIALOG = 7775; -- Now offering quick and easy delivery of packages to residences everywhere!
 
-          GUIDE_STONE = 7131; -- Up: Upper Jeuno (Selection Dialogfacing San d'Oria) Down: Port Jeuno (Selection Dialogfacing Windurst)
-  ZAUKO_IS_RECRUITING = 7248; -- Zauko is recruiting an adventurer to light the lamps.
-   STREETLAMP_EXAMINE = 7245; -- You examine the lamp. It seems that it must be lit manually.
-PARIKE_PORANKE_DIALOG = 8945; -- All these people running back and forth... There have to be a few that have munched down more mithkabobs than they can manage.
-    WAYPOINT_EXAMINE = 10336; -- An enigmatic contrivance hovers in silence...
+          GUIDE_STONE = 7132; -- Up: Upper Jeuno (Selection Dialogfacing San d'Oria) Down: Port Jeuno (Selection Dialogfacing Windurst)
+   STREETLAMP_EXAMINE = 7246; -- You examine the lamp. It seems that it must be lit manually.
+  ZAUKO_IS_RECRUITING = 7249; -- Zauko is recruiting an adventurer to light the lamps.
+PARIKE_PORANKE_DIALOG = 8946; -- All these people running back and forth... There have to be a few that have munched down more mithkabobs than they can manage.
+    WAYPOINT_EXAMINE = 10337; -- An enigmatic contrivance hovers in silence...
 
-                 NO_KEY = 9897; -- You do not have a usable key in your possession.
-            ALDO_DIALOG = 7136; -- Hi. I'm Aldo, head of Tenshodo. We deal in things you can't buy anywhere else. Take your time and have a look around.
-         CHOCOBO_DIALOG = 7310; -- Hmph.
-       PARIKE_PORANKE_1 = 8946; -- Hey you! Belly bursting? Intestines inflating? Bladder bulging? I can tell by the notch on your belt that you've been overindulging yourself in culinary delights.
-       PARIKE_PORANKE_2 = 8949; -- I mean, this is a new era. If somebody wants to go around with their flabby-flubber hanging out of their cloaks, they should have every right to do so. If someone wants to walk around town with breath reeking of Kazham pines and roasted sleepshrooms, who am I to stop them
-       PARIKE_PORANKE_3 = 8950; -- What? You want me to tend to your tummy trouble? No problem! And don't worry, this won't hurt at all! I'm only going to be flushing your bowels with thousands of tiny lightning bolts. It's all perfectly safe!
-       PARIKE_PORANKE_4 = 8951; -- Now stand still! You wouldn't want your pelvis to implode, would you? (Let's see... What were those magic words again...?)
-       PARIKE_PORANKE_5 = 8952; -- Ready? No? Well, too bad!
-       PARIKE_PORANKE_6 = 8960; -- digestive magic skill rises 0.1 points.
-       PARIKE_PORANKE_7 = 8961; -- digestive magic skill rises one level.
-       PARIKE_PORANKE_8 = 8962; -- Heh heh! I think I'm starting to get the hang of this spellcasting.
-       PARIKE_PORANKE_9 = 8963; -- Consider this a petite present from your pal Parike-Poranke!
-      PARIKE_PORANKE_10 = 8967; -- Wait a minute... Don't tell me you came to Parike-Poranke on an empty stomach! This is terrible! The minister will have my head!
-      PARIKE_PORANKE_12 = 8969; -- Phew! That was close... What were you thinking, crazy adventurer!
-      PARIKE_PORANKE_13 = 8972; -- Speaker Name's ll in the name of scienceskill rises 0.1 points. 
-      PARIKE_PORANKE_14 = 8973; -- Speaker Name's ll in the name of scienceskill rises one level.
-      PARIKE_PORANKE_15 = 8974; -- You know, I've learned a lot from my mist--er, I mean, less-than-successful attempts at weight-loss consulting.
-      PARIKE_PORANKE_16 = 8975; -- To show you my gratitude, let me try out this new spell I thought up yesterday while I was taking a nap!
-        MERTAIRE_DIALOG = 7416; -- Who are you? Leave me alone!
+                 NO_KEY = 9898; -- You do not have a usable key in your possession.
+            ALDO_DIALOG = 7137; -- Hi. I'm Aldo, head of Tenshodo. We deal in things you can't buy anywhere else. Take your time and have a look around.
+         CHOCOBO_DIALOG = 7311; -- Hmph.
+       PARIKE_PORANKE_1 = 8947; -- Hey you! Belly bursting? Intestines inflating? Bladder bulging? I can tell by the notch on your belt that you've been overindulging yourself in culinary delights.
+       PARIKE_PORANKE_2 = 8950; -- I mean, this is a new era. If somebody wants to go around with their flabby-flubber hanging out of their cloaks, they should have every right to do so. If someone wants to walk around town with breath reeking of Kazham pines and roasted sleepshrooms, who am I to stop them
+       PARIKE_PORANKE_3 = 8951; -- What? You want me to tend to your tummy trouble? No problem! And don't worry, this won't hurt at all! I'm only going to be flushing your bowels with thousands of tiny lightning bolts. It's all perfectly safe!
+       PARIKE_PORANKE_4 = 8952; -- Now stand still! You wouldn't want your pelvis to implode, would you? (Let's see... What were those magic words again...?)
+       PARIKE_PORANKE_5 = 8953; -- Ready? No? Well, too bad!
+       PARIKE_PORANKE_6 = 8961; -- digestive magic skill rises 0.1 points.
+       PARIKE_PORANKE_7 = 8962; -- digestive magic skill rises one level.
+       PARIKE_PORANKE_8 = 8963; -- Heh heh! I think I'm starting to get the hang of this spellcasting.
+       PARIKE_PORANKE_9 = 8964; -- Consider this a petite present from your pal Parike-Poranke!
+      PARIKE_PORANKE_10 = 8968; -- Wait a minute... Don't tell me you came to Parike-Poranke on an empty stomach! This is terrible! The minister will have my head!
+      PARIKE_PORANKE_12 = 8970; -- Phew! That was close... What were you thinking, crazy adventurer!
+      PARIKE_PORANKE_13 = 8973; -- Speaker Name's ll in the name of scienceskill rises 0.1 points. 
+      PARIKE_PORANKE_14 = 8974; -- Speaker Name's ll in the name of scienceskill rises one level.
+      PARIKE_PORANKE_15 = 8975; -- You know, I've learned a lot from my mist--er, I mean, less-than-successful attempts at weight-loss consulting.
+      PARIKE_PORANKE_16 = 8976; -- To show you my gratitude, let me try out this new spell I thought up yesterday while I was taking a nap!
+        MERTAIRE_DIALOG = 7417; -- Who are you? Leave me alone!
 
 -- Conquest system
-CONQUEST = 8047; -- You've earned conquest points!
+CONQUEST = 8048; -- You've earned conquest points!
 
 -- Shop Texts
- CREEPSTIX_SHOP_DIALOG = 7122; -- Hey, how ya doin'? We got the best junk in town.
-  STINKNIX_SHOP_DIALOG = 7122; -- Hey, how ya doin'? We got the best junk in town.
-     HASIM_SHOP_DIALOG = 7123; -- Welcome to Waag-Deeg's Magic Shop.
-      TAZA_SHOP_DIALOG = 7123; -- Welcome to Waag-Deeg's Magic Shop.
-      SUSU_SHOP_DIALOG = 7123; -- Welcome to Waag-Deeg's Magic Shop.
-    CHETAK_SHOP_DIALOG = 7124; -- Welcome to Othon's Garments.
-  CHENOKIH_SHOP_DIALOG = 7124; -- Welcome to Othon's Garments.
-   YOSKOLO_SHOP_DIALOG = 7125; -- Welcome to the Merry Minstrel's Meadhouse. What'll it be?
- ADELFLETE_SHOP_DIALOG = 7126; -- Here at Gems by Kshama, we aim to please.
-   MOREFIE_SHOP_DIALOG = 7126; -- Here at Gems by Kshama, we aim to please.
-   MATOAKA_SHOP_DIALOG = 7126; -- Here at Gems by Kshama, we aim to please.
-  RHIMONNE_SHOP_DIALOG = 7129; -- Howdy! Thanks for visiting the Chocobo Shop!
-   PAWKRIX_SHOP_DIALOG = 7626; -- Hey, we're fixin' up some stew. Gobbie food's good food!
-AMALASANDA_SHOP_DIALOG = 7674; -- Welcome to the Tenshodo. You want something, we got it. We got all kinds of special merchandise you won't find anywhere else!
- AKAMAFULA_SHOP_DIALOG = 7675; -- We ain't cheap, but you get what you pay for! Take your time, have a look around, see if there's somethin' you like.
+ CREEPSTIX_SHOP_DIALOG = 7123; -- Hey, how ya doin'? We got the best junk in town.
+  STINKNIX_SHOP_DIALOG = 7123; -- Hey, how ya doin'? We got the best junk in town.
+     HASIM_SHOP_DIALOG = 7124; -- Welcome to Waag-Deeg's Magic Shop.
+      TAZA_SHOP_DIALOG = 7124; -- Welcome to Waag-Deeg's Magic Shop.
+      SUSU_SHOP_DIALOG = 7124; -- Welcome to Waag-Deeg's Magic Shop.
+    CHETAK_SHOP_DIALOG = 7125; -- Welcome to Othon's Garments.
+  CHENOKIH_SHOP_DIALOG = 7125; -- Welcome to Othon's Garments.
+   YOSKOLO_SHOP_DIALOG = 7126; -- Welcome to the Merry Minstrel's Meadhouse. What'll it be?
+ ADELFLETE_SHOP_DIALOG = 7127; -- Here at Gems by Kshama, we aim to please.
+   MOREFIE_SHOP_DIALOG = 7127; -- Here at Gems by Kshama, we aim to please.
+   MATOAKA_SHOP_DIALOG = 7127; -- Here at Gems by Kshama, we aim to please.
+  RHIMONNE_SHOP_DIALOG = 7130; -- Howdy! Thanks for visiting the Chocobo Shop!
+   PAWKRIX_SHOP_DIALOG = 7627; -- Hey, we're fixin' up some stew. Gobbie food's good food!
+AMALASANDA_SHOP_DIALOG = 7675; -- Welcome to the Tenshodo. You want something, we got it. We got all kinds of special merchandise you won't find anywhere else!
+ AKAMAFULA_SHOP_DIALOG = 7676; -- We ain't cheap, but you get what you pay for! Take your time, have a look around, see if there's somethin' you like.
 
 -- conquest Base
-CONQUEST_BASE = 6538; -- Tallying conquest results...
+CONQUEST_BASE = 6539; -- Tallying conquest results...
 
 -- Porter Moogle
-    RETRIEVE_DIALOG_ID = 10177; -- You retrieve$ from the porter moogle's care.
+    RETRIEVE_DIALOG_ID = 10178; -- You retrieve$ from the porter moogle's care.

--- a/scripts/zones/Lufaise_Meadows/TextIDs.lua
+++ b/scripts/zones/Lufaise_Meadows/TextIDs.lua
@@ -2,24 +2,24 @@
 
 -- General Texts
     ITEM_CANNOT_BE_OBTAINED = 6379; -- You cannot obtain the item <item>. Come back after sorting your inventory.
-              ITEM_OBTAINED = 6384; -- Obtained: <item>.
-               GIL_OBTAINED = 6385; -- Obtained <number> gil.
-           KEYITEM_OBTAINED = 6387; -- Obtained key item: <keyitem>.
-NOTHING_OUT_OF_THE_ORDINARY = 6398; -- There is nothing out of the ordinary here.
-     FISHING_MESSAGE_OFFSET = 7547; -- You can't fish here.
+              ITEM_OBTAINED = 6385; -- Obtained: <item>.
+               GIL_OBTAINED = 6386; -- Obtained <number> gil.
+           KEYITEM_OBTAINED = 6388; -- Obtained key item: <keyitem>.
+NOTHING_OUT_OF_THE_ORDINARY = 6399; -- There is nothing out of the ordinary here.
+     FISHING_MESSAGE_OFFSET = 7548; -- You can't fish here.
 
 -- Conquest
-CONQUEST = 7213; -- You've earned conquest points!
+CONQUEST = 7214; -- You've earned conquest points!
 
 -- Logging
-LOGGING_IS_POSSIBLE_HERE = 7724; -- Logging is possible here if you have
+LOGGING_IS_POSSIBLE_HERE = 7725; -- Logging is possible here if you have
 
 -- Other Texts
- SURVEY_THE_SURROUNDINGS = 7731; -- You survey the surroundings but see nothing out of the ordinary.
-      MURDEROUS_PRESENCE = 7732; -- Wait, you sense a murderous presence...!
-   YOU_CAN_SEE_FOR_MALMS = 7733; -- You can see for malms in every direction.
- SPINE_CHILLING_PRESENCE = 7735; -- You sense a spine-chilling presence!
- KI_STOLEN = 7676; -- The ?Possible Special Code: 01??Possible Special Code: 05?3??BAD CHAR: 80??BAD CHAR: 80? has been stolen!
+ SURVEY_THE_SURROUNDINGS = 7732; -- You survey the surroundings but see nothing out of the ordinary.
+      MURDEROUS_PRESENCE = 7733; -- Wait, you sense a murderous presence...!
+   YOU_CAN_SEE_FOR_MALMS = 7734; -- You can see for malms in every direction.
+ SPINE_CHILLING_PRESENCE = 7736; -- You sense a spine-chilling presence!
+ KI_STOLEN = 7677; -- The ?Possible Special Code: 01??Possible Special Code: 05?3??BAD CHAR: 80??BAD CHAR: 80? has been stolen!
 
 -- conquest Base
-CONQUEST_BASE = 7045; -- Tallying conquest results...
+CONQUEST_BASE = 7046; -- Tallying conquest results...

--- a/scripts/zones/Mamook/TextIDs.lua
+++ b/scripts/zones/Mamook/TextIDs.lua
@@ -2,13 +2,13 @@
 
 -- General Texts
 ITEM_CANNOT_BE_OBTAINED = 6379; -- You cannot obtain the item <item> come back again after sorting your inventory
-          ITEM_OBTAINED = 6384; -- Obtained: <item>
-           GIL_OBTAINED = 6385; -- Obtained <number> gil
-       KEYITEM_OBTAINED = 6387; -- Obtained key item: <keyitem>
- FISHING_MESSAGE_OFFSET = 7045; -- You can't fish here
+          ITEM_OBTAINED = 6385; -- Obtained: <item>
+           GIL_OBTAINED = 6386; -- Obtained <number> gil
+       KEYITEM_OBTAINED = 6388; -- Obtained key item: <keyitem>
+ FISHING_MESSAGE_OFFSET = 7046; -- You can't fish here
 
 -- Logging
-LOGGING_IS_POSSIBLE_HERE = 7530; -- Logging is possible here if you have
+LOGGING_IS_POSSIBLE_HERE = 7531; -- Logging is possible here if you have
 
 -- Other Texts
 NOTHING_HAPPENS = 119; -- Nothing happens...

--- a/scripts/zones/Mamool_Ja_Training_Grounds/TextIDs.lua
+++ b/scripts/zones/Mamool_Ja_Training_Grounds/TextIDs.lua
@@ -2,6 +2,6 @@
 
 -- General Texts
 ITEM_CANNOT_BE_OBTAINED = 6379; -- You cannot obtain the item <item> come back again after sorting your inventory
-          ITEM_OBTAINED = 6384; -- Obtained: <item>
-           GIL_OBTAINED = 6385; -- Obtained <number> gil
-       KEYITEM_OBTAINED = 6387; -- Obtained key item: <keyitem>
+          ITEM_OBTAINED = 6385; -- Obtained: <item>
+           GIL_OBTAINED = 6386; -- Obtained <number> gil
+       KEYITEM_OBTAINED = 6388; -- Obtained key item: <keyitem>

--- a/scripts/zones/Manaclipper/TextIDs.lua
+++ b/scripts/zones/Manaclipper/TextIDs.lua
@@ -2,13 +2,13 @@
 
 -- General Texts
 ITEM_CANNOT_BE_OBTAINED = 6379; -- You cannot obtain the item <item> come back again after sorting your inventory.
-          ITEM_OBTAINED = 6384; -- Obtained: <item>.
-           GIL_OBTAINED = 6385; -- Obtained <number> gil.
-       KEYITEM_OBTAINED = 6387; -- Obtained key item: <keyitem>.
- FISHING_MESSAGE_OFFSET = 7215; -- You can't fish here.
+          ITEM_OBTAINED = 6385; -- Obtained: <item>.
+           GIL_OBTAINED = 6386; -- Obtained <number> gil.
+       KEYITEM_OBTAINED = 6388; -- Obtained key item: <keyitem>.
+ FISHING_MESSAGE_OFFSET = 7216; -- You can't fish here.
 
 -- NPC Dialogue
-KHOTS_CHALAHKO_OFFSET = 7388; -- Ahhh... Isn't it grrreat out here on the open sea!
+KHOTS_CHALAHKO_OFFSET = 7389; -- Ahhh... Isn't it grrreat out here on the open sea!
 
 -- conquest Base
-CONQUEST_BASE = 7045; -- Tallying conquest results...
+CONQUEST_BASE = 7046; -- Tallying conquest results...

--- a/scripts/zones/Maquette_Abdhaljs-Legion/TextIDs.lua
+++ b/scripts/zones/Maquette_Abdhaljs-Legion/TextIDs.lua
@@ -2,6 +2,6 @@
 
 -- General Texts
 ITEM_CANNOT_BE_OBTAINED = 6379; -- You cannot obtain the item <item> come back again after sorting your inventory.
-          ITEM_OBTAINED = 6384; -- Obtained: <item>.
-           GIL_OBTAINED = 6385; -- Obtained <number> gil.
-       KEYITEM_OBTAINED = 6387; -- Obtained key item: <keyitem>.
+          ITEM_OBTAINED = 6385; -- Obtained: <item>.
+           GIL_OBTAINED = 6386; -- Obtained <number> gil.
+       KEYITEM_OBTAINED = 6388; -- Obtained key item: <keyitem>.

--- a/scripts/zones/Marjami_Ravine/TextIDs.lua
+++ b/scripts/zones/Marjami_Ravine/TextIDs.lua
@@ -2,7 +2,7 @@
 
 -- General Texts
 ITEM_CANNOT_BE_OBTAINED = 6379; -- You cannot obtain the item <item> come back again after sorting your inventory
-          ITEM_OBTAINED = 6384; -- Obtained: <item>
-           GIL_OBTAINED = 6385; -- Obtained <number> gil
-       KEYITEM_OBTAINED = 6387; -- Obtained key item: <keyitem>
-            HOMEPOINT_SET = 7864; -- Home point set!
+          ITEM_OBTAINED = 6385; -- Obtained: <item>
+           GIL_OBTAINED = 6386; -- Obtained <number> gil
+       KEYITEM_OBTAINED = 6388; -- Obtained key item: <keyitem>
+            HOMEPOINT_SET = 7865; -- Home point set!

--- a/scripts/zones/Maze_of_Shakhrami/TextIDs.lua
+++ b/scripts/zones/Maze_of_Shakhrami/TextIDs.lua
@@ -2,30 +2,30 @@
 
 -- General Texts
 ITEM_CANNOT_BE_OBTAINED = 6379; -- You cannot obtain the item <item>. Come back after sorting your inventory.
-          ITEM_OBTAINED = 6384; -- Obtained: <item>.
-           GIL_OBTAINED = 6385; -- Obtained <number> gil.
-       KEYITEM_OBTAINED = 6387; -- Obtained key item: <keyitem>.
-NOTHING_OUT_OF_ORDINARY = 6398; -- There is nothing out of the ordinary here.
-       FOSSIL_EXTRACTED = 7045; -- A large fossil has been excavated from here.
-         NOTHING_FOSSIL = 7046; -- It looks like a rock with fossils embedded in it. Nothing out of the ordinary.
+          ITEM_OBTAINED = 6385; -- Obtained: <item>.
+           GIL_OBTAINED = 6386; -- Obtained <number> gil.
+       KEYITEM_OBTAINED = 6388; -- Obtained key item: <keyitem>.
+NOTHING_OUT_OF_ORDINARY = 6399; -- There is nothing out of the ordinary here.
+       FOSSIL_EXTRACTED = 7046; -- A large fossil has been excavated from here.
+         NOTHING_FOSSIL = 7047; -- It looks like a rock with fossils embedded in it. Nothing out of the ordinary.
 
 -- Treasure Coffer/Chest Dialog
-CHEST_UNLOCKED = 7350; -- You unlock the chest!
-    CHEST_FAIL = 7351; -- Fails to open the chest.
-    CHEST_TRAP = 7352; -- The chest was trapped!
-    CHEST_WEAK = 7353; -- You cannot open the chest when you are in a weakened state.
-   CHEST_MIMIC = 7354; -- The chest was a mimic!
-  CHEST_MOOGLE = 7355; -- You cannot open the chest while participating in the moogle event.
-CHEST_ILLUSION = 7356; -- The chest was but an illusion...
-  CHEST_LOCKED = 7357; -- The chest appears to be locked.
+CHEST_UNLOCKED = 7351; -- You unlock the chest!
+    CHEST_FAIL = 7352; -- Fails to open the chest.
+    CHEST_TRAP = 7353; -- The chest was trapped!
+    CHEST_WEAK = 7354; -- You cannot open the chest when you are in a weakened state.
+   CHEST_MIMIC = 7355; -- The chest was a mimic!
+  CHEST_MOOGLE = 7356; -- You cannot open the chest while participating in the moogle event.
+CHEST_ILLUSION = 7357; -- The chest was but an illusion...
+  CHEST_LOCKED = 7358; -- The chest appears to be locked.
 
 -- Mining
-MINING_IS_POSSIBLE_HERE = 7358; -- Mining is possible here if you have
+MINING_IS_POSSIBLE_HERE = 7359; -- Mining is possible here if you have
 
 -- conquest Base
-CONQUEST_BASE = 7073; -- Tallying conquest results...
+CONQUEST_BASE = 7074; -- Tallying conquest results...
 
 -- Strange Apparatus
-DEVICE_NOT_WORKING = 7246; -- The device is not working.
-      SYS_OVERLOAD = 7255; -- arning! Sys...verload! Enterin...fety mode. ID eras...d 
-      YOU_LOST_THE = 7260; -- You lost the #. 
+DEVICE_NOT_WORKING = 7247; -- The device is not working.
+      SYS_OVERLOAD = 7256; -- arning! Sys...verload! Enterin...fety mode. ID eras...d 
+      YOU_LOST_THE = 7261; -- You lost the #. 

--- a/scripts/zones/Meriphataud_Mountains/TextIDs.lua
+++ b/scripts/zones/Meriphataud_Mountains/TextIDs.lua
@@ -2,22 +2,22 @@
 
 -- General Texts
 ITEM_CANNOT_BE_OBTAINED = 6401; -- You cannot obtain the item <item>. Come back after sorting your inventory.
-          ITEM_OBTAINED = 6406; -- Obtained: <item>.
-           GIL_OBTAINED = 6407; -- Obtained <number> gil.
-       KEYITEM_OBTAINED = 6409; -- Obtained key item: <keyitem>.
-        BEASTMEN_BANNER = 7148; -- There is a beastmen's banner.
- FISHING_MESSAGE_OFFSET = 7226; -- You can't fish here.
+          ITEM_OBTAINED = 6407; -- Obtained: <item>.
+           GIL_OBTAINED = 6408; -- Obtained <number> gil.
+       KEYITEM_OBTAINED = 6410; -- Obtained key item: <keyitem>.
+        BEASTMEN_BANNER = 7149; -- There is a beastmen's banner.
+ FISHING_MESSAGE_OFFSET = 7227; -- You can't fish here.
 
 -- Conquest
-CONQUEST = 7896; -- You've earned conquest points!
+CONQUEST = 7897; -- You've earned conquest points!
 
 -- General Dialogs
-  NOTHING_FOUND = 7484; -- You find nothing.
+  NOTHING_FOUND = 7485; -- You find nothing.
 NOTHING_HAPPENS = 141; -- Nothing happens...
 
 -- conquest Base
-CONQUEST_BASE = 7067; -- Tallying conquest results...
+CONQUEST_BASE = 7068; -- Tallying conquest results...
 
 --chocobo digging
-DIG_THROW_AWAY = 7239; -- You dig up$, but your inventory is full. You regretfully throw the # away.
-FIND_NOTHING = 7241; -- You dig and you dig, but find nothing.
+DIG_THROW_AWAY = 7240; -- You dig up$, but your inventory is full. You regretfully throw the # away.
+FIND_NOTHING = 7242; -- You dig and you dig, but find nothing.

--- a/scripts/zones/Meriphataud_Mountains_[S]/TextIDs.lua
+++ b/scripts/zones/Meriphataud_Mountains_[S]/TextIDs.lua
@@ -2,10 +2,10 @@
 
 -- General Texts
 ITEM_CANNOT_BE_OBTAINED = 6379; -- You cannot obtain the item <item> come back again after sorting your inventory
-          ITEM_OBTAINED = 6384; -- Obtained: <item>
-           GIL_OBTAINED = 6385; -- Obtained <number> gil
-       KEYITEM_OBTAINED = 6387; -- Obtained key item: <keyitem>
-NOTHING_OUT_OF_ORDINARY = 6398; -- There is nothing out of the ordinary here.
+          ITEM_OBTAINED = 6385; -- Obtained: <item>
+           GIL_OBTAINED = 6386; -- Obtained <number> gil
+       KEYITEM_OBTAINED = 6388; -- Obtained key item: <keyitem>
+NOTHING_OUT_OF_ORDINARY = 6399; -- There is nothing out of the ordinary here.
 
 -- Other Texts
-ALREADY_OBTAINED_TELE = 7587; -- You already possess the gate crystal for this telepoint.
+ALREADY_OBTAINED_TELE = 7588; -- You already possess the gate crystal for this telepoint.

--- a/scripts/zones/Metalworks/TextIDs.lua
+++ b/scripts/zones/Metalworks/TextIDs.lua
@@ -3,42 +3,42 @@
 -- General Texts
    ITEM_CANNOT_BE_OBTAINED =  6434; -- You cannot obtain the item <item>. Come back after sorting your inventory.
 FULL_INVENTORY_AFTER_TRADE =  6438; -- You cannot obtain the item <item>. Try trading again after sorting your inventory.
-             ITEM_OBTAINED =  6439; -- Obtained:
-              GIL_OBTAINED =  6440; -- Obtained <<<Numeric Parameter 0>>> gil.
-       NOT_HAVE_ENOUGH_GIL =  6444; -- You do not have enough gil.
-          KEYITEM_OBTAINED =  6442; -- Obtained key item: <<<Unknown Parameter (Type: 80) 1>>>.
-            ITEMS_OBTAINED =  6448; -- You obtain
-          SMITHING_SUPPORT =  6856; -- Your ?Multiple Choice (Parameter 1)?[fishing/woodworking/smithing/goldsmithing/clothcraft/leatherworking/bonecraft/alchemy/cooking] skills went up ...
-  GUILD_TERMINATE_CONTRACT =  6870; -- You have terminated your trading contract with the Multiple Choice (Parameter 1)[Fishermen's/Carpenters'/Blacksmiths'/Goldsmiths'/Weavers'/Tanners'/Boneworkers'/Alchemists'/Culinarians'] Guild and formed a new one with the Multiple Choice (Parameter 0)[Fishermen's/Carpenters'/Blacksmiths'/Goldsmiths'/Weavers'/Tanners'/Boneworkers'/Alchemists'/Culinarians'] Guild
-        GUILD_NEW_CONTRACT =  6878; -- You have formed a new trading contract with the Multiple Choice (Parameter 0)[Fishermen's/Carpenters'/Blacksmiths'/Goldsmiths'/Weavers'/Tanners'/Boneworkers'/Alchemists'/Culinarians'] Guild
-       NO_MORE_GP_ELIGIBLE =  6885; -- You are not eligible to receive guild points at this time
-               GP_OBTAINED =  6890; -- Obtained: ?Numeric Parameter 0? guild points.
-        NOT_HAVE_ENOUGH_GP =  6891; -- You do not have enough guild points.
-    FISHING_MESSAGE_OFFSET =  8001; -- You can't fish here
-             HOMEPOINT_SET = 10998; -- Home point set!
+             ITEM_OBTAINED =  6440; -- Obtained:
+              GIL_OBTAINED =  6441; -- Obtained <<<Numeric Parameter 0>>> gil.
+       NOT_HAVE_ENOUGH_GIL =  6445; -- You do not have enough gil.
+          KEYITEM_OBTAINED =  6443; -- Obtained key item: <<<Unknown Parameter (Type: 80) 1>>>.
+            ITEMS_OBTAINED =  6449; -- You obtain
+          SMITHING_SUPPORT =  6857; -- Your ?Multiple Choice (Parameter 1)?[fishing/woodworking/smithing/goldsmithing/clothcraft/leatherworking/bonecraft/alchemy/cooking] skills went up ...
+  GUILD_TERMINATE_CONTRACT =  6871; -- You have terminated your trading contract with the Multiple Choice (Parameter 1)[Fishermen's/Carpenters'/Blacksmiths'/Goldsmiths'/Weavers'/Tanners'/Boneworkers'/Alchemists'/Culinarians'] Guild and formed a new one with the Multiple Choice (Parameter 0)[Fishermen's/Carpenters'/Blacksmiths'/Goldsmiths'/Weavers'/Tanners'/Boneworkers'/Alchemists'/Culinarians'] Guild
+        GUILD_NEW_CONTRACT =  6879; -- You have formed a new trading contract with the Multiple Choice (Parameter 0)[Fishermen's/Carpenters'/Blacksmiths'/Goldsmiths'/Weavers'/Tanners'/Boneworkers'/Alchemists'/Culinarians'] Guild
+       NO_MORE_GP_ELIGIBLE =  6886; -- You are not eligible to receive guild points at this time
+               GP_OBTAINED =  6891; -- Obtained: ?Numeric Parameter 0? guild points.
+        NOT_HAVE_ENOUGH_GP =  6892; -- You do not have enough guild points.
+    FISHING_MESSAGE_OFFSET =  8003; -- You can't fish here
+             HOMEPOINT_SET = 11000; -- Home point set!
             
 -- Mission Dialogs
     YOU_ACCEPT_THE_MISSION  =     9; -- You have accepted the mission.
    ORIGINAL_MISSION_OFFSET  =    14; -- You can consult the ission section of the main menu to review your objectives. Speed and efficiency are your priorities. Dismissed. 
-                  GOOD_LUCK =  7441; -- Good luck on your mission. Bastokers like to do things by the book, so stay out of trouble and follow their rules.
-MISSION_DIALOG_CID_TO_AYAME =  7568; -- Give it to one of his Mythril Musketeers instead. Ayame and Naji should be on guard near the President's Office. Either one will do.
-                 ITS_LOCKED =  7979; -- It's locked.
-   EXTENDED_MISSION_OFFSET  =  8592; -- Go to Ore Street and talk to Medicine Eagle. He says he was there when the commotion started.
+                  GOOD_LUCK =  7443; -- Good luck on your mission. Bastokers like to do things by the book, so stay out of trouble and follow their rules.
+MISSION_DIALOG_CID_TO_AYAME =  7570; -- Give it to one of his Mythril Musketeers instead. Ayame and Naji should be on guard near the President's Office. Either one will do.
+                 ITS_LOCKED =  7981; -- It's locked.
+   EXTENDED_MISSION_OFFSET  =  8594; -- Go to Ore Street and talk to Medicine Eagle. He says he was there when the commotion started.
 
 -- Other dialog
-NOTHING_OUT_OF_ORDINARY =  6453; -- There is nothing out of the ordinary here.
-     GLAROCIQUET_DIALOG =  8204; -- I am Speaker Name, a Temple Knight. I am one of the guards charged with overseeing San d'Oria's conquest campaign.
-   LEXUN_MARIXUN_DIALOG =  8206; -- I am Speaker Name, a War Warlock. I am one of the guards charged with overseeing Windurst's conquest campaign.
+NOTHING_OUT_OF_ORDINARY =  6454; -- There is nothing out of the ordinary here.
+     GLAROCIQUET_DIALOG =  8206; -- I am Speaker Name, a Temple Knight. I am one of the guards charged with overseeing San d'Oria's conquest campaign.
+   LEXUN_MARIXUN_DIALOG =  8208; -- I am Speaker Name, a War Warlock. I am one of the guards charged with overseeing Windurst's conquest campaign.
 
 -- Shop Texts
-VICIOUS_EYE_SHOP_DIALOG =  7996; -- Hi. This is where blacksmiths buy what they need.
-     AMULYA_SHOP_DIALOG =  7997; -- Hello. Welcome to the Blacksmiths' Guild shop.
-       OLAF_SHOP_DIALOG =  7998; -- We sell items in the Gunpowder Room, too. What do you need?
-      NOGGA_SHOP_DIALOG =  7999; -- I've got some items you won't find elsewhere!
-     TOMASA_SHOP_DIALOG =  8000; -- This is the Craftsmen's Eatery. Make room for the next customer when you're done, all right?
+VICIOUS_EYE_SHOP_DIALOG =  7998; -- Hi. This is where blacksmiths buy what they need.
+     AMULYA_SHOP_DIALOG =  7999; -- Hello. Welcome to the Blacksmiths' Guild shop.
+       OLAF_SHOP_DIALOG =  8000; -- We sell items in the Gunpowder Room, too. What do you need?
+      NOGGA_SHOP_DIALOG =  8001; -- I've got some items you won't find elsewhere!
+     TOMASA_SHOP_DIALOG =  8002; -- This is the Craftsmen's Eatery. Make room for the next customer when you're done, all right?
 
-  TAKIYAH_CLOSED_DIALOG =  9962; -- Maybe someday I'll be able to sell goods from Qufim Island... Someday...
-    TAKIYAH_OPEN_DIALOG =  9963; -- Hey, it's your lucky day! I've got a fresh batch of goods straight from the island of Qufim!
+  TAKIYAH_CLOSED_DIALOG =  9964; -- Maybe someday I'll be able to sell goods from Qufim Island... Someday...
+    TAKIYAH_OPEN_DIALOG =  9965; -- Hey, it's your lucky day! I've got a fresh batch of goods straight from the island of Qufim!
 
 -- conquest Base
-CONQUEST_BASE = 6528; -- Tallying conquest results...
+CONQUEST_BASE = 6529; -- Tallying conquest results...

--- a/scripts/zones/Mhaura/TextIDs.lua
+++ b/scripts/zones/Mhaura/TextIDs.lua
@@ -2,34 +2,34 @@
 
 -- General Texts
 ITEM_CANNOT_BE_OBTAINED = 6379; -- You cannot obtain the item <item>. Come back after sorting your inventory.
-          ITEM_OBTAINED = 6384; -- Obtained: <item>.
-           GIL_OBTAINED = 6385; -- Obtained <number> gil.
-       KEYITEM_OBTAINED = 6387; -- Obtained key item: <keyitem>.
-    NOT_HAVE_ENOUGH_GIL = 6389; -- You do not have enough gil.
-          HOMEPOINT_SET = 6475; -- Home point set!
- FISHING_MESSAGE_OFFSET = 6709; -- You can't fish here.
-         DO_NOT_POSSESS = 7755; -- You do not possess . You were not permitted to board the ship...
+          ITEM_OBTAINED = 6385; -- Obtained: <item>.
+           GIL_OBTAINED = 6386; -- Obtained <number> gil.
+       KEYITEM_OBTAINED = 6388; -- Obtained key item: <keyitem>.
+    NOT_HAVE_ENOUGH_GIL = 6390; -- You do not have enough gil.
+          HOMEPOINT_SET = 6476; -- Home point set!
+ FISHING_MESSAGE_OFFSET = 6710; -- You can't fish here.
+         DO_NOT_POSSESS = 7756; -- You do not possess . You were not permitted to board the ship...
 
 -- Other Texts
-MAURIRI_DELIVERY_DIALOG = 7752; -- Mauriri is my name, and sending parcels from Mhaura is my game.
-PANORU_DELIVERY_DIALOG =  7753; -- Looking for a delivery company that isn't lamey-wame? The quality of my service puts Mauriri to shame!
+MAURIRI_DELIVERY_DIALOG = 7753; -- Mauriri is my name, and sending parcels from Mhaura is my game.
+PANORU_DELIVERY_DIALOG =  7754; -- Looking for a delivery company that isn't lamey-wame? The quality of my service puts Mauriri to shame!
 
 -- Quest Dialog
-NOMAD_MOOGLE_DIALOG = 6809; -- I'm a traveling moogle, kupo. I help adventurers in the Outlands access items they have stored in a Mog House elsewhere, kupo.
-    SUBJOB_UNLOCKED = 7050; -- You can now use support jobs!
- GOLDSMITHING_GUILD = 7160; -- Everything you need for your goldsmithing needs!
-     SMITHING_GUILD = 7161; -- Welcome to the Blacksmiths' Guild salesroom!
-     RAMUH_UNLOCKED = 7374; -- You are now able to summon
+NOMAD_MOOGLE_DIALOG = 6810; -- I'm a traveling moogle, kupo. I help adventurers in the Outlands access items they have stored in a Mog House elsewhere, kupo.
+    SUBJOB_UNLOCKED = 7051; -- You can now use support jobs!
+ GOLDSMITHING_GUILD = 7161; -- Everything you need for your goldsmithing needs!
+     SMITHING_GUILD = 7162; -- Welcome to the Blacksmiths' Guild salesroom!
+     RAMUH_UNLOCKED = 7375; -- You are now able to summon
 
 -- Shop Texts
-      GRAINE_SHOP_DIALOG = 7156; -- Hello there, I'm Graine the armorer. I've got just what you need!
-PIKINIMIKINI_SHOP_DIALOG = 7158; -- Hi, I'm Pikini-Mikini, Mhaura's item seller. I've got the wares, so size doesn't matter!
-RUNITOMONITO_SHOP_DIALOG = 7157; -- Hi! Welcome! I'm Runito-Monito, and weapons is my middle name!
-  TYAPADOLIH_SHOP_DIALOG = 7159; -- Welcome, strrranger! Tya Padolih's the name, and dealin' in magic is my game!
+      GRAINE_SHOP_DIALOG = 7157; -- Hello there, I'm Graine the armorer. I've got just what you need!
+PIKINIMIKINI_SHOP_DIALOG = 7159; -- Hi, I'm Pikini-Mikini, Mhaura's item seller. I've got the wares, so size doesn't matter!
+RUNITOMONITO_SHOP_DIALOG = 7158; -- Hi! Welcome! I'm Runito-Monito, and weapons is my middle name!
+  TYAPADOLIH_SHOP_DIALOG = 7160; -- Welcome, strrranger! Tya Padolih's the name, and dealin' in magic is my game!
 
 
 -- conquest Base
-CONQUEST_BASE = 6533; -- Tallying conquest results...
+CONQUEST_BASE = 6534; -- Tallying conquest results...
 
 -- Porter Moogle
-    RETRIEVE_DIALOG_ID = 7790; -- You retrieve$ from the porter moogle's care.
+    RETRIEVE_DIALOG_ID = 7791; -- You retrieve$ from the porter moogle's care.

--- a/scripts/zones/Middle_Delkfutts_Tower/TextIDs.lua
+++ b/scripts/zones/Middle_Delkfutts_Tower/TextIDs.lua
@@ -2,24 +2,24 @@
 
 -- General Texts
 ITEM_CANNOT_BE_OBTAINED = 6542; -- You cannot obtain the item <item>. Come back after sorting your inventory.
-          ITEM_OBTAINED = 6547; -- Obtained: <item>.
-           GIL_OBTAINED = 6548; -- Obtained <number> gil.
-       KEYITEM_OBTAINED = 6550; -- Obtained key item: <keyitem>.
- FISHING_MESSAGE_OFFSET = 7208; -- You can't fish here.
+          ITEM_OBTAINED = 6548; -- Obtained: <item>.
+           GIL_OBTAINED = 6549; -- Obtained <number> gil.
+       KEYITEM_OBTAINED = 6551; -- Obtained key item: <keyitem>.
+ FISHING_MESSAGE_OFFSET = 7209; -- You can't fish here.
 
 -- Treasure Coffer/Chest Dialog
-CHEST_UNLOCKED = 7315; -- You unlock the chest!
-    CHEST_FAIL = 7316; -- Fails to open the chest.
-    CHEST_TRAP = 7317; -- The chest was trapped!
-    CHEST_WEAK = 7318; -- You cannot open the chest when you are in a weakened state.
-   CHEST_MIMIC = 7319; -- The chest was a mimic!
-  CHEST_MOOGLE = 7320; -- You cannot open the chest while participating in the moogle event.
-CHEST_ILLUSION = 7321; -- The chest was but an illusion...
-  CHEST_LOCKED = 7322; -- The chest appears to be locked.
+CHEST_UNLOCKED = 7316; -- You unlock the chest!
+    CHEST_FAIL = 7317; -- Fails to open the chest.
+    CHEST_TRAP = 7318; -- The chest was trapped!
+    CHEST_WEAK = 7319; -- You cannot open the chest when you are in a weakened state.
+   CHEST_MIMIC = 7320; -- The chest was a mimic!
+  CHEST_MOOGLE = 7321; -- You cannot open the chest while participating in the moogle event.
+CHEST_ILLUSION = 7322; -- The chest was but an illusion...
+  CHEST_LOCKED = 7323; -- The chest appears to be locked.
 
 -- Quest dialog
-NOTHING_OUT_OF_ORDINARY = 6561; -- There is nothing out of the ordinary here.
-    SENSE_OF_FOREBODING = 6562; -- You are suddenly overcome with a sense of foreboding...
+NOTHING_OUT_OF_ORDINARY = 6562; -- There is nothing out of the ordinary here.
+    SENSE_OF_FOREBODING = 6563; -- You are suddenly overcome with a sense of foreboding...
 
 -- conquest Base
 CONQUEST_BASE = 4;

--- a/scripts/zones/Mine_Shaft_2716/TextIDs.lua
+++ b/scripts/zones/Mine_Shaft_2716/TextIDs.lua
@@ -2,8 +2,8 @@
 
 -- General Texts
 ITEM_CANNOT_BE_OBTAINED = 6379; -- You cannot obtain the item <item> come back again after sorting your inventory
-          ITEM_OBTAINED = 6384; -- Obtained: <item>
-           GIL_OBTAINED = 6385; -- Obtained <number> gil
-       KEYITEM_OBTAINED = 6387; -- Obtained key item: <keyitem>
+          ITEM_OBTAINED = 6385; -- Obtained: <item>
+           GIL_OBTAINED = 6386; -- Obtained <number> gil
+       KEYITEM_OBTAINED = 6388; -- Obtained key item: <keyitem>
 -- conquest Base
-CONQUEST_BASE = 7416; -- Tallying conquest results...
+CONQUEST_BASE = 7417; -- Tallying conquest results...

--- a/scripts/zones/Misareaux_Coast/TextIDs.lua
+++ b/scripts/zones/Misareaux_Coast/TextIDs.lua
@@ -2,18 +2,18 @@
 
 -- General Texts
 ITEM_CANNOT_BE_OBTAINED = 6379; -- You cannot obtain the item <item>. Come back after sorting your inventory.
-          ITEM_OBTAINED = 6384; -- Obtained: <item>.
-           GIL_OBTAINED = 6385; -- Obtained <number> gil.
-       KEYITEM_OBTAINED = 6387; -- Obtained key item: <keyitem>.
- FISHING_MESSAGE_OFFSET = 7067; -- You can't fish here.
-HOMEPOINT_SET = 8854; -- Home point set!
+          ITEM_OBTAINED = 6385; -- Obtained: <item>.
+           GIL_OBTAINED = 6386; -- Obtained <number> gil.
+       KEYITEM_OBTAINED = 6388; -- Obtained key item: <keyitem>.
+ FISHING_MESSAGE_OFFSET = 7068; -- You can't fish here.
+HOMEPOINT_SET = 8855; -- Home point set!
 
 -- Other dialog
-NOTHING_OUT_OF_ORDINARY = 6398; -- There is nothing out of the ordinary here.
-            DOOR_CLOSED = 7343; -- The door is locked tight.
+NOTHING_OUT_OF_ORDINARY = 6399; -- There is nothing out of the ordinary here.
+            DOOR_CLOSED = 7344; -- The door is locked tight.
 
 -- Logging
-LOGGING_IS_POSSIBLE_HERE = 7597; -- Logging is possible here if you have
+LOGGING_IS_POSSIBLE_HERE = 7598; -- Logging is possible here if you have
 
 -- conquest Base
-CONQUEST_BASE = 7167; -- Tallying conquest results...
+CONQUEST_BASE = 7168; -- Tallying conquest results...

--- a/scripts/zones/Mog_Garden/TextIDs.lua
+++ b/scripts/zones/Mog_Garden/TextIDs.lua
@@ -2,15 +2,15 @@
 
 -- General Texts
 ITEM_CANNOT_BE_OBTAINED  = 6379; -- You cannot obtain the item <item> come back again after sorting your inventory
-          ITEM_OBTAINED  = 6384; -- Obtained: <item>
-        ITEM_OBTAINEDX   = 6390; -- You obtain <number> <item>!
-           GIL_OBTAINED  = 6385; -- Obtained <number> gil
-       KEYITEM_OBTAINED  = 6387; -- Obtained key item: <keyitem>
-    NOT_HAVE_ENOUGH_GIL  = 6389; -- You do not have enough gil
-MOGLOCKER_MESSAGE_OFFSET = 7508; -- Your particular paid period of Mog Locker patronage has been extended until the following time, kupo!
- FISHING_MESSAGE_OFFSET  = 7204; -- You can't fish here
+          ITEM_OBTAINED  = 6385; -- Obtained: <item>
+        ITEM_OBTAINEDX   = 6391; -- You obtain <number> <item>!
+           GIL_OBTAINED  = 6386; -- Obtained <number> gil
+       KEYITEM_OBTAINED  = 6388; -- Obtained key item: <keyitem>
+    NOT_HAVE_ENOUGH_GIL  = 6390; -- You do not have enough gil
+MOGLOCKER_MESSAGE_OFFSET = 7509; -- Your particular paid period of Mog Locker patronage has been extended until the following time, kupo!
+ FISHING_MESSAGE_OFFSET  = 7205; -- You can't fish here
 
 -- Other dialog
-NOTHING_OUT_OF_ORDINARY  = 6398; -- There is nothing out of the ordinary here.
-      STARS_ON_KEYITEM   = 7492; --  Singular/Plural Choice (Parameter 1)[has/have] come aglow.
-      RETRIEVE_DIALOG_ID = 8559; -- You retrieve$ from the porter moogle's care.
+NOTHING_OUT_OF_ORDINARY  = 6399; -- There is nothing out of the ordinary here.
+      STARS_ON_KEYITEM   = 7493; --  Singular/Plural Choice (Parameter 1)[has/have] come aglow.
+      RETRIEVE_DIALOG_ID = 8560; -- You retrieve$ from the porter moogle's care.

--- a/scripts/zones/Moh_Gates/TextIDs.lua
+++ b/scripts/zones/Moh_Gates/TextIDs.lua
@@ -2,6 +2,6 @@
 
 -- General Texts
 ITEM_CANNOT_BE_OBTAINED = 6379; -- You cannot obtain the item <item> come back again after sorting your inventory
-          ITEM_OBTAINED = 6384; -- Obtained: <item>
-           GIL_OBTAINED = 6385; -- Obtained <number> gil
-       KEYITEM_OBTAINED = 6387; -- Obtained key item: <keyitem>
+          ITEM_OBTAINED = 6385; -- Obtained: <item>
+           GIL_OBTAINED = 6386; -- Obtained <number> gil
+       KEYITEM_OBTAINED = 6388; -- Obtained key item: <keyitem>

--- a/scripts/zones/Monarch_Linn/TextIDs.lua
+++ b/scripts/zones/Monarch_Linn/TextIDs.lua
@@ -2,11 +2,11 @@
 
 -- General Texts
 ITEM_CANNOT_BE_OBTAINED = 6379; -- You cannot obtain the item <item> come back again after sorting your inventory
-          ITEM_OBTAINED = 6384; -- Obtained: <item>
-           GIL_OBTAINED = 6385; -- Obtained <number> gil
-       KEYITEM_OBTAINED = 6387; -- Obtained key item: <keyitem>
+          ITEM_OBTAINED = 6385; -- Obtained: <item>
+           GIL_OBTAINED = 6386; -- Obtained <number> gil
+       KEYITEM_OBTAINED = 6388; -- Obtained key item: <keyitem>
 
-           GLOWING_MIST = 7122; -- A glowing mist of ever-changing proportions floats before you...
+           GLOWING_MIST = 7123; -- A glowing mist of ever-changing proportions floats before you...
 
 -- conquest Base
-CONQUEST_BASE = 7457; -- Tallying conquest results...
+CONQUEST_BASE = 7458; -- Tallying conquest results...

--- a/scripts/zones/Monastic_Cavern/TextIDs.lua
+++ b/scripts/zones/Monastic_Cavern/TextIDs.lua
@@ -2,29 +2,29 @@
 
 -- General Texts
 ITEM_CANNOT_BE_OBTAINED = 6379; -- You cannot obtain the item <item>. Come back after sorting your inventory.
-          ITEM_OBTAINED = 6384; -- Obtained: <item>.
-           GIL_OBTAINED = 6385; -- Obtained <number> gil.
-       KEYITEM_OBTAINED = 6387; -- Obtained key item: <keyitem>.
+          ITEM_OBTAINED = 6385; -- Obtained: <item>.
+           GIL_OBTAINED = 6386; -- Obtained <number> gil.
+       KEYITEM_OBTAINED = 6388; -- Obtained key item: <keyitem>.
 
 -- Treasure Coffer/Chest Dialog
-CHEST_UNLOCKED = 7281; -- You unlock the chest!
-    CHEST_FAIL = 7282; -- Fails to open the chest.
-    CHEST_TRAP = 7283; -- The chest was trapped!
-    CHEST_WEAK = 7284; -- You cannot open the chest when you are in a weakened state.
-   CHEST_MIMIC = 7285; -- The chest was a mimic!
-  CHEST_MOOGLE = 7286; -- You cannot open the chest while participating in the moogle event.
-CHEST_ILLUSION = 7287; -- The chest was but an illusion...
-  CHEST_LOCKED = 7288; -- The chest appears to be locked.
+CHEST_UNLOCKED = 7282; -- You unlock the chest!
+    CHEST_FAIL = 7283; -- Fails to open the chest.
+    CHEST_TRAP = 7284; -- The chest was trapped!
+    CHEST_WEAK = 7285; -- You cannot open the chest when you are in a weakened state.
+   CHEST_MIMIC = 7286; -- The chest was a mimic!
+  CHEST_MOOGLE = 7287; -- You cannot open the chest while participating in the moogle event.
+CHEST_ILLUSION = 7288; -- The chest was but an illusion...
+  CHEST_LOCKED = 7289; -- The chest appears to be locked.
 
 -- Other dialog
-     NOTHING_OUT_OF_ORDINARY = 6398; -- There is nothing out of the ordinary here.
-                       ALTAR = 7260; -- This appears to be an altar.
-THE_MAGICITE_GLOWS_OMINOUSLY = 7263; -- The magicite glows ominously.
+     NOTHING_OUT_OF_ORDINARY = 6399; -- There is nothing out of the ordinary here.
+                       ALTAR = 7261; -- This appears to be an altar.
+THE_MAGICITE_GLOWS_OMINOUSLY = 7264; -- The magicite glows ominously.
 
-ORCISH_OVERLORD_ENGAGE = 7293; -- Intruders? Get outs here! We gots us some adventurers!
- ORCISH_OVERLORD_DEATH = 7294; -- Gahahahaha... You fell for our trick. I'm not the big boss. He don't need to be troubled by runty little rarabs like you.
-       ORC_KING_ENGAGE = 7295; -- Ungh? Who are you?So, you've come to kill big boss Bakgodek? I'll crush your scrawny bones myself!
-        ORC_KING_DEATH = 7296; -- Unghh... Foolish children of Altana. Defeating me won't change anything. There will be others from the north...
+ORCISH_OVERLORD_ENGAGE = 7294; -- Intruders? Get outs here! We gots us some adventurers!
+ ORCISH_OVERLORD_DEATH = 7295; -- Gahahahaha... You fell for our trick. I'm not the big boss. He don't need to be troubled by runty little rarabs like you.
+       ORC_KING_ENGAGE = 7296; -- Ungh? Who are you?So, you've come to kill big boss Bakgodek? I'll crush your scrawny bones myself!
+        ORC_KING_DEATH = 7297; -- Unghh... Foolish children of Altana. Defeating me won't change anything. There will be others from the north...
 
 -- conquest Base
-CONQUEST_BASE = 7045; -- Tallying conquest results...
+CONQUEST_BASE = 7046; -- Tallying conquest results...

--- a/scripts/zones/Mordion_Gaol/TextIDs.lua
+++ b/scripts/zones/Mordion_Gaol/TextIDs.lua
@@ -2,12 +2,12 @@
 
 -- General Texts
 ITEM_CANNOT_BE_OBTAINED = 6538; -- You cannot obtain the item <item>. Come back after sorting your inventory.
-          ITEM_OBTAINED = 6543; -- Obtained: <item>.
-           GIL_OBTAINED = 6544; -- Obtained <number> gil.
-       KEYITEM_OBTAINED = 6546; -- Obtained key item: <keyitem>.
+          ITEM_OBTAINED = 6544; -- Obtained: <item>.
+           GIL_OBTAINED = 6545; -- Obtained <number> gil.
+       KEYITEM_OBTAINED = 6547; -- Obtained key item: <keyitem>.
 
-            NO_ESCAPE = 7204; -- Any attempt at escape is futile!
-PROHIBITED_ACTIVITIES = 7220; -- Your character has been jailed due to prohibited activities. Your account will soon be suspended due to this violation.
+            NO_ESCAPE = 7205; -- Any attempt at escape is futile!
+PROHIBITED_ACTIVITIES = 7221; -- Your character has been jailed due to prohibited activities. Your account will soon be suspended due to this violation.
 
 -- conquest Base
 CONQUEST_BASE = 0;

--- a/scripts/zones/Morimar_Basalt_Fields/TextIDs.lua
+++ b/scripts/zones/Morimar_Basalt_Fields/TextIDs.lua
@@ -2,7 +2,7 @@
 
 -- General Texts
 ITEM_CANNOT_BE_OBTAINED = 6379; -- You cannot obtain the item <item> come back again after sorting your inventory
-          ITEM_OBTAINED = 6384; -- Obtained: <item>
-           GIL_OBTAINED = 6385; -- Obtained <number> gil
-       KEYITEM_OBTAINED = 6387; -- Obtained key item: <keyitem>
-            HOMEPOINT_SET = 8155; -- Home point set!
+          ITEM_OBTAINED = 6385; -- Obtained: <item>
+           GIL_OBTAINED = 6386; -- Obtained <number> gil
+       KEYITEM_OBTAINED = 6388; -- Obtained key item: <keyitem>
+            HOMEPOINT_SET = 8156; -- Home point set!

--- a/scripts/zones/Mount_Zhayolm/TextIDs.lua
+++ b/scripts/zones/Mount_Zhayolm/TextIDs.lua
@@ -2,21 +2,21 @@
 
 -- General Texts
 ITEM_CANNOT_BE_OBTAINED = 6379; -- You cannot obtain the item <item> come back again after sorting your inventory
-          ITEM_OBTAINED = 6384; -- Obtained: <item>
-           GIL_OBTAINED = 6385; -- Obtained <number> gil
-       KEYITEM_OBTAINED = 6387; -- Obtained key item: <keyitem>
- FISHING_MESSAGE_OFFSET = 7045; -- You can't fish here
-            HOMEPOINT_SET = 8720; -- Home point set!
+          ITEM_OBTAINED = 6385; -- Obtained: <item>
+           GIL_OBTAINED = 6386; -- Obtained <number> gil
+       KEYITEM_OBTAINED = 6388; -- Obtained key item: <keyitem>
+ FISHING_MESSAGE_OFFSET = 7046; -- You can't fish here
+            HOMEPOINT_SET = 8721; -- Home point set!
 
 -- Mining
-MINING_IS_POSSIBLE_HERE = 7414; -- Mining is possible here if you have
+MINING_IS_POSSIBLE_HERE = 7415; -- Mining is possible here if you have
 
 -- Assault
-CANNOT_ENTER = 7473; -- You cannot enter at this time.  Please wait a while before trying again.
-AREA_FULL = 7474; -- This area is fully occupied. You were unable to enter.
-MEMBER_NO_REQS = 7478; -- Not all of your party members meet the requirements for this objective.  Unable to enter area.
-MEMBER_TOO_FAR = 7482; -- One or more party members are too far away from the entrance.  Unable to enter area.
+CANNOT_ENTER = 7474; -- You cannot enter at this time.  Please wait a while before trying again.
+AREA_FULL = 7475; -- This area is fully occupied. You were unable to enter.
+MEMBER_NO_REQS = 7479; -- Not all of your party members meet the requirements for this objective.  Unable to enter area.
+MEMBER_TOO_FAR = 7483; -- One or more party members are too far away from the entrance.  Unable to enter area.
 
 -- Other Texts
-NOTHING_HAPPENS = 7459; -- Nothing happens...
-       RESPONSE = 7325; -- There is no response...
+NOTHING_HAPPENS = 7460; -- Nothing happens...
+       RESPONSE = 7326; -- There is no response...

--- a/scripts/zones/Nashmau/TextIDs.lua
+++ b/scripts/zones/Nashmau/TextIDs.lua
@@ -3,29 +3,29 @@
 -- General Texts
 ITEM_CANNOT_BE_OBTAINED = 6379; -- You cannot obtain the item <item> come back again after sorting your inventory
 ITEM_CANNOT_BE_OBTAINEDX = 6378; -- You cannot obtain the
-          ITEM_OBTAINED = 6384; -- Obtained: <item>
-     ITEM_OBTAINEDX = 6393; -- You obtain ?Numeric Parameter 1? ?Possible Special Code: 01??Speaker Name?)??BAD CHAR: 80??BAD CHAR: 80??BAD CHAR: 8280??BAD CHAR: 80??BAD CHAR: 80?!?Prompt?
-           GIL_OBTAINED = 6385; -- Obtained <number> gil
-       KEYITEM_OBTAINED = 6387; -- Obtained key item: <keyitem>
- FISHING_MESSAGE_OFFSET = 7045; -- You can't fish here
-          HOMEPOINT_SET = 7306; -- Home point set!
+          ITEM_OBTAINED = 6385; -- Obtained: <item>
+     ITEM_OBTAINEDX = 6394; -- You obtain ?Numeric Parameter 1? ?Possible Special Code: 01??Speaker Name?)??BAD CHAR: 80??BAD CHAR: 80??BAD CHAR: 8280??BAD CHAR: 80??BAD CHAR: 80?!?Prompt?
+           GIL_OBTAINED = 6386; -- Obtained <number> gil
+       KEYITEM_OBTAINED = 6388; -- Obtained key item: <keyitem>
+ FISHING_MESSAGE_OFFSET = 7046; -- You can't fish here
+          HOMEPOINT_SET = 7307; -- Home point set!
 
 -- Other Texts
-NENE_DELIVERY_DIALOG = 10829; -- Yooo want to send gooods? Yooo want to send link clink
-NANA_DELIVERY_DIALOG = 10830; -- Yooo send gooods. Yooo send link clink.
+NENE_DELIVERY_DIALOG = 10830; -- Yooo want to send gooods? Yooo want to send link clink
+NANA_DELIVERY_DIALOG = 10831; -- Yooo send gooods. Yooo send link clink.
 
 -- Quest Dialog
-NOMAD_MOOGLE_DIALOG = 7326; -- I'm a traveling moogle, kupo. I help adventurers in the Outlands access items they have stored in a Mog House elsewhere, kupo.
+NOMAD_MOOGLE_DIALOG = 7327; -- I'm a traveling moogle, kupo. I help adventurers in the Outlands access items they have stored in a Mog House elsewhere, kupo.
 
 -- Shop Texts
-    JAJAROON_SHOP_DIALOG = 10475; -- Hellooo. Yooo have caaard? Can do gaaame? Jajaroon have diiice.
-  TSUTSUROON_SHOP_DIALOG = 10485; -- What yooo want? Have katana, katana, and nin-nin...yooo want?
-    MAMAROON_SHOP_DIALOG = 10488; -- Welcome to maaagic shop. Lots of magics for yooo.
-    POPOROON_SHOP_DIALOG = 10490; -- Come, come. Buy aaarmor, looots of armor!
-WATAKHAMAZOM_SHOP_DIALOG = 10491; -- Looking for some bows and bolts to strrrike fear into the hearts of your enemies? You can find 'em here!
-  CHICHIROON_SHOP_DIALOG = 10493; -- Howdy-hooo! I gots soooper rare dice for yooo.
+    JAJAROON_SHOP_DIALOG = 10476; -- Hellooo. Yooo have caaard? Can do gaaame? Jajaroon have diiice.
+  TSUTSUROON_SHOP_DIALOG = 10486; -- What yooo want? Have katana, katana, and nin-nin...yooo want?
+    MAMAROON_SHOP_DIALOG = 10489; -- Welcome to maaagic shop. Lots of magics for yooo.
+    POPOROON_SHOP_DIALOG = 10491; -- Come, come. Buy aaarmor, looots of armor!
+WATAKHAMAZOM_SHOP_DIALOG = 10492; -- Looking for some bows and bolts to strrrike fear into the hearts of your enemies? You can find 'em here!
+  CHICHIROON_SHOP_DIALOG = 10494; -- Howdy-hooo! I gots soooper rare dice for yooo.
     PIPIROON_SHOP_DIALOG = 0; -- [UNKNOWN]
     YOYOROON_SHOP_DIALOG = 0; -- [UNKNOWN]
 
 -- Porter Moogle
-      RETRIEVE_DIALOG_ID = 11882; -- You retrieve$ from the porter moogle's care.
+      RETRIEVE_DIALOG_ID = 11883; -- You retrieve$ from the porter moogle's care.

--- a/scripts/zones/Navukgo_Execution_Chamber/TextIDs.lua
+++ b/scripts/zones/Navukgo_Execution_Chamber/TextIDs.lua
@@ -2,18 +2,18 @@
 
 -- General Texts
 ITEM_CANNOT_BE_OBTAINED = 6379; -- You cannot obtain the item <item> come back again after sorting your inventory
-          ITEM_OBTAINED = 6384; -- Obtained: <item>
-           GIL_OBTAINED = 6385; -- Obtained <number> gil
-       KEYITEM_OBTAINED = 6387; -- Obtained key item: <keyitem>
+          ITEM_OBTAINED = 6385; -- Obtained: <item>
+           GIL_OBTAINED = 6386; -- Obtained <number> gil
+       KEYITEM_OBTAINED = 6388; -- Obtained key item: <keyitem>
 
 -- Karababa
-        KARABABA_ENOUGH = 7624; -- That's quite enough...
-         KARABABA_ROUGH = 7625; -- Time for me to start playing rough!
-          KARABARA_FIRE = 7626; -- Fuel for the fire!
-           KARABARA_ICE = 7627; -- I'll put your sorry hide on ice!
-          KARABARA_WIND = 7628; -- How about we have a refreshing gale!
-         KARABARA_EARTH = 7629; -- how much damage you can deal with simple rock!
-     KARABARA_LIGHTNING = 7630; -- Witness the power of lightning and thunder!
-         KARABARA_WATER = 7631; -- Water is more dangerous than most expect
-          KARABABA_QUIT = 7639; -- It's time for me to quit the field
+        KARABABA_ENOUGH = 7625; -- That's quite enough...
+         KARABABA_ROUGH = 7626; -- Time for me to start playing rough!
+          KARABARA_FIRE = 7627; -- Fuel for the fire!
+           KARABARA_ICE = 7628; -- I'll put your sorry hide on ice!
+          KARABARA_WIND = 7629; -- How about we have a refreshing gale!
+         KARABARA_EARTH = 7630; -- how much damage you can deal with simple rock!
+     KARABARA_LIGHTNING = 7631; -- Witness the power of lightning and thunder!
+         KARABARA_WATER = 7632; -- Water is more dangerous than most expect
+          KARABABA_QUIT = 7640; -- It's time for me to quit the field
 

--- a/scripts/zones/Newton_Movalpolos/TextIDs.lua
+++ b/scripts/zones/Newton_Movalpolos/TextIDs.lua
@@ -2,28 +2,28 @@
 
 -- General Texts
 ITEM_CANNOT_BE_OBTAINED = 6379; -- You cannot obtain the item <item>. Come back after sorting your inventory.
-          ITEM_OBTAINED = 6384; -- Obtained: <item>.
-           GIL_OBTAINED = 6385; -- Obtained <number> gil.
-       KEYITEM_OBTAINED = 6387; -- Obtained key item: <keyitem>.
-            HOMEPOINT_SET = 7264; -- Home point set!
+          ITEM_OBTAINED = 6385; -- Obtained: <item>.
+           GIL_OBTAINED = 6386; -- Obtained <number> gil.
+       KEYITEM_OBTAINED = 6388; -- Obtained key item: <keyitem>.
+            HOMEPOINT_SET = 7265; -- Home point set!
             
 -- Mining
-MINING_IS_POSSIBLE_HERE = 7234; -- Mining is possible here if you have
+MINING_IS_POSSIBLE_HERE = 7235; -- Mining is possible here if you have
 
 -- Treasure Coffer/Chest Dialog
-CHEST_UNLOCKED = 7248; -- You unlock the chest!
-    CHEST_FAIL = 7249; -- Fails to open the chest.
-    CHEST_TRAP = 7250; -- The chest was trapped!
-    CHEST_WEAK = 7251; -- You cannot open the chest when you are in a weakened state.
-   CHEST_MIMIC = 7252; -- The chest was a mimic!
-  CHEST_MOOGLE = 7253; -- You cannot open the chest while participating in the moogle event.
-CHEST_ILLUSION = 7254; -- The chest was but an illusion...
-  CHEST_LOCKED = 7255; -- The chest appears to be locked.
+CHEST_UNLOCKED = 7249; -- You unlock the chest!
+    CHEST_FAIL = 7250; -- Fails to open the chest.
+    CHEST_TRAP = 7251; -- The chest was trapped!
+    CHEST_WEAK = 7252; -- You cannot open the chest when you are in a weakened state.
+   CHEST_MIMIC = 7253; -- The chest was a mimic!
+  CHEST_MOOGLE = 7254; -- You cannot open the chest while participating in the moogle event.
+CHEST_ILLUSION = 7255; -- The chest was but an illusion...
+  CHEST_LOCKED = 7256; -- The chest appears to be locked.
 
 -- Moblin Showman
-SHOWMAN_DECLINE = 7259; -- ... Me no want that. Thing me want not here! It not being here!!!?Prompt?
-SHOWMAN_TRIGGER = 7260; -- Hey, you there! Muscles nice. You want fight strong one? It cost you. Give me nice item.
- SHOWMAN_ACCEPT = 7261; -- Fhungaaa!!! The freshyness, the flavoryness! This very nice item! Good luck, then. Try not die. One...two...four...FIIIIIIGHT!!!
+SHOWMAN_DECLINE = 7260; -- ... Me no want that. Thing me want not here! It not being here!!!?Prompt?
+SHOWMAN_TRIGGER = 7261; -- Hey, you there! Muscles nice. You want fight strong one? It cost you. Give me nice item.
+ SHOWMAN_ACCEPT = 7262; -- Fhungaaa!!! The freshyness, the flavoryness! This very nice item! Good luck, then. Try not die. One...two...four...FIIIIIIGHT!!!
 
 -- conquest Base
-CONQUEST_BASE = 7045; -- Tallying conquest results...
+CONQUEST_BASE = 7046; -- Tallying conquest results...

--- a/scripts/zones/Norg/TextIDs.lua
+++ b/scripts/zones/Norg/TextIDs.lua
@@ -2,38 +2,38 @@
 
 -- General Texts
 ITEM_CANNOT_BE_OBTAINED = 6401; -- You cannot obtain the item <item>. Come back after sorting your inventory.
-          ITEM_OBTAINED = 6406;  -- Obtained: <item>.
-           GIL_OBTAINED = 6407;  -- Obtained <number> gil.
-       KEYITEM_OBTAINED = 6409;  -- Obtained key item: <keyitem>.
- FISHING_MESSAGE_OFFSET = 6654;  -- You can't fish here.
+          ITEM_OBTAINED = 6407;  -- Obtained: <item>.
+           GIL_OBTAINED = 6408;  -- Obtained <number> gil.
+       KEYITEM_OBTAINED = 6410;  -- Obtained key item: <keyitem>.
+ FISHING_MESSAGE_OFFSET = 6655;  -- You can't fish here.
           HOMEPOINT_SET = 2;     -- Home point set!
-         DOOR_IS_LOCKED = 10351; -- The door is locked tight.
+         DOOR_IS_LOCKED = 10352; -- The door is locked tight.
 
 -- Other Texts
- SPASIJA_DELIVERY_DIALOG = 10345; -- Hiya! I can deliver packages to anybody, anywhere, anytime. What do you say?
-PALEILLE_DELIVERY_DIALOG = 10346; -- We can deliver parcels to any residence in Vana'diel.
+ SPASIJA_DELIVERY_DIALOG = 10346; -- Hiya! I can deliver packages to anybody, anywhere, anytime. What do you say?
+PALEILLE_DELIVERY_DIALOG = 10347; -- We can deliver parcels to any residence in Vana'diel.
 
 -- Quest Dialog
-YOU_CAN_NOW_BECOME_A_SAMURAI = 10194; -- You can now become a samurai.
-   CARRYING_TOO_MUCH_ALREADY = 10195; -- I wish to give you your reward, but you seem to be carrying too much already. Come back when you have more room in your pack.
+YOU_CAN_NOW_BECOME_A_SAMURAI = 10195; -- You can now become a samurai.
+   CARRYING_TOO_MUCH_ALREADY = 10196; -- I wish to give you your reward, but you seem to be carrying too much already. Come back when you have more room in your pack.
 
-              SPASIJA_DIALOG = 10345; -- Hiya! I can deliver packages to anybody, anywhere, anytime. What do you say?
-             PALEILLE_DIALOG = 10346; -- We can deliver parcels to any residence in Vana'diel.
+              SPASIJA_DIALOG = 10346; -- Hiya! I can deliver packages to anybody, anywhere, anytime. What do you say?
+             PALEILLE_DIALOG = 10347; -- We can deliver parcels to any residence in Vana'diel.
 
-             AVATAR_UNLOCKED = 10465; -- You are now able to summon
-         NOMAD_MOOGLE_DIALOG = 10533; -- I'm a traveling moogle, kupo. I help adventurers in the Outlands access items they have stored in a Mog House elsewhere, kupo.
-               FOUIVA_DIALOG = 10557; -- Oi 'av naw business wi' de likes av you.
+             AVATAR_UNLOCKED = 10466; -- You are now able to summon
+         NOMAD_MOOGLE_DIALOG = 10534; -- I'm a traveling moogle, kupo. I help adventurers in the Outlands access items they have stored in a Mog House elsewhere, kupo.
+               FOUIVA_DIALOG = 10558; -- Oi 'av naw business wi' de likes av you.
 
 -- Shop Texts
-   JIROKICHI_SHOP_DIALOG = 10341; -- Heh-heh-heh. Feast your eyes on these beauties. You won't find stuff like this anywhere!
-     VULIAIE_SHOP_DIALOG = 10342; -- Please, stay and have a look. You may find something you can only buy here.
-      ACHIKA_SHOP_DIALOG = 10343; -- Can I interest you in some armor forged in the surrounding regions?
-       CHIYO_SHOP_DIALOG = 10344; -- Magic scrolls! Magic scrolls! We've got parchment hot off the sheep!
+   JIROKICHI_SHOP_DIALOG = 10342; -- Heh-heh-heh. Feast your eyes on these beauties. You won't find stuff like this anywhere!
+     VULIAIE_SHOP_DIALOG = 10343; -- Please, stay and have a look. You may find something you can only buy here.
+      ACHIKA_SHOP_DIALOG = 10344; -- Can I interest you in some armor forged in the surrounding regions?
+       CHIYO_SHOP_DIALOG = 10345; -- Magic scrolls! Magic scrolls! We've got parchment hot off the sheep!
 
-SOLBYMAHOLBY_SHOP_DIALOG = 10571; -- Hiya! My name's Solby-Maholby! I'm new here, so they put me on tooty-fruity shop duty. I'll give you a super-duper deal on unwanted items!
+SOLBYMAHOLBY_SHOP_DIALOG = 10572; -- Hiya! My name's Solby-Maholby! I'm new here, so they put me on tooty-fruity shop duty. I'll give you a super-duper deal on unwanted items!
 
 -- conquest Base
-CONQUEST_BASE = 6495; -- Tallying conquest results...
+CONQUEST_BASE = 6496; -- Tallying conquest results...
 
 -- Porter Moogle
-    RETRIEVE_DIALOG_ID = 11272; -- You retrieve$ from the porter moogle's care.
+    RETRIEVE_DIALOG_ID = 11273; -- You retrieve$ from the porter moogle's care.

--- a/scripts/zones/North_Gustaberg/TextIDs.lua
+++ b/scripts/zones/North_Gustaberg/TextIDs.lua
@@ -4,26 +4,26 @@
 ITEM_CANNOT_BE_OBTAINED_TWICE = 6559; -- You cannot obtain the item <item>.
       ITEM_CANNOT_BE_OBTAINED = 6560; -- You cannot obtain the item <item>. Come back after sorting your inventory.
    FULL_INVENTORY_AFTER_TRADE = 6564; -- You cannot obtain the #. Try trading again after sorting your inventory.
-                ITEM_OBTAINED = 6565; -- Obtained: <item>.
-                 GIL_OBTAINED = 6566; -- Obtained <number> gil.
-             KEYITEM_OBTAINED = 6568; -- Obtained key item: <keyitem>.
-               ITEMS_OBTAINED = 6571; -- You obtain
-       FISHING_MESSAGE_OFFSET = 7226; -- You can't fish here.
+                ITEM_OBTAINED = 6566; -- Obtained: <item>.
+                 GIL_OBTAINED = 6567; -- Obtained <number> gil.
+             KEYITEM_OBTAINED = 6569; -- Obtained key item: <keyitem>.
+               ITEMS_OBTAINED = 6572; -- You obtain
+       FISHING_MESSAGE_OFFSET = 7227; -- You can't fish here.
 
 -- Conquest
-CONQUEST = 7477; -- You've earned conquest points!
+CONQUEST = 7478; -- You've earned conquest points!
 
 -- Quests
-SHINING_OBJECT_SLIPS_AWAY = 7434; -- The shining object slips through your fingers and is washed further down the stream.
+SHINING_OBJECT_SLIPS_AWAY = 7435; -- The shining object slips through your fingers and is washed further down the stream.
 
 -- Other Dialog
         NOTHING_HAPPENS = 300;  -- Nothing happens...
-NOTHING_OUT_OF_ORDINARY = 6579; -- There is nothing out of the ordinary here.
-  REACH_WATER_FROM_HERE = 7441; -- You can reach the water from here.
+NOTHING_OUT_OF_ORDINARY = 6580; -- There is nothing out of the ordinary here.
+  REACH_WATER_FROM_HERE = 7442; -- You can reach the water from here.
 
 -- conquest Base
 CONQUEST_BASE = 0;
 
 --chocobo digging
-DIG_THROW_AWAY = 7239; -- You dig up$, but your inventory is full. You regretfully throw the # away.
-FIND_NOTHING = 7241; -- You dig and you dig, but find nothing.
+DIG_THROW_AWAY = 7240; -- You dig up$, but your inventory is full. You regretfully throw the # away.
+FIND_NOTHING = 7242; -- You dig and you dig, but find nothing.

--- a/scripts/zones/North_Gustaberg_[S]/TextIDs.lua
+++ b/scripts/zones/North_Gustaberg_[S]/TextIDs.lua
@@ -2,10 +2,10 @@
 
 -- General Texts
 ITEM_CANNOT_BE_OBTAINED = 6379; -- You cannot obtain the item <item>. Come back after sorting your inventory.
-          ITEM_OBTAINED = 6384; -- Obtained: <item>.
-           GIL_OBTAINED = 6385; -- Obtained <number> gil.
-       KEYITEM_OBTAINED = 6387; -- Obtained key item: <keyitem>.
- FISHING_MESSAGE_OFFSET = 7351; -- You can't fish here.
+          ITEM_OBTAINED = 6385; -- Obtained: <item>.
+           GIL_OBTAINED = 6386; -- Obtained <number> gil.
+       KEYITEM_OBTAINED = 6388; -- Obtained key item: <keyitem>.
+ FISHING_MESSAGE_OFFSET = 7352; -- You can't fish here.
 
 -- Mining
-MINING_IS_POSSIBLE_HERE = 7540; -- Mining is possible here if you have
+MINING_IS_POSSIBLE_HERE = 7541; -- Mining is possible here if you have

--- a/scripts/zones/Northern_San_dOria/TextIDs.lua
+++ b/scripts/zones/Northern_San_dOria/TextIDs.lua
@@ -2,121 +2,121 @@
 
 -- General Texts
     ITEM_CANNOT_BE_OBTAINED =  6587;  -- Come back after sorting your inventory.
-              ITEM_OBTAINED =  6592;  -- Obtained: <<<Unknown Parameter (Type: 80) 1>>><<<Possible Special Code: 01>>><<<Possible Special Code: 05>>>
-               GIL_OBTAINED =  6593;  -- Obtained <<<Numeric Parameter 0>>> gil.
-           KEYITEM_OBTAINED =  6595;  -- Obtained key item: <<<Unknown Parameter (Type: 80) 1>>>
-        NOT_HAVE_ENOUGH_GIL =  6597;  -- You do not have enough gil.
+              ITEM_OBTAINED =  6593;  -- Obtained: <<<Unknown Parameter (Type: 80) 1>>><<<Possible Special Code: 01>>><<<Possible Special Code: 05>>>
+               GIL_OBTAINED =  6594;  -- Obtained <<<Numeric Parameter 0>>> gil.
+           KEYITEM_OBTAINED =  6596;  -- Obtained key item: <<<Unknown Parameter (Type: 80) 1>>>
+        NOT_HAVE_ENOUGH_GIL =  6598;  -- You do not have enough gil.
               HOMEPOINT_SET =   188;  -- Home point set!
-              IMAGE_SUPPORT =  6947;  -- Your ?Multiple Choice (Parameter 1)?[fishing/woodworking/smithing/goldsmithing/clothcraft/leatherworking/bonecraft/alchemy/cooking] skills went up ...
-   GUILD_TERMINATE_CONTRACT =  6961;  -- You have terminated your trading contract with the Multiple Choice (Parameter 1)[Fishermen's/Carpenters'/Blacksmiths'/Goldsmiths'/Weavers'/Tanners'/Boneworkers'/Alchemists'/Culinarians'] Guild and formed a new one with the Multiple Choice (Parameter 0)[Fishermen's/Carpenters'/Blacksmiths'/Goldsmiths'/Weavers'/Tanners'/Boneworkers'/Alchemists'/Culinarians'] Guild
-         GUILD_NEW_CONTRACT =  6969;  -- You have formed a new trading contract with the Multiple Choice (Parameter 0)[Fishermen's/Carpenters'/Blacksmiths'/Goldsmiths'/Weavers'/Tanners'/Boneworkers'/Alchemists'/Culinarians'] Guild
-        NO_MORE_GP_ELIGIBLE =  6976;  -- You are not eligible to receive guild points at this time
-                GP_OBTAINED =  6981;  -- Obtained: ?Numeric Parameter 0? guild points.
-         NOT_HAVE_ENOUGH_GP =  6982;  -- You do not have enough guild points.
-              MOGHOUSE_EXIT = 12347;  -- You have learned your way through the back alleys of San d'Oria! Now you can exit to any area from your residence.
-     FISHING_MESSAGE_OFFSET =  7409;  -- You can't fish here.
+              IMAGE_SUPPORT =  6948;  -- Your ?Multiple Choice (Parameter 1)?[fishing/woodworking/smithing/goldsmithing/clothcraft/leatherworking/bonecraft/alchemy/cooking] skills went up ...
+   GUILD_TERMINATE_CONTRACT =  6962;  -- You have terminated your trading contract with the Multiple Choice (Parameter 1)[Fishermen's/Carpenters'/Blacksmiths'/Goldsmiths'/Weavers'/Tanners'/Boneworkers'/Alchemists'/Culinarians'] Guild and formed a new one with the Multiple Choice (Parameter 0)[Fishermen's/Carpenters'/Blacksmiths'/Goldsmiths'/Weavers'/Tanners'/Boneworkers'/Alchemists'/Culinarians'] Guild
+         GUILD_NEW_CONTRACT =  6970;  -- You have formed a new trading contract with the Multiple Choice (Parameter 0)[Fishermen's/Carpenters'/Blacksmiths'/Goldsmiths'/Weavers'/Tanners'/Boneworkers'/Alchemists'/Culinarians'] Guild
+        NO_MORE_GP_ELIGIBLE =  6977;  -- You are not eligible to receive guild points at this time
+                GP_OBTAINED =  6982;  -- Obtained: ?Numeric Parameter 0? guild points.
+         NOT_HAVE_ENOUGH_GP =  6983;  -- You do not have enough guild points.
+              MOGHOUSE_EXIT = 12349;  -- You have learned your way through the back alleys of San d'Oria! Now you can exit to any area from your residence.
+     FISHING_MESSAGE_OFFSET =  7411;  -- You can't fish here.
       
 -- Conquest System
-CONQUEST = 11696; -- You've earned conquest points!
+CONQUEST = 11698; -- You've earned conquest points!
 
 -- Mission Dialogs
 ORIGINAL_MISSION_OFFSET = 16; -- Bring me one of those axes, and your mission will be a success. No running away now; we've a proud country to defend!
  YOU_ACCEPT_THE_MISSION = 5;  -- You accept the mission.
 
 -- Quest Dialog
-   OLBERGIEUT_DIALOG = 11261; -- Friar Faurbellant is on retreat at the Crag of Holla. Please give
-       FLYER_REFUSED = 11509; -- Your flyer is refused.
-      FLYER_ACCEPTED = 12047; -- Your flyer is accepted!
-       FLYER_ALREADY = 12048; -- This person already has a flyer.
-      SHIVA_UNLOCKED = 12792; -- You are now able to summon
+   OLBERGIEUT_DIALOG = 11263; -- Friar Faurbellant is on retreat at the Crag of Holla. Please give
+       FLYER_REFUSED = 11511; -- Your flyer is refused.
+      FLYER_ACCEPTED = 12049; -- Your flyer is accepted!
+       FLYER_ALREADY = 12050; -- This person already has a flyer.
+      SHIVA_UNLOCKED = 12794; -- You are now able to summon
 
 -- Other Dialog
- GUILBERDRIER_DIALOG = 11137; -- A magic shop, you say? A bit of magic would come in handy... I know! I'll have my daughter study it for me!
-    ABIOLEGET_DIALOG = 11213; -- All of Altana's children are welcome here.
-     PELLIMIE_DIALOG = 11214; -- Is this your first time here? Join us in prayer!
-   FITTESEGAT_DIALOG = 11215; -- Paradise is a place without fear, without death!
-      MAURINE_DIALOG = 11216; -- Papsque Shamonde sometimes addresses the city from the balcony, you know. I long for his blessing, if but once!
-     PRERIVON_DIALOG = 11217; -- With each sermon, I take another step closer to Paradise.
-      MALFINE_DIALOG = 11218; -- Truly fortunate are we that words of sacrament are read every day!
-     COULLENE_DIALOG = 11219; -- Goddess above, deliver us to Paradise!
+ GUILBERDRIER_DIALOG = 11139; -- A magic shop, you say? A bit of magic would come in handy... I know! I'll have my daughter study it for me!
+    ABIOLEGET_DIALOG = 11215; -- All of Altana's children are welcome here.
+     PELLIMIE_DIALOG = 11216; -- Is this your first time here? Join us in prayer!
+   FITTESEGAT_DIALOG = 11217; -- Paradise is a place without fear, without death!
+      MAURINE_DIALOG = 11218; -- Papsque Shamonde sometimes addresses the city from the balcony, you know. I long for his blessing, if but once!
+     PRERIVON_DIALOG = 11219; -- With each sermon, I take another step closer to Paradise.
+      MALFINE_DIALOG = 11220; -- Truly fortunate are we that words of sacrament are read every day!
+     COULLENE_DIALOG = 11221; -- Goddess above, deliver us to Paradise!
 
-     GUILERME_DIALOG = 11333; -- Behold Chateau d'Oraguille, the greatest fortress in the realm!
+     GUILERME_DIALOG = 11335; -- Behold Chateau d'Oraguille, the greatest fortress in the realm!
 
-     PHAVIANE_DIALOG = 11337; -- This is Victory Arch. Beyond lies Southern San d'Oria.
-     SOCHIENE_DIALOG = 11338; -- You stand before Victory Arch. Southern San d'Oria is on the other side.
-     PEPIGORT_DIALOG = 11339; -- This gate leads to Port San d'Oria.
-   RODAILLECE_DIALOG = 11340; -- This is Ranperre Gate. Fiends lurk in the lands beyond, so take caution!
+     PHAVIANE_DIALOG = 11339; -- This is Victory Arch. Beyond lies Southern San d'Oria.
+     SOCHIENE_DIALOG = 11340; -- You stand before Victory Arch. Southern San d'Oria is on the other side.
+     PEPIGORT_DIALOG = 11341; -- This gate leads to Port San d'Oria.
+   RODAILLECE_DIALOG = 11342; -- This is Ranperre Gate. Fiends lurk in the lands beyond, so take caution!
 
-      GALAHAD_DIALOG = 11353; -- Welcome to the Consulate of Jeuno. I am Galahad, Consul to San d'Oria.
-       ISHWAR_DIALOG = 11354; -- May I assist you?
-       ARIENH_DIALOG = 11355; -- If you have business with Consul Galahad, you'll find him inside.
-       EMILIA_DIALOG = 11356; -- Welcome to the Consulate of Jeuno.
+      GALAHAD_DIALOG = 11355; -- Welcome to the Consulate of Jeuno. I am Galahad, Consul to San d'Oria.
+       ISHWAR_DIALOG = 11356; -- May I assist you?
+       ARIENH_DIALOG = 11357; -- If you have business with Consul Galahad, you'll find him inside.
+       EMILIA_DIALOG = 11358; -- Welcome to the Consulate of Jeuno.
 
-       HELAKU_DIALOG = 11385; -- Leave this building, and you'll see a great fortress to the right. That's Chateau d'Oraguille. And be polite; San d'Orians can be quite touchy.
+       HELAKU_DIALOG = 11387; -- Leave this building, and you'll see a great fortress to the right. That's Chateau d'Oraguille. And be polite; San d'Orians can be quite touchy.
 
-     KASARORO_DIALOG = 11424; -- Step right outside, and you'll see a big castle on the left. That's Chateau d'Oraguille. They're a little touchy in there, so mind your manners!
+     KASARORO_DIALOG = 11426; -- Step right outside, and you'll see a big castle on the left. That's Chateau d'Oraguille. They're a little touchy in there, so mind your manners!
 
-     MAURINNE_DIALOG = 11461; -- This part of town is so lively, I like watching everybody just go about their business.
+     MAURINNE_DIALOG = 11463; -- This part of town is so lively, I like watching everybody just go about their business.
 
-     AIVEDOIR_DIALOG = 11495; -- That's funny. I could have sworn she asked me to meet her here...
-      CAPIRIA_DIALOG = 11496; -- He's late! I do hope he hasn't forgotten.
-    BERTENONT_DIALOG = 11497; -- Stars are more beautiful up close. Don't you agree?
+     AIVEDOIR_DIALOG = 11497; -- That's funny. I could have sworn she asked me to meet her here...
+      CAPIRIA_DIALOG = 11498; -- He's late! I do hope he hasn't forgotten.
+    BERTENONT_DIALOG = 11499; -- Stars are more beautiful up close. Don't you agree?
 
-     GILIPESE_DIALOG = 11518; -- Nothing to report!
+     GILIPESE_DIALOG = 11520; -- Nothing to report!
 
-      BONCORT_DIALOG = 12043; -- Hmm... With magic, I could get hold of materials a mite easier. I'll have to check this
-      CAPIRIA_DIALOG = 12044; -- A flyer? For me? Some reading material would be a welcome change of pace, indeed!
-      VILLION_DIALOG = 12045; -- Opening a shop of magic, without consulting me first? I must pay this Regine a visit!
-     COULLENE_DIALOG = 12046; -- Magic could be of use on my journey to Paradise. Thank you so much!
+      BONCORT_DIALOG = 12045; -- Hmm... With magic, I could get hold of materials a mite easier. I'll have to check this
+      CAPIRIA_DIALOG = 12046; -- A flyer? For me? Some reading material would be a welcome change of pace, indeed!
+      VILLION_DIALOG = 12047; -- Opening a shop of magic, without consulting me first? I must pay this Regine a visit!
+     COULLENE_DIALOG = 12048; -- Magic could be of use on my journey to Paradise. Thank you so much!
 
-    COULLENE_MESSAGE = 13359; -- Coullene looks over curiously for a moment.
-GUILBERDRIER_MESSAGE = 13360; -- Guilberdrier looks over curiously for a moment.
-     BONCORT_MESSAGE = 13361; -- Boncort looks over curiously for a moment.
-     CAPIRIA_MESSAGE = 13362; -- Capiria looks over curiously for a moment.
-     VILLION_MESSAGE = 13363; -- Villion looks over curiously for a moment.
+    COULLENE_MESSAGE = 13361; -- Coullene looks over curiously for a moment.
+GUILBERDRIER_MESSAGE = 13362; -- Guilberdrier looks over curiously for a moment.
+     BONCORT_MESSAGE = 13363; -- Boncort looks over curiously for a moment.
+     CAPIRIA_MESSAGE = 13364; -- Capiria looks over curiously for a moment.
+     VILLION_MESSAGE = 13365; -- Villion looks over curiously for a moment.
 
 -- Shop Texts
-   DOGGOMEHR_SHOP_DIALOG = 11531; -- Welcome to the Blacksmiths' Guild shop.
-    LUCRETIA_SHOP_DIALOG = 11532; -- Blacksmiths' Guild shop, at your service!
+   DOGGOMEHR_SHOP_DIALOG = 11533; -- Welcome to the Blacksmiths' Guild shop.
+    LUCRETIA_SHOP_DIALOG = 11534; -- Blacksmiths' Guild shop, at your service!
 
-  CAUZERISTE_SHOP_DIALOG = 11599; -- Welcome! San d'Oria Carpenters' Guild shop, at your service.
+  CAUZERISTE_SHOP_DIALOG = 11601; -- Welcome! San d'Oria Carpenters' Guild shop, at your service.
 
-    ANTONIAN_OPEN_DIALOG = 11614; -- Interested in goods from Aragoneu?
-     BONCORT_SHOP_DIALOG = 11615; -- Welcome to the Phoenix Perch!
- PIRVIDIAUCE_SHOP_DIALOG = 11616; -- Care to see what I have?
-  PALGUEVION_OPEN_DIALOG = 11617; -- I've got a shipment straight from Valdeaunia!
-     VICHUEL_OPEN_DIALOG = 11618; -- Fauregandi produce for sale!
-     ARLENNE_SHOP_DIALOG = 11619; -- Welcome to the Royal Armory!
-   TAVOURINE_SHOP_DIALOG = 11620; -- Looking for a weapon? We've got many in stock!
+    ANTONIAN_OPEN_DIALOG = 11616; -- Interested in goods from Aragoneu?
+     BONCORT_SHOP_DIALOG = 11617; -- Welcome to the Phoenix Perch!
+ PIRVIDIAUCE_SHOP_DIALOG = 11618; -- Care to see what I have?
+  PALGUEVION_OPEN_DIALOG = 11619; -- I've got a shipment straight from Valdeaunia!
+     VICHUEL_OPEN_DIALOG = 11620; -- Fauregandi produce for sale!
+     ARLENNE_SHOP_DIALOG = 11621; -- Welcome to the Royal Armory!
+   TAVOURINE_SHOP_DIALOG = 11622; -- Looking for a weapon? We've got many in stock!
 
-  ANTONIAN_CLOSED_DIALOG = 11624; -- The Kingdom's influence is waning in Aragoneu. I cannot import goods from that region, though I long to.
-PALGUEVION_CLOSED_DIALOG = 11625; -- Would that Valdeaunia came again under San d'Orian dominion, I could then import its goods!
-   VICHUEL_CLOSED_DIALOG = 11626; -- I'd make a killing selling Fauregandi produce here, but that region's not under San d'Orian control!
-  ATTARENA_CLOSED_DIALOG = 11627; -- Once all of Li'Telor is back under San d'Orian influence, I'll fill my stock with unique goods from there!
-EUGBALLION_CLOSED_DIALOG = 11628; -- I'd be making a fortune selling goods from Qufim Island...if it were only under San d'Orian control!
-  EUGBALLION_OPEN_DIALOG = 11629; -- Have a look at these goods imported direct from Qufim Island!
-    CHAUPIRE_SHOP_DIALOG = 11630; -- San d'Orian woodcraft is the finest in the land!
+  ANTONIAN_CLOSED_DIALOG = 11626; -- The Kingdom's influence is waning in Aragoneu. I cannot import goods from that region, though I long to.
+PALGUEVION_CLOSED_DIALOG = 11627; -- Would that Valdeaunia came again under San d'Orian dominion, I could then import its goods!
+   VICHUEL_CLOSED_DIALOG = 11628; -- I'd make a killing selling Fauregandi produce here, but that region's not under San d'Orian control!
+  ATTARENA_CLOSED_DIALOG = 11629; -- Once all of Li'Telor is back under San d'Orian influence, I'll fill my stock with unique goods from there!
+EUGBALLION_CLOSED_DIALOG = 11630; -- I'd be making a fortune selling goods from Qufim Island...if it were only under San d'Orian control!
+  EUGBALLION_OPEN_DIALOG = 11631; -- Have a look at these goods imported direct from Qufim Island!
+    CHAUPIRE_SHOP_DIALOG = 11632; -- San d'Orian woodcraft is the finest in the land!
 
-    GAUDYLOX_SHOP_DIALOG = 12607; -- You never see Goblinshhh from underworld? Me no bad. Me sell chipshhh. You buy. Use with shhhtone heart. You get lucky!
-MILLECHUCA_CLOSED_DIALOG = 12608; -- I've been trying to import goods from Vollbow, but it's so hard to get items from areas that aren't under San d'Orian control.
+    GAUDYLOX_SHOP_DIALOG = 12609; -- You never see Goblinshhh from underworld? Me no bad. Me sell chipshhh. You buy. Use with shhhtone heart. You get lucky!
+MILLECHUCA_CLOSED_DIALOG = 12610; -- I've been trying to import goods from Vollbow, but it's so hard to get items from areas that aren't under San d'Orian control.
 
-    ATTARENA_OPEN_DIALOG = 12693; -- Good day! Take a look at my selection from Li'Telor!
-  MILLECHUCA_OPEN_DIALOG = 12694; -- Specialty goods from Vollbow! Specialty goods from Vollbow!
+    ATTARENA_OPEN_DIALOG = 12695; -- Good day! Take a look at my selection from Li'Telor!
+  MILLECHUCA_OPEN_DIALOG = 12696; -- Specialty goods from Vollbow! Specialty goods from Vollbow!
 
-  ARACHAGNON_SHOP_DIALOG = 12896; -- Would you be interested in purchasing some adventurer-issue armor? Be careful when selecting, as we accept no refunds.
+  ARACHAGNON_SHOP_DIALOG = 12898; -- Would you be interested in purchasing some adventurer-issue armor? Be careful when selecting, as we accept no refunds.
 
-       JUSTI_SHOP_DIALOG = 13549; -- Hello!
+       JUSTI_SHOP_DIALOG = 13551; -- Hello!
 
 -- Harvest Festival
-      TRICK_OR_TREAT = 13039; -- Trick or treat...
-     THANK_YOU_TREAT = 13040; -- And now for your treat...
-      HERE_TAKE_THIS = 12066; -- Here, take this...
-    IF_YOU_WEAR_THIS = 13042; -- If you put this on and walk around, something...unexpected might happen...
-           THANK_YOU = 13040; -- Thank you...
+      TRICK_OR_TREAT = 13041; -- Trick or treat...
+     THANK_YOU_TREAT = 13042; -- And now for your treat...
+      HERE_TAKE_THIS = 12068; -- Here, take this...
+    IF_YOU_WEAR_THIS = 13044; -- If you put this on and walk around, something...unexpected might happen...
+           THANK_YOU = 13042; -- Thank you...
 
 -- conquest Base
-CONQUEST_BASE = 7250; -- Tallying conquest results...
+CONQUEST_BASE = 7252; -- Tallying conquest results...
 
 
 -- Porter Moogle
-    RETRIEVE_DIALOG_ID = 18099; -- You retrieve$ from the porter moogle's care.
+    RETRIEVE_DIALOG_ID = 18101; -- You retrieve$ from the porter moogle's care.

--- a/scripts/zones/Oldton_Movalpolos/TextIDs.lua
+++ b/scripts/zones/Oldton_Movalpolos/TextIDs.lua
@@ -2,26 +2,26 @@
 
 -- General Texts
 ITEM_CANNOT_BE_OBTAINED = 6379; -- You cannot obtain the item <item>. Come back after sorting your inventory.
-          ITEM_OBTAINED = 6384; -- Obtained: <item>.
-           GIL_OBTAINED = 6385; -- Obtained <number> gil.
-       KEYITEM_OBTAINED = 6387; -- Obtained key item: <keyitem>.
- FISHING_MESSAGE_OFFSET = 7564; -- You can't fish here.
+          ITEM_OBTAINED = 6385; -- Obtained: <item>.
+           GIL_OBTAINED = 6386; -- Obtained <number> gil.
+       KEYITEM_OBTAINED = 6388; -- Obtained key item: <keyitem>.
+ FISHING_MESSAGE_OFFSET = 7565; -- You can't fish here.
 
 -- Mining
-MINING_IS_POSSIBLE_HERE = 7695; -- Mining is possible here if you have
+MINING_IS_POSSIBLE_HERE = 7696; -- Mining is possible here if you have
 
 -- Treasure Coffer/Chest Dialog
-CHEST_UNLOCKED = 7742; -- You unlock the chest!
-    CHEST_FAIL = 7743; -- Fails to open the chest.
-    CHEST_TRAP = 7744; -- The chest was trapped!
-    CHEST_WEAK = 7745; -- You cannot open the chest when you are in a weakened state.
-   CHEST_MIMIC = 7746; -- The chest was a mimic!
-  CHEST_MOOGLE = 7747; -- You cannot open the chest while participating in the moogle event.
-CHEST_ILLUSION = 7748; -- The chest was but an illusion...
-  CHEST_LOCKED = 7749; -- The chest appears to be locked.
+CHEST_UNLOCKED = 7743; -- You unlock the chest!
+    CHEST_FAIL = 7744; -- Fails to open the chest.
+    CHEST_TRAP = 7745; -- The chest was trapped!
+    CHEST_WEAK = 7746; -- You cannot open the chest when you are in a weakened state.
+   CHEST_MIMIC = 7747; -- The chest was a mimic!
+  CHEST_MOOGLE = 7748; -- You cannot open the chest while participating in the moogle event.
+CHEST_ILLUSION = 7749; -- The chest was but an illusion...
+  CHEST_LOCKED = 7750; -- The chest appears to be locked.
 
 -- NPCs
-RAKOROK_DIALOGUE = 7719; -- Nsy pipul. Gattohre! I bisynw!
+RAKOROK_DIALOGUE = 7720; -- Nsy pipul. Gattohre! I bisynw!
 
 -- conquest Base
-CONQUEST_BASE = 7045; -- Tallying conquest results...
+CONQUEST_BASE = 7046; -- Tallying conquest results...

--- a/scripts/zones/Open_sea_route_to_Al_Zahbi/TextIDs.lua
+++ b/scripts/zones/Open_sea_route_to_Al_Zahbi/TextIDs.lua
@@ -2,14 +2,14 @@
 
 -- General Texts
 ITEM_CANNOT_BE_OBTAINED = 6379; -- You cannot obtain the item <item> come back again after sorting your inventory
-          ITEM_OBTAINED = 6384; -- Obtained: <item>
-           GIL_OBTAINED = 6385; -- Obtained <number> gil
-       KEYITEM_OBTAINED = 6387; -- Obtained key item: <keyitem>
- FISHING_MESSAGE_OFFSET = 7045; -- You can't fish here.
-    DOCKING_IN_AL_ZAHBI = 7305; -- We are now docking in Al Zahbi.
+          ITEM_OBTAINED = 6385; -- Obtained: <item>
+           GIL_OBTAINED = 6386; -- Obtained <number> gil
+       KEYITEM_OBTAINED = 6388; -- Obtained key item: <keyitem>
+ FISHING_MESSAGE_OFFSET = 7046; -- You can't fish here.
+    DOCKING_IN_AL_ZAHBI = 7306; -- We are now docking in Al Zahbi.
 
 -- Shops
-CEHN_TEYOHNGO_SHOP_DIALOG = 7308; -- If you're looking for fishing gear, you've come to the right place!
+CEHN_TEYOHNGO_SHOP_DIALOG = 7309; -- If you're looking for fishing gear, you've come to the right place!
 
 -- Other
-ON_WAY_TO_AL_ZAHBI = 7304; -- We are on our way to Al Zahbi. We should arrive in
+ON_WAY_TO_AL_ZAHBI = 7305; -- We are on our way to Al Zahbi. We should arrive in

--- a/scripts/zones/Open_sea_route_to_Mhaura/TextIDs.lua
+++ b/scripts/zones/Open_sea_route_to_Mhaura/TextIDs.lua
@@ -2,14 +2,14 @@
 
 -- General Texts
 ITEM_CANNOT_BE_OBTAINED = 6379; -- You cannot obtain the item <item> come back again after sorting your inventory
-          ITEM_OBTAINED = 6384; -- Obtained: <item>
-           GIL_OBTAINED = 6385; -- Obtained <number> gil
-       KEYITEM_OBTAINED = 6387; -- Obtained key item: <keyitem>
- FISHING_MESSAGE_OFFSET = 7045; -- You can't fish here
-      DOCKING_IN_MHAURA = 7305; -- We are now docking in Mhaura.
+          ITEM_OBTAINED = 6385; -- Obtained: <item>
+           GIL_OBTAINED = 6386; -- Obtained <number> gil
+       KEYITEM_OBTAINED = 6388; -- Obtained key item: <keyitem>
+ FISHING_MESSAGE_OFFSET = 7046; -- You can't fish here
+      DOCKING_IN_MHAURA = 7306; -- We are now docking in Mhaura.
 
 -- Shops
-PASHI_MACCALEH_SHOP_DIALOG = 7308; -- Step right up for the best fishing gear in these parts!
+PASHI_MACCALEH_SHOP_DIALOG = 7309; -- Step right up for the best fishing gear in these parts!
 
 -- Other
-ON_WAY_TO_MHAURA = 7304; -- We are on our way to Mhaura. We should arrive in
+ON_WAY_TO_MHAURA = 7305; -- We are on our way to Mhaura. We should arrive in

--- a/scripts/zones/Ordelles_Caves/TextIDs.lua
+++ b/scripts/zones/Ordelles_Caves/TextIDs.lua
@@ -2,38 +2,38 @@
 
 -- General Texts
 ITEM_CANNOT_BE_OBTAINED = 6538; -- You cannot obtain the item <item>. Come back after sorting your inventory.
-          ITEM_OBTAINED = 6543; -- Obtained: <item>.
-           GIL_OBTAINED = 6544; -- Obtained <number> gil.
-       KEYITEM_OBTAINED = 6546; -- Obtained key item: <keyitem>.
- FISHING_MESSAGE_OFFSET = 7204; -- You can't fish here.
+          ITEM_OBTAINED = 6544; -- Obtained: <item>.
+           GIL_OBTAINED = 6545; -- Obtained <number> gil.
+       KEYITEM_OBTAINED = 6547; -- Obtained key item: <keyitem>.
+ FISHING_MESSAGE_OFFSET = 7205; -- You can't fish here.
 
 -- Treasure Coffer/Chest Dialog
-CHEST_UNLOCKED = 7387; -- You unlock the chest!
-    CHEST_FAIL = 7388; -- Fails to open the chest.
-    CHEST_TRAP = 7389; -- The chest was trapped!
-    CHEST_WEAK = 7390; -- You cannot open the chest when you are in a weakened state.
-   CHEST_MIMIC = 7391; -- The chest was a mimic!
-  CHEST_MOOGLE = 7392; -- You cannot open the chest while participating in the moogle event.
-CHEST_ILLUSION = 7393; -- The chest was but an illusion...
-  CHEST_LOCKED = 7394; -- The chest appears to be locked.
+CHEST_UNLOCKED = 7388; -- You unlock the chest!
+    CHEST_FAIL = 7389; -- Fails to open the chest.
+    CHEST_TRAP = 7390; -- The chest was trapped!
+    CHEST_WEAK = 7391; -- You cannot open the chest when you are in a weakened state.
+   CHEST_MIMIC = 7392; -- The chest was a mimic!
+  CHEST_MOOGLE = 7393; -- You cannot open the chest while participating in the moogle event.
+CHEST_ILLUSION = 7394; -- The chest was but an illusion...
+  CHEST_LOCKED = 7395; -- The chest appears to be locked.
 
 -- Quest Dialog
-      NOTHING_OUT_OF_ORDINARY = 6557; -- There is nothing out of the ordinary here.
-          SENSE_OF_FOREBODING = 6558; -- You are suddenly overcome with a sense of foreboding...
-  A_SQUIRE_S_TEST_II_DIALOG_I = 7352; -- You place your hands into the pool.
- A_SQUIRE_S_TEST_II_DIALOG_II = 7355; -- The dew from the stalactite slips through your fingers.
-A_SQUIRE_S_TEST_II_DIALOG_III = 7356; -- You have already obtained the dew.
-          GERWITZS_AXE_DIALOG = 7409; -- Mine axe shall rend thy throat!
-        GERWITZS_SWORD_DIALOG = 7410; -- Mine sword shall pierce thy tongue!
-         GERWITZS_SOUL_DIALOG = 7411; -- Long have I waited. I will tell all...
+      NOTHING_OUT_OF_ORDINARY = 6558; -- There is nothing out of the ordinary here.
+          SENSE_OF_FOREBODING = 6559; -- You are suddenly overcome with a sense of foreboding...
+  A_SQUIRE_S_TEST_II_DIALOG_I = 7353; -- You place your hands into the pool.
+ A_SQUIRE_S_TEST_II_DIALOG_II = 7356; -- The dew from the stalactite slips through your fingers.
+A_SQUIRE_S_TEST_II_DIALOG_III = 7357; -- You have already obtained the dew.
+          GERWITZS_AXE_DIALOG = 7410; -- Mine axe shall rend thy throat!
+        GERWITZS_SWORD_DIALOG = 7411; -- Mine sword shall pierce thy tongue!
+         GERWITZS_SOUL_DIALOG = 7412; -- Long have I waited. I will tell all...
 
 -- Mission Dialog
-RUILLONT_INITIAL_DIALOG = 7341; -- Confound it! If I only had my sword, I'd cut through these fiends single-handedly...
+RUILLONT_INITIAL_DIALOG = 7342; -- Confound it! If I only had my sword, I'd cut through these fiends single-handedly...
 
 -- conquest Base
 CONQUEST_BASE = 0;
 
 -- Strange Apparatus
-DEVICE_NOT_WORKING = 7318; -- The device is not working.
-      SYS_OVERLOAD = 7327; -- arning! Sys...verload! Enterin...fety mode. ID eras...d 
-      YOU_LOST_THE = 7332; -- You lost the #. 
+DEVICE_NOT_WORKING = 7319; -- The device is not working.
+      SYS_OVERLOAD = 7328; -- arning! Sys...verload! Enterin...fety mode. ID eras...d 
+      YOU_LOST_THE = 7333; -- You lost the #. 

--- a/scripts/zones/Outer_Horutoto_Ruins/TextIDs.lua
+++ b/scripts/zones/Outer_Horutoto_Ruins/TextIDs.lua
@@ -2,19 +2,19 @@
 
 -- General Texts
 ITEM_CANNOT_BE_OBTAINED = 6584; -- You cannot obtain the item <item>. Come back after sorting your inventory.
-          ITEM_OBTAINED = 6589; -- Obtained: <item>.
-           GIL_OBTAINED = 6590; -- Obtained <number> gil.
-       KEYITEM_OBTAINED = 6592; -- Obtained key item: <keyitem>.
+          ITEM_OBTAINED = 6590; -- Obtained: <item>.
+           GIL_OBTAINED = 6591; -- Obtained <number> gil.
+       KEYITEM_OBTAINED = 6593; -- Obtained key item: <keyitem>.
 
 -- Treasure Coffer/Chest Dialog
-CHEST_UNLOCKED = 7275; -- You unlock the chest!
-    CHEST_FAIL = 7276; -- Fails to open the chest.
-    CHEST_TRAP = 7277; -- The chest was trapped!
-    CHEST_WEAK = 7278; -- You cannot open the chest when you are in a weakened state.
-   CHEST_MIMIC = 7279; -- The chest was a mimic!
-  CHEST_MOOGLE = 7280; -- You cannot open the chest while participating in the moogle event.
-CHEST_ILLUSION = 7281; -- The chest was but an illusion...
-  CHEST_LOCKED = 7282; -- The chest appears to be locked.
+CHEST_UNLOCKED = 7276; -- You unlock the chest!
+    CHEST_FAIL = 7277; -- Fails to open the chest.
+    CHEST_TRAP = 7278; -- The chest was trapped!
+    CHEST_WEAK = 7279; -- You cannot open the chest when you are in a weakened state.
+   CHEST_MIMIC = 7280; -- The chest was a mimic!
+  CHEST_MOOGLE = 7281; -- You cannot open the chest while participating in the moogle event.
+CHEST_ILLUSION = 7282; -- The chest was but an illusion...
+  CHEST_LOCKED = 7283; -- The chest appears to be locked.
 
 -- Mission Texts
       ORB_ALREADY_PLACED = 0; -- A dark Mana Orb is already placed here.
@@ -29,8 +29,8 @@ FOURTH_DARK_ORB_IN_PLACE = 9; -- Forth Mana Orb Receptacle is ready for use.
  SIXTH_DARK_ORB_IN_PLACE = 11; -- Sixth Mana Orb Receptacle is ready for use.
  DARK_MANA_ORB_RECHARGER = 12; -- This appears to be a device that recharges Mana Orbs.
 
-        DOOR_FIRMLY_SHUT = 7250; -- The door is firmly shut.
-    ALL_G_ORBS_ENERGIZED = 7253; -- The six Mana Orbs have been successfully energized with magic!
+        DOOR_FIRMLY_SHUT = 7251; -- The door is firmly shut.
+    ALL_G_ORBS_ENERGIZED = 7254; -- The six Mana Orbs have been successfully energized with magic!
 
 -- conquest Base
 CONQUEST_BASE = 15;

--- a/scripts/zones/Outer_RaKaznar/TextIDs.lua
+++ b/scripts/zones/Outer_RaKaznar/TextIDs.lua
@@ -2,6 +2,6 @@
 
 -- General Texts
 ITEM_CANNOT_BE_OBTAINED = 6379; -- You cannot obtain the item <item> come back again after sorting your inventory
-          ITEM_OBTAINED = 6384; -- Obtained: <item>
-           GIL_OBTAINED = 6385; -- Obtained <number> gil
-       KEYITEM_OBTAINED = 6387; -- Obtained key item: <keyitem>
+          ITEM_OBTAINED = 6385; -- Obtained: <item>
+           GIL_OBTAINED = 6386; -- Obtained <number> gil
+       KEYITEM_OBTAINED = 6388; -- Obtained key item: <keyitem>

--- a/scripts/zones/Outer_RaKaznar_U/TextIDs.lua
+++ b/scripts/zones/Outer_RaKaznar_U/TextIDs.lua
@@ -2,6 +2,6 @@
 
 -- General Texts
 ITEM_CANNOT_BE_OBTAINED = 6379; -- You cannot obtain the item <item> come back again after sorting your inventory
-          ITEM_OBTAINED = 6384; -- Obtained: <item>
-           GIL_OBTAINED = 6385; -- Obtained <number> gil
-       KEYITEM_OBTAINED = 6387; -- Obtained key item: <keyitem>
+          ITEM_OBTAINED = 6385; -- Obtained: <item>
+           GIL_OBTAINED = 6386; -- Obtained <number> gil
+       KEYITEM_OBTAINED = 6388; -- Obtained key item: <keyitem>

--- a/scripts/zones/Palborough_Mines/TextIDs.lua
+++ b/scripts/zones/Palborough_Mines/TextIDs.lua
@@ -2,33 +2,33 @@
 
 -- General Texts
 ITEM_CANNOT_BE_OBTAINED = 6379; -- You cannot obtain the item <item>. Come back after sorting your inventory.
-          ITEM_OBTAINED = 6384; -- Obtained: <item>.
-           GIL_OBTAINED = 6385; -- Obtained <number> gil.
-       KEYITEM_OBTAINED = 6387; -- Obtained key item: <keyitem>.
- FISHING_MESSAGE_OFFSET = 7204; -- You can't fish here.
-            HOMEPOINT_SET = 7452; -- Home point set!
+          ITEM_OBTAINED = 6385; -- Obtained: <item>.
+           GIL_OBTAINED = 6386; -- Obtained <number> gil.
+       KEYITEM_OBTAINED = 6388; -- Obtained key item: <keyitem>.
+ FISHING_MESSAGE_OFFSET = 7205; -- You can't fish here.
+            HOMEPOINT_SET = 7453; -- Home point set!
             
 -- Other dialog
-NOTHING_OUT_OF_ORDINARY = 6398; -- There is nothing out of the ordinary here.
-    SENSE_OF_FOREBODING = 6399; -- You are suddenly overcome with a sense of foreboding...
+NOTHING_OUT_OF_ORDINARY = 6399; -- There is nothing out of the ordinary here.
+    SENSE_OF_FOREBODING = 6400; -- You are suddenly overcome with a sense of foreboding...
 
 -- Refiner Dialog
-SOMETHING_FALLS_OUT_OF_THE_MACHINE = 7367; -- Something falls out of the machine!
-   THE_MACHINE_SEEMS_TO_BE_WORKING = 7364; -- The machine seems to be working, but you cannot discern its purpose.
-     YOU_CANT_CARRY_ANY_MORE_ITEMS = 7370; -- There seems to be more left in the machine, but you can't carry any more items.
+SOMETHING_FALLS_OUT_OF_THE_MACHINE = 7368; -- Something falls out of the machine!
+   THE_MACHINE_SEEMS_TO_BE_WORKING = 7365; -- The machine seems to be working, but you cannot discern its purpose.
+     YOU_CANT_CARRY_ANY_MORE_ITEMS = 7371; -- There seems to be more left in the machine, but you can't carry any more items.
 
 -- Mining
-MINING_IS_POSSIBLE_HERE = 7391; -- Mining is possible here if you have
+MINING_IS_POSSIBLE_HERE = 7392; -- Mining is possible here if you have
 
 -- Treasure Coffer/Chest Dialog
-CHEST_UNLOCKED = 7405; -- You unlock the chest!
-    CHEST_FAIL = 7406; -- Fails to open the chest.
-    CHEST_TRAP = 7407; -- The chest was trapped!
-    CHEST_WEAK = 7408; -- You cannot open the chest when you are in a weakened state.
-   CHEST_MIMIC = 7409; -- The chest was a mimic!
-  CHEST_MOOGLE = 7410; -- You cannot open the chest while participating in the moogle event.
-CHEST_ILLUSION = 7411; -- The chest was but an illusion...
-  CHEST_LOCKED = 7412; -- The chest appears to be locked.
+CHEST_UNLOCKED = 7406; -- You unlock the chest!
+    CHEST_FAIL = 7407; -- Fails to open the chest.
+    CHEST_TRAP = 7408; -- The chest was trapped!
+    CHEST_WEAK = 7409; -- You cannot open the chest when you are in a weakened state.
+   CHEST_MIMIC = 7410; -- The chest was a mimic!
+  CHEST_MOOGLE = 7411; -- You cannot open the chest while participating in the moogle event.
+CHEST_ILLUSION = 7412; -- The chest was but an illusion...
+  CHEST_LOCKED = 7413; -- The chest appears to be locked.
 
 -- conquest Base
-CONQUEST_BASE = 7045; -- Tallying conquest results...
+CONQUEST_BASE = 7046; -- Tallying conquest results...

--- a/scripts/zones/Pashhow_Marshlands/TextIDs.lua
+++ b/scripts/zones/Pashhow_Marshlands/TextIDs.lua
@@ -2,21 +2,21 @@
 
 -- General Texts
 ITEM_CANNOT_BE_OBTAINED = 6401; -- You cannot obtain the item <item>. Come back after sorting your inventory.
-          ITEM_OBTAINED = 6406; -- Obtained: <item>.
-           GIL_OBTAINED = 6407; -- Obtained <number> gil.
-       KEYITEM_OBTAINED = 6409; -- Obtained key item: <keyitem>.
- FISHING_MESSAGE_OFFSET = 7226; -- You can't fish here.
+          ITEM_OBTAINED = 6407; -- Obtained: <item>.
+           GIL_OBTAINED = 6408; -- Obtained <number> gil.
+       KEYITEM_OBTAINED = 6410; -- Obtained key item: <keyitem>.
+ FISHING_MESSAGE_OFFSET = 7227; -- You can't fish here.
 
 -- Conquest
-CONQUEST = 7915; -- You've earned conquest points!
+CONQUEST = 7916; -- You've earned conquest points!
 
 -- Other Dialog
-BEASTMEN_BANNER = 7148; -- There is a beastmen's banner.
+BEASTMEN_BANNER = 7149; -- There is a beastmen's banner.
 NOTHING_HAPPENS = 141;  -- Nothing happens...
 
 -- conquest Base
-CONQUEST_BASE = 7067; -- Tallying conquest results...
+CONQUEST_BASE = 7068; -- Tallying conquest results...
 
 -- chocobo digging
-DIG_THROW_AWAY = 7239; -- You dig up ?Possible Special Code: 01??Possible Special Code: 01??Possible Special Code: 01? ?Possible Special Code: 01??Possible Special Code: 05?$?BAD CHAR: 8280??BAD CHAR: 80??BAD CHAR: 80?, but your inventory is full.
-FIND_NOTHING = 7241; -- You dig and you dig, but find nothing.
+DIG_THROW_AWAY = 7240; -- You dig up ?Possible Special Code: 01??Possible Special Code: 01??Possible Special Code: 01? ?Possible Special Code: 01??Possible Special Code: 05?$?BAD CHAR: 8280??BAD CHAR: 80??BAD CHAR: 80?, but your inventory is full.
+FIND_NOTHING = 7242; -- You dig and you dig, but find nothing.

--- a/scripts/zones/Pashhow_Marshlands_[S]/TextIDs.lua
+++ b/scripts/zones/Pashhow_Marshlands_[S]/TextIDs.lua
@@ -2,11 +2,11 @@
 
 -- General Texts
 ITEM_CANNOT_BE_OBTAINED = 6379; -- You cannot obtain the item <item> come back again after sorting your inventory
-          ITEM_OBTAINED = 6384; -- Obtained: <item>
-           GIL_OBTAINED = 6385; -- Obtained <number> gil
-       KEYITEM_OBTAINED = 6387; -- Obtained key item: <keyitem>
- FISHING_MESSAGE_OFFSET = 7142; -- You can't fish here.
-NOTHING_OUT_OF_ORDINARY = 6398; -- There is nothing out of the ordinary here.
+          ITEM_OBTAINED = 6385; -- Obtained: <item>
+           GIL_OBTAINED = 6386; -- Obtained <number> gil
+       KEYITEM_OBTAINED = 6388; -- Obtained key item: <keyitem>
+ FISHING_MESSAGE_OFFSET = 7143; -- You can't fish here.
+NOTHING_OUT_OF_ORDINARY = 6399; -- There is nothing out of the ordinary here.
 
 -- Other Texts
-ALREADY_OBTAINED_TELE = 7687; -- You already possess the gate crystal for this telepoint.
+ALREADY_OBTAINED_TELE = 7688; -- You already possess the gate crystal for this telepoint.

--- a/scripts/zones/Phanauet_Channel/TextIDs.lua
+++ b/scripts/zones/Phanauet_Channel/TextIDs.lua
@@ -2,10 +2,10 @@
 
 -- General Texts
 ITEM_CANNOT_BE_OBTAINED = 6379; -- You cannot obtain the item <item> come back again after sorting your inventory.
-          ITEM_OBTAINED = 6384; -- Obtained: <item>.
-           GIL_OBTAINED = 6385; -- Obtained <number> gil.
-       KEYITEM_OBTAINED = 6387; -- Obtained key item: <keyitem>.
- FISHING_MESSAGE_OFFSET = 7214; -- You can't fish here.
+          ITEM_OBTAINED = 6385; -- Obtained: <item>.
+           GIL_OBTAINED = 6386; -- Obtained <number> gil.
+       KEYITEM_OBTAINED = 6388; -- Obtained key item: <keyitem>.
+ FISHING_MESSAGE_OFFSET = 7215; -- You can't fish here.
 
 -- conquest Base
-CONQUEST_BASE = 7045; -- Tallying conquest results...
+CONQUEST_BASE = 7046; -- Tallying conquest results...

--- a/scripts/zones/Phomiuna_Aqueducts/TextIDs.lua
+++ b/scripts/zones/Phomiuna_Aqueducts/TextIDs.lua
@@ -2,18 +2,18 @@
 
 -- General Texts
 ITEM_CANNOT_BE_OBTAINED = 6379; -- You cannot obtain the item <item> come back again after sorting your inventory
-          ITEM_OBTAINED = 6384; -- Obtained: <item>
-           GIL_OBTAINED = 6385; -- Obtained <number> gil
-       KEYITEM_OBTAINED = 6387; -- Obtained key item: <keyitem>
- FISHING_MESSAGE_OFFSET = 7228; -- You can't fish here.
+          ITEM_OBTAINED = 6385; -- Obtained: <item>
+           GIL_OBTAINED = 6386; -- Obtained <number> gil
+       KEYITEM_OBTAINED = 6388; -- Obtained key item: <keyitem>
+ FISHING_MESSAGE_OFFSET = 7229; -- You can't fish here.
 
  -- Lamps
-LAMP_OFFSET = 7215; -- A symbol for fire is engraved on the base of the lamp...
+LAMP_OFFSET = 7216; -- A symbol for fire is engraved on the base of the lamp...
 
 -- Other
-NOTHING_OUT_HERE = 6398; -- There is nothing out of the ordinary here.
-DOOR_SEALED_SHUT = 7207; -- The door above you is sealed shut.
-     DOOR_LOCKED = 7209; -- The door is locked.You might be able to open it with
+NOTHING_OUT_HERE = 6399; -- There is nothing out of the ordinary here.
+DOOR_SEALED_SHUT = 7208; -- The door above you is sealed shut.
+     DOOR_LOCKED = 7210; -- The door is locked.You might be able to open it with
 
 -- conquest Base
-CONQUEST_BASE = 7045; -- Tallying conquest results...
+CONQUEST_BASE = 7046; -- Tallying conquest results...

--- a/scripts/zones/Port_Bastok/TextIDs.lua
+++ b/scripts/zones/Port_Bastok/TextIDs.lua
@@ -3,67 +3,67 @@
 -- General Texts
        ITEM_CANNOT_BE_OBTAINED = 6379; -- You cannot obtain the item <item>. Come back after sorting your inventory.
 FULL_INVENTORY_AFTER_TRADE = 6383; -- You cannot obtain the item (item>. Try trading again after sorting your inventory.
-                                  ITEM_OBTAINED = 6384; -- Obtained: #.
-                                     GIL_OBTAINED = 6385; -- Obtained <<<Numeric Parameter 0>>> gil.
-                          KEYITEM_OBTAINED = 6387; -- Obtained key item: <<<Unknown Parameter (Type: 80) 1>>>.
-                                    KEYITEM_LOST = 6388; -- Lost key item <<<Unknown Parameter (Type: 80) 1>>>.
-                NOT_HAVE_ENOUGH_GIL = 6389; -- You do not have enough gil.
-                                HOMEPOINT_SET = 6502; -- Home point set!
-         FISHING_MESSAGE_OFFSET = 7076; -- You can't fish here.
-                               MOGHOUSE_EXIT = 7939; -- You have learned your way through the back alleys of Bastok! Now you can exit to any area from your residence.
+                                  ITEM_OBTAINED = 6385; -- Obtained: #.
+                                     GIL_OBTAINED = 6386; -- Obtained <<<Numeric Parameter 0>>> gil.
+                          KEYITEM_OBTAINED = 6388; -- Obtained key item: <<<Unknown Parameter (Type: 80) 1>>>.
+                                    KEYITEM_LOST = 6389; -- Lost key item <<<Unknown Parameter (Type: 80) 1>>>.
+                NOT_HAVE_ENOUGH_GIL = 6390; -- You do not have enough gil.
+                                HOMEPOINT_SET = 6503; -- Home point set!
+         FISHING_MESSAGE_OFFSET = 7077; -- You can't fish here.
+                               MOGHOUSE_EXIT = 7940; -- You have learned your way through the back alleys of Bastok! Now you can exit to any area from your residence.
 
 -- Conquest System
-CONQUEST = 7995; -- You've earned conquest points!
+CONQUEST = 7996; -- You've earned conquest points!
 
 -- Mission Dialogs
-    YOU_ACCEPT_THE_MISSION = 7335; -- You have accepted the mission.
-   ORIGINAL_MISSION_OFFSET = 7340; -- You can consult the ission section of the main menu to review your objectives. Speed and efficiency are your priorities. Dismissed. 
-   EXTENDED_MISSION_OFFSET = 8460; -- Go to Ore Street and talk to Medicine Eagle. He says he was there when the commotion started.
+    YOU_ACCEPT_THE_MISSION = 7336; -- You have accepted the mission.
+   ORIGINAL_MISSION_OFFSET = 7341; -- You can consult the ission section of the main menu to review your objectives. Speed and efficiency are your priorities. Dismissed. 
+   EXTENDED_MISSION_OFFSET = 8461; -- Go to Ore Street and talk to Medicine Eagle. He says he was there when the commotion started.
 
 -- Dialog Texts
-POWHATAN_DIALOG_1 = 7264; -- I'm sick and tired of entertaining guests.
-   RONAN_DIALOG_1 = 7450; -- Do something! Isn't there anything you can do to make him come out of his shell?
- PAUJEAN_DIALOG_1 = 7641; -- Where can you find them? If you're the kind of adventurer I think you are, you should have a pretty good idea.
-     UNLOCK_NINJA = 8422; -- You can now become a ninja.
-   TITAN_UNLOCKED = 8527; -- You are now able to summon
+POWHATAN_DIALOG_1 = 7265; -- I'm sick and tired of entertaining guests.
+   RONAN_DIALOG_1 = 7451; -- Do something! Isn't there anything you can do to make him come out of his shell?
+ PAUJEAN_DIALOG_1 = 7642; -- Where can you find them? If you're the kind of adventurer I think you are, you should have a pretty good idea.
+     UNLOCK_NINJA = 8423; -- You can now become a ninja.
+   TITAN_UNLOCKED = 8528; -- You are now able to summon
 
 -- Shop Texts
-  TENSHODO_SHOP_OPEN_DIALOG = 6723; -- Ah, one of our members. Welcome to the Tenshodo shop.
+  TENSHODO_SHOP_OPEN_DIALOG = 6724; -- Ah, one of our members. Welcome to the Tenshodo shop.
 
-       EVELYN_CLOSED_DIALOG = 7569; -- I'm trying to start a business selling goods from Gustaberg,
-     ROSSWALD_CLOSED_DIALOG = 7570; -- I'm trying to start a business selling goods from Zulkheim,
-        BELKA_CLOSED_DIALOG = 7571; -- I'm trying to start a business selling goods from Derfland,
-      VATTIAN_CLOSED_DIALOG = 7572; -- I'm trying to start a business selling goods from Kuzotz,
+       EVELYN_CLOSED_DIALOG = 7570; -- I'm trying to start a business selling goods from Gustaberg,
+     ROSSWALD_CLOSED_DIALOG = 7571; -- I'm trying to start a business selling goods from Zulkheim,
+        BELKA_CLOSED_DIALOG = 7572; -- I'm trying to start a business selling goods from Derfland,
+      VATTIAN_CLOSED_DIALOG = 7573; -- I'm trying to start a business selling goods from Kuzotz,
 
-      VALERIANO_SHOP_DIALOG = 7574; -- Welcome to the Troupe Valeriano. Valeriano, at your service! Have a laugh, then spend some cash!
+      VALERIANO_SHOP_DIALOG = 7575; -- Welcome to the Troupe Valeriano. Valeriano, at your service! Have a laugh, then spend some cash!
 
-         SAWYER_SHOP_DIALOG = 7619; -- Hi, there. For here or to go?
-         MELLOA_SHOP_DIALOG = 7620; -- Welcome to the Steaming Sheep. Would you like something to drink?
+         SAWYER_SHOP_DIALOG = 7620; -- Hi, there. For here or to go?
+         MELLOA_SHOP_DIALOG = 7621; -- Welcome to the Steaming Sheep. Would you like something to drink?
 
-         EVELYN_OPEN_DIALOG = 7623; -- Hello! Might I interest you in some specialty goods from Gustaberg?
-         GALVIN_SHOP_DIALOG = 7624; -- Welcome to Galvin's Travel Gear!
-           NUMA_SHOP_DIALOG = 7625; -- Hello, hello! Won't you buy something? I'll give you a rebate!
-          BELKA_OPEN_DIALOG = 7626; -- Welcome. I've got goods from Derfland. Interested?
-       ROSSWALD_OPEN_DIALOG = 7627; -- Hello, hello! Everything I have is imported directly from Zulkheim!
-          ILITA_SHOP_DIALOG = 7628; -- Hello there. How about buying
-       SUGANDHI_SHOP_DIALOG = 7629; -- Traveler! I am sure my wares will prove useful on your journey.
-        DENVIHR_SHOP_DIALOG = 7630; -- Ah, interested in my wares, are you? You can only buy these in Bastok, my friend.
+         EVELYN_OPEN_DIALOG = 7624; -- Hello! Might I interest you in some specialty goods from Gustaberg?
+         GALVIN_SHOP_DIALOG = 7625; -- Welcome to Galvin's Travel Gear!
+           NUMA_SHOP_DIALOG = 7626; -- Hello, hello! Won't you buy something? I'll give you a rebate!
+          BELKA_OPEN_DIALOG = 7627; -- Welcome. I've got goods from Derfland. Interested?
+       ROSSWALD_OPEN_DIALOG = 7628; -- Hello, hello! Everything I have is imported directly from Zulkheim!
+          ILITA_SHOP_DIALOG = 7629; -- Hello there. How about buying
+       SUGANDHI_SHOP_DIALOG = 7630; -- Traveler! I am sure my wares will prove useful on your journey.
+        DENVIHR_SHOP_DIALOG = 7631; -- Ah, interested in my wares, are you? You can only buy these in Bastok, my friend.
 
-             MUSTAFA_DIALOG = 7621; -- Hello. This concourse is for arriving passengers.
-         BARTHOLOMEO_DIALOG = 7621; -- Hello. This concourse is for arriving passengers.
+             MUSTAFA_DIALOG = 7622; -- Hello. This concourse is for arriving passengers.
+         BARTHOLOMEO_DIALOG = 7622; -- Hello. This concourse is for arriving passengers.
 
-               KLAUS_DIALOG = 7622; -- Hello. This concourse is for departing passengers.
-               CAREY_DIALOG = 7622; -- Hello. This concourse is for departing passengers.
+               KLAUS_DIALOG = 7623; -- Hello. This concourse is for departing passengers.
+               CAREY_DIALOG = 7623; -- Hello. This concourse is for departing passengers.
 
-        VATTIAN_OPEN_DIALOG = 8355; -- Welcome to my humble establishment. I have a wide variety of specialty goods from Kuzotz.
-      ZOBYQUHYO_OPEN_DIALOG = 8356; -- Hey therrre! I've got lots of wonderrrful goodies, fresh from the Elshimo Lowlands.
-    ZOBYQUHYO_CLOSED_DIALOG = 8357; -- I'm trrrying to start a business selling goods from the Elshimo Lowlands, but it's not easy getting stuff from areas that aren't under Bastokan contrrrol.
-  DHENTEVRYUKOH_OPEN_DIALOG = 8358; -- Welcome! Welcome! Take a wonderrr at these specialty goods from the Elshimo Uplands!
-DHENTEVRYUKOH_CLOSED_DIALOG = 8359; -- I'm trrrying to start a business selling goods from the Elshimo Uplands, but it's not easy transporting goods from areas that aren't under Bastokan contrrrol.
+        VATTIAN_OPEN_DIALOG = 8356; -- Welcome to my humble establishment. I have a wide variety of specialty goods from Kuzotz.
+      ZOBYQUHYO_OPEN_DIALOG = 8357; -- Hey therrre! I've got lots of wonderrrful goodies, fresh from the Elshimo Lowlands.
+    ZOBYQUHYO_CLOSED_DIALOG = 8358; -- I'm trrrying to start a business selling goods from the Elshimo Lowlands, but it's not easy getting stuff from areas that aren't under Bastokan contrrrol.
+  DHENTEVRYUKOH_OPEN_DIALOG = 8359; -- Welcome! Welcome! Take a wonderrr at these specialty goods from the Elshimo Uplands!
+DHENTEVRYUKOH_CLOSED_DIALOG = 8360; -- I'm trrrying to start a business selling goods from the Elshimo Uplands, but it's not easy transporting goods from areas that aren't under Bastokan contrrrol.
 
-      BLABBIVIX_SHOP_DIALOG = 8631; -- I come from the underworld. These chipshhh, you knooow, are popular among us Goblinshhh. Use with heart of shhhtatue.
-    BAGNOBROK_CLOSED_DIALOG = 9114; -- Kbastok sis kweak! Smoblins yonly twant gstrong sfriends! Non sgoods mfrom Smovalpolos ytoday!
-      BAGNOBROK_OPEN_DIALOG = 9115; -- Kbastok! Crepublic sis gstrong! Smoblins lsell sgoods oto gstrong sfriends!
+      BLABBIVIX_SHOP_DIALOG = 8632; -- I come from the underworld. These chipshhh, you knooow, are popular among us Goblinshhh. Use with heart of shhhtatue.
+    BAGNOBROK_CLOSED_DIALOG = 9115; -- Kbastok sis kweak! Smoblins yonly twant gstrong sfriends! Non sgoods mfrom Smovalpolos ytoday!
+      BAGNOBROK_OPEN_DIALOG = 9116; -- Kbastok! Crepublic sis gstrong! Smoblins lsell sgoods oto gstrong sfriends!
 
 -- conquest Base
-CONQUEST_BASE = 6522; -- Tallying conquest results...
+CONQUEST_BASE = 6523; -- Tallying conquest results...

--- a/scripts/zones/Port_Jeuno/TextIDs.lua
+++ b/scripts/zones/Port_Jeuno/TextIDs.lua
@@ -2,45 +2,45 @@
 
 -- General Texts
 ITEM_CANNOT_BE_OBTAINED = 6379; -- You cannot obtain the item <item>. Come back after sorting your inventory.
-          ITEM_OBTAINED = 6384; -- Obtained: <item>.
-           GIL_OBTAINED = 6385; -- Obtained <number> gil.
-       KEYITEM_OBTAINED = 6387; -- Obtained key item: <keyitem>.
-          HOMEPOINT_SET = 6634; -- Home point set!
- FISHING_MESSAGE_OFFSET = 6891; -- You can't fish here.
-          MOGHOUSE_EXIT = 7162; -- You have learned your way through the back alleys of Jeuno! Now you can exit to any area from your residence.
-     WEATHER_DIALOG = 6843; -- Your fate rides on the changing winds of Vana'diel. I can give you insight on the local weather.<Prompt>
+          ITEM_OBTAINED = 6385; -- Obtained: <item>.
+           GIL_OBTAINED = 6386; -- Obtained <number> gil.
+       KEYITEM_OBTAINED = 6388; -- Obtained key item: <keyitem>.
+          HOMEPOINT_SET = 6635; -- Home point set!
+ FISHING_MESSAGE_OFFSET = 6892; -- You can't fish here.
+          MOGHOUSE_EXIT = 7163; -- You have learned your way through the back alleys of Jeuno! Now you can exit to any area from your residence.
+     WEATHER_DIALOG = 6844; -- Your fate rides on the changing winds of Vana'diel. I can give you insight on the local weather.<Prompt>
 
 -- Shop Texts
-   LEYLA_SHOP_DIALOG = 7008; -- Hello. All goods are duty-free.
-   GEKKO_SHOP_DIALOG = 7008; -- Hello. All goods are duty-free.
-CHALLOUX_SHOP_DIALOG = 7009; -- Good day!
+   LEYLA_SHOP_DIALOG = 7009; -- Hello. All goods are duty-free.
+   GEKKO_SHOP_DIALOG = 7009; -- Hello. All goods are duty-free.
+CHALLOUX_SHOP_DIALOG = 7010; -- Good day!
 
 -- Other Texts
-         GUIDE_STONE = 7007; -- Up: Lower Jeuno (Selection Dialogfacing Bastok) Down: Qufim Island
- CUMETOUFLAIX_DIALOG = 7047; -- This underground tunnel leads to the island of Qufim. Everyone is advised to stay out. But of course you adventurers never listen.
-             OLD_BOX = 7282; -- You find a grimy old box.
-ITEM_DELIVERY_DIALOG = 7369; -- Delivering goods to residences everywhere!
-      VEUJAIE_DIALOG = 7369; -- Delivering goods to residences everywhere!
-       DIGAGA_DIALOG = 7369; -- Delivering goods to residences everywhere!
-      CHEST_IS_EMPTY = 8643; -- The chest is empty.
+         GUIDE_STONE = 7008; -- Up: Lower Jeuno (Selection Dialogfacing Bastok) Down: Qufim Island
+ CUMETOUFLAIX_DIALOG = 7048; -- This underground tunnel leads to the island of Qufim. Everyone is advised to stay out. But of course you adventurers never listen.
+             OLD_BOX = 7283; -- You find a grimy old box.
+ITEM_DELIVERY_DIALOG = 7370; -- Delivering goods to residences everywhere!
+      VEUJAIE_DIALOG = 7370; -- Delivering goods to residences everywhere!
+       DIGAGA_DIALOG = 7370; -- Delivering goods to residences everywhere!
+      CHEST_IS_EMPTY = 8644; -- The chest is empty.
 
 -- Conquest system
-CONQUEST = 7379; -- You've earned conquest points!
+CONQUEST = 7380; -- You've earned conquest points!
 
 -- NPC Dialog
-  TSOLAG_DIALOG = 7368; -- This is the departure gate for airship passengers. If you have any questions, please inquire with Guddal.
-   GAVIN_DIALOG = 7350; -- This is the counter for the air route to the Outlands. Our airships connect Jeuno with the southeastern island of Elshimo.
-   DAPOL_DIALOG = 7078; -- Welcome to Port Jeuno, the busiest airship hub anywhere! You can't miss the awe-inspiring view of airships in flight!
-SECURITY_DIALOG = 7081; -- Port Jeuno must remain secure. After all, if anything happened to the archduke, it would change the world!
-    ARRIVAL_NPC = 7065; -- Enjoy your stay in Jeuno!
-    COUNTER_NPC = 7055; -- I think the airships are a subtle form of pressure on the other three nations. That way, Jeuno can maintain the current balance of power.
-  COUNTER_NPC_2 = 7053; -- With the airships connecting Jeuno with the three nations, the flow of goods has become much more consistent. Nowadays, everything comes through Jeuno!
- CHOCOBO_DIALOG = 7169; -- ...
-       GET_LOST = 8144; -- You want somethin' from me? Well, too bad. I don't want nothin' from you. Get lost.
-      DRYEYES_1 = 8153; -- Then why you waste my time? Get lost
-      DRYEYES_2 = 8154; -- Done deal. Deal is done.
-      DRYEYES_3 = 8155; -- Hey, you already got . What you tryin' to pull here? Save some for my other customers, eh
+  TSOLAG_DIALOG = 7369; -- This is the departure gate for airship passengers. If you have any questions, please inquire with Guddal.
+   GAVIN_DIALOG = 7351; -- This is the counter for the air route to the Outlands. Our airships connect Jeuno with the southeastern island of Elshimo.
+   DAPOL_DIALOG = 7079; -- Welcome to Port Jeuno, the busiest airship hub anywhere! You can't miss the awe-inspiring view of airships in flight!
+SECURITY_DIALOG = 7082; -- Port Jeuno must remain secure. After all, if anything happened to the archduke, it would change the world!
+    ARRIVAL_NPC = 7066; -- Enjoy your stay in Jeuno!
+    COUNTER_NPC = 7056; -- I think the airships are a subtle form of pressure on the other three nations. That way, Jeuno can maintain the current balance of power.
+  COUNTER_NPC_2 = 7054; -- With the airships connecting Jeuno with the three nations, the flow of goods has become much more consistent. Nowadays, everything comes through Jeuno!
+ CHOCOBO_DIALOG = 7170; -- ...
+       GET_LOST = 8145; -- You want somethin' from me? Well, too bad. I don't want nothin' from you. Get lost.
+      DRYEYES_1 = 8154; -- Then why you waste my time? Get lost
+      DRYEYES_2 = 8155; -- Done deal. Deal is done.
+      DRYEYES_3 = 8156; -- Hey, you already got . What you tryin' to pull here? Save some for my other customers, eh
 
 
 -- conquest Base
-CONQUEST_BASE = 6473; -- Tallying conquest results...
+CONQUEST_BASE = 6474; -- Tallying conquest results...

--- a/scripts/zones/Port_San_dOria/TextIDs.lua
+++ b/scripts/zones/Port_San_dOria/TextIDs.lua
@@ -5,61 +5,61 @@
  ITEM_CANNOT_BE_OBTAINED_2 =  6423; -- You cannot obtain the <<<Possible Special Code: 01>>><<<Possible Special Code: 05>>>#<<<BAD CHAR: 8280>>><<<BAD CHAR: 80>>><<<BAD CHAR: 80>>>. Come back after sorting your inventory.
  ITEM_CANNOT_BE_OBTAINED_3 =  6425; -- You cannot obtain the item. Come back after sorting your inventory.
 FULL_INVENTORY_AFTER_TRADE =  6427; -- You cannot obtain the <<<Possible Special Code: 01>>><<<Possible Special Code: 05>>>#<<<BAD CHAR: 8280>>><<<BAD CHAR: 80>>><<<BAD CHAR: 80>>>. Try trading again after sorting your inventory.
-             ITEM_OBTAINED =  6428; -- Obtained: <<<Unknown Parameter (Type: 80) 1>>><<<Possible Special Code: 01>>><<<Possible Special Code: 05>>>#<<<BAD CHAR: 8280>>><<<BAD CHAR: 80>>><<<BAD CHAR: 80>>>.
-              GIL_OBTAINED =  6429; -- Obtained <<<Numeric Parameter 0>>> gil.
-          KEYITEM_OBTAINED =  6431; -- Obtained key item: <<<Unknown Parameter (Type: 80) 1>>><<<Possible Special Code: 01>>><<<Possible Special Code: 05>>>3<<<BAD CHAR: 8280>>><<<BAD CHAR: 80>>><<<BAD CHAR: 80>>>.
+             ITEM_OBTAINED =  6429; -- Obtained: <<<Unknown Parameter (Type: 80) 1>>><<<Possible Special Code: 01>>><<<Possible Special Code: 05>>>#<<<BAD CHAR: 8280>>><<<BAD CHAR: 80>>><<<BAD CHAR: 80>>>.
+              GIL_OBTAINED =  6430; -- Obtained <<<Numeric Parameter 0>>> gil.
+          KEYITEM_OBTAINED =  6432; -- Obtained key item: <<<Unknown Parameter (Type: 80) 1>>><<<Possible Special Code: 01>>><<<Possible Special Code: 05>>>3<<<BAD CHAR: 8280>>><<<BAD CHAR: 80>>><<<BAD CHAR: 80>>>.
              HOMEPOINT_SET =  24;   -- Home point set!
-    FISHING_MESSAGE_OFFSET =  7219; -- You can't fish here.
+    FISHING_MESSAGE_OFFSET =  7220; -- You can't fish here.
 
-      ITEM_DELIVERY_DIALOG =  7941; -- Now delivering parcels to rooms everywhere!
+      ITEM_DELIVERY_DIALOG =  7942; -- Now delivering parcels to rooms everywhere!
 
 -- Dialogs
-   FLYER_REFUSED =  7551; -- This person isn't interested.
-   FLYER_ALREADY =  7552; -- This person already has a flyer.
-  FLYER_ACCEPTED =  7553; -- Your flyer is accepted!
-   FLYERS_HANDED =  7554; -- You've handed outflyer(s).
+   FLYER_REFUSED =  7552; -- This person isn't interested.
+   FLYER_ALREADY =  7553; -- This person already has a flyer.
+  FLYER_ACCEPTED =  7554; -- Your flyer is accepted!
+   FLYERS_HANDED =  7555; -- You've handed outflyer(s).
 
- PORTAURE_DIALOG =  7818; -- What's this? A magic shop? Hmm...I could use a new line of work, and magic just might be the ticket!
+ PORTAURE_DIALOG =  7819; -- What's this? A magic shop? Hmm...I could use a new line of work, and magic just might be the ticket!
 
-  ANSWALD_DIALOG =  7838; -- A magic shop? Oh, it's right near here. I'll go check it out sometime.
+  ANSWALD_DIALOG =  7839; -- A magic shop? Oh, it's right near here. I'll go check it out sometime.
 
-  PRIETTA_DIALOG =  7862; -- This is the first I've heard of a magic shop here in San d'Oria. Such arts have never been popular in the Kingdom.
+  PRIETTA_DIALOG =  7863; -- This is the first I've heard of a magic shop here in San d'Oria. Such arts have never been popular in the Kingdom.
 
-   AUVARE_DIALOG =  7869; -- What have I got here? Look, I can't read, but I takes what I gets, and you ain't getting it back!
+   AUVARE_DIALOG =  7870; -- What have I got here? Look, I can't read, but I takes what I gets, and you ain't getting it back!
 
-    MIENE_DIALOG =  7922; -- Oh, a magic shop... Here in San d'Oria? I'd take a look if I got more allowance.
+    MIENE_DIALOG =  7923; -- Oh, a magic shop... Here in San d'Oria? I'd take a look if I got more allowance.
 
- ANSWALD_MESSAGE =  8415; -- Answald looks over curiously for a moment.
- PRIETTA_MESSAGE =  8416; -- Prietta looks over curiously for a moment.
-   MIENE_MESSAGE =  8417; -- Miene looks over curiously for a moment.
-PORTAURE_MESSAGE =  8418; -- Portaure looks over curiously for a moment.
-  AUVARE_MESSAGE =  8419; -- Auvare looks over curiously for a moment.
+ ANSWALD_MESSAGE =  8416; -- Answald looks over curiously for a moment.
+ PRIETTA_MESSAGE =  8417; -- Prietta looks over curiously for a moment.
+   MIENE_MESSAGE =  8418; -- Miene looks over curiously for a moment.
+PORTAURE_MESSAGE =  8419; -- Portaure looks over curiously for a moment.
+  AUVARE_MESSAGE =  8420; -- Auvare looks over curiously for a moment.
 
 -- Shop Texts
-           ALBINIE_SHOP_DIALOG = 7882; -- Welcome to my simple shop.
+           ALBINIE_SHOP_DIALOG = 7883; -- Welcome to my simple shop.
 
-          COULLAVE_SHOP_DIALOG = 7928; -- Can I help you?
-        CROUMANGUE_SHOP_DIALOG = 7929; -- Can't fight on an empty stomach. How about some nourishment?
+          COULLAVE_SHOP_DIALOG = 7929; -- Can I help you?
+        CROUMANGUE_SHOP_DIALOG = 7930; -- Can't fight on an empty stomach. How about some nourishment?
 
-          VENDAVOQ_OPEN_DIALOG = 7936; -- Vandoolin! Vendavoq vring voods vack vrom Vovalpolos! Vuy! Vuy!
-        VENDAVOQ_CLOSED_DIALOG = 7937; -- Vandoolin... Vendavoq's vream vo vell voods vrom vometown vf Vovalpolos...
+          VENDAVOQ_OPEN_DIALOG = 7937; -- Vandoolin! Vendavoq vring voods vack vrom Vovalpolos! Vuy! Vuy!
+        VENDAVOQ_CLOSED_DIALOG = 7938; -- Vandoolin... Vendavoq's vream vo vell voods vrom vometown vf Vovalpolos...
 
-              FIVA_OPEN_DIALOG = 7930; -- I've got imports from Kolshushu!
-             MILVA_OPEN_DIALOG = 7931; -- How about some produce from Sarutabaruta?
-            FIVA_CLOSED_DIALOG = 7932; -- I'm trying to sell goods from Kolshushu. But I can't because we don't have enough influence there.
-           MILVA_CLOSED_DIALOG = 7933; -- I want to import produce from Sarutabaruta... But I can't do anything until we control that region!
-           NIMIA_CLOSED_DIALOG = 7934; -- I can't sell goods from the lowlands of Elshimo because it's under foreign control.
-         PATOLLE_CLOSED_DIALOG = 7935; -- I'm trying to find goods from Kuzotz. But how can I when it's under foreign control?
+              FIVA_OPEN_DIALOG = 7931; -- I've got imports from Kolshushu!
+             MILVA_OPEN_DIALOG = 7932; -- How about some produce from Sarutabaruta?
+            FIVA_CLOSED_DIALOG = 7933; -- I'm trying to sell goods from Kolshushu. But I can't because we don't have enough influence there.
+           MILVA_CLOSED_DIALOG = 7934; -- I want to import produce from Sarutabaruta... But I can't do anything until we control that region!
+           NIMIA_CLOSED_DIALOG = 7935; -- I can't sell goods from the lowlands of Elshimo because it's under foreign control.
+         PATOLLE_CLOSED_DIALOG = 7936; -- I'm trying to find goods from Kuzotz. But how can I when it's under foreign control?
 
-      DEGUERENDARS_OPEN_DIALOG = 7938; -- Welcome! Have a look at these rare goods from Tavnazia!
-    DEGUERENDARS_CLOSED_DIALOG = 7939; -- With that other nation in control of the region, there is no way for me to import goods from Tavnazia...
-DEGUERENDARS_COP_NOT_COMPLETED = 7940; -- Why must I wait for the Kingdom to issue a permit allowing me to set up shop? How am I to feed my children in the meantime!?
+      DEGUERENDARS_OPEN_DIALOG = 7939; -- Welcome! Have a look at these rare goods from Tavnazia!
+    DEGUERENDARS_CLOSED_DIALOG = 7940; -- With that other nation in control of the region, there is no way for me to import goods from Tavnazia...
+DEGUERENDARS_COP_NOT_COMPLETED = 7941; -- Why must I wait for the Kingdom to issue a permit allowing me to set up shop? How am I to feed my children in the meantime!?
 
-     BONMAURIEUT_CLOSED_DIALOG = 8275; -- I would like to sell goods from the Elshimo Uplands, but I cannot, as it's under foreign control.
-             NIMIA_OPEN_DIALOG = 8276; -- Hello, friend! Can I interest you in specialty goods from the Elshimo Lowlands?
-           PATOLLE_OPEN_DIALOG = 8277; -- How about some specialty goods from Kuzotz?
-       BONMAURIEUT_OPEN_DIALOG = 8278; -- My shipment is in! Would you like to see what has just arrived from the Elshimo Uplands?
+     BONMAURIEUT_CLOSED_DIALOG = 8276; -- I would like to sell goods from the Elshimo Uplands, but I cannot, as it's under foreign control.
+             NIMIA_OPEN_DIALOG = 8277; -- Hello, friend! Can I interest you in specialty goods from the Elshimo Lowlands?
+           PATOLLE_OPEN_DIALOG = 8278; -- How about some specialty goods from Kuzotz?
+       BONMAURIEUT_OPEN_DIALOG = 8279; -- My shipment is in! Would you like to see what has just arrived from the Elshimo Uplands?
 
 
 -- conquest Base
-CONQUEST_BASE = 7060; -- Tallying conquest results...
+CONQUEST_BASE = 7061; -- Tallying conquest results...

--- a/scripts/zones/Port_Windurst/TextIDs.lua
+++ b/scripts/zones/Port_Windurst/TextIDs.lua
@@ -3,24 +3,24 @@
 -- General Texts
        ITEM_CANNOT_BE_OBTAINED = 10962; -- Come back after sorting your inventory.
     FULL_INVENTORY_AFTER_TRADE = 10966; -- Try trading again after sorting your inventory.
-                 ITEM_OBTAINED = 10967; -- Obtained:
-                  GIL_OBTAINED = 10968; -- Obtained <<<Numeric Parameter 0>>> gil.
-              KEYITEM_OBTAINED = 10970; -- Obtained key item: <<<Unknown Parameter (Type: 80) 1>>>.
-           NOT_HAVE_ENOUGH_GIL = 10972; -- You do not have enough gil.
-                 HOMEPOINT_SET = 11058; -- Home point set!
-        FISHING_MESSAGE_OFFSET = 11566; -- You can't fish here.
-               FISHING_SUPPORT = 11670; -- Your ?Multiple Choice (Parameter 1)?[fishing/woodworking/smithing/goldsmithing/clothcraft/leatherworking/bonecraft/alchemy/cooking] skills went up ...
-      GUILD_TERMINATE_CONTRACT = 11684; -- You have terminated your trading contract with the Multiple Choice (Parameter 1)[Fishermen's/Carpenters'/Blacksmiths'/Goldsmiths'/Weavers'/Tanners'/Boneworkers'/Alchemists'/Culinarians'] Guild and formed a new one with the Multiple Choice (Parameter 0)[Fishermen's/Carpenters'/Blacksmiths'/Goldsmiths'/Weavers'/Tanners'/Boneworkers'/Alchemists'/Culinarians'] Guild
-            GUILD_NEW_CONTRACT = 11692; -- You have formed a new trading contract with the Multiple Choice (Parameter 0)[Fishermen's/Carpenters'/Blacksmiths'/Goldsmiths'/Weavers'/Tanners'/Boneworkers'/Alchemists'/Culinarians'] Guild
-           NO_MORE_GP_ELIGIBLE =  11699; --You are not eligible to receive guild points at this time.
-                   GP_OBTAINED =  11704; -- Obtained: ?Numeric Parameter 0? guild points.
-            NOT_HAVE_ENOUGH_GP =  11705; --You do not have enough guild points.
+                 ITEM_OBTAINED = 10968; -- Obtained:
+                  GIL_OBTAINED = 10969; -- Obtained <<<Numeric Parameter 0>>> gil.
+              KEYITEM_OBTAINED = 10971; -- Obtained key item: <<<Unknown Parameter (Type: 80) 1>>>.
+           NOT_HAVE_ENOUGH_GIL = 10973; -- You do not have enough gil.
+                 HOMEPOINT_SET = 11059; -- Home point set!
+        FISHING_MESSAGE_OFFSET = 11567; -- You can't fish here.
+               FISHING_SUPPORT = 11671; -- Your ?Multiple Choice (Parameter 1)?[fishing/woodworking/smithing/goldsmithing/clothcraft/leatherworking/bonecraft/alchemy/cooking] skills went up ...
+      GUILD_TERMINATE_CONTRACT = 11685; -- You have terminated your trading contract with the Multiple Choice (Parameter 1)[Fishermen's/Carpenters'/Blacksmiths'/Goldsmiths'/Weavers'/Tanners'/Boneworkers'/Alchemists'/Culinarians'] Guild and formed a new one with the Multiple Choice (Parameter 0)[Fishermen's/Carpenters'/Blacksmiths'/Goldsmiths'/Weavers'/Tanners'/Boneworkers'/Alchemists'/Culinarians'] Guild
+            GUILD_NEW_CONTRACT = 11693; -- You have formed a new trading contract with the Multiple Choice (Parameter 0)[Fishermen's/Carpenters'/Blacksmiths'/Goldsmiths'/Weavers'/Tanners'/Boneworkers'/Alchemists'/Culinarians'] Guild
+           NO_MORE_GP_ELIGIBLE =  11700; --You are not eligible to receive guild points at this time.
+                   GP_OBTAINED =  11705; -- Obtained: ?Numeric Parameter 0? guild points.
+            NOT_HAVE_ENOUGH_GP =  11706; --You do not have enough guild points.
 
 -- Conquest System
-CONQUEST = 11884; -- You've earned conquest points!
+CONQUEST = 11886; -- You've earned conquest points!
 
 -- Mission Dialogs
-YOU_ACCEPT_THE_MISSION = 11151; -- You have accepted the mission.
+YOU_ACCEPT_THE_MISSION = 11152; -- You have accepted the mission.
 
 -- Quest Dialog
     GOLD_SKULL_DIALOG = 3251;  -- Welcome back. Your mission went without incident, I trust?
@@ -28,7 +28,7 @@ YOU_ACCEPT_THE_MISSION = 11151; -- You have accepted the mission.
            MELEK_DIALOG_B = 3250;  -- Take that sword to Giddeus. Good luck.
            MELEK_DIALOG_C = 3256;  -- I hope to see you safe and well again someday. Take care, Player Name.
 
-KOHLO_LAKOLO_DIALOG_A = 12427; -- On your Star Onion Brigade honor, you can't tell anybody that Joker is hiding in the ghosty house!
+KOHLO_LAKOLO_DIALOG_A = 12429; -- On your Star Onion Brigade honor, you can't tell anybody that Joker is hiding in the ghosty house!
 
 -- Shop Texts
              KUSUSU_SHOP_DIALOG = 4133;  -- Welcome to Kususu's Hodos! We have low-level to medium-level magic on sale to help you through the early, rough spells in your life.
@@ -50,24 +50,24 @@ SHEIAPOHRICHAMAHA_CLOSED_DIALOG = 4144; -- I'm a traveling merrrchant. There arr
              ZOREEN_OPEN_DIALOG = 4145; -- Buy somethin' from Valdeaunia...?
            ZOREEN_CLOSED_DIALOG = 4146; -- Valdeaunia...
 
-      KHEL_PAHLHAMA_SHOP_DIALOG = 11197; -- These magic shells are full of mysteries...
-               RYAN_SHOP_DIALOG = 11817; -- I have no time for white-livered scum that rely on magic alone.
-             DROZGA_SHOP_DIALOG = 11818; -- Not only is Ryan a boorish lout, but his craftsmanship leaves much to be desired, as well. You're better off buyin' from me.
+      KHEL_PAHLHAMA_SHOP_DIALOG = 11198; -- These magic shells are full of mysteries...
+               RYAN_SHOP_DIALOG = 11819; -- I have no time for white-livered scum that rely on magic alone.
+             DROZGA_SHOP_DIALOG = 11820; -- Not only is Ryan a boorish lout, but his craftsmanship leaves much to be desired, as well. You're better off buyin' from me.
 
-           LEBONDUR_OPEN_DIALOG = 12538; -- I've risked my life traveling all the way from Vollbow to bring you these fine goods!
-         LEBONDUR_CLOSED_DIALOG = 12539; -- Where is my shipment from Vollbow? This is terrible for my image as a respected importer...
+           LEBONDUR_OPEN_DIALOG = 12540; -- I've risked my life traveling all the way from Vollbow to bring you these fine goods!
+         LEBONDUR_CLOSED_DIALOG = 12541; -- Where is my shipment from Vollbow? This is terrible for my image as a respected importer...
 
-   SATTSUHAHKANPARI_OPEN_DIALOG = 12540; -- You can look, but don't touch! And rememberrr, you break it, you bought it!
- SATTSUHAHKANPARI_CLOSED_DIALOG = 12541; -- You've heard of the Elshimo Uplands, haven't you? Well, if you'll hold on a minute, I'll have a shipment of goods coming in any time now.
+   SATTSUHAHKANPARI_OPEN_DIALOG = 12542; -- You can look, but don't touch! And rememberrr, you break it, you bought it!
+ SATTSUHAHKANPARI_CLOSED_DIALOG = 12543; -- You've heard of the Elshimo Uplands, haven't you? Well, if you'll hold on a minute, I'll have a shipment of goods coming in any time now.
 
-      KUCHAMALKOBHI_SHOP_DIALOG = 12686; -- How about a nice suit of adventurer-issue armorrr? Be careful though. We offer no rrrefunds!
+      KUCHAMALKOBHI_SHOP_DIALOG = 12688; -- How about a nice suit of adventurer-issue armorrr? Be careful though. We offer no rrrefunds!
 
-            ALIZABE_OPEN_DIALOG = 12866; -- Don't tell anybody, but I've managed to get my hands on some items from Tavnazia! Take a look!
-          ALIZABE_CLOSED_DIALOG = 12867; -- Pssst! Have you heard of Tavnazia? Boy, do they have some sweet items on those islands...
-      ALIZABE_COP_NOT_COMPLETED = 12868; -- It won't be long before I set up shop right here in this very place. And once I start, there won't be no stoppin' me!
+            ALIZABE_OPEN_DIALOG = 12868; -- Don't tell anybody, but I've managed to get my hands on some items from Tavnazia! Take a look!
+          ALIZABE_CLOSED_DIALOG = 12869; -- Pssst! Have you heard of Tavnazia? Boy, do they have some sweet items on those islands...
+      ALIZABE_COP_NOT_COMPLETED = 12870; -- It won't be long before I set up shop right here in this very place. And once I start, there won't be no stoppin' me!
 
 -- conquest Base
 CONQUEST_BASE = 4424;
 
 -- Porter Moogle
-            RETRIEVE_DIALOG_ID = 15867; -- You retrieve$ from the porter moogle's care.
+            RETRIEVE_DIALOG_ID = 15869; -- You retrieve$ from the porter moogle's care.

--- a/scripts/zones/Promyvion-Dem/TextIDs.lua
+++ b/scripts/zones/Promyvion-Dem/TextIDs.lua
@@ -2,6 +2,6 @@
 
 -- General Texts
 ITEM_CANNOT_BE_OBTAINED = 6379; -- You cannot obtain the item <item> come back again after sorting your inventory
-          ITEM_OBTAINED = 6384; -- Obtained: <item>
-           GIL_OBTAINED = 6385; -- Obtained <number> gil
-       KEYITEM_OBTAINED = 6387; -- Obtained key item: <keyitem>
+          ITEM_OBTAINED = 6385; -- Obtained: <item>
+           GIL_OBTAINED = 6386; -- Obtained <number> gil
+       KEYITEM_OBTAINED = 6388; -- Obtained key item: <keyitem>

--- a/scripts/zones/Promyvion-Holla/TextIDs.lua
+++ b/scripts/zones/Promyvion-Holla/TextIDs.lua
@@ -2,9 +2,9 @@
 
 -- General Texts
 ITEM_CANNOT_BE_OBTAINED = 6379; -- You cannot obtain the item <item> come back again after sorting your inventory
-          ITEM_OBTAINED = 6384; -- Obtained: <item>
-           GIL_OBTAINED = 6385; -- Obtained <number> gil
-       KEYITEM_OBTAINED = 6387; -- Obtained key item: <keyitem>
+          ITEM_OBTAINED = 6385; -- Obtained: <item>
+           GIL_OBTAINED = 6386; -- Obtained <number> gil
+       KEYITEM_OBTAINED = 6388; -- Obtained key item: <keyitem>
 
-NOTHING_OUT_OF_ORDINARY = 6398; -- There is nothing out of the ordinary here.
+NOTHING_OUT_OF_ORDINARY = 6399; -- There is nothing out of the ordinary here.
         NOTHING_HAPPENS = 119;  -- Nothing happens.

--- a/scripts/zones/Promyvion-Mea/TextIDs.lua
+++ b/scripts/zones/Promyvion-Mea/TextIDs.lua
@@ -2,6 +2,6 @@
 
 -- General Texts
 ITEM_CANNOT_BE_OBTAINED = 6379; -- You cannot obtain the item <item> come back again after sorting your inventory
-          ITEM_OBTAINED = 6384; -- Obtained: <item>
-           GIL_OBTAINED = 6385; -- Obtained <number> gil
-       KEYITEM_OBTAINED = 6387; -- Obtained key item: <keyitem>
+          ITEM_OBTAINED = 6385; -- Obtained: <item>
+           GIL_OBTAINED = 6386; -- Obtained <number> gil
+       KEYITEM_OBTAINED = 6388; -- Obtained key item: <keyitem>

--- a/scripts/zones/Promyvion-Vahzl/TextIDs.lua
+++ b/scripts/zones/Promyvion-Vahzl/TextIDs.lua
@@ -2,13 +2,13 @@
 
 -- General Texts
 ITEM_CANNOT_BE_OBTAINED = 6379; -- You cannot obtain the item <item> come back again after sorting your inventory
-          ITEM_OBTAINED = 6384; -- Obtained: <item>
-           GIL_OBTAINED = 6385; -- Obtained <number> gil
-       KEYITEM_OBTAINED = 6387; -- Obtained key item: <keyitem>
+          ITEM_OBTAINED = 6385; -- Obtained: <item>
+           GIL_OBTAINED = 6386; -- Obtained <number> gil
+       KEYITEM_OBTAINED = 6388; -- Obtained key item: <keyitem>
 
 -- Other
-OVERFLOWING_MEMORIES = 7207; -- It appears to be a barrier woven from the energy of overflowing memories...
+OVERFLOWING_MEMORIES = 7208; -- It appears to be a barrier woven from the energy of overflowing memories...
 
 -- Popped NM Spawns
-     ON_NM_SPAWN = 7211; -- You sense a dark, empty presence...
-    POPPED_NM_OFFSET = 7293; -- Remnants of a
+     ON_NM_SPAWN = 7212; -- You sense a dark, empty presence...
+    POPPED_NM_OFFSET = 7294; -- Remnants of a

--- a/scripts/zones/Provenance/TextIDs.lua
+++ b/scripts/zones/Provenance/TextIDs.lua
@@ -2,6 +2,6 @@
 
 -- General Texts
 ITEM_CANNOT_BE_OBTAINED = 6379; -- You cannot obtain the item <item> come back again after sorting your inventory
-          ITEM_OBTAINED = 6384; -- Obtained: <item>
-           GIL_OBTAINED = 6385; -- Obtained <number> gil
-       KEYITEM_OBTAINED = 6387; -- Obtained key item: <keyitem>
+          ITEM_OBTAINED = 6385; -- Obtained: <item>
+           GIL_OBTAINED = 6386; -- Obtained <number> gil
+       KEYITEM_OBTAINED = 6388; -- Obtained key item: <keyitem>

--- a/scripts/zones/PsoXja/TextIDs.lua
+++ b/scripts/zones/PsoXja/TextIDs.lua
@@ -2,33 +2,33 @@
 
 -- General Texts
 ITEM_CANNOT_BE_OBTAINED = 6379; -- You cannot obtain the item <item> come back again after sorting your inventory
-          ITEM_OBTAINED = 6384; -- Obtained: <item>
-           GIL_OBTAINED = 6385; -- Obtained <number> gil
-       KEYITEM_OBTAINED = 6387; -- Obtained key item: <keyitem>
-NOTHING_OUT_OF_ORDINARY = 6398; -- There is nothing out of the ordinary here.
-    DEVICE_IN_OPERATION = 7226; -- The device appears to be in operation...
-            DOOR_LOCKED = 7229; -- The door is locked.
-         ARCH_GLOW_BLUE = 7230; -- The arch above the door is glowing blue...
-        ARCH_GLOW_GREEN = 7231; -- The arch above the door is glowing green...
-       CANNOT_OPEN_SIDE = 7234; -- The door cannot be opened from this side.
-         TRAP_ACTIVATED = 7236; -- A trap connected to it has been activated!
-             TRAP_FAILS = 7237; -- The trap connected to it fails to activate.
-   DISCOVER_DISARM_FAIL = 7238; -- discovers a trap connected to the door, but fails to disarm it!
-DISCOVER_DISARM_SUCCESS = 7239; -- discovers a trap connected to the door and succeeds in disarming it!
-          HOMEPOINT_SET = 7471; -- Home point set!
+          ITEM_OBTAINED = 6385; -- Obtained: <item>
+           GIL_OBTAINED = 6386; -- Obtained <number> gil
+       KEYITEM_OBTAINED = 6388; -- Obtained key item: <keyitem>
+NOTHING_OUT_OF_ORDINARY = 6399; -- There is nothing out of the ordinary here.
+    DEVICE_IN_OPERATION = 7227; -- The device appears to be in operation...
+            DOOR_LOCKED = 7230; -- The door is locked.
+         ARCH_GLOW_BLUE = 7231; -- The arch above the door is glowing blue...
+        ARCH_GLOW_GREEN = 7232; -- The arch above the door is glowing green...
+       CANNOT_OPEN_SIDE = 7235; -- The door cannot be opened from this side.
+         TRAP_ACTIVATED = 7237; -- A trap connected to it has been activated!
+             TRAP_FAILS = 7238; -- The trap connected to it fails to activate.
+   DISCOVER_DISARM_FAIL = 7239; -- discovers a trap connected to the door, but fails to disarm it!
+DISCOVER_DISARM_SUCCESS = 7240; -- discovers a trap connected to the door and succeeds in disarming it!
+          HOMEPOINT_SET = 7472; -- Home point set!
 
 -- Treasure Coffer/Chest Dialog
-CHEST_UNLOCKED = 7458; -- You unlock the chest!
-    CHEST_FAIL = 7459; -- Fails to open the chest.
-    CHEST_TRAP = 7460; -- The chest was trapped!
-    CHEST_WEAK = 7461; -- You cannot open the chest when you are in a weakened state.
-   CHEST_MIMIC = 7462; -- The chest was a mimic!
-  CHEST_MOOGLE = 7463; -- You cannot open the chest while participating in the moogle event.
-CHEST_ILLUSION = 7464; -- The chest was but an illusion...
-  CHEST_LOCKED = 7465; -- The chest appears to be locked.
+CHEST_UNLOCKED = 7459; -- You unlock the chest!
+    CHEST_FAIL = 7460; -- Fails to open the chest.
+    CHEST_TRAP = 7461; -- The chest was trapped!
+    CHEST_WEAK = 7462; -- You cannot open the chest when you are in a weakened state.
+   CHEST_MIMIC = 7463; -- The chest was a mimic!
+  CHEST_MOOGLE = 7464; -- You cannot open the chest while participating in the moogle event.
+CHEST_ILLUSION = 7465; -- The chest was but an illusion...
+  CHEST_LOCKED = 7466; -- The chest appears to be locked.
 
 -- Other
-BROKEN_KNIFE = 7466; -- A broken knife blade can be seen among the rubble...
+BROKEN_KNIFE = 7467; -- A broken knife blade can be seen among the rubble...
 
 -- conquest Base
-CONQUEST_BASE = 7067; -- Tallying conquest results...
+CONQUEST_BASE = 7068; -- Tallying conquest results...

--- a/scripts/zones/QuBia_Arena/TextIDs.lua
+++ b/scripts/zones/QuBia_Arena/TextIDs.lua
@@ -2,26 +2,26 @@
 
 -- General Texts
 ITEM_CANNOT_BE_OBTAINED = 6379; -- You cannot obtain the item <item>. Come back after sorting your inventory.
-          ITEM_OBTAINED = 6384; -- Obtained: <item>.
-           GIL_OBTAINED = 6385; -- Obtained <number> gil.
-       KEYITEM_OBTAINED = 6387; -- Obtained key item: <keyitem>.
+          ITEM_OBTAINED = 6385; -- Obtained: <item>.
+           GIL_OBTAINED = 6386; -- Obtained <number> gil.
+       KEYITEM_OBTAINED = 6388; -- Obtained key item: <keyitem>.
 
 -- Maat dialog
-      YOU_DECIDED_TO_SHOW_UP = 7623; -- So, you decided to show up.
- LOOKS_LIKE_YOU_WERENT_READY = 7624; -- Looks like you weren't ready for me, were you?
-       YOUVE_COME_A_LONG_WAY = 7625; -- Hm. That was a mighty fine display of skill there, Player Name. You've come a long way...
- TEACH_YOU_TO_RESPECT_ELDERS = 7626; -- I'll teach you to respect your elders!
-TAKE_THAT_YOU_WHIPPERSNAPPER = 7627; -- Take that, you whippersnapper!
- THAT_LL_HURT_IN_THE_MORNING = 7629; -- Ungh... That'll hurt in the morning...
+      YOU_DECIDED_TO_SHOW_UP = 7624; -- So, you decided to show up.
+ LOOKS_LIKE_YOU_WERENT_READY = 7625; -- Looks like you weren't ready for me, were you?
+       YOUVE_COME_A_LONG_WAY = 7626; -- Hm. That was a mighty fine display of skill there, Player Name. You've come a long way...
+ TEACH_YOU_TO_RESPECT_ELDERS = 7627; -- I'll teach you to respect your elders!
+TAKE_THAT_YOU_WHIPPERSNAPPER = 7628; -- Take that, you whippersnapper!
+ THAT_LL_HURT_IN_THE_MORNING = 7630; -- Ungh... That'll hurt in the morning...
 
 -- trion dialog
-FLAT_PREPARE = 7617; -- I am Trion, of San d'Oria
-FLAT_LAND = 7618; -- Feel the fire of my forefathers
-RLB_PREPARE = 7619; -- The darkness before me that shrouds the light of good...
-RLB_LAND = 7620; -- ...Return to the hell you crawled out from
-SAVAGE_PREPARE = 7621; -- The anger, the pain, and the will to survive... Let the spirit of San d'Oria converge within this blade
-SAVAGE_LAND = 7622; -- And with this blade I will return the glory to my kingdom's people
+FLAT_PREPARE = 7618; -- I am Trion, of San d'Oria
+FLAT_LAND = 7619; -- Feel the fire of my forefathers
+RLB_PREPARE = 7620; -- The darkness before me that shrouds the light of good...
+RLB_LAND = 7621; -- ...Return to the hell you crawled out from
+SAVAGE_PREPARE = 7622; -- The anger, the pain, and the will to survive... Let the spirit of San d'Oria converge within this blade
+SAVAGE_LAND = 7623; -- And with this blade I will return the glory to my kingdom's people
 
 
 -- conquest Base
-CONQUEST_BASE = 7045; -- Tallying conquest results...
+CONQUEST_BASE = 7046; -- Tallying conquest results...

--- a/scripts/zones/Qufim_Island/TextIDs.lua
+++ b/scripts/zones/Qufim_Island/TextIDs.lua
@@ -2,30 +2,30 @@
 
 -- General Texts
 ITEM_CANNOT_BE_OBTAINED = 6379; -- You cannot obtain the item <item>. Come back after sorting your inventory.
-          ITEM_OBTAINED = 6384; -- Obtained: <item>.
-           GIL_OBTAINED = 6385; -- Obtained <number> gil.
-       KEYITEM_OBTAINED = 6387; -- Obtained key item: <keyitem>.
-        BEASTMEN_BANNER = 7126; -- There is a beastmen's banner.
- FISHING_MESSAGE_OFFSET = 7204; -- You can't fish here.
-HOMEPOINT_SET = 12688; -- Home point set!
+          ITEM_OBTAINED = 6385; -- Obtained: <item>.
+           GIL_OBTAINED = 6386; -- Obtained <number> gil.
+       KEYITEM_OBTAINED = 6388; -- Obtained key item: <keyitem>.
+        BEASTMEN_BANNER = 7127; -- There is a beastmen's banner.
+ FISHING_MESSAGE_OFFSET = 7205; -- You can't fish here.
+HOMEPOINT_SET = 12689; -- Home point set!
 
 
 -- Conquest
-CONQUEST = 7373; -- You've earned conquest points!
+CONQUEST = 7374; -- You've earned conquest points!
 
 -- Quest dialog
-   THESE_WITHERED_FLOWERS = 7324; -- These withered flowers seem unable to bloom.
-NOW_THAT_NIGHT_HAS_FALLEN = 7325; -- Now that night has fallen, the flowers bloom with a strange glow.
+   THESE_WITHERED_FLOWERS = 7325; -- These withered flowers seem unable to bloom.
+NOW_THAT_NIGHT_HAS_FALLEN = 7326; -- Now that night has fallen, the flowers bloom with a strange glow.
 
 -- Other Dialog
-        AN_EMPTY_LIGHT_SWIRLS =  7732; -- An empty light swirls about the cave, eating away at the surroundings...
+        AN_EMPTY_LIGHT_SWIRLS =  7733; -- An empty light swirls about the cave, eating away at the surroundings...
 
-      YOU_CANNOT_ENTER_DYNAMIS = 7842; -- You cannot enter Dynamis
-PLAYERS_HAVE_NOT_REACHED_LEVEL = 7844; -- Players who have not reached levelare prohibited from entering Dynamis.
-              MYSTERIOUS_VOICE = 7830; -- You hear a mysterious, floating voice: Bring forth the
+      YOU_CANNOT_ENTER_DYNAMIS = 7843; -- You cannot enter Dynamis
+PLAYERS_HAVE_NOT_REACHED_LEVEL = 7845; -- Players who have not reached levelare prohibited from entering Dynamis.
+              MYSTERIOUS_VOICE = 7831; -- You hear a mysterious, floating voice: Bring forth the
 
-            GIGANTIC_FOOTPRINT = 7816; -- There is a gigantic footprint here.
+            GIGANTIC_FOOTPRINT = 7817; -- There is a gigantic footprint here.
 
 
 -- conquest Base
-CONQUEST_BASE = 7045; -- Tallying conquest results...
+CONQUEST_BASE = 7046; -- Tallying conquest results...

--- a/scripts/zones/Quicksand_Caves/TextIDs.lua
+++ b/scripts/zones/Quicksand_Caves/TextIDs.lua
@@ -2,29 +2,29 @@
 
 -- General Texts
 ITEM_CANNOT_BE_OBTAINED = 6379; -- You cannot obtain the item <item> come back again after sorting your inventory
-          ITEM_OBTAINED = 6384; -- Obtained: <item>
-           GIL_OBTAINED = 6385; -- Obtained <number> gil
-       KEYITEM_OBTAINED = 6387; -- Obtained key item: <keyitem>
- FISHING_MESSAGE_OFFSET = 7204; -- You can't fish here.
-            HOMEPOINT_SET = 11419; -- Home point set!
+          ITEM_OBTAINED = 6385; -- Obtained: <item>
+           GIL_OBTAINED = 6386; -- Obtained <number> gil
+       KEYITEM_OBTAINED = 6388; -- Obtained key item: <keyitem>
+ FISHING_MESSAGE_OFFSET = 7205; -- You can't fish here.
+            HOMEPOINT_SET = 11420; -- Home point set!
 
 -- Treasure Coffer/Chest Dialog
-CHEST_UNLOCKED = 7311; -- You unlock the chest!
-    CHEST_FAIL = 7312; -- Fails to open the chest.
-    CHEST_TRAP = 7313; -- The chest was trapped!
-    CHEST_WEAK = 7314; -- You cannot open the chest when you are in a weakened state.
-   CHEST_MIMIC = 7315; -- The chest was a mimic!
-  CHEST_MOOGLE = 7316; -- You cannot open the chest while participating in the moogle event.
-CHEST_ILLUSION = 7317; -- The chest was but an illusion...
-  CHEST_LOCKED = 7318; -- The chest appears to be locked.
+CHEST_UNLOCKED = 7312; -- You unlock the chest!
+    CHEST_FAIL = 7313; -- Fails to open the chest.
+    CHEST_TRAP = 7314; -- The chest was trapped!
+    CHEST_WEAK = 7315; -- You cannot open the chest when you are in a weakened state.
+   CHEST_MIMIC = 7316; -- The chest was a mimic!
+  CHEST_MOOGLE = 7317; -- You cannot open the chest while participating in the moogle event.
+CHEST_ILLUSION = 7318; -- The chest was but an illusion...
+  CHEST_LOCKED = 7319; -- The chest appears to be locked.
 
 -- Other dialog
-NOTHING_OUT_OF_ORDINARY = 6398; -- There is nothing out of the ordinary here.
-    SENSE_OF_FOREBODING = 6399; -- You are suddenly overcome with a sense of foreboding...
-       DOOR_FIRMLY_SHUT = 7319; -- The door is firmly shut.
-          POOL_OF_WATER = 7351; -- It is a pool of water.
-       YOU_FIND_NOTHING = 7354; -- You find nothing.
-    SOMETHING_IS_BURIED = 7359; -- Something is buried in this fallen pillar.
+NOTHING_OUT_OF_ORDINARY = 6399; -- There is nothing out of the ordinary here.
+    SENSE_OF_FOREBODING = 6400; -- You are suddenly overcome with a sense of foreboding...
+       DOOR_FIRMLY_SHUT = 7320; -- The door is firmly shut.
+          POOL_OF_WATER = 7352; -- It is a pool of water.
+       YOU_FIND_NOTHING = 7355; -- You find nothing.
+    SOMETHING_IS_BURIED = 7360; -- Something is buried in this fallen pillar.
 
 -- conquest Base
-CONQUEST_BASE = 7045; -- Tallying conquest results...
+CONQUEST_BASE = 7046; -- Tallying conquest results...

--- a/scripts/zones/Qulun_Dome/TextIDs.lua
+++ b/scripts/zones/Qulun_Dome/TextIDs.lua
@@ -2,24 +2,24 @@
 
 -- General Texts
 ITEM_CANNOT_BE_OBTAINED = 6379; -- You cannot obtain the item <item> come back again after sorting your inventory
-          ITEM_OBTAINED = 6384; -- Obtained: <item>
-           GIL_OBTAINED = 6385; -- Obtained <number> gil
-       KEYITEM_OBTAINED = 6387; -- Obtained key item: <keyitem>
+          ITEM_OBTAINED = 6385; -- Obtained: <item>
+           GIL_OBTAINED = 6386; -- Obtained <number> gil
+       KEYITEM_OBTAINED = 6388; -- Obtained key item: <keyitem>
 
 -- Other Dialog
-                NOTHING_OUT_OF_ORDINARY = 6398; -- There is nothing out of the ordinary here.
-                       YOU_FIND_NOTHING = 7248; -- You find nothing.
+                NOTHING_OUT_OF_ORDINARY = 6399; -- There is nothing out of the ordinary here.
+                       YOU_FIND_NOTHING = 7249; -- You find nothing.
 
-IT_SEEMS_TO_BE_LOCKED_BY_POWERFUL_MAGIC = 7204; -- A door... It seems to be locked by powerful magic.
-               THE_3_ITEMS_GLOW_FAINTLY = 7205; -- glow faintly
-           THE_MAGICITE_GLOWS_OMINOUSLY = 7247; -- The magicite glows ominously.
-        CANNOT_BE_OPENED_FROM_THIS_SIDE = 7209; -- It cannot be opened from this side!
+IT_SEEMS_TO_BE_LOCKED_BY_POWERFUL_MAGIC = 7205; -- A door... It seems to be locked by powerful magic.
+               THE_3_ITEMS_GLOW_FAINTLY = 7206; -- glow faintly
+           THE_MAGICITE_GLOWS_OMINOUSLY = 7248; -- The magicite glows ominously.
+        CANNOT_BE_OPENED_FROM_THIS_SIDE = 7210; -- It cannot be opened from this side!
 
-DIAMOND_QUADAV_ENGAGE = 7249; -- Gwa-ha-ha, puny peoples! Ou-ur king never forge-ets a gru-udge. He'll gri-ind you into pa-aste!
- DIAMOND_QUADAV_DEATH = 7250; -- Glo-ory to the Adamantking!
-   QUADAV_KING_ENGAGE = 7251; -- Childre-en of Altana? I will ba-athe in your blood as I did at the Ba-attle of Jeuno!
-    QUADAV_KING_DEATH = 7252; -- I a-am fini-ished. Hear me, wa-arriors of the Quadav! The throne of the Adamantking and the line of Za'Dha pa-asses to my bro-other...
+DIAMOND_QUADAV_ENGAGE = 7250; -- Gwa-ha-ha, puny peoples! Ou-ur king never forge-ets a gru-udge. He'll gri-ind you into pa-aste!
+ DIAMOND_QUADAV_DEATH = 7251; -- Glo-ory to the Adamantking!
+   QUADAV_KING_ENGAGE = 7252; -- Childre-en of Altana? I will ba-athe in your blood as I did at the Ba-attle of Jeuno!
+    QUADAV_KING_DEATH = 7253; -- I a-am fini-ished. Hear me, wa-arriors of the Quadav! The throne of the Adamantking and the line of Za'Dha pa-asses to my bro-other...
 
 -- conquest Base
-CONQUEST_BASE = 7045; -- Tallying conquest results...
+CONQUEST_BASE = 7046; -- Tallying conquest results...
 

--- a/scripts/zones/RaKaznar_Inner_Court/TextIDs.lua
+++ b/scripts/zones/RaKaznar_Inner_Court/TextIDs.lua
@@ -2,7 +2,7 @@
 
 -- General Texts
 ITEM_CANNOT_BE_OBTAINED = 6379; -- You cannot obtain the item <item> come back again after sorting your inventory
-          ITEM_OBTAINED = 6384; -- Obtained: <item>
-           GIL_OBTAINED = 6385; -- Obtained <number> gil
-       KEYITEM_OBTAINED = 6387; -- Obtained key item: <keyitem>
-       HOMEPOINT_SET = 7678; -- Home point set!
+          ITEM_OBTAINED = 6385; -- Obtained: <item>
+           GIL_OBTAINED = 6386; -- Obtained <number> gil
+       KEYITEM_OBTAINED = 6388; -- Obtained key item: <keyitem>
+       HOMEPOINT_SET = 7679; -- Home point set!

--- a/scripts/zones/RaKaznar_Turris/TextIDs.lua
+++ b/scripts/zones/RaKaznar_Turris/TextIDs.lua
@@ -2,6 +2,6 @@
 
 -- General Texts
 ITEM_CANNOT_BE_OBTAINED = 6379; -- You cannot obtain the item <item> come back again after sorting your inventory
-          ITEM_OBTAINED = 6384; -- Obtained: <item>
-           GIL_OBTAINED = 6385; -- Obtained <number> gil
-       KEYITEM_OBTAINED = 6387; -- Obtained key item: <keyitem>
+          ITEM_OBTAINED = 6385; -- Obtained: <item>
+           GIL_OBTAINED = 6386; -- Obtained <number> gil
+       KEYITEM_OBTAINED = 6388; -- Obtained key item: <keyitem>

--- a/scripts/zones/Rabao/TextIDs.lua
+++ b/scripts/zones/Rabao/TextIDs.lua
@@ -2,30 +2,30 @@
 
 -- General Texts
 ITEM_CANNOT_BE_OBTAINED = 6401; -- You cannot obtain the item <item> come back again after sorting your inventory
-          ITEM_OBTAINED = 6406;  -- Obtained: <item>
-           GIL_OBTAINED = 6407;  -- Obtained <number> gil
-       KEYITEM_OBTAINED = 6409;  -- Obtained key item: <keyitem>
-    NOT_HAVE_ENOUGH_GIL = 6411;  -- You do not have enough gil.
+          ITEM_OBTAINED = 6407;  -- Obtained: <item>
+           GIL_OBTAINED = 6408;  -- Obtained <number> gil
+       KEYITEM_OBTAINED = 6410;  -- Obtained key item: <keyitem>
+    NOT_HAVE_ENOUGH_GIL = 6412;  -- You do not have enough gil.
           HOMEPOINT_SET = 2;     -- Home point set!
- FISHING_MESSAGE_OFFSET = 6654;  -- You can't fish here.
+ FISHING_MESSAGE_OFFSET = 6655;  -- You can't fish here.
 
  -- Other Texts
- PAKHI_DELIVERY_DIALOG = 10022; -- When your pack is fit to burrrst, send your non-essential items to your delivery box and bam, prrroblem solved!
-SPIRIT_DELIVERY_DIALOG = 10023; -- We can deliver goods to your residence or to the residences of your friends
+ PAKHI_DELIVERY_DIALOG = 10023; -- When your pack is fit to burrrst, send your non-essential items to your delivery box and bam, prrroblem solved!
+SPIRIT_DELIVERY_DIALOG = 10024; -- We can deliver goods to your residence or to the residences of your friends
 
 -- Quest Dialog
-    GARUDA_UNLOCKED = 10107; -- You are now able to summon
-NOMAD_MOOGLE_DIALOG = 10175; -- I'm a traveling moogle, kupo. I help adventurers in the Outlands access items they have stored in a Mog House elsewhere, kupo.
+    GARUDA_UNLOCKED = 10108; -- You are now able to summon
+NOMAD_MOOGLE_DIALOG = 10176; -- I'm a traveling moogle, kupo. I help adventurers in the Outlands access items they have stored in a Mog House elsewhere, kupo.
 
 -- Shop Texts
-SHINY_TEETH_SHOP_DIALOG = 10027;  -- Well met, adventurer. If you're looking for a weapon to carve through those desert beasts, you've come to the right place.
-  BRAVEWOLF_SHOP_DIALOG = 10028;  -- For rainy days and windy days, or for days when someone tries to thrust a spear in your guts, having a good set of armor can set your mind at ease.
-    BRAVEOX_SHOP_DIALOG = 10029;  -- These days, you can get weapons and armor cheap at the auction houses. But magic is expensive no matter where you go.
-   SCAMPLIX_SHOP_DIALOG = 10030;  -- No problem, Scamplix not bad guy. Scamplix is good guy, sells stuff to adventurers. Scamplix got lots of good stuff for you.
-   GENEROIT_SHOP_DIALOG = 10293; -- Ho there! I am called Generoit. I have everything here for the chocobo enthusiast, and other rare items galore.
+SHINY_TEETH_SHOP_DIALOG = 10028;  -- Well met, adventurer. If you're looking for a weapon to carve through those desert beasts, you've come to the right place.
+  BRAVEWOLF_SHOP_DIALOG = 10029;  -- For rainy days and windy days, or for days when someone tries to thrust a spear in your guts, having a good set of armor can set your mind at ease.
+    BRAVEOX_SHOP_DIALOG = 10030;  -- These days, you can get weapons and armor cheap at the auction houses. But magic is expensive no matter where you go.
+   SCAMPLIX_SHOP_DIALOG = 10031;  -- No problem, Scamplix not bad guy. Scamplix is good guy, sells stuff to adventurers. Scamplix got lots of good stuff for you.
+   GENEROIT_SHOP_DIALOG = 10294; -- Ho there! I am called Generoit. I have everything here for the chocobo enthusiast, and other rare items galore.
 
 -- conquest Base
-CONQUEST_BASE = 6495; -- Tallying conquest results...
+CONQUEST_BASE = 6496; -- Tallying conquest results...
 
 -- Porter Moogle
-    RETRIEVE_DIALOG_ID = 10749; -- You retrieve$ from the porter moogle's care.
+    RETRIEVE_DIALOG_ID = 10750; -- You retrieve$ from the porter moogle's care.

--- a/scripts/zones/Rala_Waterways/TextIDs.lua
+++ b/scripts/zones/Rala_Waterways/TextIDs.lua
@@ -2,6 +2,6 @@
 
 -- General Texts
 ITEM_CANNOT_BE_OBTAINED = 6379; -- You cannot obtain the item <item> come back again after sorting your inventory
-          ITEM_OBTAINED = 6384; -- Obtained: <item>
-           GIL_OBTAINED = 6385; -- Obtained <number> gil
-       KEYITEM_OBTAINED = 6387; -- Obtained key item: <keyitem>
+          ITEM_OBTAINED = 6385; -- Obtained: <item>
+           GIL_OBTAINED = 6386; -- Obtained <number> gil
+       KEYITEM_OBTAINED = 6388; -- Obtained key item: <keyitem>

--- a/scripts/zones/Rala_Waterways_U/TextIDs.lua
+++ b/scripts/zones/Rala_Waterways_U/TextIDs.lua
@@ -2,6 +2,6 @@
 
 -- General Texts
 ITEM_CANNOT_BE_OBTAINED = 6379; -- You cannot obtain the item <item> come back again after sorting your inventory
-          ITEM_OBTAINED = 6384; -- Obtained: <item>
-           GIL_OBTAINED = 6385; -- Obtained <number> gil
-       KEYITEM_OBTAINED = 6387; -- Obtained key item: <keyitem>
+          ITEM_OBTAINED = 6385; -- Obtained: <item>
+           GIL_OBTAINED = 6386; -- Obtained <number> gil
+       KEYITEM_OBTAINED = 6388; -- Obtained key item: <keyitem>

--- a/scripts/zones/Ranguemont_Pass/TextIDs.lua
+++ b/scripts/zones/Ranguemont_Pass/TextIDs.lua
@@ -2,15 +2,15 @@
 
 -- General Texts
 ITEM_CANNOT_BE_OBTAINED = 6379; -- You cannot obtain the item <item>. Come back after sorting your inventory.
-          ITEM_OBTAINED = 6384; -- Obtained: <item>.
-           GIL_OBTAINED = 6385; -- Obtained <number> gil.
-       KEYITEM_OBTAINED = 6387; -- Obtained key item: <keyitem>.
- FISHING_MESSAGE_OFFSET = 7204; -- You can't fish here.
+          ITEM_OBTAINED = 6385; -- Obtained: <item>.
+           GIL_OBTAINED = 6386; -- Obtained <number> gil.
+       KEYITEM_OBTAINED = 6388; -- Obtained key item: <keyitem>.
+ FISHING_MESSAGE_OFFSET = 7205; -- You can't fish here.
 
-    SENSE_OF_FOREBODING = 6399; -- You are suddenly overcome with a sense of foreboding...
+    SENSE_OF_FOREBODING = 6400; -- You are suddenly overcome with a sense of foreboding...
 
 -- Quest : "Painful Memory"
-NOTHING_OUT_OF_ORDINARY = 6398; -- There is nothing out of the ordinary here.
+NOTHING_OUT_OF_ORDINARY = 6399; -- There is nothing out of the ordinary here.
 
 -- conquest Base
-CONQUEST_BASE = 7045; -- Tallying conquest results...
+CONQUEST_BASE = 7046; -- Tallying conquest results...

--- a/scripts/zones/Riverne-Site_A01/TextIDs.lua
+++ b/scripts/zones/Riverne-Site_A01/TextIDs.lua
@@ -2,18 +2,18 @@
 
 -- General Texts
 ITEM_CANNOT_BE_OBTAINED = 6379; -- You cannot obtain the item <item> come back again after sorting your inventory
-          ITEM_OBTAINED = 6384; -- Obtained: <item>
-           GIL_OBTAINED = 6385; -- Obtained <number> gil
-       KEYITEM_OBTAINED = 6387; -- Obtained key item: <keyitem>
-            HOMEPOINT_SET = 7719; -- Home point set!
+          ITEM_OBTAINED = 6385; -- Obtained: <item>
+           GIL_OBTAINED = 6386; -- Obtained <number> gil
+       KEYITEM_OBTAINED = 6388; -- Obtained key item: <keyitem>
+            HOMEPOINT_SET = 7720; -- Home point set!
 
 -- Other dialogs
-        SD_VERY_SMALL = 7582; -- The spatial displacement is very small.
-         SD_HAS_GROWN = 7583; -- The spatial displacement has grown.
-SPACE_SEEMS_DISTORTED = 7584; -- The space around you seems oddly distorted and disrupted.
-             MONUMENT = 7591; -- Something has been engraved on this stone, but the message is too difficult to make out.
+        SD_VERY_SMALL = 7583; -- The spatial displacement is very small.
+         SD_HAS_GROWN = 7584; -- The spatial displacement has grown.
+SPACE_SEEMS_DISTORTED = 7585; -- The space around you seems oddly distorted and disrupted.
+             MONUMENT = 7592; -- Something has been engraved on this stone, but the message is too difficult to make out.
 
 NOTHING_OUT_OF_ORDINARY = 7595 -- There is nothing out of the ordinary here.
 
 -- conquest Base
-CONQUEST_BASE = 7045; -- Tallying conquest results...
+CONQUEST_BASE = 7046; -- Tallying conquest results...

--- a/scripts/zones/Riverne-Site_B01/TextIDs.lua
+++ b/scripts/zones/Riverne-Site_B01/TextIDs.lua
@@ -2,21 +2,21 @@
 
 -- General Texts
 ITEM_CANNOT_BE_OBTAINED = 6379; -- You cannot obtain the item <item> come back again after sorting your inventory
-          ITEM_OBTAINED = 6384; -- Obtained: <item>
-           GIL_OBTAINED = 6385; -- Obtained <number> gil
-       KEYITEM_OBTAINED = 6387; -- Obtained key item: <keyitem>
-            HOMEPOINT_SET = 7694; -- Home point set!
+          ITEM_OBTAINED = 6385; -- Obtained: <item>
+           GIL_OBTAINED = 6386; -- Obtained <number> gil
+       KEYITEM_OBTAINED = 6388; -- Obtained key item: <keyitem>
+            HOMEPOINT_SET = 7695; -- Home point set!
 
 -- Other dialogs
-        SD_VERY_SMALL = 7580; -- The spatial displacement is very small.
-         SD_HAS_GROWN = 7581; -- The spatial displacement has grown.
-SPACE_SEEMS_DISTORTED = 7582; -- The space around you seems oddly distorted and disrupted.
-             MONUMENT = 7588; -- Something has been engraved on this stone, but the message is too difficult to make out.
-   GROUND_GIVING_HEAT = 7590; -- The ground here is giving off heat.
-        BAHAMUT_TAUNT = 7658; -- Children of Vana'diel, what do you think to accomplish by fighting for your lives?
+        SD_VERY_SMALL = 7581; -- The spatial displacement is very small.
+         SD_HAS_GROWN = 7582; -- The spatial displacement has grown.
+SPACE_SEEMS_DISTORTED = 7583; -- The space around you seems oddly distorted and disrupted.
+             MONUMENT = 7589; -- Something has been engraved on this stone, but the message is too difficult to make out.
+   GROUND_GIVING_HEAT = 7591; -- The ground here is giving off heat.
+        BAHAMUT_TAUNT = 7659; -- Children of Vana'diel, what do you think to accomplish by fighting for your lives?
                               -- You know your efforts are futile, yet still you resist... (+1/+2 for the next two taunts)
 
 NOTHING_OUT_OF_ORDINARY = 7555 -- There is nothing out of the ordinary here.
 
 -- conquest Base
-CONQUEST_BASE = 7045; -- Tallying conquest results...
+CONQUEST_BASE = 7046; -- Tallying conquest results...

--- a/scripts/zones/RoMaeve/TextIDs.lua
+++ b/scripts/zones/RoMaeve/TextIDs.lua
@@ -2,13 +2,13 @@
 
 -- General Texts
 ITEM_CANNOT_BE_OBTAINED = 6379; -- You cannot obtain the item <item> come back again after sorting your inventory
-          ITEM_OBTAINED = 6384; -- Obtained: <item>
-           GIL_OBTAINED = 6385; -- Obtained <number> gil
-       KEYITEM_OBTAINED = 6387; -- Obtained key item: <keyitem>
- FISHING_MESSAGE_OFFSET = 7204; -- You can't fish here
+          ITEM_OBTAINED = 6385; -- Obtained: <item>
+           GIL_OBTAINED = 6386; -- Obtained <number> gil
+       KEYITEM_OBTAINED = 6388; -- Obtained key item: <keyitem>
+ FISHING_MESSAGE_OFFSET = 7205; -- You can't fish here
 
 -- Other dialog
-NOTHING_OUT_OF_ORDINARY = 6398; -- There is nothing out of the ordinary here.
+NOTHING_OUT_OF_ORDINARY = 6399; -- There is nothing out of the ordinary here.
 
 -- conquest Base
-CONQUEST_BASE = 7045; -- Tallying conquest results...
+CONQUEST_BASE = 7046; -- Tallying conquest results...

--- a/scripts/zones/Rolanberry_Fields/TextIDs.lua
+++ b/scripts/zones/Rolanberry_Fields/TextIDs.lua
@@ -2,25 +2,25 @@
 
 -- General Texts
 ITEM_CANNOT_BE_OBTAINED = 6401; -- You cannot obtain the item <item>. Come back after sorting your inventory.
-          ITEM_OBTAINED = 6406; -- Obtained: <item>.
-           GIL_OBTAINED = 6407; -- Obtained <number> gil.
-         NOT_ENOUGH_GIL = 6411; -- You do not have enough gil.
-       KEYITEM_OBTAINED = 6409; -- Obtained key item: <keyitem>.
- FISHING_MESSAGE_OFFSET = 7226; -- You can't fish here.
+          ITEM_OBTAINED = 6407; -- Obtained: <item>.
+           GIL_OBTAINED = 6408; -- Obtained <number> gil.
+         NOT_ENOUGH_GIL = 6412; -- You do not have enough gil.
+       KEYITEM_OBTAINED = 6410; -- Obtained key item: <keyitem>.
+ FISHING_MESSAGE_OFFSET = 7227; -- You can't fish here.
 
 -- Other Dialog
 NOTHING_HAPPENS = 141; -- Nothing happens...
 
 -- Signs
-SIGN = 7396; -- North: Grand Duchy of Jeuno, Sauromugue Champaign South: Pashhow Marshlands
+SIGN = 7397; -- North: Grand Duchy of Jeuno, Sauromugue Champaign South: Pashhow Marshlands
 
 -- Conquest Base
-CONQUEST_BASE = 7067; -- Tallying conquest results...
+CONQUEST_BASE = 7068; -- Tallying conquest results...
 
 -- Legion
-AWAIT_YOUR_CHALLENGE = 12161; -- We await your challenge
-  LACK_LEGION_POINTS = 12198; -- It would seem that you lack the necessary amount of Legion points.
+AWAIT_YOUR_CHALLENGE = 12162; -- We await your challenge
+  LACK_LEGION_POINTS = 12199; -- It would seem that you lack the necessary amount of Legion points.
 
  -- chocobo digging
-DIG_THROW_AWAY = 7239; -- You dig up ?Possible Special Code: 01??Possible Special Code: 01??Possible Special Code: 01? ?Possible Special Code: 01??Possible Special Code: 05?$?BAD CHAR: 8280??BAD CHAR: 80??BAD CHAR: 80?, but your inventory is full.
-FIND_NOTHING = 7241; -- You dig and you dig, but find nothing.
+DIG_THROW_AWAY = 7240; -- You dig up ?Possible Special Code: 01??Possible Special Code: 01??Possible Special Code: 01? ?Possible Special Code: 01??Possible Special Code: 05?$?BAD CHAR: 8280??BAD CHAR: 80??BAD CHAR: 80?, but your inventory is full.
+FIND_NOTHING = 7242; -- You dig and you dig, but find nothing.

--- a/scripts/zones/Rolanberry_Fields_[S]/TextIDs.lua
+++ b/scripts/zones/Rolanberry_Fields_[S]/TextIDs.lua
@@ -2,7 +2,7 @@
 
 -- General Texts
 ITEM_CANNOT_BE_OBTAINED = 6379; -- You cannot obtain the item <item> come back again after sorting your inventory
-          ITEM_OBTAINED = 6384; -- Obtained: <item>
-           GIL_OBTAINED = 6385; -- Obtained <number> gil
-       KEYITEM_OBTAINED = 6387; -- Obtained key item: <keyitem>
- FISHING_MESSAGE_OFFSET = 7065; -- You can't fish here
+          ITEM_OBTAINED = 6385; -- Obtained: <item>
+           GIL_OBTAINED = 6386; -- Obtained <number> gil
+       KEYITEM_OBTAINED = 6388; -- Obtained key item: <keyitem>
+ FISHING_MESSAGE_OFFSET = 7066; -- You can't fish here

--- a/scripts/zones/RuAun_Gardens/TextIDs.lua
+++ b/scripts/zones/RuAun_Gardens/TextIDs.lua
@@ -3,31 +3,31 @@
 -- General Texts
    ITEM_CANNOT_BE_OBTAINED = 6379; -- You cannot obtain the item <item>. Come back after sorting your inventory.
 FULL_INVENTORY_AFTER_TRADE = 6383; -- You cannot obtain the <item>. Try trading again after sorting your inventory.
-             ITEM_OBTAINED = 6384; -- Obtained: <item>.
-              GIL_OBTAINED = 6385; -- Obtained <number> gil.
-          KEYITEM_OBTAINED = 6387; -- Obtained key item: <keyitem>.
-            ITEMS_OBTAINED = 6393; -- You obtain
-   NOTHING_OUT_OF_ORDINARY = 6398; -- There is nothing out of the ordinary here.
-    FISHING_MESSAGE_OFFSET = 7045; -- You can't fish here.
-            HOMEPOINT_SET = 11642; -- Home point set!
+             ITEM_OBTAINED = 6385; -- Obtained: <item>.
+              GIL_OBTAINED = 6386; -- Obtained <number> gil.
+          KEYITEM_OBTAINED = 6388; -- Obtained key item: <keyitem>.
+            ITEMS_OBTAINED = 6394; -- You obtain
+   NOTHING_OUT_OF_ORDINARY = 6399; -- There is nothing out of the ordinary here.
+    FISHING_MESSAGE_OFFSET = 7046; -- You can't fish here.
+            HOMEPOINT_SET = 11643; -- Home point set!
 
 -- Treasure Coffer/Chest Dialog
-CHEST_UNLOCKED = 7338; -- You unlock the chest!
-    CHEST_FAIL = 7339; -- Fails to open the chest.
-    CHEST_TRAP = 7340; -- The chest was trapped!
-    CHEST_WEAK = 7341; -- You cannot open the chest when you are in a weakened state.
-   CHEST_MIMIC = 7342; -- The chest was a mimic!
-  CHEST_MOOGLE = 7343; -- You cannot open the chest while participating in the moogle event.
-CHEST_ILLUSION = 7344; -- The chest was but an illusion...
-  CHEST_LOCKED = 7345; -- The chest appears to be locked.
+CHEST_UNLOCKED = 7339; -- You unlock the chest!
+    CHEST_FAIL = 7340; -- Fails to open the chest.
+    CHEST_TRAP = 7341; -- The chest was trapped!
+    CHEST_WEAK = 7342; -- You cannot open the chest when you are in a weakened state.
+   CHEST_MIMIC = 7343; -- The chest was a mimic!
+  CHEST_MOOGLE = 7344; -- You cannot open the chest while participating in the moogle event.
+CHEST_ILLUSION = 7345; -- The chest was but an illusion...
+  CHEST_LOCKED = 7346; -- The chest appears to be locked.
 
 -- Other dialog
-IT_IS_ALREADY_FUNCTIONING = 7305; -- It is already functioning.
-           SKY_GOD_OFFSET = 7355; -- A strange insignia pointing north is carved into the wall.
-         SKY_GOD_OFFSET_2 = 7356; -- A strange insignia pointing east is carved into the wall.
-         SKY_GOD_OFFSET_3 = 7357; -- A strange insignia pointing west is carved into the wall.
-         SKY_GOD_OFFSET_4 = 7358; -- A strange insignia pointing south is carved into the wall.
+IT_IS_ALREADY_FUNCTIONING = 7306; -- It is already functioning.
+           SKY_GOD_OFFSET = 7356; -- A strange insignia pointing north is carved into the wall.
+         SKY_GOD_OFFSET_2 = 7357; -- A strange insignia pointing east is carved into the wall.
+         SKY_GOD_OFFSET_3 = 7358; -- A strange insignia pointing west is carved into the wall.
+         SKY_GOD_OFFSET_4 = 7359; -- A strange insignia pointing south is carved into the wall.
 
 
 -- conquest Base
-CONQUEST_BASE = 7145; -- Tallying conquest results...
+CONQUEST_BASE = 7146; -- Tallying conquest results...

--- a/scripts/zones/RuLude_Gardens/TextIDs.lua
+++ b/scripts/zones/RuLude_Gardens/TextIDs.lua
@@ -3,48 +3,48 @@
 -- General Texts
    ITEM_CANNOT_BE_OBTAINED = 6519; -- You cannot obtain the item <item>. Come back after sorting your inventory.
 FULL_INVENTORY_AFTER_TRADE = 6523; -- You cannot obtain the <item>. Try trading again after sorting your inventory.
-             ITEM_OBTAINED = 6524; -- Obtained: <item>.
-              GIL_OBTAINED = 6525; -- Obtained <number> gil.
-          KEYITEM_OBTAINED = 6527; -- Obtained key item: <keyitem>.
-            ITEMS_OBTAINED = 6533; -- You obtain <param2 number> <param1 item>!
-             HOMEPOINT_SET = 10265; -- Home point set!
+             ITEM_OBTAINED = 6525; -- Obtained: <item>.
+              GIL_OBTAINED = 6526; -- Obtained <number> gil.
+          KEYITEM_OBTAINED = 6528; -- Obtained key item: <keyitem>.
+            ITEMS_OBTAINED = 6534; -- You obtain <param2 number> <param1 item>!
+             HOMEPOINT_SET = 10266; -- Home point set!
 
 -- Conquest system
-CONQUEST = 10552; -- You've earned conquest points!
+CONQUEST = 10553; -- You've earned conquest points!
 
 -- Other dialog
-         NOTHING_OUT_OF_ORDINARY = 6538; -- There is nothing out of the ordinary here.
-SOVEREIGN_WITHOUT_AN_APPOINTMENT = 10161; -- Nobody sees the sovereign without an appointment!
-            ITEM_DELIVERY_DIALOG = 10252; -- Now offering quick and easy delivery of packages to homes everywhere!
-                     MAAT_DIALOG = 10358; -- Heh. You've got no business talking to me. Why, you're just a pup.
+         NOTHING_OUT_OF_ORDINARY = 6539; -- There is nothing out of the ordinary here.
+SOVEREIGN_WITHOUT_AN_APPOINTMENT = 10162; -- Nobody sees the sovereign without an appointment!
+            ITEM_DELIVERY_DIALOG = 10253; -- Now offering quick and easy delivery of packages to homes everywhere!
+                     MAAT_DIALOG = 10359; -- Heh. You've got no business talking to me. Why, you're just a pup.
 
 -- Mission Dialog
-WINDURST_EMBASSY = 10088; -- It reads
+WINDURST_EMBASSY = 10089; -- It reads
 
 -- Dynamis dialogs
-      YOU_CANNOT_ENTER_DYNAMIS = 11216; -- You cannot enter Dynamis
-PLAYERS_HAVE_NOT_REACHED_LEVEL = 11218; -- Players who have not reached level   are prohibited from entering Dynamis.
-    UNUSUAL_ARRANGEMENT_LEAVES = 11231; -- There is an unusual arrangement of leaves on the ground.
+      YOU_CANNOT_ENTER_DYNAMIS = 11217; -- You cannot enter Dynamis
+PLAYERS_HAVE_NOT_REACHED_LEVEL = 11219; -- Players who have not reached level   are prohibited from entering Dynamis.
+    UNUSUAL_ARRANGEMENT_LEAVES = 11232; -- There is an unusual arrangement of leaves on the ground.
 
 -- Quest Dialog
-YOUR_LEVEL_LIMIT_IS_NOW_55 = 10369; -- Your level limit is now 55.
-YOUR_LEVEL_LIMIT_IS_NOW_60 = 10381; -- Your level limit is now 60.
-YOUR_LEVEL_LIMIT_IS_NOW_65 = 10390; -- Your level limit is now 65.
-YOUR_LEVEL_LIMIT_IS_NOW_70 = 10432; -- Your level limit is now 70.
-YOUR_LEVEL_LIMIT_IS_NOW_75 = 10491; -- Your level limit is now 75.
-YOUR_LEVEL_LIMIT_IS_NOW_80 = 12182; -- Your level limit is now 80!
-YOUR_LEVEL_LIMIT_IS_NOW_85 = 12230; -- Your level limit is now 85!
-YOUR_LEVEL_LIMIT_IS_NOW_90 = 12329; -- Your level limit is now 90!
-YOUR_LEVEL_LIMIT_IS_NOW_95 = 12430; -- Your level limit is now 95!
-YOUR_LEVEL_LIMIT_IS_NOW_99 = 12510; -- Your level limit is now 99!
-        YOUR_MAXIMUM_LEVEL = 6580;  -- Your maximum level has been raised to
+YOUR_LEVEL_LIMIT_IS_NOW_55 = 10370; -- Your level limit is now 55.
+YOUR_LEVEL_LIMIT_IS_NOW_60 = 10382; -- Your level limit is now 60.
+YOUR_LEVEL_LIMIT_IS_NOW_65 = 10391; -- Your level limit is now 65.
+YOUR_LEVEL_LIMIT_IS_NOW_70 = 10433; -- Your level limit is now 70.
+YOUR_LEVEL_LIMIT_IS_NOW_75 = 10492; -- Your level limit is now 75.
+YOUR_LEVEL_LIMIT_IS_NOW_80 = 12183; -- Your level limit is now 80!
+YOUR_LEVEL_LIMIT_IS_NOW_85 = 12231; -- Your level limit is now 85!
+YOUR_LEVEL_LIMIT_IS_NOW_90 = 12330; -- Your level limit is now 90!
+YOUR_LEVEL_LIMIT_IS_NOW_95 = 12431; -- Your level limit is now 95!
+YOUR_LEVEL_LIMIT_IS_NOW_99 = 12511; -- Your level limit is now 99!
+        YOUR_MAXIMUM_LEVEL = 6581;  -- Your maximum level has been raised to
 
 -- Shop Texts
-   DABIHJAJALIOH_SHOP_DIALOG = 10889; -- Hello therrre. I worrrk for the M&P Market. I'm still new, so I don't know much about selling stuff...
-MACCHI_GAZLITAH_SHOP_DIALOG1 = 10895; -- Hello therrre. I work for the Buffalo Bonanza Ranch. I'm still new, so I don't know much about selling stuff...
-MACCHI_GAZLITAH_SHOP_DIALOG2 = 10896; -- The Buffalo Bonanza Ranch has a lot of useful items, just for you!
-MACCHI_GAZLITAH_SHOP_DIALOG3 = 10897; -- Business is booming! The Buffalo Bonanza Ranch even made me managerrr of this local shop!
-MACCHI_GAZLITAH_SHOP_DIALOG4 = 10892; -- My new shipment has finally come in. Talk to me, and I can show you what we have!
+   DABIHJAJALIOH_SHOP_DIALOG = 10890; -- Hello therrre. I worrrk for the M&P Market. I'm still new, so I don't know much about selling stuff...
+MACCHI_GAZLITAH_SHOP_DIALOG1 = 10896; -- Hello therrre. I work for the Buffalo Bonanza Ranch. I'm still new, so I don't know much about selling stuff...
+MACCHI_GAZLITAH_SHOP_DIALOG2 = 10897; -- The Buffalo Bonanza Ranch has a lot of useful items, just for you!
+MACCHI_GAZLITAH_SHOP_DIALOG3 = 10898; -- Business is booming! The Buffalo Bonanza Ranch even made me managerrr of this local shop!
+MACCHI_GAZLITAH_SHOP_DIALOG4 = 10893; -- My new shipment has finally come in. Talk to me, and I can show you what we have!
 
 
 -- conquest Base

--- a/scripts/zones/Ruhotz_Silvermines/TextIDs.lua
+++ b/scripts/zones/Ruhotz_Silvermines/TextIDs.lua
@@ -2,6 +2,6 @@
 
 -- General Texts
 ITEM_CANNOT_BE_OBTAINED = 6379; -- You cannot obtain the item <item> come back again after sorting your inventory
-          ITEM_OBTAINED = 6384; -- Obtained: <item>
-           GIL_OBTAINED = 6385; -- Obtained <number> gil
-       KEYITEM_OBTAINED = 6387; -- Obtained key item: <keyitem>
+          ITEM_OBTAINED = 6385; -- Obtained: <item>
+           GIL_OBTAINED = 6386; -- Obtained <number> gil
+       KEYITEM_OBTAINED = 6388; -- Obtained key item: <keyitem>

--- a/scripts/zones/Sacrarium/TextIDs.lua
+++ b/scripts/zones/Sacrarium/TextIDs.lua
@@ -2,37 +2,37 @@
 
 -- General Texts
 ITEM_CANNOT_BE_OBTAINED = 6379; -- You cannot obtain the item <item> come back again after sorting your inventory
-          ITEM_OBTAINED = 6384; -- Obtained: <item>
-           GIL_OBTAINED = 6385; -- Obtained <number> gil
-       KEYITEM_OBTAINED = 6387; -- Obtained key item: <keyitem>
+          ITEM_OBTAINED = 6385; -- Obtained: <item>
+           GIL_OBTAINED = 6386; -- Obtained <number> gil
+       KEYITEM_OBTAINED = 6388; -- Obtained key item: <keyitem>
 
-          LARGE_KEYHOLE = 7211; -- The gate is securely closed with two locks. This keyhole is engraved with a sealion insignia
-          SMALL_KEYHOLE = 7212; -- The gate is securely closed with two locks. This keyhole is engraved with a coral insignia.
-    KEYHOLE_DAMAGED = 7213; -- The keyhole is damaged.The gate cannot be opened from this side.
-       CANNOT_OPEN_SIDE = 7213; -- The gate cannot be opened from this side.
-        STURDY_GATE = 7216; -- A sturdy iron gate. It is secured with two locks--a main lock and a sublock.
-        CORAL_KEY_TRADE = 7218; -- is holding the lock open...
-NOTHING_OUT_OF_ORDINARY = 7222; -- There is nothing out of the ordinary here.
+          LARGE_KEYHOLE = 7212; -- The gate is securely closed with two locks. This keyhole is engraved with a sealion insignia
+          SMALL_KEYHOLE = 7213; -- The gate is securely closed with two locks. This keyhole is engraved with a coral insignia.
+    KEYHOLE_DAMAGED = 7214; -- The keyhole is damaged.The gate cannot be opened from this side.
+       CANNOT_OPEN_SIDE = 7214; -- The gate cannot be opened from this side.
+        STURDY_GATE = 7217; -- A sturdy iron gate. It is secured with two locks--a main lock and a sublock.
+        CORAL_KEY_TRADE = 7219; -- is holding the lock open...
+NOTHING_OUT_OF_ORDINARY = 7223; -- There is nothing out of the ordinary here.
 
-            EVIL_PRESENCE = 7254; -- You sense an evil presence!
-              DRAWER_OPEN = 7255; -- You open the drawer.
-             DRAWER_EMPTY = 7256; -- There is nothing inside.
-              DRAWER_SHUT = 7257; -- The drawer is jammed shut.
+            EVIL_PRESENCE = 7255; -- You sense an evil presence!
+              DRAWER_OPEN = 7256; -- You open the drawer.
+             DRAWER_EMPTY = 7257; -- There is nothing inside.
+              DRAWER_SHUT = 7258; -- The drawer is jammed shut.
 
-     START_GET_GOOSEBUMPS = 7355; -- You start to get goosebumps.
-             HEART_RACING = 7356; -- Your heart is racing.
-LEAVE_QUICKLY_AS_POSSIBLE = 7357; -- Your common sense tells you to leave as quickly as possible.
-          NOTHING_HAPPENS = 7360; -- Nothing happens.
+     START_GET_GOOSEBUMPS = 7356; -- You start to get goosebumps.
+             HEART_RACING = 7357; -- Your heart is racing.
+LEAVE_QUICKLY_AS_POSSIBLE = 7358; -- Your common sense tells you to leave as quickly as possible.
+          NOTHING_HAPPENS = 7361; -- Nothing happens.
 
 -- Treasure Coffer/Chest Dialog
-CHEST_UNLOCKED = 7345; -- You unlock the chest!
-    CHEST_FAIL = 7346; -- Fails to open the chest.
-    CHEST_TRAP = 7347; -- The chest was trapped!
-    CHEST_WEAK = 7348; -- You cannot open the chest when you are in a weakened state.
-   CHEST_MIMIC = 7349; -- The chest was a mimic!
-  CHEST_MOOGLE = 7350; -- You cannot open the chest while participating in the moogle event.
-CHEST_ILLUSION = 7351; -- The chest was but an illusion...
-  CHEST_LOCKED = 7352; -- The chest appears to be locked.
+CHEST_UNLOCKED = 7346; -- You unlock the chest!
+    CHEST_FAIL = 7347; -- Fails to open the chest.
+    CHEST_TRAP = 7348; -- The chest was trapped!
+    CHEST_WEAK = 7349; -- You cannot open the chest when you are in a weakened state.
+   CHEST_MIMIC = 7350; -- The chest was a mimic!
+  CHEST_MOOGLE = 7351; -- You cannot open the chest while participating in the moogle event.
+CHEST_ILLUSION = 7352; -- The chest was but an illusion...
+  CHEST_LOCKED = 7353; -- The chest appears to be locked.
 
 -- conquest Base
-CONQUEST_BASE = 7045; -- Tallying conquest results...
+CONQUEST_BASE = 7046; -- Tallying conquest results...

--- a/scripts/zones/Sacrificial_Chamber/TextIDs.lua
+++ b/scripts/zones/Sacrificial_Chamber/TextIDs.lua
@@ -2,11 +2,11 @@
 
 -- General Texts
 ITEM_CANNOT_BE_OBTAINED = 6379; -- You cannot obtain the item <item> come back again after sorting your inventory
-          ITEM_OBTAINED = 6384; -- Obtained: <item>
-           GIL_OBTAINED = 6385; -- Obtained <number> gil
-       KEYITEM_OBTAINED = 6387; -- Obtained key item: <keyitem>
+          ITEM_OBTAINED = 6385; -- Obtained: <item>
+           GIL_OBTAINED = 6386; -- Obtained <number> gil
+       KEYITEM_OBTAINED = 6388; -- Obtained key item: <keyitem>
 
-              DOOR_SHUT = 7685; -- The door is firmly shut.
+              DOOR_SHUT = 7686; -- The door is firmly shut.
 
 -- conquest Base
-CONQUEST_BASE = 7045; -- Tallying conquest results...
+CONQUEST_BASE = 7046; -- Tallying conquest results...

--- a/scripts/zones/San_dOria-Jeuno_Airship/TextIDs.lua
+++ b/scripts/zones/San_dOria-Jeuno_Airship/TextIDs.lua
@@ -2,13 +2,13 @@
 
 -- General Texts
 ITEM_CANNOT_BE_OBTAINED = 6379; -- You cannot obtain the item <item> come back again after sorting your inventory
-          ITEM_OBTAINED = 6384; -- Obtained: <item>
-           GIL_OBTAINED = 6385; -- Obtained <number> gil
-       KEYITEM_OBTAINED = 6387; -- Obtained key item: <keyitem>
+          ITEM_OBTAINED = 6385; -- Obtained: <item>
+           GIL_OBTAINED = 6386; -- Obtained <number> gil
+       KEYITEM_OBTAINED = 6388; -- Obtained key item: <keyitem>
 
 -- Other
 
-       WILL_REACH_JEUNO = 7204; -- The airship will reach Jeuno in Multiple Choice (Parameter 1)[less than an hour/about 1 hour/about 2 hours/about 3 hours/about 4 hours/about 5 hours/about 6 hours/about 7 hours] ( Singular/Plural Choice (Parameter 0)[minute/minutes] in Earth time). 
-    WILL_REACH_SANDORIA = 7205; -- The airship will reach San d'Oria in Multiple Choice (Parameter 1)[less than an hour/about 1 hour/about 2 hours/about 3 hours/about 4 hours/about 5 hours/about 6 hours/about 7 hours] ( Singular/Plural Choice (Parameter 0)[minute/minutes] in Earth time). 
-   IN_JEUNO_MOMENTARILY = 7207; -- We will be arriving in Jeuno momentarily.
-IN_SANDORIA_MOMENTARILY = 7208; -- We will be arriving in San d'Oria momentarily.
+       WILL_REACH_JEUNO = 7205; -- The airship will reach Jeuno in Multiple Choice (Parameter 1)[less than an hour/about 1 hour/about 2 hours/about 3 hours/about 4 hours/about 5 hours/about 6 hours/about 7 hours] ( Singular/Plural Choice (Parameter 0)[minute/minutes] in Earth time). 
+    WILL_REACH_SANDORIA = 7206; -- The airship will reach San d'Oria in Multiple Choice (Parameter 1)[less than an hour/about 1 hour/about 2 hours/about 3 hours/about 4 hours/about 5 hours/about 6 hours/about 7 hours] ( Singular/Plural Choice (Parameter 0)[minute/minutes] in Earth time). 
+   IN_JEUNO_MOMENTARILY = 7208; -- We will be arriving in Jeuno momentarily.
+IN_SANDORIA_MOMENTARILY = 7209; -- We will be arriving in San d'Oria momentarily.

--- a/scripts/zones/Sauromugue_Champaign/TextIDs.lua
+++ b/scripts/zones/Sauromugue_Champaign/TextIDs.lua
@@ -2,26 +2,26 @@
 
 -- General Texts
 ITEM_CANNOT_BE_OBTAINED = 6401; -- You cannot obtain the item <item>. Come back after sorting your inventory.
-          ITEM_OBTAINED = 6406; -- Obtained: <item>.
-           GIL_OBTAINED = 6407; -- Obtained <number> gil.
-       KEYITEM_OBTAINED = 6409; -- Obtained key item: <keyitem>.
- FISHING_MESSAGE_OFFSET = 7234; -- You can't fish here.
+          ITEM_OBTAINED = 6407; -- Obtained: <item>.
+           GIL_OBTAINED = 6408; -- Obtained <number> gil.
+       KEYITEM_OBTAINED = 6410; -- Obtained key item: <keyitem>.
+ FISHING_MESSAGE_OFFSET = 7235; -- You can't fish here.
 
 -- Quest Dialogs
-        MANY_TIGER_BONES = 7226; -- There are many tiger bones here...
- OLD_SABERTOOTH_DIALOG_I = 7232; -- You hear the distant roar of a tiger. It sounds as if the beast is approaching slowly...
-OLD_SABERTOOTH_DIALOG_II = 7233; -- The sound of the tiger's footsteps is growing louder.
+        MANY_TIGER_BONES = 7227; -- There are many tiger bones here...
+ OLD_SABERTOOTH_DIALOG_I = 7233; -- You hear the distant roar of a tiger. It sounds as if the beast is approaching slowly...
+OLD_SABERTOOTH_DIALOG_II = 7234; -- The sound of the tiger's footsteps is growing louder.
 
-              THF_AF_MOB = 7411; -- Something has come down from the tower!
-      THF_AF_WALL_OFFSET = 7430; -- It is impossible to climb this wall with your bare hands.
+              THF_AF_MOB = 7412; -- Something has come down from the tower!
+      THF_AF_WALL_OFFSET = 7431; -- It is impossible to climb this wall with your bare hands.
 
 -- Other Dialog
         NOTHING_HAPPENS = 141;  -- Nothing happens...
-NOTHING_OUT_OF_ORDINARY = 6420; -- There is nothing out of the ordinary here.
+NOTHING_OUT_OF_ORDINARY = 6421; -- There is nothing out of the ordinary here.
 
 -- conquest Base
-CONQUEST_BASE = 7067; -- Tallying conquest results...
+CONQUEST_BASE = 7068; -- Tallying conquest results...
 
 -- chocobo digging
-DIG_THROW_AWAY = 7247; -- You dig up ?Possible Special Code: 01??Possible Special Code: 01??Possible Special Code: 01? ?Possible Special Code: 01??Possible Special Code: 05?$?BAD CHAR: 8280??BAD CHAR: 80??BAD CHAR: 80?, but your inventory is full.
-FIND_NOTHING = 7249; -- You dig and you dig, but find nothing.
+DIG_THROW_AWAY = 7248; -- You dig up ?Possible Special Code: 01??Possible Special Code: 01??Possible Special Code: 01? ?Possible Special Code: 01??Possible Special Code: 05?$?BAD CHAR: 8280??BAD CHAR: 80??BAD CHAR: 80?, but your inventory is full.
+FIND_NOTHING = 7250; -- You dig and you dig, but find nothing.

--- a/scripts/zones/Sauromugue_Champaign_[S]/TextIDs.lua
+++ b/scripts/zones/Sauromugue_Champaign_[S]/TextIDs.lua
@@ -2,6 +2,6 @@
 
 -- General Texts
 ITEM_CANNOT_BE_OBTAINED = 6379; -- You cannot obtain the item <item> come back again after sorting your inventory
-          ITEM_OBTAINED = 6384; -- Obtained: <item>
-           GIL_OBTAINED = 6385; -- Obtained <number> gil
-       KEYITEM_OBTAINED = 6387; -- Obtained key item: <keyitem>
+          ITEM_OBTAINED = 6385; -- Obtained: <item>
+           GIL_OBTAINED = 6386; -- Obtained <number> gil
+       KEYITEM_OBTAINED = 6388; -- Obtained key item: <keyitem>

--- a/scripts/zones/Sea_Serpent_Grotto/TextIDs.lua
+++ b/scripts/zones/Sea_Serpent_Grotto/TextIDs.lua
@@ -3,41 +3,41 @@
 -- General Texts
    ITEM_CANNOT_BE_OBTAINED = 6379; -- You cannot obtain the item <item> come back again after sorting your inventory
 FULL_INVENTORY_AFTER_TRADE = 6383; -- You cannot obtain the <item>. Try trading again after sorting your inventory
-             ITEM_OBTAINED = 6384; -- Obtained: <item>
-              GIL_OBTAINED = 6385; -- Obtained <number> gil
-          KEYITEM_OBTAINED = 6387; -- Obtained key item: <keyitem>
-            ITEMS_OBTAINED = 6393; -- You obtain
-    FISHING_MESSAGE_OFFSET = 7204; -- You can't fish here
+             ITEM_OBTAINED = 6385; -- Obtained: <item>
+              GIL_OBTAINED = 6386; -- Obtained <number> gil
+          KEYITEM_OBTAINED = 6388; -- Obtained key item: <keyitem>
+            ITEMS_OBTAINED = 6394; -- You obtain
+    FISHING_MESSAGE_OFFSET = 7205; -- You can't fish here
 
 -- Other dialog
-NOTHING_OUT_OF_ORDINARY = 6398; -- There is nothing out of the ordinary here.
+NOTHING_OUT_OF_ORDINARY = 6399; -- There is nothing out of the ordinary here.
 
 -- Treasure Coffer/Chest Dialog
-CHEST_UNLOCKED = 7311; -- You unlock the chest!
-    CHEST_FAIL = 7312; -- Fails to open the chest.
-    CHEST_TRAP = 7313; -- The chest was trapped!
-    CHEST_WEAK = 7314; -- You cannot open the chest when you are in a weakened state.
-   CHEST_MIMIC = 7315; -- The chest was a mimic!
-  CHEST_MOOGLE = 7316; -- You cannot open the chest while participating in the moogle event.
-CHEST_ILLUSION = 7317; -- The chest was but an illusion...
-  CHEST_LOCKED = 7318; -- The chest appears to be locked.
+CHEST_UNLOCKED = 7312; -- You unlock the chest!
+    CHEST_FAIL = 7313; -- Fails to open the chest.
+    CHEST_TRAP = 7314; -- The chest was trapped!
+    CHEST_WEAK = 7315; -- You cannot open the chest when you are in a weakened state.
+   CHEST_MIMIC = 7316; -- The chest was a mimic!
+  CHEST_MOOGLE = 7317; -- You cannot open the chest while participating in the moogle event.
+CHEST_ILLUSION = 7318; -- The chest was but an illusion...
+  CHEST_LOCKED = 7319; -- The chest appears to be locked.
 
 -- Sahagin Key Door Texts
- SAHAGIN_DOOR_INSIDE = 7329; -- The door is tightly shut.
-SAHAGIN_DOOR_OUTSIDE = 7330; -- This door has an oddly shaped keyhole. It looks as if once you enter, you may not be able to get out the way you came in.
- SAHAGIN_DOOR_TRADED = 7331; -- breaks
+ SAHAGIN_DOOR_INSIDE = 7330; -- The door is tightly shut.
+SAHAGIN_DOOR_OUTSIDE = 7331; -- This door has an oddly shaped keyhole. It looks as if once you enter, you may not be able to get out the way you came in.
+ SAHAGIN_DOOR_TRADED = 7332; -- breaks
 
 -- Secret Door Texts; The first five are the same for each door, with the 6th and 7th being unique
-    FIRST_CHECK = 7335; -- You do not see anything out of the ordinary.
-   SECOND_CHECK = 7336; -- You do not see anything out of the ordinary...
-    THIRD_CHECK = 7337; -- It looks like a rock wall.
-   FOURTH_CHECK = 7338; -- It looks like a rock wall...
-    FIFTH_CHECK = 7339; -- You see a small indentation in the wall.
-   SILVER_CHECK = 7340; -- You see something silver glittering around the indentation.
-  MYTHRIL_CHECK = 7341; -- You find something that looks like mythril dust scattered about the indentation.
-     GOLD_CHECK = 7342; -- You see something gold glittering around the indentation.
-COMPLETED_CHECK = 7343; -- It is a door you can open using
+    FIRST_CHECK = 7336; -- You do not see anything out of the ordinary.
+   SECOND_CHECK = 7337; -- You do not see anything out of the ordinary...
+    THIRD_CHECK = 7338; -- It looks like a rock wall.
+   FOURTH_CHECK = 7339; -- It looks like a rock wall...
+    FIFTH_CHECK = 7340; -- You see a small indentation in the wall.
+   SILVER_CHECK = 7341; -- You see something silver glittering around the indentation.
+  MYTHRIL_CHECK = 7342; -- You find something that looks like mythril dust scattered about the indentation.
+     GOLD_CHECK = 7343; -- You see something gold glittering around the indentation.
+COMPLETED_CHECK = 7344; -- It is a door you can open using
 
 -- conquest Base
-CONQUEST_BASE = 7045; -- Tallying conquest results...
+CONQUEST_BASE = 7046; -- Tallying conquest results...
 

--- a/scripts/zones/Sealions_Den/TextIDs.lua
+++ b/scripts/zones/Sealions_Den/TextIDs.lua
@@ -2,10 +2,10 @@
 
 -- General Texts
 ITEM_CANNOT_BE_OBTAINED = 6379; -- You cannot obtain the item <item> come back again after sorting your inventory
-          ITEM_OBTAINED = 6384; -- Obtained: <item>
-           GIL_OBTAINED = 6385; -- Obtained <number> gil
-       KEYITEM_OBTAINED = 6387; -- Obtained key item: <keyitem>
+          ITEM_OBTAINED = 6385; -- Obtained: <item>
+           GIL_OBTAINED = 6386; -- Obtained <number> gil
+       KEYITEM_OBTAINED = 6388; -- Obtained key item: <keyitem>
 
 
 -- conquest Base
-CONQUEST_BASE = 7415; -- Tallying conquest results...
+CONQUEST_BASE = 7416; -- Tallying conquest results...

--- a/scripts/zones/Selbina/TextIDs.lua
+++ b/scripts/zones/Selbina/TextIDs.lua
@@ -2,34 +2,34 @@
 
 -- General Texts
 ITEM_CANNOT_BE_OBTAINED = 6379; -- You cannot obtain the item <item>. Come back after sorting your inventory.
-          ITEM_OBTAINED = 6384; -- Obtained: <item>.
-           GIL_OBTAINED = 6385; -- Obtained <number> gil.
-       KEYITEM_OBTAINED = 6387; -- Obtained key item: <keyitem>.
-    NOT_HAVE_ENOUGH_GIL = 6389; -- You do not have enough gil.
-          HOMEPOINT_SET = 6475; -- Home point set!
- FISHING_MESSAGE_OFFSET = 6550; -- You can't fish here.
-        SUBJOB_UNLOCKED = 6853; -- You can now designate a support job.
+          ITEM_OBTAINED = 6385; -- Obtained: <item>.
+           GIL_OBTAINED = 6386; -- Obtained <number> gil.
+       KEYITEM_OBTAINED = 6388; -- Obtained key item: <keyitem>.
+    NOT_HAVE_ENOUGH_GIL = 6390; -- You do not have enough gil.
+          HOMEPOINT_SET = 6476; -- Home point set!
+ FISHING_MESSAGE_OFFSET = 6551; -- You can't fish here.
+        SUBJOB_UNLOCKED = 6854; -- You can now designate a support job.
 
 -- NPC texts
-NOMAD_MOOGLE_DIALOG = 6650; -- I'm a traveling moogle, kupo. I help adventurers in the Outlands access items they have stored in a Mog House elsewhere, kupo.
+NOMAD_MOOGLE_DIALOG = 6651; -- I'm a traveling moogle, kupo. I help adventurers in the Outlands access items they have stored in a Mog House elsewhere, kupo.
 
 -- Shop Texts
-  HERMINIA_SHOP_DIALOG = 7027; -- Hello there. What can I do for you?
- TORAPIONT_SHOP_DIALOG = 7028; -- Arm yourself before you step outside.
-  DOHDJUMA_SHOP_DIALOG = 7029; -- I'm Dohdjuma, and I sell all kinds of things.
-CLOTHCRAFT_SHOP_DIALOG = 7030; -- Welcome to the Weavers' Guild salesroom.
-   FISHING_SHOP_DIALOG = 7031; -- Welcome to the Fishermen's Guild salesroom.
-   QUELPIA_SHOP_DIALOG = 7032; -- In need of otherworldly protection?
-CHUTARMIRE_SHOP_DIALOG = 7033; -- I have items for those who delve in the black arts!
-   FALGIMA_SHOP_DIALOG = 7034; -- In the market for spells, hexes, and incantations? Well, you've come to the right place!
+  HERMINIA_SHOP_DIALOG = 7028; -- Hello there. What can I do for you?
+ TORAPIONT_SHOP_DIALOG = 7029; -- Arm yourself before you step outside.
+  DOHDJUMA_SHOP_DIALOG = 7030; -- I'm Dohdjuma, and I sell all kinds of things.
+CLOTHCRAFT_SHOP_DIALOG = 7031; -- Welcome to the Weavers' Guild salesroom.
+   FISHING_SHOP_DIALOG = 7032; -- Welcome to the Fishermen's Guild salesroom.
+   QUELPIA_SHOP_DIALOG = 7033; -- In need of otherworldly protection?
+CHUTARMIRE_SHOP_DIALOG = 7034; -- I have items for those who delve in the black arts!
+   FALGIMA_SHOP_DIALOG = 7035; -- In the market for spells, hexes, and incantations? Well, you've come to the right place!
 
 -- Item Delivery
-WENZEL_DELIVERY_DIALOG = 7581; -- My independent survey confirms the town entrance as the preferred location from which adventurers send parcels.
- BORIS_DELIVERY_DIALOG = 7582; -- My independent survey confirms the inn as the preferred location from which adventurers send parcels.
+WENZEL_DELIVERY_DIALOG = 7582; -- My independent survey confirms the town entrance as the preferred location from which adventurers send parcels.
+ BORIS_DELIVERY_DIALOG = 7583; -- My independent survey confirms the inn as the preferred location from which adventurers send parcels.
 
 
 -- conquest Base
-CONQUEST_BASE = 7098; -- Tallying conquest results...
+CONQUEST_BASE = 7099; -- Tallying conquest results...
 
 -- Porter Moogle
-    RETRIEVE_DIALOG_ID = 7742; -- You retrieve$ from the porter moogle's care.
+    RETRIEVE_DIALOG_ID = 7743; -- You retrieve$ from the porter moogle's care.

--- a/scripts/zones/Ship_bound_for_Mhaura/TextIDs.lua
+++ b/scripts/zones/Ship_bound_for_Mhaura/TextIDs.lua
@@ -2,15 +2,15 @@
 
 -- General Texts
 ITEM_CANNOT_BE_OBTAINED = 6379; -- You cannot obtain the item <item> come back again after sorting your inventory
-          ITEM_OBTAINED = 6384; -- Obtained: <item>
-           GIL_OBTAINED = 6385; -- Obtained <number> gil
-       KEYITEM_OBTAINED = 6387; -- Obtained key item: <keyitem>
- FISHING_MESSAGE_OFFSET = 7226; -- You can't fish here.
+          ITEM_OBTAINED = 6385; -- Obtained: <item>
+           GIL_OBTAINED = 6386; -- Obtained <number> gil
+       KEYITEM_OBTAINED = 6388; -- Obtained key item: <keyitem>
+ FISHING_MESSAGE_OFFSET = 7227; -- You can't fish here.
 
 -- Shop Texts
-LOKHONG_SHOP_DIALOG = 7332; -- There's nothing like fishing to pass the time!
- CHHAYA_SHOP_DIALOG = 7333; -- May I offer you items to help you on your journey?
+LOKHONG_SHOP_DIALOG = 7333; -- There's nothing like fishing to pass the time!
+ CHHAYA_SHOP_DIALOG = 7334; -- May I offer you items to help you on your journey?
 
  -- Other
-    ON_WAY_TO_MHAURA = 7327; -- We're on our way to Mhaura
-ARRIVING_SOON_MHAURA = 7334; -- We will be arriving soon
+    ON_WAY_TO_MHAURA = 7328; -- We're on our way to Mhaura
+ARRIVING_SOON_MHAURA = 7335; -- We will be arriving soon

--- a/scripts/zones/Ship_bound_for_Selbina/TextIDs.lua
+++ b/scripts/zones/Ship_bound_for_Selbina/TextIDs.lua
@@ -2,15 +2,15 @@
 
 -- General Texts
 ITEM_CANNOT_BE_OBTAINED = 6379; -- You cannot obtain the item <item> come back again after sorting your inventory
-          ITEM_OBTAINED = 6384; -- Obtained: <item>
-           GIL_OBTAINED = 6385; -- Obtained <number> gil
-       KEYITEM_OBTAINED = 6387; -- Obtained key item: <keyitem>
- FISHING_MESSAGE_OFFSET = 7226; -- You can't fish here
+          ITEM_OBTAINED = 6385; -- Obtained: <item>
+           GIL_OBTAINED = 6386; -- Obtained <number> gil
+       KEYITEM_OBTAINED = 6388; -- Obtained key item: <keyitem>
+ FISHING_MESSAGE_OFFSET = 7227; -- You can't fish here
 
 -- Shop texts
-RAJMONDA_SHOP_DIALOG = 7332; -- There's nothing like fishing to pass the time!
-   MAERA_SHOP_DIALOG = 7333; -- May I offer you items to help you on your journey?
+RAJMONDA_SHOP_DIALOG = 7333; -- There's nothing like fishing to pass the time!
+   MAERA_SHOP_DIALOG = 7334; -- May I offer you items to help you on your journey?
 
 -- Other
-    ON_WAY_TO_SELBINA = 7327; -- We're on our way to Selbina.
-ARRIVING_SOON_SELBINA = 7334; -- We will be arriving soon
+    ON_WAY_TO_SELBINA = 7328; -- We're on our way to Selbina.
+ARRIVING_SOON_SELBINA = 7335; -- We will be arriving soon

--- a/scripts/zones/Sih_Gates/TextIDs.lua
+++ b/scripts/zones/Sih_Gates/TextIDs.lua
@@ -2,6 +2,6 @@
 
 -- General Texts
 ITEM_CANNOT_BE_OBTAINED = 6379; -- You cannot obtain the item <item> come back again after sorting your inventory
-          ITEM_OBTAINED = 6384; -- Obtained: <item>
-           GIL_OBTAINED = 6385; -- Obtained <number> gil
-       KEYITEM_OBTAINED = 6387; -- Obtained key item: <keyitem>
+          ITEM_OBTAINED = 6385; -- Obtained: <item>
+           GIL_OBTAINED = 6386; -- Obtained <number> gil
+       KEYITEM_OBTAINED = 6388; -- Obtained key item: <keyitem>

--- a/scripts/zones/Silver_Sea_Remnants/TextIDs.lua
+++ b/scripts/zones/Silver_Sea_Remnants/TextIDs.lua
@@ -2,6 +2,6 @@
 
 -- General Texts
 ITEM_CANNOT_BE_OBTAINED = 6379; -- You cannot obtain the item <item> come back again after sorting your inventory
-          ITEM_OBTAINED = 6384; -- Obtained: <item>
-           GIL_OBTAINED = 6385; -- Obtained <number> gil
-       KEYITEM_OBTAINED = 6387; -- Obtained key item: <keyitem>
+          ITEM_OBTAINED = 6385; -- Obtained: <item>
+           GIL_OBTAINED = 6386; -- Obtained <number> gil
+       KEYITEM_OBTAINED = 6388; -- Obtained key item: <keyitem>

--- a/scripts/zones/Silver_Sea_route_to_Al_Zahbi/TextIDs.lua
+++ b/scripts/zones/Silver_Sea_route_to_Al_Zahbi/TextIDs.lua
@@ -2,13 +2,13 @@
 
 -- General Texts
 ITEM_CANNOT_BE_OBTAINED = 6379; -- You cannot obtain the item <item> come back again after sorting your inventory
-          ITEM_OBTAINED = 6384; -- Obtained: <item>
-           GIL_OBTAINED = 6385; -- Obtained <number> gil
-       KEYITEM_OBTAINED = 6387; -- Obtained key item: <keyitem>
- FISHING_MESSAGE_OFFSET = 7045; -- You can't fish here
+          ITEM_OBTAINED = 6385; -- Obtained: <item>
+           GIL_OBTAINED = 6386; -- Obtained <number> gil
+       KEYITEM_OBTAINED = 6388; -- Obtained key item: <keyitem>
+ FISHING_MESSAGE_OFFSET = 7046; -- You can't fish here
 
 -- Shops
-YAHLIQ_SHOP_DIALOG = 7308; -- You've picked the best place to shop for your items, guaranteed!
+YAHLIQ_SHOP_DIALOG = 7309; -- You've picked the best place to shop for your items, guaranteed!
 
 -- Other
-ON_WAY_TO_AL_ZAHBI = 7304; -- We are on our way to Al Zahbi
+ON_WAY_TO_AL_ZAHBI = 7305; -- We are on our way to Al Zahbi

--- a/scripts/zones/Silver_Sea_route_to_Nashmau/TextIDs.lua
+++ b/scripts/zones/Silver_Sea_route_to_Nashmau/TextIDs.lua
@@ -2,13 +2,13 @@
 
 -- General Texts
 ITEM_CANNOT_BE_OBTAINED = 6379; -- You cannot obtain the item <item> come back again after sorting your inventory
-          ITEM_OBTAINED = 6384; -- Obtained: <item>
-           GIL_OBTAINED = 6385; -- Obtained <number> gil
-       KEYITEM_OBTAINED = 6387; -- Obtained key item: <keyitem>
- FISHING_MESSAGE_OFFSET = 7045; -- You can't fish here.
+          ITEM_OBTAINED = 6385; -- Obtained: <item>
+           GIL_OBTAINED = 6386; -- Obtained <number> gil
+       KEYITEM_OBTAINED = 6388; -- Obtained key item: <keyitem>
+ FISHING_MESSAGE_OFFSET = 7046; -- You can't fish here.
 
 -- Shops
-JIDWAHN_SHOP_DIALOG = 7308; -- Would you care for some items to use on your travels?
+JIDWAHN_SHOP_DIALOG = 7309; -- Would you care for some items to use on your travels?
 
 -- Other
-ON_WAY_TO_NASHMAU = 7304; -- We are on our way to Nashmau
+ON_WAY_TO_NASHMAU = 7305; -- We are on our way to Nashmau

--- a/scripts/zones/South_Gustaberg/TextIDs.lua
+++ b/scripts/zones/South_Gustaberg/TextIDs.lua
@@ -2,27 +2,27 @@
 
 -- General Texts
 ITEM_CANNOT_BE_OBTAINED = 6401; -- You cannot obtain the item <item>. Come back after sorting your inventory.
-          ITEM_OBTAINED = 6406; -- Obtained: <item>.
-           GIL_OBTAINED = 6407; -- Obtained <number> gil.
-       KEYITEM_OBTAINED = 6409; -- Obtained key item: <keyitem>.
- FISHING_MESSAGE_OFFSET = 7226; -- You can't fish here.
+          ITEM_OBTAINED = 6407; -- Obtained: <item>.
+           GIL_OBTAINED = 6408; -- Obtained <number> gil.
+       KEYITEM_OBTAINED = 6410; -- Obtained key item: <keyitem>.
+ FISHING_MESSAGE_OFFSET = 7227; -- You can't fish here.
 
 -- Standard Text
-       FIRE_GOOD = 7400; -- The fire seems to be good enough for cooking.
-        FIRE_PUT = 7401; -- You put$ in the fire.
-       FIRE_TAKE = 7402; -- You take$ out of the fire.
-     FIRE_LONGER = 7403; -- It may take a little while more to cook
-MEAT_ALREADY_PUT = 7404; -- is already in the fire
+       FIRE_GOOD = 7401; -- The fire seems to be good enough for cooking.
+        FIRE_PUT = 7402; -- You put$ in the fire.
+       FIRE_TAKE = 7403; -- You take$ out of the fire.
+     FIRE_LONGER = 7404; -- It may take a little while more to cook
+MEAT_ALREADY_PUT = 7405; -- is already in the fire
 
 -- Other dialog
         NOTHING_HAPPENS = 141;  -- Nothing happens...
-NOTHING_OUT_OF_ORDINARY = 6420; -- There is nothing out of the ordinary here.
+NOTHING_OUT_OF_ORDINARY = 6421; -- There is nothing out of the ordinary here.
 
-      MONSTER_TRACKS = 7396; -- You see monster tracks on the ground.
-MONSTER_TRACKS_FRESH = 7397; -- You see fresh monster tracks on the ground.
+      MONSTER_TRACKS = 7397; -- You see monster tracks on the ground.
+MONSTER_TRACKS_FRESH = 7398; -- You see fresh monster tracks on the ground.
 -- conquest Base
-CONQUEST_BASE = 7067; -- Tallying conquest results...
+CONQUEST_BASE = 7068; -- Tallying conquest results...
 
 --chocobo digging
-DIG_THROW_AWAY = 7239; -- You dig up$, but your inventory is full. You regretfully throw the # away.
-FIND_NOTHING = 7241; -- You dig and you dig, but find nothing.
+DIG_THROW_AWAY = 7240; -- You dig up$, but your inventory is full. You regretfully throw the # away.
+FIND_NOTHING = 7242; -- You dig and you dig, but find nothing.

--- a/scripts/zones/Southern_San_dOria/TextIDs.lua
+++ b/scripts/zones/Southern_San_dOria/TextIDs.lua
@@ -3,104 +3,104 @@
 -- General Texts
    ITEM_CANNOT_BE_OBTAINED = 6423; -- Come back after sorting your inventory.
 FULL_INVENTORY_AFTER_TRADE = 6427; -- Try trading again after sorting your inventory.
-             ITEM_OBTAINED = 6428; -- Obtained: <<<Unknown Parameter (Type: 80) 1>>><<<Possible Special Code: 01>>><<<Possible Special Code: 05>>>
-              GIL_OBTAINED = 6429; -- Obtained <<<Numeric Parameter 0>>> gil.
-          KEYITEM_OBTAINED = 6431; -- Obtained key item: <<<Unknown Parameter (Type: 80) 1>>>
-              KEYITEM_LOST = 6432; -- Lost key item:
+             ITEM_OBTAINED = 6429; -- Obtained: <<<Unknown Parameter (Type: 80) 1>>><<<Possible Special Code: 01>>><<<Possible Special Code: 05>>>
+              GIL_OBTAINED = 6430; -- Obtained <<<Numeric Parameter 0>>> gil.
+          KEYITEM_OBTAINED = 6432; -- Obtained key item: <<<Unknown Parameter (Type: 80) 1>>>
+              KEYITEM_LOST = 6433; -- Lost key item:
              HOMEPOINT_SET = 24; -- Home point set!
-       NOT_HAVE_ENOUGH_GIL = 6433; -- You do not have enough gil.
-           LEATHER_SUPPORT = 6769; -- Your ?Multiple Choice (Parameter 1)?[fishing/woodworking/smithing/goldsmithing/clothcraft/leatherworking/bonecraft/alchemy/cooking] skills went up ?Multiple Choice (Parameter 2)?[a little/ever so slightly/ever so slightly].?Prompt?
-  GUILD_TERMINATE_CONTRACT = 6783; -- You have terminated your trading contract with the Multiple Choice (Parameter 1)[Fishermen's/Carpenters'/Blacksmiths'/Goldsmiths'/Weavers'/Tanners'/Boneworkers'/Alchemists'/Culinarians'] Guild and formed a new one with the Multiple Choice (Parameter 0)[Fishermen's/Carpenters'/Blacksmiths'/Goldsmiths'/Weavers'/Tanners'/Boneworkers'/Alchemists'/Culinarians'] Guild
-        GUILD_NEW_CONTRACT = 6791; -- You have formed a new trading contract with the Multiple Choice (Parameter 0)[Fishermen's/Carpenters'/Blacksmiths'/Goldsmiths'/Weavers'/Tanners'/Boneworkers'/Alchemists'/Culinarians'] Guild
-       NO_MORE_GP_ELIGIBLE = 6798; -- You are not eligible to receive guild points at this time
-               GP_OBTAINED = 6803; -- Obtained: ?Numeric Parameter 0? guild points.
-        NOT_HAVE_ENOUGH_GP = 6804; -- You do not have enough guild points.
-   NOTHING_OUT_OF_ORDINARY = 6442; -- There is nothing out of the ordinary here.<Prompt>
+       NOT_HAVE_ENOUGH_GIL = 6434; -- You do not have enough gil.
+           LEATHER_SUPPORT = 6770; -- Your ?Multiple Choice (Parameter 1)?[fishing/woodworking/smithing/goldsmithing/clothcraft/leatherworking/bonecraft/alchemy/cooking] skills went up ?Multiple Choice (Parameter 2)?[a little/ever so slightly/ever so slightly].?Prompt?
+  GUILD_TERMINATE_CONTRACT = 6784; -- You have terminated your trading contract with the Multiple Choice (Parameter 1)[Fishermen's/Carpenters'/Blacksmiths'/Goldsmiths'/Weavers'/Tanners'/Boneworkers'/Alchemists'/Culinarians'] Guild and formed a new one with the Multiple Choice (Parameter 0)[Fishermen's/Carpenters'/Blacksmiths'/Goldsmiths'/Weavers'/Tanners'/Boneworkers'/Alchemists'/Culinarians'] Guild
+        GUILD_NEW_CONTRACT = 6792; -- You have formed a new trading contract with the Multiple Choice (Parameter 0)[Fishermen's/Carpenters'/Blacksmiths'/Goldsmiths'/Weavers'/Tanners'/Boneworkers'/Alchemists'/Culinarians'] Guild
+       NO_MORE_GP_ELIGIBLE = 6799; -- You are not eligible to receive guild points at this time
+               GP_OBTAINED = 6804; -- Obtained: ?Numeric Parameter 0? guild points.
+        NOT_HAVE_ENOUGH_GP = 6805; -- You do not have enough guild points.
+   NOTHING_OUT_OF_ORDINARY = 6443; -- There is nothing out of the ordinary here.<Prompt>
 
 -- Tutorial NPC
-TUTORIAL_NPC = 13502; -- Greetings and well met! Guardian of the Kingdom, Alaune, at your most humble service.
+TUTORIAL_NPC = 13504; -- Greetings and well met! Guardian of the Kingdom, Alaune, at your most humble service.
 
 -- Conquest System
-CONQUEST =  8475; -- You've earned conquest points!
+CONQUEST =  8477; -- You've earned conquest points!
 
 -- Mission Dialogs
- YOU_ACCEPT_THE_MISSION = 7188; -- You accept the mission.
-ORIGINAL_MISSION_OFFSET = 7199; -- Bring me one of those axes, and your mission will be a success. No running away now; we've a proud country to defend!
+ YOU_ACCEPT_THE_MISSION = 7190; -- You accept the mission.
+ORIGINAL_MISSION_OFFSET = 7201; -- Bring me one of those axes, and your mission will be a success. No running away now; we've a proud country to defend!
 
 -- Dynamis dialogs
-      YOU_CANNOT_ENTER_DYNAMIS = 7405; -- You cannot enter Dynamis
-PLAYERS_HAVE_NOT_REACHED_LEVEL = 7407; -- Players who have not reached level <<<Numeric Parameter 0>>> are prohibited from entering Dynamis.
-  UNUSUAL_ARRANGEMENT_BRANCHES = 7417; -- There is an unusual arrangement of branches here.
+      YOU_CANNOT_ENTER_DYNAMIS = 7407; -- You cannot enter Dynamis
+PLAYERS_HAVE_NOT_REACHED_LEVEL = 7409; -- Players who have not reached level <<<Numeric Parameter 0>>> are prohibited from entering Dynamis.
+  UNUSUAL_ARRANGEMENT_BRANCHES = 7419; -- There is an unusual arrangement of branches here.
 
 -- Quest Dialogs
-      UNLOCK_PALADIN = 8000; -- You can now become a paladin!
-       FLYER_REFUSED = 8171; -- Your flyer is refused.
-      FLYER_ACCEPTED = 8820; -- The flyer is accepted.
-       FLYER_ALREADY = 8821; -- This person already has a flyer.
-    VARCHET_BET_LOST = 7748; -- You lose your bet of 5 gil.
-VARCHET_KEEP_PROMISE = 7757; -- As promised, I shall go and see about those woodchippers. Maybe we can play another game later.
+      UNLOCK_PALADIN = 8002; -- You can now become a paladin!
+       FLYER_REFUSED = 8173; -- Your flyer is refused.
+      FLYER_ACCEPTED = 8822; -- The flyer is accepted.
+       FLYER_ALREADY = 8823; -- This person already has a flyer.
+    VARCHET_BET_LOST = 7750; -- You lose your bet of 5 gil.
+VARCHET_KEEP_PROMISE = 7759; -- As promised, I shall go and see about those woodchippers. Maybe we can play another game later.
 
 -- Harvest Festival
-  TRICK_OR_TREAT = 7347; -- Trick or treat...
- THANK_YOU_TREAT = 7348; -- And now for your treat...
-  HERE_TAKE_THIS = 7349; -- Here, take this...
-IF_YOU_WEAR_THIS = 7350; -- If you put this on and walk around, something...unexpected might happen...
-       THANK_YOU = 7348; -- Thank you...<<<Prompt>>>
+  TRICK_OR_TREAT = 7349; -- Trick or treat...
+ THANK_YOU_TREAT = 7350; -- And now for your treat...
+  HERE_TAKE_THIS = 7351; -- Here, take this...
+IF_YOU_WEAR_THIS = 7352; -- If you put this on and walk around, something...unexpected might happen...
+       THANK_YOU = 7350; -- Thank you...<<<Prompt>>>
 
 -- Other dialog
-ITEM_DELIVERY_DIALOG = 8400; -- Parcels delivered to rooms anywhere in Vana'diel!
-        ROSEL_DIALOG = 7777; -- Hrmm... Now, this is interesting! It pays to keep an eye on the competition. Thanks for letting me know!
+ITEM_DELIVERY_DIALOG = 8402; -- Parcels delivered to rooms anywhere in Vana'diel!
+        ROSEL_DIALOG = 7779; -- Hrmm... Now, this is interesting! It pays to keep an eye on the competition. Thanks for letting me know!
 
-     BLENDARE_DIALOG = 8084; -- Wait! If I had magic, maybe I could keep my brother's hands off my sweets...
+     BLENDARE_DIALOG = 8086; -- Wait! If I had magic, maybe I could keep my brother's hands off my sweets...
 
-    BLENDARE_MESSAGE = 8822; -- Blendare looks over curiously for a moment.
-       ROSEL_MESSAGE = 8823; -- Rosel looks over curiously for a moment.
-       MAUGIE_DIALOG = 8824; -- A magic shop, eh? Hmm... A little magic could go a long way for making a leisurely retirement! Ho ho ho!
-      MAUGIE_MESSAGE = 8825; -- Maugie looks over curiously for a moment.
-      ADAUNEL_DIALOG = 8826; -- A magic shop? Maybe I'll check it out one of these days. Could help with my work, even...
-     ADAUNEL_MESSAGE = 8827; -- Adaunel looks over curiously for a moment.
-     LEUVERET_DIALOG = 8828; -- A magic shop? That'd be a fine place to peddle my wares. I smell a profit! I'll be up to my gills in gil, I will!
-    LEUVERET_MESSAGE = 8829; -- Leuveret looks over curiously for a moment.
+    BLENDARE_MESSAGE = 8824; -- Blendare looks over curiously for a moment.
+       ROSEL_MESSAGE = 8825; -- Rosel looks over curiously for a moment.
+       MAUGIE_DIALOG = 8826; -- A magic shop, eh? Hmm... A little magic could go a long way for making a leisurely retirement! Ho ho ho!
+      MAUGIE_MESSAGE = 8827; -- Maugie looks over curiously for a moment.
+      ADAUNEL_DIALOG = 8828; -- A magic shop? Maybe I'll check it out one of these days. Could help with my work, even...
+     ADAUNEL_MESSAGE = 8829; -- Adaunel looks over curiously for a moment.
+     LEUVERET_DIALOG = 8830; -- A magic shop? That'd be a fine place to peddle my wares. I smell a profit! I'll be up to my gills in gil, I will!
+    LEUVERET_MESSAGE = 8831; -- Leuveret looks over curiously for a moment.
 
-     PAUNELIE_DIALOG = 8300; -- I'm sorry, can I help you?
+     PAUNELIE_DIALOG = 8302; -- I'm sorry, can I help you?
 
 -- Shop Texts
-      LUSIANE_SHOP_DIALOG = 7951; -- Hello! Let Taumila's handle all your sundry needs!
-      OSTALIE_SHOP_DIALOG = 7952; -- Welcome, customer. Please have a look.
+      LUSIANE_SHOP_DIALOG = 7953; -- Hello! Let Taumila's handle all your sundry needs!
+      OSTALIE_SHOP_DIALOG = 7954; -- Welcome, customer. Please have a look.
 
-ASH_THADI_ENE_SHOP_DIALOG = 7973; -- Welcome to Helbort's Blades!
+ASH_THADI_ENE_SHOP_DIALOG = 7975; -- Welcome to Helbort's Blades!
 
-       SHILAH_SHOP_DIALOG = 8105; -- Welcome, weary traveler. Make yourself at home!
+       SHILAH_SHOP_DIALOG = 8107; -- Welcome, weary traveler. Make yourself at home!
 
-            CLETAE_DIALOG = 8191; -- Why, hello. All our skins are guild-approved.
-   KUEH_IGUNAHMORI_DIALOG = 8192; -- Good day! We have lots in stock today.
+            CLETAE_DIALOG = 8193; -- Why, hello. All our skins are guild-approved.
+   KUEH_IGUNAHMORI_DIALOG = 8194; -- Good day! We have lots in stock today.
 
-FERDOULEMIONT_SHOP_DIALOG = 7951; -- Hello!
-      AVELINE_SHOP_DIALOG = 8410; -- Welcome to Raimbroy's Grocery!
-      BENAIGE_SHOP_DIALOG = 8411; -- Looking for something in particular?
-     CAPUCINE_SHOP_DIALOG = 8404; -- Hello!
-    MACHIELLE_OPEN_DIALOG = 8406; -- Might I interest you in produce from Norvallen?
-        CORUA_OPEN_DIALOG = 8407; -- Ronfaure produce for sale!
-    PHAMELISE_OPEN_DIALOG = 8408; -- I've got fresh produce from Zulkheim!
-   APAIREMANT_OPEN_DIALOG = 8409; -- Might you be interested in produce from Gustaberg
+FERDOULEMIONT_SHOP_DIALOG = 7953; -- Hello!
+      AVELINE_SHOP_DIALOG = 8412; -- Welcome to Raimbroy's Grocery!
+      BENAIGE_SHOP_DIALOG = 8413; -- Looking for something in particular?
+     CAPUCINE_SHOP_DIALOG = 8406; -- Hello!
+    MACHIELLE_OPEN_DIALOG = 8408; -- Might I interest you in produce from Norvallen?
+        CORUA_OPEN_DIALOG = 8409; -- Ronfaure produce for sale!
+    PHAMELISE_OPEN_DIALOG = 8410; -- I've got fresh produce from Zulkheim!
+   APAIREMANT_OPEN_DIALOG = 8411; -- Might you be interested in produce from Gustaberg
 
-     PAUNELIE_SHOP_DIALOG = 8305; -- These magic shells are full of mysteries...
+     PAUNELIE_SHOP_DIALOG = 8307; -- These magic shells are full of mysteries...
 
-  MACHIELLE_CLOSED_DIALOG = 8413; -- We want to sell produce from Norvallen, but the entire region is under foreign control!
-      CORUA_CLOSED_DIALOG = 8414; -- We specialize in Ronfaure produce, but we cannot import from that region without a strong San d'Orian presence there.
-  PHAMELISE_CLOSED_DIALOG = 8415; -- I'd be making a killing selling produce from Zulkheim, but the region's under foreign control!
- APAIREMANT_CLOSED_DIALOG = 8416; -- I'd love to import produce from Gustaberg, but the foreign powers in control there make me feel unsafe!
-     POURETTE_OPEN_DIALOG = 8417; -- Derfland produce for sale!
-   POURETTE_CLOSED_DIALOG = 8418; -- Listen, adventurer... I can't import from Derfland until the region knows San d'Orian power!
+  MACHIELLE_CLOSED_DIALOG = 8415; -- We want to sell produce from Norvallen, but the entire region is under foreign control!
+      CORUA_CLOSED_DIALOG = 8416; -- We specialize in Ronfaure produce, but we cannot import from that region without a strong San d'Orian presence there.
+  PHAMELISE_CLOSED_DIALOG = 8417; -- I'd be making a killing selling produce from Zulkheim, but the region's under foreign control!
+ APAIREMANT_CLOSED_DIALOG = 8418; -- I'd love to import produce from Gustaberg, but the foreign powers in control there make me feel unsafe!
+     POURETTE_OPEN_DIALOG = 8419; -- Derfland produce for sale!
+   POURETTE_CLOSED_DIALOG = 8420; -- Listen, adventurer... I can't import from Derfland until the region knows San d'Orian power!
 
-     MIOGIQUE_SHOP_DIALOG = 8411; -- Looking for something in particular?
-     CARAUTIA_SHOP_DIALOG = 8412; -- Well, what sort of armor would you like?
-    VALERIANO_SHOP_DIALOG = 8123; -- Oh, a fellow outsider! We are Troupe Valeriano. I am Valeriano, at your service!
+     MIOGIQUE_SHOP_DIALOG = 8413; -- Looking for something in particular?
+     CARAUTIA_SHOP_DIALOG = 8414; -- Well, what sort of armor would you like?
+    VALERIANO_SHOP_DIALOG = 8125; -- Oh, a fellow outsider! We are Troupe Valeriano. I am Valeriano, at your service!
 
-        RAMINEL_DELIVERY  = 8088; -- Here's your delivery!
-            LUSIANE_THANK = 8089; -- Thank you!?Prompt?
-       RAMINEL_DELIVERIES = 8090; -- Sorry, I have deliveries to make!
+        RAMINEL_DELIVERY  = 8090; -- Here's your delivery!
+            LUSIANE_THANK = 8091; -- Thank you!?Prompt?
+       RAMINEL_DELIVERIES = 8092; -- Sorry, I have deliveries to make!
 
 -- conquest Base
-CONQUEST_BASE = 7024; -- Tallying conquest results...
+CONQUEST_BASE = 7026; -- Tallying conquest results...
 

--- a/scripts/zones/Southern_San_dOria_[S]/TextIDs.lua
+++ b/scripts/zones/Southern_San_dOria_[S]/TextIDs.lua
@@ -2,17 +2,17 @@
 
 -- General Texts
 ITEM_CANNOT_BE_OBTAINED = 6379; -- You cannot obtain the item <item> come back again after sorting your inventory
-          ITEM_OBTAINED = 6384; -- Obtained: <item>
-           GIL_OBTAINED = 6385; -- Obtained <number> gil
-       KEYITEM_OBTAINED = 6387; -- Obtained key item: <keyitem>
+          ITEM_OBTAINED = 6385; -- Obtained: <item>
+           GIL_OBTAINED = 6386; -- Obtained <number> gil
+       KEYITEM_OBTAINED = 6388; -- Obtained key item: <keyitem>
 
-           ALLIED_SIGIL = 12905; -- You have received the Allied Sigil!
+           ALLIED_SIGIL = 12906; -- You have received the Allied Sigil!
 
 -- Other Texts
-ITEM_DELIVERY_DIALOG = 11204; -- If'n ye have goods tae deliver, then Nembet be yer man!
+ITEM_DELIVERY_DIALOG = 11205; -- If'n ye have goods tae deliver, then Nembet be yer man!
 
 -- NPC Dialogs
-WYATT_DIALOG = 11073; -- Ahhh, sorry, sorry. The name's Wyatt, an' I be an armor merchant from Jeuno. Ended up 'ere in San d'Oria some way or another, though.
+WYATT_DIALOG = 11074; -- Ahhh, sorry, sorry. The name's Wyatt, an' I be an armor merchant from Jeuno. Ended up 'ere in San d'Oria some way or another, though.
 
 -- Porter Moogle
-    RETRIEVE_DIALOG_ID = 15568; -- You retrieve$ from the porter moogle's care.
+    RETRIEVE_DIALOG_ID = 15569; -- You retrieve$ from the porter moogle's care.

--- a/scripts/zones/Spire_of_Dem/TextIDs.lua
+++ b/scripts/zones/Spire_of_Dem/TextIDs.lua
@@ -2,9 +2,9 @@
 
 -- General Texts
 ITEM_CANNOT_BE_OBTAINED = 6379; -- You cannot obtain the item <item> come back again after sorting your inventory
-          ITEM_OBTAINED = 6384; -- Obtained: <item>
-           GIL_OBTAINED = 6385; -- Obtained <number> gil
-       KEYITEM_OBTAINED = 6387; -- Obtained key item: <keyitem>
+          ITEM_OBTAINED = 6385; -- Obtained: <item>
+           GIL_OBTAINED = 6386; -- Obtained <number> gil
+       KEYITEM_OBTAINED = 6388; -- Obtained key item: <keyitem>
 
-         FAINT_SCRAPING = 7077; -- You can hear a faint scraping sound from within, but the way is barred by some strange membrane...
-          CANT_REMEMBER = 7628; -- You cannot remember when exactly, but you have obtained
+         FAINT_SCRAPING = 7078; -- You can hear a faint scraping sound from within, but the way is barred by some strange membrane...
+          CANT_REMEMBER = 7629; -- You cannot remember when exactly, but you have obtained

--- a/scripts/zones/Spire_of_Holla/TextIDs.lua
+++ b/scripts/zones/Spire_of_Holla/TextIDs.lua
@@ -2,9 +2,9 @@
 
 -- General Texts
 ITEM_CANNOT_BE_OBTAINED = 6379; -- You cannot obtain the item <item> come back again after sorting your inventory
-          ITEM_OBTAINED = 6384; -- Obtained: <item>
-           GIL_OBTAINED = 6385; -- Obtained <number> gil
-       KEYITEM_OBTAINED = 6387; -- Obtained key item: <keyitem>
+          ITEM_OBTAINED = 6385; -- Obtained: <item>
+           GIL_OBTAINED = 6386; -- Obtained <number> gil
+       KEYITEM_OBTAINED = 6388; -- Obtained key item: <keyitem>
 
-        FAINT_SCRAPING = 7077; -- You can hear a faint scraping sound from within, but the way is barred by some strange membrane...
-         CANT_REMEMBER = 7628; -- You cannot remember when exactly, but you have obtained
+        FAINT_SCRAPING = 7078; -- You can hear a faint scraping sound from within, but the way is barred by some strange membrane...
+         CANT_REMEMBER = 7629; -- You cannot remember when exactly, but you have obtained

--- a/scripts/zones/Spire_of_Mea/TextIDs.lua
+++ b/scripts/zones/Spire_of_Mea/TextIDs.lua
@@ -2,10 +2,10 @@
 
 -- General Texts
 ITEM_CANNOT_BE_OBTAINED = 6379; -- You cannot obtain the item <item> come back again after sorting your inventory
-          ITEM_OBTAINED = 6384; -- Obtained: <item>
-           GIL_OBTAINED = 6385; -- Obtained <number> gil
-       KEYITEM_OBTAINED = 6387; -- Obtained key item: <keyitem>
+          ITEM_OBTAINED = 6385; -- Obtained: <item>
+           GIL_OBTAINED = 6386; -- Obtained <number> gil
+       KEYITEM_OBTAINED = 6388; -- Obtained key item: <keyitem>
 
-         FAINT_SCRAPING = 7077; -- You can hear a faint scraping sound from within, but the way is barred by some strange membrane...
-          CANT_REMEMBER = 7628; -- You cannot remember when exactly, but you have obtained
+         FAINT_SCRAPING = 7078; -- You can hear a faint scraping sound from within, but the way is barred by some strange membrane...
+          CANT_REMEMBER = 7629; -- You cannot remember when exactly, but you have obtained
 

--- a/scripts/zones/Spire_of_Vahzl/TextIDs.lua
+++ b/scripts/zones/Spire_of_Vahzl/TextIDs.lua
@@ -2,9 +2,9 @@
 
 -- General Texts
 ITEM_CANNOT_BE_OBTAINED = 6379; -- You cannot obtain the item <item> come back again after sorting your inventory
-          ITEM_OBTAINED = 6384; -- Obtained: <item>
-           GIL_OBTAINED = 6385; -- Obtained <number> gil
-       KEYITEM_OBTAINED = 6387; -- Obtained key item: <keyitem>
+          ITEM_OBTAINED = 6385; -- Obtained: <item>
+           GIL_OBTAINED = 6386; -- Obtained <number> gil
+       KEYITEM_OBTAINED = 6388; -- Obtained key item: <keyitem>
 
 -- Other
-FAINT_SCRAPING = 7077; -- You can hear a faint scraping sound from within, but the way is barred by some strange membrane...
+FAINT_SCRAPING = 7078; -- You can hear a faint scraping sound from within, but the way is barred by some strange membrane...

--- a/scripts/zones/Stellar_Fulcrum/TextIDs.lua
+++ b/scripts/zones/Stellar_Fulcrum/TextIDs.lua
@@ -2,9 +2,9 @@
 
 -- General Texts
 ITEM_CANNOT_BE_OBTAINED = 6379; -- You cannot obtain the item <item>. Come back after sorting your inventory.
-          ITEM_OBTAINED = 6384; -- Obtained: <item>.
-           GIL_OBTAINED = 6385; -- Obtained <number> gil.
-       KEYITEM_OBTAINED = 6387; -- Obtained key item: <keyitem>.
+          ITEM_OBTAINED = 6385; -- Obtained: <item>.
+           GIL_OBTAINED = 6386; -- Obtained <number> gil.
+       KEYITEM_OBTAINED = 6388; -- Obtained key item: <keyitem>.
 
 -- conquest Base
-CONQUEST_BASE = 7045; -- Tallying conquest results...
+CONQUEST_BASE = 7046; -- Tallying conquest results...

--- a/scripts/zones/Tahrongi_Canyon/TextIDs.lua
+++ b/scripts/zones/Tahrongi_Canyon/TextIDs.lua
@@ -2,44 +2,44 @@
 
 -- General Texts
 ITEM_CANNOT_BE_OBTAINED = 6560; -- You cannot obtain the item <item> come back again after sorting your inventory.
-          ITEM_OBTAINED = 6565; -- Obtained: <item>.
-           GIL_OBTAINED = 6566; -- Obtained <number> gil.
-       KEYITEM_OBTAINED = 6568; -- Obtained key item: <keyitem>.
+          ITEM_OBTAINED = 6566; -- Obtained: <item>.
+           GIL_OBTAINED = 6567; -- Obtained <number> gil.
+       KEYITEM_OBTAINED = 6569; -- Obtained key item: <keyitem>.
 
- FISHING_MESSAGE_OFFSET = 7226; -- You can't fish here.
-  ALREADY_OBTAINED_TELE = 7326; -- You already possess the gate crystal for this telepoint.
+ FISHING_MESSAGE_OFFSET = 7227; -- You can't fish here.
+  ALREADY_OBTAINED_TELE = 7327; -- You already possess the gate crystal for this telepoint.
         NOTHING_HAPPENS = 300; -- Nothing happens.
 
 -- Mining
-MINING_IS_POSSIBLE_HERE = 7428; -- Mining is possible here if you have
+MINING_IS_POSSIBLE_HERE = 7429; -- Mining is possible here if you have
 
 -- ??? that spawns NM Yara Ma Yha Who
-     SPROUT_LOOKS_WITHERED = 7545; -- There is something sprouting from the ground here. It looks a little withered.
-REPULSIVE_CREATURE_EMERGES = 7546; -- A repulsive creature emerges from the ground!
-SPROUT_DOES_NOT_NEED_WATER = 7547; -- The sprout does not need any more water now.
-     SPROUT_LOOKING_BETTER = 7549; -- The sprout is looking better.
+     SPROUT_LOOKS_WITHERED = 7546; -- There is something sprouting from the ground here. It looks a little withered.
+REPULSIVE_CREATURE_EMERGES = 7547; -- A repulsive creature emerges from the ground!
+SPROUT_DOES_NOT_NEED_WATER = 7548; -- The sprout does not need any more water now.
+     SPROUT_LOOKING_BETTER = 7550; -- The sprout is looking better.
 
 -- Tahrongi Cactus
-            BUD_BREAKS_OFF = 7405; -- The bud breaks off. You obtain
-    POISONOUS_LOOKING_BUDS = 7406; -- The flowers have poisonous-looking buds.
-        CANT_TAKE_ANY_MORE = 7407; -- You can't take any more.
+            BUD_BREAKS_OFF = 7406; -- The bud breaks off. You obtain
+    POISONOUS_LOOKING_BUDS = 7407; -- The flowers have poisonous-looking buds.
+        CANT_TAKE_ANY_MORE = 7408; -- You can't take any more.
 
 -- Luck Rune
-NOTHING_OUT_OF_THE_ORDINARY = 6579;  -- There is nothing out of the ordinary here.
+NOTHING_OUT_OF_THE_ORDINARY = 6580;  -- There is nothing out of the ordinary here.
 
 -- Other Texts
-TELEPOINT_HAS_BEEN_SHATTERED = 7502; -- The telepoint has been shattered into a thousand pieces...
-       TELEPOINT_DISAPPEARED = 7327; -- The telepoint has disappeared...
+TELEPOINT_HAS_BEEN_SHATTERED = 7503; -- The telepoint has been shattered into a thousand pieces...
+       TELEPOINT_DISAPPEARED = 7328; -- The telepoint has disappeared...
 
 -- Signs
-SIGN_1 = 7401; -- North: Meriphataud Mountains Northeast: Crag of Mea South: East Sarutabaruta
-SIGN_3 = 7402; -- North: Meriphataud Mountains East: Crag of Mea South: East Sarutabaruta
-SIGN_5 = 7403; -- North: Meriphataud Mountains East: Buburimu Peninsula South: East Sarutabaruta
-SIGN_7 = 7404; -- East: Buburimu Peninsula West: East Sarutabaruta
+SIGN_1 = 7402; -- North: Meriphataud Mountains Northeast: Crag of Mea South: East Sarutabaruta
+SIGN_3 = 7403; -- North: Meriphataud Mountains East: Crag of Mea South: East Sarutabaruta
+SIGN_5 = 7404; -- North: Meriphataud Mountains East: Buburimu Peninsula South: East Sarutabaruta
+SIGN_7 = 7405; -- East: Buburimu Peninsula West: East Sarutabaruta
 
 -- conquest Base
 CONQUEST_BASE = 0;
 
 -- chocobo digging
-DIG_THROW_AWAY = 7239; -- You dig up ?Possible Special Code: 01??Possible Special Code: 01??Possible Special Code: 01? ?Possible Special Code: 01??Possible Special Code: 05?$?BAD CHAR: 8280??BAD CHAR: 80??BAD CHAR: 80?, but your inventory is full.
-FIND_NOTHING = 7241; -- You dig and you dig, but find nothing.
+DIG_THROW_AWAY = 7240; -- You dig up ?Possible Special Code: 01??Possible Special Code: 01??Possible Special Code: 01? ?Possible Special Code: 01??Possible Special Code: 05?$?BAD CHAR: 8280??BAD CHAR: 80??BAD CHAR: 80?, but your inventory is full.
+FIND_NOTHING = 7242; -- You dig and you dig, but find nothing.

--- a/scripts/zones/Talacca_Cove/TextIDs.lua
+++ b/scripts/zones/Talacca_Cove/TextIDs.lua
@@ -2,10 +2,10 @@
 
 -- General Texts
 ITEM_CANNOT_BE_OBTAINED = 6379; -- You cannot obtain the item <item> come back again after sorting your inventory
-          ITEM_OBTAINED = 6384; -- Obtained: <item>
-           GIL_OBTAINED = 6385; -- Obtained <number> gil
-       KEYITEM_OBTAINED = 6387; -- Obtained key item: <keyitem>
- FISHING_MESSAGE_OFFSET = 7045; -- You can't fish here
+          ITEM_OBTAINED = 6385; -- Obtained: <item>
+           GIL_OBTAINED = 6386; -- Obtained <number> gil
+       KEYITEM_OBTAINED = 6388; -- Obtained key item: <keyitem>
+ FISHING_MESSAGE_OFFSET = 7046; -- You can't fish here
 
 -- Quest Texts
-YOU_CAN_NOW_BECOME_A_CORSAIR = 7777; -- You can now become a corsair!
+YOU_CAN_NOW_BECOME_A_CORSAIR = 7778; -- You can now become a corsair!

--- a/scripts/zones/Tavnazian_Safehold/TextIDs.lua
+++ b/scripts/zones/Tavnazian_Safehold/TextIDs.lua
@@ -2,34 +2,34 @@
 
 -- General Texts
 ITEM_CANNOT_BE_OBTAINED = 6379;  -- You cannot obtain the item <item> come back again after sorting your inventory
-          ITEM_OBTAINED = 6384;  -- Obtained: <item>
-           GIL_OBTAINED = 6385;  -- Obtained <number> gil
-       KEYITEM_OBTAINED = 6387;  -- Obtained key item: <keyitem>
-          HOMEPOINT_SET = 10914; -- Home point set!
- FISHING_MESSAGE_OFFSET = 10253; -- You can't fish here
+          ITEM_OBTAINED = 6385;  -- Obtained: <item>
+           GIL_OBTAINED = 6386;  -- Obtained <number> gil
+       KEYITEM_OBTAINED = 6388;  -- Obtained key item: <keyitem>
+          HOMEPOINT_SET = 10915; -- Home point set!
+ FISHING_MESSAGE_OFFSET = 10254; -- You can't fish here
 
 -- Other Texts
-ITEM_DELIVERY_DIALOG = 10911; -- I can send your items to anywhere in Vana'diel!
+ITEM_DELIVERY_DIALOG = 10912; -- I can send your items to anywhere in Vana'diel!
 -- Quest Dialog
-NOMAD_MOOGLE_DIALOG = 10885; -- I'm a traveling moogle, kupo. I help adventurers in the Outlands access items they have stored in a Mog House elsewhere, kupo.
+NOMAD_MOOGLE_DIALOG = 10886; -- I'm a traveling moogle, kupo. I help adventurers in the Outlands access items they have stored in a Mog House elsewhere, kupo.
 
 -- Shop Text
-CAIPHIMONRIDE_SHOP_DIALOG = 10898; -- Welcome! Thanks to the supplies from Jeuno, I've been able to fix some of the weapons I had in storage!
-   MELLEUPAUX_SHOP_DIALOG = 10900; -- Hello! With the arrival of supplies from Jeuno, we are now able to sell some of the items we had stored in these warehouses.
-     KOMALATA_SHOP_DIALOG = 10895; -- Do you need any Tavnazian produce? We don't have much, but find a fine cook and your problems will be solved!
- MAZUROOOZURO_SHOP_DIALOG = 10894; -- Hidely-howdy-ho! I'll sell you what I've got if you fork over enough dough!
-       MIGRAN_SHOP_DIALOG = 10904; -- Even with the aid from Jeuno, I still have trouble feeding my six children...
-   NILEROUCHE_SHOP_DIALOG = 10893; -- Hello, traveler! Please have a look at these fine Tavnazian-built products!
-   MISSEULIEU_SHOP_DIALOG = 10902; -- Greetings, adventurer! I've been given authorization to begin the sale of the old Tavnazian armor we had in storage!
+CAIPHIMONRIDE_SHOP_DIALOG = 10899; -- Welcome! Thanks to the supplies from Jeuno, I've been able to fix some of the weapons I had in storage!
+   MELLEUPAUX_SHOP_DIALOG = 10901; -- Hello! With the arrival of supplies from Jeuno, we are now able to sell some of the items we had stored in these warehouses.
+     KOMALATA_SHOP_DIALOG = 10896; -- Do you need any Tavnazian produce? We don't have much, but find a fine cook and your problems will be solved!
+ MAZUROOOZURO_SHOP_DIALOG = 10895; -- Hidely-howdy-ho! I'll sell you what I've got if you fork over enough dough!
+       MIGRAN_SHOP_DIALOG = 10905; -- Even with the aid from Jeuno, I still have trouble feeding my six children...
+   NILEROUCHE_SHOP_DIALOG = 10894; -- Hello, traveler! Please have a look at these fine Tavnazian-built products!
+   MISSEULIEU_SHOP_DIALOG = 10903; -- Greetings, adventurer! I've been given authorization to begin the sale of the old Tavnazian armor we had in storage!
 
-YOU_CANNOT_ENTER_DYNAMIS = 11824; -- You cannot enter Dynamis
+YOU_CANNOT_ENTER_DYNAMIS = 11825; -- You cannot enter Dynamis
 
-PLAYERS_HAVE_NOT_REACHED_LEVEL = 11826; -- Players who have not reached levelare prohibited from entering Dynamis.
+PLAYERS_HAVE_NOT_REACHED_LEVEL = 11827; -- Players who have not reached levelare prohibited from entering Dynamis.
 
-MYSTERIOUS_VOICE = 11812; -- You hear a mysterious, floating voice:
+MYSTERIOUS_VOICE = 11813; -- You hear a mysterious, floating voice:
 
 -- conquest Base
-CONQUEST_BASE = 6532; -- Tallying conquest results...
+CONQUEST_BASE = 6533; -- Tallying conquest results...
 
 -- Porter Moogle
-    RETRIEVE_DIALOG_ID = 12249; -- You retrieve$ from the porter moogle's care.
+    RETRIEVE_DIALOG_ID = 12250; -- You retrieve$ from the porter moogle's care.

--- a/scripts/zones/Temenos/TextIDs.lua
+++ b/scripts/zones/Temenos/TextIDs.lua
@@ -2,11 +2,11 @@
 
 -- General Texts
 ITEM_CANNOT_BE_OBTAINED = 6379; -- You cannot obtain the item <item> come back again after sorting your inventory
-          ITEM_OBTAINED = 6384; -- Obtained: <item>
-           GIL_OBTAINED = 6385; -- Obtained <number> gil
-       KEYITEM_OBTAINED = 6387; -- Obtained key item: <keyitem>
-CONDITION_FOR_LIMBUS_T = 7051;  -- You have clearance to enter Limbus, but cannot enter while you or a party member is engaged in battle.
+          ITEM_OBTAINED = 6385; -- Obtained: <item>
+           GIL_OBTAINED = 6386; -- Obtained <number> gil
+       KEYITEM_OBTAINED = 6388; -- Obtained key item: <keyitem>
+CONDITION_FOR_LIMBUS_T = 7052;  -- You have clearance to enter Limbus, but cannot enter while you or a party member is engaged in battle.
           CHIP_TRADE_T = 7027;  --
 
 -- conquest Base
-CONQUEST_BASE = 7371; -- Tallying conquest results...
+CONQUEST_BASE = 7372; -- Tallying conquest results...

--- a/scripts/zones/Temple_of_Uggalepih/TextIDs.lua
+++ b/scripts/zones/Temple_of_Uggalepih/TextIDs.lua
@@ -2,42 +2,42 @@
 
 -- General Texts
 ITEM_CANNOT_BE_OBTAINED = 6379; -- You cannot obtain the item <item> come back again after sorting your inventory
-          ITEM_OBTAINED = 6384; -- Obtained: <item>
-           GIL_OBTAINED = 6385; -- Obtained <number> gil
-       KEYITEM_OBTAINED = 6387; -- Obtained key item: <keyitem>
- FISHING_MESSAGE_OFFSET = 7204; -- You can't fish here
-        BITS_OF_VEGETABLE = 7495; -- Bits of vegetable matter are strewn around. They appear to have been gnawed on by insects...
+          ITEM_OBTAINED = 6385; -- Obtained: <item>
+           GIL_OBTAINED = 6386; -- Obtained <number> gil
+       KEYITEM_OBTAINED = 6388; -- Obtained key item: <keyitem>
+ FISHING_MESSAGE_OFFSET = 7205; -- You can't fish here
+        BITS_OF_VEGETABLE = 7496; -- Bits of vegetable matter are strewn around. They appear to have been gnawed on by insects...
 
 -- Treasure Coffer/Chest Dialog
-CHEST_UNLOCKED = 7311; -- You unlock the chest!
-    CHEST_FAIL = 7312; -- Fails to open the chest.
-    CHEST_TRAP = 7313; -- The chest was trapped!
-    CHEST_WEAK = 7314; -- You cannot open the chest when you are in a weakened state.
-   CHEST_MIMIC = 7315; -- The chest was a mimic!
-  CHEST_MOOGLE = 7316; -- You cannot open the chest while participating in the moogle event.
-CHEST_ILLUSION = 7317; -- The chest was but an illusion...
-  CHEST_LOCKED = 7318; -- The chest appears to be locked.
+CHEST_UNLOCKED = 7312; -- You unlock the chest!
+    CHEST_FAIL = 7313; -- Fails to open the chest.
+    CHEST_TRAP = 7314; -- The chest was trapped!
+    CHEST_WEAK = 7315; -- You cannot open the chest when you are in a weakened state.
+   CHEST_MIMIC = 7316; -- The chest was a mimic!
+  CHEST_MOOGLE = 7317; -- You cannot open the chest while participating in the moogle event.
+CHEST_ILLUSION = 7318; -- The chest was but an illusion...
+  CHEST_LOCKED = 7319; -- The chest appears to be locked.
 
 -- Dialog Texts
-  NO_REASON_TO_INVESTIGATE = 7319; -- There is no reason to investigate further.
-         THE_BOX_IS_LOCKED = 7320; -- The box is locked.
-         PAINTBRUSH_OFFSET = 7323; -- projects the deepest, darkest corner of your soul onto the blank canvas...only then will the doors to rancor open
-       FALLS_FROM_THE_BOOK = 7333; -- falls from the book!
-        THE_DOOR_IS_LOCKED = 7347; -- The door is locked. You might be able to open it with
-PROTECTED_BY_UNKNOWN_FORCE = 7348; -- The door is protected by some unknown force.
-           YOUR_KEY_BREAKS = 7350; -- breaks!
-               DOOR_LOCKED = 7368; -- The door is locked.
-     SOME_SORT_OF_CEREMONY = 7440; -- Some sort of ceremony was performed here...
-                 NM_OFFSET = 7490; -- It looks like some sort of device. A thin thread leads down to the floor...
-           IT_IS_A_BEEHIVE = 7494; -- It is a beehive...
+  NO_REASON_TO_INVESTIGATE = 7320; -- There is no reason to investigate further.
+         THE_BOX_IS_LOCKED = 7321; -- The box is locked.
+         PAINTBRUSH_OFFSET = 7324; -- projects the deepest, darkest corner of your soul onto the blank canvas...only then will the doors to rancor open
+       FALLS_FROM_THE_BOOK = 7334; -- falls from the book!
+        THE_DOOR_IS_LOCKED = 7348; -- The door is locked. You might be able to open it with
+PROTECTED_BY_UNKNOWN_FORCE = 7349; -- The door is protected by some unknown force.
+           YOUR_KEY_BREAKS = 7351; -- breaks!
+               DOOR_LOCKED = 7369; -- The door is locked.
+     SOME_SORT_OF_CEREMONY = 7441; -- Some sort of ceremony was performed here...
+                 NM_OFFSET = 7491; -- It looks like some sort of device. A thin thread leads down to the floor...
+           IT_IS_A_BEEHIVE = 7495; -- It is a beehive...
 
            NOTHING_HAPPENS = 119;  -- Nothing happens...
-   NOTHING_OUT_OF_ORDINARY = 6398; -- There is nothing out of the ordinary here.
+   NOTHING_OUT_OF_ORDINARY = 6399; -- There is nothing out of the ordinary here.
 
 -- Other
-HATE_RESET = 7421; -- The built-up hate has been cleansed...!
- DOOR_SHUT = 7423; -- The door is firmly shut.
-   NO_HATE = 7424; -- You have no built-up hate to cleanse.
+HATE_RESET = 7422; -- The built-up hate has been cleansed...!
+ DOOR_SHUT = 7424; -- The door is firmly shut.
+   NO_HATE = 7425; -- You have no built-up hate to cleanse.
 
 -- conquest Base
-CONQUEST_BASE = 7045; -- Tallying conquest results...
+CONQUEST_BASE = 7046; -- Tallying conquest results...

--- a/scripts/zones/The_Boyahda_Tree/TextIDs.lua
+++ b/scripts/zones/The_Boyahda_Tree/TextIDs.lua
@@ -2,30 +2,30 @@
 
 -- General Texts
 ITEM_CANNOT_BE_OBTAINED = 6379; -- You cannot obtain the item <item>. Come back after sorting your inventory.
-          ITEM_OBTAINED = 6384; -- Obtained: <item>
-           GIL_OBTAINED = 6385; -- Obtained <number> gil
-       KEYITEM_OBTAINED = 6387; -- Obtained key item: <keyitem>
- FISHING_MESSAGE_OFFSET = 7045; -- You can't fish here.
-            HOMEPOINT_SET = 11429; -- Home point set!
+          ITEM_OBTAINED = 6385; -- Obtained: <item>
+           GIL_OBTAINED = 6386; -- Obtained <number> gil
+       KEYITEM_OBTAINED = 6388; -- Obtained key item: <keyitem>
+ FISHING_MESSAGE_OFFSET = 7046; -- You can't fish here.
+            HOMEPOINT_SET = 11430; -- Home point set!
 
 -- Treasure Coffer/Chest Dialog
-CHEST_UNLOCKED = 7152; -- You unlock the chest!
-    CHEST_FAIL = 7153; -- Fails to open the chest.
-    CHEST_TRAP = 7154; -- The chest was trapped!
-    CHEST_WEAK = 7155; -- You cannot open the chest when you are in a weakened state.
-   CHEST_MIMIC = 7156; -- The chest was a mimic!
-  CHEST_MOOGLE = 7157; -- You cannot open the chest while participating in the moogle event.
-CHEST_ILLUSION = 7158; -- The chest was but an illusion...
-  CHEST_LOCKED = 7159; -- The chest appears to be locked.
+CHEST_UNLOCKED = 7153; -- You unlock the chest!
+    CHEST_FAIL = 7154; -- Fails to open the chest.
+    CHEST_TRAP = 7155; -- The chest was trapped!
+    CHEST_WEAK = 7156; -- You cannot open the chest when you are in a weakened state.
+   CHEST_MIMIC = 7157; -- The chest was a mimic!
+  CHEST_MOOGLE = 7158; -- You cannot open the chest while participating in the moogle event.
+CHEST_ILLUSION = 7159; -- The chest was but an illusion...
+  CHEST_LOCKED = 7160; -- The chest appears to be locked.
 
 -- Other
-NOTHING_OUT_OF_ORDINARY = 6398; -- There is nothing out of the ordinary here.
-       OMINOUS_PRESENCE = 7388; -- You sense an ominous presence...
+NOTHING_OUT_OF_ORDINARY = 6399; -- There is nothing out of the ordinary here.
+       OMINOUS_PRESENCE = 7389; -- You sense an ominous presence...
 
 -- Quests
-        CAN_SEE_SKY = 7165; -- You can see the sky from here.
-SOMETHING_NOT_RIGHT = 7166; -- Something is not right!
-    CANNOT_SEE_MOON = 7167; -- You cannot see the moon right now.
+        CAN_SEE_SKY = 7166; -- You can see the sky from here.
+SOMETHING_NOT_RIGHT = 7167; -- Something is not right!
+    CANNOT_SEE_MOON = 7168; -- You cannot see the moon right now.
 
 -- conquest Base
-CONQUEST_BASE = 7168; -- Tallying conquest results...
+CONQUEST_BASE = 7169; -- Tallying conquest results...

--- a/scripts/zones/The_Celestial_Nexus/TextIDs.lua
+++ b/scripts/zones/The_Celestial_Nexus/TextIDs.lua
@@ -2,9 +2,9 @@
 
 -- General Texts
 ITEM_CANNOT_BE_OBTAINED = 6379; -- You cannot obtain the item <item> come back again after sorting your inventory
-          ITEM_OBTAINED = 6384; -- Obtained: <item>
-           GIL_OBTAINED = 6385; -- Obtained <number> gil
-       KEYITEM_OBTAINED = 6387; -- Obtained key item: <keyitem>
+          ITEM_OBTAINED = 6385; -- Obtained: <item>
+           GIL_OBTAINED = 6386; -- Obtained <number> gil
+       KEYITEM_OBTAINED = 6388; -- Obtained key item: <keyitem>
 
 -- conquest Base
-CONQUEST_BASE = 7045; -- Tallying conquest results...
+CONQUEST_BASE = 7046; -- Tallying conquest results...

--- a/scripts/zones/The_Colosseum/TextIDs.lua
+++ b/scripts/zones/The_Colosseum/TextIDs.lua
@@ -2,11 +2,11 @@
 
 -- General Texts
 ITEM_CANNOT_BE_OBTAINED = 6379; -- You cannot obtain the item <item> come back again after sorting your inventory
-          ITEM_OBTAINED = 6384; -- Obtained: <item>
-           GIL_OBTAINED = 6385; -- Obtained <number> gil
-       KEYITEM_OBTAINED = 6387; -- Obtained key item: <keyitem>
+          ITEM_OBTAINED = 6385; -- Obtained: <item>
+           GIL_OBTAINED = 6386; -- Obtained <number> gil
+       KEYITEM_OBTAINED = 6388; -- Obtained key item: <keyitem>
 
 -- Pankration
-     THANKS_FOR_STOPPING_BY = 11494; -- Thanks for stopping by. I'll be seeing you around
-             I_CAN_GIVE_YOU = 11495; -- Let me see... I can give you
-EXCEED_THE_LIMIT_OF_JETTONS = 11497; -- By exchanging for this amount, you will exceed the limit of jettons that you can carry.
+     THANKS_FOR_STOPPING_BY = 11495; -- Thanks for stopping by. I'll be seeing you around
+             I_CAN_GIVE_YOU = 11496; -- Let me see... I can give you
+EXCEED_THE_LIMIT_OF_JETTONS = 11498; -- By exchanging for this amount, you will exceed the limit of jettons that you can carry.

--- a/scripts/zones/The_Eldieme_Necropolis/TextIDs.lua
+++ b/scripts/zones/The_Eldieme_Necropolis/TextIDs.lua
@@ -2,43 +2,43 @@
 
 -- General Texts
 ITEM_CANNOT_BE_OBTAINED = 6538; -- You cannot obtain the item <item> come back again after sorting your inventory
-          ITEM_OBTAINED = 6543; -- Obtained: <item>
-           GIL_OBTAINED = 6544; -- Obtained <number> gil
-       KEYITEM_OBTAINED = 6546; -- Obtained key item: <keyitem>
-            SOLID_STONE = 7378; -- This door is made of solid stone.
+          ITEM_OBTAINED = 6544; -- Obtained: <item>
+           GIL_OBTAINED = 6545; -- Obtained <number> gil
+       KEYITEM_OBTAINED = 6547; -- Obtained key item: <keyitem>
+            SOLID_STONE = 7379; -- This door is made of solid stone.
 
 -- Treasure Coffer/Chest Dialog
-CHEST_UNLOCKED = 7397; -- You unlock the chest!
-    CHEST_FAIL = 7398; -- Fails to open the chest.
-    CHEST_TRAP = 7399; -- The chest was trapped!
-    CHEST_WEAK = 7400; -- You cannot open the chest when you are in a weakened state.
-   CHEST_MIMIC = 7401; -- The chest was a mimic!
-  CHEST_MOOGLE = 7402; -- You cannot open the chest while participating in the moogle event.
-CHEST_ILLUSION = 7403; -- The chest was but an illusion...
-  CHEST_LOCKED = 7404; -- The chest appears to be locked.
+CHEST_UNLOCKED = 7398; -- You unlock the chest!
+    CHEST_FAIL = 7399; -- Fails to open the chest.
+    CHEST_TRAP = 7400; -- The chest was trapped!
+    CHEST_WEAK = 7401; -- You cannot open the chest when you are in a weakened state.
+   CHEST_MIMIC = 7402; -- The chest was a mimic!
+  CHEST_MOOGLE = 7403; -- You cannot open the chest while participating in the moogle event.
+CHEST_ILLUSION = 7404; -- The chest was but an illusion...
+  CHEST_LOCKED = 7405; -- The chest appears to be locked.
 
 -- Quests
-         NOTHING_OUT_OF_ORDINARY = 6557; -- There is nothing out of the ordinary here.
-             SENSE_OF_FOREBODING = 6558; -- You are suddenly overcome with a sense of foreboding...
-                NOTHING_HAPPENED = 7338; -- Nothing happened...
+         NOTHING_OUT_OF_ORDINARY = 6558; -- There is nothing out of the ordinary here.
+             SENSE_OF_FOREBODING = 6559; -- You are suddenly overcome with a sense of foreboding...
+                NOTHING_HAPPENED = 7339; -- Nothing happened...
 
-            RETURN_RIBBON_TO_HER = 7351; -- You can hear a voice from somewhere. (...return...ribbon to...her...)
+            RETURN_RIBBON_TO_HER = 7352; -- You can hear a voice from somewhere. (...return...ribbon to...her...)
 
-              THE_BRAZIER_IS_LIT = 7365; -- The brazier is lit.
-                 REFUSE_TO_LIGHT = 7366; -- Unexpectedly, therefuses to light.
-                LANTERN_GOES_OUT = 7367; -- For some strange reason, the light of thegoes out...
-                 THE_LIGHT_DIMLY = 7368; -- lights dimly. It doesn't look like this will be effective yet.?Prompt?
-       THE_LIGHT_HAS_INTENSIFIED = 7369; -- The light of thehas intensified.
-          THE_LIGHT_IS_FULLY_LIT = 7370; --  is fully lit!
+              THE_BRAZIER_IS_LIT = 7366; -- The brazier is lit.
+                 REFUSE_TO_LIGHT = 7367; -- Unexpectedly, therefuses to light.
+                LANTERN_GOES_OUT = 7368; -- For some strange reason, the light of thegoes out...
+                 THE_LIGHT_DIMLY = 7369; -- lights dimly. It doesn't look like this will be effective yet.?Prompt?
+       THE_LIGHT_HAS_INTENSIFIED = 7370; -- The light of thehas intensified.
+          THE_LIGHT_IS_FULLY_LIT = 7371; --  is fully lit!
 
-SPIRIT_INCENSE_EMITS_PUTRID_ODOR = 7407; -- emits a putrid odor and burns up. Your attempt this time has failed...?Prompt?
+SPIRIT_INCENSE_EMITS_PUTRID_ODOR = 7408; -- emits a putrid odor and burns up. Your attempt this time has failed...?Prompt?
 
-    SARCOPHAGUS_CANNOT_BE_OPENED = 7424; -- It is a stone sarcophagus with the lid sealed tight. It cannot be opened.
+    SARCOPHAGUS_CANNOT_BE_OPENED = 7425; -- It is a stone sarcophagus with the lid sealed tight. It cannot be opened.
 
 -- conquest Base
 CONQUEST_BASE = 0;
 
 -- Strange Apparatus
-DEVICE_NOT_WORKING = 7314; -- The device is not working.
-      SYS_OVERLOAD = 7323; -- arning! Sys...verload! Enterin...fety mode. ID eras...d 
-      YOU_LOST_THE = 7328; -- You lost the #. 
+DEVICE_NOT_WORKING = 7315; -- The device is not working.
+      SYS_OVERLOAD = 7324; -- arning! Sys...verload! Enterin...fety mode. ID eras...d 
+      YOU_LOST_THE = 7329; -- You lost the #. 

--- a/scripts/zones/The_Eldieme_Necropolis_[S]/TextIDs.lua
+++ b/scripts/zones/The_Eldieme_Necropolis_[S]/TextIDs.lua
@@ -2,16 +2,16 @@
 
 -- General Texts
 ITEM_CANNOT_BE_OBTAINED = 6379; -- You cannot obtain the item <item> come back again after sorting your inventory
-          ITEM_OBTAINED = 6384; -- Obtained: <item>
-           GIL_OBTAINED = 6385; -- Obtained <number> gil
-       KEYITEM_OBTAINED = 6387; -- Obtained key item: <keyitem>
+          ITEM_OBTAINED = 6385; -- Obtained: <item>
+           GIL_OBTAINED = 6386; -- Obtained <number> gil
+       KEYITEM_OBTAINED = 6388; -- Obtained key item: <keyitem>
 
 -- Other Texts
-ITEM_DELIVERY_DIALOG = 7898; -- Have something to send?
+ITEM_DELIVERY_DIALOG = 7899; -- Have something to send?
 
 -- Shop Texts
-LAYTON_SHOP_DIALOG = 7099; -- Might you be a student of the same field as I? If that is the case, I might be able to provide you with the proper grimoires...at a price, of course.
+LAYTON_SHOP_DIALOG = 7100; -- Might you be a student of the same field as I? If that is the case, I might be able to provide you with the proper grimoires...at a price, of course.
 
 -- Quest Dialog
- YOU_CAN_NOW_BECOME_A_SCHOLAR = 7708; -- You can now become a scholar!
-YOU_LEARN_EMBRAVA_AND_KAUSTRA = 7892; -- Player Name learns Embrava and Kaustra!
+ YOU_CAN_NOW_BECOME_A_SCHOLAR = 7709; -- You can now become a scholar!
+YOU_LEARN_EMBRAVA_AND_KAUSTRA = 7893; -- Player Name learns Embrava and Kaustra!

--- a/scripts/zones/The_Garden_of_RuHmet/TextIDs.lua
+++ b/scripts/zones/The_Garden_of_RuHmet/TextIDs.lua
@@ -2,18 +2,18 @@
 
 -- General Texts
 ITEM_CANNOT_BE_OBTAINED = 6379; -- You cannot obtain the item <item> come back again after sorting your inventory
-          ITEM_OBTAINED = 6384; -- Obtained: <item>
-           GIL_OBTAINED = 6385; -- Obtained <number> gil
-       KEYITEM_OBTAINED = 6387; -- Obtained key item: <keyitem>
-          HOMEPOINT_SET = 7758; -- Home point set!
+          ITEM_OBTAINED = 6385; -- Obtained: <item>
+           GIL_OBTAINED = 6386; -- Obtained <number> gil
+       KEYITEM_OBTAINED = 6388; -- Obtained key item: <keyitem>
+          HOMEPOINT_SET = 7759; -- Home point set!
             
 -- Other
-NO_NEED_INVESTIGATE = 7613; -- There is no need to investigate further.
-   UNKNOWN_PRESENCE = 7750; -- You sense some unknown presence...
-       NONE_HOSTILE = 7751; -- You sense some unknown presence, but it does not seem hostile.
-    SHEER_ANIMOSITY = 7753; -- Player Name is enveloped in sheer animosity!
-      PORTAL_SEALED = 7642; -- The portal is firmly sealed by a mysterious energy.
+NO_NEED_INVESTIGATE = 7614; -- There is no need to investigate further.
+   UNKNOWN_PRESENCE = 7751; -- You sense some unknown presence...
+       NONE_HOSTILE = 7752; -- You sense some unknown presence, but it does not seem hostile.
+    SHEER_ANIMOSITY = 7754; -- Player Name is enveloped in sheer animosity!
+      PORTAL_SEALED = 7643; -- The portal is firmly sealed by a mysterious energy.
 
 -- conquest Base
-CONQUEST_BASE = 7434; -- Tallying conquest results...
+CONQUEST_BASE = 7435; -- Tallying conquest results...
 

--- a/scripts/zones/The_Sanctuary_of_ZiTah/TextIDs.lua
+++ b/scripts/zones/The_Sanctuary_of_ZiTah/TextIDs.lua
@@ -3,30 +3,30 @@
 -- General Texts
    ITEM_CANNOT_BE_OBTAINED = 6379; -- You cannot obtain the item <item>. Come back after sorting your inventory.
 FULL_INVENTORY_AFTER_TRADE = 6383; -- You cannot obtain the <item>. Try trading again after sorting your inventory.
-             ITEM_OBTAINED = 6384; -- Obtained: <item>.
-              GIL_OBTAINED = 6385; -- Obtained <number> gil.
-          KEYITEM_OBTAINED = 6387; -- Obtained key item: <keyitem>.
-            ITEMS_OBTAINED = 6390; -- You obtain <param2 number> <param1 item>!
-           BEASTMEN_BANNER = 7126; -- There is a beastmen's banner.
-    FISHING_MESSAGE_OFFSET = 7546; -- You can't fish here.
+             ITEM_OBTAINED = 6385; -- Obtained: <item>.
+              GIL_OBTAINED = 6386; -- Obtained <number> gil.
+          KEYITEM_OBTAINED = 6388; -- Obtained key item: <keyitem>.
+            ITEMS_OBTAINED = 6391; -- You obtain <param2 number> <param1 item>!
+           BEASTMEN_BANNER = 7127; -- There is a beastmen's banner.
+    FISHING_MESSAGE_OFFSET = 7547; -- You can't fish here.
 
 -- Conquest
-CONQUEST = 7213; -- You've earned conquest points!
+CONQUEST = 7214; -- You've earned conquest points!
 
 -- Quest Dialogs
-    SENSE_OF_FOREBODING = 6399; -- You are suddenly overcome with a sense of foreboding...
-          STURDY_BRANCH = 7759; -- It is a beautiful, sturdy branch.
-NOTHING_OUT_OF_ORDINARY = 6398; -- There is nothing out of the ordinary here.
+    SENSE_OF_FOREBODING = 6400; -- You are suddenly overcome with a sense of foreboding...
+          STURDY_BRANCH = 7760; -- It is a beautiful, sturdy branch.
+NOTHING_OUT_OF_ORDINARY = 6399; -- There is nothing out of the ordinary here.
 
 -- ZM4 Dialog
-   CANNOT_REMOVE_FRAG = 7732; -- It is an oddly shaped stone monument. A shining stone is embedded in it, but cannot be removed...
-ALREADY_OBTAINED_FRAG = 7733; -- You have already obtained this monument's
-      FOUND_ALL_FRAGS = 7735; -- You now have all 8 fragments of light!
-      ZILART_MONUMENT = 7736; -- It is an ancient Zilart monument.
+   CANNOT_REMOVE_FRAG = 7733; -- It is an oddly shaped stone monument. A shining stone is embedded in it, but cannot be removed...
+ALREADY_OBTAINED_FRAG = 7734; -- You have already obtained this monument's
+      FOUND_ALL_FRAGS = 7736; -- You now have all 8 fragments of light!
+      ZILART_MONUMENT = 7737; -- It is an ancient Zilart monument.
 
 -- conquest Base
-CONQUEST_BASE = 7045; -- Tallying conquest results...
+CONQUEST_BASE = 7046; -- Tallying conquest results...
 
 -- chocobo digging
-DIG_THROW_AWAY = 7559; -- You dig up ?Possible Special Code: 01??Possible Special Code: 01??Possible Special Code: 01? ?Possible Special Code: 01??Possible Special Code: 05?$?BAD CHAR: 8280??BAD CHAR: 80??BAD CHAR: 80?, but your inventory is full.
-FIND_NOTHING = 7561; -- You dig and you dig, but find nothing.
+DIG_THROW_AWAY = 7560; -- You dig up ?Possible Special Code: 01??Possible Special Code: 01??Possible Special Code: 01? ?Possible Special Code: 01??Possible Special Code: 05?$?BAD CHAR: 8280??BAD CHAR: 80??BAD CHAR: 80?, but your inventory is full.
+FIND_NOTHING = 7562; -- You dig and you dig, but find nothing.

--- a/scripts/zones/The_Shrine_of_RuAvitau/TextIDs.lua
+++ b/scripts/zones/The_Shrine_of_RuAvitau/TextIDs.lua
@@ -2,16 +2,16 @@
 
 -- General Texts
 ITEM_CANNOT_BE_OBTAINED = 6379; -- You cannot obtain the item <item> come back again after sorting your inventory
-          ITEM_OBTAINED = 6384; -- Obtained: <item>
-           GIL_OBTAINED = 6385; -- Obtained <number> gil
-       KEYITEM_OBTAINED = 6387; -- Obtained key item: <keyitem>
- FISHING_MESSAGE_OFFSET = 7045; -- You can't fish here.
-            HOMEPOINT_SET = 11421; -- Home point set!
+          ITEM_OBTAINED = 6385; -- Obtained: <item>
+           GIL_OBTAINED = 6386; -- Obtained <number> gil
+       KEYITEM_OBTAINED = 6388; -- Obtained key item: <keyitem>
+ FISHING_MESSAGE_OFFSET = 7046; -- You can't fish here.
+            HOMEPOINT_SET = 11422; -- Home point set!
 
 -- Other dialog
-NOTHING_OUT_OF_ORDINARY = 6398; -- There is nothing out of the ordinary here.
-           KIRIN_OFFSET = 7343; -- I am Kirin, master of the Shijin. The one who stands above all. You, who have risen above your mortal status to contend with the gods... It is time to reap your reward.
-        SMALL_HOLE_HERE = 7332; -- There is a small hole here. It appears to be damp inside...
+NOTHING_OUT_OF_ORDINARY = 6399; -- There is nothing out of the ordinary here.
+           KIRIN_OFFSET = 7344; -- I am Kirin, master of the Shijin. The one who stands above all. You, who have risen above your mortal status to contend with the gods... It is time to reap your reward.
+        SMALL_HOLE_HERE = 7333; -- There is a small hole here. It appears to be damp inside...
 
 -- conquest Base
-CONQUEST_BASE = 7145; -- Tallying conquest results...
+CONQUEST_BASE = 7146; -- Tallying conquest results...

--- a/scripts/zones/The_Shrouded_Maw/TextIDs.lua
+++ b/scripts/zones/The_Shrouded_Maw/TextIDs.lua
@@ -2,9 +2,9 @@
 
 -- General Texts
 ITEM_CANNOT_BE_OBTAINED = 6379; -- You cannot obtain the item <item>. Come back after sorting your inventory.
-          ITEM_OBTAINED = 6384; -- Obtained: <item>.
-           GIL_OBTAINED = 6385; -- Obtained <number> gil.
-       KEYITEM_OBTAINED = 6387; -- Obtained key item: <keyitem>.
+          ITEM_OBTAINED = 6385; -- Obtained: <item>.
+           GIL_OBTAINED = 6386; -- Obtained <number> gil.
+       KEYITEM_OBTAINED = 6388; -- Obtained key item: <keyitem>.
 
 -- conquest Base
-CONQUEST_BASE = 7416; -- Tallying conquest results...
+CONQUEST_BASE = 7417; -- Tallying conquest results...

--- a/scripts/zones/Throne_Room/TextIDs.lua
+++ b/scripts/zones/Throne_Room/TextIDs.lua
@@ -2,17 +2,17 @@
 
 -- General Texts
 ITEM_CANNOT_BE_OBTAINED = 6379; -- You cannot obtain the item <item>. Come back after sorting your inventory.
-          ITEM_OBTAINED = 6384; -- Obtained: <item>.
-           GIL_OBTAINED = 6385; -- Obtained <number> gil.
-       KEYITEM_OBTAINED = 6387; -- Obtained key item: <keyitem>.
+          ITEM_OBTAINED = 6385; -- Obtained: <item>.
+           GIL_OBTAINED = 6386; -- Obtained <number> gil.
+       KEYITEM_OBTAINED = 6388; -- Obtained key item: <keyitem>.
 
 -- conquest Base
-CONQUEST_BASE = 7045; -- Tallying conquest results...
+CONQUEST_BASE = 7046; -- Tallying conquest results...
 
 -- Volker special
-              NO_HIDE_AWAY = 7693; -- I have not been hiding away from my troubles! 
-              FEEL_MY_PAIN = 7694; -- Feel my twenty years of pain! 
-               YOUR_ANSWER = 7695; -- Is that your answer! 
-    RETURN_TO_THE_DARKNESS = 7696; -- Return with your soul to the darkness you came from! 
-           CANT_UNDERSTAND = 7697; -- You--a man who has never lived bound by the chains of his country--how can you understand my pain! 
-              BLADE_ANSWER = 7698; -- Let my blade be the answer! 
+              NO_HIDE_AWAY = 7694; -- I have not been hiding away from my troubles! 
+              FEEL_MY_PAIN = 7695; -- Feel my twenty years of pain! 
+               YOUR_ANSWER = 7696; -- Is that your answer! 
+    RETURN_TO_THE_DARKNESS = 7697; -- Return with your soul to the darkness you came from! 
+           CANT_UNDERSTAND = 7698; -- You--a man who has never lived bound by the chains of his country--how can you understand my pain! 
+              BLADE_ANSWER = 7699; -- Let my blade be the answer! 

--- a/scripts/zones/Throne_Room_[S]/TextIDs.lua
+++ b/scripts/zones/Throne_Room_[S]/TextIDs.lua
@@ -2,6 +2,6 @@
 
 -- General Texts
 ITEM_CANNOT_BE_OBTAINED = 6379; -- You cannot obtain the item <item> come back again after sorting your inventory
-          ITEM_OBTAINED = 6384; -- Obtained: <item>
-           GIL_OBTAINED = 6385; -- Obtained <number> gil
-       KEYITEM_OBTAINED = 6387; -- Obtained key item: <keyitem>
+          ITEM_OBTAINED = 6385; -- Obtained: <item>
+           GIL_OBTAINED = 6386; -- Obtained <number> gil
+       KEYITEM_OBTAINED = 6388; -- Obtained key item: <keyitem>

--- a/scripts/zones/Toraimarai_Canal/TextIDs.lua
+++ b/scripts/zones/Toraimarai_Canal/TextIDs.lua
@@ -2,24 +2,24 @@
 
 -- General Texts
 ITEM_CANNOT_BE_OBTAINED = 6425; -- You cannot obtain the item <item>. Come back after sorting your inventory.
-          ITEM_OBTAINED = 6430; -- Obtained: <item>.
-           GIL_OBTAINED = 6431; -- Obtained <number> gil.
-       KEYITEM_OBTAINED = 6433; -- Obtained key item: <keyitem>.
- FISHING_MESSAGE_OFFSET = 7250; -- You can't fish here.
+          ITEM_OBTAINED = 6431; -- Obtained: <item>.
+           GIL_OBTAINED = 6432; -- Obtained <number> gil.
+       KEYITEM_OBTAINED = 6434; -- Obtained key item: <keyitem>.
+ FISHING_MESSAGE_OFFSET = 7251; -- You can't fish here.
 
 -- Treasure Coffer/Chest Dialog
-CHEST_UNLOCKED = 7357; -- You unlock the chest!
-    CHEST_FAIL = 7358; -- Fails to open the chest.
-    CHEST_TRAP = 7359; -- The chest was trapped!
-    CHEST_WEAK = 7360; -- You cannot open the chest when you are in a weakened state.
-   CHEST_MIMIC = 7361; -- The chest was a mimic!
-  CHEST_MOOGLE = 7362; -- You cannot open the chest while participating in the moogle event.
-CHEST_ILLUSION = 7363; -- The chest was but an illusion...
-  CHEST_LOCKED = 7364; -- The chest appears to be locked.
+CHEST_UNLOCKED = 7358; -- You unlock the chest!
+    CHEST_FAIL = 7359; -- Fails to open the chest.
+    CHEST_TRAP = 7360; -- The chest was trapped!
+    CHEST_WEAK = 7361; -- You cannot open the chest when you are in a weakened state.
+   CHEST_MIMIC = 7362; -- The chest was a mimic!
+  CHEST_MOOGLE = 7363; -- You cannot open the chest while participating in the moogle event.
+CHEST_ILLUSION = 7364; -- The chest was but an illusion...
+  CHEST_LOCKED = 7365; -- The chest appears to be locked.
 
 -- Quest dialog
      SEALED_SHUT = 3; -- It's sealed shut with incredibly strong magic.
- CHEST_IS_LOCKED = 7350; -- This chest is locked. It can be opened with
+ CHEST_IS_LOCKED = 7351; -- This chest is locked. It can be opened with
 
 -- conquest Base
-CONQUEST_BASE = 7091; -- Tallying conquest results...
+CONQUEST_BASE = 7092; -- Tallying conquest results...

--- a/scripts/zones/Uleguerand_Range/TextIDs.lua
+++ b/scripts/zones/Uleguerand_Range/TextIDs.lua
@@ -2,14 +2,14 @@
 
 -- General Texts
 ITEM_CANNOT_BE_OBTAINED = 6392; -- You cannot obtain the item <item>. Come back after sorting your inventory.
-          ITEM_OBTAINED = 6397; -- Obtained: <item>.
-           GIL_OBTAINED = 6398; -- Obtained <number> gil.
-       KEYITEM_OBTAINED = 6400; -- Obtained key item: <keyitem>.
-            HOMEPOINT_SET = 8323; -- Home point set!
+          ITEM_OBTAINED = 6398; -- Obtained: <item>.
+           GIL_OBTAINED = 6399; -- Obtained <number> gil.
+       KEYITEM_OBTAINED = 6401; -- Obtained key item: <keyitem>.
+            HOMEPOINT_SET = 8324; -- Home point set!
 
 -- Other dialog
-NOTHING_OUT_OF_ORDINARY = 6411; -- There is nothing out of the ordinary here.
+NOTHING_OUT_OF_ORDINARY = 6412; -- There is nothing out of the ordinary here.
         NOTHING_HAPPENS =  119; -- Nothing happens...
 
 -- conquest Base
-CONQUEST_BASE = 7058; -- Tallying conquest results...
+CONQUEST_BASE = 7059; -- Tallying conquest results...

--- a/scripts/zones/Upper_Delkfutts_Tower/TextIDs.lua
+++ b/scripts/zones/Upper_Delkfutts_Tower/TextIDs.lua
@@ -2,24 +2,24 @@
 
 -- General Texts
 ITEM_CANNOT_BE_OBTAINED = 6414; -- You cannot obtain the item <item>. Come back after sorting your inventory.
-          ITEM_OBTAINED = 6419; -- Obtained: <item>.
-           GIL_OBTAINED = 6420; -- Obtained <number> gil.
-       KEYITEM_OBTAINED = 6422; -- Obtained key item: <keyitem>.
- FISHING_MESSAGE_OFFSET = 7080; -- You can't fish here.
-            HOMEPOINT_SET = 10511; -- Home point set!
+          ITEM_OBTAINED = 6420; -- Obtained: <item>.
+           GIL_OBTAINED = 6421; -- Obtained <number> gil.
+       KEYITEM_OBTAINED = 6423; -- Obtained key item: <keyitem>.
+ FISHING_MESSAGE_OFFSET = 7081; -- You can't fish here.
+            HOMEPOINT_SET = 10512; -- Home point set!
 
 -- Treasure Coffer/Chest Dialog
-CHEST_UNLOCKED = 7346; -- You unlock the chest!
-    CHEST_FAIL = 7347; -- Fails to open the chest.
-    CHEST_TRAP = 7348; -- The chest was trapped!
-    CHEST_WEAK = 7349; -- You cannot open the chest when you are in a weakened state.
-   CHEST_MIMIC = 7350; -- The chest was a mimic!
-  CHEST_MOOGLE = 7351; -- You cannot open the chest while participating in the moogle event.
-CHEST_ILLUSION = 7352; -- The chest was but an illusion...
-  CHEST_LOCKED = 7353; -- The chest appears to be locked.
+CHEST_UNLOCKED = 7347; -- You unlock the chest!
+    CHEST_FAIL = 7348; -- Fails to open the chest.
+    CHEST_TRAP = 7349; -- The chest was trapped!
+    CHEST_WEAK = 7350; -- You cannot open the chest when you are in a weakened state.
+   CHEST_MIMIC = 7351; -- The chest was a mimic!
+  CHEST_MOOGLE = 7352; -- You cannot open the chest while participating in the moogle event.
+CHEST_ILLUSION = 7353; -- The chest was but an illusion...
+  CHEST_LOCKED = 7354; -- The chest appears to be locked.
 
 -- Other Dialog
 THIS_ELEVATOR_GOES_DOWN = 25; -- This elevator goes down, but it is locked. Perhaps a key is needed to activate it.
 
 -- conquest Base
-CONQUEST_BASE = 7180; -- Tallying conquest results...
+CONQUEST_BASE = 7181; -- Tallying conquest results...

--- a/scripts/zones/Upper_Jeuno/TextIDs.lua
+++ b/scripts/zones/Upper_Jeuno/TextIDs.lua
@@ -2,38 +2,38 @@
 
 -- General Texts
 ITEM_CANNOT_BE_OBTAINED = 6538; -- You cannot obtain the item <item>. Come back after sorting your inventory.
-          ITEM_OBTAINED = 6543; -- Obtained: <item>.
-           GIL_OBTAINED = 6544; -- Obtained <number> gil.
-       KEYITEM_OBTAINED = 6546; -- Obtained key item: <keyitem>.
-           KEYITEM_LOST = 6547; -- Lost key item:
-    NOT_HAVE_ENOUGH_GIL = 6548; -- You do not have enough gil.
-          HOMEPOINT_SET = 6672; -- Home point set!
-NOTHING_OUT_OF_ORDINARY = 6557; -- There is nothing out of the ordinary here.
+          ITEM_OBTAINED = 6544; -- Obtained: <item>.
+           GIL_OBTAINED = 6545; -- Obtained <number> gil.
+       KEYITEM_OBTAINED = 6547; -- Obtained key item: <keyitem>.
+           KEYITEM_LOST = 6548; -- Lost key item:
+    NOT_HAVE_ENOUGH_GIL = 6549; -- You do not have enough gil.
+          HOMEPOINT_SET = 6673; -- Home point set!
+NOTHING_OUT_OF_ORDINARY = 6558; -- There is nothing out of the ordinary here.
 
 -- Other Texts
-ITEM_DELIVERY_DIALOG = 8065; -- Delivering goods to residences everywhere!
+ITEM_DELIVERY_DIALOG = 8066; -- Delivering goods to residences everywhere!
 
 -- Conquest system
-CONQUEST = 7732; -- You've earned conquest points!
+CONQUEST = 7733; -- You've earned conquest points!
 
 -- NPC Texts
-            KIRISOMANRISO_DIALOG = 8065; -- Delivering goods to residences everywhere!
-YOU_CAN_NOW_BECOME_A_BEASTMASTER = 7176; -- You can now become a beastmaster.
+            KIRISOMANRISO_DIALOG = 8066; -- Delivering goods to residences everywhere!
+YOU_CAN_NOW_BECOME_A_BEASTMASTER = 7177; -- You can now become a beastmaster.
 
-                   UNLOCK_DANCER = 11819; -- You can now become a dancer!
+                   UNLOCK_DANCER = 11820; -- You can now become a dancer!
 
-GUIDE_STONE = 6971; -- Up: Ru'Lude Gardens Down: Lower Jeuno
+GUIDE_STONE = 6972; -- Up: Ru'Lude Gardens Down: Lower Jeuno
 
 -- Shop Texts
-       GLYKE_SHOP_DIALOG = 6966; -- Can I help you?
-     MEJUONE_SHOP_DIALOG = 6967; -- Welcome to the Chocobo Shop.
-     COUMUNA_SHOP_DIALOG = 6968; -- Welcome to Viette's Finest Weapons.
-     ANTONIA_SHOP_DIALOG = 6968; -- Welcome to Viette's Finest Weapons.
-DEADLYMINNOW_SHOP_DIALOG = 6969; -- Welcome to Durable Shields.
- KHECHALAHKO_SHOP_DIALOG = 6969; -- Welcome to Durable Shields.
-     AREEBAH_SHOP_DIALOG = 6970; -- Welcome to M & P's Market.
- CHAMPALPIEU_SHOP_DIALOG = 6970; -- Welcome to M & P's Market.
-   LEILLAINE_SHOP_DIALOG = 6996; -- Hello. Are you feeling all right?
+       GLYKE_SHOP_DIALOG = 6967; -- Can I help you?
+     MEJUONE_SHOP_DIALOG = 6968; -- Welcome to the Chocobo Shop.
+     COUMUNA_SHOP_DIALOG = 6969; -- Welcome to Viette's Finest Weapons.
+     ANTONIA_SHOP_DIALOG = 6969; -- Welcome to Viette's Finest Weapons.
+DEADLYMINNOW_SHOP_DIALOG = 6970; -- Welcome to Durable Shields.
+ KHECHALAHKO_SHOP_DIALOG = 6970; -- Welcome to Durable Shields.
+     AREEBAH_SHOP_DIALOG = 6971; -- Welcome to M & P's Market.
+ CHAMPALPIEU_SHOP_DIALOG = 6971; -- Welcome to M & P's Market.
+   LEILLAINE_SHOP_DIALOG = 6997; -- Hello. Are you feeling all right?
 
 -- conquest Base
 CONQUEST_BASE = 0;

--- a/scripts/zones/Valkurm_Dunes/TextIDs.lua
+++ b/scripts/zones/Valkurm_Dunes/TextIDs.lua
@@ -2,33 +2,33 @@
 
 -- General Texts
 ITEM_CANNOT_BE_OBTAINED = 6401; -- You cannot obtain the item <item>. Come back after sorting your inventory.
-          ITEM_OBTAINED = 6406; -- Obtained: <item>.
-           GIL_OBTAINED = 6407; -- Obtained <number> gil.
-       KEYITEM_OBTAINED = 6409; -- Obtained key item: <keyitem>.
-        BEASTMEN_BANNER = 7148; -- There is a beastmen's banner.
- FISHING_MESSAGE_OFFSET = 7226; -- You can't fish here.
+          ITEM_OBTAINED = 6407; -- Obtained: <item>.
+           GIL_OBTAINED = 6408; -- Obtained <number> gil.
+       KEYITEM_OBTAINED = 6410; -- Obtained key item: <keyitem>.
+        BEASTMEN_BANNER = 7149; -- There is a beastmen's banner.
+ FISHING_MESSAGE_OFFSET = 7227; -- You can't fish here.
 
 -- Conquest
-CONQUEST = 7366; -- You've earned conquest points!
+CONQUEST = 7367; -- You've earned conquest points!
 
 -- Quest Dialog
-NOTHING_OUT_OF_ORDINARY = 6420; -- There is nothing out of the ordinary here.
-            UNLOCK_BARD = 7347; -- You can now become a bard!
+NOTHING_OUT_OF_ORDINARY = 6421; -- There is nothing out of the ordinary here.
+            UNLOCK_BARD = 7348; -- You can now become a bard!
 
 -- Signposts
-SIGNPOST2 = 7355; -- Northeast: La Theine Plateau Southeast: Konschtat Highlands West: Selbina
-SIGNPOST1 = 7356; -- Northeast: La Theine Plateau Southeast: Konschtat Highlands Southwest: Selbina
+SIGNPOST2 = 7356; -- Northeast: La Theine Plateau Southeast: Konschtat Highlands West: Selbina
+SIGNPOST1 = 7357; -- Northeast: La Theine Plateau Southeast: Konschtat Highlands Southwest: Selbina
 
 -- Other Dialog
-         AN_EMPTY_LIGHT_SWIRLS = 7744; -- An empty light swirls about the cave, eating away at the surroundings..
-   MONSTERS_KILLED_ADVENTURERS = 7820; -- Long ago, monsters killed many adventurers and merchants just off the coast here. If you find any vestige of the victims and return it to the sea, perhaps it would appease the spirits of the dead.
-              MYSTERIOUS_VOICE = 7846; -- You hear a mysterious, floating voice: Bring forth the
-      YOU_CANNOT_ENTER_DYNAMIS = 7858; -- You cannot enter Dynamis
-PLAYERS_HAVE_NOT_REACHED_LEVEL = 7860; -- Players who have not reached levelare prohibited from entering Dynamis.
+         AN_EMPTY_LIGHT_SWIRLS = 7745; -- An empty light swirls about the cave, eating away at the surroundings..
+   MONSTERS_KILLED_ADVENTURERS = 7821; -- Long ago, monsters killed many adventurers and merchants just off the coast here. If you find any vestige of the victims and return it to the sea, perhaps it would appease the spirits of the dead.
+              MYSTERIOUS_VOICE = 7847; -- You hear a mysterious, floating voice: Bring forth the
+      YOU_CANNOT_ENTER_DYNAMIS = 7859; -- You cannot enter Dynamis
+PLAYERS_HAVE_NOT_REACHED_LEVEL = 7861; -- Players who have not reached levelare prohibited from entering Dynamis.
 
 -- conquest Base
-CONQUEST_BASE = 7067; -- Tallying conquest results...
+CONQUEST_BASE = 7068; -- Tallying conquest results...
 
 -- chocobo digging
 DIG_THROW_AWAY = 7216 -- You dig up ?Possible Special Code: 01??Possible Special Code: 01??Possible Special Code: 01? ?Possible Special Code: 01??Possible Special Code: 05?$?BAD CHAR: 8280??BAD CHAR: 80??BAD CHAR: 80?, but your inventory is full.
-FIND_NOTHING = 7241; -- You dig and you dig, but find nothing.?Prompt?
+FIND_NOTHING = 7242; -- You dig and you dig, but find nothing.?Prompt?

--- a/scripts/zones/Valley_of_Sorrows/TextIDs.lua
+++ b/scripts/zones/Valley_of_Sorrows/TextIDs.lua
@@ -3,18 +3,18 @@
 -- General Texts
    ITEM_CANNOT_BE_OBTAINED = 6379; -- You cannot obtain the item <item>. Come back after sorting your inventory.
 FULL_INVENTORY_AFTER_TRADE = 6383; -- You cannot obtain the <item>. Try trading again after sorting your inventory.
-             ITEM_OBTAINED = 6384; -- Obtained: <item>.
-              GIL_OBTAINED = 6385; -- Obtained <number> gil.
-          KEYITEM_OBTAINED = 6387; -- Obtained key item: <keyitem>.
-            ITEMS_OBTAINED = 6393; -- You obtain <param2 number> <param1 item>!
+             ITEM_OBTAINED = 6385; -- Obtained: <item>.
+              GIL_OBTAINED = 6386; -- Obtained <number> gil.
+          KEYITEM_OBTAINED = 6388; -- Obtained key item: <keyitem>.
+            ITEMS_OBTAINED = 6394; -- You obtain <param2 number> <param1 item>!
 
-   NOTHING_OUT_OF_ORDINARY = 6398; -- There is nothing out of the ordinary here.
+   NOTHING_OUT_OF_ORDINARY = 6399; -- There is nothing out of the ordinary here.
 
 -- HNM
-            AURA_THREATENS = 6402; -- An aura of irrepressible might threatens to overwhelm you...
+            AURA_THREATENS = 6403; -- An aura of irrepressible might threatens to overwhelm you...
 
 -- Mission
-         SOMETHING_BURRIED = 7304; -- It looks like something was buried here.
+         SOMETHING_BURRIED = 7305; -- It looks like something was buried here.
 
 -- conquest Base
-CONQUEST_BASE = 7045; -- Tallying conquest results...
+CONQUEST_BASE = 7046; -- Tallying conquest results...

--- a/scripts/zones/VeLugannon_Palace/TextIDs.lua
+++ b/scripts/zones/VeLugannon_Palace/TextIDs.lua
@@ -2,22 +2,22 @@
 
 -- General Texts
 ITEM_CANNOT_BE_OBTAINED = 6379; -- You cannot obtain the item <item> come back again after sorting your inventory
-          ITEM_OBTAINED = 6384; -- Obtained: <item>
-           GIL_OBTAINED = 6385; -- Obtained <number> gil
-       KEYITEM_OBTAINED = 6387; -- Obtained key item: <keyitem>
+          ITEM_OBTAINED = 6385; -- Obtained: <item>
+           GIL_OBTAINED = 6386; -- Obtained <number> gil
+       KEYITEM_OBTAINED = 6388; -- Obtained key item: <keyitem>
 
 -- Treasure Coffer/Chest Dialog
-CHEST_UNLOCKED = 7211; -- You unlock the chest!
-    CHEST_FAIL = 7212; -- Fails to open the chest.
-    CHEST_TRAP = 7213; -- The chest was trapped!
-    CHEST_WEAK = 7214; -- You cannot open the chest when you are in a weakened state.
-   CHEST_MIMIC = 7215; -- The chest was a mimic!
-  CHEST_MOOGLE = 7216; -- You cannot open the chest while participating in the moogle event.
-CHEST_ILLUSION = 7217; -- The chest was but an illusion...
-  CHEST_LOCKED = 7218; -- The chest appears to be locked.
+CHEST_UNLOCKED = 7212; -- You unlock the chest!
+    CHEST_FAIL = 7213; -- Fails to open the chest.
+    CHEST_TRAP = 7214; -- The chest was trapped!
+    CHEST_WEAK = 7215; -- You cannot open the chest when you are in a weakened state.
+   CHEST_MIMIC = 7216; -- The chest was a mimic!
+  CHEST_MOOGLE = 7217; -- You cannot open the chest while participating in the moogle event.
+CHEST_ILLUSION = 7218; -- The chest was but an illusion...
+  CHEST_LOCKED = 7219; -- The chest appears to be locked.
 
 -- Other dialog
-NOTHING_OUT_OF_ORDINARY = 6398; -- There is nothing out of the ordinary here.
+NOTHING_OUT_OF_ORDINARY = 6399; -- There is nothing out of the ordinary here.
 
 -- conquest Base
-CONQUEST_BASE = 7045; -- Tallying conquest results...
+CONQUEST_BASE = 7046; -- Tallying conquest results...

--- a/scripts/zones/Vunkerl_Inlet_[S]/TextIDs.lua
+++ b/scripts/zones/Vunkerl_Inlet_[S]/TextIDs.lua
@@ -2,8 +2,8 @@
 
 -- General Texts
 ITEM_CANNOT_BE_OBTAINED = 6379; -- You cannot obtain the item <item> come back again after sorting your inventory
-          ITEM_OBTAINED = 6384; -- Obtained: <item>
-           GIL_OBTAINED = 6385; -- Obtained <number> gil
-       KEYITEM_OBTAINED = 6387; -- Obtained key item: <keyitem>
- FISHING_MESSAGE_OFFSET = 7045; -- You can't fish here
-NOTHING_OUT_OF_ORDINARY = 6398; -- There is nothing out of the ordinary here
+          ITEM_OBTAINED = 6385; -- Obtained: <item>
+           GIL_OBTAINED = 6386; -- Obtained <number> gil
+       KEYITEM_OBTAINED = 6388; -- Obtained key item: <keyitem>
+ FISHING_MESSAGE_OFFSET = 7046; -- You can't fish here
+NOTHING_OUT_OF_ORDINARY = 6399; -- There is nothing out of the ordinary here

--- a/scripts/zones/Wajaom_Woodlands/TextIDs.lua
+++ b/scripts/zones/Wajaom_Woodlands/TextIDs.lua
@@ -2,23 +2,23 @@
 
 -- General Texts
 ITEM_CANNOT_BE_OBTAINED = 6379; -- You cannot obtain the item <item>. Come back after sorting your inventory.
-          ITEM_OBTAINED = 6384; -- Obtained: <item>.
-           GIL_OBTAINED = 6385; -- Obtained <number> gil.
-       KEYITEM_OBTAINED = 6387; -- Obtained key item: <keyitem>.
- FISHING_MESSAGE_OFFSET = 7045; -- You can't fish here.
+          ITEM_OBTAINED = 6385; -- Obtained: <item>.
+           GIL_OBTAINED = 6386; -- Obtained <number> gil.
+       KEYITEM_OBTAINED = 6388; -- Obtained key item: <keyitem>.
+ FISHING_MESSAGE_OFFSET = 7046; -- You can't fish here.
 
 -- Other Texts
 NOTHING_HAPPENS =  119; -- Nothing happens...
-       LEYPOINT = 7394; -- An eerie red glow emanates from this stone platform
+       LEYPOINT = 7395; -- An eerie red glow emanates from this stone platform
 
 -- Harvesting
-HARVESTING_IS_POSSIBLE_HERE = 7402; -- Harvesting is possible here if you have
+HARVESTING_IS_POSSIBLE_HERE = 7403; -- Harvesting is possible here if you have
 
 -- Quest: NAVIGATING_THE_UNFRIENDLY_SEAS
-PLACE_HYDROGAUGE = 7338; -- You set the # in the glowing trench.
- ENIGMATIC_LIGHT = 7339; -- is giving off an enigmatic light.
+PLACE_HYDROGAUGE = 7339; -- You set the # in the glowing trench.
+ ENIGMATIC_LIGHT = 7340; -- is giving off an enigmatic light.
 
  -- chocobo digging
-DIG_THROW_AWAY = 7058; -- You dig up ?Possible Special Code: 01??Possible Special Code: 01??Possible Special Code: 01? ?Possible Special Code: 01??Possible Special Code: 05?$?BAD CHAR: 8280??BAD CHAR: 80??BAD CHAR: 80?, but your inventory is full.
-FIND_NOTHING = 7060; -- You dig and you dig, but find nothing.
+DIG_THROW_AWAY = 7059; -- You dig up ?Possible Special Code: 01??Possible Special Code: 01??Possible Special Code: 01? ?Possible Special Code: 01??Possible Special Code: 05?$?BAD CHAR: 8280??BAD CHAR: 80??BAD CHAR: 80?, but your inventory is full.
+FIND_NOTHING = 7061; -- You dig and you dig, but find nothing.
 

--- a/scripts/zones/Walk_of_Echoes/TextIDs.lua
+++ b/scripts/zones/Walk_of_Echoes/TextIDs.lua
@@ -2,6 +2,6 @@
 
 -- General Texts
 ITEM_CANNOT_BE_OBTAINED = 6379; -- You cannot obtain the item <item> come back again after sorting your inventory
-          ITEM_OBTAINED = 6384; -- Obtained: <item>
-           GIL_OBTAINED = 6385; -- Obtained <number> gil
-       KEYITEM_OBTAINED = 6387; -- Obtained key item: <keyitem>
+          ITEM_OBTAINED = 6385; -- Obtained: <item>
+           GIL_OBTAINED = 6386; -- Obtained <number> gil
+       KEYITEM_OBTAINED = 6388; -- Obtained key item: <keyitem>

--- a/scripts/zones/Waughroon_Shrine/TextIDs.lua
+++ b/scripts/zones/Waughroon_Shrine/TextIDs.lua
@@ -2,17 +2,17 @@
 
 -- General Texts
 ITEM_CANNOT_BE_OBTAINED = 6379; -- You cannot obtain the item <item>. Come back after sorting your inventory.
-          ITEM_OBTAINED = 6384; -- Obtained: <item>.
-           GIL_OBTAINED = 6385; -- Obtained <number> gil.
-       KEYITEM_OBTAINED = 6387; -- Obtained key item: <keyitem>.
+          ITEM_OBTAINED = 6385; -- Obtained: <item>.
+           GIL_OBTAINED = 6386; -- Obtained <number> gil.
+       KEYITEM_OBTAINED = 6388; -- Obtained key item: <keyitem>.
 
 -- Maat dialog
-      YOU_DECIDED_TO_SHOW_UP = 7672; -- So, you decided to show up.
- LOOKS_LIKE_YOU_WERENT_READY = 7673; -- Looks like you weren't ready for me, were you?
-       YOUVE_COME_A_LONG_WAY = 7674; -- Hm. That was a mighty fine display of skill there, Player Name. You've come a long way...
- TEACH_YOU_TO_RESPECT_ELDERS = 7675; -- I'll teach you to respect your elders!
-TAKE_THAT_YOU_WHIPPERSNAPPER = 7676; -- Take that, you whippersnapper!
- THAT_LL_HURT_IN_THE_MORNING = 7678; -- Ungh... That'll hurt in the morning...
+      YOU_DECIDED_TO_SHOW_UP = 7673; -- So, you decided to show up.
+ LOOKS_LIKE_YOU_WERENT_READY = 7674; -- Looks like you weren't ready for me, were you?
+       YOUVE_COME_A_LONG_WAY = 7675; -- Hm. That was a mighty fine display of skill there, Player Name. You've come a long way...
+ TEACH_YOU_TO_RESPECT_ELDERS = 7676; -- I'll teach you to respect your elders!
+TAKE_THAT_YOU_WHIPPERSNAPPER = 7677; -- Take that, you whippersnapper!
+ THAT_LL_HURT_IN_THE_MORNING = 7679; -- Ungh... That'll hurt in the morning...
 
 -- conquest Base
-CONQUEST_BASE = 7045; -- Tallying conquest results...
+CONQUEST_BASE = 7046; -- Tallying conquest results...

--- a/scripts/zones/West_Ronfaure/TextIDs.lua
+++ b/scripts/zones/West_Ronfaure/TextIDs.lua
@@ -2,29 +2,29 @@
 
 -- General Texts
 ITEM_CANNOT_BE_OBTAINED = 6401; -- You cannot obtain the item <item> come back again after sorting your inventory.
-          ITEM_OBTAINED = 6406; -- Obtained: <item>.
-           GIL_OBTAINED = 6407; -- Obtained <number> gil.
-       KEYITEM_OBTAINED = 6409; -- Obtained key item: <keyitem>.
- FISHING_MESSAGE_OFFSET = 7226; -- You can't fish here.
+          ITEM_OBTAINED = 6407; -- Obtained: <item>.
+           GIL_OBTAINED = 6408; -- Obtained <number> gil.
+       KEYITEM_OBTAINED = 6410; -- Obtained key item: <keyitem>.
+ FISHING_MESSAGE_OFFSET = 7227; -- You can't fish here.
 
 -- Conquest
-CONQUEST = 7526; -- You've earned conquest points!
+CONQUEST = 7527; -- You've earned conquest points!
 
 -- Other
-    COLMAIE_DIALOG = 7327; -- Orcish scouts lurk in the shadows. Consider yourself warned!
-  GACHEMAGE_DIALOG = 7327; -- Orcish scouts lurk in the shadows. Consider yourself warned!
-  ADALEFONT_DIALOG = 7328; -- If you sense danger, just flee into the city. I'll not endanger myself on your account!
-   LAILLERA_DIALOG = 7329; -- I mustn't chat while on duty. Sorry.
-PALCOMONDAU_REPORT = 7373; -- Scout reporting! All is quiet on the road to Ghelsba!
-PALCOMONDAU_DIALOG = 7374; -- Let me be! I must patrol the road to Ghelsba.
-   ZOVRIACE_REPORT = 7376; -- Scout reporting! All is quiet on the roads to La Theine!
-   ZOVRIACE_DIALOG = 7378; -- Let me be! I return to Southgate with word on La Theine.
- DISMAYED_CUSTOMER = 7404; -- You find some worthless scraps of paper.
+    COLMAIE_DIALOG = 7328; -- Orcish scouts lurk in the shadows. Consider yourself warned!
+  GACHEMAGE_DIALOG = 7328; -- Orcish scouts lurk in the shadows. Consider yourself warned!
+  ADALEFONT_DIALOG = 7329; -- If you sense danger, just flee into the city. I'll not endanger myself on your account!
+   LAILLERA_DIALOG = 7330; -- I mustn't chat while on duty. Sorry.
+PALCOMONDAU_REPORT = 7374; -- Scout reporting! All is quiet on the road to Ghelsba!
+PALCOMONDAU_DIALOG = 7375; -- Let me be! I must patrol the road to Ghelsba.
+   ZOVRIACE_REPORT = 7377; -- Scout reporting! All is quiet on the roads to La Theine!
+   ZOVRIACE_DIALOG = 7379; -- Let me be! I return to Southgate with word on La Theine.
+ DISMAYED_CUSTOMER = 7405; -- You find some worthless scraps of paper.
 
 
 -- conquest Base
-CONQUEST_BASE = 7067; -- Tallying conquest results...
+CONQUEST_BASE = 7068; -- Tallying conquest results...
 
 -- chocobo digging
-DIG_THROW_AWAY = 7239; -- You dig up ?Possible Special Code: 01??Possible Special Code: 01??Possible Special Code: 01? ?Possible Special Code: 01??Possible Special Code: 05?$?BAD CHAR: 8280??BAD CHAR: 80??BAD CHAR: 80?, but your inventory is full.
-FIND_NOTHING = 7241;  -- You dig and you dig, but find nothing.
+DIG_THROW_AWAY = 7240; -- You dig up ?Possible Special Code: 01??Possible Special Code: 01??Possible Special Code: 01? ?Possible Special Code: 01??Possible Special Code: 05?$?BAD CHAR: 8280??BAD CHAR: 80??BAD CHAR: 80?, but your inventory is full.
+FIND_NOTHING = 7242;  -- You dig and you dig, but find nothing.

--- a/scripts/zones/West_Sarutabaruta/TextIDs.lua
+++ b/scripts/zones/West_Sarutabaruta/TextIDs.lua
@@ -2,50 +2,50 @@
 
 -- General Texts
 ITEM_CANNOT_BE_OBTAINED = 6379; -- You cannot obtain the item <item> come back again after sorting your inventory.
-          ITEM_OBTAINED = 6384; -- Obtained: <item>.
-           GIL_OBTAINED = 6385; -- Obtained <number> gil.
-       KEYITEM_OBTAINED = 6387; -- Obtained key item: <keyitem>.
- FISHING_MESSAGE_OFFSET = 7045; -- You can't fish here.
+          ITEM_OBTAINED = 6385; -- Obtained: <item>.
+           GIL_OBTAINED = 6386; -- Obtained <number> gil.
+       KEYITEM_OBTAINED = 6388; -- Obtained key item: <keyitem>.
+ FISHING_MESSAGE_OFFSET = 7046; -- You can't fish here.
 
 -- Fields of Valor Texts
-REGIME_ACCEPTED = 10179; -- New training regime registered!
- DONT_SWAP_JOBS = 10180; -- your job will result in the cancellation of your current training regime.
-REGIME_CANCELED = 10181; -- Training regime canceled.
+REGIME_ACCEPTED = 10180; -- New training regime registered!
+ DONT_SWAP_JOBS = 10181; -- your job will result in the cancellation of your current training regime.
+REGIME_CANCELED = 10182; -- Training regime canceled.
 
 -- Conquest
-CONQUEST = 7450; -- You've earned conquest points!
+CONQUEST = 7451; -- You've earned conquest points!
 
 -- Harvesting
-HARVESTING_IS_POSSIBLE_HERE = 7434; -- Harvesting is possible here if you have
+HARVESTING_IS_POSSIBLE_HERE = 7435; -- Harvesting is possible here if you have
 
 -- NPC Dialog
-  PAORE_KUORE_DIALOG = 7384; -- Welcome to Windurst! Proceed through this gateway to entaru Port Windurst.
-KOLAPO_OILAPO_DIALOG = 7385; -- Hi-diddly-diddly! This is the gateway to Windurst! The grasslands you're on now are known as West Sarutabaruta.
-        MAATA_ULAATA = 7386; -- Hello-wello! This is the central tower of the Horutoto Ruins. It's one of the several ancient-wancient magic towers which dot these grasslands.
-        IPUPU_DIALOG = 7389; -- I decided to take a little strolly-wolly, but before I realized it, I found myself way out here! Now I am sorta stuck... Woe is me!
+  PAORE_KUORE_DIALOG = 7385; -- Welcome to Windurst! Proceed through this gateway to entaru Port Windurst.
+KOLAPO_OILAPO_DIALOG = 7386; -- Hi-diddly-diddly! This is the gateway to Windurst! The grasslands you're on now are known as West Sarutabaruta.
+        MAATA_ULAATA = 7387; -- Hello-wello! This is the central tower of the Horutoto Ruins. It's one of the several ancient-wancient magic towers which dot these grasslands.
+        IPUPU_DIALOG = 7390; -- I decided to take a little strolly-wolly, but before I realized it, I found myself way out here! Now I am sorta stuck... Woe is me!
 
 -- Quest Dialog
-    FROST_DEPOSIT_TWINKLES = 7396; -- A frost deposit at the base of the tree twinkles in the starlight.
-    MELT_BARE_HANDS = 7398; -- It looks like it would melt if you touched it with your bare hands...
+    FROST_DEPOSIT_TWINKLES = 7397; -- A frost deposit at the base of the tree twinkles in the starlight.
+    MELT_BARE_HANDS = 7399; -- It looks like it would melt if you touched it with your bare hands...
 
 -- Other Dialog
-        NOTHING_HAPPENS = 7304; -- Nothing happens...
-NOTHING_OUT_OF_ORDINARY = 7399; -- There is nothing out of the ordinary here.
+        NOTHING_HAPPENS = 7305; -- Nothing happens...
+NOTHING_OUT_OF_ORDINARY = 7400; -- There is nothing out of the ordinary here.
 
 -- Signs
- SIGN_1 = 7374; -- Northeast: Central Tower, Horutoto Ruins Northwest: Giddeus South: Port Windurst
- SIGN_3 = 7375; -- East: East Sarutabaruta West: Giddeus
- SIGN_5 = 7376; -- Northeast: Central Tower, Horutoto Ruins East: East Sarutabaruta West: Giddeus
- SIGN_7 = 7377; -- South: Windurst East: East Sarutabaruta
- SIGN_9 = 7378; -- West: Giddeus North: East Sarutabaruta South: Windurst
-SIGN_11 = 7379; -- North: East Sarutabaruta Southeast: Windurst
-SIGN_13 = 7380; -- East: Port Windurst West: West Tower, Horutoto Ruins
-SIGN_15 = 7381; -- East: East Sarutabaruta West: Giddeus Southeast: Windurst
-SIGN_17 = 7382; -- Northwest: Northwest Tower, Horutoto RuinsEast: Outpost Southwest: Giddeus
+ SIGN_1 = 7375; -- Northeast: Central Tower, Horutoto Ruins Northwest: Giddeus South: Port Windurst
+ SIGN_3 = 7376; -- East: East Sarutabaruta West: Giddeus
+ SIGN_5 = 7377; -- Northeast: Central Tower, Horutoto Ruins East: East Sarutabaruta West: Giddeus
+ SIGN_7 = 7378; -- South: Windurst East: East Sarutabaruta
+ SIGN_9 = 7379; -- West: Giddeus North: East Sarutabaruta South: Windurst
+SIGN_11 = 7380; -- North: East Sarutabaruta Southeast: Windurst
+SIGN_13 = 7381; -- East: Port Windurst West: West Tower, Horutoto Ruins
+SIGN_15 = 7382; -- East: East Sarutabaruta West: Giddeus Southeast: Windurst
+SIGN_17 = 7383; -- Northwest: Northwest Tower, Horutoto RuinsEast: Outpost Southwest: Giddeus
 -- conquest Base
-CONQUEST_BASE = 7145; -- Tallying conquest results...
+CONQUEST_BASE = 7146; -- Tallying conquest results...
 
 -- chocobo digging
-DIG_THROW_AWAY = 7058; -- You dig up ?Possible Special Code: 01??Possible Special Code: 01??Possible Special Code: 01? ?Possible Special Code: 01??Possible Special Code: 05?$?BAD CHAR: 8280??BAD CHAR: 80??BAD CHAR: 80?, but your inventory is full.
-FIND_NOTHING = 7060; -- You dig and you dig, but find nothing.
+DIG_THROW_AWAY = 7059; -- You dig up ?Possible Special Code: 01??Possible Special Code: 01??Possible Special Code: 01? ?Possible Special Code: 01??Possible Special Code: 05?$?BAD CHAR: 8280??BAD CHAR: 80??BAD CHAR: 80?, but your inventory is full.
+FIND_NOTHING = 7061; -- You dig and you dig, but find nothing.
 

--- a/scripts/zones/West_Sarutabaruta_[S]/TextIDs.lua
+++ b/scripts/zones/West_Sarutabaruta_[S]/TextIDs.lua
@@ -2,16 +2,16 @@
 
 -- General Texts
 ITEM_CANNOT_BE_OBTAINED = 6379; -- You cannot obtain the item <item>. Come back after sorting your inventory.
-          ITEM_OBTAINED = 6384; -- Obtained: <item>.
-           GIL_OBTAINED = 6385; -- Obtained <number> gil.
-       KEYITEM_OBTAINED = 6387; -- Obtained key item: <keyitem>.
- FISHING_MESSAGE_OFFSET = 7072; -- You can't fish here.
+          ITEM_OBTAINED = 6385; -- Obtained: <item>.
+           GIL_OBTAINED = 6386; -- Obtained <number> gil.
+       KEYITEM_OBTAINED = 6388; -- Obtained key item: <keyitem>.
+ FISHING_MESSAGE_OFFSET = 7073; -- You can't fish here.
 
 -- Harvesting
-HARVESTING_IS_POSSIBLE_HERE = 7065; -- Harvesting is possible here if you have
+HARVESTING_IS_POSSIBLE_HERE = 7066; -- Harvesting is possible here if you have
 
 -- "Snake on the Plains"
-DOOR_OFFSET = 7430; -- The door is sealed shut...
+DOOR_OFFSET = 7431; -- The door is sealed shut...
 --  +1        7416; -- You apply ?Possible Special Code: 01??Possible Special Code: 05?3?BAD CHAR: 8280??BAD CHAR: 80??BAD CHAR: 80? to the cracks on the entrance.?Possible Special Code: 00?
 --  +2        7417; -- This door has already been repaired with ?Possible Special Code: 01??Possible Special Code: 05?3?BAD CHAR: 8280??BAD CHAR: 80??BAD CHAR: 80?.?Possible Special Code: 00?
 --  +3        7418; -- The door is badly cracked...?Possible Special Code: 00?

--- a/scripts/zones/Western_Adoulin/TextIDs.lua
+++ b/scripts/zones/Western_Adoulin/TextIDs.lua
@@ -4,27 +4,27 @@
   ITEM_CANNOT_BE_OBTAINED = 6379; -- You cannot obtain the <item>. Come back after sorting your inventory.
 ITEM_CANNOT_BE_OBTAINED_2 = 6379; -- You cannot obtain the #. Come back after sorting your inventory.
 ITEM_CANNOT_BE_OBTAINED_3 = 6380; -- You cannot obtain the %. Come back after sorting your inventory.
-            ITEM_OBTAINED = 6384; -- Obtained: <item>
-             GIL_OBTAINED = 6385; -- Obtained <number> gil
-         KEYITEM_OBTAINED = 6387; -- Obtained key item: <keyitem>
-             KEYITEM_LOST = 6388; -- Lost key item: <keyitem>
-      NOT_HAVE_ENOUGH_GIL = 6389; -- You do not have enough gil.
-           BAYLD_OBTAINED = 7001; -- You have obtainedbayld!
-       RETRIEVE_DIALOG_ID = 7736; -- You retrieve$ from the porter moogle's care.
-            HOMEPOINT_SET = 8295; -- Home point set!
+            ITEM_OBTAINED = 6385; -- Obtained: <item>
+             GIL_OBTAINED = 6386; -- Obtained <number> gil
+         KEYITEM_OBTAINED = 6388; -- Obtained key item: <keyitem>
+             KEYITEM_LOST = 6389; -- Lost key item: <keyitem>
+      NOT_HAVE_ENOUGH_GIL = 6390; -- You do not have enough gil.
+           BAYLD_OBTAINED = 7002; -- You have obtainedbayld!
+       RETRIEVE_DIALOG_ID = 7737; -- You retrieve$ from the porter moogle's care.
+            HOMEPOINT_SET = 8296; -- Home point set!
 
 -- Shop Texts
-        HUJETTE_SHOP_TEXT = 9784; -- How about indulging in some regional delicacies while taking a load off those tired feet of yours?
-       PRETERIG_SHOP_TEXT = 9785; -- Want a way to beat the heat? Try some of the tasty beverages we have on hand.
-      LEDERICUS_SHOP_TEXT = 9819; -- We've got a doozy of a magic scroll selection, tailored especially to your pioneering needs!
-         ISHVAD_SHOP_TEXT = 9820; -- ...A pioneer, are ya? If that's the case, maybe we've finally found a client for our geomantic plates.
-      EUKALLINE_SHOP_TEXT = 9821; -- Why, hello there! If you're looking for geomantic plates, look no further! I don't like to brag, but I'd say our selection is a bit more...sophisticated than what they offer next door.
-        FLAPANO_SHOP_TEXT = 9822; -- Welcome, welcome! Going out into the eye of the jungle's storm? Then the last thing you want is your stomach rumbling during an important battle!
-   THEOPHYLACTE_SHOP_TEXT = 9827; -- Would you care for some of my wares? If you do not, I cannot fault you, but please keep in mind that my revolutionary research into a new Ulbukan toxin antidote will have to be put on hold unless I can accrue the necessary funds.
-          KANIL_SHOP_TEXT = 9828; -- Good day, Multiple Choice (Player Gender)[good sir/fair maiden]! You're certainly not in the Middle Lands anymore, but would you care for some products from your homeland in addition to some more traditional fare
-        DEFLIAA_SHOP_TEXT = 9846; -- Hi there, pioneer! We wouldn't want you going out to the scary jungle on an empty stomach. Stock up on some of our delicious bread for the journey!
-     ANSEGUSELE_SHOP_TEXT = 9847; -- Would you care for some fresh vegetables direct from the Rala Waterways? They're some of our most popular items!
-       TEVIGOGO_SHOP_TEXT = 9848; -- Hidey ho! Make sure not to forgetaru anything before heading out into the great unknown!
+        HUJETTE_SHOP_TEXT = 9785; -- How about indulging in some regional delicacies while taking a load off those tired feet of yours?
+       PRETERIG_SHOP_TEXT = 9786; -- Want a way to beat the heat? Try some of the tasty beverages we have on hand.
+      LEDERICUS_SHOP_TEXT = 9820; -- We've got a doozy of a magic scroll selection, tailored especially to your pioneering needs!
+         ISHVAD_SHOP_TEXT = 9821; -- ...A pioneer, are ya? If that's the case, maybe we've finally found a client for our geomantic plates.
+      EUKALLINE_SHOP_TEXT = 9822; -- Why, hello there! If you're looking for geomantic plates, look no further! I don't like to brag, but I'd say our selection is a bit more...sophisticated than what they offer next door.
+        FLAPANO_SHOP_TEXT = 9823; -- Welcome, welcome! Going out into the eye of the jungle's storm? Then the last thing you want is your stomach rumbling during an important battle!
+   THEOPHYLACTE_SHOP_TEXT = 9828; -- Would you care for some of my wares? If you do not, I cannot fault you, but please keep in mind that my revolutionary research into a new Ulbukan toxin antidote will have to be put on hold unless I can accrue the necessary funds.
+          KANIL_SHOP_TEXT = 9829; -- Good day, Multiple Choice (Player Gender)[good sir/fair maiden]! You're certainly not in the Middle Lands anymore, but would you care for some products from your homeland in addition to some more traditional fare
+        DEFLIAA_SHOP_TEXT = 9847; -- Hi there, pioneer! We wouldn't want you going out to the scary jungle on an empty stomach. Stock up on some of our delicious bread for the journey!
+     ANSEGUSELE_SHOP_TEXT = 9848; -- Would you care for some fresh vegetables direct from the Rala Waterways? They're some of our most popular items!
+       TEVIGOGO_SHOP_TEXT = 9849; -- Hidey ho! Make sure not to forgetaru anything before heading out into the great unknown!
 
 -- NPC Dialog
-         MINNIFI_DIALOGUE = 10231; -- Come, ladies and gentlemen, and enjoy our delightful array of frrresh vegetables!
+         MINNIFI_DIALOGUE = 10232; -- Come, ladies and gentlemen, and enjoy our delightful array of frrresh vegetables!

--- a/scripts/zones/Western_Altepa_Desert/TextIDs.lua
+++ b/scripts/zones/Western_Altepa_Desert/TextIDs.lua
@@ -3,27 +3,27 @@
 -- General Texts
    ITEM_CANNOT_BE_OBTAINED = 6379; -- You cannot obtain the item <item>. Come back after sorting your inventory.
 FULL_INVENTORY_AFTER_TRADE = 6383; -- You cannot obtain the <item>. Try trading again after sorting your inventory.
-             ITEM_OBTAINED = 6384; -- Obtained: <item>.
-              GIL_OBTAINED = 6385; -- Obtained <number> gil.
-          KEYITEM_OBTAINED = 6387; -- Obtained key item: <keyitem>.
-            ITEMS_OBTAINED = 6393; -- You obtain <param2 number> <param1 item>!
-   NOTHING_OUT_OF_ORDINARY = 6398; -- There is nothing out of the ordinary here.
-    FISHING_MESSAGE_OFFSET = 7204; -- You can't fish here.
+             ITEM_OBTAINED = 6385; -- Obtained: <item>.
+              GIL_OBTAINED = 6386; -- Obtained <number> gil.
+          KEYITEM_OBTAINED = 6388; -- Obtained key item: <keyitem>.
+            ITEMS_OBTAINED = 6394; -- You obtain <param2 number> <param1 item>!
+   NOTHING_OUT_OF_ORDINARY = 6399; -- There is nothing out of the ordinary here.
+    FISHING_MESSAGE_OFFSET = 7205; -- You can't fish here.
 
 -- ZM4 dialog
-    CANNOT_REMOVE_FRAG = 7341; -- It is an oddly shaped stone monument. A shining stone is embedded in it, but cannot be removed...
- ALREADY_OBTAINED_FRAG = 7342; -- You have already obtained this monument's
-ALREADY_HAVE_ALL_FRAGS = 7343; -- You have obtained all of the fragments. You must hurry to the ruins of the ancient shrine!
-       FOUND_ALL_FRAGS = 7344; -- You now have all 8 fragments of light!
-       ZILART_MONUMENT = 7345; -- It is an ancient Zilart monument.
+    CANNOT_REMOVE_FRAG = 7342; -- It is an oddly shaped stone monument. A shining stone is embedded in it, but cannot be removed...
+ ALREADY_OBTAINED_FRAG = 7343; -- You have already obtained this monument's
+ALREADY_HAVE_ALL_FRAGS = 7344; -- You have obtained all of the fragments. You must hurry to the ruins of the ancient shrine!
+       FOUND_ALL_FRAGS = 7345; -- You now have all 8 fragments of light!
+       ZILART_MONUMENT = 7346; -- It is an ancient Zilart monument.
 
 -- Other dialog
-     THE_DOOR_IS_LOCKED = 7324; -- The door is locked.
-       DOES_NOT_RESPOND = 7325; -- It does not respond.
+     THE_DOOR_IS_LOCKED = 7325; -- The door is locked.
+       DOES_NOT_RESPOND = 7326; -- It does not respond.
 
 -- conquest Base
-CONQUEST_BASE = 7045; -- Tallying conquest results...
+CONQUEST_BASE = 7046; -- Tallying conquest results...
 
 --chocobo digging
-DIG_THROW_AWAY = 7217; -- You dig up$, but your inventory is full. You regretfully throw the # away.
-FIND_NOTHING = 7219; -- You dig and you dig, but find nothing.
+DIG_THROW_AWAY = 7218; -- You dig up$, but your inventory is full. You regretfully throw the # away.
+FIND_NOTHING = 7220; -- You dig and you dig, but find nothing.

--- a/scripts/zones/Windurst-Jeuno_Airship/TextIDs.lua
+++ b/scripts/zones/Windurst-Jeuno_Airship/TextIDs.lua
@@ -2,13 +2,13 @@
 
 -- General Texts
 ITEM_CANNOT_BE_OBTAINED = 6379; -- You cannot obtain the item <item> come back again after sorting your inventory
-          ITEM_OBTAINED = 6384; -- Obtained: <item>
-           GIL_OBTAINED = 6385; -- Obtained <number> gil
-       KEYITEM_OBTAINED = 6387; -- Obtained key item: <keyitem>
+          ITEM_OBTAINED = 6385; -- Obtained: <item>
+           GIL_OBTAINED = 6386; -- Obtained <number> gil
+       KEYITEM_OBTAINED = 6388; -- Obtained key item: <keyitem>
 
 -- Other
 
-       WILL_REACH_JEUNO = 7045; -- The airship will reach Jeuno in Multiple Choice (Parameter 1)[less than an hour/about 1 hour/about 2 hours/about 3 hours/about 4 hours/about 5 hours/about 6 hours/about 7 hours] ( Singular/Plural Choice (Parameter 0)[minute/minutes] in Earth time). 
-    WILL_REACH_WINDURST = 7046; -- The airship will reach Windurst in Multiple Choice (Parameter 1)[less than an hour/about 1 hour/about 2 hours/about 3 hours/about 4 hours/about 5 hours/about 6 hours/about 7 hours] ( Singular/Plural Choice (Parameter 0)[minute/minutes] in Earth time). 
-   IN_JEUNO_MOMENTARILY = 7047; -- We will be arriving in Jeuno momentarily.
-IN_WINDURST_MOMENTARILY = 7048; -- We will be arriving in Windurst momentarily.
+       WILL_REACH_JEUNO = 7046; -- The airship will reach Jeuno in Multiple Choice (Parameter 1)[less than an hour/about 1 hour/about 2 hours/about 3 hours/about 4 hours/about 5 hours/about 6 hours/about 7 hours] ( Singular/Plural Choice (Parameter 0)[minute/minutes] in Earth time). 
+    WILL_REACH_WINDURST = 7047; -- The airship will reach Windurst in Multiple Choice (Parameter 1)[less than an hour/about 1 hour/about 2 hours/about 3 hours/about 4 hours/about 5 hours/about 6 hours/about 7 hours] ( Singular/Plural Choice (Parameter 0)[minute/minutes] in Earth time). 
+   IN_JEUNO_MOMENTARILY = 7048; -- We will be arriving in Jeuno momentarily.
+IN_WINDURST_MOMENTARILY = 7049; -- We will be arriving in Windurst momentarily.

--- a/scripts/zones/Windurst_Walls/TextIDs.lua
+++ b/scripts/zones/Windurst_Walls/TextIDs.lua
@@ -2,25 +2,25 @@
 
 -- General Texts
     ITEM_CANNOT_BE_OBTAINED = 6538; -- Come back after sorting your inventory.
-                               ITEM_OBTAINED = 6543; -- Obtained:
-                            ITEMS_OBTAINED = 6552; -- You obtain
-                                  GIL_OBTAINED = 6544; -- Obtained gil
-                       KEYITEM_OBTAINED = 6546; -- Obtained key item:
-                            HOMEPOINT_SET = 6634; -- Home point set!
-      FISHING_MESSAGE_OFFSET = 7050; -- You can't fish here.
-                           MOGHOUSE_EXIT = 8182; -- You have learned your way through the back alleys of Windurst! Now you can exit to any area from your residence.
+                               ITEM_OBTAINED = 6544; -- Obtained:
+                            ITEMS_OBTAINED = 6553; -- You obtain
+                                  GIL_OBTAINED = 6545; -- Obtained gil
+                       KEYITEM_OBTAINED = 6547; -- Obtained key item:
+                            HOMEPOINT_SET = 6635; -- Home point set!
+      FISHING_MESSAGE_OFFSET = 7051; -- You can't fish here.
+                           MOGHOUSE_EXIT = 8183; -- You have learned your way through the back alleys of Windurst! Now you can exit to any area from your residence.
 
 -- Other Texts
-ITEM_DELIVERY_DIALOG = 6954; -- We can deliver goods to your residence or to the residences of your friends.
-  DOORS_SEALED_SHUT = 7725; -- The doors are firmly sealed shut.
+ITEM_DELIVERY_DIALOG = 6955; -- We can deliver goods to your residence or to the residences of your friends.
+  DOORS_SEALED_SHUT = 7726; -- The doors are firmly sealed shut.
 
 -- Dynamis dialogs
-                YOU_CANNOT_ENTER_DYNAMIS = 9077; -- You cannot enter Dynamis
-PLAYERS_HAVE_NOT_REACHED_LEVEL = 9079; -- Players who have not reached levelare prohibited from entering Dynamis.
-                      STRANDS_OF_GRASS_HERE = 9091; -- The strands of grass here have been tied together.
+                YOU_CANNOT_ENTER_DYNAMIS = 9078; -- You cannot enter Dynamis
+PLAYERS_HAVE_NOT_REACHED_LEVEL = 9080; -- Players who have not reached levelare prohibited from entering Dynamis.
+                      STRANDS_OF_GRASS_HERE = 9092; -- The strands of grass here have been tied together.
 
 -- Shop Texts
-SCAVNIX_SHOP_DIALOG = 8666; -- I'm goood Goblin from underwooorld.I find lotshhh of gooodieshhh.You want try shhhome chipshhh? Cheap for yooou.
+SCAVNIX_SHOP_DIALOG = 8667; -- I'm goood Goblin from underwooorld.I find lotshhh of gooodieshhh.You want try shhhome chipshhh? Cheap for yooou.
 
 -- conquest Base
 CONQUEST_BASE = 0;

--- a/scripts/zones/Windurst_Waters/TextIDs.lua
+++ b/scripts/zones/Windurst_Waters/TextIDs.lua
@@ -2,67 +2,67 @@
 
 -- General Texts
  ITEM_CANNOT_BE_OBTAINED = 6538; -- Come back after sorting your inventory.
-           ITEM_OBTAINED = 6543; -- Obtained: <<<Unknown Parameter (Type: 80) 1>>><<<Possible Special Code: 01>>><<<Possible Special Code: 05>>>
-            GIL_OBTAINED = 6544; -- Obtained <<<Numeric Parameter 0>>> gil.
-        KEYITEM_OBTAINED = 6546; -- Obtained key item: <<<Unknown Parameter (Type: 80) 1>>>
-           HOMEPOINT_SET = 6634; -- Home point set!
-  FISHING_MESSAGE_OFFSET = 7040; -- You can't fish here.
-         COOKING_SUPPORT = 7144; -- Your ?Multiple Choice (Parameter 1)?[fishing/woodworking/smithing/goldsmithing/clothcraft/leatherworking/bonecraft/alchemy/cooking] skills went up ...
-GUILD_TERMINATE_CONTRACT = 7158; -- You have terminated your trading contract with the Multiple Choice (Parameter 1)[Fishermen's/Carpenters'/Blacksmiths'/Goldsmiths'/Weavers'/Tanners'/Boneworkers'/Alchemists'/Culinarians'] Guild and formed a new one with the Multiple Choice (Parameter 0)[Fishermen's/Carpenters'/Blacksmiths'/Goldsmiths'/Weavers'/Tanners'/Boneworkers'/Alchemists'/Culinarians'] Guild
-      GUILD_NEW_CONTRACT = 7166; -- You have formed a new trading contract with the Multiple Choice (Parameter 0)[Fishermen's/Carpenters'/Blacksmiths'/Goldsmiths'/Weavers'/Tanners'/Boneworkers'/Alchemists'/Culinarians'] Guild
-     NO_MORE_GP_ELIGIBLE = 7173; -- You are not eligible to receive guild points at this time.
-             GP_OBTAINED = 7178; -- Obtained: ?Numeric Parameter 0? guild points.
-      NOT_HAVE_ENOUGH_GP = 7179; -- You do not have enough guild points.
+           ITEM_OBTAINED = 6544; -- Obtained: <<<Unknown Parameter (Type: 80) 1>>><<<Possible Special Code: 01>>><<<Possible Special Code: 05>>>
+            GIL_OBTAINED = 6545; -- Obtained <<<Numeric Parameter 0>>> gil.
+        KEYITEM_OBTAINED = 6547; -- Obtained key item: <<<Unknown Parameter (Type: 80) 1>>>
+           HOMEPOINT_SET = 6635; -- Home point set!
+  FISHING_MESSAGE_OFFSET = 7041; -- You can't fish here.
+         COOKING_SUPPORT = 7145; -- Your ?Multiple Choice (Parameter 1)?[fishing/woodworking/smithing/goldsmithing/clothcraft/leatherworking/bonecraft/alchemy/cooking] skills went up ...
+GUILD_TERMINATE_CONTRACT = 7159; -- You have terminated your trading contract with the Multiple Choice (Parameter 1)[Fishermen's/Carpenters'/Blacksmiths'/Goldsmiths'/Weavers'/Tanners'/Boneworkers'/Alchemists'/Culinarians'] Guild and formed a new one with the Multiple Choice (Parameter 0)[Fishermen's/Carpenters'/Blacksmiths'/Goldsmiths'/Weavers'/Tanners'/Boneworkers'/Alchemists'/Culinarians'] Guild
+      GUILD_NEW_CONTRACT = 7167; -- You have formed a new trading contract with the Multiple Choice (Parameter 0)[Fishermen's/Carpenters'/Blacksmiths'/Goldsmiths'/Weavers'/Tanners'/Boneworkers'/Alchemists'/Culinarians'] Guild
+     NO_MORE_GP_ELIGIBLE = 7174; -- You are not eligible to receive guild points at this time.
+             GP_OBTAINED = 7179; -- Obtained: ?Numeric Parameter 0? guild points.
+      NOT_HAVE_ENOUGH_GP = 7180; -- You do not have enough guild points.
 
 
 -- Other
-NOTHING_OUT_OF_ORDINARY =  6557; -- There is nothing out of the ordinary here.
-      DIABOLOS_UNLOCKED = 11885; -- You are now able to summon Diabolos!
+NOTHING_OUT_OF_ORDINARY =  6558; -- There is nothing out of the ordinary here.
+      DIABOLOS_UNLOCKED = 11887; -- You are now able to summon Diabolos!
 
 -- Conquest System
-CONQUEST = 9209; -- You've earned conquest points!
+CONQUEST = 9211; -- You've earned conquest points!
 
 -- Mission Dialogs
-YOU_ACCEPT_THE_MISSION = 6727; -- You have accepted the mission.
+YOU_ACCEPT_THE_MISSION = 6728; -- You have accepted the mission.
 
 -- Shop Texts
-        KOPOPO_SHOP_DIALOG = 7832; -- Cooking is as much an art as music and painting are. Can your taste buds appreciate the full value of our works of art?
-  CHOMOJINJAHL_SHOP_DIALOG = 7837; -- The qualities needed to be a good cook are strong arms, a sense of taste, and devotion.
+        KOPOPO_SHOP_DIALOG = 7834; -- Cooking is as much an art as music and painting are. Can your taste buds appreciate the full value of our works of art?
+  CHOMOJINJAHL_SHOP_DIALOG = 7839; -- The qualities needed to be a good cook are strong arms, a sense of taste, and devotion.
 
-        ENSASA_SHOP_DIALOG = 8904; -- Welcome to my little catalyst shop, where you'll find a range of general and unusual goods!
-   UPIHKHACHLA_SHOP_DIALOG = 8905; -- For adventurerrrs on the go, Ensasa's Catalyst Shop is the place for all you need in generrral goods!
- SHOHRUNTUHRUN_SHOP_DIALOG = 8907; -- Oh, hidey-widey! This is the Federal Magic Reservey-wervey. What can I do for you today-oway?
-  HIKOMUMAKIMU_SHOP_DIALOG = 8908; -- Welcome to the Federal Magic Reserve, the only place in the Federation where high-level magic is allowed to be sold.
-     OREZEBREZ_SHOP_DIALOG = 8909; -- Welcome to Baren-Moren's, makers of the finest headwear. Our slogan is: he smarter the hat, the smarter the head.
-       TAAJIJI_SHOP_DIALOG = 8911; -- May I take your order, please...
-NESSRUGETOMALL_SHOP_DIALOG = 11456; -- Welcome to the Rarab Tail Hostelry.
+        ENSASA_SHOP_DIALOG = 8906; -- Welcome to my little catalyst shop, where you'll find a range of general and unusual goods!
+   UPIHKHACHLA_SHOP_DIALOG = 8907; -- For adventurerrrs on the go, Ensasa's Catalyst Shop is the place for all you need in generrral goods!
+ SHOHRUNTUHRUN_SHOP_DIALOG = 8909; -- Oh, hidey-widey! This is the Federal Magic Reservey-wervey. What can I do for you today-oway?
+  HIKOMUMAKIMU_SHOP_DIALOG = 8910; -- Welcome to the Federal Magic Reserve, the only place in the Federation where high-level magic is allowed to be sold.
+     OREZEBREZ_SHOP_DIALOG = 8911; -- Welcome to Baren-Moren's, makers of the finest headwear. Our slogan is: he smarter the hat, the smarter the head.
+       TAAJIJI_SHOP_DIALOG = 8913; -- May I take your order, please...
+NESSRUGETOMALL_SHOP_DIALOG = 11458; -- Welcome to the Rarab Tail Hostelry.
 
-    MAQUMOLPIH_OPEN_DIALOG = 8912; -- Psst... Check out these things my suppliers in Aragoneu dug up.
-  MAQUMOLPIH_CLOSED_DIALOG = 8913; -- Sorrrry, but I'm waiting on my next shipment from Aragoneu, so I'm all out of things to sell you at the moment.
-    BAEHUFAEHU_OPEN_DIALOG = 8914; -- Can I interest you in some of Sarutabaruta's wares? Come on, have a look, and see how I fares!
-  BAEHUFAEHU_CLOSED_DIALOG = 8915; -- Sorry-dorry, but I'm taking a breaky-wakey! (Or, as you'll be knowing,  since control of Sarutabaruta was lost, I'm out of stock, so go on, get going!)
+    MAQUMOLPIH_OPEN_DIALOG = 8914; -- Psst... Check out these things my suppliers in Aragoneu dug up.
+  MAQUMOLPIH_CLOSED_DIALOG = 8915; -- Sorrrry, but I'm waiting on my next shipment from Aragoneu, so I'm all out of things to sell you at the moment.
+    BAEHUFAEHU_OPEN_DIALOG = 8916; -- Can I interest you in some of Sarutabaruta's wares? Come on, have a look, and see how I fares!
+  BAEHUFAEHU_CLOSED_DIALOG = 8917; -- Sorry-dorry, but I'm taking a breaky-wakey! (Or, as you'll be knowing,  since control of Sarutabaruta was lost, I'm out of stock, so go on, get going!)
 
-      AHYEEKIH_OPEN_DIALOG = 8916; -- Psst... Wanna buy somethin' cheap from Kolshushu?
-    AHYEEKIH_CLOSED_DIALOG = 8917; -- Hee-hee-hee... Can you hang on a while? I can start selling you good stuff from Kolshushu once I'm ready.
+      AHYEEKIH_OPEN_DIALOG = 8918; -- Psst... Wanna buy somethin' cheap from Kolshushu?
+    AHYEEKIH_CLOSED_DIALOG = 8919; -- Hee-hee-hee... Can you hang on a while? I can start selling you good stuff from Kolshushu once I'm ready.
 
-        FOMINA_OPEN_DIALOG = 8918; -- Hello, adventurer! Can I interest you in something a little different--something from Elshimo?
-      FOMINA_CLOSED_DIALOG = 8919; -- Well, um, let me see... This should be a good spot to open shop. There are some wealthy-looking Tarutaru houses nearby. It's quiet and yet there're plenty of passers-by...
+        FOMINA_OPEN_DIALOG = 8920; -- Hello, adventurer! Can I interest you in something a little different--something from Elshimo?
+      FOMINA_CLOSED_DIALOG = 8921; -- Well, um, let me see... This should be a good spot to open shop. There are some wealthy-looking Tarutaru houses nearby. It's quiet and yet there're plenty of passers-by...
 
-         OTETE_OPEN_DIALOG = 8920; -- He-he-he... Hey! How's about... Items from Li'Telor that you can't do without? Reckon you could do, with one of these or two?
-       OTETE_CLOSED_DIALOG = 8921; -- Oh... Phew... My heart is so blue... Bluer than these flowers... Leave me be for a couple hours...
+         OTETE_OPEN_DIALOG = 8922; -- He-he-he... Hey! How's about... Items from Li'Telor that you can't do without? Reckon you could do, with one of these or two?
+       OTETE_CLOSED_DIALOG = 8923; -- Oh... Phew... My heart is so blue... Bluer than these flowers... Leave me be for a couple hours...
 
-      JOURILLE_OPEN_DIALOG = 8922; -- Greetings.  Can I interest you in some of these goods from Ronfaure...?
-    JOURILLE_CLOSED_DIALOG = 8923; -- Greetings! I am Jourille, your friendly neighborhood traveling merchant. I would most like to sell you something from Ronfaure right now, but I regret that I am waiting on my next shipment.
+      JOURILLE_OPEN_DIALOG = 8924; -- Greetings.  Can I interest you in some of these goods from Ronfaure...?
+    JOURILLE_CLOSED_DIALOG = 8925; -- Greetings! I am Jourille, your friendly neighborhood traveling merchant. I would most like to sell you something from Ronfaure right now, but I regret that I am waiting on my next shipment.
 
-   PRESTAPIQ_CLOSED_DIALOG = 10651; -- Goodebyongo! Wingdorsht tooo fhar awayz fhrum mai hormtowne! Dropt arll goodhys whylle ahn trripp!
-     PRESTAPIQ_OPEN_DIALOG = 10652; -- Helgohelgo! Me's bhrink goodhys arll ja wayz fhrum hormtowne ovf Morvalporlis!
+   PRESTAPIQ_CLOSED_DIALOG = 10653; -- Goodebyongo! Wingdorsht tooo fhar awayz fhrum mai hormtowne! Dropt arll goodhys whylle ahn trripp!
+     PRESTAPIQ_OPEN_DIALOG = 10654; -- Helgohelgo! Me's bhrink goodhys arll ja wayz fhrum hormtowne ovf Morvalporlis!
 
 -- Harvest Festival
-  TRICK_OR_TREAT = 10158; -- Trick or treat...
- THANK_YOU_TREAT = 10159; -- And now for your treat...
-  HERE_TAKE_THIS = 10160; -- Here, take this...
-IF_YOU_WEAR_THIS = 10161; -- If you put this on and walk around, something...unexpected might happen...
-       THANK_YOU = 10159; -- Thank you...
+  TRICK_OR_TREAT = 10160; -- Trick or treat...
+ THANK_YOU_TREAT = 10161; -- And now for your treat...
+  HERE_TAKE_THIS = 10162; -- Here, take this...
+IF_YOU_WEAR_THIS = 10163; -- If you put this on and walk around, something...unexpected might happen...
+       THANK_YOU = 10161; -- Thank you...
 
 -- conquest Base
 CONQUEST_BASE = 0;

--- a/scripts/zones/Windurst_Waters_[S]/TextIDs.lua
+++ b/scripts/zones/Windurst_Waters_[S]/TextIDs.lua
@@ -2,21 +2,21 @@
 
 -- General Texts
 ITEM_CANNOT_BE_OBTAINED = 6379;  -- You cannot obtain the item <item> come back again after sorting your inventory
-          ITEM_OBTAINED = 6384;  -- Obtained: <item>
-           GIL_OBTAINED = 6385;  -- Obtained <number> gil
-       KEYITEM_OBTAINED = 6387;  -- Obtained key item: <keyitem>
-          HOMEPOINT_SET = 10855; -- Home point set!
- FISHING_MESSAGE_OFFSET = 7045;  -- You can't fish here
+          ITEM_OBTAINED = 6385;  -- Obtained: <item>
+           GIL_OBTAINED = 6386;  -- Obtained <number> gil
+       KEYITEM_OBTAINED = 6388;  -- Obtained key item: <keyitem>
+          HOMEPOINT_SET = 10856; -- Home point set!
+ FISHING_MESSAGE_OFFSET = 7046;  -- You can't fish here
 
 
 -- General Dialog
-   YASSI_POSSI_DIALOG = 10875; -- Swifty-wifty and safey-wafey parcel delivery! Is there something you need to send?
-MIKHE_ARYOHCHA_DIALOG = 12455; -- Do you like the headpiece? I made it from my firrrst victim. I wear it to let everrryone know what happens when they cross Mikhe Aryohcha!
-        LUTETE_DIALOG = 12457; -- Mastering these Near Eastern magics can be quite taxing. If I had a choice, I'd rather be back in bed, relaxing...
+   YASSI_POSSI_DIALOG = 10876; -- Swifty-wifty and safey-wafey parcel delivery! Is there something you need to send?
+MIKHE_ARYOHCHA_DIALOG = 12456; -- Do you like the headpiece? I made it from my firrrst victim. I wear it to let everrryone know what happens when they cross Mikhe Aryohcha!
+        LUTETE_DIALOG = 12458; -- Mastering these Near Eastern magics can be quite taxing. If I had a choice, I'd rather be back in bed, relaxing...
 
 -- Shop Texts
-     PELFTRIX_SHOP_DIALOG = 7196; -- Boodlix's Emporium open for business! Boodlix's gots whats you wants, at the price yous likes! It's okay, we takes yours gils, too!
-EZURAROMAZURA_SHOP_DIALOG = 10876; -- A potent spelly-well or two can be the key to survival in this time of war. But can you mastaru my magic, or will it master you
+     PELFTRIX_SHOP_DIALOG = 7197; -- Boodlix's Emporium open for business! Boodlix's gots whats you wants, at the price yous likes! It's okay, we takes yours gils, too!
+EZURAROMAZURA_SHOP_DIALOG = 10877; -- A potent spelly-well or two can be the key to survival in this time of war. But can you mastaru my magic, or will it master you
 
 -- Porter Moogle
-    RETRIEVE_DIALOG_ID = 14968; -- You retrieve$ from the porter moogle's care.
+    RETRIEVE_DIALOG_ID = 14969; -- You retrieve$ from the porter moogle's care.

--- a/scripts/zones/Windurst_Woods/TextIDs.lua
+++ b/scripts/zones/Windurst_Woods/TextIDs.lua
@@ -2,78 +2,78 @@
 
 -- General Texts
    ITEM_CANNOT_BE_OBTAINED = 6538; -- Come back after sorting your inventory.
-             ITEM_OBTAINED = 6543; -- Obtained: <<<Unknown Parameter (Type: 80) 1>>><<<Possible Special Code: 01>>><<<Possible Special Code: 05>>>
-              GIL_OBTAINED = 6544; -- Obtained <<<Numeric Parameter 0>>> gil.
-          KEYITEM_OBTAINED = 6546; -- Obtained key item: <<<Unknown Parameter (Type: 80) 1>>>
-              KEYITEM_LOST = 6547; -- Lost key item: <<<Unknown Parameter (Type: 80) 1>>>
-       NOT_HAVE_ENOUGH_GIL = 6548; -- You do not have enough gil.
-             HOMEPOINT_SET = 6634; -- Home point set!
-    FISHING_MESSAGE_OFFSET = 7090; -- You can't fish here.
-             IMAGE_SUPPORT = 7194; -- Your ?Multiple Choice (Parameter 1)?[fishing/woodworking/smithing/goldsmithing/clothcraft/leatherworking/bonecraft/alchemy/cooking] skills went up ...
-       NO_MORE_GP_ELIGIBLE = 7223; -- You are not eligible to receive guild points at this time.
-  GUILD_TERMINATE_CONTRACT = 7208; -- You have terminated your trading contract with the Multiple Choice (Parameter 1)[Fishermen's/Carpenters'/Blacksmiths'/Goldsmiths'/Weavers'/Tanners'/Boneworkers'/Alchemists'/Culinarians'] Guild and formed a new one with the Multiple Choice (Parameter 0)[Fishermen's/Carpenters'/Blacksmiths'/Goldsmiths'/Weavers'/Tanners'/Boneworkers'/Alchemists'/Culinarians'] Guild
-        GUILD_NEW_CONTRACT = 7216; -- You have formed a new trading contract with the Multiple Choice (Parameter 0)[Fishermen's/Carpenters'/Blacksmiths'/Goldsmiths'/Weavers'/Tanners'/Boneworkers'/Alchemists'/Culinarians'] Guild
-               GP_OBTAINED = 7228; -- Obtained: ?Numeric Parameter 0? guild points.
-        NOT_HAVE_ENOUGH_GP = 7229; -- You do not have enough guild points.
+             ITEM_OBTAINED = 6544; -- Obtained: <<<Unknown Parameter (Type: 80) 1>>><<<Possible Special Code: 01>>><<<Possible Special Code: 05>>>
+              GIL_OBTAINED = 6545; -- Obtained <<<Numeric Parameter 0>>> gil.
+          KEYITEM_OBTAINED = 6547; -- Obtained key item: <<<Unknown Parameter (Type: 80) 1>>>
+              KEYITEM_LOST = 6548; -- Lost key item: <<<Unknown Parameter (Type: 80) 1>>>
+       NOT_HAVE_ENOUGH_GIL = 6549; -- You do not have enough gil.
+             HOMEPOINT_SET = 6635; -- Home point set!
+    FISHING_MESSAGE_OFFSET = 7091; -- You can't fish here.
+             IMAGE_SUPPORT = 7195; -- Your ?Multiple Choice (Parameter 1)?[fishing/woodworking/smithing/goldsmithing/clothcraft/leatherworking/bonecraft/alchemy/cooking] skills went up ...
+       NO_MORE_GP_ELIGIBLE = 7224; -- You are not eligible to receive guild points at this time.
+  GUILD_TERMINATE_CONTRACT = 7209; -- You have terminated your trading contract with the Multiple Choice (Parameter 1)[Fishermen's/Carpenters'/Blacksmiths'/Goldsmiths'/Weavers'/Tanners'/Boneworkers'/Alchemists'/Culinarians'] Guild and formed a new one with the Multiple Choice (Parameter 0)[Fishermen's/Carpenters'/Blacksmiths'/Goldsmiths'/Weavers'/Tanners'/Boneworkers'/Alchemists'/Culinarians'] Guild
+        GUILD_NEW_CONTRACT = 7217; -- You have formed a new trading contract with the Multiple Choice (Parameter 0)[Fishermen's/Carpenters'/Blacksmiths'/Goldsmiths'/Weavers'/Tanners'/Boneworkers'/Alchemists'/Culinarians'] Guild
+               GP_OBTAINED = 7229; -- Obtained: ?Numeric Parameter 0? guild points.
+        NOT_HAVE_ENOUGH_GP = 7230; -- You do not have enough guild points.
 
 
 -- Conquest System
-CONQUEST = 8920; -- You've earned conquest points!
+CONQUEST = 8922; -- You've earned conquest points!
 
 -- Other Texts
-ITEM_DELIVERY_DIALOG =  6823; -- We can deliver goods to your residence or to the residences of your friends.
-      CHOCOBO_DIALOG = 10395; -- Kweh!
+ITEM_DELIVERY_DIALOG =  6824; -- We can deliver goods to your residence or to the residences of your friends.
+      CHOCOBO_DIALOG = 10397; -- Kweh!
 
 -- Mission Dialogs
-YOU_ACCEPT_THE_MISSION = 6727; -- You have accepted the mission.
+YOU_ACCEPT_THE_MISSION = 6728; -- You have accepted the mission.
 
 -- Shop Texts
-              JU_KAMJA_DIALOG = 6823; -- We can deliver goods to your residence or to the residences of your friends.
-         PEW_SAHBARAEF_DIALOG = 6823; -- We can deliver goods to your residence or to the residences of your friends.
+              JU_KAMJA_DIALOG = 6824; -- We can deliver goods to your residence or to the residences of your friends.
+         PEW_SAHBARAEF_DIALOG = 6824; -- We can deliver goods to your residence or to the residences of your friends.
 
-        VALERIANO_SHOP_DIALOG = 7537; -- Halfling philosophers and heroine beauties, welcome to the Troupe Valeriano show! And how gorgeous and green this fair town is!
+        VALERIANO_SHOP_DIALOG = 7539; -- Halfling philosophers and heroine beauties, welcome to the Troupe Valeriano show! And how gorgeous and green this fair town is!
 
-         RETTO_MARUTTO_DIALOG = 7950; -- Allo-allo! If you're after boneworking materials, then make sure you buy them herey in Windurst! We're the cheapest in the whole wide worldy!
-           SHIH_TAYUUN_DIALOG = 7952; -- Oh, that Retto-Marutto... If he keeps carrying on while speaking to the customers, he'll get in trouble with the guildmaster again!
-       KUZAH_HPIROHPON_DIALOG = 7961; -- want to get your paws on the top-quality materials as used in the Weaverrrs' Guild?
-                MERIRI_DIALOG = 7963; -- If you're interested in buying some works of art from our Weavers' Guild, then you've come to the right placey-wacey.
+         RETTO_MARUTTO_DIALOG = 7952; -- Allo-allo! If you're after boneworking materials, then make sure you buy them herey in Windurst! We're the cheapest in the whole wide worldy!
+           SHIH_TAYUUN_DIALOG = 7954; -- Oh, that Retto-Marutto... If he keeps carrying on while speaking to the customers, he'll get in trouble with the guildmaster again!
+       KUZAH_HPIROHPON_DIALOG = 7963; -- want to get your paws on the top-quality materials as used in the Weaverrrs' Guild?
+                MERIRI_DIALOG = 7965; -- If you're interested in buying some works of art from our Weavers' Guild, then you've come to the right placey-wacey.
 
-           QUESSE_SHOP_DIALOG = 8503; -- Welcome to the Windurst Chocobo Stables.
-        MONONCHAA_SHOP_DIALOG = 8504; -- , then hurry up and decide, then get the heck out of herrre!
-           MANYNY_SHOP_DIALOG = 8505; -- Are you in urgent needy-weedy of anything? I have a variety of thingy-wingies you may be interested in.
-        WIJETIREN_SHOP_DIALOG = 8510; -- From humble Mithran cold medicines to the legendary Windurstian ambrrrosia of immortality, we have it all...
+           QUESSE_SHOP_DIALOG = 8505; -- Welcome to the Windurst Chocobo Stables.
+        MONONCHAA_SHOP_DIALOG = 8506; -- , then hurry up and decide, then get the heck out of herrre!
+           MANYNY_SHOP_DIALOG = 8507; -- Are you in urgent needy-weedy of anything? I have a variety of thingy-wingies you may be interested in.
+        WIJETIREN_SHOP_DIALOG = 8512; -- From humble Mithran cold medicines to the legendary Windurstian ambrrrosia of immortality, we have it all...
 
-     NHOBI_ZALKIA_OPEN_DIALOG = 8513; -- Psst... Interested in some rrreal hot property? From lucky chocobo digs to bargain goods that fell off the back of an airship...all my stuff is a rrreal steal!
-   NHOBI_ZALKIA_CLOSED_DIALOG = 8514; -- You're interested in some cheap shopping, rrright? I'm real sorry. I'm not doing business rrright now.
+     NHOBI_ZALKIA_OPEN_DIALOG = 8515; -- Psst... Interested in some rrreal hot property? From lucky chocobo digs to bargain goods that fell off the back of an airship...all my stuff is a rrreal steal!
+   NHOBI_ZALKIA_CLOSED_DIALOG = 8516; -- You're interested in some cheap shopping, rrright? I'm real sorry. I'm not doing business rrright now.
 
-      NYALABICCIO_OPEN_DIALOG = 8515; -- Ladies and gentlemen, kittens and cubs! Do we have the sale that you've been waiting forrr!
-    NYALABICCIO_CLOSED_DIALOG = 8516; -- Sorry, but our shop is closed rrright now. Why don't you go to Gustaberg and help the situation out therrre?
+      NYALABICCIO_OPEN_DIALOG = 8517; -- Ladies and gentlemen, kittens and cubs! Do we have the sale that you've been waiting forrr!
+    NYALABICCIO_CLOSED_DIALOG = 8518; -- Sorry, but our shop is closed rrright now. Why don't you go to Gustaberg and help the situation out therrre?
 
-     BIN_STEJIHNA_OPEN_DIALOG = 8517; -- Why don't you buy something from me? You won't regrrret it! I've got all sorts of goods from the Zulkheim region!
-   BIN_STEJIHNA_CLOSED_DIALOG = 8518; -- I'm taking a brrreak from  the saleswoman gig to give dirrrections.  So...through this arrrch is the residential  area.
+     BIN_STEJIHNA_OPEN_DIALOG = 8519; -- Why don't you buy something from me? You won't regrrret it! I've got all sorts of goods from the Zulkheim region!
+   BIN_STEJIHNA_CLOSED_DIALOG = 8520; -- I'm taking a brrreak from  the saleswoman gig to give dirrrections.  So...through this arrrch is the residential  area.
 
-   TARAIHIPERUNHI_OPEN_DIALOG = 8519; -- Ooh...do I have some great merchandise for you! Man...these are once-in-a-lifetime offers, so get them while you can.
- TARAIHIPERUNHI_CLOSED_DIALOG = 8520; -- I am but a poor  merchant. Mate, but you just wait! Strife...one day I'll live the high life. Hey, that's my dream, anyway...
+   TARAIHIPERUNHI_OPEN_DIALOG = 8521; -- Ooh...do I have some great merchandise for you! Man...these are once-in-a-lifetime offers, so get them while you can.
+ TARAIHIPERUNHI_CLOSED_DIALOG = 8522; -- I am but a poor  merchant. Mate, but you just wait! Strife...one day I'll live the high life. Hey, that's my dream, anyway...
 
-   MILLEROVIEUNET_OPEN_DIALOG = 9970; -- Please have a look at these wonderful products from Qufim Island! You won't regret it!
- MILLEROVIEUNET_CLOSED_DIALOG = 9971; -- Now that I've finally learned the language here, I'd like to start my own business. If I could only find a supplier...
+   MILLEROVIEUNET_OPEN_DIALOG = 9972; -- Please have a look at these wonderful products from Qufim Island! You won't regret it!
+ MILLEROVIEUNET_CLOSED_DIALOG = 9973; -- Now that I've finally learned the language here, I'd like to start my own business. If I could only find a supplier...
 
 
 --Test
-RAKOHBUUMA_OPEN_DIALOG = 7634; -- To expel those who would subvert the law and order of Windurst Woods...
+RAKOHBUUMA_OPEN_DIALOG = 7636; -- To expel those who would subvert the law and order of Windurst Woods...
 
 -- Quest Dialog
-PERIH_VASHAI_DIALOG = 8249; -- You can now become a ranger!
-     CATALIA_DIALOG = 8551; -- While we cannot break our promise to the Windurstians, to ensure justice is served, we would secretly like you to take two shields off of the Yagudo who you meet en route.
-      FORINE_DIALOG = 8552; -- Act according to our convictions while fulfilling our promise with the Tarutaru. This is indeed a fitting course for us, the people of glorious San d'Oria.
-     APURURU_DIALOG = 9483; -- There's no way Semih Lafihna will just hand it over for no good reason. Maybe if you try talking with Kupipi...
+PERIH_VASHAI_DIALOG = 8251; -- You can now become a ranger!
+     CATALIA_DIALOG = 8553; -- While we cannot break our promise to the Windurstians, to ensure justice is served, we would secretly like you to take two shields off of the Yagudo who you meet en route.
+      FORINE_DIALOG = 8554; -- Act according to our convictions while fulfilling our promise with the Tarutaru. This is indeed a fitting course for us, the people of glorious San d'Oria.
+     APURURU_DIALOG = 9485; -- There's no way Semih Lafihna will just hand it over for no good reason. Maybe if you try talking with Kupipi...
 
 -- Harvest Festival
-      TRICK_OR_TREAT = 9728; -- Trick or treat...
-     THANK_YOU_TREAT = 9729; -- And now for your treat...
-      HERE_TAKE_THIS = 9730; -- Here, take this...
-    IF_YOU_WEAR_THIS = 9731; -- If you put this on and walk around, something...unexpected might happen...
-           THANK_YOU = 9729; -- Thank you...
+      TRICK_OR_TREAT = 9730; -- Trick or treat...
+     THANK_YOU_TREAT = 9731; -- And now for your treat...
+      HERE_TAKE_THIS = 9732; -- Here, take this...
+    IF_YOU_WEAR_THIS = 9733; -- If you put this on and walk around, something...unexpected might happen...
+           THANK_YOU = 9731; -- Thank you...
 
 -- conquest Base
 CONQUEST_BASE = 0;

--- a/scripts/zones/Woh_Gates/TextIDs.lua
+++ b/scripts/zones/Woh_Gates/TextIDs.lua
@@ -2,6 +2,6 @@
 
 -- General Texts
 ITEM_CANNOT_BE_OBTAINED = 6379; -- You cannot obtain the item <item> come back again after sorting your inventory
-          ITEM_OBTAINED = 6384; -- Obtained: <item>
-           GIL_OBTAINED = 6385; -- Obtained <number> gil
-       KEYITEM_OBTAINED = 6387; -- Obtained key item: <keyitem>
+          ITEM_OBTAINED = 6385; -- Obtained: <item>
+           GIL_OBTAINED = 6386; -- Obtained <number> gil
+       KEYITEM_OBTAINED = 6388; -- Obtained key item: <keyitem>

--- a/scripts/zones/Xarcabard/TextIDs.lua
+++ b/scripts/zones/Xarcabard/TextIDs.lua
@@ -2,25 +2,25 @@
 
 -- General Texts
 ITEM_CANNOT_BE_OBTAINED = 6392; -- You cannot obtain the item <item>. Come back after sorting your inventory.
-          ITEM_OBTAINED = 6397; -- Obtained: <item>.
-           GIL_OBTAINED = 6398; -- Obtained <number> gil.
-       KEYITEM_OBTAINED = 6400; -- Obtained key item: <keyitem>.
-        BEASTMEN_BANNER = 7137; -- There was a curse on the beastmen's banner!
-  ALREADY_OBTAINED_TELE = 7367; -- You already possess the gate crystal for this telepoint.
+          ITEM_OBTAINED = 6398; -- Obtained: <item>.
+           GIL_OBTAINED = 6399; -- Obtained <number> gil.
+       KEYITEM_OBTAINED = 6401; -- Obtained key item: <keyitem>.
+        BEASTMEN_BANNER = 7138; -- There was a curse on the beastmen's banner!
+  ALREADY_OBTAINED_TELE = 7368; -- You already possess the gate crystal for this telepoint.
 
 -- Conquest
-CONQUEST = 7380; -- You've earned conquest points!
+CONQUEST = 7381; -- You've earned conquest points!
 
 -- Other
-NOTHING_OUT_OF_ORDINARY = 6411; -- There is nothing out of the ordinary here.
-            ONLY_SHARDS = 7713; -- Only shards of ice lie upon the ground.
-          BLOCKS_OF_ICE = 7714; -- You can hear blocks of ice moving from deep within the cave.
+NOTHING_OUT_OF_ORDINARY = 6412; -- There is nothing out of the ordinary here.
+            ONLY_SHARDS = 7714; -- Only shards of ice lie upon the ground.
+          BLOCKS_OF_ICE = 7715; -- You can hear blocks of ice moving from deep within the cave.
 
 -- Dynamis dialogs
-       YOU_CANNOT_ENTER_DYNAMIS = 7839; -- You cannot enter Dynamis
- PLAYERS_HAVE_NOT_REACHED_LEVEL = 7841; -- Players who have not reached levelare prohibited from entering Dynamis
- UNUSUAL_ARRANGEMENT_OF_PEBBLES = 7852; -- There is an unusual arrangement of pebbles here.
+       YOU_CANNOT_ENTER_DYNAMIS = 7840; -- You cannot enter Dynamis
+ PLAYERS_HAVE_NOT_REACHED_LEVEL = 7842; -- Players who have not reached levelare prohibited from entering Dynamis
+ UNUSUAL_ARRANGEMENT_OF_PEBBLES = 7853; -- There is an unusual arrangement of pebbles here.
 
 -- conquest Base
-CONQUEST_BASE = 7058; -- Tallying conquest results...
+CONQUEST_BASE = 7059; -- Tallying conquest results...
 

--- a/scripts/zones/Xarcabard_[S]/TextIDs.lua
+++ b/scripts/zones/Xarcabard_[S]/TextIDs.lua
@@ -2,7 +2,7 @@
 
 -- General Texts
 ITEM_CANNOT_BE_OBTAINED = 6379; -- You cannot obtain the item <item> come back again after sorting your inventory
-          ITEM_OBTAINED = 6384; -- Obtained: <item>
-           GIL_OBTAINED = 6385; -- Obtained <number> gil
-       KEYITEM_OBTAINED = 6387; -- Obtained key item: <keyitem>
-            HOMEPOINT_SET = 8744; -- Home point set!
+          ITEM_OBTAINED = 6385; -- Obtained: <item>
+           GIL_OBTAINED = 6386; -- Obtained <number> gil
+       KEYITEM_OBTAINED = 6388; -- Obtained key item: <keyitem>
+            HOMEPOINT_SET = 8745; -- Home point set!

--- a/scripts/zones/Yahse_Hunting_Grounds/TextIDs.lua
+++ b/scripts/zones/Yahse_Hunting_Grounds/TextIDs.lua
@@ -2,6 +2,6 @@
 
 -- General Texts
 ITEM_CANNOT_BE_OBTAINED = 6379; -- You cannot obtain the item <item> come back again after sorting your inventory
-          ITEM_OBTAINED = 6384; -- Obtained: <item>
-           GIL_OBTAINED = 6385; -- Obtained <number> gil
-       KEYITEM_OBTAINED = 6387; -- Obtained key item: <keyitem>
+          ITEM_OBTAINED = 6385; -- Obtained: <item>
+           GIL_OBTAINED = 6386; -- Obtained <number> gil
+       KEYITEM_OBTAINED = 6388; -- Obtained key item: <keyitem>

--- a/scripts/zones/Yhoator_Jungle/TextIDs.lua
+++ b/scripts/zones/Yhoator_Jungle/TextIDs.lua
@@ -2,28 +2,28 @@
 
 -- General Texts
 ITEM_CANNOT_BE_OBTAINED = 6379; -- You cannot obtain the item <item>. Come back after sorting your inventory.
-          ITEM_OBTAINED = 6384; -- Obtained: <item>.
-           GIL_OBTAINED = 6385; -- Obtained <number> gil.
-       KEYITEM_OBTAINED = 6387; -- Obtained key item: <keyitem>.
-NOTHING_OUT_OF_ORDINARY = 6398; -- There is nothing out of the ordinary here.
-        BEASTMEN_BANNER = 7126; -- There is a beastmen's banner.
- FISHING_MESSAGE_OFFSET = 7546; -- You can't fish here.
-  ALREADY_OBTAINED_TELE = 7646; -- You already possess the gate crystal for this telepoint.
+          ITEM_OBTAINED = 6385; -- Obtained: <item>.
+           GIL_OBTAINED = 6386; -- Obtained <number> gil.
+       KEYITEM_OBTAINED = 6388; -- Obtained key item: <keyitem>.
+NOTHING_OUT_OF_ORDINARY = 6399; -- There is nothing out of the ordinary here.
+        BEASTMEN_BANNER = 7127; -- There is a beastmen's banner.
+ FISHING_MESSAGE_OFFSET = 7547; -- You can't fish here.
+  ALREADY_OBTAINED_TELE = 7647; -- You already possess the gate crystal for this telepoint.
 
 -- Conquest
-CONQUEST = 7213; -- You've earned conquest points!
+CONQUEST = 7214; -- You've earned conquest points!
 
 -- Logging
-   LOGGING_IS_POSSIBLE_HERE = 7659; -- Logging is possible here if you have
-HARVESTING_IS_POSSIBLE_HERE = 7666; -- Harvesting is possible here if you have
+   LOGGING_IS_POSSIBLE_HERE = 7660; -- Logging is possible here if you have
+HARVESTING_IS_POSSIBLE_HERE = 7667; -- Harvesting is possible here if you have
 
 -- Other dialog
-TREE_CHECK = 7673; -- The hole in this tree is filled with a sweet-smelling liquid.
- TREE_FULL = 7674; -- Your wine barrel is already full.
+TREE_CHECK = 7674; -- The hole in this tree is filled with a sweet-smelling liquid.
+ TREE_FULL = 7675; -- Your wine barrel is already full.
 
 -- conquest Base
-CONQUEST_BASE = 7045; -- Tallying conquest results...
+CONQUEST_BASE = 7046; -- Tallying conquest results...
 
 -- chocobo digging
-DIG_THROW_AWAY = 7559; -- You dig up ?Possible Special Code: 01??Possible Special Code: 01??Possible Special Code: 01? ?Possible Special Code: 01??Possible Special Code: 05?$?BAD CHAR: 8280??BAD CHAR: 80??BAD CHAR: 80?, but your inventory is full.
-FIND_NOTHING = 7561; -- You dig and you dig, but find nothing.?Prompt?
+DIG_THROW_AWAY = 7560; -- You dig up ?Possible Special Code: 01??Possible Special Code: 01??Possible Special Code: 01? ?Possible Special Code: 01??Possible Special Code: 05?$?BAD CHAR: 8280??BAD CHAR: 80??BAD CHAR: 80?, but your inventory is full.
+FIND_NOTHING = 7562; -- You dig and you dig, but find nothing.?Prompt?

--- a/scripts/zones/Yorcia_Weald/TextIDs.lua
+++ b/scripts/zones/Yorcia_Weald/TextIDs.lua
@@ -2,7 +2,7 @@
 
 -- General Texts
 ITEM_CANNOT_BE_OBTAINED = 6379; -- You cannot obtain the item <item> come back again after sorting your inventory
-          ITEM_OBTAINED = 6384; -- Obtained: <item>
-           GIL_OBTAINED = 6385; -- Obtained <number> gil
-       KEYITEM_OBTAINED = 6387; -- Obtained key item: <keyitem>
-            HOMEPOINT_SET = 8472; -- Home point set!
+          ITEM_OBTAINED = 6385; -- Obtained: <item>
+           GIL_OBTAINED = 6386; -- Obtained <number> gil
+       KEYITEM_OBTAINED = 6388; -- Obtained key item: <keyitem>
+            HOMEPOINT_SET = 8669; -- Home point set!

--- a/scripts/zones/Yorcia_Weald_U/TextIDs.lua
+++ b/scripts/zones/Yorcia_Weald_U/TextIDs.lua
@@ -2,6 +2,6 @@
 
 -- General Texts
 ITEM_CANNOT_BE_OBTAINED = 6379; -- You cannot obtain the item <item> come back again after sorting your inventory
-          ITEM_OBTAINED = 6384; -- Obtained: <item>
-           GIL_OBTAINED = 6385; -- Obtained <number> gil
-       KEYITEM_OBTAINED = 6387; -- Obtained key item: <keyitem>
+          ITEM_OBTAINED = 6385; -- Obtained: <item>
+           GIL_OBTAINED = 6386; -- Obtained <number> gil
+       KEYITEM_OBTAINED = 6388; -- Obtained key item: <keyitem>

--- a/scripts/zones/Yughott_Grotto/TextIDs.lua
+++ b/scripts/zones/Yughott_Grotto/TextIDs.lua
@@ -2,24 +2,24 @@
 
 -- General Texts
 ITEM_CANNOT_BE_OBTAINED = 6538; -- You cannot obtain the item <item>. Come back after sorting your inventory.
-          ITEM_OBTAINED = 6543; -- Obtained: <item>.
-           GIL_OBTAINED = 6544; -- Obtained <number> gil.
-       KEYITEM_OBTAINED = 6546; -- Obtained key item: <keyitem>.
- FISHING_MESSAGE_OFFSET = 7204; -- You can't fish here.
-            HOMEPOINT_SET = 7437; -- Home point set!
+          ITEM_OBTAINED = 6544; -- Obtained: <item>.
+           GIL_OBTAINED = 6545; -- Obtained <number> gil.
+       KEYITEM_OBTAINED = 6547; -- Obtained key item: <keyitem>.
+ FISHING_MESSAGE_OFFSET = 7205; -- You can't fish here.
+            HOMEPOINT_SET = 7438; -- Home point set!
 
 -- Treasure Coffer/Chest Dialog
-CHEST_UNLOCKED = 7329; -- You unlock the chest!
-    CHEST_FAIL = 7330; -- Fails to open the chest.
-    CHEST_TRAP = 7331; -- The chest was trapped!
-    CHEST_WEAK = 7332; -- You cannot open the chest when you are in a weakened state.
-   CHEST_MIMIC = 7333; -- The chest was a mimic!
-  CHEST_MOOGLE = 7334; -- You cannot open the chest while participating in the moogle event.
-CHEST_ILLUSION = 7335; -- The chest was but an illusion...
-  CHEST_LOCKED = 7336; -- The chest appears to be locked.
+CHEST_UNLOCKED = 7330; -- You unlock the chest!
+    CHEST_FAIL = 7331; -- Fails to open the chest.
+    CHEST_TRAP = 7332; -- The chest was trapped!
+    CHEST_WEAK = 7333; -- You cannot open the chest when you are in a weakened state.
+   CHEST_MIMIC = 7334; -- The chest was a mimic!
+  CHEST_MOOGLE = 7335; -- You cannot open the chest while participating in the moogle event.
+CHEST_ILLUSION = 7336; -- The chest was but an illusion...
+  CHEST_LOCKED = 7337; -- The chest appears to be locked.
 
 -- Mining
-MINING_IS_POSSIBLE_HERE = 7337; -- Mining is possible here if you have
+MINING_IS_POSSIBLE_HERE = 7338; -- Mining is possible here if you have
 
 -- conquest Base
 CONQUEST_BASE = 0;

--- a/scripts/zones/Yuhtunga_Jungle/TextIDs.lua
+++ b/scripts/zones/Yuhtunga_Jungle/TextIDs.lua
@@ -2,37 +2,37 @@
 
 -- General Texts
 ITEM_CANNOT_BE_OBTAINED = 6379; -- You cannot obtain the item <item>. Come back after sorting your inventory.
-          ITEM_OBTAINED = 6384; -- Obtained: <item>.
-           GIL_OBTAINED = 6385; -- Obtained <number> gil.
-       KEYITEM_OBTAINED = 6387; -- Obtained key item: <keyitem>.
-        BEASTMEN_BANNER = 7126; -- There is a beastmen's banner.
- FISHING_MESSAGE_OFFSET = 7546; -- You can't fish here.
+          ITEM_OBTAINED = 6385; -- Obtained: <item>.
+           GIL_OBTAINED = 6386; -- Obtained <number> gil.
+       KEYITEM_OBTAINED = 6388; -- Obtained key item: <keyitem>.
+        BEASTMEN_BANNER = 7127; -- There is a beastmen's banner.
+ FISHING_MESSAGE_OFFSET = 7547; -- You can't fish here.
 
 -- Conquest
-CONQUEST = 7213; -- You've earned conquest points!
+CONQUEST = 7214; -- You've earned conquest points!
 
 -- Logging
-   LOGGING_IS_POSSIBLE_HERE = 7693; -- Logging is possible here if you have
-HARVESTING_IS_POSSIBLE_HERE = 7700; -- Harvesting is possible here if you have
+   LOGGING_IS_POSSIBLE_HERE = 7694; -- Logging is possible here if you have
+HARVESTING_IS_POSSIBLE_HERE = 7701; -- Harvesting is possible here if you have
 
 -- ZM4 Dialog
-    CANNOT_REMOVE_FRAG = 7672; -- It is an oddly shaped stone monument. A shining stone is embedded in it, but cannot be removed...
- ALREADY_OBTAINED_FRAG = 7673; -- You have already obtained this monument's
-ALREADY_HAVE_ALL_FRAGS = 7674; -- You have obtained all of the fragments. You must hurry to the ruins of the ancient shrine!
-       FOUND_ALL_FRAGS = 7675; -- You now have all 8 fragments of light!
-       ZILART_MONUMENT = 7676; -- It is an ancient Zilart monument.
+    CANNOT_REMOVE_FRAG = 7673; -- It is an oddly shaped stone monument. A shining stone is embedded in it, but cannot be removed...
+ ALREADY_OBTAINED_FRAG = 7674; -- You have already obtained this monument's
+ALREADY_HAVE_ALL_FRAGS = 7675; -- You have obtained all of the fragments. You must hurry to the ruins of the ancient shrine!
+       FOUND_ALL_FRAGS = 7676; -- You now have all 8 fragments of light!
+       ZILART_MONUMENT = 7677; -- It is an ancient Zilart monument.
 
 -- Rafflesia Scent
-FLOWER_BLOOMING = 7652; -- A large flower is blooming.
-FOUND_NOTHING_IN_FLOWER = 7655; -- You find nothing inside the flower.
-FEEL_DIZZY = 7656; -- You feel slightly dizzy. You must have breathed in too much of the pollen.
+FLOWER_BLOOMING = 7653; -- A large flower is blooming.
+FOUND_NOTHING_IN_FLOWER = 7656; -- You find nothing inside the flower.
+FEEL_DIZZY = 7657; -- You feel slightly dizzy. You must have breathed in too much of the pollen.
 -- Other
 NOTHING_HAPPENS = 119; -- Nothing happens...
 
 -- conquest Base
-CONQUEST_BASE = 7045; -- Tallying conquest results...
+CONQUEST_BASE = 7046; -- Tallying conquest results...
 
 -- chocobo digging
-DIG_THROW_AWAY = 7559; -- You dig up ?Possible Special Code: 01??Possible Special Code: 01??Possible Special Code: 01? ?Possible Special Code: 01??Possible Special Code: 05?$?BAD CHAR: 8280??BAD CHAR: 80??BAD CHAR: 80?, but your inventory is full.
-FIND_NOTHING = 7561; -- You dig and you dig, but find nothing.
+DIG_THROW_AWAY = 7560; -- You dig up ?Possible Special Code: 01??Possible Special Code: 01??Possible Special Code: 01? ?Possible Special Code: 01??Possible Special Code: 05?$?BAD CHAR: 8280??BAD CHAR: 80??BAD CHAR: 80?, but your inventory is full.
+FIND_NOTHING = 7562; -- You dig and you dig, but find nothing.
 

--- a/scripts/zones/Zeruhn_Mines/TextIDs.lua
+++ b/scripts/zones/Zeruhn_Mines/TextIDs.lua
@@ -2,16 +2,16 @@
 
 -- General Texts
 ITEM_CANNOT_BE_OBTAINED = 6538; -- You cannot obtain the item <item> come back again after sorting your inventory.
-          ITEM_OBTAINED = 6543; -- Obtained: <item>.
-           GIL_OBTAINED = 6544; -- Obtained <number> gil.
-       KEYITEM_OBTAINED = 6546; -- Obtained key item: <keyitem>.
- FISHING_MESSAGE_OFFSET = 7204; -- You can't fish here.
+          ITEM_OBTAINED = 6544; -- Obtained: <item>.
+           GIL_OBTAINED = 6545; -- Obtained <number> gil.
+       KEYITEM_OBTAINED = 6547; -- Obtained key item: <keyitem>.
+ FISHING_MESSAGE_OFFSET = 7205; -- You can't fish here.
 
 -- Mission Texts
-MAKARIM_DIALOG_I = 7311; -- Be careful on your way out. Remember, you should give my report to Naji, one of the Mythril Musketeers on post at the President's Office.
+MAKARIM_DIALOG_I = 7312; -- Be careful on your way out. Remember, you should give my report to Naji, one of the Mythril Musketeers on post at the President's Office.
 
 -- Mining
-MINING_IS_POSSIBLE_HERE = 7343; -- Mining is possible here if you have
+MINING_IS_POSSIBLE_HERE = 7344; -- Mining is possible here if you have
 
 
 -- conquest Base

--- a/scripts/zones/Zhayolm_Remnants/TextIDs.lua
+++ b/scripts/zones/Zhayolm_Remnants/TextIDs.lua
@@ -2,6 +2,6 @@
 
 -- General Texts
 ITEM_CANNOT_BE_OBTAINED = 6379; -- You cannot obtain the item <item> come back again after sorting your inventory
-          ITEM_OBTAINED = 6384; -- Obtained: <item>
-           GIL_OBTAINED = 6385; -- Obtained <number> gil
-       KEYITEM_OBTAINED = 6387; -- Obtained key item: <keyitem>
+          ITEM_OBTAINED = 6385; -- Obtained: <item>
+           GIL_OBTAINED = 6386; -- Obtained <number> gil
+       KEYITEM_OBTAINED = 6388; -- Obtained key item: <keyitem>

--- a/version.info
+++ b/version.info
@@ -1,7 +1,7 @@
 #DarkStar Version Info
 
 #Expected Client version (wrong version cannot log in)
-CLIENT_VER: 30161227_1
+CLIENT_VER: 30170204_1
 
 #Current Server Version. Not the same thing as source revision.
 #DSP_VER: Unused because we aren't even close to a "release" yet.


### PR DESCRIPTION
**NPC List:**
This update was my first full test of a redone NPC batch tool which I've been working on, which takes a "chunk based" approach towards solving the list. I'll go into how it works when I'm more confident in the newer tool and do a PR for the utils repo, so I'll spare everyone the explaination for now. 

While it no longer has the leapfroging issue the current tool has, it's still a bit oversensitive at the moment and required more manual adjustments than I would have liked. The problem spots it had were places where we're lacking captured NPCs (a problem shared with the current tool), especially among batches of NPCs all with the same name. Think groups of coffers, or our current progress on Chocobo Circuit. I'm considering special placeholder comments for NPCs which DSP currently doesn't have captured, which would serve two purposes:
1) Reserve slots so the batch tool doesn't try to place a NPC with the same name there.
2) Doubles as documentation of what NPCs we still need to capture.

As far as what moved, despite the very vibrant diff bar I got after running the current/older batch tool, there actually weren't any real shifts. A lot of stuff shifted in Yorcia Weald, but I don't know if that's because they're actually different from last client version, or if they just weren't being picked up before.

The rest is mostly just formatting and me running the name scraper.

**Text IDs:**
SE decided to increment almost every text ID in the game. From what I can gather, there is a message (which I think is new; I don't recognize it) that they added in the vicinity of item/gil obtainment:
"You must free at least ≺Numeric Parameter 0≻ space≺Singular/Plural Choice (Parameter 0)≻[/s] before trading those items."