### PR TITLE
Version update 2017/03/10 (client: 30170304_1)

### DIFF
--- a/version.info
+++ b/version.info
@@ -1,7 +1,7 @@
 #DarkStar Version Info
 
 #Expected Client version (wrong version cannot log in)
-CLIENT_VER: 30170204_1
+CLIENT_VER: 30170304_1
 
 #Current Server Version. Not the same thing as source revision.
 #DSP_VER: Unused because we aren't even close to a "release" yet.


### PR DESCRIPTION
Just Ambuscade shifting IDs.

Don't know what happened in East Ronfaure, but I've manually made that section align with POLUtils. If it were an event thing, one would think West Sarutabaruta and South Gustaberg would be hit too, but they were fine. I'm chalking this one up to East Ronfaure being previously incorrect.

No text ID changes.