### PR TITLE
Reworking latent_effect_container

### DIFF
--- a/scripts/commands/getmod.lua
+++ b/scripts/commands/getmod.lua
@@ -1,24 +1,31 @@
 ---------------------------------------------------------------------------------------------------
--- func: getmod
--- desc: gets a mod on the target/player
+-- func: getmod <modID>
+-- desc: gets a mod by ID on the player or cursor target
 ---------------------------------------------------------------------------------------------------
 
 cmdprops =
 {
     permission = 3,
-    parameters = "is"
+    parameters = "i"
 };
 
-function onTrigger(player, id, target)
-    local effectTarget = player;
-    if (target ~= nil) then
-        effectTarget = target;
-    end
+function error(player, msg)
+    player:PrintToPlayer(msg);
+    player:PrintToPlayer("@getmod <modID>");
+end;
 
+function onTrigger(player, id)
+    -- validate modID
     if (id == nil) then
-        player:PrintToPlayer( "Mod id cannot be nil." );
+        error(player, "Invalid modID.");
         return;
     end
 
-    player:PrintToPlayer(string.format("Mod %i: %i", id, effectTarget:getMod(id)));
-end
+    -- validate target
+    local effectTarget = player:getCursorTarget();
+    if (effectTarget == nil) then
+        effectTarget = player;
+    end
+
+    player:PrintToPlayer(string.format("%s's Mod ID %i: %i", effectTarget:getName(), id, effectTarget:getMod(id)));
+end;

--- a/scripts/commands/getmod.lua
+++ b/scripts/commands/getmod.lua
@@ -1,0 +1,24 @@
+---------------------------------------------------------------------------------------------------
+-- func: getmod
+-- desc: gets a mod on the target/player
+---------------------------------------------------------------------------------------------------
+
+cmdprops =
+{
+    permission = 3,
+    parameters = "is"
+};
+
+function onTrigger(player, id, target)
+    local effectTarget = player;
+    if (target ~= nil) then
+        effectTarget = target;
+    end
+
+    if (id == nil) then
+        player:PrintToPlayer( "Mod id cannot be nil." );
+        return;
+    end
+
+    player:PrintToPlayer(string.format("Mod %i: %i", id, effectTarget:getMod(id)));
+end

--- a/src/map/entities/charentity.cpp
+++ b/src/map/entities/charentity.cpp
@@ -344,7 +344,7 @@ int16 CCharEntity::addTP(int16 tp)
     tp = CBattleEntity::addTP(tp);
     //	if ((oldtp < 1000 && health.tp >= 1000 ) || (oldtp >= 1000 && health.tp < 1000))
     //	{
-    PLatentEffectContainer->CheckLatentsTP(health.tp);
+    PLatentEffectContainer->CheckLatentsTP();
     //	}
     return abs(tp);
 }
@@ -352,7 +352,7 @@ int16 CCharEntity::addTP(int16 tp)
 int32 CCharEntity::addHP(int32 hp)
 {
     hp = CBattleEntity::addHP(hp);
-    PLatentEffectContainer->CheckLatentsHP(health.hp);
+    PLatentEffectContainer->CheckLatentsHP();
 
     return abs(hp);
 }
@@ -360,7 +360,7 @@ int32 CCharEntity::addHP(int32 hp)
 int32 CCharEntity::addMP(int32 mp)
 {
     mp = CBattleEntity::addMP(mp);
-    PLatentEffectContainer->CheckLatentsMP(health.mp);
+    PLatentEffectContainer->CheckLatentsMP();
 
     return abs(mp);
 }
@@ -698,7 +698,7 @@ void CCharEntity::OnWeaponSkillFinished(CWeaponSkillState& state, action_t& acti
     int16 tp = state.GetSpentTP();
     tp = battleutils::CalculateWeaponSkillTP(this, PWeaponSkill, tp);
 
-    PLatentEffectContainer->CheckLatentsTP(this->health.tp);
+    PLatentEffectContainer->CheckLatentsTP();
 
     SLOTTYPE damslot = SLOT_MAIN;
     if (distance(loc.p, PBattleTarget->loc.p) - PBattleTarget->m_ModelSize <= PWeaponSkill->getRange())

--- a/src/map/latent_effect.h
+++ b/src/map/latent_effect.h
@@ -34,23 +34,23 @@ enum LATENT
     LATENT_HP_OVER_PERCENT          = 1,  //hp more than % - PARAM: HP PERCENT
     LATENT_HP_UNDER_TP_UNDER_100    = 2,  //hp less than or equal to %, tp under 100 - PARAM: HP PERCENT
     LATENT_HP_OVER_TP_UNDER_100     = 3,  //hp more than %, tp over 100 - PARAM: HP PERCENT
-    LATENT_HP_OVER_VISIBLE_GEAR     = 46, //hp more than or equal to %, calculated using HP bonuses from visible gear only 
     LATENT_MP_UNDER_PERCENT         = 4,  //mp less than or equal to % - PARAM: MP PERCENT
     LATENT_MP_UNDER                 = 5,  //mp less than # - PARAM: MP #
-    LATENT_MP_OVER                  = 55, //mp greater than # - PARAM: MP #
-    LATENT_WEAPON_DRAWN_MP_OVER     = 56, //while weapon is drawn and mp greater than # - PARAM: MP #
-    LATENT_MP_UNDER_VISIBLE_GEAR    = 45, //mp less than or equal to %, calculated using MP bonuses from visible gear only
     LATENT_TP_UNDER                 = 6,  //tp under # and during WS - PARAM: TP VALUE
     LATENT_TP_OVER                  = 7,  //tp over # - PARAM: TP VALUE
     LATENT_SUBJOB                   = 8,  //subjob - PARAM: JOBTYPE
     LATENT_PET_ID                   = 9,  //pettype - PARAM: PETID
     LATENT_WEAPON_DRAWN             = 10, //weapon drawn
     LATENT_WEAPON_SHEATHED          = 11, //weapon sheathed
+    //                              = 12  //Unused
     LATENT_STATUS_EFFECT_ACTIVE     = 13, //status effect on player - PARAM: EFFECTID
-    LATENT_FOOD_ACTIVE              = 49, //food effect (foodId) active - PARAM: FOOD ITEMID
     LATENT_NO_FOOD_ACTIVE           = 14, //no food effects active on player
     LATENT_PARTY_MEMBERS            = 15, //party size # - PARAM: # OF MEMBERS
     LATENT_PARTY_MEMBERS_IN_ZONE    = 16, //party size # and members in zone - PARAM: # OF MEMBERS
+    //                              = 17  //Unused
+    //                              = 18  //Unused
+    //                              = 19  //Unused
+    //                              = 20  //Unused
     LATENT_AVATAR_IN_PARTY          = 21, //party has a specific avatar - PARAM: same as globals/pets.lua (21 for any avatar)
     LATENT_JOB_IN_PARTY             = 22, //party has job - PARAM: JOBTYPE
     LATENT_ZONE                     = 23, //in zone - PARAM: zoneid
@@ -73,13 +73,19 @@ enum LATENT
     LATENT_JOB_LEVEL_ODD            = 41,
     LATENT_JOB_LEVEL_EVEN           = 42,
     LATENT_WEAPON_DRAWN_HP_UNDER    = 43, //PARAM: HP PERCENT
+    //                              = 44  //Unused
+    LATENT_MP_UNDER_VISIBLE_GEAR    = 45, //mp less than or equal to %, calculated using MP bonuses from visible gear only
+    LATENT_HP_OVER_VISIBLE_GEAR     = 46, //hp more than or equal to %, calculated using HP bonuses from visible gear only 
     LATENT_WEAPON_BROKEN            = 47,
     LATENT_IN_DYNAMIS               = 48,
+    LATENT_FOOD_ACTIVE              = 49, //food effect (foodId) active - PARAM: FOOD ITEMID
     LATENT_JOB_LEVEL_BELOW          = 50, //PARAM: level
     LATENT_JOB_LEVEL_ABOVE          = 51, //PARAM: level
     LATENT_WEATHER_ELEMENT          = 52, //PARAM: 0: NONE, 1: FIRE, 2: EARTH, 3: WATER, 4: WIND, 5: ICE, 6: THUNDER, 7: LIGHT, 8: DARK
     LATENT_NATION_CONTROL           = 53, //checks if player region is under nation's control - PARAM: 0: Under own nation's control, 1: Outside own nation's control
-    LATENT_ZONE_HOME_NATION         = 54  //in zone and citizen of nation (aketons)
+    LATENT_ZONE_HOME_NATION         = 54 , //in zone and citizen of nation (aketons)
+    LATENT_MP_OVER                  = 55, //mp greater than # - PARAM: MP #
+    LATENT_WEAPON_DRAWN_MP_OVER     = 56 //while weapon is drawn and mp greater than # - PARAM: MP #
 };
 
 #define MAX_LATENTEFFECTID    57

--- a/src/map/latent_effect_container.cpp
+++ b/src/map/latent_effect_container.cpp
@@ -112,86 +112,24 @@ void CLatentEffectContainer::DelLatentEffects(uint8 reqLvl, uint8 slot)
 *  the conditions are met.												*
 *																		*
 ************************************************************************/
-
-void CLatentEffectContainer::CheckLatentsHP(int32 hp)
+void CLatentEffectContainer::CheckLatentsHP()
 {
     //TODO: hook into this from anywhere HP changes
-    for (uint16 i = 0; i < m_LatentEffectList.size(); ++i)
+    ProcessLatentEffects([this](CLatentEffect* latentEffect)
     {
-        switch (m_LatentEffectList.at(i)->GetConditionsID())
+        switch (latentEffect->GetConditionsID())
         {
         case LATENT_HP_UNDER_PERCENT:
-            if (((float)hp / m_POwner->health.maxhp) * 100 <= m_LatentEffectList.at(i)->GetConditionsValue())
-            {
-                m_LatentEffectList.at(i)->Activate();
-            }
-            else
-            {
-                m_LatentEffectList.at(i)->Deactivate();
-            }
-            break;
         case LATENT_HP_OVER_PERCENT:
-            if (((float)hp / m_POwner->health.maxhp) * 100 >= m_LatentEffectList.at(i)->GetConditionsValue())
-            {
-                m_LatentEffectList.at(i)->Activate();
-            }
-            else
-            {
-                m_LatentEffectList.at(i)->Deactivate();
-            }
-            break;
         case LATENT_HP_UNDER_TP_UNDER_100:
-            if (((float)hp / m_POwner->health.maxhp) * 100 <= m_LatentEffectList.at(i)->GetConditionsValue() && m_POwner->health.tp < 1000)
-            {
-                m_LatentEffectList.at(i)->Activate();
-            }
-            else
-            {
-                m_LatentEffectList.at(i)->Deactivate();
-            }
-            break;
         case LATENT_HP_OVER_TP_UNDER_100:
-            if (((float)hp / m_POwner->health.maxhp) * 100 >= m_LatentEffectList.at(i)->GetConditionsValue() && m_POwner->health.tp < 1000)
-            {
-                m_LatentEffectList.at(i)->Activate();
-            }
-            else
-            {
-                m_LatentEffectList.at(i)->Deactivate();
-            }
+        case LATENT_HP_OVER_VISIBLE_GEAR:
+            ProcessLatentEffect(latentEffect);
             break;
-            //case LATENT_HP_OVER_VISIBLE_GEAR:
-            //    {
-            //    //TODO: figure out if this is actually right
-            //    CItemArmor* head = (CItemArmor*)(m_POwner->getStorage(LOC_INVENTORY)->GetItem(m_POwner->equip[SLOT_HEAD]));
-            //    CItemArmor* body = (CItemArmor*)(m_POwner->getStorage(LOC_INVENTORY)->GetItem(m_POwner->equip[SLOT_BODY]));
-            //    CItemArmor* hands = (CItemArmor*)(m_POwner->getStorage(LOC_INVENTORY)->GetItem(m_POwner->equip[SLOT_HANDS]));
-            //    CItemArmor* legs = (CItemArmor*)(m_POwner->getStorage(LOC_INVENTORY)->GetItem(m_POwner->equip[SLOT_LEGS]));
-            //    CItemArmor* feet = (CItemArmor*)(m_POwner->getStorage(LOC_INVENTORY)->GetItem(m_POwner->equip[SLOT_FEET]));
-
-            //    int32 visibleHp = 0;
-            //    visibleHp += (head ? head->getModifier(Mod::HP) : 0);
-            //    visibleHp += (body ? body->getModifier(Mod::HP) : 0);
-            //    visibleHp += (hands ? hands->getModifier(Mod::HP) : 0);
-            //    visibleHp += (legs ? legs->getModifier(Mod::HP) : 0);
-            //    visibleHp += (feet ? feet->getModifier(Mod::HP) : 0);
-
-            //    //TODO: add mp percent too
-            //    if ((float)( hp / ((m_POwner->health.hp - m_POwner->health.modhp) + (m_POwner->PMeritPoints->GetMerit(MERIT_MAX_HP)->count * 10 ) + 
-            //        visibleHp) ) <= m_LatentEffectList.at(i)->GetConditionsValue())
-            //    {
-            //        m_LatentEffectList.at(i)->Activate();
-            //    }
-            //    else
-            //    {
-            //        m_LatentEffectList.at(i)->Deactivate();
-            //    }
-            //    }
-            //    break;
         default:
             break;
         }
-    }
+    });
 }
 
 /************************************************************************
@@ -200,57 +138,22 @@ void CLatentEffectContainer::CheckLatentsHP(int32 hp)
 *  the conditions are met.												*
 *																		*
 ************************************************************************/
