### PR TITLE
Pre-battle cutscenes for COR AF3 (does not include the battle)

### DIFF
--- a/scripts/zones/Aht_Urhgan_Whitegate/Zone.lua
+++ b/scripts/zones/Aht_Urhgan_Whitegate/Zone.lua
@@ -7,8 +7,10 @@ package.loaded["scripts/zones/Aht_Urhgan_Whitegate/TextIDs"] = nil;
 -----------------------------------
 require("scripts/zones/Aht_Urhgan_Whitegate/TextIDs");
 require("scripts/globals/settings");
+require("scripts/globals/status");
 require("scripts/globals/keyitems");
 require("scripts/globals/missions");
+require("scripts/globals/quests");
 require("scripts/globals/titles");
 
 -----------------------------------
@@ -20,7 +22,7 @@ function onInitialize(zone)
     zone:registerRegion(2,-96,-7,121,-64,-5,137); -- Sets Mark for "Vanishing Act" Quest cutscene.
     zone:registerRegion(3,14,-7,-65,37,-2,-41); -- TOAU Mission 1 CS area
     zone:registerRegion(4,75,-3,25,90,1,59);
-    zone:registerRegion(5,73,-7,-137,95,-3,-115);
+    zone:registerRegion(5,73,-7,-137,95,-3,-115); -- entering Shaharat Teahouse
 end;
 
 -----------------------------------
@@ -112,6 +114,8 @@ function onRegionEnter(player,region)
                 player:startEvent(3092);
             elseif (player:getCurrentMission(TOAU) == STIRRINGS_OF_WAR and player:getVar("AhtUrganStatus") == 1) then
                 player:startEvent(3136,0,0,0,0,0,0,0,0,0);
+            elseif (player:getQuestStatus(AHT_URHGAN,NAVIGATING_THE_UNFRIENDLY_SEAS) == QUEST_COMPLETED and player:getQuestStatus(AHT_URHGAN,AGAINST_ALL_ODDS) == QUEST_AVAILABLE and player:getMainJob() == JOBS.COR and player:getMainLvl() >= AF3_QUEST_LEVEL) then
+                player:startEvent(797);
             end
         end,
     }
@@ -250,5 +254,11 @@ function onEventFinish(player,csid,option)
         player:addKeyItem(ALLIED_COUNCIL_SUMMONS);
         player:messageSpecial(KEYITEM_OBTAINED,ALLIED_COUNCIL_SUMMONS);
         player:addMission(TOAU,ALLIED_RUMBLINGS);
+    elseif (csid == 797) then
+        player:setVar("AgainstAllOdds",1); -- Set For Corsair BCNM
+        player:setVar("AgainstAllOddsSideQuests",1); -- Set For Corsair Side Quests
+        player:addQuest(AHT_URHGAN,AGAINST_ALL_ODDS); -- Start of af 3 not completed yet
+        player:addKeyItem(LIFE_FLOAT); -- BCNM KEY ITEM TO ENTER BCNM
+        player:messageSpecial(KEYITEM_OBTAINED, LIFE_FLOAT);
     end
 end;

--- a/scripts/zones/Aht_Urhgan_Whitegate/npcs/Ratihb.lua
+++ b/scripts/zones/Aht_Urhgan_Whitegate/npcs/Ratihb.lua
@@ -41,10 +41,10 @@ function onTrigger(player,npc)
         player:startEvent(0x0304);
         player:setVar("EquipedforAllOccasions",5);
         player:setVar("LuckOfTheDraw",0);
-    elseif (player:getQuestStatus(AHT_URHGAN,NAVIGATING_THE_UNFRIENDLY_SEAS) == QUEST_COMPLETED and player:getMainJob() == JOBS.COR and mLvl >= AF1_QUEST_LEVEL) then
-        player:startEvent(0x031D);
     elseif (player:getQuestStatus(AHT_URHGAN,LUCK_OF_THE_DRAW) == QUEST_COMPLETED and player:getQuestStatus(AHT_URHGAN,EQUIPED_FOR_ALL_OCCASIONS) == QUEST_COMPLETED) then
         player:setVar("EquipedforAllOccasions",0);
+    elseif (player:getQuestStatus(AHT_URHGAN,AGAINST_ALL_ODDS) == QUEST_ACCEPTED and not player:hasKeyItem(LIFE_FLOAT)) then
+        player:startEvent(0x025C); -- reacquire life float
     else    
         player:startEvent(0x025B);    -- standard dialog
     end
@@ -79,11 +79,7 @@ function onEventFinish(player,csid,option)
         else
             player:messageSpecial(ITEM_CANNOT_BE_OBTAINED,AFgun);
         end
