### PR TITLE
command input validation and standardization [o-r]

### DIFF
--- a/scripts/commands/pettp.lua
+++ b/scripts/commands/pettp.lua
@@ -9,10 +9,25 @@ cmdprops =
     parameters = "i"
 };
 
+function error(player, msg)
+    player:PrintToPlayer(msg);
+    player:PrintToPlayer("@pettp {amount}");
+end;
+
 function onTrigger(player, tp)
-    if (player:getPet() == nil or tp == nil) then
+    -- validate target
+    local targ = player:getPet();
+    if (targ == nil) then
+        error(player, "You do not have a pet.");
         return;
     end
 
-    player:getPet():addTP( tp );
+    -- validate tp amount
+    if (tp == nil or tp < 0) then
+        error(player, "Invalid amount of tp.");
+        return;
+    end
+
+    -- set pet tp
+    targ:setTP( tp );
 end

--- a/scripts/commands/pos.lua
+++ b/scripts/commands/pos.lua
@@ -6,29 +6,79 @@
 cmdprops =
 {
     permission = 1,
-    parameters = "iiiis"
+    parameters = "sssss"
 };
 
-function onTrigger(player, x, y, z, zone, target)
+function error(player, msg)
+    player:PrintToPlayer(msg);
+    player:PrintToPlayer("@pos {x} {y} {z} {zone ID} {player}");
+end;
+
+function onTrigger(player, arg1, arg2, arg3, arg4, arg5)
+    local target;
+    local zoneId;
+    local x;
+    local y;
+    local z;
     local targ;
-    if (target == nil) then
-        targ = player
-    else
-        targ = GetPlayerByName( target );
-    end
 
-    if (targ == nil) then
-        player:PrintToPlayer( string.format( "Player named '%s' not found!", target ) );
-        return
-    end
-
-    if (x == nil or y == nil or z == nil and zone == nil) then
-        targ:showPosition();
-    else
-        if (zone == nil) then
-            targ:setPos(x, y, z, 0);
+    -- shift arguments depending on number passed
+    if (arg5 ~= nil) then
+        x = tonumber(arg1);
+        y = tonumber(arg2);
+        z = tonumber(arg3);
+        zoneId = arg4;
+        target = arg5;
+    elseif (arg4 ~= nil) then
+        x = tonumber(arg1);
+        y = tonumber(arg2);
+        z = tonumber(arg3);
+        if (GetPlayerByName(arg4) == nil) then
+            zoneId = arg4;
         else
-            targ:setPos(x, y, z, 0, zone);
+            target = arg4;
+        end
+    elseif (arg3 ~= nil) then
+        x = tonumber(arg1);
+        y = tonumber(arg2);
+        z = tonumber(arg3);
+    elseif (arg1 ~= nil) then
+        target = arg1;
+    end
+    
+    -- validate target
+    if (target == nil) then
+        targ = player;
+    else
+        targ = GetPlayerByName(target);
+        if (targ == nil) then
+            error(player, string.format( "Player named '%s' not found!", target ) );
+            return;
         end
     end
+    
+    -- validate zone
+    if (zoneId ~= nil) then
+        zoneId = tonumber(zoneId);
+        if (zoneId == nil or zoneId < 0 or zoneId > 285) then
+            error(player, "Invalid zone ID.");
+            return;
+        end
+    end
+
+    -- report or move position
+    if (x == nil or y == nil or z == nil) then
+        player:PrintToPlayer(string.format("%s's position: X %.4f  Y %.4f  Z %.4f", targ:getName(), targ:getXPos(), targ:getYPos(), targ:getZPos() ));
+    else
+        if (zoneId == nil) then
+            zoneId = targ:getZoneID();
+            targ:setPos(x, y, z, 0);
+        else
+            targ:setPos(x, y, z, 0, zoneId);
+        end
+        if (player:getID() ~= targ:getID()) then
+            player:PrintToPlayer(string.format("Moved %s to (%.4f, %.4f, %.4f) in zone %i.", targ:getName(), x, y, z, zoneId));
+        end
+    end
+
 end;

--- a/scripts/commands/posfix.lua
+++ b/scripts/commands/posfix.lua
@@ -9,11 +9,17 @@ cmdprops =
     parameters = "s"
 };
 
