### PR TITLE
Addressing some Lua Issues

### DIFF
--- a/scripts/globals/bcnm.lua
+++ b/scripts/globals/bcnm.lua
@@ -90,7 +90,7 @@ function TradeBCNM(player, zone, trade, npc)
     if (player:hasStatusEffect(EFFECT_BATTLEFIELD)) then -- cant start a new bc
         player:messageBasic(94, 0, 0);
         return false;
-    elseif (player:hasWornItem(trade:getItemId())) then -- If already used orb or testimony
+    elseif (trade ~= nil and player:hasWornItem(trade:getItemId())) then -- If already used orb or testimony
         player:messageBasic(56, 0, 0); -- i need correct dialog
         return false;
     end

--- a/scripts/globals/crafting.lua
+++ b/scripts/globals/crafting.lua
@@ -272,7 +272,7 @@ function unionRepresentativeTriggerFinish(player, option, target, guildID, curre
                player:messageText(target, NOT_HAVE_ENOUGH_GP, false, 6);
             end
         end
-    elseif (category == 0) then -- HQ crystal
+    elseif (category == 0 and option ~= 1073741824) then -- HQ crystal
         local i = HQCrystals[bit.band(bit.rshift(option, 5), 15)];
         local quantity = bit.rshift(option, 9);
         local cost = quantity * i.cost;

--- a/scripts/zones/Attohwa_Chasm/Zone.lua
+++ b/scripts/zones/Attohwa_Chasm/Zone.lua
@@ -80,16 +80,16 @@ end;
 -----------------------------------
 
 function onRegionEnter(player,region)
-    local Gasponia_Offset = 16806299;
+    local Gasponia_Offset = 16806327;
 
     if (region:GetRegionID() <= 30) then
     -- TODO: Gasponia's shouldn't "always" poison you. However, in retail regions constantly reapply themselves without having to re-enter the region. In DSP that doesn't happen so I'm leaving it as-is for now.
         for i = 0, 30, 1 do
             if (region:GetRegionID() == i) then
-            local Gasponia_Offset = Gasponia_Offset + (i -1);
+                local Gasponia_Offset = Gasponia_Offset + (i -1);
                 GetNPCByID(Gasponia_Offset):openDoor(3);
                 -- print("i is "..i);
-            -- printf("Player is: %s | Flower ID is: %i",player:getName(), Gasponia_Offset);
+                -- printf("Player is: %s | Flower ID is: %i",player:getName(), Gasponia_Offset);
             end
         end
 

--- a/scripts/zones/Attohwa_Chasm/Zone.lua
+++ b/scripts/zones/Attohwa_Chasm/Zone.lua
@@ -86,7 +86,7 @@ function onRegionEnter(player,region)
     -- TODO: Gasponia's shouldn't "always" poison you. However, in retail regions constantly reapply themselves without having to re-enter the region. In DSP that doesn't happen so I'm leaving it as-is for now.
         for i = 0, 30, 1 do
             if (region:GetRegionID() == i) then
-                local Gasponia_Offset = Gasponia_Offset + (i -1);
+                Gasponia_Offset = Gasponia_Offset + (i -1);
                 GetNPCByID(Gasponia_Offset):openDoor(3);
                 -- print("i is "..i);
                 -- printf("Player is: %s | Flower ID is: %i",player:getName(), Gasponia_Offset);

--- a/scripts/zones/Promyvion-Holla/Zone.lua
+++ b/scripts/zones/Promyvion-Holla/Zone.lua
@@ -91,12 +91,12 @@ function onRegionEnter(player,region)
                 player:startEvent(0x002E);
             end,
             [2] = function (x)
-                if (GetNPCByID(16843057):getAnimation() == 8) then
+                if (GetNPCByID(16843058):getAnimation() == 8) then
                     player:startEvent(0x0025);
                 end
             end,
             [3] = function (x)
-                if (GetNPCByID(16843056):getAnimation() == 8) then
+                if (GetNPCByID(16843057):getAnimation() == 8) then
                     if (player:getVar("MemoryReceptacle") == 2) then
                         player:startEvent(0x0021);
                     else
@@ -105,7 +105,7 @@ function onRegionEnter(player,region)
                 end
             end,
             [4] = function (x)
-                if (GetNPCByID(16843055):getAnimation() == 8) then
+                if (GetNPCByID(16843056):getAnimation() == 8) then
                     if (player:getVar("MemoryReceptacle") == 2) then
                         player:startEvent(0x0021);
                     else
@@ -114,7 +114,7 @@ function onRegionEnter(player,region)
                 end
             end,
             [5] = function (x)
-                if (GetNPCByID(16843054):getAnimation() == 8) then
+                if (GetNPCByID(16843055):getAnimation() == 8) then
                     if (player:getVar("MemoryReceptacle") == 2) then
                         player:startEvent(0x0021);
                     else
@@ -123,7 +123,7 @@ function onRegionEnter(player,region)
                 end
             end,
             [6] = function (x)
-                if (GetNPCByID(16843053):getAnimation() == 8) then
+                if (GetNPCByID(16843054):getAnimation() == 8) then
                     if (player:getVar("MemoryReceptacle") == 2) then
                         player:startEvent(0x0021);
                     else
@@ -138,17 +138,17 @@ function onRegionEnter(player,region)
                 player:startEvent(0x002A);
             end,
             [9] = function (x)
-                if (GetNPCByID(16843052):getAnimation() == 8) then
+                if (GetNPCByID(16843053):getAnimation() == 8) then
                     player:startEvent(0x001E);
                 end
             end,
             [10] = function (x)
-                if (GetNPCByID(16843051):getAnimation() == 8) then
+                if (GetNPCByID(16843052):getAnimation() == 8) then
                     player:startEvent(0x001E);
                 end
             end,
             [11] = function (x)
-                if (GetNPCByID(16843050):getAnimation() == 8) then
+                if (GetNPCByID(16843051):getAnimation() == 8) then
                     player:startEvent(0x001E);
                 end
             end,
@@ -156,17 +156,17 @@ function onRegionEnter(player,region)
                 player:startEvent(0x002A);
             end,
             [13] = function (x)
-                if (GetNPCByID(16843060):getAnimation() == 8) then
+                if (GetNPCByID(16843061):getAnimation() == 8) then
                     player:startEvent(0x001E);
                 end
             end,
             [14] = function (x)
-                if (GetNPCByID(16843058):getAnimation() == 8) then
+                if (GetNPCByID(16843059):getAnimation() == 8) then
                     player:startEvent(0x001E);
                 end
             end,
             [15] = function (x)
-                if (GetNPCByID(16843059):getAnimation() == 8) then
+                if (GetNPCByID(16843060):getAnimation() == 8) then
                     player:startEvent(0x001E);
                 end
             end,


### PR DESCRIPTION
- bcnm.lua - accessing trade container when nil (might not be needed)
- crafting.lua - when talking with guild representative and choosing to
exit the conversation it will send a category 0 but with the exit id
(1073741824) and we were trying to handle it like an HQ crystal purchase
- Attohwa Chasm - Gasponia offset shift and caused issues with
displaying the poison
- Promy-Holla - Id's for teleporters near Memory Reps shifted and needed
adjustment
- Fixes #3901