### PR TITLE
Script: Fixed CoP Ring Selection Bug

### DIFF
--- a/scripts/zones/Upper_Jeuno/npcs/_6s1.lua
+++ b/scripts/zones/Upper_Jeuno/npcs/_6s1.lua
@@ -1,106 +1,124 @@
------------------------------------
+----------------------------------------------------------------------------------------------------------------------------------------------
 -- Area: Upper Jeuno
 -- NPC:  Marble Bridge Eatery (Door)
 -- @pos -96.6 -0.2 92.3 244
------------------------------------
-package.loaded["scripts/zones/Upper_Jeuno/TextIDs"] = nil;
------------------------------------
-
-require("scripts/globals/settings");
-require("scripts/globals/missions");
-require("scripts/zones/Upper_Jeuno/TextIDs");
-
-local RajasRing = 15543;
-local SattvaRing = 15544;
-local TamasRing = 15545;
-
------------------------------------
+----------------------------------------------------------------------------------------------------------------------------------------------
+package.loaded["scripts/zones/Upper_Jeuno/TextIDs"] = nil
+----------------------------------------------------------------------------------------------------------------------------------------------
+require("scripts/zones/Upper_Jeuno/TextIDs")
+require("scripts/globals/missions")
+require("scripts/globals/settings")
+----------------------------------------------------------------------------------------------------------------------------------------------
+local ring = {
+             15543, --Rajas Ring
+             15544, --Sattva Ring
+             15545  --Tamas Ring
+             }
+----------------------------------------------------------------------------------------------------------------------------------------------
 -- onTrade Action
------------------------------------
-
+----------------------------------------------------------------------------------------------------------------------------------------------
 function onTrade(player,npc,trade)
-end; 
 
------------------------------------
+end
+----------------------------------------------------------------------------------------------------------------------------------------------
 -- onTrigger Action
------------------------------------
+----------------------------------------------------------------------------------------------------------------------------------------------
 function onTrigger(player,npc)
 
-    local playerhaveCOPring=false;
-    local ringtakeNbr=player:getVar("COP-RingTakeNbr");
-    local currentday = tonumber(os.date("%j")); 
-    local lastRingday =player:getVar("COP-lastRingday");
+    local status = player:getVar("PromathiaStatus")
+    local mission = player:getCurrentMission(COP)
 
-    if (player:hasItem(RajasRing) or player:hasItem(SattvaRing) or player:hasItem(TamasRing)) then
-        playerhaveCOPring=true;
+    if (mission == FOR_WHOM_THE_VERSE_IS_SUNG and status == 1) then 
+        player:startEvent(0x271B)
+    elseif (mission == FLAMES_IN_THE_DARKNESS and status == 3) then
+        player:startEvent(0x271C)
+    elseif (mission == DAWN and status == 4) then
+        player:startEvent(0x0081)
+    elseif ((mission == DAWN and status > 4) or player:hasCompletedMission(COP,DAWN)) then
+    
+        local hasRing = false
+    
+        for key, value in pairs(ring) do
+            if (player:hasItem(value)) then hasRing = true end
+        end
+        
+        if not (hasRing) then
+        
+            local currentDay = tonumber(os.date("%j"))
+            local ringTaken = player:getVar("COP-RingTakeNbr")
+            local dateObtained = player:getVar("COP-lastRingday")
+            
+            if (ringTaken == 0) then
+                player:startEvent(0x0054, ring[1], ring[2], ring[3]) 
+            elseif (ringTaken == 1) then -- First time you throw away, no wait
+                player:startEvent(0x00CC, ring[1], ring[2], ring[3])
+            elseif (ringTaken > 1 and (currentDay - dateObtained) >= 28) then -- Wait time is >= 28 days, not 26
+                player:startEvent(0x00CC, ring[1], ring[2], ring[3])
+            else
+                return -1
+            end
+            
+        else
+            return -1
+        end
+        
+    else
+        return -1
+    end
+   
+end
+----------------------------------------------------------------------------------------------------------------------------------------------
+-- onEventUpdate
+----------------------------------------------------------------------------------------------------------------------------------------------
+function onEventUpdate(player,csid,option)
+
+    -- printf("CSID: %u",csid)
+    -- printf("RESULT: %u",option)
+   
+    if ((csid == 0x0054 or csid == 0x00CC) and option == 4) then
+        player:updateEvent(ring[1],ring[2],ring[3])
+    end
+   
+end
+----------------------------------------------------------------------------------------------------------------------------------------------
+-- onEventFinish
+----------------------------------------------------------------------------------------------------------------------------------------------
+function onEventFinish(player,csid,option)
+
+    -- printf("CSID: %u",csid)
+    -- printf("RESULT: %u",option)
+    
+    local ringelection = false
+    
+    if (csid == 0x0054 or csid == 0x00CC) then
+        ringelection = true
     end
     
