### PR TITLE
Latents did not check for Storm Spells when checking for Weather - based

### DIFF
--- a/sql/item_latents.sql
+++ b/sql/item_latents.sql
@@ -2709,8 +2709,8 @@ INSERT INTO `item_latents` VALUES(17814, 23, 10, 52, 6); -- Attack +10 in Thunde
 -- -------------------------------------------------------
 -- Desert Boots
 -- -------------------------------------------------------
-INSERT INTO `item_latents` VALUES (14166, 169, 12, 52, 2); -- movement speed +12% in Earth weather
-INSERT INTO `item_latents` VALUES (14167, 169, 12, 52, 2); -- Desert Boots +1
+INSERT INTO `item_latents` VALUES (14166, 169, 12, 52, 4); -- movement speed +12% in Earth weather
+INSERT INTO `item_latents` VALUES (14167, 169, 12, 52, 4); -- Desert Boots +1
 
 -- -------------------------------------------------------
 -- Marabout Sandals

--- a/src/map/latent_effect_container.cpp
+++ b/src/map/latent_effect_container.cpp
@@ -26,6 +26,7 @@ This file is part of DarkStar-server source code.
 #include "latent_effect.h"
 #include "entities/charentity.h"
 #include "entities/battleentity.h"
+#include "utils/battleutils.h"
 #include "utils/zoneutils.h"
 #include "conquest_system.h"
 #include "modifier.h"
@@ -626,7 +627,9 @@ void CLatentEffectContainer::CheckLatentsEquip(uint8 slot)
                 }
                 break;
             case LATENT_WEATHER_ELEMENT:
-                if (zoneutils::GetWeatherElement(zoneutils::GetZone(m_POwner->getZone())->GetWeather()) == m_LatentEffectList.at(i)->GetConditionsValue())
+            {
+                auto weatherElement = m_LatentEffectList.at(i)->GetConditionsValue();
+                if (weatherElement == zoneutils::GetWeatherElement(zoneutils::GetZone(m_POwner->getZone())->GetWeather()) || weatherElement == zoneutils::GetWeatherElement(battleutils::GetWeather((CBattleEntity*)m_POwner, false)))
                 {
                     m_LatentEffectList.at(i)->Activate();
                 }
@@ -635,6 +638,7 @@ void CLatentEffectContainer::CheckLatentsEquip(uint8 slot)
                     m_LatentEffectList.at(i)->Deactivate();
                 }
                 break;
+            }
             case LATENT_NATION_CONTROL:
                 CheckLatentsZone();
                 break;
@@ -1674,7 +1678,9 @@ void CLatentEffectContainer::CheckLatentsZone()
             }
             break;
         case LATENT_WEATHER_ELEMENT:
-            if (zoneutils::GetWeatherElement(zoneutils::GetZone(m_POwner->getZone())->GetWeather()) == m_LatentEffectList.at(i)->GetConditionsValue())
+        {
+            auto weatherElement = m_LatentEffectList.at(i)->GetConditionsValue();
+            if (weatherElement == zoneutils::GetWeatherElement(zoneutils::GetZone(m_POwner->getZone())->GetWeather()) || weatherElement == zoneutils::GetWeatherElement(battleutils::GetWeather((CBattleEntity*)m_POwner, false)))
             {
                 m_LatentEffectList.at(i)->Activate();
             }
@@ -1683,6 +1689,7 @@ void CLatentEffectContainer::CheckLatentsZone()
                 m_LatentEffectList.at(i)->Deactivate();
             }
             break;
