### PR TITLE
removed weather condition for Qu'Hua Spring

### DIFF
--- a/scripts/zones/RoMaeve/npcs/Qu_Hau_Spring.lua
+++ b/scripts/zones/RoMaeve/npcs/Qu_Hau_Spring.lua
@@ -18,7 +18,7 @@ function onTrade(player,npc,trade)
     local DMRepeat = player:getQuestStatus(OUTLANDS,DIVINE_MIGHT_REPEAT);
     local Hour = VanadielHour();
 
-    if (player:getWeather() == 1 and Hour >= 0 and Hour <= 2 and IsMoonFull() == true) then -- Yes, sunshine weather, as Ro'Maeve can't have clear. Misconception on the wiki.
+    if ((Hour >= 18 or Hour < 6) and IsMoonFull() == true) then
         if (DMfirst == QUEST_ACCEPTED or DMRepeat == QUEST_ACCEPTED) then -- allow for Ark Pentasphere on both first and repeat quests
             if (trade:hasItemQty(1408,1) and trade:hasItemQty(917,1) and trade:getItemCount() == 2) then
                 player:startEvent(7,917,1408); -- Ark Pentasphere Trade


### PR DESCRIPTION
set time condition to [18 - 6) to match [bgwiki]( https://www.bg-wiki.com/bg/Ark_Pentasphere).

fixes issue #3957 