### PR TITLE
Fix (Moari-Kaaori): Enable completing "Say It With Flowers"

### DIFF
--- a/scripts/zones/Windurst_Waters/npcs/Moari-Kaaori.lua
+++ b/scripts/zones/Windurst_Waters/npcs/Moari-Kaaori.lua
@@ -19,11 +19,11 @@ function onTrade(player,npc,trade)
     local FlowerProgress = player:getVar("FLOWER_PROGRESS");
     local offer = trade:getItemId();
     
-    if (player:getVar("FLOWER_PROGRESS") == 2) then
+    if (FlowerProgress >= 1) then
         if (trade:hasItemQty(950, 1) and trade:getItemCount() == 1) then
             if (SayFlowers == QUEST_COMPLETED) then
                 player:startEvent(0x020D,GIL_RATE*400);
-            elseif (SayFlowers == QUEST_ACCEPTED) then
+            else
                 player:startEvent(0x0208);
             end
         elseif (offer == 941 or offer == 948 or offer == 949 or offer == 956 or offer == 957 or offer == 958) then


### PR DESCRIPTION
FlowerProgress is equal to 1 when you select the correct options when describing the flower to Ohbiru-Dohbiru (see https://github.com/DarkstarProject/darkstar/blob/824fbbd7c79eea6d43524c0d96131abffac56881/scripts/zones/Windurst_Waters/npcs/Ohbiru-Dohbiru.lua#L255) and equal to 2 when you begin the repeatable quest (see https://github.com/DarkstarProject/darkstar/blob/master/scripts/zones/Windurst_Waters/npcs/Moari-Kaaori.lua#L76). Therefore, either 1 or 2 is an acceptable condition for the quest completion.