-
-void CLatentEffectContainer::CheckLatentsTP(int16 tp)
+void CLatentEffectContainer::CheckLatentsTP()
 {
-    for (uint16 i = 0; i < m_LatentEffectList.size(); ++i)
+    ProcessLatentEffects([this](CLatentEffect* latentEffect)
     {
-        switch (m_LatentEffectList.at(i)->GetConditionsID())
+        switch (latentEffect->GetConditionsID())
         {
         case LATENT_TP_UNDER:
-            if (m_POwner->health.tp < m_LatentEffectList.at(i)->GetConditionsValue())
-            {
-                m_LatentEffectList.at(i)->Activate();
-            }
-            else
-            {
-                m_LatentEffectList.at(i)->Deactivate();
-            }
-            break;
         case LATENT_TP_OVER:
-            if (m_POwner->health.tp > m_LatentEffectList.at(i)->GetConditionsValue())
-            {
-                m_LatentEffectList.at(i)->Activate();
-            }
-            else
-            {
-                m_LatentEffectList.at(i)->Deactivate();
-            }
-            break;
         case LATENT_HP_UNDER_TP_UNDER_100:
-            if (((float)m_POwner->health.hp / (float)m_POwner->health.maxhp) * 100 <= m_LatentEffectList.at(i)->GetConditionsValue() && m_POwner->health.tp < 1000)
-            {
-                m_LatentEffectList.at(i)->Activate();
-            }
-            else
-            {
-                m_LatentEffectList.at(i)->Deactivate();
-            }
-            break;
         case LATENT_HP_OVER_TP_UNDER_100:
-            if (((float)m_POwner->health.hp / (float)m_POwner->health.maxhp) * 100 >= m_LatentEffectList.at(i)->GetConditionsValue() && m_POwner->health.tp < 1000)
-            {
-                m_LatentEffectList.at(i)->Activate();
-            }
-            else
-            {
-                m_LatentEffectList.at(i)->Deactivate();
-            }
+            ProcessLatentEffect(latentEffect);
             break;
         default:
             break;
         }
-    }
+    });
 }
 
 /************************************************************************
@@ -259,86 +162,24 @@ void CLatentEffectContainer::CheckLatentsTP(int16 tp)
 *  the conditions are met.												*
 *																		*
 ************************************************************************/
-
-void CLatentEffectContainer::CheckLatentsMP(int32 mp)
+void CLatentEffectContainer::CheckLatentsMP()
 {
     //TODO: hook into this from anywhere MP changes
-    for (uint16 i = 0; i < m_LatentEffectList.size(); ++i)
+    ProcessLatentEffects([this](CLatentEffect* latentEffect)
     {
-        switch (m_LatentEffectList.at(i)->GetConditionsID())
+        switch (latentEffect->GetConditionsID())
         {
         case LATENT_MP_UNDER_PERCENT:
-            if (m_POwner->health.maxmp && (float)(mp / m_POwner->health.maxmp) * 100 <= m_LatentEffectList.at(i)->GetConditionsValue())
-            {
-                m_LatentEffectList.at(i)->Activate();
-            }
-            else
-            {
-                m_LatentEffectList.at(i)->Deactivate();
-            }
-            break;
         case LATENT_MP_UNDER:
-            if (mp <= m_LatentEffectList.at(i)->GetConditionsValue())
-            {
-                m_LatentEffectList.at(i)->Activate();
-            }
-            else
-            {
-                m_LatentEffectList.at(i)->Deactivate();
-            }
-            break;
         case LATENT_MP_OVER:
-            if (mp >= m_LatentEffectList.at(i)->GetConditionsValue())
-            {
-               m_LatentEffectList.at(i)->Activate();
-            }
-            else
-            {
-               m_LatentEffectList.at(i)->Deactivate();
-            }
-            break;
         case LATENT_WEAPON_DRAWN_MP_OVER:
-            if (mp > m_LatentEffectList.at(i)->GetConditionsValue() && m_POwner->animation == ANIMATION_ATTACK)
-            {
-                m_LatentEffectList.at(i)->Activate();
-            }
-            else
-            {
-                m_LatentEffectList.at(i)->Deactivate();
-            }
+        case LATENT_MP_UNDER_VISIBLE_GEAR:
+            ProcessLatentEffect(latentEffect);
             break;
-            //case LATENT_MP_UNDER_VISIBLE_GEAR:
-            //    {
-            //    //TODO: figure out if this is actually right
-            //    CItemArmor* head = (CItemArmor*)(m_POwner->getStorage(LOC_INVENTORY)->GetItem(m_POwner->equip[SLOT_HEAD]));
-            //    CItemArmor* body = (CItemArmor*)(m_POwner->getStorage(LOC_INVENTORY)->GetItem(m_POwner->equip[SLOT_BODY]));
-            //    CItemArmor* hands = (CItemArmor*)(m_POwner->getStorage(LOC_INVENTORY)->GetItem(m_POwner->equip[SLOT_HANDS]));
-            //    CItemArmor* legs = (CItemArmor*)(m_POwner->getStorage(LOC_INVENTORY)->GetItem(m_POwner->equip[SLOT_LEGS]));
-            //    CItemArmor* feet = (CItemArmor*)(m_POwner->getStorage(LOC_INVENTORY)->GetItem(m_POwner->equip[SLOT_FEET]));
-
-            //    int32 visibleMp = 0;
-            //    visibleMp += (head ? head->getModifier(Mod::MP) : 0);
-            //    visibleMp += (body ? body->getModifier(Mod::MP) : 0);
-            //    visibleMp += (hands ? hands->getModifier(Mod::MP) : 0);
-            //    visibleMp += (legs ? legs->getModifier(Mod::MP) : 0);
-            //    visibleMp += (feet ? feet->getModifier(Mod::MP) : 0);
-
-            //    //TODO: add mp percent too
-            //    if ((float)( mp / ((m_POwner->health.mp - m_POwner->health.modmp) + (m_POwner->PMeritPoints->GetMerit(MERIT_MAX_MP)->count * 10 ) + 
-            //        visibleMp) ) <= m_LatentEffectList.at(i)->GetConditionsValue())
-            //    {
-            //        m_LatentEffectList.at(i)->Activate();
-            //    }
-            //    else
-            //    {
-            //        m_LatentEffectList.at(i)->Deactivate();
-            //    }
-            //    }
-            //    break;
         default:
             break;
         }
-    }
+    });
 }
 
 /************************************************************************
@@ -346,316 +187,15 @@ void CLatentEffectContainer::CheckLatentsMP(int32 mp)
 *  Checks all latents for a given slot (ie. on equip)					*
 *																		*
 ************************************************************************/
