### PR TITLE
Fix (Nbu Latteh): Tweaked Nbu, especially for Mom, the Adventurer quest

### DIFF
--- a/scripts/zones/Bastok_Markets/npcs/Nbu_Latteh.lua
+++ b/scripts/zones/Bastok_Markets/npcs/Nbu_Latteh.lua
@@ -25,18 +25,20 @@ end;
 
 function onTrigger(player,npc)
     local pFame = player:getFameLevel(BASTOK);
-    local MomTheAdventurer = player:getQuestStatus(BASTOK,MOM_THE_ADVENTURER)
+    local momTheAdventurer = player:getQuestStatus(BASTOK,MOM_THE_ADVENTURER);
     local questStatus = player:getVar("MomTheAdventurer_Event");
 
     if (player:needToZone()) then
-        player:startEvent(127); -- chat about my work
-    elseif (pFame < 2 and MomTheAdventurer ~= QUEST_ACCEPTED and questStatus == 0) then
-            player:startEvent(0x00e6);  
-    elseif (MomTheAdventurer >= QUEST_ACCEPTED and questStatus == 2) then
+        player:startEvent(0x007f); -- chat about my work
+    elseif (pFame < 2 and momTheAdventurer ~= QUEST_ACCEPTED and questStatus == 0) then
+        player:startEvent(0x00e6);
+    elseif (momTheAdventurer >= QUEST_ACCEPTED and questStatus == 2) then
         if (player:seenKeyItem(LETTER_FROM_ROH_LATTEH)) then
             player:startEvent(0x00ea);
         elseif (player:hasKeyItem(LETTER_FROM_ROH_LATTEH)) then
             player:startEvent(0x00e9);
+        else
+            player:startEvent(0x00e7);
         end
     elseif (pFame >= 2 and player:getQuestStatus(BASTOK,THE_SIGNPOST_MARKS_THE_SPOT) == QUEST_AVAILABLE) then
         player:startEvent(0x00eb);
@@ -65,10 +67,12 @@ function onEventFinish(player,csid,option)
 
     if (csid == 0x00e6 and option == 0) then
         if (player:getFreeSlotsCount(0) > 0) then
-            player:addQuest(BASTOK,MOM_THE_ADVENTURER);
             player:setVar("MomTheAdventurer_Event",1);
             player:addItem(4096);
             player:messageSpecial(ITEM_OBTAINED,4096); -- Fire Crystal
+            if (player:questStatus(BASTOK,MOM_THE_ADVENTURER == QUEST_AVAILABLE)) then
+                player:addQuest(BASTOK,MOM_THE_ADVENTURER);
+            end
         else
             player:messageSpecial(ITEM_CANNOT_BE_OBTAINED,4096);
         end
@@ -86,7 +90,7 @@ function onEventFinish(player,csid,option)
         player:setVar("MomTheAdventurer_Event",0);
 
         if (player:getQuestStatus(BASTOK,MOM_THE_ADVENTURER) == QUEST_ACCEPTED) then
-            player:addFame(BASTOK,50);
+            player:addFame(BASTOK,20);
             player:completeQuest(BASTOK,MOM_THE_ADVENTURER);
         else
             player:addFame(BASTOK,8)


### PR DESCRIPTION
She was giving a bit too much fame, which put you immediately at Bastok fame 2, preventing you from repeating the repeatable quest. Additionally, there was some minor dialog that wasn't included. I also cleaned up the syntax while I was in there.