### PR TITLE
command input validation and standardization [h-n]

### DIFF
--- a/scripts/commands/deleffect.lua
+++ b/scripts/commands/deleffect.lua
@@ -36,7 +36,7 @@ function onTrigger(player, arg1, arg2)
         error(player, string.format("Player named '%s' not found!", arg1));
         return;
     end
-    
+
     -- validate effect
     id = tonumber(id) or _G[string.upper(id)];
     if (id == nil) then
@@ -45,10 +45,10 @@ function onTrigger(player, arg1, arg2)
     elseif (id == 0) then
         id = 1;
     end
-    
+
     -- delete status effect
     targ:delStatusEffect(id);
-    if(targ:getID() ~= player:getID()) then
+    if (targ:getID() ~= player:getID()) then
         player:PrintToPlayer(string.format("Removed effect %i from %s.",id,targ:getName()));
     end
 end

--- a/scripts/commands/deleffect.lua
+++ b/scripts/commands/deleffect.lua
@@ -48,5 +48,7 @@ function onTrigger(player, arg1, arg2)
     
     -- delete status effect
     targ:delStatusEffect(id);
-    player:PrintToPlayer(string.format("Removed effect %i from %s.",id,targ:getName()));
+    if(targ:getID() ~= player:getID()) then
+        player:PrintToPlayer(string.format("Removed effect %i from %s.",id,targ:getName()));
+    end
 end

--- a/scripts/commands/hasitem.lua
+++ b/scripts/commands/hasitem.lua
@@ -9,28 +9,40 @@ cmdprops =
     parameters = "is"
 };
 
+function error(player, msg)
+    player:PrintToPlayer(msg);
+    player:PrintToPlayer("@hasitem <itemID> {player}");
+end;
+
 function onTrigger(player, itemId, target)
-    if (itemId == nil or tonumber(itemId) == 0 or tonumber(itemId) == nil or itemId == 0) then
-        player:PrintToPlayer("You must enter a valid item ID.");
-        player:PrintToPlayer( "@hasitem <ID> <player>" );
+    -- validate itemId
+    if (itemId == nil) then
+        error(player, "You must provide an itemID.");
+        return;
+    elseif (itemId < 1) then
+        error(player, "Invalid itemID.");
         return;
     end
 
+    -- validate target
+    local targ;
     if (target == nil) then
-        player:PrintToPlayer("You must enter a valid target name.");
-        player:PrintToPlayer( "@hasitem <ID> <player>" );
-        return;
-    end
-
-    local targ = GetPlayerByName(target);
-    if (targ ~= nil) then
-        if (targ:hasItem(itemId)) then
-            player:PrintToPlayer(string.format("Player '%s' has item with ID %u.", target, itemId));
-        else
-            player:PrintToPlayer(string.format("Player '%s' does not have item with ID %u.", target, itemId));
+        targ = player:getCursorTarget();
+        if (targ == nil or not targ:isPC()) then
+            targ = player;
         end
     else
-        player:PrintToPlayer( string.format( "Player named '%s' not found!", target ) );
-        player:PrintToPlayer( "@hasitem <ID> <player>" );
+        targ = GetPlayerByName(target);
+        if (targ == nil) then
+            error(player, string.format("Player named '%s' not found!", target));
+            return;
+        end
+    end
+
+    -- report hasItem
+    if (targ:hasItem(itemId)) then
+        player:PrintToPlayer(string.format("%s has item %i.", targ:getName(), itemId));
+    else
+        player:PrintToPlayer(string.format("%s does not have item %i.", targ:getName(), itemId));
     end
 end;

--- a/scripts/commands/haskeyitem.lua
+++ b/scripts/commands/haskeyitem.lua
@@ -12,31 +12,43 @@ cmdprops =
     parameters = "ss"
 };
 
-function onTrigger(player, KI, target)
-    if (KI == nil) then
-        player:PrintToPlayer("You must enter a valid KeyItem to check.");
-        player:PrintToPlayer("@haskeyitem <KeyItem> <player>");
+function error(player, msg)
+    player:PrintToPlayer(msg);
+    player:PrintToPlayer("@haskeyitem <key item ID> {player}");
+end;
+
+function onTrigger(player, keyId, target)
+    -- validate itemId
+    if (keyId == nil) then
+        error(player, "You must provide a key item ID.");
         return;