-
 void CLatentEffectContainer::CheckLatentsEquip(uint8 slot)
 {
-    for (uint16 i = 0; i < m_LatentEffectList.size(); ++i)
+    ProcessLatentEffects([this, slot](CLatentEffect* latentEffect)
     {
-        if (m_LatentEffectList.at(i)->GetSlot() == slot)
+        if (latentEffect->GetSlot() == slot)
         {
-            switch (m_LatentEffectList.at(i)->GetConditionsID())
-            {
-            case LATENT_HP_UNDER_PERCENT:
-                if (((float)m_POwner->health.hp / m_POwner->health.maxhp) * 100 <= m_LatentEffectList.at(i)->GetConditionsValue())
-                {
-                    m_LatentEffectList.at(i)->Activate();
-                }
-                else
-                {
-                    m_LatentEffectList.at(i)->Deactivate();
-                }
-                break;
-            case LATENT_HP_OVER_PERCENT:
-                if (((float)m_POwner->health.hp / m_POwner->health.maxhp) * 100 >= m_LatentEffectList.at(i)->GetConditionsValue())
-                {
-                    m_LatentEffectList.at(i)->Activate();
-                }
-                else
-                {
-                    m_LatentEffectList.at(i)->Deactivate();
-                }
-                break;
-            case LATENT_HP_UNDER_TP_UNDER_100:
-                if (((float)m_POwner->health.hp / m_POwner->health.maxhp) * 100 <= m_LatentEffectList.at(i)->GetConditionsValue() && m_POwner->health.tp < 1000)
-                {
-                    m_LatentEffectList.at(i)->Activate();
-                }
-                else
-                {
-                    m_LatentEffectList.at(i)->Deactivate();
-                }
-                break;
-            case LATENT_HP_OVER_TP_UNDER_100:
-                if (((float)m_POwner->health.hp / m_POwner->health.maxhp) * 100 >= m_LatentEffectList.at(i)->GetConditionsValue() && m_POwner->health.tp < 1000)
-                {
-                    m_LatentEffectList.at(i)->Activate();
-                }
-                else
-                {
-                    m_LatentEffectList.at(i)->Deactivate();
-                }
-                break;
-            case LATENT_MP_UNDER_PERCENT:
-                if (m_POwner->health.maxmp && (float)(m_POwner->health.mp / m_POwner->health.maxmp) * 100 <= m_LatentEffectList.at(i)->GetConditionsValue())
-                {
-                    m_LatentEffectList.at(i)->Activate();
-                }
-                else
-                {
-                    m_LatentEffectList.at(i)->Deactivate();
-                }
-                break;
-            case LATENT_MP_UNDER:
-                if (m_POwner->health.mp <= m_LatentEffectList.at(i)->GetConditionsValue())
-                {
-                    m_LatentEffectList.at(i)->Activate();
-                }
-                else
-                {
-                    m_LatentEffectList.at(i)->Deactivate();
-                }
-                break;
-            case LATENT_MP_OVER:
-                if (m_POwner->health.mp >= m_LatentEffectList.at(i)->GetConditionsValue())
-                {
-                    m_LatentEffectList.at(i)->Activate();
-                }
-                else
-                {
-                    m_LatentEffectList.at(i)->Deactivate();
-                }
-                break;
-            case LATENT_WEAPON_DRAWN_MP_OVER:
-                if (m_POwner->health.mp > m_LatentEffectList.at(i)->GetConditionsValue() && m_POwner->animation == ANIMATION_ATTACK)
-                {
-                    m_LatentEffectList.at(i)->Activate();
-                }
-                else
-                {
-                    m_LatentEffectList.at(i)->Deactivate();
-                }
-                break;
-            case LATENT_TP_UNDER:
-                if (m_POwner->health.tp < m_LatentEffectList.at(i)->GetConditionsValue())
-                {
-                    m_LatentEffectList.at(i)->Activate();
-                }
-                else
-                {
-                    m_LatentEffectList.at(i)->Deactivate();
-                }
-                break;
-            case LATENT_TP_OVER:
-                if (m_POwner->health.tp > m_LatentEffectList.at(i)->GetConditionsValue())
-                {
-                    m_LatentEffectList.at(i)->Activate();
-                }
-                else
-                {
-                    m_LatentEffectList.at(i)->Deactivate();
-                }
-                break;
-            case LATENT_PET_ID:
-                if (m_POwner->PPet && m_POwner->PPet->objtype == TYPE_PET && ((CPetEntity*)m_POwner->PPet)->m_PetID == m_LatentEffectList.at(i)->GetConditionsValue())
-                {
-                    m_LatentEffectList.at(i)->Activate();
-                }
-                else
-                {
-                    m_LatentEffectList.at(i)->Deactivate();
-                }
-                break;
-            case LATENT_SUBJOB:
-                if (m_POwner->GetSJob() == m_LatentEffectList.at(i)->GetConditionsValue())
-                {
-                    m_LatentEffectList.at(i)->Activate();
-                }
-                break;
-            case LATENT_WEAPON_BROKEN:
-            {
-                CItemWeapon* PWeaponMain = (CItemWeapon*)m_POwner->getEquip(SLOT_MAIN);
-                CItemWeapon* PWeaponSub = (CItemWeapon*)m_POwner->getEquip(SLOT_SUB);
-                CItemWeapon* PWeaponRanged = (CItemWeapon*)m_POwner->getEquip(SLOT_RANGED);
-                if (PWeaponMain && PWeaponMain->isUnlocked() && m_LatentEffectList.at(i)->GetSlot() == SLOT_MAIN)
-                {
-                    m_LatentEffectList.at(i)->Activate();
-                }
-                if (PWeaponSub && PWeaponSub->isUnlocked() && m_LatentEffectList.at(i)->GetSlot() == SLOT_SUB)
-                {
-                    m_LatentEffectList.at(i)->Activate();
-                }
-                if (PWeaponRanged && PWeaponRanged->isUnlocked() && m_LatentEffectList.at(i)->GetSlot() == SLOT_RANGED)
-                {
-                    m_LatentEffectList.at(i)->Activate();
-                }
-                break;
-            }
-            case LATENT_ZONE:
-                if (m_LatentEffectList.at(i)->GetConditionsValue() == m_POwner->getZone())
-                {
-                    m_LatentEffectList.at(i)->Activate();
-                }
-                else
-                {
-                    m_LatentEffectList.at(i)->Deactivate();
-                }
-                break;
-            case LATENT_ZONE_HOME_NATION:
-                CheckLatentsZone();
-                break;
-            case LATENT_IN_DYNAMIS:
-                if (m_POwner->isInDynamis())
-                {
-                    m_LatentEffectList.at(i)->Activate();
-                }
-                else
-                {
-                    m_LatentEffectList.at(i)->Deactivate();
-                }
-                break;
-            case LATENT_FOOD_ACTIVE:
-            case LATENT_NO_FOOD_ACTIVE:
-                CheckLatentsFoodEffect();
-                break;
-            case LATENT_STATUS_EFFECT_ACTIVE:
-                CheckLatentsStatusEffect();
-                break;
-            case LATENT_JOB_IN_PARTY:
-                CheckLatentsPartyJobs();
-                break;
-            case LATENT_PARTY_MEMBERS:
-            case LATENT_PARTY_MEMBERS_IN_ZONE:
-            {
-                if (m_POwner->PParty != nullptr)
-                    CheckLatentsPartyMembers(m_POwner->PParty->members.size());
-            }
-            break;
-            case LATENT_AVATAR_IN_PARTY:
-                CheckLatentsPartyAvatar();
-                break;
-            case LATENT_MOON_PHASE:
-                CheckLatentsMoonPhase();
-                break;
-            case LATENT_TIME_OF_DAY:
-                CheckLatentsDay();
-                break;
-            case LATENT_HOUR_OF_DAY:
-                CheckLatentsHours();
-                break;
-
-            case LATENT_FIRESDAY:
-            case LATENT_EARTHSDAY:
-            case LATENT_WATERSDAY:
-            case LATENT_WINDSDAY:
-            case LATENT_DARKSDAY:
-            case LATENT_ICEDAY:
-            case LATENT_LIGHTNINGSDAY:
-            case LATENT_LIGHTSDAY:
-                CheckLatentsWeekDay();
-                break;
-            case LATENT_JOB_LEVEL_EVEN:
-                if (m_POwner->GetMLevel() % 2 == 0)
-                {
-                    m_LatentEffectList.at(i)->Activate();
-                }
-                else
-                {
-                    m_LatentEffectList.at(i)->Deactivate();
-                }
-                break;
-            case LATENT_JOB_LEVEL_ODD:
-                if (m_POwner->GetMLevel() % 2 == 1)
-                {
-                    m_LatentEffectList.at(i)->Activate();
-                }
-                else
-                {
-                    m_LatentEffectList.at(i)->Deactivate();
-                }
-                break;
-            case LATENT_JOB_MULTIPLE_5:
-                if (m_POwner->GetMLevel() % 5 == 0)
-                {
-                    m_LatentEffectList.at(i)->Activate();
-                }
-                else
-                {
-                    m_LatentEffectList.at(i)->Deactivate();
-                }
-                break;
-            case LATENT_JOB_MULTIPLE_10:
-                if (m_POwner->GetMLevel() % 10 == 0)
-                {
-                    m_LatentEffectList.at(i)->Activate();
-                }
-                else
-                {
-                    m_LatentEffectList.at(i)->Deactivate();
-                }
-                break;
-            case LATENT_JOB_MULTIPLE_13_NIGHT:
-            {
-                TIMETYPE VanadielTOTD = CVanaTime::getInstance()->SyncTime();
-                if (m_POwner->GetMLevel() % 13 == 0 && (VanadielTOTD == TIME_NIGHT))
-                {
-                    m_LatentEffectList.at(i)->Activate();
-                }
-                else
-                {
-                    m_LatentEffectList.at(i)->Deactivate();
-                }
-            }
-            break;
-            case LATENT_JOB_LEVEL_BELOW:
-                if (m_POwner->GetMLevel() < m_LatentEffectList.at(i)->GetConditionsValue())
-                {
-                    m_LatentEffectList.at(i)->Activate();
-                }
-                else
-                {
-                    m_LatentEffectList.at(i)->Deactivate();
-                }
-                break;
-            case LATENT_JOB_LEVEL_ABOVE:
-                if (m_POwner->GetMLevel() >= m_LatentEffectList.at(i)->GetConditionsValue())
-                {
-                    m_LatentEffectList.at(i)->Activate();
-                }
-                else
-                {
-                    m_LatentEffectList.at(i)->Deactivate();
-                }
-                break;
-            case LATENT_WEATHER_ELEMENT:
-                if (m_LatentEffectList.at(i)->GetConditionsValue() == zoneutils::GetWeatherElement(battleutils::GetWeather((CBattleEntity*)m_POwner, false)))
-                {
-                    m_LatentEffectList.at(i)->Activate();
-                }
-                else
-                {
-                    m_LatentEffectList.at(i)->Deactivate();
-                }
-                break;
-            case LATENT_NATION_CONTROL:
-                CheckLatentsZone();
-                break;
-            case LATENT_WEAPON_DRAWN:
-            case LATENT_WEAPON_DRAWN_HP_UNDER:
-            case LATENT_WEAPON_SHEATHED:
-            {
-                CheckLatentsWeaponDraw(m_POwner->animation == ANIMATION_ATTACK);
-            }
-            break;
-            case LATENT_SONG_ROLL_ACTIVE:
-                    CheckLatentsRollSong(m_POwner->StatusEffectContainer->HasStatusEffectByFlag(EFFECTFLAG_ROLL | EFFECTFLAG_SONG));
-                break;
-            default:
-                ShowWarning("Latent ID %d unhandled in CheckLatentsEquip\n", m_LatentEffectList.at(i)->GetConditionsID());
-                break;
-            }
+            ProcessLatentEffect(latentEffect);
         }
-    }
-    m_POwner->UpdateHealth();
+    });
 }
 
 /************************************************************************
@@ -668,42 +208,59 @@ void CLatentEffectContainer::CheckLatentsEquip(uint8 slot)
 //easy: when animationType changes to ANIMATION_ATTACK or to something else
 void CLatentEffectContainer::CheckLatentsWeaponDraw(bool drawn)
 {
-    if (drawn)
+    ProcessLatentEffects([this, drawn](CLatentEffect* latentEffect)
     {
-        for (uint16 i = 0; i < m_LatentEffectList.size(); ++i)
+        if (drawn)
         {
-            switch (m_LatentEffectList.at(i)->GetConditionsID())
+            switch (latentEffect->GetConditionsID())
             {
             case LATENT_WEAPON_DRAWN:
-                m_LatentEffectList.at(i)->Activate();
+                latentEffect->Activate();
+                break;
+            case LATENT_WEAPON_DRAWN_MP_OVER:
+                if (m_POwner->health.mp > latentEffect->GetConditionsValue())
+                {
+                    latentEffect->Activate();
+                }
+                else
+                {
+                    latentEffect->Deactivate();
+                }
                 break;
             case LATENT_WEAPON_DRAWN_HP_UNDER:
-                //todo: hp drain
+                if (m_POwner->health.hp < latentEffect->GetConditionsValue())
+                {
+                    latentEffect->Activate();
+                }
+                else
+                {
+                    latentEffect->Deactivate();
+                }
                 break;
             case LATENT_WEAPON_SHEATHED:
-                m_LatentEffectList.at(i)->Deactivate();
+                latentEffect->Deactivate();
+                break;
             default:
                 break;
             }
         }
-    }
-    else
-    {
-        for (uint16 i = 0; i < m_LatentEffectList.size(); ++i)
+        else
         {
-            switch (m_LatentEffectList.at(i)->GetConditionsID())
+            switch (latentEffect->GetConditionsID())
             {
             case LATENT_WEAPON_DRAWN:
+            case LATENT_WEAPON_DRAWN_MP_OVER:
             case LATENT_WEAPON_DRAWN_HP_UNDER:
-                m_LatentEffectList.at(i)->Deactivate();
+                latentEffect->Deactivate();
                 break;
             case LATENT_WEAPON_SHEATHED:
-                m_LatentEffectList.at(i)->Activate();
+                latentEffect->Activate();
+                break;
             default:
                 break;
             }
         }
-    }
+    });
 }
 
 /************************************************************************
@@ -712,34 +269,21 @@ void CLatentEffectContainer::CheckLatentsWeaponDraw(bool drawn)
 *  them if the conditions are met.										*
 *																		*
 ************************************************************************/
-
 void CLatentEffectContainer::CheckLatentsStatusEffect()
 {
-    for (uint16 i = 0; i < m_LatentEffectList.size(); ++i)
+    ProcessLatentEffects([this](CLatentEffect* latentEffect)
     {
-        if (m_LatentEffectList.at(i)->GetConditionsID() == LATENT_STATUS_EFFECT_ACTIVE)
+        switch (latentEffect->GetConditionsID())
         {
-            if (m_POwner->StatusEffectContainer->HasStatusEffect((EFFECT)m_LatentEffectList.at(i)->GetConditionsValue()))
-            {
-                m_LatentEffectList.at(i)->Activate();
-            }
-            else
-            {
-                m_LatentEffectList.at(i)->Deactivate();
-            }
+        case LATENT_STATUS_EFFECT_ACTIVE:
+        case LATENT_WEATHER_ELEMENT:
+        case LATENT_NATION_CONTROL:
+            ProcessLatentEffect(latentEffect);
+            break;
+        default:
+            break;
         }
-        else if (m_LatentEffectList.at(i)->GetConditionsID() == LATENT_WEATHER_ELEMENT)
-        {
-            if (m_LatentEffectList.at(i)->GetConditionsValue() == zoneutils::GetWeatherElement(battleutils::GetWeather((CBattleEntity*)m_POwner, false)))
-            {
-                m_LatentEffectList.at(i)->Activate();
-            }
-            else
-            {
-                m_LatentEffectList.at(i)->Deactivate();
-            }
-        }
-    }
+    });
 }
 
 /************************************************************************
@@ -749,37 +293,20 @@ void CLatentEffectContainer::CheckLatentsStatusEffect()
 *  LATENT_NO_FOOD_ACTIVE: (14,0)										*
 *																		*
 ************************************************************************/
-
 void CLatentEffectContainer::CheckLatentsFoodEffect()
 {
-
-    for (uint16 i = 0; i < m_LatentEffectList.size(); ++i)
+    ProcessLatentEffects([this](CLatentEffect* latentEffect)
     {
-        if (m_LatentEffectList.at(i)->GetConditionsID() == LATENT_FOOD_ACTIVE)
+        switch (latentEffect->GetConditionsID())
         {
-            if (m_POwner->StatusEffectContainer->HasStatusEffect(EFFECT_FOOD) &&
-                m_POwner->StatusEffectContainer->GetStatusEffect(EFFECT_FOOD)->GetSubID() == m_LatentEffectList.at(i)->GetConditionsValue())
-            {
-                m_LatentEffectList.at(i)->Activate();
-            }
-            else
-            {
-                m_LatentEffectList.at(i)->Deactivate();
-            }
+        case LATENT_FOOD_ACTIVE:
+        case LATENT_NO_FOOD_ACTIVE:
+            ProcessLatentEffect(latentEffect);
+            break;
+        default:
+            break;
         }
-        if (m_LatentEffectList.at(i)->GetConditionsID() == LATENT_NO_FOOD_ACTIVE)
-        {
-            if (!m_POwner->StatusEffectContainer->HasStatusEffect(EFFECT_FOOD))
-            {
-                m_LatentEffectList.at(i)->Activate();
-            }
-            else
-            {
-                m_LatentEffectList.at(i)->Deactivate();
-            }
-        }
-    }
-    m_POwner->UpdateHealth();
+    });
 }
 
 /************************************************************************
@@ -788,23 +315,19 @@ void CLatentEffectContainer::CheckLatentsFoodEffect()
 *  them if the conditions are met.										*
 *																		*
 ************************************************************************/
