### PR TITLE
command input validation and standardization [b-c]

### DIFF
--- a/scripts/commands/addmission.lua
+++ b/scripts/commands/addmission.lua
@@ -17,11 +17,18 @@ function error(player, msg)
 end;
 
 function onTrigger(player, logId, missionId, target)
-    local logName;
 
     -- validate logId
+    local logName;
+    if (logId == nil) then
+        error(player, "You must provide a logID.");
+        return;
+    elseif (tonumber(logId) ~= nil) then
+        logId = tonumber(logId);
+        logId = MISSION_LOGS[logId];
+    end
     if (logId ~= nil) then
-        logId = tonumber(logId) or _G[string.upper(logId)];
+        logId = _G[string.upper(logId)];
     end
     if ((type(logId) == "table") and logId.mission_log ~= nil) then
         logName = logId.full_name;
@@ -31,6 +38,15 @@ function onTrigger(player, logId, missionId, target)
         return;
     end
     
+    -- validate missionId
+    if (missionId ~= nil) then
+        missionId = tonumber(missionId) or _G[string.upper(missionId)];
+    end
+    if (missionId == nil or missionId < 0) then
+        error(player, "Invalid missionID.");
+        return;
+    end
+
     -- validate target
     local targ;
     if (target == nil) then
@@ -41,14 +57,6 @@ function onTrigger(player, logId, missionId, target)
             error(player, string.format("Player named '%s' not found!", target));
             return;
         end
-    end
-
-    -- validate missionId
-    if (missionId == nil) then
-        error(player, "Invalid missionID.");
-        return;
-    else
-        missionId = tonumber(missionId) or _G[string.upper(missionId)];
     end
 
     -- add mission

--- a/scripts/commands/addquest.lua
+++ b/scripts/commands/addquest.lua
@@ -17,11 +17,18 @@ function error(player, msg)
 end;
 
 function onTrigger(player, logId, questId, target)
-    local logName;
 
     -- validate logId
+    local logName;
+    if (logId == nil) then
+        error(player, "You must provide a logID.");
+        return;
+    elseif (tonumber(logId) ~= nil) then
+        logId = tonumber(logId);
+        logId = QUEST_LOGS[logId];
+    end
     if (logId ~= nil) then
-        logId = tonumber(logId) or _G[string.upper(logId)];
+        logId = _G[string.upper(logId)];
     end
     if ((type(logId) == "table") and logId.quest_log ~= nil) then
         logName = logId.full_name;
@@ -31,6 +38,15 @@ function onTrigger(player, logId, questId, target)
         return;
     end
     
+    -- validate questId
+    if (questId ~= nil) then
+        questId = tonumber(questId) or _G[string.upper(questId)];
+    end
+    if (questId == nil or questId < 0) then
+        error(player, "Invalid questID.");
+        return;
+    end
+
     -- validate target
     local targ;
     if (target == nil) then
@@ -41,14 +57,6 @@ function onTrigger(player, logId, questId, target)
             error(player, string.format("Player named '%s' not found!", target));
             return;
         end
-    end
-
-    -- validate questId
-    if (questId == nil) then
-        error(player, "Invalid questID.");
-        return;
-    else
-        questId = tonumber(questId) or _G[string.upper(questId)];
     end
 
     -- add quest

--- a/scripts/commands/bring.lua
+++ b/scripts/commands/bring.lua
@@ -9,16 +9,26 @@ cmdprops =
     parameters = "s"
 };
 
+function error(player, msg)
+    player:PrintToPlayer(msg);
+    player:PrintToPlayer("@bring <player>");
+end;
+
 function onTrigger(player, target)
+    -- validate target
     if (target == nil) then
-        player:PrintToPlayer("You must enter a target player name.");
+        error(player, "You must enter a target player name.");
         return;
     end
-
     local targ = GetPlayerByName( target );
-    if (targ ~= nil) then
-        targ:setPos( player:getXPos(), player:getYPos(), player:getZPos(), 0, player:getZoneID() );
+    if (targ == nil) then
+        error(player, string.format( "Player named '%s' not found!", target ) );
+    end
+    
+    -- bring target
+    if (targ:getZoneID() == player:getZoneID()) then
+        targ:setPos( player:getXPos(), player:getYPos(), player:getZPos(), player:getRotPos() );
     else
-        player:PrintToPlayer( string.format( "Player named '%s' not found!", target ) );
+        targ:setPos( player:getXPos(), player:getYPos(), player:getZPos(), player:getRotPos(), player:getZoneID() );
     end
 end

