### PR TITLE
Corrected weapon npcs in Upper Jeuno to match retail

### DIFF
--- a/scripts/zones/Upper_Jeuno/npcs/Antonia.lua
+++ b/scripts/zones/Upper_Jeuno/npcs/Antonia.lua
@@ -23,14 +23,22 @@ function onTrigger(player,npc)
     
 player:showText(npc,ANTONIA_SHOP_DIALOG);
 
-stock = {0x42A5,6256,  -- Mythril Rod
-         0x4283,11232, -- Oak Cudgel
-         0x428C,18048, -- Mythril Mace
-         0x4294,6033,  -- Warhammer
-         0x42CA,37440, -- Oak Pole
-         0x41C4,44550, -- Halberd
-         0x4186,10596, -- Scythe
-         0x43A8,7}    -- Iron Arrow
+stock = {0x5400,100100, -- Arasy Sainti
+     0x5432,100100, -- Arasy Knife
+     0x5464,100100, -- Arasy Sword
+     0x5496,100100, -- Arasy Claymore
+     0x54C8,100100, -- Arasy Tabar
+     0x5502,100100, -- Arasy Axe
+     0x5534,100100, -- Arasy Scythe
+     0x5569,100100, -- Arasy Lance
+     0x5595,100100, -- Yoshikiri
+     0x55C8,100100, -- Ashijiro no Tachi
+     0x55FF,100100, -- Arasy Rod
+     0x563A,100100, -- Arasy Staff
+     0x566A,100100, -- Arasy Bow
+     0x5677,100100, -- Arasy Gun
+     0x5390,100100, -- Animator Z
+     0x5391,100100} -- Arasy Sachet
  
 showShop(player, STATIC, stock);
 end; 

--- a/scripts/zones/Upper_Jeuno/npcs/Coumuna.lua
+++ b/scripts/zones/Upper_Jeuno/npcs/Coumuna.lua
@@ -23,14 +23,23 @@ function onTrigger(player,npc)
     
 player:showText(npc,COUMUNA_SHOP_DIALOG);
 
-stock = {0x4141,4186, -- Greataxe
+stock = {0x4141,4550, -- Greataxe
      0x4086,31000, -- Mythril Degen
-     0x404C,11128, -- Kris 
+     0x404C,12096, -- Kris 
      0x4053,14560, -- Mythril Knife
      0x400F,15488, -- Katars
-     0x40CD,13926, -- Two-Handed Sword
+     0x40CD,13962, -- Two-Handed Sword
      0x401C,29760, -- Mythril Claws
-     0x40B7,85250} -- Knight's Sword
+     0x40B7,85250, -- Knight's Sword
+     0x4104,48600, -- Mythril Axe
+     0x42A5,6256,  -- Mythril Rod
+     0x4283,11232, -- Oak Cudgel
+     0x428C,18048, -- Mythril Mace
+     0x4294,6558,  -- Warhammer
+     0x42CA,37440, -- Oak Pole
+     0x41C4,44550, -- Halberd
+     0x4186,10596, -- Scythe
+     0x43A8,8}     -- Iron Arrow
  
 showShop(player, STATIC, stock);
 end; 


### PR DESCRIPTION
Coumuna now has correct listings and prices combined with what Antonia was previously selling.

https://www.bg-wiki.com/bg/Coumuna

Antonia now has correct listings as updated from SE with ilvl weapons.

https://www.bg-wiki.com/bg/Antonia

Here's the link straight from the May 2016 version update:

http://forum.square-enix.com/ffxi/threads/50529?_ga=1.115613697.664791456.1474977004