+        }
         case LATENT_NATION_CONTROL:
         {
             //player is logging in/zoning

--- a/src/map/latent_effect_container.cpp
+++ b/src/map/latent_effect_container.cpp
@@ -1782,11 +1782,8 @@ void CLatentEffectContainer::CheckLatentsWeather(uint16 weather)
     {
         if (m_LatentEffectList.at(i)->GetConditionsID() == LATENT_WEATHER_ELEMENT)
         {
-            // get the scholar weather and convert to a weather element
-            auto sch_weather = zoneutils::GetWeatherElement(battleutils::GetScholarWeather(m_POwner));
-
-            // if either the new weather or the scholar weather satisfy the latent then activate it
-            if (m_LatentEffectList.at(i)->GetConditionsValue() == weather || m_LatentEffectList.at(i)->GetConditionsValue() == sch_weather)
+            auto element = zoneutils::GetWeatherElement(battleutils::GetWeather((CBattleEntity*)m_POwner, false, weather));
+            if (m_LatentEffectList.at(i)->GetConditionsValue() == element)
             {
                 m_LatentEffectList.at(i)->Activate();
             }

--- a/src/map/latent_effect_container.cpp
+++ b/src/map/latent_effect_container.cpp
@@ -728,6 +728,17 @@ void CLatentEffectContainer::CheckLatentsStatusEffect()
                 m_LatentEffectList.at(i)->Deactivate();
             }
         }
+        else if (m_LatentEffectList.at(i)->GetConditionsID() == LATENT_WEATHER_ELEMENT)
+        {
+            if (m_LatentEffectList.at(i)->GetConditionsValue() == zoneutils::GetWeatherElement(battleutils::GetWeather((CBattleEntity*)m_POwner, false)))
+            {
+                m_LatentEffectList.at(i)->Activate();
+            }
+            else
+            {
+                m_LatentEffectList.at(i)->Deactivate();
+            }
+        }
     }
 }
 

--- a/src/map/latent_effect_container.cpp
+++ b/src/map/latent_effect_container.cpp
@@ -1775,6 +1775,10 @@ void CLatentEffectContainer::CheckLatentsZone()
 *  Checks all latents regarding current weather							*
 *																		*
 ************************************************************************/
+void CLatentEffectContainer::CheckLatentsWeather()
+{
+    CheckLatentsWeather(zoneutils::GetZone(m_POwner->getZone())->GetWeather());
+}
 
 void CLatentEffectContainer::CheckLatentsWeather(uint16 weather)
 {

--- a/src/map/latent_effect_container.cpp
+++ b/src/map/latent_effect_container.cpp
@@ -1648,7 +1648,7 @@ void CLatentEffectContainer::CheckLatentsWeaponBreak(uint8 slot)
 *																		*
 ************************************************************************/
 
-void CLatentEffectContainer::CheckLatentsZone(uint16 weather)
+void CLatentEffectContainer::CheckLatentsZone()
 {
     for (uint16 i = 0; i < m_LatentEffectList.size(); ++i)
     {
@@ -1675,23 +1675,7 @@ void CLatentEffectContainer::CheckLatentsZone(uint16 weather)
             }
             break;
         case LATENT_WEATHER_ELEMENT:
-            // In the default case we need to pull weather from zone/player
-            if (weather == MAX_WEATHER_ID)
-            {
-                weather = zoneutils::GetWeatherElement(battleutils::GetWeather((CBattleEntity*)m_POwner, false));
-            }
-            // otherwise pull it from scholar storm effects
-            else
-            {
-                auto sch_weather = battleutils::GetScholarWeather(m_POwner);
-                // if there is a scholar weather convert to the weather element
-                if (sch_weather != WEATHER_NONE)
-                {
-                    weather = zoneutils::GetWeatherElement(sch_weather);
-                }
-            }
-
-            if (m_LatentEffectList.at(i)->GetConditionsValue() == weather)
+            if (m_LatentEffectList.at(i)->GetConditionsValue() == zoneutils::GetWeatherElement(battleutils::GetWeather((CBattleEntity*)m_POwner, false)))
             {
                 m_LatentEffectList.at(i)->Activate();
             }
@@ -1784,4 +1768,34 @@ void CLatentEffectContainer::CheckLatentsZone(uint16 weather)
         }
     }
     m_POwner->UpdateHealth();
