### PR TITLE
Updates to only send a version related message if there was a version…

### DIFF
--- a/src/map/packet_system.cpp
+++ b/src/map/packet_system.cpp
@@ -488,10 +488,9 @@ void SmallPacket0x011(map_session_data_t* session, CCharEntity* PChar, CBasicPac
     int32 ret = Sql_Query(SqlHandle, fmtQuery, PChar->id);
     if (ret != SQL_ERROR && Sql_NextRow(SqlHandle) == SQL_SUCCESS)
     {
+        // On zone change, only sending a version message if mismatch
         if ((bool)Sql_GetUIntData(SqlHandle, 0))
             PChar->pushPacket(new CChatMessagePacket(PChar, CHAT_MESSAGE_TYPE::MESSAGE_SYSTEM_1, "Server does not support this client version. Please refrain from posting issues on DSP bugtracker."));
-        else
-            PChar->pushPacket(new CChatMessagePacket(PChar, CHAT_MESSAGE_TYPE::MESSAGE_SYSTEM_1, "Report bugs at DSP bugtracker if !revision output matches latest commit hash and server admin confirms the bug occurs on stock DSP."));
     }
     return;
 }


### PR DESCRIPTION
… mismatch on zone change (0x011). Does not remove version match message sent on /servmes (0x04B).