### PR TITLE
Adding lua hooks to modify mob skills on the fly per mob

### DIFF
--- a/src/map/ai/controllers/mob_controller.cpp
+++ b/src/map/ai/controllers/mob_controller.cpp
@@ -283,6 +283,9 @@ bool CMobController::MobSkill(int wsList)
         {
             continue;
         }
+
+        luautils::OnMobWeaponSkillPrecast(PMob, PMobSkill);
+
         if (PMobSkill->getValidTargets() == TARGET_ENEMY) //enemy
         {
             PActionTarget = PTarget;
@@ -319,6 +322,8 @@ bool CMobController::TrySpecialSkill()
         ShowError("CAIMobDummy::ActionSpawn Special skill was set but not found! (%d)\n", PMob->getMobMod(MOBMOD_SPECIAL_SKILL));
         return false;
     }
+
+    luautils::OnMobWeaponSkillPrecast(PMob, PSpecialSkill);
 
     if (!IsWeaponSkillEnabled())
     {

--- a/src/map/lua/lua_mobskill.cpp
+++ b/src/map/lua/lua_mobskill.cpp
@@ -167,6 +167,42 @@ inline int32 CLuaMobSkill::getHPP(lua_State* L)
     return 1;
 }
 
+inline int32 CLuaMobSkill::setFlag(lua_State* L)
+{
+    DSP_DEBUG_BREAK_IF(m_PLuaMobSkill == nullptr);
+    DSP_DEBUG_BREAK_IF(lua_isnil(L, -1) || !lua_isnumber(L, -1));
+
+    m_PLuaMobSkill->setFlag(lua_tointeger(L, -1));
+    return 0;
+}
+
+inline int32 CLuaMobSkill::setAoE(lua_State* L)
+{
+    DSP_DEBUG_BREAK_IF(m_PLuaMobSkill == nullptr);
+    DSP_DEBUG_BREAK_IF(lua_isnil(L, -1) || !lua_isnumber(L, -1));
+
+    m_PLuaMobSkill->setAoe(lua_tointeger(L, -1));
+    return 0;
+}
+
+inline int32 CLuaMobSkill::setDistance(lua_State* L)
+{
+    DSP_DEBUG_BREAK_IF(m_PLuaMobSkill == nullptr);
+    DSP_DEBUG_BREAK_IF(lua_isnil(L, -1) || !lua_isnumber(L, -1));
+
+    m_PLuaMobSkill->setDistance(lua_tointeger(L, -1));
+    return 0;
+}
+
+inline int32 CLuaMobSkill::setKnockback(lua_State* L)
+{
+    DSP_DEBUG_BREAK_IF(m_PLuaMobSkill == nullptr);
+    DSP_DEBUG_BREAK_IF(lua_isnil(L, -1) || !lua_isnumber(L, -1));
+
+    m_PLuaMobSkill->setKnockback(lua_tointeger(L, -1));
+    return 0;
+}
+
 /************************************************************************
 *																		*
 *  declare lua function													*
@@ -188,5 +224,9 @@ Lunar<CLuaMobSkill>::Register_t CLuaMobSkill::methods[] =
     LUNAR_DECLARE_METHOD(CLuaMobSkill,getTP),
     LUNAR_DECLARE_METHOD(CLuaMobSkill,getHPP),
     LUNAR_DECLARE_METHOD(CLuaMobSkill,setSkillchain),
+    LUNAR_DECLARE_METHOD(CLuaMobSkill,setFlag),
+    LUNAR_DECLARE_METHOD(CLuaMobSkill,setAoE),
+    LUNAR_DECLARE_METHOD(CLuaMobSkill,setDistance),
+    LUNAR_DECLARE_METHOD(CLuaMobSkill,setKnockback),
     {nullptr,nullptr}
 };

--- a/src/map/lua/lua_mobskill.h
+++ b/src/map/lua/lua_mobskill.h
@@ -56,6 +56,11 @@ public:
     int32 getMsg(lua_State*);
     int32 getTotalTargets(lua_State*);
     int32 setSkillchain(lua_State*);
+
+    int32 setFlag(lua_State*);
+    int32 setAoE(lua_State*);
+    int32 setDistance(lua_State*);
+    int32 setKnockback(lua_State*);
 };
 
 #endif

--- a/src/map/lua/luautils.cpp
+++ b/src/map/lua/luautils.cpp
@@ -3292,6 +3292,39 @@ namespace luautils
         return retVal;
     }
 
+    int32 OnMobWeaponSkillPrecast(CBaseEntity* PMob, CMobSkill* PMobSkill)
+    {
+        if (PMob->objtype == TYPE_MOB)
+        {
+            lua_prepscript("scripts/zones/%s/mobs/%s.lua", PMob->loc.zone->GetName(), PMob->GetName());
+
+            if (prepFile(File, "onMobWeaponSkillPrecast"))
+            {
+                return 0;
+            }
+
+            CLuaBaseEntity LuaMobEntity(PMob);
+            Lunar<CLuaBaseEntity>::push(LuaHandle, &LuaMobEntity);
+
+            CLuaMobSkill LuaMobSkill(PMobSkill);
+            Lunar<CLuaMobSkill>::push(LuaHandle, &LuaMobSkill);
+
+            if (lua_pcall(LuaHandle, 2, LUA_MULTRET, 0))
+            {
+                ShowError("luautils::onMobWeaponSkillPrecast: %s\n", lua_tostring(LuaHandle, -1));
+                lua_pop(LuaHandle, 1);
+                return 0;
+            }
+            int32 returns = lua_gettop(LuaHandle) - oldtop;
+            if (returns > 0)
+            {
+                ShowError("luautils::onMobWeaponSkillPrecast (%s): 0 returns expected, got %d\n", File, returns);
+                lua_pop(LuaHandle, returns);
+            }
+        }
+        return 0;
+    }
+
     /***********************************************************************
     *                                                                       *
     *                                                                       *

--- a/src/map/lua/luautils.h
+++ b/src/map/lua/luautils.h
@@ -238,6 +238,8 @@ namespace luautils
     int32 OnMobSkillCheck(CBaseEntity* PChar, CBaseEntity* PMob, CMobSkill* PMobSkill);                             // triggers before mob weapon skill is used, returns 0 if the move is valid
     int32 OnMobAutomatonSkillCheck(CBaseEntity* PChar, CAutomatonEntity* PAutomaton, CMobSkill* PMobSkill);
 
+    int32 OnMobWeaponSkillPrecast(CBaseEntity* PMob, CMobSkill* PMobSkill);                         // triggered just before mob weapon skill is used
+
     int32 OnAbilityCheck(CBaseEntity* PChar, CBaseEntity* PTarget, CAbility* PAbility, CBaseEntity** PMsgTarget);   // triggers when a player attempts to use a job ability or roll
     int32 OnPetAbility(CBaseEntity* PPet, CBaseEntity* PMob, CMobSkill* PMobSkill, CBaseEntity* PPetMaster, action_t* action);      // triggers when pet uses an ability
     std::tuple<int32, uint8, uint8> OnUseWeaponSkill(CCharEntity* PChar, CBaseEntity* PMob, CWeaponSkill* wskill, uint16 tp, bool primary, action_t& action, CBattleEntity* taChar);// returns: damage, tphits landed, extra hits landed


### PR DESCRIPTION
- Adds onMobWeaponSkillPrecast that can be added to any zone mob lua to
change parameters similar to onSpellPrecast
- Expose methods on lua mob skill object to set distance, aoe, flags,
knockback