### PR TITLE
Allow Quest Empty Memories to flag as complete

### DIFF
--- a/scripts/zones/RuLude_Gardens/npcs/Harith.lua
+++ b/scripts/zones/RuLude_Gardens/npcs/Harith.lua
@@ -100,6 +100,8 @@ function onEventFinish(player,csid,option)
         player:addItem(objecttrade);
         player:messageSpecial(ITEM_OBTAINED,objecttrade);
         player:setVar("harithreward",0);
+		player:completeQuest(JEUNO, EMPTY_MEMORIES)
+		player:addFame(JEUNO, 5);
     end
 
 end;


### PR DESCRIPTION
Fix for #3761 

Note: I don't know how much fame to add at the end, so I looked up some repeatable quests already in the scripts and used that. Should hardly matter, I guess.