### PR TITLE
Allow Quest Empty Memories to flag as completed

### DIFF
--- a/scripts/zones/RuLude_Gardens/npcs/Harith.lua
+++ b/scripts/zones/RuLude_Gardens/npcs/Harith.lua
@@ -99,7 +99,13 @@ function onEventFinish(player,csid,option)
         player:tradeComplete();
         player:addItem(objecttrade);
         player:messageSpecial(ITEM_OBTAINED,objecttrade);
-        player:setVar("harithreward",0);
+        player:setVar("harithreward", 0);
+        if (player:getQuestStatus(JEUNO, EMPTY_MEMORIES) == QUEST_ACCEPTED) then
+            player:addFame(JEUNO, 30);
+            player:completeQuest(JEUNO, EMPTY_MEMORIES)
+        else
+            player:addFame(JEUNO, 5);
+        end
     end
 
 end;


### PR DESCRIPTION
fix for #3761 

Copied added fame values from another repeatable quest.

There was probably a cleaner way to fix the mistake I made on the first PR than deleting it and resubmitting. ; ;