### PR TITLE
Need to handle the special case of shared recast

### DIFF
--- a/src/map/ai/states/ability_state.cpp
+++ b/src/map/ai/states/ability_state.cpp
@@ -132,7 +132,7 @@ bool CAbilityState::CanUseAbility()
     {
         auto PAbility = GetAbility();
         auto PChar = static_cast<CCharEntity*>(m_PEntity);
-        if (PChar->PRecastContainer->HasRecast(RECAST_ABILITY, PAbility->getRecastId(), PAbility->getRecastTime()))
+        if (PChar->PRecastContainer->HasRecast(RECAST_ABILITY, PAbility->getRecastId(), PAbility->getRecastTime(), ABILITY_SIC == PAbility->getID()))
         {
             PChar->pushPacket(new CMessageBasicPacket(PChar, PChar, 0, 0, MSGBASIC_WAIT_LONGER));
             return false;

--- a/src/map/entities/charentity.cpp
+++ b/src/map/entities/charentity.cpp
@@ -826,7 +826,7 @@ void CCharEntity::OnWeaponSkillFinished(CWeaponSkillState& state, action_t& acti
 void CCharEntity::OnAbility(CAbilityState& state, action_t& action)
 {
     auto PAbility = state.GetAbility();
-    if (this->PRecastContainer->HasRecast(RECAST_ABILITY, PAbility->getRecastId(), PAbility->getRecastTime()))
+    if (this->PRecastContainer->HasRecast(RECAST_ABILITY, PAbility->getRecastId(), PAbility->getRecastTime(), ABILITY_SIC == PAbility->getID()))
     {
         pushPacket(new CMessageBasicPacket(this, this, 0, 0, MSGBASIC_WAIT_LONGER));
         return;

--- a/src/map/recast_container.cpp
+++ b/src/map/recast_container.cpp
@@ -234,7 +234,7 @@ bool CRecastContainer::Has(RECASTTYPE type, uint16 id)
 *                                                                       *
 ************************************************************************/
 
-bool CRecastContainer::HasRecast(RECASTTYPE type, uint16 id, uint32 recast)
+bool CRecastContainer::HasRecast(RECASTTYPE type, uint16 id, uint32 recast, bool isSic)
 {
     RecastList_t* PRecastList = GetRecastList(type);
 
@@ -242,7 +242,12 @@ bool CRecastContainer::HasRecast(RECASTTYPE type, uint16 id, uint32 recast)
     {
         if (PRecastList->at(i).ID == id && PRecastList->at(i).RecastTime > 0)
         {
-            if (PRecastList->at(i).chargeTime == 0)
+			// Sic/Ready share the same recastId, but Ready is based on charges
+			if (isSic)
+			{
+				return true;
+			}
+            else if (PRecastList->at(i).chargeTime == 0)
             {
                 return true;
             }

--- a/src/map/recast_container.h
+++ b/src/map/recast_container.h
@@ -67,7 +67,7 @@ class CRecastContainer
     void Del(RECASTTYPE type, uint16 id);
 	void DeleteByIndex(RECASTTYPE type, uint8 index);
     bool Has(RECASTTYPE type, uint16 id);
-    bool HasRecast(RECASTTYPE type, uint16 id, uint32 recast);
+    bool HasRecast(RECASTTYPE type, uint16 id, uint32 recast, bool isSic = false);
     void Add(RECASTTYPE type, uint16 id, uint32 duration, uint32 chargeTime = 0, uint8 maxCharges = 0);
     Recast_t* Load(RECASTTYPE type, uint16 id, uint32 duration, uint32 chargeTime = 0, uint8 maxCharges = 0);
     void ResetAbilities();


### PR DESCRIPTION
Reward/Sic share a recast, but each operates differently:
Sic - Uses the recast timer
Reward - Uses charges and has a charge time
Modifying CRecastContainer::HasRecast(...) to take an optional parameter we can identify if this request is for Sic and have handling to exit early instead of incorrectly checking (and finding) that there are charges available