+    else
+        keyId = tonumber(keyId) or _G[string.upper(keyId)];
+        if (keyId == nil or keyId < 1) then
+            error(player, "Invalid key item ID.");
+            return;
+        end
     end
 
-    KI = string.upper(KI);
-    local keyId = tonumber(KI) or _G[string.upper(KI)];
-
+    -- validate target
     local targ;
     if (target == nil) then
-        targ = player;
-    else
-        targ = GetPlayerByName(target);
-    end
-
-    if (targ ~= nil) then
-        if (targ:hasKeyItem(keyId)) then
-            player:PrintToPlayer(string.format("Player has KeyItem '%s'", KI));
-        else
-            player:PrintToPlayer(string.format("Player does not have KeyItem '%s'", KI));
+        targ = player:getCursorTarget();
+        if (targ == nil or not targ:isPC()) then
+            targ = player;
         end
     else
-        player:PrintToPlayer(string.format("Player named '%s' not found!", target));
-        player:PrintToPlayer("@haskeyitem <ID> <player>");
+        targ = GetPlayerByName(target);
+        if (targ == nil) then
+            error(player, string.format("Player named '%s' not found!", target));
+            return;
+        end
+    end
+
+    -- report hasKeyItem
+    if (targ:hasKeyItem(keyId)) then
+        player:PrintToPlayer(string.format("%s has key item %i.", targ:getName(), keyId));
+    else
+        player:PrintToPlayer(string.format("%s does not have key item %i.", targ:getName(), keyId));
     end
 end;

--- a/scripts/commands/homepoint.lua
+++ b/scripts/commands/homepoint.lua
@@ -9,15 +9,27 @@ cmdprops =
     parameters = "s"
 };
 
+function error(player, msg)
+    player:PrintToPlayer(msg);
+    player:PrintToPlayer("@homepoint {player}");
+end;
+
 function onTrigger(player, target)
+    -- validate target
+    local targ;
     if (target == nil) then
-        target = player:getName();
+        targ = player;
+    else
+        targ = GetPlayerByName( target );
+        if (targ == nil) then
+            error(player, string.format( "Player named '%s' not found!", target ) );
+            return;
+        end
     end
 
-    local targ = GetPlayerByName( target );
-    if (targ ~= nil) then
-        targ:warp();
-    else
-        player:PrintToPlayer( string.format( "Player named '%s' not found!", target ) );
+    -- homepoint target
+    targ:warp();
+    if (targ:getID() ~= player:getID()) then
+        player:PrintToPlayer(string.format("Sent %s to their homepoint.",targ:getName()));
     end
 end

--- a/scripts/commands/hp.lua
+++ b/scripts/commands/hp.lua
@@ -9,26 +9,40 @@ cmdprops =
     parameters = "is"
 };
 
+function error(player, msg)
+    player:PrintToPlayer(msg);
+    player:PrintToPlayer("@hp <amount> {player}");
+end;
+
 function onTrigger(player, hp, target)
-    if (hp == nil) then
-        player:PrintToPlayer("You must enter a valid amount.");
-        player:PrintToPlayer( "@hp <amount> <player>" );
+    -- validate amount
+    if (hp == nil or tonumber(hp) == nil) then
+        error(player, "You must provide an amount.");
+        return;
+    elseif (hp < 0) then
+        error(player, "Invalid amount.");
         return;
     end
 
+    -- validate target
+    local targ;
     if (target == nil) then
-        if (player:getHP() > 0) then
-            player:setHP(hp);
+        targ = player;
+    else
+        targ = GetPlayerByName(target);
+        if (targ == nil) then
+            error(player, string.format( "Player named '%s' not found!", target ) );
+            return;
+        end
+    end
+    
+    -- set hp
+    if (targ:getHP() > 0) then
+        targ:setHP(hp);
+        if(targ:getID() ~= player:getID()) then
+            player:PrintToPlayer(string.format("Set %s's HP to %i.", targ:getName(), targ:getHP()));
         end
     else
-        local targ = GetPlayerByName(target);
-        if (targ ~= nil) then
-            if (targ:getHP() > 0) then
-                targ:setHP(hp);
-            end
-        else
-            player:PrintToPlayer( string.format( "Player named '%s' not found!", target ) );
-            player:PrintToPlayer( "@hp <amount> <player>" );
-        end
+        player:PrintToPlayer(string.format("%s is currently dead.", targ:getName()));
     end
 end

