### PR TITLE
Added -elemental resistance effect to Ancient Magic

### DIFF
--- a/scripts/globals/spells/burst.lua
+++ b/scripts/globals/spells/burst.lua
@@ -27,5 +27,8 @@ function onSpellCast(caster, target, spell)
     spellParams.M100 = 2;
     spellParams.M200 = 2;
 
+    -- no point in making a separate function for this if the only thing they won't have in common is the name
+    handleNinjutsuDebuff(caster,target,spell,30,10,MOD_EARTHRES);
+
     return doElementalNuke(caster, spell, target, spellParams);
 end;

--- a/scripts/globals/spells/burst_ii.lua
+++ b/scripts/globals/spells/burst_ii.lua
@@ -27,5 +27,8 @@ function onSpellCast(caster, target, spell)
     spellParams.M100 = 2;
     spellParams.M200 = 2;
 
+    -- no point in making a separate function for this if the only thing they won't have in common is the name
+    handleNinjutsuDebuff(caster,target,spell,30,10,MOD_EARTHRES);
+
     return doElementalNuke(caster, spell, target, spellParams);
 end;

--- a/scripts/globals/spells/flare.lua
+++ b/scripts/globals/spells/flare.lua
@@ -27,5 +27,8 @@ function onSpellCast(caster, target, spell)
     spellParams.M100 = 2;
     spellParams.M200 = 2;
 
+    -- no point in making a separate function for this if the only thing they won't have in common is the name
+    handleNinjutsuDebuff(caster,target,spell,30,10,MOD_WATERRES);
+
     return doElementalNuke(caster, spell, target, spellParams);
 end;

--- a/scripts/globals/spells/flare_ii.lua
+++ b/scripts/globals/spells/flare_ii.lua
@@ -27,5 +27,8 @@ function onSpellCast(caster, target, spell)
     spellParams.M100 = 2;
     spellParams.M200 = 2;
 
+    -- no point in making a separate function for this if the only thing they won't have in common is the name
+    handleNinjutsuDebuff(caster,target,spell,30,10,MOD_WATERRES);
+
     return doElementalNuke(caster, spell, target, spellParams);
 end;

--- a/scripts/globals/spells/flood.lua
+++ b/scripts/globals/spells/flood.lua
@@ -27,5 +27,8 @@ function onSpellCast(caster, target, spell)
     spellParams.M100 = 2;
     spellParams.M200 = 2;
 
+    -- no point in making a separate function for this if the only thing they won't have in common is the name
+    handleNinjutsuDebuff(caster,target,spell,30,10,MOD_THUNDERRES);
+
     return doElementalNuke(caster, spell, target, spellParams);
 end;

--- a/scripts/globals/spells/flood_ii.lua
+++ b/scripts/globals/spells/flood_ii.lua
@@ -27,5 +27,8 @@ function onSpellCast(caster, target, spell)
     spellParams.M100 = 2;
     spellParams.M200 = 2;
 
+    -- no point in making a separate function for this if the only thing they won't have in common is the name
+    handleNinjutsuDebuff(caster,target,spell,30,10,MOD_THUNDERRES);
+
     return doElementalNuke(caster, spell, target, spellParams);
 end;

--- a/scripts/globals/spells/freeze.lua
+++ b/scripts/globals/spells/freeze.lua
@@ -27,5 +27,8 @@ function onSpellCast(caster, target, spell)
     spellParams.M100 = 2;
     spellParams.M200 = 2;
 
+    -- no point in making a separate function for this if the only thing they won't have in common is the name
+    handleNinjutsuDebuff(caster,target,spell,30,10,MOD_FIRERES);
+
     return doElementalNuke(caster, spell, target, spellParams);
 end;

--- a/scripts/globals/spells/freeze_ii.lua
+++ b/scripts/globals/spells/freeze_ii.lua
@@ -27,5 +27,8 @@ function onSpellCast(caster, target, spell)
     spellParams.M100 = 2;
     spellParams.M200 = 2;
 
+    -- no point in making a separate function for this if the only thing they won't have in common is the name
+    handleNinjutsuDebuff(caster,target,spell,30,10,MOD_FIRERES);
+
     return doElementalNuke(caster, spell, target, spellParams);
 end;

--- a/scripts/globals/spells/quake.lua
+++ b/scripts/globals/spells/quake.lua
@@ -27,5 +27,8 @@ function onSpellCast(caster, target, spell)
     spellParams.M100 = 2;
     spellParams.M200 = 2;
 
+    -- no point in making a separate function for this if the only thing they won't have in common is the name
+    handleNinjutsuDebuff(caster,target,spell,30,10,MOD_WINDRES);
+
     return doElementalNuke(caster, spell, target, spellParams);
 end;

--- a/scripts/globals/spells/quake_ii.lua
+++ b/scripts/globals/spells/quake_ii.lua
@@ -27,5 +27,8 @@ function onSpellCast(caster, target, spell)
     spellParams.M100 = 2;
     spellParams.M200 = 2;
 
+    -- no point in making a separate function for this if the only thing they won't have in common is the name
+    handleNinjutsuDebuff(caster,target,spell,30,10,MOD_WINDRES);
+
     return doElementalNuke(caster, spell, target, spellParams);
 end;

--- a/scripts/globals/spells/tornado.lua
+++ b/scripts/globals/spells/tornado.lua
@@ -27,5 +27,8 @@ function onSpellCast(caster, target, spell)
     spellParams.M100 = 2;
     spellParams.M200 = 2;
 
+    -- no point in making a separate function for this if the only thing they won't have in common is the name
+    handleNinjutsuDebuff(caster,target,spell,30,10,MOD_ICERES);
+
     return doElementalNuke(caster, spell, target, spellParams);
 end;

--- a/scripts/globals/spells/tornado_ii.lua
+++ b/scripts/globals/spells/tornado_ii.lua
@@ -27,5 +27,8 @@ function onSpellCast(caster, target, spell)
     spellParams.M100 = 2;
     spellParams.M200 = 2;
 
+    -- no point in making a separate function for this if the only thing they won't have in common is the name
+    handleNinjutsuDebuff(caster,target,spell,30,10,MOD_ICERES);
+
     return doElementalNuke(caster, spell, target, spellParams);
 end;


### PR DESCRIPTION
Which is just the debuff from NIN spells, nerfed to a constant duration of 10 seconds.

Sources: https://www.bg-wiki.com/bg/Category:Ancient_Magic

Band-aid fix for #3945 

Notes: I don't see any reason why AMII should have a different elemental resistance reduction effect compared to AM's -30 magic evasion on the next element. AMII is just more mp-efficient AM, that does more damage on magic bursts. The -elemental resistance in AMII's case is just a hold-over from its ugly days as AM.

P.S. It's been brought up in a number of issues, but while we do not have separate mods for species-specific elemental damage taken and elemental resist, this might end up affecting damage taken for certain mobs as well. Then again, the effect lasts 10 seconds. And that issue is also present for NIN nukes.