+}
+
+/************************************************************************
+*																		*
+*  Checks all latents regarding current weather							*
+*																		*
+************************************************************************/
+
+void CLatentEffectContainer::CheckLatentsWeather(uint16 weather)
+{
+    for (uint16 i = 0; i < m_LatentEffectList.size(); ++i)
+    {
+        if (m_LatentEffectList.at(i)->GetConditionsID() == LATENT_WEATHER_ELEMENT)
+        {
+            // get the scholar weather and convert to a weather element
+            auto sch_weather = zoneutils::GetWeatherElement(battleutils::GetScholarWeather(m_POwner));
+
+            // if either the new weather or the scholar weather satisfy the latent then activate it
+            if (m_LatentEffectList.at(i)->GetConditionsValue() == weather || m_LatentEffectList.at(i)->GetConditionsValue() == sch_weather)
+            {
+                m_LatentEffectList.at(i)->Activate();
+            }
+            else
+            {
+                m_LatentEffectList.at(i)->Deactivate();
+            }
+
+            m_POwner->UpdateHealth();
+        }
+    }
 }

--- a/src/map/latent_effect_container.cpp
+++ b/src/map/latent_effect_container.cpp
@@ -627,9 +627,7 @@ void CLatentEffectContainer::CheckLatentsEquip(uint8 slot)
                 }
                 break;
             case LATENT_WEATHER_ELEMENT:
-            {
-                auto weatherElement = m_LatentEffectList.at(i)->GetConditionsValue();
-                if (weatherElement == zoneutils::GetWeatherElement(zoneutils::GetZone(m_POwner->getZone())->GetWeather()) || weatherElement == zoneutils::GetWeatherElement(battleutils::GetWeather((CBattleEntity*)m_POwner, false)))
+                if (m_LatentEffectList.at(i)->GetConditionsValue() == zoneutils::GetWeatherElement(battleutils::GetWeather((CBattleEntity*)m_POwner, false)))
                 {
                     m_LatentEffectList.at(i)->Activate();
                 }
@@ -638,7 +636,6 @@ void CLatentEffectContainer::CheckLatentsEquip(uint8 slot)
                     m_LatentEffectList.at(i)->Deactivate();
                 }
                 break;
-            }
             case LATENT_NATION_CONTROL:
                 CheckLatentsZone();
                 break;
@@ -1651,7 +1648,7 @@ void CLatentEffectContainer::CheckLatentsWeaponBreak(uint8 slot)
 *																		*
 ************************************************************************/
 
