### PR TITLE
Attempt at fixing zlib compression errors (#3394)

### DIFF
--- a/src/map/map.cpp
+++ b/src/map/map.cpp
@@ -658,33 +658,57 @@ int32 send_parse(int8 *buff, size_t* buffsize, sockaddr_in* from, map_session_da
     uint32 PacketCount = PChar->getPacketCount();
     uint8 packets = 0;
 
-    while (PacketSize > 1300 - FFXI_HEADER_SIZE - 16) //max size for client to accept
-    {
-        *buffsize = FFXI_HEADER_SIZE;
-        PacketList_t packetList = PChar->getPacketList();
-        packets = 0;
+    do {
+        do {
+            *buffsize = FFXI_HEADER_SIZE;
+            PacketList_t packetList = PChar->getPacketList();
+            packets = 0;
 
-        while (!packetList.empty() && *buffsize + packetList.front()->length() < map_config.buffer_size &&
-            packets < PacketCount)
+            while (!packetList.empty() && *buffsize + packetList.front()->length() < map_config.buffer_size &&
+                packets < PacketCount)
+            {
+                PSmallPacket = packetList.front();
+
+                PSmallPacket->sequence(map_session_data->server_packet_id);
+                memcpy(buff + *buffsize, *PSmallPacket, PSmallPacket->length());
+
+                *buffsize += PSmallPacket->length();
+                packetList.pop_front();
+                packets++;
+            }
+
+            PacketCount /= 2;
+
+            //Сжимаем данные без учета заголовка
+            //Возвращаемый размер в 8 раз больше реальных данных
+            PacketSize = zlib_compress(buff + FFXI_HEADER_SIZE, *buffsize - FFXI_HEADER_SIZE, PTempBuff, map_config.buffer_size);
+
+            // handle compression error
+            if (PacketSize == static_cast<uint32>(-1))
+            {
+                continue;
+            }
+
+            WBUFL(PTempBuff, zlib_compressed_size(PacketSize)) = PacketSize;
+
+            PacketSize = zlib_compressed_size(PacketSize) + 4;
+
+        } while (PacketCount > 0 && PacketSize > 1300 - FFXI_HEADER_SIZE - 16); //max size for client to accept
+
+        if (PacketSize == static_cast<uint32>(-1))
         {
-            PSmallPacket = packetList.front();
-
-            PSmallPacket->sequence(map_session_data->server_packet_id);
-            memcpy(buff + *buffsize, *PSmallPacket, PSmallPacket->length());
-
-            *buffsize += PSmallPacket->length();
-            packetList.pop_front();
-            packets++;
+            if (PChar->getPacketCount() > 0)
+            {
+                PChar->erasePackets(1);
+                PacketCount = PChar->getPacketCount();
+            }
+            else
+            {
+                *buffsize = 0;
+                return -1;
+            }
         }
-        //Сжимаем данные без учета заголовка
-        //Возвращаемый размер в 8 раз больше реальных данных
-        PacketSize = zlib_compress(buff + FFXI_HEADER_SIZE, *buffsize - FFXI_HEADER_SIZE, PTempBuff, map_config.buffer_size);
-        WBUFL(PTempBuff, zlib_compressed_size(PacketSize)) = PacketSize;
-
-        PacketSize = zlib_compressed_size(PacketSize) + 4;
-
-        PacketCount /= 2;
-    }
+    } while (PacketSize == static_cast<uint32>(-1));
     PChar->erasePackets(packets);
 
     //Запись размера данных без учета заголовка

--- a/src/map/map.cpp
+++ b/src/map/map.cpp
@@ -678,7 +678,7 @@ int32 send_parse(int8 *buff, size_t* buffsize, sockaddr_in* from, map_session_da
         }
         //Сжимаем данные без учета заголовка
         //Возвращаемый размер в 8 раз больше реальных данных
-        PacketSize = zlib_compress(buff + FFXI_HEADER_SIZE, *buffsize - FFXI_HEADER_SIZE, PTempBuff, *buffsize);
+        PacketSize = zlib_compress(buff + FFXI_HEADER_SIZE, *buffsize - FFXI_HEADER_SIZE, PTempBuff, map_config.buffer_size);
         WBUFL(PTempBuff, zlib_compressed_size(PacketSize)) = PacketSize;
 
         PacketSize = zlib_compressed_size(PacketSize) + 4;


### PR DESCRIPTION
Using the data posted by https://github.com/DarkstarProject/darkstar/issues/3394#issuecomment-263086362 @eraffxi I confirmed that zlib_compress always failed even with the old "zlib" routine.

We can get rid of the failure by allowing zlib_compress function to use the whole allocated space of PTempBuff.  

I'm not sure if the routine can fail anymore, but just in case I added another commit that will split the packets in case it does. In anycase, if map.cpp gets refactored, it may also be good idea to reconsider changing the -1 returns in zlib.cpp just to fatal errors, to reduce the error handling overall in codebase, assuming the function doesn't fail anymore.