### PR TITLE
Add ballista nation flags and their action IDs for quarry, sprint

### DIFF
--- a/src/map/packets/action.h
+++ b/src/map/packets/action.h
@@ -49,7 +49,8 @@ enum ACTIONTYPE : uint8
     ACTION_RANGED_START = 12,
     ACTION_PET_MOBABILITY_FINISH = 13,
     ACTION_DANCE = 14,
-    ACTION_UNKNOWN_15 = 15,
+    ACTION_QUARRY = 15,
+    ACTION_SPRINT = 16,
 
     //these aren't actual action packet IDs - they exist for simplicity
     // because we are too lazy to figure out 0x0A - 0x0F in the action packet

--- a/src/map/packets/char_update.cpp
+++ b/src/map/packets/char_update.cpp
@@ -87,7 +87,7 @@ CCharUpdatePacket::CCharUpdatePacket(CCharEntity* PChar)
     if (PChar->StatusEffectContainer->HasStatusEffect(EFFECT_TERROR))
         flag |= 0x08;
     if (PChar->allegiance > 1)
-        flag |= (allegiance << 5);
+        flag |= (PChar->allegiance << 5);
     
     WBUFB(data, (0x36)) = flag;
 

--- a/src/map/packets/char_update.cpp
+++ b/src/map/packets/char_update.cpp
@@ -87,14 +87,8 @@ CCharUpdatePacket::CCharUpdatePacket(CCharEntity* PChar)
     if (PChar->StatusEffectContainer->HasStatusEffect(EFFECT_TERROR))
         flag |= 0x08;
     if (PChar->allegiance > 1)
-    {
-        if (PChar->allegiance == ALLEGIANCE_SAN_DORIA)
-            flag |= 0x40;
-        else if (PChar->allegiance == ALLEGIANCE_BASTOK)
-            flag |= 0x60;
-        else if (PChar->allegiance == ALLEGIANCE_WINDURST)
-            flag |= 0x80;
-    }
+        flag |= (allegiance << 5);
+    
     WBUFB(data, (0x36)) = flag;
 
     if (!PChar->isDead() || PChar->m_DeathCounter == 0) //prevent this packet from resetting the homepoint timer after tractor

--- a/src/map/packets/char_update.cpp
+++ b/src/map/packets/char_update.cpp
@@ -86,6 +86,15 @@ CCharUpdatePacket::CCharUpdatePacket(CCharEntity* PChar)
     uint8 flag = 0x20;
     if (PChar->StatusEffectContainer->HasStatusEffect(EFFECT_TERROR))
         flag |= 0x08;
+    if (PChar->allegiance > 1)
+    {
+        if (PChar->allegiance == ALLEGIANCE_SAN_DORIA)
+            flag |= 0x40;
+        else if (PChar->allegiance == ALLEGIANCE_BASTOK)
+            flag |= 0x60;
+        else if (PChar->allegiance == ALLEGIANCE_WINDURST)
+            flag |= 0x80;
+    }
     WBUFB(data, (0x36)) = flag;
 
     if (!PChar->isDead() || PChar->m_DeathCounter == 0) //prevent this packet from resetting the homepoint timer after tractor


### PR DESCRIPTION
nation flags activate when allegiance is set
active nation flags enable the quarry and sprint options on the action menu
using these actions triggers action ID 15 and 16 in the console.