--- a/scripts/commands/capskill.lua
+++ b/scripts/commands/capskill.lua
@@ -11,31 +11,24 @@ cmdprops =
     parameters = "s"
 };
 
-function onTrigger(player, skill)
-    if (skill == nil) then
-        player:PrintToPlayer( "You must enter a valid skill enum." );
+function error(player, msg)
+    player:PrintToPlayer(msg);
+    player:PrintToPlayer("@capskill <skillID>");
+end;
+
+function onTrigger(player, skillId)
+    -- validate skillId
+    if (skillId == nil) then
+        error(player, "You must provide a skillID.");
+        return;
+    end
+    skillId = tonumber(skillId) or _G[string.upper(skillId)];
+    if (skillId == nil or skillId == 0) then
+        error(player, "Invalid skillID.");
         return;
     end
 
-    skill = tonumber(skill) or _G(skill);
-
-    if (tonumber(skill) ~= 0 and tonumber(skill) ~= nil) then
-        local skillId = tonumber(skill);
-        player:capSkill( skillId );
-
-        for k, v in pairs(skillList) do
-            if (v == skillId) then
-                player:PrintToPlayer( string.format( "Capped skill '%s'.", k ) );
-                return;
-            end
-        end
-    end
-
-    local skillId = skillList[ string.lower( skill ) ];
-    if (skillId == nil) then
-        player:PrintToPlayer( string.format( "Invalid skill '%s' given.", skill ) );
-    else
-        player:capSkill( skillId );
-        player:PrintToPlayer( string.format( "Capped skill '%s'.", skill ) );
-    end
+    -- cap skill
+    player:capSkill( skillId );
+    player:PrintToPlayer( string.format( "Capped skillID %i.", skillId ) );
 end

--- a/scripts/commands/changejob.lua
+++ b/scripts/commands/changejob.lua
@@ -11,26 +11,43 @@ cmdprops =
     parameters = "si"
 };
 
-function onTrigger(player, jobId, level)
-    jobId = tonumber(jobId) or JOBS[string.upper(jobId)];
+function error(player, msg)
+    player:PrintToPlayer(msg);
+    player:PrintToPlayer("@changejob <jobID> {level}");
+end;
 
+function onTrigger(player, jobId, level)
+    -- validate jobId
     if (jobId == nil) then
-        player:PrintToPlayer("You must enter a job ID or short-name.");
+        error(player, "You must enter a job short-name, e.g. WAR, or its equivalent numeric ID.");
+        return;
+    end
+    jobId = tonumber(jobId) or JOBS[string.upper(jobId)];
+    if (JobId == nil or jobId <= 0 or jobId >= MAX_JOB_TYPE) then
+        error(player, "Invalid jobID.  Use job short name, e.g. WAR, or its equivalent numeric ID.");
         return;
     end
 
-   if (jobId <= 0 or jobId >= MAX_JOB_TYPE) then
-       player:PrintToPlayer(string.format("Invalid job '%s' given. Use short-name or id. e.g. WAR", jobId));
-       return;
-   end
-
-    -- Change the players job..
-    player:changeJob(jobId);
-
-    -- Attempt to set the players level..
-    if (level ~= nil and level > 0 and level <= 99) then
-        player:setLevel(level);
-    else
-        player:PrintToPlayer("Invalid level given. Level must be between 1 and 99!");
+    -- validate level
+    if (level ~= nil) then
+        if (level < 1 or level > 99) then
+            error(player, "Invalid level. Level must be between 1 and 99!");
+            return;
+        end
     end
+
+    -- change job and (optionally) level
+    player:changeJob(jobId);
+    if (level ~= nil) then
+        player:setLevel(level);
+    end
+
+    -- invert JOBS table
+    local jobNameByNum={};
+    for k,v in pairs(JOBS) do
+        jobNameByNum[v]=k;
+    end
+
+    -- output new job to player
+    player:PrintToPlayer(string.format("You are now a %s%i/%s%i.", jobNameByNum[player:getMainJob()], player:getMainLvl(), jobNameByNum[player:getSubJob()], player:getSubLvl()));
 end

--- a/scripts/commands/changesjob.lua
+++ b/scripts/commands/changesjob.lua
@@ -11,26 +11,43 @@ cmdprops =
     parameters = "si"
 };
 