--- a/scripts/commands/inject.lua
+++ b/scripts/commands/inject.lua
@@ -9,11 +9,18 @@ cmdprops =
     parameters = "s"
 };
 
+function error(player, msg)
+    player:PrintToPlayer(msg);
+    player:PrintToPlayer("@inject <packet>");
+end;
+
 function onTrigger(player, packet)
+    -- validate packet
     if (packet == nil) then
-        player:PrintToPlayer("You must enter a packet file name.");
+        error(player, "You must enter a packet file name.");
         return;
     end
 
+    -- inject packet
     player:injectPacket( packet );
 end

--- a/scripts/commands/injectaction.lua
+++ b/scripts/commands/injectaction.lua
@@ -9,9 +9,28 @@ cmdprops =
     parameters = "iiiii"
 };
 
+function error(player, msg)
+    player:PrintToPlayer(msg);
+    player:PrintToPlayer("@injectaction <action ID> <animation ID> {speceffect} {reaction} {message}");
+end;
+
 function onTrigger(player, actionId, animationId, speceffect, reaction, message)
+    -- validate actionId
+    if (actionId == nil) then
+        error(player, "You must provide an action ID.");
+        return;
+    end
+    
+    -- validate animationId
+    if (animationId == nil) then
+        error(player, "You must provide an animation ID.");
+        return;
+    end
+    
     if (message == nil) then
         message = 185; -- Default message
     end
+
+    -- inject action packet
     player:injectActionPacket(actionId, animationId, speceffect, reaction, message);
 end

--- a/scripts/commands/logoff.lua
+++ b/scripts/commands/logoff.lua
@@ -29,7 +29,7 @@ function onTrigger(player, target)
 
     -- logoff target
     targ:leavegame();
-    if(targ:getID() ~= player:getID()) then
+    if (targ:getID() ~= player:getID()) then
         player:PrintToPlayer(string.format("%s has been logged off.",targ:getName()));
     end
 end

--- a/scripts/commands/logoff.lua
+++ b/scripts/commands/logoff.lua
@@ -9,15 +9,27 @@ cmdprops =
     parameters = "s"
 };
 
+function error(player, msg)
+    player:PrintToPlayer(msg);
+    player:PrintToPlayer("@logoff {player}");
+end;
+
 function onTrigger(player, target)
+    -- validate target
+    local targ;
     if (target == nil) then
-        target = player:getName();
+        targ = player;
+    else
+        targ = GetPlayerByName( target );
+        if (targ == nil) then
+            error(player, string.format( "Invalid player '%s' given.", target ) );
+            return;
+        end
     end
 
-    local targ = GetPlayerByName( target );
-    if (targ ~= nil) then
-        targ:leavegame();
-    else
-        player:PrintToPlayer( string.format( "Invalid player '%s' given.", target ) );
+    -- logoff target
+    targ:leavegame();
+    if(targ:getID() ~= player:getID()) then
+        player:PrintToPlayer(string.format("%s has been logged off.",targ:getName()));
     end
 end

--- a/scripts/commands/messagebasic.lua
+++ b/scripts/commands/messagebasic.lua
@@ -9,6 +9,18 @@ cmdprops =
     parameters = "iii"
 };
 
+function error(player, msg)
+    player:PrintToPlayer(msg);
+    player:PrintToPlayer("@messagebasic <message ID> {param1} {param2}");
+end;
+
 function onTrigger(player, msgId, param1, param2)
+    -- validate msgId
+    if (msgId == nil) then
+        error(player, "You must provide a message ID.");
+        return;
+    end
+    
+    -- inject message packet
     player:messageBasic(msgId, param1, param2);
 end

--- a/scripts/commands/messagespecial.lua
+++ b/scripts/commands/messagespecial.lua
@@ -9,18 +9,30 @@ cmdprops =
     parameters = "iiiii"
 };
 
