### PR TITLE
Update Spirit surge to transfer wyvern TP. Wyvern gets Damage reduction.

### DIFF
--- a/scripts/globals/abilities/call_wyvern.lua
+++ b/scripts/globals/abilities/call_wyvern.lua
@@ -33,6 +33,4 @@ end;
 
 function onUseAbility(player,target,ability)
     player:spawnPet(PET_WYVERN);
-    local pet = player:getPet();
-    pet:addMod(MOD_DMG, -40);
 end;

--- a/scripts/globals/abilities/call_wyvern.lua
+++ b/scripts/globals/abilities/call_wyvern.lua
@@ -33,4 +33,6 @@ end;
 
 function onUseAbility(player,target,ability)
     player:spawnPet(PET_WYVERN);
+    local pet = player:getPet();
+    pet:addMod(MOD_DMG, -40);
 end;

--- a/scripts/globals/abilities/spirit_surge.lua
+++ b/scripts/globals/abilities/spirit_surge.lua
@@ -29,7 +29,10 @@ function onUseAbility(player,target,ability)
     -- Spirit Surge increases dragoon's MAX HP increases by 25% of wyvern MaxHP
     -- bg wiki says 25% ffxiclopedia says 15%, going with 25 for now
     local mhp_boost = target:getPet():getMaxHP()*0.25;
-
+    -- Dragoon gets all of wyverns TP when using Spirit Surge
+    local petTP = pet:getTP();
+    target:addTP(petTP); --add pet TP to dragoon
+    pet:delTP(petTP); -- remove TP from pet
     -- Spirit Surge increases dragoon's Strength
     local strBoost = 0;
     if (target:getMainJob() == JOBS.DRG) then

--- a/scripts/globals/abilities/spirit_surge.lua
+++ b/scripts/globals/abilities/spirit_surge.lua
@@ -30,6 +30,7 @@ function onUseAbility(player,target,ability)
     -- bg wiki says 25% ffxiclopedia says 15%, going with 25 for now
     local mhp_boost = target:getPet():getMaxHP()*0.25;
     -- Dragoon gets all of wyverns TP when using Spirit Surge
+    local pet = player:getPet();
     local petTP = pet:getTP();
     target:addTP(petTP); --add pet TP to dragoon
     pet:delTP(petTP); -- remove TP from pet


### PR DESCRIPTION
I got information about wyvern 40% DMG reduction from these links:
http://forum.square-enix.com/ffxi/threads/11592-Dragoon-Manifesto-thoughts?p=178646#post178646
http://www.ffxivpro.com/forum/topic/24793/dragoon-update-additional-information/

Dragoon pet wyvern was updated with 40% damage reduction from both physical and magical damage in 2011.

Dragoon gets TP from pet wyvern during Spirit Surge
"The wyvern's current TP transfers to the Dragoon."
https://www.bg-wiki.com/bg/Spirit_Surge