-function onTrigger(player, jobId, level)
-    jobId = tonumber(jobId) or JOBS[string.upper(jobId)];
+function error(player, msg)
+    player:PrintToPlayer(msg);
+    player:PrintToPlayer("@changesjob <jobID> {level}");
+end;
 
+function onTrigger(player, jobId, level)
+    -- validate jobId
     if (jobId == nil) then
-        player:PrintToPlayer("You must enter a job ID or short-name.");
+        error(player, "You must enter a job short-name, e.g. WAR, or its equivalent numeric ID.");
+        return;
+    end
+    jobId = tonumber(jobId) or JOBS[string.upper(jobId)];
+    if (jobId == nil or jobId <= 0 or jobId >= MAX_JOB_TYPE) then
+        error(player, "Invalid jobID.  Use job short name, e.g. WAR, or its equivalent numeric ID.");
         return;
     end
 
-   if (jobId <= 0 or jobId >= MAX_JOB_TYPE) then
-       player:PrintToPlayer(string.format("Invalid job '%s' given. Use short-name or id. e.g. WAR", jobId));
-       return;
-   end
-
-    -- Change the players subjob..
-    player:changesJob(jobId);
-
-    -- Attempt to set the players subjob level..
-    if (level ~= nil and level > 0 and level <= 99) then
-        player:setsLevel(level);
-    else
-        player:PrintToPlayer("Invalid level given. Level must be between 1 and 99!");
+    -- validate level
+    if (level ~= nil) then
+        if (level < 1 or level > 99) then
+            error(player, "Invalid level. Level must be between 1 and 99!");
+            return;
+        end
     end
+
+    -- change job and (optionally) level
+    player:changesJob(jobId);
+    if (level ~= nil) then
+        player:setsLevel(level);
+    end
+
+    -- invert JOBS table
+    local jobNameByNum={};
+    for k,v in pairs(JOBS) do
+        jobNameByNum[v]=k;
+    end
+
+    -- output new job to player
+    player:PrintToPlayer(string.format("You are now a %s%i/%s%i.", jobNameByNum[player:getMainJob()], player:getMainLvl(), jobNameByNum[player:getSubJob()], player:getSubLvl()));
 end

--- a/scripts/commands/checkmission.lua
+++ b/scripts/commands/checkmission.lua
@@ -11,49 +11,54 @@ cmdprops =
     parameters = "ss"
 };
 
-function onTrigger(player,logId,target)
-    if (logId == nil) then
-        player:PrintToPlayer( "You must enter a valid LogID!" );
-        player:PrintToPlayer( "@checkmission <Log ID> <Player>" );
-        return;
-    end
+function error(player, msg)
+    player:PrintToPlayer(msg);
+    player:PrintToPlayer("@checkmission <logID> {player}");
+end;
 
+function onTrigger(player,logId,target)
+
+    -- validate logId
     local logName;
-    logId = tonumber(logId) or _G[string.upper(logId)];
-    if ((type(logId) == "table")) then
+    if (logId == nil) then
+        error(player, "You must provide a logID.");
+        return;
+    elseif (tonumber(logId) ~= nil) then
+        logId = tonumber(logId);
+        logId = MISSION_LOGS[logId];
+    end
+    if (logId ~= nil) then
+        logId = _G[string.upper(logId)];
+    end
+    if ((type(logId) == "table") and logId.mission_log ~= nil) then
         logName = logId.full_name;
         logId = logId.mission_log;
     else
-        if (logId <= 2) then
-            local logNames = {"San d'Oria", "Bastok", "Windurst"}
-            logName = logNames[logId + 1];
-        else
-            local missionAreas = {ZILART, TOAU, WOTG, COP, ASSAULT, CAMPAIGN, ACP, AMK, ASA, SOA, ROV};
-            logName = missionAreas[logId - 2].full_name;
-        end
+        error(player, "Invalid logID.");
+        return;
     end
 
-    local Log = targ:getCurrentMission(logId)
-
+    -- validate target
     local targ;
     if (target == nil) then
-        targ = player;
-    else
-        targ = GetPlayerByName(target);
-    end
-
-    if (targ ~= nil) then
-        if (logId <= 13) then
-            if ((logId <= 3) and (Log == 255)) then
-                player:PrintToPlayer( string.format( "No current %s mission.", logName ) );
-            else
-                player:PrintToPlayer( string.format( "Current %s Mission ID is: '%s' !", logName, Log ) );
-            end
-        else     -- Everything not valid or not currently handled
-            player:PrintToPlayer("Invalid or unsupported LogID. The LogID must be 0-13.");
+        targ = player:getCursorTarget();
+        if (targ == nil or not targ:isPC()) then
+            targ = player;
         end
     else