-void CLatentEffectContainer::CheckLatentsZone()
+void CLatentEffectContainer::CheckLatentsZone(uint16 weather)
 {
     for (uint16 i = 0; i < m_LatentEffectList.size(); ++i)
     {
@@ -1678,9 +1675,23 @@ void CLatentEffectContainer::CheckLatentsZone()
             }
             break;
         case LATENT_WEATHER_ELEMENT:
-        {
-            auto weatherElement = m_LatentEffectList.at(i)->GetConditionsValue();
-            if (weatherElement == zoneutils::GetWeatherElement(zoneutils::GetZone(m_POwner->getZone())->GetWeather()) || weatherElement == zoneutils::GetWeatherElement(battleutils::GetWeather((CBattleEntity*)m_POwner, false)))
+            // In the default case we need to pull weather from zone/player
+            if (weather == MAX_WEATHER_ID)
+            {
+                weather = zoneutils::GetWeatherElement(battleutils::GetWeather((CBattleEntity*)m_POwner, false));
+            }
+            // otherwise pull it from scholar storm effects
+            else
+            {
+                auto sch_weather = battleutils::GetScholarWeather(m_POwner);
+                // if there is a scholar weather convert to the weather element
+                if (sch_weather != WEATHER_NONE)
+                {
+                    weather = zoneutils::GetWeatherElement(sch_weather);
+                }
+            }
+
+            if (m_LatentEffectList.at(i)->GetConditionsValue() == weather)
             {
                 m_LatentEffectList.at(i)->Activate();
             }
@@ -1689,7 +1700,6 @@ void CLatentEffectContainer::CheckLatentsZone()
                 m_LatentEffectList.at(i)->Deactivate();
             }
             break;
-        }
         case LATENT_NATION_CONTROL:
         {
             //player is logging in/zoning

--- a/src/map/latent_effect_container.h
+++ b/src/map/latent_effect_container.h
@@ -61,7 +61,8 @@ public:
 	void CheckLatentsPetType(uint8 petID);
 	void CheckLatentsTime();
 	void CheckLatentsWeaponBreak(uint8 slot);
-	void CheckLatentsZone(uint16 weather = MAX_WEATHER_ID);
+	void CheckLatentsZone();
+    void CheckLatentsWeather(uint16 weather);
 
 	void AddLatentEffect(CLatentEffect* LatentEffect);
 	void AddLatentEffects(std::vector<CLatentEffect*> *latentList, uint8 reqLvl, uint8 slot);

--- a/src/map/latent_effect_container.h
+++ b/src/map/latent_effect_container.h
@@ -61,7 +61,7 @@ public:
 	void CheckLatentsPetType(uint8 petID);
 	void CheckLatentsTime();
 	void CheckLatentsWeaponBreak(uint8 slot);
-	void CheckLatentsZone();
+	void CheckLatentsZone(uint16 weather = MAX_WEATHER_ID);
 
 	void AddLatentEffect(CLatentEffect* LatentEffect);
 	void AddLatentEffects(std::vector<CLatentEffect*> *latentList, uint8 reqLvl, uint8 slot);

--- a/src/map/latent_effect_container.h
+++ b/src/map/latent_effect_container.h
@@ -62,6 +62,7 @@ public:
 	void CheckLatentsTime();
 	void CheckLatentsWeaponBreak(uint8 slot);
 	void CheckLatentsZone();
+    void CheckLatentsWeather();
     void CheckLatentsWeather(uint16 weather);
 
 	void AddLatentEffect(CLatentEffect* LatentEffect);

--- a/src/map/status_effect_container.cpp
+++ b/src/map/status_effect_container.cpp
@@ -394,6 +394,7 @@ bool CStatusEffectContainer::AddStatusEffect(CStatusEffect* PStatusEffect, bool 
                 PChar->PLatentEffectContainer->CheckLatentsFoodEffect();
                 PChar->PLatentEffectContainer->CheckLatentsStatusEffect();
                 PChar->PLatentEffectContainer->CheckLatentsRollSong(PStatusEffect->GetFlag() & (EFFECTFLAG_SONG | EFFECTFLAG_ROLL));
+                PChar->PLatentEffectContainer->CheckLatentsZone();
                 PChar->UpdateHealth();
             }
             PChar->pushPacket(new CCharSyncPacket(PChar));
@@ -447,6 +448,7 @@ void CStatusEffectContainer::RemoveStatusEffect(uint32 id, bool silent)
         PChar->PLatentEffectContainer->CheckLatentsFoodEffect();
         PChar->PLatentEffectContainer->CheckLatentsStatusEffect();
         PChar->PLatentEffectContainer->CheckLatentsRollSong(HasStatusEffectByFlag(EFFECTFLAG_SONG | EFFECTFLAG_ROLL));
+        PChar->PLatentEffectContainer->CheckLatentsZone();
         PChar->UpdateHealth();
 
         PChar->pushPacket(new CCharSyncPacket(PChar));

--- a/src/map/status_effect_container.cpp
+++ b/src/map/status_effect_container.cpp
@@ -394,7 +394,7 @@ bool CStatusEffectContainer::AddStatusEffect(CStatusEffect* PStatusEffect, bool 
                 PChar->PLatentEffectContainer->CheckLatentsFoodEffect();
                 PChar->PLatentEffectContainer->CheckLatentsStatusEffect();
                 PChar->PLatentEffectContainer->CheckLatentsRollSong(PStatusEffect->GetFlag() & (EFFECTFLAG_SONG | EFFECTFLAG_ROLL));
-                PChar->PLatentEffectContainer->CheckLatentsZone();
+                PChar->PLatentEffectContainer->CheckLatentsWeather();
                 PChar->UpdateHealth();
             }
             PChar->pushPacket(new CCharSyncPacket(PChar));
@@ -448,7 +448,7 @@ void CStatusEffectContainer::RemoveStatusEffect(uint32 id, bool silent)
         PChar->PLatentEffectContainer->CheckLatentsFoodEffect();
         PChar->PLatentEffectContainer->CheckLatentsStatusEffect();
         PChar->PLatentEffectContainer->CheckLatentsRollSong(HasStatusEffectByFlag(EFFECTFLAG_SONG | EFFECTFLAG_ROLL));
-        PChar->PLatentEffectContainer->CheckLatentsZone();
+        PChar->PLatentEffectContainer->CheckLatentsWeather();
         PChar->UpdateHealth();
 
         PChar->pushPacket(new CCharSyncPacket(PChar));

--- a/src/map/status_effect_container.cpp
+++ b/src/map/status_effect_container.cpp
@@ -394,7 +394,6 @@ bool CStatusEffectContainer::AddStatusEffect(CStatusEffect* PStatusEffect, bool 
                 PChar->PLatentEffectContainer->CheckLatentsFoodEffect();
                 PChar->PLatentEffectContainer->CheckLatentsStatusEffect();
                 PChar->PLatentEffectContainer->CheckLatentsRollSong(PStatusEffect->GetFlag() & (EFFECTFLAG_SONG | EFFECTFLAG_ROLL));
-                PChar->PLatentEffectContainer->CheckLatentsWeather();
                 PChar->UpdateHealth();
             }
             PChar->pushPacket(new CCharSyncPacket(PChar));
@@ -448,7 +447,6 @@ void CStatusEffectContainer::RemoveStatusEffect(uint32 id, bool silent)
         PChar->PLatentEffectContainer->CheckLatentsFoodEffect();
         PChar->PLatentEffectContainer->CheckLatentsStatusEffect();
         PChar->PLatentEffectContainer->CheckLatentsRollSong(HasStatusEffectByFlag(EFFECTFLAG_SONG | EFFECTFLAG_ROLL));
-        PChar->PLatentEffectContainer->CheckLatentsWeather();
         PChar->UpdateHealth();
 
         PChar->pushPacket(new CCharSyncPacket(PChar));

--- a/src/map/utils/battleutils.cpp
+++ b/src/map/utils/battleutils.cpp
@@ -4522,8 +4522,7 @@ namespace battleutils
         return PSpell->getAOE();
     }
 