-    if (player:getCurrentMission(COP) == FOR_WHOM_THE_VERSE_IS_SUNG  and  player:getVar("PromathiaStatus") == 1) then 
-        player:startEvent(0x271B);
-    elseif (player:getCurrentMission(COP) ==FLAMES_IN_THE_DARKNESS and player:getVar("PromathiaStatus")==3) then
-        player:startEvent(0x271C);
-    elseif (player:getCurrentMission(COP) == DAWN and player:getVar("PromathiaStatus")== 4) then
-        player:startEvent(0x0081);
-    elseif ((player:getCurrentMission(COP) == DAWN and player:getVar("PromathiaStatus")> 4) or player:hasCompletedMission(COP,DAWN)) then        
-        if (playerhaveCOPring == false  ) then
-            if (ringtakeNbr==0) then
-                player:startEvent(0x0054,RajasRing,SattvaRing,TamasRing); 
-            elseif (ringtakeNbr ==1) then -- First time you throw away
-                player:startEvent(0x00CC,RajasRing,SattvaRing,TamasRing);
-            elseif (ringtakeNbr >1 and (currentday-lastRingday)>26) then -- Ring was thrown away more than once
-                player:startEvent(0x00CC,RajasRing,SattvaRing,TamasRing);
-            end
-        end
-    else
-        return -1; 
-    end
-end;
-
------------------------------------
--- onEventUpdate
------------------------------------
-
-function onEventUpdate(player,csid,option)
-    -- printf("CSID: %u",csid);
-    -- printf("RESULT: %u",option);
-end;
-
------------------------------------
--- onEventFinish
------------------------------------
-
-function onEventFinish(player,csid,option)
-local currentday = tonumber(os.date("%j")); 
-    -- printf("CSID: %u",csid);
-    -- printf("RESULT: %u",option);
-local ringtakeNbr=player:getVar("COP-RingTakeNbr");
-    if (csid ==  0x271B) then 
-       player:setVar("PromathiaStatus",2);
-    elseif (csid ==  0x271C) then  
-       player:setVar("PromathiaStatus",0);
-       player:completeMission(COP,FLAMES_IN_THE_DARKNESS);
-       player:addMission(COP,FIRE_IN_THE_EYES_OF_MEN);
-    elseif (csid ==  0x0081) then
-       player:setVar("PromathiaStatus",5);
-       
-    elseif ((csid == 0x0054 or csid == 0x00CC) and  option > 4 and player:getFreeSlotsCount() == 0) then
-        player:messageSpecial(ITEM_CANNOT_BE_OBTAINED,(option-5)+RajasRing);
+    if (csid == 0x271B) then
+        player:setVar("PromathiaStatus", 2)
+    elseif (csid == 0x271C) then
+        player:setVar("PromathiaStatus", 0)
+        player:completeMission(COP,FLAMES_IN_THE_DARKNESS)
+        player:addMission(COP,FIRE_IN_THE_EYES_OF_MEN)
+    elseif (csid == 0x0081) then
+        player:setVar("PromathiaStatus", 5)
+    elseif (ringelection) then
+    
+        if (player:getFreeSlotsCount() ~= 0) then
         