-        player:PrintToPlayer( string.format( "Player named '%s' not found!", target ) );
-        player:PrintToPlayer( "@checkmission <logID> <player>" );
+        targ = GetPlayerByName(target);
+        if (targ == nil) then
+            error(player, string.format("Player named '%s' not found!", target));
+            return;
+        end
+    end
+
+    -- report mission
+    local currentMission = targ:getCurrentMission(logId);
+
+    if ((logId <= 3) and (currentMission == 255)) then
+        player:PrintToPlayer( string.format( "No current %s mission for %s.", logName, targ:getName() ) );
+    else
+        player:PrintToPlayer( string.format( "Current %s Mission ID is %s for %s.", logName, currentMission, targ:getName() ) );
     end
 end

--- a/scripts/commands/checkvar.lua
+++ b/scripts/commands/checkvar.lua
@@ -9,21 +9,53 @@ cmdprops =
     parameters = "ss"
 };
 
-function onTrigger(player, varType, varName)
-    if (varType == nil or varName == nil) then
-        player:PrintToPlayer("Incorrect command syntax or missing paramters.");
-        player:PrintToPlayer("@checkvar <player name or server> <variable name>");
+function error(player, msg)
+    player:PrintToPlayer(msg);
+    player:PrintToPlayer("@checkvar {'server', or player} <variable name>");
+end;
+
+function onTrigger(player, arg1, arg2)
+    local targ;
+    local varName;
+    
+    if (arg2 == nil) then
+        -- no player provided. shift arguments by one.
+        targ = nil;
+        varName = arg1;    
+    else
+        targ = arg1;
+        varName = arg2;
+    end
+    
+    -- validate target
+    if (targ == nil) then
+        targ = player:getCursorTarget();
+        if (targ == nil or not targ:isPC()) then
+            targ = player;
+        end
+    else
+        if (string.upper(targ) == 'SERVER') then
+            targ = 'server';
+        else
+            local target = targ;
+            targ = GetPlayerByName(targ);
+            if (targ == nil) then
+                error(player, string.format("Player named '%s' not found!", target));
+                return;
+            end
+        end
+    end
+    
+    -- validate varName
+    if (varName == nil) then
+        error(player, "You must provide a variable name.");
         return;
     end
 
-    if (varType == "server") then
-        player:PrintToPlayer(string.format("Server Variable '%s' : %u ", varName, GetServerVariable(varName)));
+    -- show variable
+    if (targ == "server") then
+        player:PrintToPlayer(string.format("Server variable '%s' : %u ", varName, GetServerVariable(varName)));
     else
-        local targ = GetPlayerByName(varType);
-        if (targ ~= nil) then
-            player:PrintToPlayer(string.format("Player '%s' variable '%s' : %u ", varType, varName, targ:getVar(varName)));
-        else
-            player:PrintToPlayer(string.format( "Player named '%s' not found!", varType));
-        end
+        player:PrintToPlayer(string.format("%s's variable '%s' : %u", targ:getName(), varName, targ:getVar(varName)));
     end
 end

--- a/scripts/commands/cnation.lua
+++ b/scripts/commands/cnation.lua
@@ -6,24 +6,49 @@
 cmdprops =
 {
     permission = 1,
-    parameters = "si"
+    parameters = "ss"
 };
 
+function error(player, msg)
+    player:PrintToPlayer(msg);
+    player:PrintToPlayer("@cnation <player> <campaign allegiance>");
+end;
+
 function onTrigger(player, target, nation)
+    -- nation xref tables
+    local nationNameToNum = {
+        ["NONE"]     =  0,
+        ["SANDORIA"] =  1,
+        ["BASTOK"]   =  2,
+        ["WINDURST"] =  3
+    }
+    local nationNumToName ={};
+    for k,v in pairs(nationNameToNum) do
+        nationNumToName[v]=k;
+    end
+    
+    -- validate target
     if (target == nil) then
-        player:PrintToPlayer("You must specify an online player by name.");
+        error(player, "You must specify an online player by name.");
+        return;
+    end
+    local targ = GetPlayerByName( target );
+    if (targ == nil) then
+        error(player, string.format( "Player named '%s' not found!", target ) );
+        return;
+    end;
+    
+    -- show or set allegiance
+    if (nation == nil) then
+        player:PrintToPlayer(string.format("%s's current campaign allegiance: %s", targ:getName(), nationNumToName[targ:getCampaignAllegiance()]));
     else
