### PR TITLE
Nokkhi Jinjahl (quiver-making NPC) updated

### DIFF
--- a/scripts/zones/Port_Bastok/TextIDs.lua
+++ b/scripts/zones/Port_Bastok/TextIDs.lua
@@ -1,16 +1,16 @@
 -- Variable TextID   Description text
 
 -- General Texts
-       ITEM_CANNOT_BE_OBTAINED = 6379; -- You cannot obtain the item <item>. Come back after sorting your inventory.
+   ITEM_CANNOT_BE_OBTAINED = 6379; -- You cannot obtain the item <item>. Come back after sorting your inventory.
 FULL_INVENTORY_AFTER_TRADE = 6383; -- You cannot obtain the item (item>. Try trading again after sorting your inventory.
-                                  ITEM_OBTAINED = 6385; -- Obtained: #.
-                                     GIL_OBTAINED = 6386; -- Obtained <<<Numeric Parameter 0>>> gil.
-                          KEYITEM_OBTAINED = 6388; -- Obtained key item: <<<Unknown Parameter (Type: 80) 1>>>.
-                                    KEYITEM_LOST = 6389; -- Lost key item <<<Unknown Parameter (Type: 80) 1>>>.
-                NOT_HAVE_ENOUGH_GIL = 6390; -- You do not have enough gil.
-                                HOMEPOINT_SET = 6503; -- Home point set!
-         FISHING_MESSAGE_OFFSET = 7079; -- You can't fish here.
-                               MOGHOUSE_EXIT = 7942; -- You have learned your way through the back alleys of Bastok! Now you can exit to any area from your residence.
+             ITEM_OBTAINED = 6385; -- Obtained: #.
+              GIL_OBTAINED = 6386; -- Obtained <<<Numeric Parameter 0>>> gil.
+          KEYITEM_OBTAINED = 6388; -- Obtained key item: <<<Unknown Parameter (Type: 80) 1>>>.
+              KEYITEM_LOST = 6389; -- Lost key item <<<Unknown Parameter (Type: 80) 1>>>.
+       NOT_HAVE_ENOUGH_GIL = 6390; -- You do not have enough gil.
+             HOMEPOINT_SET = 6503; -- Home point set!
+    FISHING_MESSAGE_OFFSET = 7079; -- You can't fish here.
+             MOGHOUSE_EXIT = 7942; -- You have learned your way through the back alleys of Bastok! Now you can exit to any area from your residence.
 
 -- Conquest System
 CONQUEST = 7998; -- You've earned conquest points!
@@ -26,6 +26,9 @@ POWHATAN_DIALOG_1 = 7267; -- I'm sick and tired of entertaining guests.
  PAUJEAN_DIALOG_1 = 7644; -- Where can you find them? If you're the kind of adventurer I think you are, you should have a pretty good idea.
      UNLOCK_NINJA = 8425; -- You can now become a ninja.
    TITAN_UNLOCKED = 8530; -- You are now able to summon
+ NOKKHI_BAD_COUNT = 8786; -- What kinda smart-alecky baloney is this!? I told you to bring me the same kinda ammunition in complete sets. And don't forget the flowers, neither.
+NOKKHI_GOOD_TRADE = 8788; -- And here you go! Come back soon, and bring your friends!
+  NOKKHI_BAD_ITEM = 8789; -- I'm real sorry, but there's nothing I can do with those.
 
 -- Shop Texts
   TENSHODO_SHOP_OPEN_DIALOG = 6724; -- Ah, one of our members. Welcome to the Tenshodo shop.

--- a/scripts/zones/Port_Bastok/npcs/Nokkhi_Jinjahl.lua
+++ b/scripts/zones/Port_Bastok/npcs/Nokkhi_Jinjahl.lua
@@ -2,8 +2,7 @@
 --  Area: Port Bastok
 --   NPC: Nokkhi Jinjahl
 --  Type: Travelling Merchant NPC / NPC Quiver Maker / Bastok 1st Place
--- @zone 236
--- @pos 112.667 7.455 -46.174
+-- !pos 111 8 -47 236
 -----------------------------------
 package.loaded["scripts/zones/Port_Bastok/TextIDs"] = nil;
 -----------------------------------
@@ -14,307 +13,153 @@ require("scripts/zones/Port_Bastok/TextIDs");
 -----------------------------------
 
 function onTrade(player,npc,trade)
-    local count = trade:getItemCount();
-    local carnation   = trade:getItemQty(948)
-    ----------------ARROWS----------------------------
-    local antlion     =    (trade:getItemQty(19195) / 99)
-    local beetle      =    (trade:getItemQty(18154) / 99)
-    local demon       =    (trade:getItemQty(18159) / 99)
-    local gargou      =    (trade:getItemQty(19800) / 99)
-    local horn        =    (trade:getItemQty(18156) / 99)
-    local irona       =    (trade:getItemQty(17320) / 99)
-    local kabura      =    (trade:getItemQty(17325) / 99)
-    local ruszor      =    (trade:getItemQty(19182) / 99)
-    local scorpion    =    (trade:getItemQty(18155) / 99)
-    local silvera     =    (trade:getItemQty(17321) / 99)
-    local sleepa      =    (trade:getItemQty(18158) / 99)
-    ----------------BOLTS-----------------------------
-    local acid        =    (trade:getItemQty(18148) / 99)
-    local adamana     =    (trade:getItemQty(19801) / 99)
-    local blind       =    (trade:getItemQty(18150) / 99)
-    local bloody      =    (trade:getItemQty(18151) / 99)
-    local darka       =    (trade:getItemQty(19183) / 99)
-    local darkling    =    (trade:getItemQty(19196) / 99)
-    local darksteel   =    (trade:getItemQty(17338) / 99)
-    local fusion      =    (trade:getItemQty(19197) / 99)
-    local holy        =    (trade:getItemQty(18153) / 99)
-    local mythril     =    (trade:getItemQty(17337) / 99)
-    local sleepb      =    (trade:getItemQty(18149) / 99)
-    local venom       =    (trade:getItemQty(18152) / 99)
-    ----------------BULLETS---------------------------
-    local adamanb     =    (trade:getItemQty(19803) / 99)
-    local bullet      =    (trade:getItemQty(17340) / 99)
-    local bronze      =    (trade:getItemQty(17343) / 99)
-    local darkb       =    (trade:getItemQty(19184) / 99)
-    local dweomer     =    (trade:getItemQty(19198) / 99)
-    local ironb       =    (trade:getItemQty(17312) / 99)
-    local oberons     =    (trade:getItemQty(19199) / 99)
-    local orichalcum  =    (trade:getItemQty(19802) / 99)
-    local silverb     =    (trade:getItemQty(17341) / 99)
-    local steel       =    (trade:getItemQty(18723) / 99)
-    local spartan     =    (trade:getItemQty(18160) / 99)
-    ----------------CARDS-----------------------------
-    local fire        =    (trade:getItemQty(2176) / 99)
-    local ice         =    (trade:getItemQty(2177) / 99)
-    local wind        =    (trade:getItemQty(2178) / 99)
-    local earth       =    (trade:getItemQty(2179) / 99)
-    local thunder     =    (trade:getItemQty(2180) / 99)
-    local water       =    (trade:getItemQty(2181) / 99)
-    local light       =    (trade:getItemQty(2182) / 99)
-    local dark        =    (trade:getItemQty(2183) / 99)
------------------------------------------------------
+    local ammoList = 
+    {
+        {21307, 6199}, -- arrow, achiyalabopa
+        {21306, 6200}, -- arrow, adlivun
+        {19195, 5819}, -- arrow, antlion
+        {18154, 4221}, -- arrow, beetle
+        {21309, 6137}, -- arrow, chapuli
+        {18159, 4224}, -- arrow, demon
+        {21302, 6269}, -- arrow, eminent
+        {19800, 5912}, -- arrow, gargouille
+        {18156, 4222}, -- arrow, horn
+        {17320, 4225}, -- arrow, iron
+        {17325, 5332}, -- arrow, kabura
+        {21308, 6138}, -- arrow, mantid
+        {21303, 6280}, -- arrow, ra'kaznar
+        {21304, 6202}, -- arrow, raaz
+        {19182, 5871}, -- arrow, ruszor
+        {18155, 4223}, -- arrow, scorpion
+        {17321, 4226}, -- arrow, silver
+        {18158, 5333}, -- arrow, sleep
+        {17330, 4219}, -- arrow, stone
+        {21305, 6201}, -- arrow, tulfaire
+        
+        {21314, 6278}, -- bolt, abrasion
+        {21321, 6203}, -- bolt, achiyalabopa
+        {18148, 5335}, -- bolt, acid
+        {19801, 5913}, -- bolt, adaman
+        {21320, 6204}, -- bolt, adlivun
+        {21318, 6206}, -- bolt, bismuth
+        {18150, 5334}, -- bolt, blind
+        {18151, 5339}, -- bolt, bloody
+        {21322, 6140}, -- bolt, damascus
+        {19183, 5872}, -- bolt, dark adaman
+        {19196, 5820}, -- bolt, darkling
+        {17338, 4229}, -- bolt, darksteel
+        {21316, 6270}, -- bolt, eminent
+        {19197, 5821}, -- bolt, fusion
+        {21313, 6310}, -- bolt, gashing
+        {18153, 5336}, -- bolt, holy
+        {21324, 6139}, -- bolt, midrium
+        {17337, 4228}, -- bolt, mythril
+        {21323, 6141}, -- bolt, oxidant
+        {21317, 6281}, -- bolt, ra'kaznar
+        {21315, 6279}, -- bolt, righteous
+        {18149, 5337}, -- bolt, sleep
+        {21319, 6205}, -- bolt, titanium
+        {18152, 5338}, -- bolt, venom
+        
+        {19803, 5915}, -- bullet, adaman
+        {21336, 6208}, -- bullet, adlivun
+        {21337, 6207}, -- bullet, achiyalabopa
+        {17340, 5363}, -- bullet
+        {21333, 6210}, -- bullet, bismuth
+        {17343, 5359}, -- bullet, bronze
+        {21338, 6143}, -- bullet, damascus
+        {19184, 5873}, -- bullet, dark adaman
+        {21330, 6311}, -- bullet, decimating
+        {21328, 6437}, -- bullet, divine
+        {19198, 5822}, -- bullet, dweomer
+        {21331, 6271}, -- bullet, eminent
+        {17312, 5353}, -- bullet, iron
+        {19802, 5914}, -- bullet, orichalcum
+        {19199, 5823}, -- bullet, oberon's
+        {21332, 6282}, -- bullet, ra'kaznar
+        {17341, 5340}, -- bullet, silver
+        {18723, 5416}, -- bullet, steel
+        {18160, 5341}, -- bullet, spartan
+        {21335, 6209}, -- bullet, titanium
+        
+        {2176, 5402}, -- card, fire
+        {2177, 5403}, -- card, ice
+        {2178, 5404}, -- card, wind
+        {2179, 5405}, -- card, earth
+        {2180, 5406}, -- card, thunder
+        {2181, 5407}, -- card, water
+        {2182, 5408}, -- card, light
+        {2183, 5409}, -- card, dark
+    };
 
-    local quiver = (antlion + beetle + demon + gargou + horn + irona + kabura + ruszor + scorpion + silvera + sleepa + acid + adamana + blind + bloody + darka + darkling + darksteel + fusion + holy + mythril + sleepb + venom + adamanb + bullet + bronze + darkb + dweomer + ironb + oberons + orichalcum + silverb + steel + spartan + fire + ice + wind + earth + thunder + water + light + dark)
-    if (((quiver * 99) + carnation) == count) then
-        if ((quiver == math.floor(quiver)) and (quiver == carnation) and (player:getFreeSlotsCount() >= carnation)) then
-            player:tradeComplete();
-            ----------------ARROWS----------------------------
-            if (antlion > 0) then
-                player:addItem(5819,antlion);
-                player:messageSpecial(ITEM_OBTAINED,5819);
+    local carnationsNeeded = 0;
+    local giveToPlayer = {};
+
+    -- check for invalid items
+    for i = 0,8,1 do
+        local itemId = trade:getItemId(i);
+        if (itemId > 0 and itemId ~= 948) then
+            local validSlot = false;
+            for k, v in pairs(ammoList) do
+                if (v[1] == itemId) then
+                    local itemQty = trade:getSlotQty(i);
+                    if (itemQty % 99 ~= 0) then
+                        player:messageSpecial(NOKKHI_BAD_COUNT);
+                        return;
+                    end;
+                    local stacks = itemQty / 99;
+                    carnationsNeeded = carnationsNeeded + stacks;
+                    giveToPlayer[#giveToPlayer+1] = {v[2], stacks};
+                    validSlot = true;
+                    break;
+                end
             end
-            if (beetle > 0) then
-                player:addItem(4221,beetle);
-                player:messageSpecial(ITEM_OBTAINED,4221);
-            end
-            if (demon > 0) then
-                player:addItem(4224,demon);
-                player:messageSpecial(ITEM_OBTAINED,4224);
-            end
-            if (gargou > 0) then
-                player:addItem(5912,gargouille);
-                player:messageSpecial(ITEM_OBTAINED,5912);
-            end
-            if (horn > 0) then
-                player:addItem(4222,horn);
-                player:messageSpecial(ITEM_OBTAINED,4222);
-            end
-            if (irona > 0) then
-                player:addItem(4225,irona);
-                player:messageSpecial(ITEM_OBTAINED,4225);
-            end
-            if (kabura > 0) then
-                player:addItem(5332,kabura);
-                player:messageSpecial(ITEM_OBTAINED,5332);
-            end
-            if (ruszor > 0) then
-                player:addItem(5871,ruszor);
-                player:messageSpecial(ITEM_OBTAINED,5871);
-            end
-            if (scorpion > 0) then
-                player:addItem(4223,scorpion);
-                player:messageSpecial(ITEM_OBTAINED,4223);
-            end
-            if (silvera > 0) then
-                player:addItem(4226,silvera);
-                player:messageSpecial(ITEM_OBTAINED,4226);
-            end
-            if (sleepa > 0) then
-                player:addItem(5333,sleepa);
-                player:messageSpecial(ITEM_OBTAINED,5333);
-            end
-            ----------------BOLTS-----------------------------
-            if (acid > 0) then
-                player:addItem(5335,acid);
-                player:messageSpecial(ITEM_OBTAINED,5335);
-            end
-            if (adamana > 0) then
-                player:addItem(5913,adamana);
-                player:messageSpecial(ITEM_OBTAINED,5913);
-            end
-            if (blind > 0) then
-                player:addItem(5334,blind);
-                player:messageSpecial(ITEM_OBTAINED,5334);
-            end
-            if (bloody > 0) then
-                player:addItem(5339,bloody);
-                player:messageSpecial(ITEM_OBTAINED,5339);
-            end
-            if (darka > 0) then
-                player:addItem(5872,darka);
-                player:messageSpecial(ITEM_OBTAINED,5872);
-            end
-            if (darkling > 0) then
-                player:addItem(5820,darkling);
-                player:messageSpecial(ITEM_OBTAINED,5820);
-            end
-            if (darksteel > 0) then
-                player:addItem(4229,darksteel);
-                player:messageSpecial(ITEM_OBTAINED,4229);
-            end
-            if (fusion > 0) then
-                player:addItem(5821,fusion);
-                player:messageSpecial(ITEM_OBTAINED,5821);
-            end
-            if (holy > 0) then
-                player:addItem(5336,holy);
-                player:messageSpecial(ITEM_OBTAINED,5336);
-            end
-            if (mythril > 0) then
-                player:addItem(4228,mythril);
-                player:messageSpecial(ITEM_OBTAINED,4228);
-            end
-            if (sleepb > 0) then
-                player:addItem(5337,sleepb);
-                player:messageSpecial(ITEM_OBTAINED,5337);
-            end
-            if (venom > 0) then
-                player:addItem(5338,venom);
-                player:messageSpecial(ITEM_OBTAINED,5338);
-            end
-            ----------------BULLETS---------------------------
-            if (adamanb > 0) then
-                player:addItem(5915,adamanb);
-                player:messageSpecial(ITEM_OBTAINED,5915);
-            end
-            if (bullet > 0) then
-                player:addItem(5363,bullet);
-                player:messageSpecial(ITEM_OBTAINED,5363);
-            end
-            if (bronze > 0) then
-                player:addItem(5359,bronze);
-                player:messageSpecial(ITEM_OBTAINED,5359);
-            end
-            if (darkb > 0) then
-                player:addItem(5873,darkb);
-                player:messageSpecial(ITEM_OBTAINED,5873);
-            end
-            if (dweomer > 0) then
-                player:addItem(5822,dweomer);
-                player:messageSpecial(ITEM_OBTAINED,5822);
-            end
-            if (ironb > 0) then
-                player:addItem(5353,ironb);
-                player:messageSpecial(ITEM_OBTAINED,5353);
-            end
-            if (oberons > 0) then
-                player:addItem(5823,oberons);
-                player:messageSpecial(ITEM_OBTAINED,5823);
-            end
-            if (orichalcum > 0) then
-                player:addItem(5914,orichalcum);
-                player:messageSpecial(ITEM_OBTAINED,5914);
-            end
-            if (silverb > 0) then
-                player:addItem(5340,silverb);
-                player:messageSpecial(ITEM_OBTAINED,5340);
-            end
-            if (steel > 0) then
-                player:addItem(5416,steel);
-                player:messageSpecial(ITEM_OBTAINED,5416);
-            end
-            if (spartan > 0) then
-                player:addItem(5341,spartan);
-                player:messageSpecial(ITEM_OBTAINED,5341);
-            end
-            ----------------CARDS-----------------------------
-            if (fire > 0) then
-                player:addItem(5402,fire);
-                player:messageSpecial(ITEM_OBTAINED,5402);
-            end
-            if (ice > 0) then
-                player:addItem(5403,ice);
-                player:messageSpecial(ITEM_OBTAINED,5403);
-            end
-            if (wind > 0) then
-                player:addItem(5404,wind);
-                player:messageSpecial(ITEM_OBTAINED,5404);
-            end
-            if (earth > 0) then
-                player:addItem(5405,earth);
-                player:messageSpecial(ITEM_OBTAINED,5405);
-            end
-            if (thunder > 0) then
-                player:addItem(5406,thunder);
-                player:messageSpecial(ITEM_OBTAINED,5406);
-            end
-            if (water > 0) then
-                player:addItem(5407,water);
-                player:messageSpecial(ITEM_OBTAINED,5407);
-            end
-            if (light > 0) then
-                player:addItem(5408,light);
-                player:messageSpecial(ITEM_OBTAINED,5408);
-            end
-            if (dark > 0) then
-                player:addItem(5409,dark);
-                player:messageSpecial(ITEM_OBTAINED,5409);
+            if (not validSlot) then
+                player:messageSpecial(NOKKHI_BAD_ITEM);
+                return;
             end
         end
     end
 
--- 948      - carnation
--- SINGLE -- ARROWS---------------- STACK
--- 19195    - antlion arrow      -    5819
--- 18154    - beetle arrow       -    4221
--- 18159    - demon arrow        -    4224
--- 19800    - gargouille arrow   -    5912
--- 18156    - horn arrow         -    4222
--- 17320    - iron arrow         -    4225
--- 17325    - kabura arrow       -    5332
--- 19182    - ruszor arrow       -    5871
--- 18155    - scorpion arrow     -    4223
--- 17321    - silver arrow       -    4226
--- 18158    - sleep arrow        -    5333
----------- BOLTS -----------------------
--- 18148    - acid bolt          -    5335
--- 19801    - adaman bolt        -    5913
--- 18150    - blind bolt         -    5334
--- 18151    - bloody bolt        -    5339
--- 19183    - dark adaman bolt   -    5872
--- 19196    - darkling bolt      -    5820
--- 17338    - darksteel bolt     -    4229
--- 19197    - fusion bolt        -    5821
--- 18153    - holy bolt          -    5336
--- 17337    - mythril bolt       -    4228
--- 18149    - sleep bolt         -    5337
--- 18152    - venom bolt         -    5338
----------- BULLETS ---------------------
--- 19803    - adaman bullet      -    5915
--- 17340    - bullet             -    5363
--- 17343    - bronze bullet      -    5359
--- 19184    - dark adaman bullet -    5873
--- 19198    - dweomer bullet     -    5822
--- 17312    - iron bullet        -    5353
--- 19199    - oberon's bullet    -    5823
--- 19802    - orichalcum bullet  -    5914
--- 17341    - silver bullet      -    5340
--- 18723    - steel bullet       -    5416
--- 18160    - spartan bullet     -    5341
----------- CARDS -----------------------
--- 2176    - fire card           -    5402
--- 2177    - ice card            -    5403
--- 2178    - wind card           -    5404
--- 2179    - earth card          -    5405
--- 2180    - thunder card        -    5406
--- 2181    - water card          -    5407
--- 2182    - light card          -    5408
--- 2183    - dark card           -    5409
---------------------------------------
-end;
+    -- check for correct number of carnations
+    if (carnationsNeeded == 0 or trade:getItemQty(948) ~= carnationsNeeded) then
+        player:messageSpecial(NOKKHI_BAD_COUNT);
+        return;
+    end
+    
+    -- check for enough inventory space
+    if (player:getFreeSlotsCount() < carnationsNeeded) then
+        player:messageSpecial(ITEM_CANNOT_BE_OBTAINED, giveToPlayer[1][1]);
+        return;
+    end
+
+    -- make the trade
+    player:messageSpecial(NOKKHI_GOOD_TRADE);
+    for k, v in pairs(giveToPlayer) do
+        player:addItem(v[1], v[2]);
+        player:messageSpecial(ITEM_OBTAINED,v[1]);
+    end
+    player:tradeComplete();
+end
 
 -----------------------------------
 -- onTrigger Action
 -----------------------------------
 
 function onTrigger(player,npc)
-    player:startEvent(0x011d,npc:getID());
-end;
+    player:startEvent(285,npc:getID());
+end
 
 -----------------------------------
 -- onEventUpdate
 -----------------------------------
 
 function onEventUpdate(player,csid,option)
-    -- printf("CSID: %u",csid);
-    -- printf("RESULT: %u",option);
-end;
+end
 
 -----------------------------------
 -- onEventFinish
 -----------------------------------
 
 function onEventFinish(player,csid,option)
-    -- printf("CSID: %u",csid);
-    -- printf("RESULT: %u",option);
-end;
+end

--- a/scripts/zones/Southern_San_dOria/TextIDs.lua
+++ b/scripts/zones/Southern_San_dOria/TextIDs.lua
@@ -48,6 +48,9 @@ IF_YOU_WEAR_THIS = 7355; -- If you put this on and walk around, something...unex
        THANK_YOU = 7353; -- Thank you...<<<Prompt>>>
 
 -- Other dialog
+    NOKKHI_BAD_COUNT = 7373; -- What kinda smart-alecky baloney is this!? I told you to bring me the same kinda ammunition in complete sets. And don't forget the flowers, neither.
+   NOKKHI_GOOD_TRADE = 7375; -- And here you go! Come back soon, and bring your friends!
+     NOKKHI_BAD_ITEM = 7376; -- I'm real sorry, but there's nothing I can do with those.
 ITEM_DELIVERY_DIALOG = 8405; -- Parcels delivered to rooms anywhere in Vana'diel!
         ROSEL_DIALOG = 7782; -- Hrmm... Now, this is interesting! It pays to keep an eye on the competition. Thanks for letting me know!
 

--- a/scripts/zones/Southern_San_dOria/npcs/Nokkhi_Jinjahl.lua
+++ b/scripts/zones/Southern_San_dOria/npcs/Nokkhi_Jinjahl.lua
@@ -2,8 +2,7 @@
 --  Area: Southern San d'Oria
 --   NPC: Nokkhi Jinjahl
 --  Type: Travelling Merchant NPC / NPC Quiver Maker / San d'Oria 1st Place
--- @zone 230
--- @pos 24.829 0.978 -13.110
+-- !pos 23 2 -13 230
 -----------------------------------
 package.loaded["scripts/zones/Southern_San_dOria/TextIDs"] = nil;
 -----------------------------------
@@ -14,307 +13,153 @@ require("scripts/zones/Southern_San_dOria/TextIDs");
 -----------------------------------
 
 function onTrade(player,npc,trade)
-    local count = trade:getItemCount();
-    local carnation   = trade:getItemQty(948)
-    ----------------ARROWS----------------------------
-    local antlion     =    (trade:getItemQty(19195) / 99)
-    local beetle      =    (trade:getItemQty(18154) / 99)
-    local demon       =    (trade:getItemQty(18159) / 99)
-    local gargou      =    (trade:getItemQty(19800) / 99)
-    local horn        =    (trade:getItemQty(18156) / 99)
-    local irona       =    (trade:getItemQty(17320) / 99)
-    local kabura      =    (trade:getItemQty(17325) / 99)
-    local ruszor      =    (trade:getItemQty(19182) / 99)
-    local scorpion    =    (trade:getItemQty(18155) / 99)
-    local silvera     =    (trade:getItemQty(17321) / 99)
-    local sleepa      =    (trade:getItemQty(18158) / 99)
-    ----------------BOLTS-----------------------------
-    local acid        =    (trade:getItemQty(18148) / 99)
-    local adamana     =    (trade:getItemQty(19801) / 99)
-    local blind       =    (trade:getItemQty(18150) / 99)
-    local bloody      =    (trade:getItemQty(18151) / 99)
-    local darka       =    (trade:getItemQty(19183) / 99)
-    local darkling    =    (trade:getItemQty(19196) / 99)
-    local darksteel   =    (trade:getItemQty(17338) / 99)
-    local fusion      =    (trade:getItemQty(19197) / 99)
-    local holy        =    (trade:getItemQty(18153) / 99)
-    local mythril     =    (trade:getItemQty(17337) / 99)
-    local sleepb      =    (trade:getItemQty(18149) / 99)
-    local venom       =    (trade:getItemQty(18152) / 99)
-    ----------------BULLETS---------------------------
-    local adamanb     =    (trade:getItemQty(19803) / 99)
-    local bullet      =    (trade:getItemQty(17340) / 99)
-    local bronze      =    (trade:getItemQty(17343) / 99)
-    local darkb       =    (trade:getItemQty(19184) / 99)
-    local dweomer     =    (trade:getItemQty(19198) / 99)
-    local ironb       =    (trade:getItemQty(17312) / 99)
-    local oberons     =    (trade:getItemQty(19199) / 99)
-    local orichalcum  =    (trade:getItemQty(19802) / 99)
-    local silverb     =    (trade:getItemQty(17341) / 99)
-    local steel       =    (trade:getItemQty(18723) / 99)
-    local spartan     =    (trade:getItemQty(18160) / 99)
-    ----------------CARDS-----------------------------
-    local fire        =    (trade:getItemQty(2176) / 99)
-    local ice         =    (trade:getItemQty(2177) / 99)
-    local wind        =    (trade:getItemQty(2178) / 99)
-    local earth       =    (trade:getItemQty(2179) / 99)
-    local thunder     =    (trade:getItemQty(2180) / 99)
-    local water       =    (trade:getItemQty(2181) / 99)
-    local light       =    (trade:getItemQty(2182) / 99)
-    local dark        =    (trade:getItemQty(2183) / 99)
------------------------------------------------------
+    local ammoList = 
+    {
+        {21307, 6199}, -- arrow, achiyalabopa
+        {21306, 6200}, -- arrow, adlivun
+        {19195, 5819}, -- arrow, antlion
+        {18154, 4221}, -- arrow, beetle
+        {21309, 6137}, -- arrow, chapuli
+        {18159, 4224}, -- arrow, demon
+        {21302, 6269}, -- arrow, eminent
+        {19800, 5912}, -- arrow, gargouille
+        {18156, 4222}, -- arrow, horn
+        {17320, 4225}, -- arrow, iron
+        {17325, 5332}, -- arrow, kabura
+        {21308, 6138}, -- arrow, mantid
+        {21303, 6280}, -- arrow, ra'kaznar
+        {21304, 6202}, -- arrow, raaz
+        {19182, 5871}, -- arrow, ruszor
+        {18155, 4223}, -- arrow, scorpion
+        {17321, 4226}, -- arrow, silver
+        {18158, 5333}, -- arrow, sleep
+        {17330, 4219}, -- arrow, stone
+        {21305, 6201}, -- arrow, tulfaire
+        
+        {21314, 6278}, -- bolt, abrasion
+        {21321, 6203}, -- bolt, achiyalabopa
+        {18148, 5335}, -- bolt, acid
+        {19801, 5913}, -- bolt, adaman
+        {21320, 6204}, -- bolt, adlivun
+        {21318, 6206}, -- bolt, bismuth
+        {18150, 5334}, -- bolt, blind
+        {18151, 5339}, -- bolt, bloody
+        {21322, 6140}, -- bolt, damascus
+        {19183, 5872}, -- bolt, dark adaman
+        {19196, 5820}, -- bolt, darkling
+        {17338, 4229}, -- bolt, darksteel
+        {21316, 6270}, -- bolt, eminent
+        {19197, 5821}, -- bolt, fusion
+        {21313, 6310}, -- bolt, gashing
+        {18153, 5336}, -- bolt, holy
+        {21324, 6139}, -- bolt, midrium
+        {17337, 4228}, -- bolt, mythril
+        {21323, 6141}, -- bolt, oxidant
+        {21317, 6281}, -- bolt, ra'kaznar
+        {21315, 6279}, -- bolt, righteous
+        {18149, 5337}, -- bolt, sleep
+        {21319, 6205}, -- bolt, titanium
+        {18152, 5338}, -- bolt, venom
+        
+        {19803, 5915}, -- bullet, adaman
+        {21336, 6208}, -- bullet, adlivun
+        {21337, 6207}, -- bullet, achiyalabopa
+        {17340, 5363}, -- bullet
+        {21333, 6210}, -- bullet, bismuth
+        {17343, 5359}, -- bullet, bronze
+        {21338, 6143}, -- bullet, damascus
+        {19184, 5873}, -- bullet, dark adaman
+        {21330, 6311}, -- bullet, decimating
+        {21328, 6437}, -- bullet, divine
+        {19198, 5822}, -- bullet, dweomer
+        {21331, 6271}, -- bullet, eminent
+        {17312, 5353}, -- bullet, iron
+        {19802, 5914}, -- bullet, orichalcum
+        {19199, 5823}, -- bullet, oberon's
+        {21332, 6282}, -- bullet, ra'kaznar
+        {17341, 5340}, -- bullet, silver
+        {18723, 5416}, -- bullet, steel
+        {18160, 5341}, -- bullet, spartan
+        {21335, 6209}, -- bullet, titanium
+        
+        {2176, 5402}, -- card, fire
+        {2177, 5403}, -- card, ice
+        {2178, 5404}, -- card, wind
+        {2179, 5405}, -- card, earth
+        {2180, 5406}, -- card, thunder
+        {2181, 5407}, -- card, water
+        {2182, 5408}, -- card, light
+        {2183, 5409}, -- card, dark
+    };
 
-    local quiver = (antlion + beetle + demon + gargou + horn + irona + kabura + ruszor + scorpion + silvera + sleepa + acid + adamana + blind + bloody + darka + darkling + darksteel + fusion + holy + mythril + sleepb + venom + adamanb + bullet + bronze + darkb + dweomer + ironb + oberons + orichalcum + silverb + steel + spartan + fire + ice + wind + earth + thunder + water + light + dark)
-    if (((quiver * 99) + carnation) == count) then
-        if ((quiver == math.floor(quiver)) and (quiver == carnation) and (player:getFreeSlotsCount() >= carnation)) then
-            player:tradeComplete();
-            ----------------ARROWS----------------------------
-            if (antlion > 0) then
-                player:addItem(5819,antlion);
-                player:messageSpecial(ITEM_OBTAINED,5819);
+    local carnationsNeeded = 0;
+    local giveToPlayer = {};
+
+    -- check for invalid items
+    for i = 0,8,1 do
+        local itemId = trade:getItemId(i);
+        if (itemId > 0 and itemId ~= 948) then
+            local validSlot = false;
+            for k, v in pairs(ammoList) do
+                if (v[1] == itemId) then
+                    local itemQty = trade:getSlotQty(i);
+                    if (itemQty % 99 ~= 0) then
+                        player:messageSpecial(NOKKHI_BAD_COUNT);
+                        return;
+                    end;
+                    local stacks = itemQty / 99;
+                    carnationsNeeded = carnationsNeeded + stacks;
+                    giveToPlayer[#giveToPlayer+1] = {v[2], stacks};
+                    validSlot = true;
+                    break;
+                end
             end
-            if (beetle > 0) then
-                player:addItem(4221,beetle);
-                player:messageSpecial(ITEM_OBTAINED,4221);
-            end
-            if (demon > 0) then
-                player:addItem(4224,demon);
-                player:messageSpecial(ITEM_OBTAINED,4224);
-            end
-            if (gargou > 0) then
-                player:addItem(5912,gargouille);
-                player:messageSpecial(ITEM_OBTAINED,5912);
-            end
-            if (horn > 0) then
-                player:addItem(4222,horn);
-                player:messageSpecial(ITEM_OBTAINED,4222);
-            end
-            if (irona > 0) then
-                player:addItem(4225,irona);
-                player:messageSpecial(ITEM_OBTAINED,4225);
-            end
-            if (kabura > 0) then
-                player:addItem(5332,kabura);
-                player:messageSpecial(ITEM_OBTAINED,5332);
-            end
-            if (ruszor > 0) then
-                player:addItem(5871,ruszor);
-                player:messageSpecial(ITEM_OBTAINED,5871);
-            end
-            if (scorpion > 0) then
-                player:addItem(4223,scorpion);
-                player:messageSpecial(ITEM_OBTAINED,4223);
-            end
-            if (silvera > 0) then
-                player:addItem(4226,silvera);
-                player:messageSpecial(ITEM_OBTAINED,4226);
-            end
-            if (sleepa > 0) then
-                player:addItem(5333,sleepa);
-                player:messageSpecial(ITEM_OBTAINED,5333);
-            end
-            ----------------BOLTS-----------------------------
-            if (acid > 0) then
-                player:addItem(5335,acid);
-                player:messageSpecial(ITEM_OBTAINED,5335);
-            end
-            if (adamana > 0) then
-                player:addItem(5913,adamana);
-                player:messageSpecial(ITEM_OBTAINED,5913);
-            end
-            if (blind > 0) then
-                player:addItem(5334,blind);
-                player:messageSpecial(ITEM_OBTAINED,5334);
-            end
-            if (bloody > 0) then
-                player:addItem(5339,bloody);
-                player:messageSpecial(ITEM_OBTAINED,5339);
-            end
-            if (darka > 0) then
-                player:addItem(5872,darka);
-                player:messageSpecial(ITEM_OBTAINED,5872);
-            end
-            if (darkling > 0) then
-                player:addItem(5820,darkling);
-                player:messageSpecial(ITEM_OBTAINED,5820);
-            end
-            if (darksteel > 0) then
-                player:addItem(4229,darksteel);
-                player:messageSpecial(ITEM_OBTAINED,4229);
-            end
-            if (fusion > 0) then
-                player:addItem(5821,fusion);
-                player:messageSpecial(ITEM_OBTAINED,5821);
-            end
-            if (holy > 0) then
-                player:addItem(5336,holy);
-                player:messageSpecial(ITEM_OBTAINED,5336);
-            end
-            if (mythril > 0) then
-                player:addItem(4228,mythril);
-                player:messageSpecial(ITEM_OBTAINED,4228);
-            end
-            if (sleepb > 0) then
-                player:addItem(5337,sleepb);
-                player:messageSpecial(ITEM_OBTAINED,5337);
-            end
-            if (venom > 0) then
-                player:addItem(5338,venom);
-                player:messageSpecial(ITEM_OBTAINED,5338);
-            end
-            ----------------BULLETS---------------------------
-            if (adamanb > 0) then
-                player:addItem(5915,adamanb);
-                player:messageSpecial(ITEM_OBTAINED,5915);
-            end
-            if (bullet > 0) then
-                player:addItem(5363,bullet);
-                player:messageSpecial(ITEM_OBTAINED,5363);
-            end
-            if (bronze > 0) then
-                player:addItem(5359,bronze);
-                player:messageSpecial(ITEM_OBTAINED,5359);
-            end
-            if (darkb > 0) then
-                player:addItem(5873,darkb);
-                player:messageSpecial(ITEM_OBTAINED,5873);
-            end
-            if (dweomer > 0) then
-                player:addItem(5822,dweomer);
-                player:messageSpecial(ITEM_OBTAINED,5822);
-            end
-            if (ironb > 0) then
-                player:addItem(5353,ironb);
-                player:messageSpecial(ITEM_OBTAINED,5353);
-            end
-            if (oberons > 0) then
-                player:addItem(5823,oberons);
-                player:messageSpecial(ITEM_OBTAINED,5823);
-            end
-            if (orichalcum > 0) then
-                player:addItem(5914,orichalcum);
-                player:messageSpecial(ITEM_OBTAINED,5914);
-            end
-            if (silverb > 0) then
-                player:addItem(5340,silverb);
-                player:messageSpecial(ITEM_OBTAINED,5340);
-            end
-            if (steel > 0) then
-                player:addItem(5416,steel);
-                player:messageSpecial(ITEM_OBTAINED,5416);
-            end
-            if (spartan > 0) then
-                player:addItem(5341,spartan);
-                player:messageSpecial(ITEM_OBTAINED,5341);
-            end
-            ----------------CARDS-----------------------------
-            if (fire > 0) then
-                player:addItem(5402,fire);
-                player:messageSpecial(ITEM_OBTAINED,5402);
-            end
-            if (ice > 0) then
-                player:addItem(5403,ice);
-                player:messageSpecial(ITEM_OBTAINED,5403);
-            end
-            if (wind > 0) then
-                player:addItem(5404,wind);
-                player:messageSpecial(ITEM_OBTAINED,5404);
-            end
-            if (earth > 0) then
-                player:addItem(5405,earth);
-                player:messageSpecial(ITEM_OBTAINED,5405);
-            end
-            if (thunder > 0) then
-                player:addItem(5406,thunder);
-                player:messageSpecial(ITEM_OBTAINED,5406);
-            end
-            if (water > 0) then
-                player:addItem(5407,water);
-                player:messageSpecial(ITEM_OBTAINED,5407);
-            end
-            if (light > 0) then
-                player:addItem(5408,light);
-                player:messageSpecial(ITEM_OBTAINED,5408);
-            end
-            if (dark > 0) then
-                player:addItem(5409,dark);
-                player:messageSpecial(ITEM_OBTAINED,5409);
+            if (not validSlot) then
+                player:messageSpecial(NOKKHI_BAD_ITEM);
+                return;
             end
         end
     end
 
--- 948      - carnation
--- SINGLE -- ARROWS---------------- STACK
--- 19195    - antlion arrow      -    5819
--- 18154    - beetle arrow       -    4221
--- 18159    - demon arrow        -    4224
--- 19800    - gargouille arrow   -    5912
--- 18156    - horn arrow         -    4222
--- 17320    - iron arrow         -    4225
--- 17325    - kabura arrow       -    5332
--- 19182    - ruszor arrow       -    5871
--- 18155    - scorpion arrow     -    4223
--- 17321    - silver arrow       -    4226
--- 18158    - sleep arrow        -    5333
----------- BOLTS -----------------------
--- 18148    - acid bolt          -    5335
--- 19801    - adaman bolt        -    5913
--- 18150    - blind bolt         -    5334
--- 18151    - bloody bolt        -    5339
--- 19183    - dark adaman bolt   -    5872
--- 19196    - darkling bolt      -    5820
--- 17338    - darksteel bolt     -    4229
--- 19197    - fusion bolt        -    5821
--- 18153    - holy bolt          -    5336
--- 17337    - mythril bolt       -    4228
--- 18149    - sleep bolt         -    5337
--- 18152    - venom bolt         -    5338
----------- BULLETS ---------------------
--- 19803    - adaman bullet      -    5915
--- 17340    - bullet             -    5363
--- 17343    - bronze bullet      -    5359
--- 19184    - dark adaman bullet -    5873
--- 19198    - dweomer bullet     -    5822
--- 17312    - iron bullet        -    5353
--- 19199    - oberon's bullet    -    5823
--- 19802    - orichalcum bullet  -    5914
--- 17341    - silver bullet      -    5340
--- 18723    - steel bullet       -    5416
--- 18160    - spartan bullet     -    5341
----------- CARDS -----------------------
--- 2176    - fire card           -    5402
--- 2177    - ice card            -    5403
--- 2178    - wind card           -    5404
--- 2179    - earth card          -    5405
--- 2180    - thunder card        -    5406
--- 2181    - water card          -    5407
--- 2182    - light card          -    5408
--- 2183    - dark card           -    5409
---------------------------------------
-end;
+    -- check for correct number of carnations
+    if (carnationsNeeded == 0 or trade:getItemQty(948) ~= carnationsNeeded) then
+        player:messageSpecial(NOKKHI_BAD_COUNT);
+        return;
+    end
+    
+    -- check for enough inventory space
+    if (player:getFreeSlotsCount() < carnationsNeeded) then
+        player:messageSpecial(ITEM_CANNOT_BE_OBTAINED, giveToPlayer[1][1]);
+        return;
+    end
+
+    -- make the trade
+    player:messageSpecial(NOKKHI_GOOD_TRADE);
+    for k, v in pairs(giveToPlayer) do
+        player:addItem(v[1], v[2]);
+        player:messageSpecial(ITEM_OBTAINED,v[1]);
+    end
+    player:tradeComplete();
+end
 
 -----------------------------------
 -- onTrigger Action
 -----------------------------------
 
 function onTrigger(player,npc)
-    player:startEvent(0x02ab,npc:getID());
-end;
+    player:startEvent(683,npc:getID());
+end
 
 -----------------------------------
 -- onEventUpdate
 -----------------------------------
 
 function onEventUpdate(player,csid,option)
-    -- printf("CSID: %u",csid);
-    -- printf("RESULT: %u",option);
-end;
+end
 
 -----------------------------------
 -- onEventFinish
 -----------------------------------
 
 function onEventFinish(player,csid,option)
-    -- printf("CSID: %u",csid);
-    -- printf("RESULT: %u",option);
-end;
+end

--- a/scripts/zones/Windurst_Woods/TextIDs.lua
+++ b/scripts/zones/Windurst_Woods/TextIDs.lua
@@ -22,6 +22,9 @@ CONQUEST = 8925; -- You've earned conquest points!
 
 -- Other Texts
 ITEM_DELIVERY_DIALOG =  6824; -- We can deliver goods to your residence or to the residences of your friends.
+    NOKKHI_BAD_COUNT =  9754; -- What kinda smart-alecky baloney is this!? I told you to bring me the same kinda ammunition in complete sets. And don't forget the flowers, neither.
+   NOKKHI_GOOD_TRADE =  9756; -- And here you go! Come back soon, and bring your friends!
+     NOKKHI_BAD_ITEM =  9757; -- I'm real sorry, but there's nothing I can do with those.
       CHOCOBO_DIALOG = 10400; -- Kweh!
 
 -- Mission Dialogs

--- a/scripts/zones/Windurst_Woods/npcs/Nokkhi_Jinjahl.lua
+++ b/scripts/zones/Windurst_Woods/npcs/Nokkhi_Jinjahl.lua
@@ -2,8 +2,7 @@
 --  Area: Windurst Woods
 --   NPC: Nokkhi Jinjahl
 --  Type: Travelling Merchant NPC / NPC Quiver Maker / Windurst 1st Place
--- @zone 241
--- @pos 3.306 0.84 -41.601
+-- !pos 4 1 -43 241
 -----------------------------------
 package.loaded["scripts/zones/Windurst_Woods/TextIDs"] = nil;
 -----------------------------------
@@ -14,307 +13,153 @@ require("scripts/zones/Windurst_Woods/TextIDs");
 -----------------------------------
 
 function onTrade(player,npc,trade)
-    local count = trade:getItemCount();
-    local carnation   = trade:getItemQty(948)
-    ----------------ARROWS----------------------------
-    local antlion     =    (trade:getItemQty(19195) / 99)
-    local beetle      =    (trade:getItemQty(18154) / 99)
-    local demon       =    (trade:getItemQty(18159) / 99)
-    local gargou      =    (trade:getItemQty(19800) / 99)
-    local horn        =    (trade:getItemQty(18156) / 99)
-    local irona       =    (trade:getItemQty(17320) / 99)
-    local kabura      =    (trade:getItemQty(17325) / 99)
-    local ruszor      =    (trade:getItemQty(19182) / 99)
-    local scorpion    =    (trade:getItemQty(18155) / 99)
-    local silvera     =    (trade:getItemQty(17321) / 99)
-    local sleepa      =    (trade:getItemQty(18158) / 99)
-    ----------------BOLTS-----------------------------
-    local acid        =    (trade:getItemQty(18148) / 99)
-    local adamana     =    (trade:getItemQty(19801) / 99)
-    local blind       =    (trade:getItemQty(18150) / 99)
-    local bloody      =    (trade:getItemQty(18151) / 99)
-    local darka       =    (trade:getItemQty(19183) / 99)
-    local darkling    =    (trade:getItemQty(19196) / 99)
-    local darksteel   =    (trade:getItemQty(17338) / 99)
-    local fusion      =    (trade:getItemQty(19197) / 99)
-    local holy        =    (trade:getItemQty(18153) / 99)
-    local mythril     =    (trade:getItemQty(17337) / 99)
-    local sleepb      =    (trade:getItemQty(18149) / 99)
-    local venom       =    (trade:getItemQty(18152) / 99)
-    ----------------BULLETS---------------------------
-    local adamanb     =    (trade:getItemQty(19803) / 99)
-    local bullet      =    (trade:getItemQty(17340) / 99)
-    local bronze      =    (trade:getItemQty(17343) / 99)
-    local darkb       =    (trade:getItemQty(19184) / 99)
-    local dweomer     =    (trade:getItemQty(19198) / 99)
-    local ironb       =    (trade:getItemQty(17312) / 99)
-    local oberons     =    (trade:getItemQty(19199) / 99)
-    local orichalcum  =    (trade:getItemQty(19802) / 99)
-    local silverb     =    (trade:getItemQty(17341) / 99)
-    local steel       =    (trade:getItemQty(18723) / 99)
-    local spartan     =    (trade:getItemQty(18160) / 99)
-    ----------------CARDS-----------------------------
-    local fire        =    (trade:getItemQty(2176) / 99)
-    local ice         =    (trade:getItemQty(2177) / 99)
-    local wind        =    (trade:getItemQty(2178) / 99)
-    local earth       =    (trade:getItemQty(2179) / 99)
-    local thunder     =    (trade:getItemQty(2180) / 99)
-    local water       =    (trade:getItemQty(2181) / 99)
-    local light       =    (trade:getItemQty(2182) / 99)
-    local dark        =    (trade:getItemQty(2183) / 99)
------------------------------------------------------
+    local ammoList = 
+    {
+        {21307, 6199}, -- arrow, achiyalabopa
+        {21306, 6200}, -- arrow, adlivun
+        {19195, 5819}, -- arrow, antlion
+        {18154, 4221}, -- arrow, beetle
+        {21309, 6137}, -- arrow, chapuli
+        {18159, 4224}, -- arrow, demon
+        {21302, 6269}, -- arrow, eminent
+        {19800, 5912}, -- arrow, gargouille
+        {18156, 4222}, -- arrow, horn
+        {17320, 4225}, -- arrow, iron
+        {17325, 5332}, -- arrow, kabura
+        {21308, 6138}, -- arrow, mantid
+        {21303, 6280}, -- arrow, ra'kaznar
+        {21304, 6202}, -- arrow, raaz
+        {19182, 5871}, -- arrow, ruszor
+        {18155, 4223}, -- arrow, scorpion
+        {17321, 4226}, -- arrow, silver
+        {18158, 5333}, -- arrow, sleep
+        {17330, 4219}, -- arrow, stone
+        {21305, 6201}, -- arrow, tulfaire
+        
+        {21314, 6278}, -- bolt, abrasion
+        {21321, 6203}, -- bolt, achiyalabopa
+        {18148, 5335}, -- bolt, acid
+        {19801, 5913}, -- bolt, adaman
+        {21320, 6204}, -- bolt, adlivun
+        {21318, 6206}, -- bolt, bismuth
+        {18150, 5334}, -- bolt, blind
+        {18151, 5339}, -- bolt, bloody
+        {21322, 6140}, -- bolt, damascus
+        {19183, 5872}, -- bolt, dark adaman
+        {19196, 5820}, -- bolt, darkling
+        {17338, 4229}, -- bolt, darksteel
+        {21316, 6270}, -- bolt, eminent
+        {19197, 5821}, -- bolt, fusion
+        {21313, 6310}, -- bolt, gashing
+        {18153, 5336}, -- bolt, holy
+        {21324, 6139}, -- bolt, midrium
+        {17337, 4228}, -- bolt, mythril
+        {21323, 6141}, -- bolt, oxidant
+        {21317, 6281}, -- bolt, ra'kaznar
+        {21315, 6279}, -- bolt, righteous
+        {18149, 5337}, -- bolt, sleep
+        {21319, 6205}, -- bolt, titanium
+        {18152, 5338}, -- bolt, venom
+        
+        {19803, 5915}, -- bullet, adaman
+        {21336, 6208}, -- bullet, adlivun
+        {21337, 6207}, -- bullet, achiyalabopa
+        {17340, 5363}, -- bullet
+        {21333, 6210}, -- bullet, bismuth
+        {17343, 5359}, -- bullet, bronze
+        {21338, 6143}, -- bullet, damascus
+        {19184, 5873}, -- bullet, dark adaman
+        {21330, 6311}, -- bullet, decimating
+        {21328, 6437}, -- bullet, divine
+        {19198, 5822}, -- bullet, dweomer
+        {21331, 6271}, -- bullet, eminent
+        {17312, 5353}, -- bullet, iron
+        {19802, 5914}, -- bullet, orichalcum
+        {19199, 5823}, -- bullet, oberon's
+        {21332, 6282}, -- bullet, ra'kaznar
+        {17341, 5340}, -- bullet, silver
+        {18723, 5416}, -- bullet, steel
+        {18160, 5341}, -- bullet, spartan
+        {21335, 6209}, -- bullet, titanium
+        
+        {2176, 5402}, -- card, fire
+        {2177, 5403}, -- card, ice
+        {2178, 5404}, -- card, wind
+        {2179, 5405}, -- card, earth
+        {2180, 5406}, -- card, thunder
+        {2181, 5407}, -- card, water
+        {2182, 5408}, -- card, light
+        {2183, 5409}, -- card, dark
+    };
 
-    local quiver = (antlion + beetle + demon + gargou + horn + irona + kabura + ruszor + scorpion + silvera + sleepa + acid + adamana + blind + bloody + darka + darkling + darksteel + fusion + holy + mythril + sleepb + venom + adamanb + bullet + bronze + darkb + dweomer + ironb + oberons + orichalcum + silverb + steel + spartan + fire + ice + wind + earth + thunder + water + light + dark)
-    if (((quiver * 99) + carnation) == count) then
-        if ((quiver == math.floor(quiver)) and (quiver == carnation) and (player:getFreeSlotsCount() >= carnation)) then
-            player:tradeComplete();
-            ----------------ARROWS----------------------------
-            if (antlion > 0) then
-                player:addItem(5819,antlion);
-                player:messageSpecial(ITEM_OBTAINED,5819);
+    local carnationsNeeded = 0;
+    local giveToPlayer = {};
+
+    -- check for invalid items
+    for i = 0,8,1 do
+        local itemId = trade:getItemId(i);
+        if (itemId > 0 and itemId ~= 948) then
+            local validSlot = false;
+            for k, v in pairs(ammoList) do
+                if (v[1] == itemId) then
+                    local itemQty = trade:getSlotQty(i);
+                    if (itemQty % 99 ~= 0) then
+                        player:messageSpecial(NOKKHI_BAD_COUNT);
+                        return;
+                    end;
+                    local stacks = itemQty / 99;
+                    carnationsNeeded = carnationsNeeded + stacks;
+                    giveToPlayer[#giveToPlayer+1] = {v[2], stacks};
+                    validSlot = true;
+                    break;
+                end
             end
-            if (beetle > 0) then
-                player:addItem(4221,beetle);
-                player:messageSpecial(ITEM_OBTAINED,4221);
-            end
-            if (demon > 0) then
-                player:addItem(4224,demon);
-                player:messageSpecial(ITEM_OBTAINED,4224);
-            end
-            if (gargou > 0) then
-                player:addItem(5912,gargouille);
-                player:messageSpecial(ITEM_OBTAINED,5912);
-            end
-            if (horn > 0) then
-                player:addItem(4222,horn);
-                player:messageSpecial(ITEM_OBTAINED,4222);
-            end
-            if (irona > 0) then
-                player:addItem(4225,irona);
-                player:messageSpecial(ITEM_OBTAINED,4225);
-            end
-            if (kabura > 0) then
-                player:addItem(5332,kabura);
-                player:messageSpecial(ITEM_OBTAINED,5332);
-            end
-            if (ruszor > 0) then
-                player:addItem(5871,ruszor);
-                player:messageSpecial(ITEM_OBTAINED,5871);
-            end
-            if (scorpion > 0) then
-                player:addItem(4223,scorpion);
-                player:messageSpecial(ITEM_OBTAINED,4223);
-            end
-            if (silvera > 0) then
-                player:addItem(4226,silvera);
-                player:messageSpecial(ITEM_OBTAINED,4226);
-            end
-            if (sleepa > 0) then
-                player:addItem(5333,sleepa);
-                player:messageSpecial(ITEM_OBTAINED,5333);
-            end
-            ----------------BOLTS-----------------------------
-            if (acid > 0) then
-                player:addItem(5335,acid);
-                player:messageSpecial(ITEM_OBTAINED,5335);
-            end
-            if (adamana > 0) then
-                player:addItem(5913,adamana);
-                player:messageSpecial(ITEM_OBTAINED,5913);
-            end
-            if (blind > 0) then
-                player:addItem(5334,blind);
-                player:messageSpecial(ITEM_OBTAINED,5334);
-            end
-            if (bloody > 0) then
-                player:addItem(5339,bloody);
-                player:messageSpecial(ITEM_OBTAINED,5339);
-            end
-            if (darka > 0) then
-                player:addItem(5872,darka);
-                player:messageSpecial(ITEM_OBTAINED,5872);
-            end
-            if (darkling > 0) then
-                player:addItem(5820,darkling);
-                player:messageSpecial(ITEM_OBTAINED,5820);
-            end
-            if (darksteel > 0) then
-                player:addItem(4229,darksteel);
-                player:messageSpecial(ITEM_OBTAINED,4229);
-            end
-            if (fusion > 0) then
-                player:addItem(5821,fusion);
-                player:messageSpecial(ITEM_OBTAINED,5821);
-            end
-            if (holy > 0) then
-                player:addItem(5336,holy);
-                player:messageSpecial(ITEM_OBTAINED,5336);
-            end
-            if (mythril > 0) then
-                player:addItem(4228,mythril);
-                player:messageSpecial(ITEM_OBTAINED,4228);
-            end
-            if (sleepb > 0) then
-                player:addItem(5337,sleepb);
-                player:messageSpecial(ITEM_OBTAINED,5337);
-            end
-            if (venom > 0) then
-                player:addItem(5338,venom);
-                player:messageSpecial(ITEM_OBTAINED,5338);
-            end
-            ----------------BULLETS---------------------------
-            if (adamanb > 0) then
-                player:addItem(5915,adamanb);
-                player:messageSpecial(ITEM_OBTAINED,5915);
-            end
-            if (bullet > 0) then
-                player:addItem(5363,bullet);
-                player:messageSpecial(ITEM_OBTAINED,5363);
-            end
-            if (bronze > 0) then
-                player:addItem(5359,bronze);
-                player:messageSpecial(ITEM_OBTAINED,5359);
-            end
-            if (darkb > 0) then
-                player:addItem(5873,darkb);
-                player:messageSpecial(ITEM_OBTAINED,5873);
-            end
-            if (dweomer > 0) then
-                player:addItem(5822,dweomer);
-                player:messageSpecial(ITEM_OBTAINED,5822);
-            end
-            if (ironb > 0) then
-                player:addItem(5353,ironb);
-                player:messageSpecial(ITEM_OBTAINED,5353);
-            end
-            if (oberons > 0) then
-                player:addItem(5823,oberons);
-                player:messageSpecial(ITEM_OBTAINED,5823);
-            end
-            if (orichalcum > 0) then
-                player:addItem(5914,orichalcum);
-                player:messageSpecial(ITEM_OBTAINED,5914);
-            end
-            if (silverb > 0) then
-                player:addItem(5340,silverb);
-                player:messageSpecial(ITEM_OBTAINED,5340);
-            end
-            if (steel > 0) then
-                player:addItem(5416,steel);
-                player:messageSpecial(ITEM_OBTAINED,5416);
-            end
-            if (spartan > 0) then
-                player:addItem(5341,spartan);
-                player:messageSpecial(ITEM_OBTAINED,5341);
-            end
-            ----------------CARDS-----------------------------
-            if (fire > 0) then
-                player:addItem(5402,fire);
-                player:messageSpecial(ITEM_OBTAINED,5402);
-            end
-            if (ice > 0) then
-                player:addItem(5403,ice);
-                player:messageSpecial(ITEM_OBTAINED,5403);
-            end
-            if (wind > 0) then
-                player:addItem(5404,wind);
-                player:messageSpecial(ITEM_OBTAINED,5404);
-            end
-            if (earth > 0) then
-                player:addItem(5405,earth);
-                player:messageSpecial(ITEM_OBTAINED,5405);
-            end
-            if (thunder > 0) then
-                player:addItem(5406,thunder);
-                player:messageSpecial(ITEM_OBTAINED,5406);
-            end
-            if (water > 0) then
-                player:addItem(5407,water);
-                player:messageSpecial(ITEM_OBTAINED,5407);
-            end
-            if (light > 0) then
-                player:addItem(5408,light);
-                player:messageSpecial(ITEM_OBTAINED,5408);
-            end
-            if (dark > 0) then
-                player:addItem(5409,dark);
-                player:messageSpecial(ITEM_OBTAINED,5409);
+            if (not validSlot) then
+                player:messageSpecial(NOKKHI_BAD_ITEM);
+                return;
             end
         end
     end
 
--- 948      - carnation
--- SINGLE -- ARROWS---------------- STACK
--- 19195    - antlion arrow      -    5819
--- 18154    - beetle arrow       -    4221
--- 18159    - demon arrow        -    4224
--- 19800    - gargouille arrow   -    5912
--- 18156    - horn arrow         -    4222
--- 17320    - iron arrow         -    4225
--- 17325    - kabura arrow       -    5332
--- 19182    - ruszor arrow       -    5871
--- 18155    - scorpion arrow     -    4223
--- 17321    - silver arrow       -    4226
--- 18158    - sleep arrow        -    5333
----------- BOLTS -----------------------
--- 18148    - acid bolt          -    5335
--- 19801    - adaman bolt        -    5913
--- 18150    - blind bolt         -    5334
--- 18151    - bloody bolt        -    5339
--- 19183    - dark adaman bolt   -    5872
--- 19196    - darkling bolt      -    5820
--- 17338    - darksteel bolt     -    4229
--- 19197    - fusion bolt        -    5821
--- 18153    - holy bolt          -    5336
--- 17337    - mythril bolt       -    4228
--- 18149    - sleep bolt         -    5337
--- 18152    - venom bolt         -    5338
----------- BULLETS ---------------------
--- 19803    - adaman bullet      -    5915
--- 17340    - bullet             -    5363
--- 17343    - bronze bullet      -    5359
--- 19184    - dark adaman bullet -    5873
--- 19198    - dweomer bullet     -    5822
--- 17312    - iron bullet        -    5353
--- 19199    - oberon's bullet    -    5823
--- 19802    - orichalcum bullet  -    5914
--- 17341    - silver bullet      -    5340
--- 18723    - steel bullet       -    5416
--- 18160    - spartan bullet     -    5341
----------- CARDS -----------------------
--- 2176    - fire card           -    5402
--- 2177    - ice card            -    5403
--- 2178    - wind card           -    5404
--- 2179    - earth card          -    5405
--- 2180    - thunder card        -    5406
--- 2181    - water card          -    5407
--- 2182    - light card          -    5408
--- 2183    - dark card           -    5409
---------------------------------------
-end;
+    -- check for correct number of carnations
+    if (carnationsNeeded == 0 or trade:getItemQty(948) ~= carnationsNeeded) then
+        player:messageSpecial(NOKKHI_BAD_COUNT);
+        return;
+    end
+    
+    -- check for enough inventory space
+    if (player:getFreeSlotsCount() < carnationsNeeded) then
+        player:messageSpecial(ITEM_CANNOT_BE_OBTAINED, giveToPlayer[1][1]);
+        return;
+    end
+
+    -- make the trade
+    player:messageSpecial(NOKKHI_GOOD_TRADE);
+    for k, v in pairs(giveToPlayer) do
+        player:addItem(v[1], v[2]);
+        player:messageSpecial(ITEM_OBTAINED,v[1]);
+    end
+    player:tradeComplete();
+end
 
 -----------------------------------
 -- onTrigger Action
 -----------------------------------
 
 function onTrigger(player,npc)
-    player:startEvent(0x029b,npc:getID());
-end;
+    player:startEvent(667,npc:getID());
+end
 
 -----------------------------------
 -- onEventUpdate
 -----------------------------------
 
 function onEventUpdate(player,csid,option)
-    -- printf("CSID: %u",csid);
-    -- printf("RESULT: %u",option);
-end;
+end
 
 -----------------------------------
 -- onEventFinish
 -----------------------------------
 
 function onEventFinish(player,csid,option)
-    -- printf("CSID: %u",csid);
-    -- printf("RESULT: %u",option);
-end;
+end


### PR DESCRIPTION
Nokkhi Jinjahl now has valid ammo trades in LUA table.
Added missing trades, per https://www.bg-wiki.com/bg/Nokkhi_Jinjahl
She speaks both good and bad trade dialog.