### PR TITLE
Added code to catch and fix issue with missing Entity pointer

### DIFF
--- a/src/map/enmity_container.cpp
+++ b/src/map/enmity_container.cpp
@@ -128,6 +128,7 @@ void CEnmityContainer::UpdateEnmity(CBattleEntity* PEntity, int16 CE, int16 VE, 
 
     if (enmity_obj != m_EnmityList.end())
     {
+        if (enmity_obj->second.PEnmityOwner == nullptr) enmity_obj->second.PEnmityOwner = PEntity;
         float bonus = CalculateEnmityBonus(PEntity);
 
         int newCE = enmity_obj->second.CE + ((CE > 0) ? CE * bonus : CE);


### PR DESCRIPTION
We've recently run into a bug on Era where after our THF dies and gets autohomepointed or just releases and runs back, we always got worse loot than expected. I looked into it and confirmed the issue by echoing out m_THLvl in DropItems() in mobentity.cpp as well as the value during UpdateEnmity() in enmity_container.cpp when the maxTH variable is set. Here are the results of my testing:

Tests done with TH5 THF and a BLM:
THF hits and stays, TH5
THF hits and leaves zone, TH0
THF hits and runs 24 yards away, TH5
THF hits and runs 26 yards away, TH0
THF hits and runs out of aggro range, comes back and kills, TH5
THF hits and leaves zone, comes back and kills, TH0 (bug confirmed)
BLM subs THF, THF hits and leaves zone, comes back and kills, TH2, it only bugs the one that leaves

With this info, I decided to echo what was in the EnmityList when GetHighestTH() is called. I discovered that PEntity was null for the THF, causing the function to ignore his EnmityObject because it could not call the IsDead() function on PEntity and therefore could not use it for maxTH calculations.

I added a patch to the code that catches and fixes this issue during UpdateEnmity(). It turned out that the THF was still routing through UpdateEnmity() correctly finding the EnmityObject via it's ID. I'm assuming that the EnmityObject had lost the pointer to the PEntity but didn't remove it from the EnmityList for some reason when the THF left the zone. Interestingly, I found that if the THF was first on the EnmityList, he was removed when leaving zone and was re-added upon returning as a new entry. Based on that, I expect my patch isn't even needed, someone who understands the code better just needs to run with my findings. It does work though.