### PR TITLE
Store per-account expansion and feature bitmasks in account table.

### DIFF
--- a/conf/login_darkstar.conf
+++ b/conf/login_darkstar.conf
@@ -55,54 +55,6 @@ mysql_database:  dspdb
 #Search Server Port
 search_server_port: 54002
 
-#Expansion Icons - 2 Bytes
-#
-#Byte 1 - Zilart to A Shantotto Ascension
-#00000000 Bit0 - Not Used - Original FFXI bit
-#00000010 Bit1 - Enables Rise of Zilart Icon
-#00000100 Bit2 - Enables Chains of Promathia Icon
-#00001000 Bit3 - Enables Treasures of Aht Urhgan Icon
-#00010000 Bit4 - Enables Wings of The Goddess
-#00100000 Bit5 - Enables A Crystalline Prophecy Icon
-#01000000 Bit6 - Enables A Moogle Kupod'Etat Icon
-#10000000 Bit7 - Enables A Shantotto Ascension Icon
-#
-#Byte 2 - Vision of Abyssea to Seekers of Adoulin
-#00000001 Bit0 - Enables Vision of Abyssea
-#00000010 Bit1 - Enables Scars of Abyssea
-#00000100 Bit2 - Enables Heroes of Abyssea
-#00001000 Bit3 - Enables Seekers of Adoulin
-#00010000 Bit4 - Not Used - Future expansion
-#00100000 Bit5 - Not Used - Future expansion
-#01000000 Bit6 - Not Used - Future expansion
-#10000000 Bit7 - Not Used - Future expansion
-
-expansions: 30
-
-#Account features - 2 Bytes?
-#
-#Byte 1
-#00000001 Bit0 - Secure Token Icon
-#00000010 Bit1 - Unknown - Not Used
-#00000100 Bit2 - Mog Wardrobe 3
-#00001000 Bit3 - Mog Wardrobe 4
-#00010000 Bit4 - Not Used
-#00100000 Bit5 - Not Used
-#01000000 Bit6 - Not Used
-#10000000 Bit7 - Not Used
-#
-#Byte 2 - Not Used
-#00000001 Bit0 - Not Used
-#00000010 Bit1 - Not Used
-#00000100 Bit2 - Not Used
-#00001000 Bit3 - Not Used
-#00010000 Bit4 - Not Used
-#00100000 Bit5 - Not Used
-#01000000 Bit6 - Not Used
-#10000000 Bit7 - Not Used
-
-features: 12
-
 #Server name (not longer than 15 characters)
 servername: DarkStar
 

--- a/sql/accounts.sql
+++ b/sql/accounts.sql
@@ -35,6 +35,8 @@ CREATE TABLE IF NOT EXISTS `accounts` (
   `timecreate` datetime NOT NULL DEFAULT '0000-00-00 00:00:00',
   `timelastmodify` timestamp NOT NULL DEFAULT '0000-00-00 00:00:00',
   `content_ids` tinyint(2) unsigned NOT NULL DEFAULT '16',
+  `expansions` smallint(4) UNSIGNED NOT NULL DEFAULT '30',
+  `features` tinyint(2) UNSIGNED NOT NULL DEFAULT '12',
   `status` tinyint(3) unsigned NOT NULL DEFAULT '1',
   `priv` tinyint(3) unsigned NOT NULL DEFAULT '1',
   PRIMARY KEY (`id`)

--- a/src/login/lobby.cpp
+++ b/src/login/lobby.cpp
@@ -495,10 +495,20 @@ int32 lobbyview_parse(int32 fd)
             }
             else
             {
-                LOBBY_026_RESERVEPACKET(ReservePacket);
-                WBUFW(ReservePacket, 32) = login_config.expansions; // BitMask for expansions;
-                WBUFW(ReservePacket, 36) = login_config.features; // Bitmask for account features
-                memcpy(MainReservePacket, ReservePacket, sendsize);
+                const int8 *pfmtQuery = "SELECT expansions,features FROM accounts WHERE id = %u;";
+                int32 ret = Sql_Query(SqlHandle, pfmtQuery, sd->accid);
+                if (ret != SQL_ERROR && Sql_NumRows(SqlHandle) != 0 && Sql_NextRow(SqlHandle) == SQL_SUCCESS)
+                {
+                    LOBBY_026_RESERVEPACKET(ReservePacket);
+                    WBUFW(ReservePacket, 32) = Sql_GetUIntData(SqlHandle, 0); // Expansion Bitmask
+                    WBUFW(ReservePacket, 36) = Sql_GetUIntData(SqlHandle, 1); // Feature Bitmask
+                    memcpy(MainReservePacket, ReservePacket, sendsize);
+                }
+                else
+                {
+                    do_close_lobbydata(sd, fd);
+                    return -1;
+                }
             }
 
             //Хеширование пакета, и запись значения Хеш функции в пакет

--- a/src/login/login.cpp
+++ b/src/login/login.cpp
@@ -371,14 +371,6 @@ int32 login_config_read(const char *cfgName)
         {
             login_config.search_server_port = atoi(w2);
         }
-        else if (strcmp(w1, "expansions") == 0)
-        {
-            login_config.expansions = atoi(w2);
-        }
-        else if (strcmp(w1, "features") == 0)
-        {
-            login_config.features = atoi(w2);
-        }
         else if (strcmp(w1, "servername") == 0)
         {
             login_config.servername = std::string(w2);
@@ -458,7 +450,6 @@ int32 login_config_default()
     login_config.login_auth_ip = "127.0.0.1";
     login_config.login_auth_port = 54231;
 
-    login_config.expansions = 0xFFFF;
     login_config.servername = "DarkStar";
 
     login_config.mysql_host = "";

--- a/src/login/login.h
+++ b/src/login/login.h
@@ -48,9 +48,6 @@ struct login_config_t
     uint16 login_view_port;
     std::string login_view_ip;
 
-    uint16 expansions;
-    uint16 features;
-
     std::string servername;
 
     std::string mysql_host;         // mysql addr     -> localhost:3306


### PR DESCRIPTION
Default bitmasks are the same as the values that were in login_darkstar.conf.

![image](https://user-images.githubusercontent.com/17911103/31106193-c2c56ccc-a7b7-11e7-98b1-cf8bf25c059c.png)