-    elseif ((csid == 0x0054 or csid == 0x00CC)and option == 5) then--5 rajas
-          player:addItem(RajasRing);
-        player:messageSpecial(ITEM_OBTAINED,RajasRing);
-        player:setVar("COP-RingTakeNbr",ringtakeNbr+1);
-        player:setVar("COP-lastRingday",currentday);
-    elseif ((csid == 0x0054 or csid == 0x00CC)and option == 6) then--6 Sattva
-        player:addItem(SattvaRing);
-        player:messageSpecial(ITEM_OBTAINED,SattvaRing);
-        player:setVar("COP-RingTakeNbr",ringtakeNbr+1);    
-        player:setVar("COP-lastRingday",currentday);
-    elseif ((csid == 0x0054 or csid == 0x00CC) and option == 7) then--7 Tamas
-         player:addItem(TamasRing);
-        player:messageSpecial(ITEM_OBTAINED,TamasRing);
-        player:setVar("COP-RingTakeNbr",ringtakeNbr+1);
-        player:setVar("COP-lastRingday",currentday);
+            if (option >= 5 and option <= 7) then
+                local currentDay = tonumber(os.date("%j")) 
+                local ringTaken = player:getVar("COP-RingTakeNbr")
+                player:addItem(ring[option - 4])
+                player:messageSpecial(ITEM_OBTAINED, ring[option - 4])
+                player:setVar("COP-RingTakeNbr", ringTaken + 1)
+                player:setVar("COP-lastRingday", currentDay)
+            end
+            
+        else
+            player:messageSpecial(ITEM_CANNOT_BE_OBTAINED, ring[option - 4])
+        end
+        
     end
-end;
-
+    
+end

--- a/scripts/zones/Upper_Jeuno/npcs/_6s1.lua
+++ b/scripts/zones/Upper_Jeuno/npcs/_6s1.lua
@@ -1,34 +1,34 @@
-----------------------------------------------------------------------------------------------------------------------------------------------
+----------------------------------------------------------------------------------------------------------------------------
 -- Area: Upper Jeuno
 -- NPC:  Marble Bridge Eatery (Door)
 -- @pos -96.6 -0.2 92.3 244
-----------------------------------------------------------------------------------------------------------------------------------------------
+----------------------------------------------------------------------------------------------------------------------------
 package.loaded["scripts/zones/Upper_Jeuno/TextIDs"] = nil
-----------------------------------------------------------------------------------------------------------------------------------------------
+----------------------------------------------------------------------------------------------------------------------------
 require("scripts/zones/Upper_Jeuno/TextIDs")
 require("scripts/globals/missions")
 require("scripts/globals/settings")
-----------------------------------------------------------------------------------------------------------------------------------------------
+----------------------------------------------------------------------------------------------------------------------------
 local ring = {
-             15543, --Rajas Ring
-             15544, --Sattva Ring
-             15545  --Tamas Ring
-             }
-----------------------------------------------------------------------------------------------------------------------------------------------
+                        15543, --Rajas Ring
+                        15544, --Sattva Ring
+                        15545  --Tamas Ring
+                    }
+----------------------------------------------------------------------------------------------------------------------------
 -- onTrade Action
-----------------------------------------------------------------------------------------------------------------------------------------------
+----------------------------------------------------------------------------------------------------------------------------
 function onTrade(player,npc,trade)
 
 end
-----------------------------------------------------------------------------------------------------------------------------------------------
+----------------------------------------------------------------------------------------------------------------------------
 -- onTrigger Action
-----------------------------------------------------------------------------------------------------------------------------------------------
+----------------------------------------------------------------------------------------------------------------------------
 function onTrigger(player,npc)
 
     local status = player:getVar("PromathiaStatus")
     local mission = player:getCurrentMission(COP)
 