-        
-    elseif (csid == 0x031D) then
-        player:setVar("AgainstAllOdds",1); -- Set For Corsair BCNM
-        player:setVar("AgainstAllOddsSideQuests",1); -- Set For Corsair Side Quests
-        player:addQuest(AHT_URHGAN,AGAINST_ALL_ODDS); -- Start of af 3 not completed yet
+    elseif (csid == 0x025C) then
         player:addKeyItem(LIFE_FLOAT); -- BCNM KEY ITEM TO ENTER BCNM
         player:messageSpecial(KEYITEM_OBTAINED, LIFE_FLOAT);
     end

--- a/scripts/zones/Arrapago_Reef/Zone.lua
+++ b/scripts/zones/Arrapago_Reef/Zone.lua
@@ -7,6 +7,7 @@ package.loaded["scripts/zones/Arrapago_Reef/TextIDs"] = nil;
 -----------------------------------
 require("scripts/zones/Arrapago_Reef/TextIDs");
 require("scripts/globals/missions");
+require("scripts/globals/quests");
 require("scripts/globals/keyitems");
 require("scripts/globals/settings");
 
@@ -15,7 +16,7 @@ require("scripts/globals/settings");
 -----------------------------------
 
 function onInitialize(zone)
-    zone:registerRegion(1,-462,-4,-420,-455,-1,-392);
+    zone:registerRegion(1,-462,-4,-420,-455,-1,-392); -- approach the Cutter
 end;
 
 -----------------------------------
@@ -32,8 +33,8 @@ function onZoneIn(player,prevZone)
             else
                 player:setPos(-456, -3, -405, 64);
             end
-	elseif (prevZone == 79 and player:getCurrentMission(TOAU) == PREVALENCE_OF_PIRATES and player:getVar("AhtUrganStatus") == 0) then
-	    cs = 13;
+    elseif (prevZone == 79 and player:getCurrentMission(TOAU) == PREVALENCE_OF_PIRATES and player:getVar("AhtUrganStatus") == 0) then
+        cs = 13;
         else
             player:setPos(-180.028,-10.335,-559.987,182);
         end
@@ -62,6 +63,8 @@ function onRegionEnter(player,region)
         player:startEvent(14);
     elseif (player:getCurrentMission(TOAU) == TESTING_THE_WATERS and player:hasKeyItem(EPHRAMADIAN_GOLD_COIN)) then
         player:startEvent(15);
+    elseif (player:getQuestStatus(AHT_URHGAN,AGAINST_ALL_ODDS) == QUEST_ACCEPTED and player:getVar("AgainstAllOdds") == 1) then
+        player:startEvent(237);
     end
 end;
 
@@ -100,5 +103,9 @@ function onEventFinish(player,csid,option)
         player:setPos(0,0,0,0,57);
     elseif (csid == 34 and player:getVar("AhtUrganStatus") == 1) then
         player:startEvent(35);
+    elseif (csid == 237) then
+        player:startEvent(240);
+    elseif (csid == 240) then
+        player:setVar("AgainstAllOdds",2);
     end
 end;

--- a/scripts/zones/Nashmau/npcs/Leleroon.lua
+++ b/scripts/zones/Nashmau/npcs/Leleroon.lua
@@ -9,6 +9,7 @@ package.loaded["scripts/zones/Nashmau/TextIDs"] = nil;
 
 require("scripts/zones/Nashmau/TextIDs");
 require("scripts/globals/settings");
+require("scripts/globals/status");
 require("scripts/globals/quests");
 require("scripts/globals/keyitems");
 
@@ -37,7 +38,7 @@ function onTrigger(player,npc)
     local mJob = player:getMainJob();
     local mLvl = player:getMainLvl();
     
-    if (player:getVar("AgainstAllOddsSideQuests") == 1 and mJob == 17 and mLvl >= AF3_QUEST_LEVEL) then
+    if (player:getVar("AgainstAllOddsSideQuests") == 1 and mJob == JOBS.COR and mLvl >= AF3_QUEST_LEVEL) then
         player:startEvent(0x11A); -- CS with 3 Options
     else
         player:startEvent(0x0108); -- Basic Dialog    


### PR DESCRIPTION
[Pre-battle cutscenes for COR AF3. This commit does not include the battle itself.]

COR AF3 initial cutscene now occurs as you approach the teahouse, rather than clicking on Ratihb.
You can now reacquire the LIFE_FLOAT key item if you speak to Ratihb.
A two-part cutscene now plays as you approach the cutter in Arrapago Reef.
Fixed a player job check in Leleroon.