### PR TITLE
Mobutils.cpp Update - Correct NM Max HP

### DIFF
--- a/src/map/utils/mobutils.cpp
+++ b/src/map/utils/mobutils.cpp
@@ -363,11 +363,11 @@ void CalculateStats(CMobEntity * PMob)
 
         if(isNM)
         {
-            PMob->health.maxhp *= map_config.nm_mp_multiplier;
+            PMob->health.maxmp *= map_config.nm_mp_multiplier;
         }
         else
         {
-            PMob->health.maxhp *= map_config.mob_mp_multiplier;
+            PMob->health.maxmp *= map_config.mob_mp_multiplier;
         }
     }
 


### PR DESCRIPTION
map_config.nm_mp_multiplier was being used to determine the max HP of the NM.