-
-    WEATHER GetWeather(CBattleEntity* PEntity, bool ignoreScholar)
+    WEATHER GetScholarWeather(CBattleEntity* PEntity)
     {
         WEATHER scholarSpell = WEATHER_NONE;
         if (PEntity->StatusEffectContainer->HasStatusEffect(EFFECT_FIRESTORM))
@@ -4542,6 +4541,13 @@ namespace battleutils
             scholarSpell = WEATHER_AURORAS;
         if (PEntity->StatusEffectContainer->HasStatusEffect(EFFECT_VOIDSTORM))
             scholarSpell = WEATHER_GLOOM;
+
+        return scholarSpell;
+    }
+
+    WEATHER GetWeather(CBattleEntity* PEntity, bool ignoreScholar)
+    {
+        WEATHER scholarSpell = GetScholarWeather(PEntity);
         WEATHER zoneWeather = zoneutils::GetZone(PEntity->getZone())->GetWeather();
 
         if (ignoreScholar || scholarSpell == WEATHER_NONE || zoneWeather == (scholarSpell + 1)) // Strong weather overwrites scholar spell weak weather

--- a/src/map/utils/battleutils.cpp
+++ b/src/map/utils/battleutils.cpp
@@ -4522,7 +4522,7 @@ namespace battleutils
         return PSpell->getAOE();
     }
 