-
-void CLatentEffectContainer::CheckLatentsRollSong(bool active)
+void CLatentEffectContainer::CheckLatentsRollSong()
 {
-    for (uint16 i = 0; i < m_LatentEffectList.size(); ++i)
+    ProcessLatentEffects([this](CLatentEffect* latentEffect)
     {
-        if (m_LatentEffectList.at(i)->GetConditionsID() == LATENT_SONG_ROLL_ACTIVE)
+        switch (latentEffect->GetConditionsID())
         {
-            if (active)
-            {
-                m_LatentEffectList.at(i)->Activate();
-            }
-            else
-            {
-                m_LatentEffectList.at(i)->Deactivate();
-            }
+        case LATENT_SONG_ROLL_ACTIVE:
+            ProcessLatentEffect(latentEffect);
+            break;
+        default:
+            break;
         }
-    }
+    });
 }
 
 /************************************************************************
@@ -817,76 +340,17 @@ void CLatentEffectContainer::CheckLatentsRollSong(bool active)
 //probably call this at 00:00 vana time only
 void CLatentEffectContainer::CheckLatentsDay()
 {
-
-    TIMETYPE VanadielTOTD = CVanaTime::getInstance()->SyncTime();
-    uint32 VanadielHour = CVanaTime::getInstance()->getHour();
-
-    for (uint16 i = 0; i < m_LatentEffectList.size(); ++i)
+    ProcessLatentEffects([this](CLatentEffect* latentEffect)
     {
-        /* Time of Day */
-
-        if (m_LatentEffectList.at(i)->GetConditionsID() == LATENT_TIME_OF_DAY)
+        switch (latentEffect->GetConditionsID())
         {
-
-            //daytime: 06:00 to 18:00
-            if (m_LatentEffectList.at(i)->GetConditionsValue() == 0)
-            {
-                if (VanadielHour > 5 && VanadielHour < 18)
-                {
-                    if (m_LatentEffectList.at(i)->IsActivated())
-                        m_LatentEffectList.at(i)->Deactivate();
-
-                    m_LatentEffectList.at(i)->Activate();
-                }
-                else
-                {
-                    if (m_LatentEffectList.at(i)->IsActivated())
-                    {
-                        m_LatentEffectList.at(i)->Deactivate();
-                    }
-                }
-            }
-
-            //nighttime: 18:00 to 06:00
-            if (m_LatentEffectList.at(i)->GetConditionsValue() == 1)
-            {
-                if ((VanadielHour >= 18) || (VanadielHour < 6))
-                {
-                    if (m_LatentEffectList.at(i)->IsActivated())
-                        m_LatentEffectList.at(i)->Deactivate();
-
-                    m_LatentEffectList.at(i)->Activate();
-                }
-                else
-                {
-                    if (m_LatentEffectList.at(i)->IsActivated())
-                    {
-                        m_LatentEffectList.at(i)->Deactivate();
-                    }
-                }
-            }
-
-            //dusk - dawn: 17:00 to 7:00
-            if (m_LatentEffectList.at(i)->GetConditionsValue() == 2)
-            {
-                if ((VanadielHour >= 17) || (VanadielHour < 7))
-                {
-                    if (m_LatentEffectList.at(i)->IsActivated())
-                        m_LatentEffectList.at(i)->Deactivate();
-
-                    m_LatentEffectList.at(i)->Activate();
-                }
-                else
-                {
-                    if (m_LatentEffectList.at(i)->IsActivated())
-                    {
-                        m_LatentEffectList.at(i)->Deactivate();
-                    }
-                }
-            }
+        case LATENT_TIME_OF_DAY:
+            ProcessLatentEffect(latentEffect);
+            break;
+        default:
+            break;
         }
-    }
-    m_POwner->UpdateHealth();
+    });
 }
 
 /************************************************************************
@@ -896,173 +360,17 @@ void CLatentEffectContainer::CheckLatentsDay()
 ************************************************************************/
 void CLatentEffectContainer::CheckLatentsMoonPhase()
 {
-    for (uint16 i = 0; i < m_LatentEffectList.size(); ++i)
+    ProcessLatentEffects([this](CLatentEffect* latentEffect)
     {
-        if (m_LatentEffectList.at(i)->GetConditionsID() == LATENT_MOON_PHASE)
+        switch (latentEffect->GetConditionsID())
         {
-            uint32 MoonPhase = CVanaTime::getInstance()->getMoonPhase();
-            uint32 MoonDirection = CVanaTime::getInstance()->getMoonDirection(); //directions: 1 = waning, 2 = waxing, 0 = neither
-            //New Moon - 10% waning -> 5% waxing
-            if (m_LatentEffectList.at(i)->GetConditionsValue() == 0)
-            {
-                if (MoonPhase <= 5)
-                {
-                    if (!m_LatentEffectList.at(i)->IsActivated())
-                    {
-                        m_LatentEffectList.at(i)->Activate();
-                    }
-                }
-                else if (MoonPhase <= 10 && MoonDirection == 1) //only 10%- if waning
-                {
-                    if (!m_LatentEffectList.at(i)->IsActivated())
-                    {
-                        m_LatentEffectList.at(i)->Activate();
-                    }
-                }
-                else
-                {
-                    if (m_LatentEffectList.at(i)->IsActivated())
-                    {
-                        m_LatentEffectList.at(i)->Deactivate();
-                    }
-                }
-            }
-            //Waxing Crescent - 7% -> 38% waxing
-            if (m_LatentEffectList.at(i)->GetConditionsValue() == 1)
-            {
-                if (MoonPhase >= 7 && MoonPhase <= 38 && MoonDirection == 2)
-                {
-                    if (!m_LatentEffectList.at(i)->IsActivated())
-                    {
-                        m_LatentEffectList.at(i)->Activate();
-                    }
-                }
-                else
-                {
-                    if (m_LatentEffectList.at(i)->IsActivated())
-                    {
-                        m_LatentEffectList.at(i)->Deactivate();
-                    }
-                }
-            }
-            //First Quarter - 40%% -> 55% waxing
-            if (m_LatentEffectList.at(i)->GetConditionsValue() == 2)
-            {
-                if (MoonPhase >= 40 && MoonPhase <= 55 && MoonDirection == 2)
-                {
-                    if (!m_LatentEffectList.at(i)->IsActivated())
-                    {
-                        m_LatentEffectList.at(i)->Activate();
-                    }
-                }
-                else
-                {
-                    if (m_LatentEffectList.at(i)->IsActivated())
-                    {
-                        m_LatentEffectList.at(i)->Deactivate();
-                    }
-                }
-            }
-            //Waxing Gibbous - 57% -> 88%
-            if (m_LatentEffectList.at(i)->GetConditionsValue() == 3)
-            {
-                if (MoonPhase >= 57 && MoonPhase <= 88 && MoonDirection == 2)
-                {
-                    if (!m_LatentEffectList.at(i)->IsActivated())
-                    {
-                        m_LatentEffectList.at(i)->Activate();
-                    }
-                }
-                else
-                {
-                    if (m_LatentEffectList.at(i)->IsActivated())
-                    {
-                        m_LatentEffectList.at(i)->Deactivate();
-                    }
-                }
-            }
-            //Full Moon - waxing 90% -> waning 95%
-            if (m_LatentEffectList.at(i)->GetConditionsValue() == 4)
-            {
-                if (MoonPhase >= 95)
-                {
-                    if (!m_LatentEffectList.at(i)->IsActivated())
-                    {
-                        m_LatentEffectList.at(i)->Activate();
-                    }
-                }
-                else if (MoonPhase >= 90 && MoonDirection == 2) //only 90%+ if waxing
-                {
-                    if (!m_LatentEffectList.at(i)->IsActivated())
-                    {
-                        m_LatentEffectList.at(i)->Activate();
-                    }
-                }
-                else
-                {
-                    if (m_LatentEffectList.at(i)->IsActivated())
-                    {
-                        m_LatentEffectList.at(i)->Deactivate();
-                    }
-                }
-            }
-            //Waning Gibbous - 93% -> 62%
-            if (m_LatentEffectList.at(i)->GetConditionsValue() == 5)
-            {
-                if (MoonPhase >= 62 && MoonPhase <= 93 && MoonDirection == 1)
-                {
-                    if (!m_LatentEffectList.at(i)->IsActivated())
-                    {
-                        m_LatentEffectList.at(i)->Activate();
-                    }
-                }
-                else
-                {
-                    if (m_LatentEffectList.at(i)->IsActivated())
-                    {
-                        m_LatentEffectList.at(i)->Deactivate();
-                    }
-                }
-            }
-            //Last Quarter - 60% -> 45%
-            if (m_LatentEffectList.at(i)->GetConditionsValue() == 6)
-            {
-                if (MoonPhase >= 45 && MoonPhase <= 60 && MoonDirection == 1)
-                {
-                    if (!m_LatentEffectList.at(i)->IsActivated())
-                    {
-                        m_LatentEffectList.at(i)->Activate();
-                    }
-                }
-                else
-                {
-                    if (m_LatentEffectList.at(i)->IsActivated())
-                    {
-                        m_LatentEffectList.at(i)->Deactivate();
-                    }
-                }
-            }
-            //Waning Crescent - 43% -> 12%
-            if (m_LatentEffectList.at(i)->GetConditionsValue() == 7)
-            {
-                if (MoonPhase >= 12 && MoonPhase <= 43 && MoonDirection == 1)
-                {
-                    if (!m_LatentEffectList.at(i)->IsActivated())
-                    {
-                        m_LatentEffectList.at(i)->Activate();
-                    }
-                }
-                else
-                {
-                    if (m_LatentEffectList.at(i)->IsActivated())
-                    {
-                        m_LatentEffectList.at(i)->Deactivate();
-                    }
-                }
-            }
+        case LATENT_MOON_PHASE:
+            ProcessLatentEffect(latentEffect);
+            break;
+        default:
+            break;
         }
-    }
-    m_POwner->UpdateHealth();
+    });
 }
 
 /************************************************************************
@@ -1071,160 +379,26 @@ void CLatentEffectContainer::CheckLatentsMoonPhase()
 *  activates them if the conditions are met.							*
 *																		*
 ************************************************************************/