-function onTrigger(player, msgid, param1, param2, param3, param4, param5)
+function error(player, msg)
+    player:PrintToPlayer(msg);
+    player:PrintToPlayer("@messagespecial <message ID> {param1} {param2} {param3} {param4} {param5}");
+end;
+
+function onTrigger(player, msgId, param1, param2, param3, param4, param5)
+    -- validate msgId
+    if (msgId == nil) then
+        error(player, "You must provide a message ID.");
+        return;
+    end
+
+    -- inject message special packet    
     if (param5 ~= nil) then
-        player:messageSpecial(msgid, param1, param2, param3, param4, param5);
+        player:messageSpecial(msgId, param1, param2, param3, param4, param5);
     elseif (param4 ~= nil) then
-        player:messageSpecial(msgid, param1, param2, param3, param4);
+        player:messageSpecial(msgId, param1, param2, param3, param4);
     elseif (param3 ~= nil) then
-        player:messageSpecial(msgid, param1, param2, param3);
+        player:messageSpecial(msgId, param1, param2, param3);
     elseif (param2 ~= nil) then
-        player:messageSpecial(msgid, param1, param2);
+        player:messageSpecial(msgId, param1, param2);
     elseif (param1 ~= nil) then
-        player:messageSpecial(msgid, param1);
+        player:messageSpecial(msgId, param1);
     else
-        player:messageSpecial(msgid);
+        player:messageSpecial(msgId);
     end
 end

--- a/scripts/commands/mobhere.lua
+++ b/scripts/commands/mobhere.lua
@@ -10,21 +10,33 @@ cmdprops =
     parameters = "is"
 };
 
+function error(player, msg)
+    player:PrintToPlayer(msg);
+    player:PrintToPlayer("@mobhere {mobID} {noDepop}");
+end;
+
 function onTrigger(player, mobId, noDepop)
+    -- validate mobId
+    local targ;
     if (mobId == nil) then
-        player:PrintToPlayer("You must enter a valid MobID.");
-        return;
+        targ = player:getCursorTarget();
+        if (targ == nil or not targ:isMob()) then
+            error(player, "You must either provide a mobID or target a mob.");
+            return;
+        end
+    else
+        targ = GetMobByID(mobId);
+        if (targ == nil) then
+            error(player, "Invalid mobID.");
+            return;
+        end
     end
-
-    local mob = GetMobByID(mobId);
-    if (mob == nil) then
-        player:PrintToPlayer( string.format( "Mob with ID '%i' not found!", mobId ) );
-        return;
-    end
-
+    mobId = targ:getID();
+    
+    -- attempt to bring mob here
     SpawnMob( mobId );
-    if (player:getZoneID() == mob:getZoneID()) then
-        mob:setPos( player:getXPos(), player:getYPos(), player:getZPos(), player:getRotPos(), player:getZoneID() );
+    if (player:getZoneID() == targ:getZoneID()) then
+        targ:setPos( player:getXPos(), player:getYPos(), player:getZPos(), player:getRotPos(), player:getZoneID() );
     else
         if (noDepop == nil or noDepop == 0) then
             DespawnMob( mobId );

--- a/scripts/commands/mobsub.lua
+++ b/scripts/commands/mobsub.lua
@@ -11,14 +11,48 @@ cmdprops =
     parameters = "ss"
 };
 
-function onTrigger(player, target, animationId)
-    if (mob == nil and animationId == nil) then
-        player:PrintToPlayer( "A mob ID and Animation ID must be specified." );
+function error(player, msg)
+    player:PrintToPlayer(msg);
+    player:PrintToPlayer("@mobsub {mob ID} <animation ID>");
+end;
+
+function onTrigger(player, arg1, arg2)
+    local target;
+    local animationId;
+    
+    if (arg2 ~= nil) then
+        target = arg1;
+        animationId = arg2;
+    elseif (arg1 ~= nil) then
+        animationId = arg1;
+    else
+        error(player, "You must provide an animation ID.");
         return;
     end
 
-    animationId = tonumber(animationId) or _G[string.upper(animationId)];
+    -- validate target
+    local targ;
+    if (target == nil) then
+        targ = player:getCursorTarget();
+        if (targ == nil or not targ:isMob()) then
+            error(player, "You must either provide a mob ID or target a mob.");
+            return;
+        end
+    else
+        targ = GetMobByID(target);
+        if (targ == nil) then
+            error(player, "Invalid mob ID.");
+            return;
+        end
+    end;
 
