### PR TITLE
Make SMN AF quests available

### DIFF
--- a/scripts/zones/Windurst_Walls/npcs/_6n2.lua
+++ b/scripts/zones/Windurst_Walls/npcs/_6n2.lua
@@ -41,7 +41,7 @@ function onTrigger(player,npc)
             player:startEvent(0x0181,1125,1125,1125,1125,1125,1125,1125,1125);
         ----------------------------------------------------
         -- The Puppet Master (AF weapon)
-        elseif (player:getMainLvl() >= AF1_QUEST_LEVEL and player:getMainJob() == JOBS.SMN and ThePuppetMaster ~= QUEST_ACCEPTED and player:needToZone() == false and ClassReunion ~= QUEST_ACCEPTED and CarbuncleDebacle ~= QUEST_ACCEPTED) then -- you need to be on SMN as well to repeat the quest
+        elseif (player:getMainLvl() >= AF1_QUEST_LEVEL and player:getMainJob() == JOBS.SMN and player:hasItem(17532) == false and ThePuppetMaster ~= QUEST_ACCEPTED and player:needToZone() == false and ClassReunion ~= QUEST_ACCEPTED and CarbuncleDebacle ~= QUEST_ACCEPTED) then -- you need to be on SMN as well to repeat the quest
             player:startEvent(0x0192); -- Carby asks for your help, visit Juroro
         elseif (player:getQuestStatus(WINDURST,THE_PUPPET_MASTER) == QUEST_ACCEPTED and player:getVar("ThePuppetMasterProgress") == 1) then
             player:startEvent(0x0193); -- reminder to visit Juroro

--- a/scripts/zones/Windurst_Walls/npcs/_6n2.lua
+++ b/scripts/zones/Windurst_Walls/npcs/_6n2.lua
@@ -41,7 +41,7 @@ function onTrigger(player,npc)
             player:startEvent(0x0181,1125,1125,1125,1125,1125,1125,1125,1125);
         ----------------------------------------------------
         -- The Puppet Master (AF weapon)
-        elseif (player:getMainLvl() >= AF1_QUEST_LEVEL and player:getMainJob() == JOBS.SMN and player:hasItem(17532) == false and ThePuppetMaster ~= QUEST_ACCEPTED and player:needToZone() == false and ClassReunion ~= QUEST_ACCEPTED and CarbuncleDebacle ~= QUEST_ACCEPTED) then -- you need to be on SMN as well to repeat the quest
+        elseif (player:getMainLvl() >= AF1_QUEST_LEVEL and player:getMainJob() == JOBS.SMN and ThePuppetMaster == QUEST_AVAILABLE and player:needToZone() == false and ClassReunion ~= QUEST_ACCEPTED and CarbuncleDebacle ~= QUEST_ACCEPTED) then -- you need to be on SMN as well to repeat the quest
             player:startEvent(0x0192); -- Carby asks for your help, visit Juroro
         elseif (player:getQuestStatus(WINDURST,THE_PUPPET_MASTER) == QUEST_ACCEPTED and player:getVar("ThePuppetMasterProgress") == 1) then
             player:startEvent(0x0193); -- reminder to visit Juroro


### PR DESCRIPTION
The Puppet Master will keep repeating, rather than allow people to get the next AF quest.  Added a check for the weapon so it will go on.  Drop the weapon and you will get The Puppet Master again.