### PR TITLE
Fixed infinite laying of flowers with no Key Item

### DIFF
--- a/scripts/zones/North_Gustaberg/npcs/Monument.lua
+++ b/scripts/zones/North_Gustaberg/npcs/Monument.lua
@@ -27,7 +27,7 @@ function onTrigger(player,npc)
 
     local Hearts = player:getQuestStatus(BASTOK,HEARTS_OF_MYTHRIL);
 
-    if (Hearts == QUEST_ACCEPTED) then
+    if (Hearts == QUEST_ACCEPTED and player:hasKeyItem(BOUQUETS_FOR_THE_PIONEERS)) then
         player:startEvent(0x000b);
     end
 


### PR DESCRIPTION
Minor tweak for "Hearts of Mythril" quest involving the monument in North Gustaberg. Fixed so you can only lay the bouquet once.