-        local targ = GetPlayerByName( target )
-        if (targ == nil) then
-            player:PrintToPlayer( string.format( "Player named '%s' not found!", target ) );
-        else
-            if (nation == nil) then
-                player:PrintToPlayer(string.format("Current Campaign Allegiance: %i", targ:getCampaignAllegiance()));
-            else
-                player:PrintToPlayer(string.format("Previous Campaign Allegiance: %i", targ:getCampaignAllegiance()));
-                targ:setCampaignAllegiance(nation);
-                player:PrintToPlayer(string.format("New Campaign Allegiance: %i", targ:getCampaignAllegiance()));
-            end
+        nation = tonumber(nation) or nationNameToNum[string.upper(nation)];
+        if (nation == nil or nation < 0 or nation > 3) then
+            error(player, "Invalid campaign allegiange. Valid choices are SANDORIA (1), BASTOK (2), or WINDURST (3).");
+            return;
         end
+        player:PrintToPlayer(string.format("%s's old campaign allegiance: %s", targ:getName(), nationNumToName[targ:getCampaignAllegiance()]));
+        targ:setCampaignAllegiance(nation);
+        player:PrintToPlayer(string.format("%s's new campaign allegiance: %s", targ:getName(), nationNumToName[targ:getCampaignAllegiance()]));
     end
 end;

--- a/scripts/commands/completemission.lua
+++ b/scripts/commands/completemission.lua
@@ -11,38 +11,55 @@ cmdprops =
     parameters = "sss"
 };
 
+function error(player, msg)
+    player:PrintToPlayer(msg);
+    player:PrintToPlayer("@completemission <logID> <missionID> {player}");
+end;
+
 function onTrigger(player, logId, missionId, target)
-    if (missionId == nil or logId == nil) then
-        player:PrintToPlayer( "You must enter a valid log id and mission id!" );
-        player:PrintToPlayer( "@completemission <logID> <missionID> <player>" );
+
+    -- validate logId
+    local logName;
+    if (logId == nil) then
+        error(player, "You must provide a logID.");
+        return;
+    elseif (tonumber(logId) ~= nil) then
+        logId = tonumber(logId);
+        logId = MISSION_LOGS[logId];
+    end
+    if (logId ~= nil) then
+        logId = _G[string.upper(logId)];
+    end
+    if ((type(logId) == "table") and logId.mission_log ~= nil) then
+        logName = logId.full_name;
+        logId = logId.mission_log;
+    else
+        error(player, "Invalid logID.");
         return;
     end
 
-    local logName;
-    logId = tonumber(logId) or _G[string.upper(logId)];
-    if ((type(logId) == "table")) then
-        logName = logId.full_name;
-        logId = logId.mission_log;
+    -- validate missionId
+    if (missionId ~= nil) then
+        missionId = tonumber(missionId) or _G[string.upper(missionId)];
+    end
+    if (missionId == nil or missionId < 0) then
+        error(player, "Invalid missionID.");
+        return;
     end
 
-    missionId = tonumber(missionId) or _G[string.upper(missionId)];
-
+    -- validate target
     local targ;
     if (target == nil) then
         targ = player;
     else
         targ = GetPlayerByName(target);
+        if (targ == nil) then
+            error(player, string.format("Player named '%s' not found!", target));
+            return;
+        end
     end
 
-    if (targ ~= nil) then
-        targ:completeMission( logId, missionId );
-        if (logName) then
-            player:PrintToPlayer( string.format( "Completed %s Mission with ID %u for %s", logName, missionId, target ) );
-        else
-            player:PrintToPlayer( string.format( "Completed Mission for log %u with ID %u for %s", logId, missionId, target ) );
-        end
-    else
-        player:PrintToPlayer( string.format( "Player named '%s' not found!", target ) );
-        player:PrintToPlayer( "@completemission <logID> <missionID> <player>" );
-    end
+    -- complete mission
+    targ:completeMission( logId, missionId );
+    player:PrintToPlayer( string.format( "Completed %s Mission with ID %u for %s", logName, missionId, targ:getName() ) );
 end;

--- a/scripts/commands/costume.lua
+++ b/scripts/commands/costume.lua
@@ -9,6 +9,18 @@ cmdprops =
     parameters = "i"
 };
 