-
 void CLatentEffectContainer::CheckLatentsWeekDay()
 {
-
-    uint8 WeekDay = (uint8)CVanaTime::getInstance()->getWeekday();
-
-    for (uint16 i = 0; i < m_LatentEffectList.size(); ++i)
+    ProcessLatentEffects([this](CLatentEffect* latentEffect)
     {
-
-        if (m_LatentEffectList.at(i)->GetConditionsID() == LATENT_FIRESDAY)
+        switch (latentEffect->GetConditionsID())
         {
-            if (WeekDay == FIRESDAY)
-            {
-                if (!m_LatentEffectList.at(i)->IsActivated())
-                {
-                    m_LatentEffectList.at(i)->Activate();
-                }
-            }
-            else
-            {
-                if (m_LatentEffectList.at(i)->IsActivated())
-                {
-                    m_LatentEffectList.at(i)->Deactivate();
-                }
-            }
+        case LATENT_FIRESDAY:
+        case LATENT_EARTHSDAY:
+        case LATENT_WATERSDAY:
+        case LATENT_WINDSDAY:
+        case LATENT_DARKSDAY:
+        case LATENT_ICEDAY:
+        case LATENT_LIGHTNINGSDAY:
+        case LATENT_LIGHTSDAY:
+            ProcessLatentEffect(latentEffect);
+            break;
+        default:
+            break;
         }
-
-        if (m_LatentEffectList.at(i)->GetConditionsID() == LATENT_EARTHSDAY)
-        {
-            if (WeekDay == EARTHSDAY)
-            {
-                if (!m_LatentEffectList.at(i)->IsActivated())
-                {
-                    m_LatentEffectList.at(i)->Activate();
-                }
-            }
-            else
-            {
-                if (m_LatentEffectList.at(i)->IsActivated())
-                {
-                    m_LatentEffectList.at(i)->Deactivate();
-                }
-            }
-        }
-
-        if (m_LatentEffectList.at(i)->GetConditionsID() == LATENT_WATERSDAY)
-        {
-            if (WeekDay == WATERSDAY)
-            {
-                if (!m_LatentEffectList.at(i)->IsActivated())
-                {
-                    m_LatentEffectList.at(i)->Activate();
-                }
-            }
-            else
-            {
-                if (m_LatentEffectList.at(i)->IsActivated())
-                {
-                    m_LatentEffectList.at(i)->Deactivate();
-                }
-            }
-        }
-
-        if (m_LatentEffectList.at(i)->GetConditionsID() == LATENT_WINDSDAY)
-        {
-            if (WeekDay == WINDSDAY)
-            {
-                if (!m_LatentEffectList.at(i)->IsActivated())
-                {
-                    m_LatentEffectList.at(i)->Activate();
-                }
-            }
-            else
-            {
-                if (m_LatentEffectList.at(i)->IsActivated())
-                {
-                    m_LatentEffectList.at(i)->Deactivate();
-                }
-            }
-        }
-
-        if (m_LatentEffectList.at(i)->GetConditionsID() == LATENT_DARKSDAY)
-        {
-            if (WeekDay == DARKSDAY)
-            {
-                if (!m_LatentEffectList.at(i)->IsActivated())
-                {
-                    m_LatentEffectList.at(i)->Activate();
-                }
-            }
-            else
-            {
-                if (m_LatentEffectList.at(i)->IsActivated())
-                {
-                    m_LatentEffectList.at(i)->Deactivate();
-                }
-            }
-        }
-
-        if (m_LatentEffectList.at(i)->GetConditionsID() == LATENT_ICEDAY)
-        {
-            if (WeekDay == ICEDAY)
-            {
-                if (!m_LatentEffectList.at(i)->IsActivated())
-                {
-                    m_LatentEffectList.at(i)->Activate();
-                }
-            }
-            else
-            {
-                if (m_LatentEffectList.at(i)->IsActivated())
-                {
-                    m_LatentEffectList.at(i)->Deactivate();
-                }
-            }
-        }
-
-        if (m_LatentEffectList.at(i)->GetConditionsID() == LATENT_LIGHTNINGSDAY)
-        {
-            if (WeekDay == LIGHTNINGDAY)
-            {
-                if (!m_LatentEffectList.at(i)->IsActivated())
-                {
-                    m_LatentEffectList.at(i)->Activate();
-                }
-            }
-            else
-            {
-                if (m_LatentEffectList.at(i)->IsActivated())
-                {
-                    m_LatentEffectList.at(i)->Deactivate();
-                }
-            }
-        }
-
-        if (m_LatentEffectList.at(i)->GetConditionsID() == LATENT_LIGHTSDAY)
-        {
-            if (WeekDay == LIGHTSDAY)
-            {
-                if (!m_LatentEffectList.at(i)->IsActivated())
-                {
-                    m_LatentEffectList.at(i)->Activate();
-                }
-            }
-            else
-            {
-                if (m_LatentEffectList.at(i)->IsActivated())
-                {
-                    m_LatentEffectList.at(i)->Deactivate();
-                }
-            }
-        }
-    }
-    m_POwner->UpdateHealth();
+    });
 }
 
 /************************************************************************
@@ -1235,116 +409,17 @@ void CLatentEffectContainer::CheckLatentsWeekDay()
 ************************************************************************/
 void CLatentEffectContainer::CheckLatentsHours()
 {
-    uint32 VanadielHour = CVanaTime::getInstance()->getHour();
-
-    for (uint16 i = 0; i < m_LatentEffectList.size(); ++i)
+    ProcessLatentEffects([this](CLatentEffect* latentEffect)
     {
-        if (m_LatentEffectList.at(i)->GetConditionsID() == LATENT_HOUR_OF_DAY)
+        switch (latentEffect->GetConditionsID())
         {
-            //new day
-            if (m_LatentEffectList.at(i)->GetConditionsValue() == 1)
-            {
-                if (VanadielHour == 4)
-                {
-                    if (m_LatentEffectList.at(i)->IsActivated())
-                        m_LatentEffectList.at(i)->Deactivate();
-
-                    m_LatentEffectList.at(i)->Activate();
-                }
-                else
-                {
-                    if (m_LatentEffectList.at(i)->IsActivated())
-                        m_LatentEffectList.at(i)->Deactivate();
-                }
-            }
-
-            //dawn
-            if (m_LatentEffectList.at(i)->GetConditionsValue() == 2)
-            {
-                if (VanadielHour == 6)
-                {
-                    if (m_LatentEffectList.at(i)->IsActivated())
-                        m_LatentEffectList.at(i)->Deactivate();
-
-                    m_LatentEffectList.at(i)->Activate();
-                }
-                else
-                {
-                    if (m_LatentEffectList.at(i)->IsActivated())
-                        m_LatentEffectList.at(i)->Deactivate();
-                }
-            }
-
-            //day
-            if (m_LatentEffectList.at(i)->GetConditionsValue() == 3)
-            {
-                if (VanadielHour >= 7 && VanadielHour < 17)
-                {
-                    if (m_LatentEffectList.at(i)->IsActivated())
-                        m_LatentEffectList.at(i)->Deactivate();
-
-                    m_LatentEffectList.at(i)->Activate();
-                }
-                else
-                {
-                    if (m_LatentEffectList.at(i)->IsActivated())
-                        m_LatentEffectList.at(i)->Deactivate();
-                }
-            }
-
-            //dusk
-            if (m_LatentEffectList.at(i)->GetConditionsValue() == 4)
-            {
-                if (VanadielHour >= 16 && VanadielHour < 18)
-                {
-                    if (m_LatentEffectList.at(i)->IsActivated())
-                        m_LatentEffectList.at(i)->Deactivate();
-
-                    m_LatentEffectList.at(i)->Activate();
-                }
-                else
-                {
-                    if (m_LatentEffectList.at(i)->IsActivated())
-                        m_LatentEffectList.at(i)->Deactivate();
-                }
-            }
-
-            //evening
-            if (m_LatentEffectList.at(i)->GetConditionsValue() == 5)
-            {
-                if (VanadielHour >= 18 && VanadielHour < 20)
-                {
-                    if (m_LatentEffectList.at(i)->IsActivated())
-                        m_LatentEffectList.at(i)->Deactivate();
-
-                    m_LatentEffectList.at(i)->Activate();
-                }
-                else
-                {
-                    if (m_LatentEffectList.at(i)->IsActivated())
-                        m_LatentEffectList.at(i)->Deactivate();
-                }
-            }
-
-            //dead of night
-            if (m_LatentEffectList.at(i)->GetConditionsValue() == 6)
-            {
-                if ((VanadielHour < 4) || (VanadielHour <= 20))
-                {
-                    if (m_LatentEffectList.at(i)->IsActivated())
-                        m_LatentEffectList.at(i)->Deactivate();
-
-                    m_LatentEffectList.at(i)->Activate();
-                }
-                else
-                {
-                    if (m_LatentEffectList.at(i)->IsActivated())
-                        m_LatentEffectList.at(i)->Deactivate();
-                }
-            }
+        case LATENT_HOUR_OF_DAY:
+            ProcessLatentEffect(latentEffect);
+            break;
+        default:
+            break;
         }
-    }
-    m_POwner->UpdateHealth();
+    });
 }
 
 /************************************************************************
@@ -1353,99 +428,68 @@ void CLatentEffectContainer::CheckLatentsHours()
 *  activates them if the conditions are met.							*
 *																		*
 ************************************************************************/
-
 void CLatentEffectContainer::CheckLatentsPartyMembers(uint8 members)
 {
-
-    for (uint16 i = 0; i < m_LatentEffectList.size(); ++i)
+    // todo: fix this
+    ProcessLatentEffects([this, members](CLatentEffect* latentEffect)
     {
-
-        if (m_LatentEffectList.at(i)->GetConditionsID() == LATENT_PARTY_MEMBERS)
+        switch (latentEffect->GetConditionsID())
         {
-
-            if (m_LatentEffectList.at(i)->GetConditionsValue() <= members)
+        case LATENT_PARTY_MEMBERS:
+            if (latentEffect->GetConditionsValue() <= members)
             {
-                m_LatentEffectList.at(i)->Activate();
+                latentEffect->Activate();
             }
             else
             {
-                m_LatentEffectList.at(i)->Deactivate();
+                latentEffect->Deactivate();
             }
-        }
-
-        if (m_LatentEffectList.at(i)->GetConditionsID() == LATENT_PARTY_MEMBERS_IN_ZONE)
-        {
-            int inZone = 0;
-
-            if (m_LatentEffectList.at(i)->GetConditionsValue() <= members)
+        case LATENT_PARTY_MEMBERS_IN_ZONE:
+            if (latentEffect->GetConditionsValue() <= members)
             {
-                for (uint8 m = 0; m < members; ++m)
+                auto inZone = 0;
+                for (auto m = 0; m < members; ++m)
                 {
-                    CCharEntity* PMember = (CCharEntity*)m_POwner->PParty->members.at(m);
+                    auto PMember = (CCharEntity*)m_POwner->PParty->members.at(m);
                     if (PMember->getZone() == m_POwner->getZone())
                     {
                         inZone++;
                     }
                 }
 
-                if (inZone == m_LatentEffectList.at(i)->GetConditionsValue())
-                    m_LatentEffectList.at(i)->Activate();
+                if (inZone == latentEffect->GetConditionsValue())
+                {
+                    latentEffect->Activate();
+                }
                 else
-                    m_LatentEffectList.at(i)->Deactivate();
+                {
+                    latentEffect->Deactivate();
+                }
             }
             else
             {
-                if (m_LatentEffectList.at(i)->IsActivated())
-                    m_LatentEffectList.at(i)->Deactivate();
+                latentEffect->Deactivate();
             }
+            break;
+        default:
+            break;
         }
-
-    }
-
-    m_POwner->UpdateHealth();
+    });
 }
 
 void CLatentEffectContainer::CheckLatentsPartyJobs()
 {
-    for (uint16 i = 0; i < m_LatentEffectList.size(); ++i)
+    ProcessLatentEffects([this](CLatentEffect* latentEffect)
     {
-        if (m_LatentEffectList.at(i)->GetConditionsID() == LATENT_JOB_IN_PARTY)
+        switch (latentEffect->GetConditionsID())
         {
-            if (m_POwner->PParty == nullptr)
-            {
-                if (m_LatentEffectList.at(i)->IsActivated() == true)
-                {
-                    m_LatentEffectList.at(i)->Deactivate();
-                }
-            }
-
-            bool ActivateLatent = false;
-
-            if (m_POwner->PParty != nullptr)
-            {
-                for (uint8 m = 0; m < m_POwner->PParty->members.size(); m++)
-                {
-                    CCharEntity* PMember = (CCharEntity*)m_POwner->PParty->members[m];
-                    if (PMember->id != m_POwner->id)
-                    {
-                        if (PMember->GetMJob() == m_LatentEffectList.at(i)->GetConditionsValue())
-                        {
-                            ActivateLatent = true;
-                            break;
-                        }
-                    }
-                }
-
-                if (ActivateLatent == true)
-                    m_LatentEffectList.at(i)->Activate();
-            }
-
-            if (ActivateLatent == false)
-                m_LatentEffectList.at(i)->Deactivate();
+        case LATENT_JOB_IN_PARTY:
+            ProcessLatentEffect(latentEffect);
+            break;
+        default:
+            break;
         }
-    }
-
-    m_POwner->UpdateHealth();
+    });
 }
 
 /************************************************************************
@@ -1454,52 +498,19 @@ void CLatentEffectContainer::CheckLatentsPartyJobs()
 *  activates them if the conditions are met.							*
 *																		*
 ************************************************************************/