+function error(player, msg)
+    player:PrintToPlayer(msg);
+    player:PrintToPlayer("@posfix <player>");
+end;
+
 function onTrigger(player, target)
+    -- validate target
     if (target == nil) then
-        player:PrintToPlayer("An offline player name must be specified.");
+        error(player, "You must supply the name of an offline player.");
     else
         player:resetPlayer( target );
-        player:PrintToPlayer("Done.");
+        player:PrintToPlayer(string.format("Fixed %s's position.", target));
     end
 end;

--- a/scripts/commands/promote.lua
+++ b/scripts/commands/promote.lua
@@ -15,10 +15,12 @@ function error(player, msg)
 end;
 
 function onTrigger(player, target, level)
-    local maxLevel = player:getGMLevel();
-    local targ;
+    -- determine maximum level player can promote to
+    local maxLevel = player:getGMLevel() - 1;
+    if (maxLevel < 1) then maxLevel = 0;
     
     -- validate target
+    local targ;
     if (target == nil) then
         error(player, "You must provide a player name.");
         return;

--- a/scripts/commands/promote.lua
+++ b/scripts/commands/promote.lua
@@ -9,35 +9,43 @@ cmdprops =
     parameters = "si"
 };
 
+function error(player, msg)
+    player:PrintToPlayer(msg);
+    player:PrintToPlayer("@promote <player> <level>");
+end;
+
 function onTrigger(player, target, level)
-    if (level == nil) then
-        level = target;
-        target = player:getName();
-    end
-
+    local maxLevel = player:getGMLevel();
+    local targ;
+    
+    -- validate target
     if (target == nil) then
-        target = player:getName();
+        error(player, "You must provide a player name.");
+        return;
+    else
+        targ = GetPlayerByName(target);
+        if (targ == nil) then
+            error(player, string.format( "Player named '%s' not found!", target ) );
+            return;
+        end
     end
 
-    -- Validate the target..
-    local targ = GetPlayerByName( target );
-    if (targ == nil) then
-        player:PrintToPlayer( string.format( "Invalid player '%s' given.", target ) );
+    -- catch players trying to change level of equal or higher tiered GMs.
+    if (targ:getGMLevel() >= player:getGMLevel()) then
+        printf( "%s attempting to adjust same or higher tier GM %s.", player:getName(), targ:getName() );
+        targ:PrintToPlayer(string.format( "%s attempted to adjust your GM rank.", player:getName() ));
+        error(player, "You can not use this command on same or higher tiered GMs.");
         return;
     end
 
-    -- Validate the level..
-    if (level < 0) then 
-        level = 0;
+    -- validate level
+    if (level == nil or level < 0 or level > maxLevel) then
+        error(player, string.format("Invalid level.  Must be 0 to %i.", maxLevel ));
+        return;
     end
 
-    if (targ:getGMLevel() < player:getGMLevel()) then
-        if (level < player:getGMLevel()) then
-            targ:setGMLevel(level);
-        else
-            player:PrintToPlayer( "Target's new level is too high." );
-        end
-    else
-        printf( "%s attempting to adjust higher GM: %s", player:getName(), targ:getName() );
-    end
+    -- change target gm level
+    targ:setGMLevel(level);
+    player:PrintToPlayer(string.format( "%s set to tier %i.", targ:getName(), level ));
+    targ:PrintToPlayer(string.format( "You have been set to tier %i.", level ));
 end;

--- a/scripts/commands/raise.lua
+++ b/scripts/commands/raise.lua
@@ -6,24 +6,56 @@
 cmdprops =
 {
     permission = 1,
-    parameters = "is"
+    parameters = "ss"
 };
 
-function onTrigger(player,power,target)
+function error(player, msg)
+    player:PrintToPlayer(msg);
+    player:PrintToPlayer("@raise {power} {player}");
+end;
+
+function onTrigger(player, arg1, arg2)
+    local power;
+    local target;
+    local targ;
+
+    -- decide inputs
+    if (arg2 ~= nil) then
+        power = tonumber(arg1);
+        target = arg2;
+    elseif (arg1 ~= nil) then
+        if (GetPlayerByName(arg1) == nil) then
+            power = tonumber(arg1);
+        else
+            target = arg1;
+        end
+    end
+    
+    -- validate power
     if (power == nil or power > 3) then
         power = 3;
     elseif (power < 1) then
         power = 1;
     end
 