-function onTrigger(player, costume)
-    player:costume( costume );
+function error(player, msg)
+    player:PrintToPlayer(msg);
+    player:PrintToPlayer("@costume <costumeID>");
+end;
+
+function onTrigger(player, costumeId)
+    -- validate costumeId
+    if (costumeId == nil or costumeId < 0) then
+        error(player, "Invalid costumeID.");
+        return;
+    end
+    
+    -- put on costume
+    player:costume( costumeId );
 end

--- a/scripts/commands/cp.lua
+++ b/scripts/commands/cp.lua
@@ -9,10 +9,19 @@ cmdprops =
     parameters = "i"
 };
 
+function error(player, msg)
+    player:PrintToPlayer(msg);
+    player:PrintToPlayer("@cp <amount>");
+end;
+
 function onTrigger(player, cp)
-    if (cp == nil or tonumber(cp) == 0) then
-        player:PrintToPlayer("You must enter an amount.");
+    -- validate amount
+    if (cp == nil or cp == 0) then
+        error(player, "Invalid amount.");
         return;
     end
+    
+    -- add cp
     player:addCP( cp );
+    player:PrintToPlayer(string.format("Added %i cp to %s.", cp, player:getName()));
 end

--- a/scripts/commands/cs.lua
+++ b/scripts/commands/cs.lua
@@ -9,12 +9,19 @@ cmdprops =
     parameters = "ssssssssss"
 };
 
+function error(player, msg)
+    player:PrintToPlayer(msg);
+    player:PrintToPlayer("@cs <csID> {op1} {op2} {op3} {op4} {op5} {op6} {op7} {op8} {texttable}");
+end;
+
 function onTrigger(player, csid, op1, op2, op3, op4, op5, op6, op7, op8, texttable)
+    -- validate csid
     if (csid == nil) then
-        player:PrintToPlayer("You must enter a cutscene id.");
+        error(player, "You must enter a cutscene id.");
         return;
     end
     
+    -- play cutscene
     if (op1 == nil) then
         player:startEvent(csid);
     else    

--- a/scripts/commands/cs2.lua
+++ b/scripts/commands/cs2.lua
@@ -9,10 +9,18 @@ cmdprops =
     parameters = "sssssiiiiiiii"
 };
 
+function error(player, msg)
+    player:PrintToPlayer(msg);
+    player:PrintToPlayer("@cs2 <csID> {string1} {string2} {string3} {string4} {op1} {op2} {op3} {op4} {op5} {op6} {op7} {op8}");
+end;
+
 function onTrigger(player, csid, string1, string2, string3, string4, op1, op2, op3, op4, op5, op6, op7, op8)
+    -- validate csid
     if (csid == nil) then
-        player:PrintToPlayer("You must enter a cutscene id.");
+        error(player, "You must enter a cutscene id.");
         return;
     end
+    
+    -- play cs
     player:startEventString(csid, string1, string2, string3, string4, op1, op2, op3, op4, op5, op6, op7, op8);
 end

--- a/scripts/globals/log_ids.lua
+++ b/scripts/globals/log_ids.lua
@@ -219,3 +219,34 @@ ROV =
     ['full_name'] = "Rhapsodies of Vana'diel",
     ['mission_log']= 13
 };
+
+QUEST_LOGS = {
+    [0] = "SANDORIA",
+    [1] = "BASTOK",
+    [2] = "WINDURST",
+    [3] = "JEUNO",
+    [4] = "OTHER_AREAS",
+    [5] = "OUTLANDS",
+    [6] = "TOAU",
+    [7] = "WOTG",
+    [8] = "ABYSSEA",
+    [9] = "SOA",
+    [10] = "COALITION",
+};
+
+MISSION_LOGS = {
+    [0] = "SANDORIA",
+    [1] = "BASTOK",
+    [2] = "WINDURST",
+    [3] = "ZILART",
+    [4] = "TOAU",
+    [5] = "WOTG",
+    [6] = "COP",
+    [7] = "ASSAULT",
+    [8] = "CAMPAIGN",
+    [9] = "ACP",
+    [10] = "AMK",
+    [11] = "ASA",
+    [12] = "SOA",
+    [13] = "ROV",
+};


### PR DESCRIPTION
Added `@checkquest` command. (Thanks for the code, @kushdr).
`@checkquest`, `@checkmission`, `@checkvar` can now be targeted via cursor.
QUEST_LOGS and MISSION_LOGS globals now allow logName output when player enters numeric logId.
`@changejob` and `@changesjob` now report resulting job/sjob.
`@bring` now sets player rotation and does not zone target if they're in correct zone already.