### PR TITLE
Fix wyvern pet leveling up more than 5 times when receiving large exp…

### DIFF
--- a/scripts/globals/pets/wyvern.lua
+++ b/scripts/globals/pets/wyvern.lua
@@ -123,12 +123,12 @@ function onMobSpawn(mob)
     master:addListener("EXPERIENCE_POINTS", "PET_WYVERN_EXP", function(player, exp)
         local pet = player:getPet()
         local prev_exp = pet:getLocalVar("wyvern_exp")
-        -- cap exp at 1000 to prevent wyvern leveling up many times from large exp awards
-        local currentExp = exp
-        if exp > 1000 then
-            currentExp = 1000
-        end
         if (prev_exp < 1000) then
+        -- cap exp at 1000 to prevent wyvern leveling up many times from large exp awards
+            local currentExp = exp
+            if (prev_exp+exp > 1000) then
+                currentExp = 1000 - prev_exp
+            end
             local diff = math.floor((prev_exp + currentExp)/200) - math.floor(prev_exp/200)
             if diff ~= 0 then
                 -- wyvern levelled up (diff is the number of level ups)

--- a/scripts/globals/pets/wyvern.lua
+++ b/scripts/globals/pets/wyvern.lua
@@ -123,8 +123,13 @@ function onMobSpawn(mob)
     master:addListener("EXPERIENCE_POINTS", "PET_WYVERN_EXP", function(player, exp)
         local pet = player:getPet()
         local prev_exp = pet:getLocalVar("wyvern_exp")
+        -- cap exp at 1000 to prevent wyvern leveling up many times from large exp awards
+        local currentExp = exp
+        if exp > 1000 then
+            currentExp = 1000
+        end
         if (prev_exp < 1000) then
-            local diff = math.floor((prev_exp + exp)/200) - math.floor(prev_exp/200)
+            local diff = math.floor((prev_exp + currentExp)/200) - math.floor(prev_exp/200)
             if diff ~= 0 then
                 -- wyvern levelled up (diff is the number of level ups)
                 pet:addMod(MOD_ACC,2*diff)


### PR DESCRIPTION
… award

Number of level ups formula seems to not work when receiving a huge exp award like from grounds tomes. 
For example a 4000 exp page from zeruhn mines, if prev_exp was 200, and the exp from page was 4000 points: 
(200 + 4000)/200 - (200/200) = 21 - 1 = 20 Level ups. 

The wyvern pet would level up 20 times and thus greatly increases its attack power and healing breaths.

Doing a check for if exp is greater than 1000 and capping it at 1000 I think fixes it. 
Lets say prev_exp was 999 and and exp from page was 4000. Capping 4000 to 1000 would...
math.floor(999 + 1000)/200 - (999/200) = 9 - 4 = 5! Only 5 level ups! 

Pretty sure it's large exp gain causing wyvern going over 5 levels from testing it in zeruhn. (Getting large page exp, before getting 1000 exp from regular mobs is when it happens I think)