-    local mob = GetMobByID( target );
-    mob:AnimationSub( animationId );
+    -- validate animationId
+    animationId = tonumber(animationId) or _G[string.upper(animationId)];
+    if (animationId == nil or animationId < 0) then
+        error(player, "Invalid animation ID.");
+        return;
+    end
+
+    -- set animation sub
+    targ:AnimationSub( animationId );
 end

--- a/scripts/commands/mp.lua
+++ b/scripts/commands/mp.lua
@@ -9,22 +9,41 @@ cmdprops =
     parameters = "is"
 };
 
+function error(player, msg)
+    player:PrintToPlayer(msg);
+    player:PrintToPlayer("@mp <amount> {player}");
+end;
+
 function onTrigger(player, mp, target)
-    if (mp == nil) then
-        player:PrintToPlayer("You must enter a valid amount.");
-        player:PrintToPlayer( "@mp <amount> <player>" );
+    -- validate amount
+    if (mp == nil or tonumber(mp) == nil) then
+        error(player, "You must provide an amount.");
+        return;
+    elseif (mp < 0) then
+        error(player, "Invalid amount.");
         return;
     end
 
+    -- validate target
+    local targ;
     if (target == nil) then
-        player:setMP(mp);
+        targ = player;
     else
-        local targ = GetPlayerByName(target);
-        if (targ ~= nil) then
-            targ:setMP(mp);
-        else
-            player:PrintToPlayer( string.format( "Player named '%s' not found!", target ) );
-            player:PrintToPlayer( "@mp <amount> <player>" );
+        targ = GetPlayerByName(target);
+        if (targ == nil) then
+            error(player, string.format( "Player named '%s' not found!", target ) );
+            return;
         end
     end
+    
+    -- set mp
+    if (targ:getHP() > 0) then
+        targ:setMP(mp);
+        if(targ:getID() ~= player:getID()) then
+            player:PrintToPlayer(string.format("Set %s's MP to %i.", targ:getName(), targ:getMP()));
+        end
+    else
+        player:PrintToPlayer(string.format("%s is currently dead.", targ:getName()));
+    end
+
 end;

--- a/scripts/commands/npchere.lua
+++ b/scripts/commands/npchere.lua
@@ -10,26 +10,36 @@ cmdprops =
     parameters = "is"
 };
 
+function error(player, msg)
+    player:PrintToPlayer(msg);
+    player:PrintToPlayer("@npchere {npcID} {noDepop}");
+end;
+
 function onTrigger(player, npcId, noDepop)
     require("scripts/globals/status");
 
+    -- validate npc
+    local targ;
     if (npcId == nil) then
-        player:PrintToPlayer("You must enter a valid npcId.");
-        return;
+        targ = player:getCursorTarget();
+        if (targ == nil or not targ:isNPC()) then
+            error(player, "You must either provide an npcID or target an NPC.");
+            return;
+        end
+    else
+        targ = GetNPCByID(npcId);
+        if (targ == nil) then
+            error(player, "Invalid npcID.");
+            return;
+        end
     end
 
-    local npc = GetNPCByID(npcId);
-    if (npc == nil) then
-        player:PrintToPlayer( string.format( "NPC with ID '%i' not found!", npcId ) );
-        return;
-    end
-
-    if (player:getZoneID() == npc:getZoneID()) then
-        npc:setPos( player:getXPos(), player:getYPos(), player:getZPos(), player:getRotPos(), player:getZoneID() );
-        npc:setStatus(STATUS_NORMAL);
+    if (player:getZoneID() == targ:getZoneID()) then
+        targ:setPos( player:getXPos(), player:getYPos(), player:getZPos(), player:getRotPos(), player:getZoneID() );
+        targ:setStatus(STATUS_NORMAL);
     else
         if (noDepop == nil or noDepop == 0) then
-            npc:setStatus(STATUS_DISAPPEAR);
+            targ:setStatus(STATUS_DISAPPEAR);
             player:PrintToPlayer("Despawned the NPC because of an error.");
         end
         player:PrintToPlayer("NPC could not be moved to current pos - you are probably in the wrong zone.");


### PR DESCRIPTION
`@hasitem`, `@haskeyitem`, `@mobsub`, `@mobhere`, and `@npchere` can now be targeted via cursor.
`@messagebasic` and `@mesagespecial` no longer crash when no arguments are supplied.