+    -- validate target
     if (target == nil) then
-        player:sendRaise(power);
+        targ = player;
     else
-        local targ = GetPlayerByName(target);
-        if (targ ~= nil) then
-            targ:sendRaise(power);
-        else
-            player:PrintToPlayer( string.format( "Player named '%s' not found!", target ) );
+        targ = GetPlayerByName(target);
+        if (targ == nil) then
+            error(player, string.format( "Player named '%s' not found!", target ) );
+            return;
         end
+    end
+
+    -- raise target
+    if (targ:isDead()) then
+        targ:sendRaise(power);
+        if (targ:getID() ~= player:getID()) then
+            player:PrintToPlayer( string.format( "Raise %i sent to %s.", power, targ:getName() ) );
+        end
+    else
+        player:PrintToPlayer( string.format( "%s is not dead.", targ:getName() ) );
     end
 end;

--- a/scripts/commands/reset.lua
+++ b/scripts/commands/reset.lua
@@ -10,15 +10,27 @@ cmdprops =
     parameters = "s"
 };
 
+function error(player, msg)
+    player:PrintToPlayer(msg);
+    player:PrintToPlayer("@reset {player}");
+end;
+
 function onTrigger(player,target)
+    -- validate target
+    local targ;
     if (target == nil) then
-        player:resetRecasts();
+        targ = player;
     else
-        local targ = GetPlayerByName(target);
-        if (targ ~= nil) then
-            targ:resetRecasts();
-        else
-            player:PrintToPlayer( string.format( "Player named '%s' not found!", target ) );
+        targ = GetPlayerByName(target);
+        if (targ == nil) then
+            error(player, string.format( "Player named '%s' not found!", target ) );
+            return;
         end
+    end
+    
+    -- reset target recasts
+    targ:resetRecasts();
+    if (targ:getID() ~= player:getID()) then
+        player:PrintToPlayer( string.format( "Reset %s's recast timers.", targ:getName() ) );
     end
 end;

--- a/scripts/commands/return.lua
+++ b/scripts/commands/return.lua
@@ -9,21 +9,35 @@ cmdprops =
     parameters = "s"
 };
 
-function onTrigger(player, target)
-    local ZoneID = 0;
-    if (target == nil) then
-        target = player:getName();
-    end
+function error(player, msg)
+    player:PrintToPlayer(msg);
+    player:PrintToPlayer("@return {player}");
+end;
 
-    local targ = GetPlayerByName( target );
-    if (targ ~= nil) then
-        ZoneID = targ:getPreviousZone();
-        if (ZoneID == nil or ZoneID == 0 or ZoneID == 214) then
-            player:PrintToPlayer( "Previous Zone was a Mog House or there was a problem fetching the ID.");
-        else
-            targ:setPos( 0, 0, 0, 0, ZoneID );
-        end
+function onTrigger(player, target)
+
+    -- validate target
+    local targ;
+    if (target == nil) then
+        targ = player;
     else
-        player:PrintToPlayer( string.format( "Player named '%s' not found!", target ) );
+        targ = GetPlayerByName(target);
+        if (targ == nil) then
+            error(player, string.format( "Player named '%s' not found!", target ) );
+            return;
+        end
+    end    
+
+    -- get previous zone
+    zoneId = targ:getPreviousZone();
+    if (zoneId == nil or zoneId == 0 or zoneId == 214) then
+        error(player, "Previous zone was a Mog House or there was a problem fetching the ID.");
+        return;
+    end
+    
+    -- zone target
+    targ:setPos( 0, 0, 0, 0, zoneId );
+    if (targ:getID() ~= player:getID()) then
+        player:PrintToPlayer( string.format( "%s was returned to zone %i.", targ:getName(), zoneId ) );
     end
 end


### PR DESCRIPTION
`@pettp` now sets pet tp to given amount, rather than adding given amount.
`@pos` now reports target position to player, rather than target, when not self-targeted.
`@promote` now warns same- or higher-tiered GMs of attempted targeting.