-    WEATHER GetScholarWeather(CBattleEntity* PEntity)
+    WEATHER GetWeather(CBattleEntity* PEntity, bool ignoreScholar, uint16 zoneWeather)
     {
         WEATHER scholarSpell = WEATHER_NONE;
         if (PEntity->StatusEffectContainer->HasStatusEffect(EFFECT_FIRESTORM))
@@ -4541,17 +4541,13 @@ namespace battleutils
             scholarSpell = WEATHER_AURORAS;
         if (PEntity->StatusEffectContainer->HasStatusEffect(EFFECT_VOIDSTORM))
             scholarSpell = WEATHER_GLOOM;
-
-        return scholarSpell;
-    }
-
-    WEATHER GetWeather(CBattleEntity* PEntity, bool ignoreScholar)
-    {
-        WEATHER scholarSpell = GetScholarWeather(PEntity);
-        WEATHER zoneWeather = zoneutils::GetZone(PEntity->getZone())->GetWeather();
+        if (zoneWeather == MAX_WEATHER_ID)
+        {
+            zoneWeather = zoneutils::GetZone(PEntity->getZone())->GetWeather();
+        }
 
         if (ignoreScholar || scholarSpell == WEATHER_NONE || zoneWeather == (scholarSpell + 1)) // Strong weather overwrites scholar spell weak weather
-            return zoneWeather;
+            return (WEATHER)zoneWeather;
         else if (scholarSpell == zoneWeather)
             return (WEATHER)(zoneWeather + 1); // Storm spells stack with weather
         else

--- a/src/map/utils/battleutils.cpp
+++ b/src/map/utils/battleutils.cpp
@@ -4522,6 +4522,11 @@ namespace battleutils
         return PSpell->getAOE();
     }
 