-
 void CLatentEffectContainer::CheckLatentsPartyAvatar()
 {
-
-    for (uint16 i = 0; i < m_LatentEffectList.size(); ++i)
+    ProcessLatentEffects([this](CLatentEffect* latentEffect)
     {
-        if (m_LatentEffectList.at(i)->GetConditionsID() == LATENT_AVATAR_IN_PARTY)
+        switch (latentEffect->GetConditionsID())
         {
-            bool ActivateLatent = false;
-            if (m_POwner->PParty != nullptr)
-            {
-                for (uint8 m = 0; m < m_POwner->PParty->members.size(); ++m)
-                {
-                    CCharEntity* PMember = (CCharEntity*)m_POwner->PParty->members.at(m);
-                    if (PMember->PPet != nullptr)
-                    {
-                        CPetEntity* PPet = (CPetEntity*)PMember->PPet;
-
-                        if (PPet->m_PetID == m_LatentEffectList.at(i)->GetConditionsValue() &&
-                            PPet->PAI->IsSpawned())
-                        {
-                            ActivateLatent = true;
-                            break;
-                        }
-                    }
-                }
-            }
-            if (m_POwner->PParty == nullptr && m_POwner->PPet != nullptr)
-            {
-                CPetEntity* PPet = (CPetEntity*)m_POwner->PPet;
-
-                if (PPet->m_PetID == m_LatentEffectList.at(i)->GetConditionsValue() &&
-                    !PPet->isDead())
-                {
-                    ActivateLatent = true;
-                }
-            }
-
-            if (ActivateLatent == true)
-                m_LatentEffectList.at(i)->Activate();
-
-            if (ActivateLatent == false)
-                m_LatentEffectList.at(i)->Deactivate();
+        case LATENT_AVATAR_IN_PARTY:
+            ProcessLatentEffect(latentEffect);
+            break;
+        default:
+            break;
         }
-    }
-    m_POwner->UpdateHealth();
+    });
 }
 
 /************************************************************************
@@ -1508,89 +519,25 @@ void CLatentEffectContainer::CheckLatentsPartyAvatar()
 *  activates them if the conditions are met.							*
 *																		*
 ************************************************************************/
-
 void CLatentEffectContainer::CheckLatentsJobLevel()
 {
-    for (uint16 i = 0; i < m_LatentEffectList.size(); ++i)
+    ProcessLatentEffects([this](CLatentEffect* latentEffect)
     {
-        switch (m_LatentEffectList.at(i)->GetConditionsID())
+        switch (latentEffect->GetConditionsID())
         {
         case LATENT_JOB_LEVEL_EVEN:
-            if (m_POwner->GetMLevel() % 2 == 0)
-            {
-                m_LatentEffectList.at(i)->Activate();
-            }
-            else
-            {
-                m_LatentEffectList.at(i)->Deactivate();
-            }
-            break;
         case LATENT_JOB_LEVEL_ODD:
-            if (m_POwner->GetMLevel() % 2 == 1)
-            {
-                m_LatentEffectList.at(i)->Activate();
-            }
-            else
-            {
-                m_LatentEffectList.at(i)->Deactivate();
-            }
-            break;
         case LATENT_JOB_MULTIPLE_5:
-            if (m_POwner->GetMLevel() % 5 == 0)
-            {
-                m_LatentEffectList.at(i)->Activate();
-            }
-            else
-            {
-                m_LatentEffectList.at(i)->Deactivate();
-            }
-            break;
         case LATENT_JOB_MULTIPLE_10:
-            if (m_POwner->GetMLevel() % 10 == 0)
-            {
-                m_LatentEffectList.at(i)->Activate();
-            }
-            else
-            {
-                m_LatentEffectList.at(i)->Deactivate();
-            }
-            break;
         case LATENT_JOB_MULTIPLE_13_NIGHT:
-        {
-            TIMETYPE VanadielTOTD = CVanaTime::getInstance()->SyncTime();
-            if (m_POwner->GetMLevel() % 13 == 0 && (VanadielTOTD == TIME_NIGHT))
-            {
-                m_LatentEffectList.at(i)->Activate();
-            }
-            else
-            {
-                m_LatentEffectList.at(i)->Deactivate();
-            }
-        }
-        break;
         case LATENT_JOB_LEVEL_BELOW:
-            if (m_POwner->GetMLevel() < m_LatentEffectList.at(i)->GetConditionsValue())
-            {
-                m_LatentEffectList.at(i)->Activate();
-            }
-            else
-            {
-                m_LatentEffectList.at(i)->Deactivate();
-            }
-            break;
         case LATENT_JOB_LEVEL_ABOVE:
-            if (m_POwner->GetMLevel() >= m_LatentEffectList.at(i)->GetConditionsValue())
-            {
-                m_LatentEffectList.at(i)->Activate();
-            }
-            else
-            {
-                m_LatentEffectList.at(i)->Deactivate();
-            }
+            ProcessLatentEffect(latentEffect);
+            break;
         default:
             break;
         }
-    }
+    });
 }
 
 /************************************************************************
@@ -1599,24 +546,19 @@ void CLatentEffectContainer::CheckLatentsJobLevel()
 *  activates them if the conditions are met.							*
 *																		*
 ************************************************************************/
-
-void CLatentEffectContainer::CheckLatentsPetType(uint8 petID)
+void CLatentEffectContainer::CheckLatentsPetType()
 {
-    for (uint16 i = 0; i < m_LatentEffectList.size(); ++i)
+    ProcessLatentEffects([this](CLatentEffect* latentEffect)
     {
-        if (m_LatentEffectList.at(i)->GetConditionsID() == LATENT_PET_ID)
+        switch (latentEffect->GetConditionsID())
         {
-            CLatentEffect* latent = m_LatentEffectList.at(i);
-            if (latent->GetConditionsValue() == petID)
-            {
-                latent->Activate();
-            }
-            else
-            {
-                latent->Deactivate();
-            }
+        case LATENT_PET_ID:
+            ProcessLatentEffect(latentEffect);
+            break;
+        default:
+            break;
         }
-    }
+    });
 }
 
 /************************************************************************
@@ -1629,7 +571,7 @@ void CLatentEffectContainer::CheckLatentsPetType(uint8 petID)
 //will probably only call this at transition points in the day
 void CLatentEffectContainer::CheckLatentsTime()
 {
-
+    // todo: this isn't called anywhere
 }
 
 /************************************************************************
@@ -1637,20 +579,15 @@ void CLatentEffectContainer::CheckLatentsTime()
 *  Checks all latents that are affected by weapon skill points			*
 *																		*
 ************************************************************************/
-
 void CLatentEffectContainer::CheckLatentsWeaponBreak(uint8 slot)
 {
-    for (uint16 i = 0; i < m_LatentEffectList.size(); ++i)
+    ProcessLatentEffects([this, slot](CLatentEffect* latentEffect)
     {
-        if (m_LatentEffectList.at(i)->GetConditionsID() == LATENT_WEAPON_BROKEN && m_LatentEffectList.at(i)->GetConditionsValue() == slot)
+        if (latentEffect->GetConditionsID() == LATENT_WEAPON_BROKEN && latentEffect->GetConditionsValue() == slot)
         {
-            CItemWeapon* PWeaponMain = (CItemWeapon*)m_POwner->getEquip((SLOTTYPE)slot);
-            if (PWeaponMain && PWeaponMain->isUnlocked() && m_LatentEffectList.at(i)->GetSlot() == slot)
-            {
-                m_LatentEffectList.at(i)->Activate();
-            }
+            ProcessLatentEffect(latentEffect);
         }
-    }
+    });
 }
 
 /************************************************************************
@@ -1658,127 +595,23 @@ void CLatentEffectContainer::CheckLatentsWeaponBreak(uint8 slot)
 *  Checks all latents regarding current zone							*
 *																		*
 ************************************************************************/