-    if (mission == FOR_WHOM_THE_VERSE_IS_SUNG and status == 1) then 
+    if (mission == FOR_WHOM_THE_VERSE_IS_SUNG  and status == 1) then 
         player:startEvent(0x271B)
     elseif (mission == FLAMES_IN_THE_DARKNESS and status == 3) then
         player:startEvent(0x271C)
@@ -45,14 +45,14 @@ function onTrigger(player,npc)
         if not (hasRing) then
         
             local currentDay = tonumber(os.date("%j"))
-            local ringTaken = player:getVar("COP-RingTakeNbr")
+            local ringsTaken = player:getVar("COP-ringsTakenbr")
             local dateObtained = player:getVar("COP-lastRingday")
             
-            if (ringTaken == 0) then
+            if (ringsTaken == 0) then
                 player:startEvent(0x0054, ring[1], ring[2], ring[3]) 
-            elseif (ringTaken == 1) then -- First time you throw away, no wait
+            elseif (ringsTaken == 1) then -- First time you throw away, no wait
                 player:startEvent(0x00CC, ring[1], ring[2], ring[3])
-            elseif (ringTaken > 1 and (currentDay - dateObtained) >= 28) then -- Wait time is >= 28 days, not 26
+            elseif (ringsTaken > 1 and (currentDay - dateObtained) >= 28) then -- Wait time is >= 28 days, not 26
                 player:startEvent(0x00CC, ring[1], ring[2], ring[3])
             else
                 return -1
@@ -67,9 +67,9 @@ function onTrigger(player,npc)
     end
    
 end
-----------------------------------------------------------------------------------------------------------------------------------------------
+----------------------------------------------------------------------------------------------------------------------------
 -- onEventUpdate
-----------------------------------------------------------------------------------------------------------------------------------------------
+----------------------------------------------------------------------------------------------------------------------------
 function onEventUpdate(player,csid,option)
 
     -- printf("CSID: %u",csid)
@@ -80,18 +80,18 @@ function onEventUpdate(player,csid,option)
     end
    
 end
-----------------------------------------------------------------------------------------------------------------------------------------------
+----------------------------------------------------------------------------------------------------------------------------
 -- onEventFinish
-----------------------------------------------------------------------------------------------------------------------------------------------
+----------------------------------------------------------------------------------------------------------------------------
 function onEventFinish(player,csid,option)
 
     -- printf("CSID: %u",csid)
     -- printf("RESULT: %u",option)
     
-    local ringelection = false
+    local ringSelection = false
     
     if (csid == 0x0054 or csid == 0x00CC) then
-        ringelection = true
+        ringSelection = true
     end
     
     if (csid == 0x271B) then
@@ -102,16 +102,16 @@ function onEventFinish(player,csid,option)
         player:addMission(COP,FIRE_IN_THE_EYES_OF_MEN)
     elseif (csid == 0x0081) then
         player:setVar("PromathiaStatus", 5)
-    elseif (ringelection) then
+    elseif (ringSelection) then
     
         if (player:getFreeSlotsCount() ~= 0) then
         
             if (option >= 5 and option <= 7) then
                 local currentDay = tonumber(os.date("%j")) 
-                local ringTaken = player:getVar("COP-RingTakeNbr")
+                local ringsTaken = player:getVar("COP-ringsTakenbr")
                 player:addItem(ring[option - 4])
                 player:messageSpecial(ITEM_OBTAINED, ring[option - 4])
-                player:setVar("COP-RingTakeNbr", ringTaken + 1)
+                player:setVar("COP-ringsTakenbr", ringsTaken + 1)
                 player:setVar("COP-lastRingday", currentDay)
             end
             


### PR DESCRIPTION
Event now displays correct order and selection of CoP rings even when a user selection "Choose a different one." Cleaned up script to initialize variables only when needed and re-use common variables already defined. Changed minimum wait day to what's specified on Wiki.  Kept SQL variable naming convention the same to prevent user head->wall damage.