+    WEATHER GetWeather(CBattleEntity* PEntity, bool ignoreScholar)
+    {
+        return GetWeather(PEntity, ignoreScholar, zoneutils::GetZone(PEntity->getZone())->GetWeather());
+    }
+
     WEATHER GetWeather(CBattleEntity* PEntity, bool ignoreScholar, uint16 zoneWeather)
     {
         WEATHER scholarSpell = WEATHER_NONE;
@@ -4541,10 +4546,6 @@ namespace battleutils
             scholarSpell = WEATHER_AURORAS;
         if (PEntity->StatusEffectContainer->HasStatusEffect(EFFECT_VOIDSTORM))
             scholarSpell = WEATHER_GLOOM;
-        if (zoneWeather == MAX_WEATHER_ID)
-        {
-            zoneWeather = zoneutils::GetZone(PEntity->getZone())->GetWeather();
-        }
 
         if (ignoreScholar || scholarSpell == WEATHER_NONE || zoneWeather == (scholarSpell + 1)) // Strong weather overwrites scholar spell weak weather
             return (WEATHER)zoneWeather;

--- a/src/map/utils/battleutils.h
+++ b/src/map/utils/battleutils.h
@@ -223,7 +223,8 @@ namespace battleutils
     void				assistTarget(CCharEntity* PChar, uint16 TargID);
 
     uint8               GetSpellAoEType(CBattleEntity* PCaster, CSpell* PSpell);
-    WEATHER             GetWeather(CBattleEntity* PEntity, bool ignoreScholar, uint16 zoneWeather = MAX_WEATHER_ID);
+    WEATHER             GetWeather(CBattleEntity* PEntity, bool ignoreScholar);
+    WEATHER             GetWeather(CBattleEntity* PEntity, bool ignoreScholar, uint16 zoneWeather);
     bool                WeatherMatchesElement(WEATHER weather, uint8 element);
     bool				DrawIn(CBattleEntity* PEntity, CMobEntity* PMob, float offset);
     void				DoWildCardToEntity(CCharEntity* PCaster, CCharEntity* PTarget, uint8 roll);

--- a/src/map/utils/battleutils.h
+++ b/src/map/utils/battleutils.h
@@ -223,8 +223,7 @@ namespace battleutils
     void				assistTarget(CCharEntity* PChar, uint16 TargID);
 
     uint8               GetSpellAoEType(CBattleEntity* PCaster, CSpell* PSpell);
-    WEATHER             GetScholarWeather(CBattleEntity* PEntity);
-    WEATHER             GetWeather(CBattleEntity* PEntity, bool ignoreScholar);
+    WEATHER             GetWeather(CBattleEntity* PEntity, bool ignoreScholar, uint16 zoneWeather = MAX_WEATHER_ID);
     bool                WeatherMatchesElement(WEATHER weather, uint8 element);
     bool				DrawIn(CBattleEntity* PEntity, CMobEntity* PMob, float offset);
     void				DoWildCardToEntity(CCharEntity* PCaster, CCharEntity* PTarget, uint8 roll);

--- a/src/map/utils/battleutils.h
+++ b/src/map/utils/battleutils.h
@@ -223,6 +223,7 @@ namespace battleutils
     void				assistTarget(CCharEntity* PChar, uint16 TargID);
 
     uint8               GetSpellAoEType(CBattleEntity* PCaster, CSpell* PSpell);
+    WEATHER             GetScholarWeather(CBattleEntity* PEntity);
     WEATHER             GetWeather(CBattleEntity* PEntity, bool ignoreScholar);
     bool                WeatherMatchesElement(WEATHER weather, uint8 element);
     bool				DrawIn(CBattleEntity* PEntity, CMobEntity* PMob, float offset);

--- a/src/map/zone_entities.cpp
+++ b/src/map/zone_entities.cpp
@@ -262,7 +262,7 @@ void CZoneEntities::WeatherChange(WEATHER weather)
     {
         CCharEntity* PChar = (CCharEntity*)it->second;
 
-        PChar->PLatentEffectContainer->CheckLatentsZone(element);
+        PChar->PLatentEffectContainer->CheckLatentsWeather(element);
         PChar->PAI->EventHandler.triggerListener("WEATHER_CHANGE", PChar, static_cast<int>(weather), element);
     }
 }

--- a/src/map/zone_entities.cpp
+++ b/src/map/zone_entities.cpp
@@ -262,7 +262,7 @@ void CZoneEntities::WeatherChange(WEATHER weather)
     {
         CCharEntity* PChar = (CCharEntity*)it->second;
 
-        PChar->PLatentEffectContainer->CheckLatentsZone();
+        PChar->PLatentEffectContainer->CheckLatentsZone(element);
         PChar->PAI->EventHandler.triggerListener("WEATHER_CHANGE", PChar, static_cast<int>(weather), element);
     }
 }

--- a/src/map/zone_entities.cpp
+++ b/src/map/zone_entities.cpp
@@ -262,7 +262,7 @@ void CZoneEntities::WeatherChange(WEATHER weather)
     {
         CCharEntity* PChar = (CCharEntity*)it->second;
 
-        PChar->PLatentEffectContainer->CheckLatentsWeather(element);
+        PChar->PLatentEffectContainer->CheckLatentsWeather(weather);
         PChar->PAI->EventHandler.triggerListener("WEATHER_CHANGE", PChar, static_cast<int>(weather), element);
     }
 }


### PR DESCRIPTION
- Get the player's status effect and check if under a scholar storm
spell
- Check for Zone Latents on effect add / remove
- Fix Desert Boots to check for earth - storms instead of ice - storms