-
 void CLatentEffectContainer::CheckLatentsZone()
 {
-    for (uint16 i = 0; i < m_LatentEffectList.size(); ++i)
+    ProcessLatentEffects([this](CLatentEffect* latentEffect)
     {
-        switch (m_LatentEffectList.at(i)->GetConditionsID())
+        switch (latentEffect->GetConditionsID())
         {
         case LATENT_ZONE:
-            if (m_LatentEffectList.at(i)->GetConditionsValue() == m_POwner->getZone())
-            {
-                m_LatentEffectList.at(i)->Activate();
-            }
-            else
-            {
-                m_LatentEffectList.at(i)->Deactivate();
-            }
-            break;
         case LATENT_IN_DYNAMIS:
-            if (m_POwner->isInDynamis())
-            {
-                m_LatentEffectList.at(i)->Activate();
-            }
-            else
-            {
-                m_LatentEffectList.at(i)->Deactivate();
-            }
-            break;
         case LATENT_WEATHER_ELEMENT:
-            if (m_LatentEffectList.at(i)->GetConditionsValue() == zoneutils::GetWeatherElement(battleutils::GetWeather((CBattleEntity*)m_POwner, false)))
-            {
-                m_LatentEffectList.at(i)->Activate();
-            }
-            else
-            {
-                m_LatentEffectList.at(i)->Deactivate();
-            }
-            break;
         case LATENT_NATION_CONTROL:
-        {
-            //player is logging in/zoning
-            if (m_POwner->loc.zone == nullptr)
-            {
-                continue;
-            }
-
-            bool ActivateLatent = false;
-
-            REGIONTYPE region = m_POwner->loc.zone->GetRegionID();
-
-            bool hasSignet = m_POwner->StatusEffectContainer->HasStatusEffect(EFFECT_SIGNET);
-            bool hasSanction = m_POwner->StatusEffectContainer->HasStatusEffect(EFFECT_SANCTION);
-            bool hasSigil = m_POwner->StatusEffectContainer->HasStatusEffect(EFFECT_SIGIL);
-
-            //under own nation's control
-            if (m_LatentEffectList.at(i)->GetConditionsValue() == 0)
-            {
-                if (region < 28)
-                {
-                    if (conquest::GetRegionOwner(region) == m_POwner->profile.nation && (hasSignet || hasSanction || hasSigil))
-                        ActivateLatent = true;
-                }
-            }
-
-            //outside of own nation's control
-            if (m_LatentEffectList.at(i)->GetConditionsValue() == 1)
-            {
-                if (region < 28)
-                {
-
-                    if (m_POwner->profile.nation != conquest::GetRegionOwner(region) && (hasSignet || hasSanction || hasSigil))
-                        ActivateLatent = true;
-                }
-
-            }
-
-            if (ActivateLatent == true)
-                m_LatentEffectList.at(i)->Activate();
-            else
-                m_LatentEffectList.at(i)->Deactivate();
-
-        }
-        break;
         case LATENT_ZONE_HOME_NATION:
-        {
-            //player is logging in/zoning
-            if (m_POwner->loc.zone == nullptr)
-            {
-                continue;
-            }
-
-            CZone* PZone = m_POwner->loc.zone;
-
-            bool ActivateLatent = false;
-
-            //sandoria
-            if (m_POwner->profile.nation == 0 && PZone->GetRegionID() == REGION_SANDORIA && m_LatentEffectList.at(i)->GetConditionsValue() == REGION_SANDORIA)
-            {
-                ActivateLatent = true;
-            }
-            //bastok
-            else if (m_POwner->profile.nation == 1 && PZone->GetRegionID() == REGION_BASTOK && m_LatentEffectList.at(i)->GetConditionsValue() == REGION_BASTOK)
-            {
-                ActivateLatent = true;
-            }
-            //windurst
-            else if (m_POwner->profile.nation == 2 && PZone->GetRegionID() == REGION_WINDURST && m_LatentEffectList.at(i)->GetConditionsValue() == REGION_WINDURST)
-            {
-                ActivateLatent = true;
-            }
-
-            if (ActivateLatent)
-                m_LatentEffectList.at(i)->Activate();
-            else
-                m_LatentEffectList.at(i)->Deactivate();
-        }
-        break;
+            ProcessLatentEffect(latentEffect);
+            break;
         default:
             break;
         }
-    }
-    m_POwner->UpdateHealth();
+    });
 }
 
 /************************************************************************
@@ -1798,16 +631,444 @@ void CLatentEffectContainer::CheckLatentsWeather(uint16 weather)
         if (m_LatentEffectList.at(i)->GetConditionsID() == LATENT_WEATHER_ELEMENT)
         {
             auto element = zoneutils::GetWeatherElement(battleutils::GetWeather((CBattleEntity*)m_POwner, false, weather));
-            if (m_LatentEffectList.at(i)->GetConditionsValue() == element)
-            {
-                m_LatentEffectList.at(i)->Activate();
-            }
-            else
-            {
-                m_LatentEffectList.at(i)->Deactivate();
-            }
-
-            m_POwner->UpdateHealth();
+            ApplyLatentEffect(m_LatentEffectList.at(i), m_LatentEffectList.at(i)->GetConditionsValue() == element);
         }
+    }
+    m_POwner->UpdateHealth();
+}
+
+// Process the latent effects container and apply a logic function responsible for
+// filtering the appropriate latents to be activated/deactivated and finally update
+// health post looping
+void CLatentEffectContainer::ProcessLatentEffects(std::function <void(CLatentEffect*)> logic)
+{
+    for (auto latentEffect : m_LatentEffectList)
+    {
+        logic(latentEffect);
+    }
+    m_POwner->UpdateHealth();
+}
+
+// Processes a single CLatentEffect* and finds the expression to evaluate for
+// activation/deactivation and attempts to apply
+void CLatentEffectContainer::ProcessLatentEffect(CLatentEffect* latentEffect)
+{
+    // Our default case un-finds our latent prevent us from toggling a latent we don't have programmed
+    auto expression = false;
+    auto latentFound = true;
+
+    // find the latent type from the enum and find the expression to tests againts
+    switch (latentEffect->GetConditionsID())
+    {
+    case LATENT_HP_UNDER_PERCENT:
+        expression = ((float)m_POwner->health.hp / m_POwner->health.maxhp) * 100 <= latentEffect->GetConditionsValue();
+        break;
+    case LATENT_HP_OVER_PERCENT:
+        expression = ((float)m_POwner->health.hp / m_POwner->health.maxhp) * 100 >= latentEffect->GetConditionsValue();
+        break;
+    case LATENT_HP_UNDER_TP_UNDER_100:
+        expression = ((float)m_POwner->health.hp / m_POwner->health.maxhp) * 100 <= latentEffect->GetConditionsValue() && m_POwner->health.tp < 1000;
+        break;
+    case LATENT_HP_OVER_TP_UNDER_100:
+        expression = ((float)m_POwner->health.hp / m_POwner->health.maxhp) * 100 >= latentEffect->GetConditionsValue() && m_POwner->health.tp < 1000;
+        break;
+    case LATENT_MP_UNDER_PERCENT:
+        expression = m_POwner->health.maxmp && (float)(m_POwner->health.mp / m_POwner->health.maxmp) * 100 <= latentEffect->GetConditionsValue();
+        break;
+    case LATENT_MP_UNDER:
+        expression = m_POwner->health.mp <= latentEffect->GetConditionsValue();
+        break;
+    case LATENT_TP_UNDER:
+        expression = m_POwner->health.tp < latentEffect->GetConditionsValue();
+        break;
+    case LATENT_TP_OVER:
+        expression = m_POwner->health.tp > latentEffect->GetConditionsValue();
+        break;
+    case LATENT_SUBJOB:
+        expression = m_POwner->GetSJob() == latentEffect->GetConditionsValue();
+        break;
+    case LATENT_PET_ID:
+        expression = m_POwner->PPet != nullptr && m_POwner->PPet->objtype == TYPE_PET && ((CPetEntity*)m_POwner->PPet)->m_PetID == latentEffect->GetConditionsValue();
+        break;
+    case LATENT_WEAPON_DRAWN:
+        expression = m_POwner->animation == ANIMATION_ATTACK;
+        break;
+    case LATENT_WEAPON_SHEATHED:
+        expression = m_POwner->animation != ANIMATION_ATTACK;
+        break;
+    case LATENT_STATUS_EFFECT_ACTIVE:
+        expression = m_POwner->StatusEffectContainer->HasStatusEffect((EFFECT)latentEffect->GetConditionsValue());
+        break;
+    case LATENT_NO_FOOD_ACTIVE:
+        expression = !m_POwner->StatusEffectContainer->HasStatusEffect(EFFECT_FOOD);
+        break;
+    case LATENT_PARTY_MEMBERS:
+        expression = m_POwner->PParty != nullptr && latentEffect->GetConditionsValue() <= m_POwner->PParty->members.size();
+        break;
+    case LATENT_PARTY_MEMBERS_IN_ZONE:
+    {
+        auto inZone = 0;
+        if (m_POwner->PParty != nullptr)
+        {
+            for (auto member : m_POwner->PParty->members)
+            {
+                if (member->getZone() == m_POwner->getZone())
+                {
+                    ++inZone;
+                }
+            }
+        }
+        expression = latentEffect->GetConditionsValue() <= inZone;
+        break;
+    }
+    case LATENT_AVATAR_IN_PARTY:
+        if (m_POwner->PParty != nullptr)
+        {
+            for (auto member : m_POwner->PParty->members)
+            {
+                if (member->PPet != nullptr)
+                {
+                    auto PPet = (CPetEntity*)member->PPet;
+                    if (PPet->m_PetID == latentEffect->GetConditionsValue() &&
+                        PPet->PAI->IsSpawned())
+                    {
+                        expression = true;
+                        break;
+                    }
+                }
+            }
+        }
+        else if (m_POwner->PParty == nullptr && m_POwner->PPet != nullptr)
+        {
+            auto PPet = (CPetEntity*)m_POwner->PPet;
+            if (PPet->m_PetID == latentEffect->GetConditionsValue() &&
+                !PPet->isDead())
+            {
+                expression = true;
+            }
+        }
+        break;
+    case LATENT_JOB_IN_PARTY:
+        if (m_POwner->PParty != nullptr)
+        {
+            for (auto member : m_POwner->PParty->members)
+            {
+                if (member->id != m_POwner->id)
+                {
+                    if (member->GetMJob() == latentEffect->GetConditionsValue())
+                    {
+                        expression = true;
+                        break;
+                    }
+                }
+            }
+        }
+        break;
+    case LATENT_ZONE:
+        expression = latentEffect->GetConditionsValue() == m_POwner->getZone();
+        break;
+    case LATENT_SYNTH_TRAINEE:
+        // todo: figure this out
+        break;
+    case LATENT_SONG_ROLL_ACTIVE:
+        expression = m_POwner->StatusEffectContainer->HasStatusEffectByFlag(EFFECTFLAG_ROLL | EFFECTFLAG_SONG);
+        break;
+    case LATENT_TIME_OF_DAY:
+    {
+        uint32 VanadielHour = CVanaTime::getInstance()->getHour();
+        switch (latentEffect->GetConditionsValue())
+        {
+        case 0:
+            //daytime: 06:00 to 18:00
+            expression = VanadielHour > 5 && VanadielHour < 18;
+            break;
+        case 1:
+            //nighttime: 18:00 to 06:00
+            expression = VanadielHour >= 18 || VanadielHour < 6;
+            break;
+        case 2:
+            //dusk - dawn: 17:00 to 7:00
+            expression = VanadielHour >= 17 || VanadielHour < 7;
+            break;
+        }
+        break;
+    }
+    case LATENT_HOUR_OF_DAY:
+    {
+        uint32 VanadielHour = CVanaTime::getInstance()->getHour();
+        switch (latentEffect->GetConditionsValue())
+        {
+        case 1:
+            //new day
+            expression = VanadielHour == 4;
+            break;
+        case 2:
+            //dawn
+            expression = VanadielHour == 6;
+            break;
+        case 3:
+            //day
+            expression = VanadielHour >= 7 && VanadielHour < 17;
+            break;
+        case 4:
+            //dusk
+            expression = VanadielHour >= 16 && VanadielHour < 18;
+            break;
+        case 5:
+            //evening
+            expression = VanadielHour >= 18 && VanadielHour < 20;
+            break;
+        case 6:
+            //dead of night
+            expression = VanadielHour < 4 || VanadielHour <= 20;
+            break;
+        }
+        break;
+    }
+    case LATENT_FIRESDAY:
+        expression = CVanaTime::getInstance()->getWeekday() == FIRESDAY;
+        break;
+    case LATENT_EARTHSDAY:
+        expression = CVanaTime::getInstance()->getWeekday() == EARTHSDAY;
+        break;
+    case LATENT_WATERSDAY:
+        expression = CVanaTime::getInstance()->getWeekday() == WATERSDAY;
+        break;
+    case LATENT_WINDSDAY:
+        expression = CVanaTime::getInstance()->getWeekday() == WINDSDAY;
+        break;
+    case LATENT_DARKSDAY:
+        expression = CVanaTime::getInstance()->getWeekday() == DARKSDAY;
+        break;
+    case LATENT_ICEDAY:
+        expression = CVanaTime::getInstance()->getWeekday() == ICEDAY;
+        break;
+    case LATENT_LIGHTNINGSDAY:
+        expression = CVanaTime::getInstance()->getWeekday() == LIGHTNINGDAY;
+        break;
+    case LATENT_LIGHTSDAY:
+        expression = CVanaTime::getInstance()->getWeekday() == LIGHTSDAY;
+        break;
+    case LATENT_MOON_PHASE:
+    {
+        uint32 MoonPhase = CVanaTime::getInstance()->getMoonPhase();
+        uint32 MoonDirection = CVanaTime::getInstance()->getMoonDirection(); //directions: 1 = waning, 2 = waxing, 0 = neither
+        switch (latentEffect->GetConditionsValue())
+        {
+        case 0:
+            //New Moon - 10% waning -> 5% waxing
+            expression = MoonPhase <= 5 || (MoonPhase <= 10 && MoonDirection == 1);
+            break;
+        case 1:
+            //Waxing Crescent - 7% -> 38% waxing
+            expression = MoonPhase >= 7 && MoonPhase <= 38 && MoonDirection == 2;
+            break;
+        case 2:
+            //First Quarter - 40%% -> 55% waxing
+            expression = MoonPhase >= 40 && MoonPhase <= 55 && MoonDirection == 2;
+            break;
+        case 3:
+            //Waxing Gibbous - 57% -> 88%
+            expression = MoonPhase >= 57 && MoonPhase <= 88 && MoonDirection == 2;
+            break;
+        case 4:
+            //Full Moon - waxing 90% -> waning 95%
+            expression = MoonPhase >= 95 || (MoonPhase >= 90 && MoonDirection == 2);
+            break;
+        case 5:
+            //Waning Gibbous - 93% -> 62%
+            expression = MoonPhase >= 62 && MoonPhase <= 93 && MoonDirection == 1;
+            break;
+        case 6:
+            //Last Quarter - 60% -> 45%
+            expression = MoonPhase >= 45 && MoonPhase <= 60 && MoonDirection == 1;
+            break;
+        case 7:
+            //Waning Crescent - 43% -> 12%
+            expression = MoonPhase >= 12 && MoonPhase <= 43 && MoonDirection == 1;
+            break;
+        }
+        break;
+    }
+    case LATENT_JOB_MULTIPLE_5:
+        expression = m_POwner->GetMLevel() % 5 == 0;
+        break;
+    case LATENT_JOB_MULTIPLE_10:
+        expression = m_POwner->GetMLevel() % 10 == 0;
+        break;
+    case LATENT_JOB_MULTIPLE_13_NIGHT:
+        expression = m_POwner->GetMLevel() % 13 == 0 && CVanaTime::getInstance()->SyncTime() == TIME_NIGHT;
+        break;
+    case LATENT_JOB_LEVEL_ODD:
+        expression = m_POwner->GetMLevel() % 2 == 1;
+        break;
+    case LATENT_JOB_LEVEL_EVEN:
+        expression = m_POwner->GetMLevel() % 2 == 0;
+        break;
+    case LATENT_WEAPON_DRAWN_HP_UNDER:
+        expression = m_POwner->health.hp < latentEffect->GetConditionsValue() && m_POwner->animation == ANIMATION_ATTACK;
+        break;
+    case LATENT_MP_UNDER_VISIBLE_GEAR:
+        //TODO: figure out if this is actually right
+        //CItemArmor* head = (CItemArmor*)(m_POwner->getStorage(LOC_INVENTORY)->GetItem(m_POwner->equip[SLOT_HEAD]));
+        //CItemArmor* body = (CItemArmor*)(m_POwner->getStorage(LOC_INVENTORY)->GetItem(m_POwner->equip[SLOT_BODY]));
+        //CItemArmor* hands = (CItemArmor*)(m_POwner->getStorage(LOC_INVENTORY)->GetItem(m_POwner->equip[SLOT_HANDS]));
+        //CItemArmor* legs = (CItemArmor*)(m_POwner->getStorage(LOC_INVENTORY)->GetItem(m_POwner->equip[SLOT_LEGS]));
+        //CItemArmor* feet = (CItemArmor*)(m_POwner->getStorage(LOC_INVENTORY)->GetItem(m_POwner->equip[SLOT_FEET]));
+
+        //int32 visibleMp = 0;
+        //visibleMp += (head ? head->getModifier(Mod::MP) : 0);
+        //visibleMp += (body ? body->getModifier(Mod::MP) : 0);
+        //visibleMp += (hands ? hands->getModifier(Mod::MP) : 0);
+        //visibleMp += (legs ? legs->getModifier(Mod::MP) : 0);
+        //visibleMp += (feet ? feet->getModifier(Mod::MP) : 0);
+
+        //TODO: add mp percent too
+        //if ((float)( mp / ((m_POwner->health.mp - m_POwner->health.modmp) + (m_POwner->PMeritPoints->GetMerit(MERIT_MAX_MP)->count * 10 ) + 
+        //    visibleMp) ) <= m_LatentEffectList.at(i)->GetConditionsValue())
+        //{
+        //    m_LatentEffectList.at(i)->Activate();
+        //}
+        //else
+        //{
+        //    m_LatentEffectList.at(i)->Deactivate();
+        //}
+        break;
+    case LATENT_HP_OVER_VISIBLE_GEAR:
+        //TODO: figure out if this is actually right
+        //CItemArmor* head = (CItemArmor*)(m_POwner->getStorage(LOC_INVENTORY)->GetItem(m_POwner->equip[SLOT_HEAD]));
+        //CItemArmor* body = (CItemArmor*)(m_POwner->getStorage(LOC_INVENTORY)->GetItem(m_POwner->equip[SLOT_BODY]));
+        //CItemArmor* hands = (CItemArmor*)(m_POwner->getStorage(LOC_INVENTORY)->GetItem(m_POwner->equip[SLOT_HANDS]));
+        //CItemArmor* legs = (CItemArmor*)(m_POwner->getStorage(LOC_INVENTORY)->GetItem(m_POwner->equip[SLOT_LEGS]));
+        //CItemArmor* feet = (CItemArmor*)(m_POwner->getStorage(LOC_INVENTORY)->GetItem(m_POwner->equip[SLOT_FEET]));
+
+        //int32 visibleHp = 0;
+        //visibleHp += (head ? head->getModifier(Mod::HP) : 0);
+        //visibleHp += (body ? body->getModifier(Mod::HP) : 0);
+        //visibleHp += (hands ? hands->getModifier(Mod::HP) : 0);
+        //visibleHp += (legs ? legs->getModifier(Mod::HP) : 0);
+        //visibleHp += (feet ? feet->getModifier(Mod::HP) : 0);
+
+        //TODO: add mp percent too
+        //if ((float)( hp / ((m_POwner->health.hp - m_POwner->health.modhp) + (m_POwner->PMeritPoints->GetMerit(MERIT_MAX_HP)->count * 10 ) + 
+        //    visibleHp) ) <= m_LatentEffectList.at(i)->GetConditionsValue())
+        //{
+        //    m_LatentEffectList.at(i)->Activate();
+        //}
+        //else
+        //{
+        //    m_LatentEffectList.at(i)->Deactivate();
+        //}
+        break;
+    case LATENT_WEAPON_BROKEN:
+    {
+        auto slot = latentEffect->GetSlot();
+        auto item = (CItemWeapon*)m_POwner->getEquip((SLOTTYPE)slot);
+        switch (slot)
+        {
+        case SLOT_MAIN:
+        case SLOT_SUB:
+        case SLOT_RANGED:
+            expression = item != nullptr && item->isUnlocked();
+            break;
+        }
+        break;
+    }
+    case LATENT_IN_DYNAMIS:
+        expression = m_POwner->isInDynamis();
+        break;
+    case LATENT_FOOD_ACTIVE:
+        expression = m_POwner->StatusEffectContainer->HasStatusEffect(EFFECT_FOOD) &&
+            m_POwner->StatusEffectContainer->GetStatusEffect(EFFECT_FOOD)->GetSubID() == latentEffect->GetConditionsValue();
+        break;
+    case LATENT_JOB_LEVEL_BELOW:
+        expression = m_POwner->GetMLevel() < latentEffect->GetConditionsValue();
+        break;
+    case LATENT_JOB_LEVEL_ABOVE:
+        expression = m_POwner->GetMLevel() >= latentEffect->GetConditionsValue();
+        break;
+    case LATENT_WEATHER_ELEMENT:
+        expression = latentEffect->GetConditionsValue() == zoneutils::GetWeatherElement(battleutils::GetWeather((CBattleEntity*)m_POwner, false));
+        break;
+    case LATENT_NATION_CONTROL:
+    {
+        //player is logging in/zoning
+        if (m_POwner->loc.zone == nullptr)
+        {
+            break;
+        }
+
+        auto region = m_POwner->loc.zone->GetRegionID();
+        auto hasSignet = m_POwner->StatusEffectContainer->HasStatusEffect(EFFECT_SIGNET);
+        auto hasSanction = m_POwner->StatusEffectContainer->HasStatusEffect(EFFECT_SANCTION);
+        auto hasSigil = m_POwner->StatusEffectContainer->HasStatusEffect(EFFECT_SIGIL);
+
+        switch (latentEffect->GetConditionsValue())
+        {
+        case 0:
+            //under own nation's control
+            expression = region < 28 && conquest::GetRegionOwner(region) == m_POwner->profile.nation && (hasSignet || hasSanction || hasSigil);
+            break;
+        case 1:
+            //outside of own nation's control
+            expression = region < 28 && m_POwner->profile.nation != conquest::GetRegionOwner(region) && (hasSignet || hasSanction || hasSigil);
+            break;
+        }
+        break;
+    }
+    case LATENT_ZONE_HOME_NATION:
+    {
+        //player is logging in/zoning
+        if (m_POwner->loc.zone == nullptr)
+        {
+            break;
+        }
+
+        auto PZone = m_POwner->loc.zone;
+        auto region = (REGIONTYPE)latentEffect->GetConditionsValue();
+
+        switch (region)
+        {
+        case REGION_SANDORIA:
+            expression = m_POwner->profile.nation == 0 && PZone->GetRegionID() == region;
+            break;
+        case REGION_BASTOK:
+            expression = m_POwner->profile.nation == 1 && PZone->GetRegionID() == region;
+            break;
+        case REGION_WINDURST:
+            expression = m_POwner->profile.nation == 2 && PZone->GetRegionID() == region;
+            break;
+        }
+        break;
+    }
+    case LATENT_MP_OVER:
+        expression = m_POwner->health.mp >= latentEffect->GetConditionsValue();
+        break;
+    case LATENT_WEAPON_DRAWN_MP_OVER:
+        expression = m_POwner->health.mp > latentEffect->GetConditionsValue() && m_POwner->animation == ANIMATION_ATTACK;
+        break;
+    default:
+        latentFound = false;
+        ShowWarning("Latent ID %d unhandled in ProcessLatentEffect\n", latentEffect->GetConditionsID());
+        break;
+    }
+
+    // if we did not hit the default case, attempt to apply the latent effect based on the expression
+    if (latentFound)
+    {
+        ApplyLatentEffect(latentEffect, expression);
+    }
+}
+
+// Activates a latent effect if true otherwise deactivates the latent effect
+void CLatentEffectContainer::ApplyLatentEffect(CLatentEffect* effect, bool expression)
+{
+    if (expression)
+    {
+        effect->Activate();
+    }
+    else
+    {
+        effect->Deactivate();
     }
 }

--- a/src/map/latent_effect_container.h
+++ b/src/map/latent_effect_container.h
@@ -42,14 +42,14 @@ class CLatentEffectContainer
 {
 public:
 
-	void CheckLatentsHP(int32 hp);
-	void CheckLatentsTP(int16 tp);
-	void CheckLatentsMP(int32 mp);
+	void CheckLatentsHP();
+	void CheckLatentsTP();
+	void CheckLatentsMP();
 	void CheckLatentsEquip(uint8 slot);
 	void CheckLatentsWeaponDraw(bool drawn);
 	void CheckLatentsStatusEffect();
 	void CheckLatentsFoodEffect();
-	void CheckLatentsRollSong(bool active);
+	void CheckLatentsRollSong();
 	void CheckLatentsDay();
 	void CheckLatentsMoonPhase();
 	void CheckLatentsHours();
@@ -58,7 +58,7 @@ public:
 	void CheckLatentsPartyJobs();
 	void CheckLatentsPartyAvatar();
 	void CheckLatentsJobLevel();
-	void CheckLatentsPetType(uint8 petID);
+	void CheckLatentsPetType();
 	void CheckLatentsTime();
 	void CheckLatentsWeaponBreak(uint8 slot);
 	void CheckLatentsZone();
@@ -67,9 +67,7 @@ public:
 
 	void AddLatentEffect(CLatentEffect* LatentEffect);
 	void AddLatentEffects(std::vector<CLatentEffect*> *latentList, uint8 reqLvl, uint8 slot);
-	void DelLatentEffects(uint8 reqLvl, uint8 slot);   
-
-    CLatentEffect* GetLatentEffect(uint8 slot, uint16 modId);
+	void DelLatentEffects(uint8 reqLvl, uint8 slot);
 
 	 CLatentEffectContainer(CCharEntity* PEntity);
 	~CLatentEffectContainer();
@@ -77,8 +75,11 @@ public:
 private:
 
 	CCharEntity* m_POwner;
-
 	std::vector<CLatentEffect*>	m_LatentEffectList;
+
+    void ProcessLatentEffects(std::function <void(CLatentEffect*)> logic);
+    void ProcessLatentEffect(CLatentEffect* latentEffect);
+    void ApplyLatentEffect(CLatentEffect* effect, bool expression);
 };
 
 #endif

--- a/src/map/status_effect_container.cpp
+++ b/src/map/status_effect_container.cpp
@@ -393,7 +393,7 @@ bool CStatusEffectContainer::AddStatusEffect(CStatusEffect* PStatusEffect, bool 
                 //check for latents
                 PChar->PLatentEffectContainer->CheckLatentsFoodEffect();
                 PChar->PLatentEffectContainer->CheckLatentsStatusEffect();
-                PChar->PLatentEffectContainer->CheckLatentsRollSong(PStatusEffect->GetFlag() & (EFFECTFLAG_SONG | EFFECTFLAG_ROLL));
+                PChar->PLatentEffectContainer->CheckLatentsRollSong();
                 PChar->UpdateHealth();
             }
             PChar->pushPacket(new CCharSyncPacket(PChar));
@@ -446,7 +446,7 @@ void CStatusEffectContainer::RemoveStatusEffect(uint32 id, bool silent)
         //check for latents
         PChar->PLatentEffectContainer->CheckLatentsFoodEffect();
         PChar->PLatentEffectContainer->CheckLatentsStatusEffect();
-        PChar->PLatentEffectContainer->CheckLatentsRollSong(HasStatusEffectByFlag(EFFECTFLAG_SONG | EFFECTFLAG_ROLL));
+        PChar->PLatentEffectContainer->CheckLatentsRollSong();
         PChar->UpdateHealth();
 
         PChar->pushPacket(new CCharSyncPacket(PChar));

--- a/src/map/utils/petutils.cpp
+++ b/src/map/utils/petutils.cpp
@@ -768,7 +768,7 @@ namespace petutils
                 ((CCharEntity*)PMaster)->pushPacket(new CPetSyncPacket((CCharEntity*)PMaster));
 
                 // check latents affected by pets
-                ((CCharEntity*)PMaster)->PLatentEffectContainer->CheckLatentsPetType(PetID);
+                ((CCharEntity*)PMaster)->PLatentEffectContainer->CheckLatentsPetType();
                 PMaster->ForParty([](CBattleEntity* PMember) {
                     ((CCharEntity*)PMember)->PLatentEffectContainer->CheckLatentsPartyAvatar();
                 });
@@ -908,7 +908,7 @@ namespace petutils
             if (PPetEnt->getPetType() == PETTYPE_AVATAR)
                 PMaster->setModifier(Mod::AVATAR_PERPETUATION, 0);
 
-            ((CCharEntity*)PMaster)->PLatentEffectContainer->CheckLatentsPetType(-1);
+            ((CCharEntity*)PMaster)->PLatentEffectContainer->CheckLatentsPetType();
             PMaster->ForParty([](CBattleEntity* PMember){
                 ((CCharEntity*)PMember)->PLatentEffectContainer->CheckLatentsPartyAvatar();
             });


### PR DESCRIPTION
- Adding getmod to check the mod value of a player - getmod $modid
- Sorting latent_effect.h and adding placeholders for unused values
- Adding three helper methods to streamline latent processing:
ProcessLatentEffects, ProcessLatentEffect, and ApplyLatentEffect
- Removing GetLatentEffect definition in header - not declared/used
anywhere
- Removing parameters from some latent check functions because the value
is available in the checking code already
- Updating functions that called latent check functions that previously
required parameters
- We currently duplicate "ALOT" of latent checking code and in some
instances we would be mid-loop processing and dive into another loop of
processing for specific latent types (I made this mistake for weather,
but prior cases existed)