### PR TITLE
Add message when receiving gil for quest(s) complete

### DIFF
--- a/scripts/zones/Windurst_Woods/npcs/Kopuro-Popuro.lua
+++ b/scripts/zones/Windurst_Woods/npcs/Kopuro-Popuro.lua
@@ -26,12 +26,12 @@ function onTrade(player,npc,trade)
 
     -- The All New C-2000
     if (allnew == QUEST_ACCEPTED) then
-      count = trade:getItemCount();
-      if (trade:hasItemQty(856,1) and trade:hasItemQty(4368,1) and trade:hasItemQty(846,1) and count == 3) then
-         player:startEvent(0x0124,GIL_RATE*200); -- Correct items given, complete quest.
-      else
-         player:startEvent(0x0120,0,856,846,4368); -- Incorrect or not enough items.
-      end
+        count = trade:getItemCount();
+        if (trade:hasItemQty(856,1) and trade:hasItemQty(4368,1) and trade:hasItemQty(846,1) and count == 3) then
+            player:startEvent(0x0124,GIL_RATE*200); -- Correct items given, complete quest.
+        else
+            player:startEvent(0x0120,0,856,846,4368); -- Incorrect or not enough items.
+        end
 
     -- Legendary Plan B
     elseif (LPB == QUEST_ACCEPTED) then
@@ -108,11 +108,11 @@ function onTrigger(player,npc)
 
     -- The All New C-2000
     elseif (allnew == QUEST_AVAILABLE) then
-      player:startEvent(0x011d,0,856,846,4368); -- Start Quest
+        player:startEvent(0x011d,0,856,846,4368); -- Start Quest
     elseif (allnew == QUEST_ACCEPTED) then
-      player:startEvent(0x0120,0,856,846,4368); -- Reminder Dialogue
+        player:startEvent(0x0120,0,856,846,4368); -- Reminder Dialogue
     elseif (allnew == QUEST_COMPLETED) then
-      player:startEvent(0x0125); -- Post Quest Finish Text
+        player:startEvent(0x0125); -- Post Quest Finish Text
 
     -- No Quest Available
     else
@@ -140,13 +140,14 @@ function onEventFinish(player,csid,option)
 
     -- The All New C-2000
     if (csid == 0x011d and option ~= 2) then  -- option 2 is declining the quest for the second question
-      player:addQuest(WINDURST,THE_ALL_NEW_C_2000);
-     elseif (csid == 0x0124) then
-      player:tradeComplete();
-      player:addFame(WINDURST,80);
-      player:addTitle(CARDIAN_TUTOR);
-      player:addGil(GIL_RATE*200);
-      player:completeQuest(WINDURST,THE_ALL_NEW_C_2000);
+        player:addQuest(WINDURST,THE_ALL_NEW_C_2000);
+    elseif (csid == 0x0124) then
+        player:tradeComplete();
+        player:addFame(WINDURST,80);
+        player:addTitle(CARDIAN_TUTOR);
+        player:addGil(GIL_RATE*200);
+        player:messageSpecial(GIL_OBTAINED,GIL_RATE*200);
+        player:completeQuest(WINDURST,THE_ALL_NEW_C_2000);
 
     -- Start LPB
     elseif (csid == 0x0134) then
@@ -162,6 +163,7 @@ function onEventFinish(player,csid,option)
         player:addGil(GIL_RATE*700);
         player:addItem(12749);
         player:messageSpecial(ITEM_OBTAINED,12749); -- Scentless Armlets
+        player:messageSpecial(GIL_OBTAINED,GIL_RATE*700);
         player:completeQuest(WINDURST,LEGENDARY_PLAN_B);
         player:needToZone(true); -- zone before starting The All New C-3000
         end
@@ -175,6 +177,7 @@ function onEventFinish(player,csid,option)
         player:tradeComplete();
         player:addFame(WINDURST,10);
         player:addGil(GIL_RATE*600);
+        player:messageSpecial(GIL_OBTAINED,GIL_RATE*600);
         player:completeQuest(WINDURST,THE_ALL_NEW_C_3000);
     end
 end;


### PR DESCRIPTION
There were no notifications you have received any gil when Kopuro-Popuro's quests were completed. Also, fixed some spacing to comply with Teo's standards.