### PR TITLE
Battlefield Overhaul

### DIFF
--- a/scripts/globals/bcnm.lua
+++ b/scripts/globals/bcnm.lua
@@ -1,761 +1,956 @@
-require("scripts/globals/status")
+--[[
+
+--]]
+
 require("scripts/globals/keyitems")
 require("scripts/globals/missions")
 require("scripts/globals/quests")
+require("scripts/globals/status")
 
--- NEW SYSTEM BCNM NOTES
--- The "core" functions TradeBCNM EventUpdateBCNM EventTriggerBCNM EventFinishBCNM all return TRUE if the action performed is covered by the function.
--- This means all the old code will still be executed if the new functions don't support it. This means that there is effectively 'backwards compatibility' with the old system.
+-----------------------------------------------
+-- battlefields by zone
+-- captured from client 2017-10-02
+-----------------------------------------------
 
--- array to map (for each zone) the item id of the valid trade item with the bcnmid in the database
--- e.g. zone, {itemid, bcnmid, itemid, bcnmid, itemid, bcnmid}
--- DO NOT INCLUDE MAAT FIGHTS
-itemid_bcnmid_map =
-{
-    6,   {0, 0}, -- Bearclaw_Pinnacle
-    8,   {0, 0}, -- Boneyard_Gully
-    10,  {0, 0}, -- The_Shrouded_Maw
-    13,  {0, 0}, -- Mine_Shaft_2716
-    17,  {0, 0}, -- Spire of Holla
-    19,  {0, 0}, -- Spire of Dem
-    21,  {0, 0}, -- Spire of Mea
-    23,  {0, 0}, -- Spire of Vahzl
-    29,  {0, 0}, -- Riverne Site #B01
-    31,  {0, 0}, -- Monarch Linn
-    32,  {0, 0}, -- Sealion's Den
-    35,  {0, 0}, -- The Garden of RuHmet
-    36,  {0, 0}, -- Empyreal Paradox
-    57,  {0, 0}, -- Talacca Cove
-    64,  {0, 0}, -- Navukgo Execution Chamber
-    67,  {0, 0}, -- Jade Sepulcher
-    139, {1177, 4, 1552, 10, 1553, 11, 1131, 12, 1175, 15, 1180, 17}, -- Horlais Peak
-    140, {1551, 34, 1552, 35, 1552, 36}, -- Ghelsba Outpost
-    144, {1166, 68, 1178, 81, 1553, 76, 1180, 82, 1130, 79, 1552, 73}, -- Waughroon Shrine
-    146, {1553, 107, 1551, 105, 1177, 100}, -- Balgas Dias
-    163, {1130, 129, 1130, 130}, -- Sacrificial Chamber
-    168, {0, 0}, -- Chamber of Oracles
-    170, {0, 0}, -- Full Moon Fountain
-    180, {1550, 293}, -- LaLoff Amphitheater
-    181, {0, 0}, -- The Celestial Nexus
-    201, {1546, 418, 1174, 417}, -- Cloister of Gales
-    202, {1548, 450, 1172, 449}, -- Cloister of Storms
-    203, {1545, 482, 1171, 481}, -- Cloister of Frost
-    206, {0, 0}, -- Qu'Bia Arena
-    207, {1544, 545}, -- Cloister of Flames
-    209, {1547, 578, 1169, 577}, -- Cloister of Tremors
-    211, {1549, 609} -- Cloister of Tides
-}
+--[[
+    [zoneId] = {
+        {bit, battlefieldIdInDatabase, requiredItemToTrade}
+    },
+--]]
 
--- [zoneId] = {bcnm, ids, in, order}
-battlefield_bitmask_map =
-{
-    [6] = {640, 641, 642, 643, 644},
-    [8] = {672, 673, 674, 675, 676, 677, 678, 679},
-    [10] = {704, 705, 706},
-    [13] = {736, 737, 738, 739, 740, 741},
-    [17] = {768, 769, 770},
-    [19] = {800,801,802},
-    [21] = {832,833,834},
-    [23] = {864,865,866},
-    [29] = {896,897},
-    [30] = {928},
-    [31] = {960,961,962,963,964,965,966,967},
-    [32] = {992,993},
-    [35] = {1024},
-    [36] = {1056,1057},
-    [37] = {1298,1299,1300,1301,1302,1303,1304,1305,1306,1307},
-    [38] = {1290,1291,1292,1293,1294,1295,1296,1297},
-    [39] = {1286},
-    [40] = {1287},
-    [41] = {1288},
-    [42] = {1289},
-    [57] = {1088,1089,1090,1091,1092},
-    [64] = {1120,1121,1122,1123,1124},
-    [67] = {1152,1153,1154,1155,1156},
-    [78] = {1184},
-    [186] = {1280},
-    [185] = {1281},
-    [187] = {1282},
-    [188] = {1283},
-    [134] = {1284},
-    [135] = {1285},
-    [139] = {0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20},
-    [140] = {32,33,34,35,36,37},
-    [144] = {64,65,66,67,68,69,70,71,72,73,74,75,76,77,78,79,80,81,82,83,84,85},
-    [146] = {96,97,98,99,100,101,102,103,104,105,106,107,108,109,110,111,112,113,114,115,116},
-    [156] = {352,353,354},
-    [163] = {128,129,130,131,132},
-    [165] = {160,161,162,163,164},
-    [168] = {192,193,194,195,196,197,198,199,200,201},
-    [170] = {224,225,226,227},
-    [179] = {256,257,258,259,260,261,262},
-    [180] = {288,289,290,291,292,293},
-    [181] = {320},
-    [182] = {385},
-    [201] = {416,417,418,419,420},
-    [202] = {448,449,450,451,452},
-    [203] = {480,481,482,483,484},
-    [206] = {512,513,514,515,516,517,518,519,520,521,522,523,524,525,526,527,528,529,530,531,532,533},
-    [207] = {544,545,546,547},
-    [209] = {576,577,578,579,580},
-    [211] = {608,609,610,611},
+local battlefields = {
+    [6] = {                 -- BEARCLAW PINNACLE
+        { 0,  640,    0},   -- Flames of the Dead (PM5-3 U3)
+     -- { 1,  641,    0},   -- Follow the White Rabbit (ENM)
+     -- { 2,  642,    0},   -- When Hell Freezes Over (ENM)
+        { 3,  643,    0},   -- Brothers (ENM)
+     -- { 4,  644,    0},   -- Holy Cow (ENM)
+     -- { 5,    ?, 3454},   -- Taurassic Park (HKC30)
+    },
+
+    [8] = {                 -- BONEYARD GULLY
+        { 0,  672,    0},   -- Head Wind (PM5-3 U2)
+        { 1,  673,    0},   -- Like the Wind (ENM)
+     -- { 2,  674,    0},   -- Sheep in Antlion's Clothing (ENM)
+     -- { 3,  675,    0},   -- Shell We Dance? (ENM)
+     -- { 4,  676,    0},   -- Totentanz (ENM)
+     -- { 5,  677,    0},   -- Tango with a Tracker (Quest)
+     -- { 6,  678,    0},   -- Requiem of Sin (Quest)
+     -- { 7,  679, 3454},   -- Antagonistic Ambuscade (HKC30)
+     -- { 8,    ?,    0},   -- *Head Wind (HTMBF)
+    },
+    
+    [10] = {                -- THE SHROUDED MAW
+        { 0,  704,    0},   -- Darkness Named (PM3-5)
+     -- { 1,  705,    0},   -- Test Your Mite (ENM)
+        { 2,  706,    0},   -- Waking Dreams (Quest)
+     -- { 3,    ?,    0},   -- *Waking Dreams (HTMBF)
+    },
+
+    [13] = {                -- MINE SHAFT 2716
+        { 0,  736,    0},   -- A Century of Hardship (PM5-3 L3)
+     -- { 1,  737,    0},   -- Return to the Depths (Quest)
+     -- { 2,  738,    0},   -- Bionic Bug (ENM)
+     -- { 3,  739,    0},   -- Pulling the Strings (ENM)
+     -- { 4,  740,    0},   -- Automaton Assault (ENM)
+     -- { 5,  741, 3455},   -- The Mobline Comedy (HKC50)
+    },
+
+    [17] = {                -- SPIRE OF HOLLA
+        { 0,  768,    0},   -- Ancient Flames Beckon (PM1-3)
+     -- { 1,  769,    0},   -- Simulant (ENM)
+     -- { 2,  770, 3351},   -- Empty Hopes (KC30)
+    },
+
+    [19] = {                -- SPIRE OF DEM
+        { 0,  800,    0},   -- Ancient Flames Beckon (PM1-3)
+     -- { 1,  801,    0},   -- You Are What You Eat (ENM)
+     -- { 2,  802, 3351},   -- Empty Dreams (KC30)
+    },
+
+    [21] = {                -- SPIRE OF MEA
+        { 0,  832,    0},   -- Ancient Flames Beckon (PM1-3)
+     -- { 1,  833,    0},   -- Playing Host (ENM)
+     -- { 2,  834, 3351},   -- Empty Desires (KC30)
+    },
+
+    [23] = {                -- SPIRE OF VAHZL
+        { 0,  864,    0},   -- Desires of Emptiness (PM5-2)
+     -- { 1,  865,    0},   -- Pulling the Plug (ENM)
+     -- { 2,  866, 3352},   -- Empty Aspirations (KC50)
+    },
+
+    [29] = {                -- RIVERNE SITE #B01
+        { 0,  896,    0},   -- Storms of Fate (Quest)
+     -- { 1,  897, 2108},   -- The Wyrmking Descends (BCNM)
+    },
+
+    [30] = {                -- RIVERNE SITE #A01
+     -- { 0,  928, 1842},   -- Ouryu Cometh (BCNM)
+    },
+
+    [31] = {                -- MONARCH LINN
+        { 0,  960,    0},   -- Ancient Vows (PM2-5)
+        { 1,  961,    0},   -- The Savage (PM4-2)
+     -- { 2,  962,    0},   -- Fire in the Sky (ENM)
+     -- { 3,  963,    0},   -- Bad Seed (ENM)
+     -- { 4,  964,    0},   -- Bugard in the Clouds (ENM)
+     -- { 5,  965,    0},   -- Beloved of the Atlantes (ENM)
+     -- { 6,  966,    0},   -- Uninvited Guests (Quest)
+     -- { 7,  967, 3455},   -- Nest of Nightmares (HKC50)
+     -- { 8,    ?,    0},   -- *The Savage (HTMBF)
+    },
+
+    [32] = {                -- SEALION'S DEN
+        { 0,  992,    0},   -- One to Be Feared (PM6-4)
+        { 1,  993,    0},   -- The Warrior's Path (PM7-5)
+     -- { 2,    ?,    0},   -- *The Warrior's Path (HTMBF)
+     -- { 3,    ?,    0},   -- *One to Be Feared (HTMBF)
+    },
+
+    [35] = {                -- THE GARDEN OF RU'HMET
+        { 0, 1024,    0},   -- When Angels Fall (PM8-3)
+    },
+
+    [36] = {                -- EMPYREAL PARADOX
+        { 0, 1056,    0},   -- Dawn (PM8-4)
+     -- { 1, 1057,    0},   -- Apocalypse Nigh (Quest)
+     -- { 2,    ?,    0},   -- Both Paths Taken (ROVM2-9-2)
+     -- { 3,    ?,    0},   -- *Dawn (HTMBF)
+     -- { 4,    ?,    0},   -- The Winds of Time (ROVM3-1-26)
+     -- { 5,    ?,    0},   -- Sealed Fate (Master Trial)
+    },
+
+    [37] = {                -- TEMENOS
+        { 0, 1299,    0},   -- Northern Tower
+        { 1, 1300,    0},   -- Eastern Tower
+        { 2, 1298,    0},   -- Western Tower
+        { 3, 1306,   -1},   -- Central 4th Floor (multiple items needed: 1907, 1908, 1986)
+        { 4, 1305, 1904},   -- Central 3rd Floor
+        { 5, 1304, 1905},   -- Central 2nd Floor
+        { 6, 1303, 1906},   -- Central 1st Floor
+        { 7, 1301, 2127},   -- Central Basement
+     -- { 8, 1302,    0},   -- Central Basement II
+     -- { 9, 1307,    0},   -- Central 4th Floor II
+    },
+
+    [38] = {                -- APOLLYON
+        { 0, 1291,    0},   -- SW Apollyon
+        { 1, 1290,    0},   -- NW Apollyon
+        { 2, 1293,    0},   -- SE Apollyon
+        { 3, 1292,    0},   -- NE Apollyon
+        { 4, 1296,   -2},   -- Central Apollyon (multiple items needed: 1909 1910 1987 1988)
+        { 5, 1294, 2127},   -- CS Apollyon
+     -- { 6, 1295,    0},   -- CS Apollyon II
+     -- { 7, 1297,    0},   -- Central Apollyon II
+    },
+
+    [57] = {                -- TALACCA COVE
+     -- { 0, 1088,    0},   -- Call to Arms (ISNM)
+     -- { 1, 1089,    0},   -- Compliments to the Chef (ISNM)
+     -- { 2, 1090,    0},   -- Puppetmaster Blues (Quest)
+        { 3, 1091, 2332},   -- Breaking the Bonds of Fate (COR LB5)
+        { 4, 1092,    0},   -- Legacy of the Lost (TOAU35)
+     -- { 5,    ?,    0},   -- *Legacy of the Lost (HTMBF)
+    },
+
+    [64] = {                -- NAVUKGO EXECUTION CHAMBER
+     -- { 0, 1120,    0},   -- Tough Nut to Crack (ISNM)
+     -- { 1, 1121,    0},   -- Happy Caster (ISNM)
+     -- { 2, 1122,    0},   -- Omens (Quest)
+        { 3, 1123, 2333},   -- Achieving True Power (PUP LB5)
+        { 4, 1124,    0},   -- Shield of Diplomacy (TOAU22)
+    },
+
+    [67] = {                -- JADE SEPULCHER
+     -- { 0, 1152,    0},   -- Making a Mockery (ISNM)
+     -- { 1, 1153,    0},   -- Shadows of the Mind (ISNM)
+        { 2, 1154, 2331},   -- The Beast Within (BLU LB5)
+     -- { 3, 1155,    0},   -- Moment of Truth (Quest)
+        { 4, 1156,    0},   -- Puppet in Peril (TOAU29)
+     -- { 5,    ?,    0},   -- *Puppet in Peril (HTMBF)
+    },
+
+    [78] = {                -- HAZHALM TESTING GROUNDS
+     -- { 0, 1184,    0},   -- The Rider Cometh (Quest)
+    },
+
+    [139] = {               -- HORLAIS PEAK
+        { 0,    0,    0},   -- The Rank 2 Final Mission (Mission 2-3)
+     -- { 1,    1, 1131},   -- Tails of Woe (BS40)
+     -- { 2,    2, 1130},   -- Dismemberment Brigade (BS60)
+        { 3,    3,    0},   -- The Secret Weapon (Sandy 7-2)
+        { 4,    4, 1177},   -- Hostile Herbivores (BS50)
+        { 5,    5, 1426},   -- Shattering Stars (WAR LB5)
+        { 6,    6, 1429},   -- Shattering Stars (BLM LB5)
+        { 7,    7, 1436},   -- Shattering Stars (RNG LB5)
+     -- { 8,    8, 1552},   -- Carapace Combatants (BS30)
+     -- { 9,    9, 1551},   -- Shooting Fish (BS20)
+        {10,   10, 1552},   -- Dropping Like Flies (BS30)
+        {11,   11, 1553},   -- Horns of War (KS99)
+        {12,   12, 1131},   -- Under Observation (BS40)
+     -- {13,   13, 1177},   -- Eye of the Tiger (BS50)
+     -- {14,   14, 1130},   -- Shots in the Dark (BS60)
+        {15,   15, 1175},   -- Double Dragonian (KS30)
+     -- {16,   16, 1178},   -- Today's Horoscope (KS30)
+        {17,   17, 1180},   -- Contaminated Colosseum (KS30)
+     -- {18,   18, 3351},   -- Kindergarten Cap (KC30)
+     -- {19,   19, 3352},   -- Last Orc-Shunned Hero (KC50)
+     -- {20,   20,    0},   -- Beyond Infinity (Quest)
+     -- {21,    ?, 4062},   -- *Tails of Woe (SKC10)
+     -- {22,    ?, 4063},   -- *Dismemberment Brigade (SKC20)
+     -- {23,    ?,    0},   -- A Feast Most Dire (Quest)
+    },
+
+    [140] = {               -- GHELSBA OUTPOST
+        { 0,   32,    0},   -- Save the Children (Sandy 1-3)
+        { 1,   33,    0},   -- The Holy Crest (Quest)
+        { 2,   34, 1551},   -- Wings of Fury (BS20)
+        { 3,   35, 1552},   -- Petrifying Pair (BS30)
+        { 4,   36, 1552},   -- Toadal Recall (BS30)
+     -- { 5,   37,    0},   -- Mirror, Mirror (Quest)
+    },
+
+    [144] = {               -- WAUGHROON SHRINE
+        { 0,   64,    0},   -- The Rank 2 Final Mission (Mission 2-3)
+     -- { 1,   65, 1131},   -- The Worm's Turn (BS40)
+     -- { 2,   66, 1130},   -- Grimshell Shocktroopers (BS60)
+        { 3,   67,    0},   -- On My Way (Basty 7-2)
+        { 4,   68, 1166},   -- A Thief in Norg!? (Quest)
+     -- { 5,   69, 1177},   -- 3, 2, 1... (BS50)
+        { 6,   70, 1430},   -- Shattering Stars (RDM LB5)
+        { 7,   71, 1431},   -- Shattering Stars (THF LB5)
+        { 8,   72, 1434},   -- Shattering Stars (BST LB5)
+     -- { 9,   73, 1552},   -- Birds of a Feather (BS30)
+     -- {10,   74, 1551},   -- Crustacean Conundrum (BS20)
+     -- {11,   75, 1552},   -- Grove Guardians (BS30)
+        {12,   76, 1553},   -- The Hills are Alive (KS99)
+     -- {13,   77, 1131},   -- Royal Jelly (BS40)
+     -- {14,   78, 1177},   -- The Final Bout (BS50)
+        {15,   79, 1130},   -- Up in Arms (BS60)
+     -- {16,   80, 1175},   -- Copycat (KS30)
+        {17,   81, 1178},   -- Operation Desert Storm (KS30)
+        {18,   82, 1180},   -- Prehistoric Pigeons (KS30)
+     -- {19,   83, 3351},   -- The Palborough Project (KC30)
+     -- {20,   84, 3352},   -- Shell Shocked (KC50)
+     -- {21,   85,    0},   -- Beyond Infinity (Quest)
+     -- {22,    ?, 4062},   -- *The Worm's Tail (SKC10)
+     -- {23,    ?, 4063},   -- *Grimshell Shocktroopers (SKC20)
+     -- {24,    ?,    0},   -- A Feast Most Dire (Quest)
+    },
+
+    [146] = {               -- BALGA'S DIAS
+        { 0,   96,    0},   -- The Rank 2 Final Mission (Mission 2-3)
+     -- { 1,   97, 1131},   -- Steamed Sprouts (BS40)
+     -- { 2,   98, 1130},   -- Divine Punishers (BS60)
+        { 3,   99,    0},   -- Saintly Invitation (Windy 6-2)
+     -- { 4,  100, 1177},   -- Treasure and Tribulations (BS50)
+        { 5,  101, 1427},   -- Shattering Stars (MNK LB5)
+        { 6,  102, 1428},   -- Shattering Stars (WHM LB5)
+        { 7,  103, 1440},   -- Shattering Stars (SMN LB5)
+     -- { 8,  104, 1552},   -- Creeping Doom (BS30)
+        { 9,  105, 1551},   -- Charming Trio (BS20)
+     -- {10,  106, 1552},   -- Harem Scarem (BS30)
+        {11,  107, 1553},   -- Early Bird Catches the Wyrm (KS99)
+     -- {12,  108, 1131},   -- Royal Succession (BS40)
+     -- {13,  109, 1177},   -- Rapid Raptors (BS50)
+     -- {14,  110, 1130},   -- Wild Wild Whiskers (BS60)
+     -- {15,  111, 1175},   -- Seasons Greetings (KS30)
+     -- {16,  112, 1178},   -- Royale Ramble (KS30)
+     -- {17,  113, 1180},   -- Moa Constrictors (KS30)
+     -- {18,  114, 3351},   -- The V Formation (KC30)
+     -- {19,  115, 3352},   -- Avian Apostates (KC50)
+     -- {20,  116,    0},   -- Beyond Infinity (Quest)
+     -- {21,    ?, 4062},   -- *Steamed Sprouts (SKC10)
+     -- {22,    ?, 4063},   -- *Divine Punishers (SKC20)
+     -- {23,    ?,    0},   -- A Feast Most Dire (Quest)
+    },
+
+    [156] = {               -- THRONE ROOM [S]
+     -- { 0,  352,    0},   -- Fiat Lux (Campaign)
+     -- { 1,  353,    0},   -- Darkness Descends (WOTG37)
+     -- { 2,  354,    0},   -- Bonds of Mythril (Quest)
+     -- { 3,    ?,    0},   -- Unafraid of the Dark (Merit Battlefield)
+    },
+
+    [163] = {               -- SACRIFICIAL CHAMBER
+        { 0,  128,    0},   -- The Temple of Uggalepih (ZM4)
+        { 1,  129, 1130},   -- Jungle Boogymen (BS60)
+        { 2,  130, 1130},   -- Amphibian Assault (BS60)
+     -- { 3,  131,    0},   -- Project: Shantottofication (ASA13)
+     -- { 4,  132, 3352},   -- Whom Wilt Thou Call (KC50)
+     -- { 5,    ?, 4063},   -- *Jungle Boogymen (SKC20)
+     -- { 6,    ?, 4063},   -- *Amphibian Assault (SKC20)
+    },
+
+    [165] = {               -- THRONE ROOM
+        { 0,  160,    0},   -- The Shadow Lord Battle (Mission 5-2)
+        { 1,  161,    0},   -- Where Two Paths Converge (Basty 9-2)
+     -- { 2,  162, 1130},   -- Kindred Spirits (BS60)
+        { 3,  163, 2557},   -- Survival of the Wisest (SCH LB5)
+     -- { 4,  164,    0},   -- Smash! A Malevolent Menace (MKD14)
+     -- { 5,    ?, 4063},   -- *Kindred Spirits (SKC20)
+     -- { 6,    ?,    0},   -- *The Shadowlord Battle (HTMBF)
+    },
+
+    [168] = {               -- CHAMBER OF ORACLES
+        { 0,  192,    0},   -- Through the Quicksand Caves (ZM6)
+     -- { 1,  193, 1130},   -- Legion XI Comitatensis (BS60)
+        { 2,  194, 1437},   -- Shattering Stars (SAM LB5)
+        { 3,  195, 1438},   -- Shattering Stars (NIN LB5)
+        { 4,  196, 1439},   -- Shattering Stars (DRG LB5)
+     -- { 5,  197, 1175},   -- Cactuar Suave (KS30)
+     -- { 6,  198, 1178},   -- Eye of the Storm (KS30)
+     -- { 7,  199, 1180},   -- The Scarlet King (KS30)
+     -- { 8,  200,    0},   -- Roar! A Cat Burglar Bares Her Fangs (MKD10)
+     -- { 9,  201, 3352},   -- Dragon Scales (KC50)
+     -- {10,    ?, 4063},   -- *Legion XI Comitatensis (SKC20)
+    },
+
+    [170] = {               -- FULL MOON FOUNTAIN
+        { 0,  224,    0},   -- The Moonlit Path (Quest)
+     -- { 1,  225,    0},   -- Moon Reading (Windy 9-2)
+     -- { 2,  226,    0},   -- Waking the Beast (Quest)
+     -- { 3,  227,    0},   -- Battaru Royale (ASA10)
+     -- { 4,    ?,    0},   -- *The Moonlit Path (HTMBF)
+     -- { 5,    ?,    0},   -- *Waking the Beast (HTMBF)
+    },
+
+    [179] = {               -- STELLAR FULCRUM
+        { 0,  256,    0},   -- Return to Delkfutt's Tower (ZM8)
+     -- { 1,  257,    0},   -- The Indomitable Triumvirate (Mog Bonanza)
+     -- { 2,  258,    0},   -- The Dauntless Duo (Mog Bonanza)
+     -- { 3,  259,    0},   -- The Solitary Demolisher (Mog Bonanza)
+     -- { 4,  260,    0},   -- Heroine's Combat (Mog Bonanza)
+     -- { 5,  261,    0},   -- Mercenary Camp (Mog Bonanza)
+     -- { 6,  262,    0},   -- Ode of Life Bestowing (ACP11)
+     -- { 7,    ?,    0},   -- *Return to Delkfutt's Tower (HTMBF)
+    },
+
+    [180] = {               -- LALOFF AMPHITHEATER
+        { 0,  288,    0},   -- Ark Angels 1 (ZM14)
+        { 1,  289,    0},   -- Ark Angels 2 (ZM14)
+        { 2,  290,    0},   -- Ark Angels 3 (ZM14)
+        { 3,  291,    0},   -- Ark Angels 4 (ZM14)
+        { 4,  292,    0},   -- Ark Angels 5 (ZM14)
+        { 5,  293, 1550},   -- Divine Might (ZM14)
+     -- { 6,    ?,    0},   -- *Ark Angels 1 (HTMBF)
+     -- { 7,    ?,    0},   -- *Ark Angels 2 (HTMBF)
+     -- { 8,    ?,    0},   -- *Ark Angels 3 (HTMBF)
+     -- { 9,    ?,    0},   -- *Ark Angels 4 (HTMBF)
+     -- {10,    ?,    0},   -- *Ark Angels 5 (HTMBF)
+     -- {11,    ?,    0},   -- *Divine Might (HTMBF)
+    },
+
+    [181] = {               -- THE CELESTIAL NEXUS
+        { 0,  320,    0},   -- The Celestial Nexus (ZM16)
+     -- { 1,    ?,    0},   -- *The Celestial Nexus (HTMBF)
+    },
+
+    [182] = {               -- WALK OF ECHOES
+     -- { 0,    ?,    0},   -- When Wills Collide (WOTG46)
+     -- { 1,  385,    0},   -- Maiden of the Dusk (WOTG51)
+     -- { 2,    ?,    0},   -- Champion of the Dawn (Quest)
+     -- { 3,    ?,    0},   -- A Forbidden Reunion (Quest)
+    },
+
+    [201] = {               -- CLOISTER OF GALES
+        { 0,  416,    0},   -- Trial by Wind (Quest)
+        { 1,  417, 1174},   -- Carbuncle Debacle (Quest)
+        { 2,  418, 1546},   -- Trial-size Trial by Wind (Quest)
+     -- { 3,  419,    0},   -- Waking the Beast (Quest)
+        { 4,  420,    0},   -- Sugar-coated Directive (ASA4)
+     -- { 5,    ?,    0},   -- *Trial by Wind (HTMBF)
+    },
+
+    [202] = {               -- CLOISTER OF STORMS
+        { 0,  448,    0},   -- Trial by Lightning (Quest)
+        { 1,  449, 1172},   -- Carbuncle Debacle (Quest)
+        { 2,  450, 1548},   -- Trial-size Trial by Lightning (Quest)
+     -- { 3,  451,    0},   -- Waking the Beast (Quest)
+        { 4,  452,    0},   -- Sugar-coated Directive (ASA4)
+     -- { 5,    ?,    0},   -- *Trial by Lightning (HTMBF)
+    },
+
+    [203] = {               -- CLOISTER OF FROST
+        { 0,  480,    0},   -- Trial by Ice (Quest)
+        { 1,  481, 1171},   -- Class Reunion (Quest)
+        { 2,  482, 1545},   -- Trial-size Trial by Ice (Quest)
+     -- { 3,  483,    0},   -- Waking the Beast (Quest)
+        { 4,  484,    0},   -- Sugar-coated Directive (ASA4)
+     -- { 5,    ?,    0},   -- *Trial by Ice (HTMBF)
+    },
+
+    [206] = {               -- QU'BIA ARENA
+        { 0,  512,    0},   -- The Rank 5 Mission (Mission 5-1)
+     -- { 1,  513, 1175},   -- Come Into My Parlor (KS30)
+     -- { 2,  514, 1178},   -- E-vase-ive Action (KS30)
+     -- { 3,  515, 1180},   -- Infernal Swarm (KS30)
+        { 4,  516,    0},   -- The Heir to the Light (Sandy 9-2)
+        { 5,  517, 1432},   -- Shattering Stars (PLD LB5)
+        { 6,  518, 1433},   -- Shattering Stars (DRK LB5)
+        { 7,  519, 1435},   -- Shattering Stars (BRD LB5)
+     -- { 8,  520, 1130},   -- Demolition Squad (BS60)
+     -- { 9,  521, 1552},   -- Die by the Sword (BS30)
+     -- {10,  522, 1552},   -- Let Sleeping Dogs Lie (BS30)
+     -- {11,  523, 1130},   -- Brothers D'Aurphe (BS60)
+     -- {12,  524, 1131},   -- Undying Promise (BS40)
+     -- {13,  525, 1131},   -- Factory Rejects (BS40)
+     -- {14,  526, 1177},   -- Idol Thoughts (BS50)
+     -- {15,  527, 1177},   -- An Awful Autopsy (BS50)
+     -- {16,  528, 1130},   -- Celery (BS60)
+     -- {17,  529,    0},   -- Mirror Images (Quest)
+        {18,  530, 2556},   -- A Furious Finale (DNC LB5)
+     -- {19,  531,    0},   -- Clash of the Comrades (Quest)
+     -- {20,  532,    0},   -- Those Who Lurk in Shadows (ACP7)
+     -- {21,  533,    0},   -- Beyond Infinity (Quest)
+     -- {22,    ?, 4062},   -- *Factory Rejects (SKC10)
+     -- {23,    ?, 4063},   -- *Demolition Squad (SKC20)
+     -- {24,    ?, 4063},   -- *Brothers D'Aurphe (SKC20)
+     -- {25,    ?,    0},   -- Mumor's Encore (Sunbreeze Festival)
+    },
+
+    [207] = {               -- CLOISTER OF FLAMES
+        { 0,  544,    0},   -- Trial by Fire (Quest)
+        { 1,  545, 1544},   -- Trial-size Trial by Fire (Quest)
+     -- { 2,  546,    0},   -- Waking the Beast (Quest)
+        { 3,  547,    0},   -- Sugar-coated Directive (ASA4)
+     -- { 4,    ?,    0},   -- *Trial by Fire (HTMBF)
+    },
+
+    [209] = {               -- CLOISTER OF TREMORS
+        { 0,  576,    0},   -- Trial by Earth (Quest)
+        { 1,  577, 1169},   -- The Puppet Master (Quest)
+        { 2,  578, 1547},   -- Trial-size Trial by Earth (Quest)
+     -- { 3,  579,    0},   -- Waking the Beast (Quest)
+        { 4,  580,    0},   -- Sugar-coated Directive (ASA4)
+     -- { 5,    ?,    0},   -- *Trial by Earth (HTMBF)
+    },
+
+    [211] = {               -- CLOISTER OF TIDES
+        { 0,  608,    0},   -- Trial by Water (Quest)
+        { 1,  609, 1549},   -- Trial-size Trial by Water (Quest)
+     -- { 2,  610,    0},   -- Waking the Beast (Quest)
+        { 3,  611,    0},   -- Sugar-coated Directive (ASA4)
+     -- { 4,    ?,    0},   -- *Trial by Water (HTMBF)
+    },
+
 };
 
--- Call this onTrade for burning circles
-function TradeBCNM(player, zone, trade, npc)
-    if (trade == nil) then
-        print("TradeBCNM was sent a nil trade!\n\t Player: "..player:getName().."\n\t zone: "..zone.."\n")
-        return false
+-----------------------------------------------
+-- for checks, mission 255 is mission -1
+-----------------------------------------------
+
+function fix255(n)
+    if (n == 255) then
+        return -1;
     end
-
-    if (player:hasStatusEffect(EFFECT_BATTLEFIELD)) then -- cant start a new bc
-        player:messageBasic(94, 0, 0)
-        return false
-    elseif (player:hasWornItem(trade:getItemId())) then -- If already used orb or testimony
-        player:messageBasic(56, 0, 0) -- i need correct dialog
-        return false
-    end
-
-    if (CheckMaatFights(player, zone, trade, npc)) then -- This function returns true for maat fights
-        return true
-    end
-    -- the following is for orb battles, etc
-
-    local id = ItemToBCNMID(player, zone, trade)
-
-    if (id == -1) then -- no valid BCNMs with this item
-        -- todo: display message based on zone text offset
-        player:setVar("trade_bcnmid", 0)
-        player:setVar("trade_itemid", 0)
-        return false
-    else -- a valid BCNM with this item, start it.
-        mask = GetBattleBitmask(id, zone, 1)
-
-        if (mask == -1) then -- Cannot resolve this BCNMID to an event number, edit bcnmid_param_map!
-            print("Item is for a valid BCNM but cannot find the event parameter to display to client.")
-            player:setVar("trade_bcnmid", 0)
-            player:setVar("trade_itemid", 0)
-            return false
-        end
-        if (player:isBcnmsFull() == 1) then -- temp measure, this will precheck the instances
-            print("all bcnm instances are currently occupied.")
-            npc:messageBasic(246, 0, 0) -- this wont look right in other languages!
-            return true
-        end
-        player:startEvent(0x7d00, 0, 0, 0, mask, 0, 0, 0, 0)
-        return true
-    end
+    return n;
 end
 
-function EventTriggerBCNM(player, npc)
-    player:setVar("trade_bcnmid", 0)
-    player:setVar("trade_itemid", 0)
+-----------------------------------------------
+-- check requirements for registrant and allies
+-----------------------------------------------
 
-    if (player:hasStatusEffect(EFFECT_BATTLEFIELD)) then
-        if (player:isInBcnm() == 1) then
-            player:startEvent(0x7d03) -- Run Away or Stay menu
-        else -- You're not in the BCNM but you have the Battlefield effect. Think: non-trader in a party
-            status = player:getStatusEffect(EFFECT_BATTLEFIELD)
-            playerbcnmid = status:getPower()
-            playermask = GetBattleBitmask(playerbcnmid, player:getZoneID(), 1)
-            if (playermask~=-1) then
-                -- This gives players who did not trade to go in the option of entering the fight
-                player:startEvent(0x7d00, 0, 0, 0, playermask, 0, 0, 0, 0)
-            else
-                player:messageBasic(94, 0, 0)
-            end
-        end
-        return true
+function checkReqs(player, npc, bfid, registrant)
+    local npcid   = npc:getID();
+    local mjob    = player:getMainJob();
+    local mlvl    = player:getMainLvl();
+    local nat     = fix255(player:getCurrentMission(player:getNation()));
+    local sandy   = fix255(player:getCurrentMission(SANDORIA));
+    local basty   = fix255(player:getCurrentMission(BASTOK));
+    local windy   = fix255(player:getCurrentMission(WINDURST));
+    local roz     = fix255(player:getCurrentMission(ZILART));
+    local cop     = fix255(player:getCurrentMission(COP));
+    local toau    = fix255(player:getCurrentMission(TOAU));
+    local asa     = fix255(player:getCurrentMission(ASA));
+    local natStat  = player:getVar("MissionStatus");
+    local rozStat  = player:getVar("ZilartStatus");
+    local copStat  = player:getVar("PromathiaStatus");
+    local toauStat = player:getVar("AhtUrganStatus");
+    local stc = player:hasCompletedMission(SANDORIA, SAVE_THE_CHILDREN);
+    local dm1 = player:getQuestStatus(OUTLANDS, DIVINE_MIGHT);
+    local dm2 = player:getQuestStatus(OUTLANDS, DIVINE_MIGHT_REPEAT);
+
+    -- requirements to register a battlefield
+    local registerReqs = {
+        [   0] = function() return ( (basty == THE_EMISSARY_SANDORIA2 or windy == THE_THREE_KINGDOMS_SANDORIA2) and natStat == 9                    ) end, -- Mission 2-3
+        [   3] = function() return ( sandy == THE_SECRET_WEAPON and player:getVar("SecretWeaponStatus") == 2                                        ) end, -- Sandy 7-2: The Secret Weapon
+        [   5] = function() return ( mjob == JOBS.WAR and mlvl >= 66                                                                                ) end, -- Quest: Shattering Stars (WAR LB5)
+        [   6] = function() return ( mjob == JOBS.BLM and mlvl >= 66                                                                                ) end, -- Quest: Shattering Stars (BLM LB5)
+        [   7] = function() return ( mjob == JOBS.RNG and mlvl >= 66                                                                                ) end, -- Quest: Shattering Stars (RNG LB5)
+        [  20] = function() return ( player:hasKeyItem(SOUL_GEM_CLASP)                                                                              ) end, -- Quest: Beyond Infinity
+        [  32] = function() return ( sandy == SAVE_THE_CHILDREN and ((stc and missionStatus <= 2) or (not stc and natStat == 2))                    ) end, -- Sandy 1-3: Save the Children
+        [  33] = function() return ( player:hasKeyItem(DRAGON_CURSE_REMEDY)                                                                         ) end, -- Quest: The Holy Crest
+        [  64] = function() return ( (sandy == JOURNEY_TO_BASTOK2 or windy == THE_THREE_KINGDOMS_BASTOK2) and natStat == 10                         ) end, -- Mission 2-3
+        [  67] = function() return ( basty == ON_MY_WAY and natStat == 2                                                                            ) end, -- Basty 7-2: On My Way
+        [  68] = function() return ( player:getVar("aThiefinNorgCS") == 6                                                                           ) end, -- Quest: A Thief in Norg!?
+        [  70] = function() return ( mjob == JOBS.RDM and mlvl >= 66                                                                                ) end, -- Quest: Shattering Stars (RDM LB5)
+        [  71] = function() return ( mjob == JOBS.THF and mlvl >= 66                                                                                ) end, -- Quest: Shattering Stars (THF LB5)
+        [  72] = function() return ( mjob == JOBS.BST and mlvl >= 66                                                                                ) end, -- Quest: Shattering Stars (BST LB5)
+        [  96] = function() return ( player:hasKeyItem(DARK_KEY)                                                                                    ) end, -- Mission 2-3
+        [  99] = function() return ( windy == SAINTLY_INVITATION and natStat == 1                                                                   ) end, -- Windy 6-2: A Saintly Invitation
+        [ 101] = function() return ( mjob == JOBS.MNK and mlvl >= 66                                                                                ) end, -- Quest: Shattering Stars (MNK LB5)
+        [ 102] = function() return ( mjob == JOBS.WHM and mlvl >= 66                                                                                ) end, -- Quest: Shattering Stars (WHM LB5)
+        [ 103] = function() return ( mjob == JOBS.SMN and mlvl >= 66                                                                                ) end, -- Quest: Shattering Stars (SMN LB5)
+        [ 128] = function() return ( roz == THE_TEMPLE_OF_UGGALEPIH                                                                                 ) end, -- ZM4: The Temple of Uggalepih
+        [ 160] = function() return ( mission == 15 and natStat == 3                                                                                 ) end, -- Mission 5-2
+        [ 161] = function() return ( basty == WHERE_TWO_PATHS_CONVERGE and player:getVar("BASTOK92") == 1                                           ) end, -- Basty 9-2: Where Two Paths Converge
+        [ 163] = function() return ( mjob == JOBS.SCH and mlvl >= 66                                                                                ) end, -- Quest: Survival of the Wisest (SCH LB5)
+        [ 192] = function() return ( roz == THROUGH_THE_QUICKSAND_CAVES                                                                             ) end, -- ZM6: Through the Quicksand Caves
+        [ 194] = function() return ( mjob == JOBS.SAM and mlvl >= 66                                                                                ) end, -- Quest: Shattering Stars (SAM LB5)
+        [ 195] = function() return ( mjob == JOBS.NIN and mlvl >= 66                                                                                ) end, -- Quest: Shattering Stars (NIN LB5)
+        [ 196] = function() return ( mjob == JOBS.DRG and mlvl >= 66                                                                                ) end, -- Quest: Shattering Stars (DRG LB5)
+        [ 224] = function() return ( player:hasKeyItem(MOON_BAUBLE)                                                                                 ) end, -- Quest: The Moonlit Path
+        [ 225] = function() return ( windy == MOON_READING and player:getVar("WINDURST92") == 2                                                     ) end, -- Windy 9-2: Moon Reading
+        [ 256] = function() return ( roz == RETURN_TO_DELKFUTTS_TOWER and rozStat == 3                                                              ) end, -- ZM8: Return to Delkfutt's Tower
+        [ 288] = function() return ( roz == ARK_ANGELS and rozStat == 1 and npcid == 17514791 and not player:hasKeyItem(SHARD_OF_APATHY)            ) end, -- ZM14: Ark Angels (Hume)
+        [ 289] = function() return ( roz == ARK_ANGELS and rozStat == 1 and npcid == 17514792 and not player:hasKeyItem(SHARD_OF_COWARDICE)         ) end, -- ZM14: Ark Angels (Tarutaru)
+        [ 290] = function() return ( roz == ARK_ANGELS and rozStat == 1 and npcid == 17514793 and not player:hasKeyItem(SHARD_OF_ENVY)              ) end, -- ZM14: Ark Angels (Mithra)
+        [ 291] = function() return ( roz == ARK_ANGELS and rozStat == 1 and npcid == 17514794 and not player:hasKeyItem(SHARD_OF_ARROGANCE)         ) end, -- ZM14: Ark Angels (Elvaan)
+        [ 292] = function() return ( roz == ARK_ANGELS and rozStat == 1 and npcid == 17514795 and not player:hasKeyItem(SHARD_OF_RAGE)              ) end, -- ZM14: Ark Angels (Galka)
+        [ 293] = function() return ( dm1 == QUEST_ACCEPTED or dm2 == QUEST_ACCEPTED                                                                 ) end, -- ZM14 Divine Might
+        [ 320] = function() return ( roz == THE_CELESTIAL_NEXUS                                                                                     ) end, -- ZM16: The Celestial Nexus
+        [ 416] = function() return ( player:hasKeyItem(TUNING_FORK_OF_WIND)                                                                         ) end, -- Quest: Trial by Wind
+        [ 417] = function() return ( player:getVar("CarbuncleDebacleProgress") == 6                                                                 ) end, -- Quest: Carbuncle Debacle
+        [ 418] = function() return ( mjob == JOBS.SMN and mlvl >= 20                                                                                ) end, -- Quest: Trial-size Trial by Wind
+        [ 420] = function() return ( asa == SUGAR_COATED_DIRECTIVE and player:hasKeyItem(DOMINAS_EMERALD_SEAL)                                      ) end, -- ASA4: Sugar-coated Directive
+        [ 448] = function() return ( player:hasKeyItem(TUNING_FORK_OF_LIGHTNING)                                                                    ) end, -- Quest: Trial by Lightning
+        [ 449] = function() return ( player:getVar("CarbuncleDebacleProgress") == 3                                                                 ) end, -- Quest: Carbuncle Debacle
+        [ 450] = function() return ( mjob == JOBS.SMN and mlvl >= 20                                                                                ) end, -- Quest: Trial-size Trial by Lightning
+        [ 452] = function() return ( asa == SUGAR_COATED_DIRECTIVE and player:hasKeyItem(DOMINAS_VIOLET_SEAL)                                       ) end, -- ASA4: Sugar-coated Directive
+        [ 480] = function() return ( player:hasKeyItem(TUNING_FORK_OF_ICE)                                                                          ) end, -- Quest: Trial by Ice
+        [ 481] = function() return ( player:getVar("ClassReunionProgress") == 5                                                                     ) end, -- Quest: Class Reunion
+        [ 482] = function() return ( mjob == JOBS.SMN and mlvl >= 20                                                                                ) end, -- Quest: Trial-size Trial by Ice
+        [ 484] = function() return ( asa == SUGAR_COATED_DIRECTIVE and player:hasKeyItem(DOMINAS_AZURE_SEAL)                                        ) end, -- ASA4: Sugar-coated Directive
+        [ 512] = function() return ( nat == 14 and natStat == 11                                                                                    ) end, -- Mission 5-1
+        [ 516] = function() return ( sandy == THE_HEIR_TO_THE_LIGHT and natStat == 3                                                                ) end, -- Sandy 9-2: The Heir to the Light
+        [ 517] = function() return ( mjob == JOBS.PLD and mlvl >= 66                                                                                ) end, -- Quest: Shattering Stars (PLD LB5)
+        [ 518] = function() return ( mjob == JOBS.DRK and mlvl >= 66                                                                                ) end, -- Quest: Shattering Stars (DRK LB5)
+        [ 519] = function() return ( mjob == JOBS.BRD and mlvl >= 66                                                                                ) end, -- Quest: Shattering Stars (BRD LB5)
+        [ 530] = function() return ( mjob == JOBS.DNC and mlvl >= 66                                                                                ) end, -- Quest: A Furious Finale (DNC LB5)
+        [ 544] = function() return ( player:hasKeyItem(TUNING_FORK_OF_FIRE)                                                                         ) end, -- Quest: Trial by Fire
+        [ 545] = function() return ( mjob == JOBS.SMN and mlvl >= 20                                                                                ) end, -- Quest: Trial-size Trial by Fire
+        [ 547] = function() return ( asa == SUGAR_COATED_DIRECTIVE and player:hasKeyItem(DOMINAS_SCARLET_SEAL)                                      ) end, -- ASA4: Sugar-coated Directive
+        [ 576] = function() return ( player:hasKeyItem(TUNING_FORK_OF_EARTH)                                                                        ) end, -- Quest: Trial by Earth
+        [ 577] = function() return ( player:getVar("ThePuppetMasterProgress") == 2                                                                  ) end, -- Quest: The Puppet Master
+        [ 578] = function() return ( mjob == JOBS.SMN and mlvl >= 20                                                                                ) end, -- Quest: Trial-size Trial by Earth
+        [ 580] = function() return ( asa == SUGAR_COATED_DIRECTIVE and player:hasKeyItem(DOMINAS_AMBER_SEAL)                                        ) end, -- ASA4: Sugar-coated Directive
+        [ 608] = function() return ( player:hasKeyItem(TUNING_FORK_OF_WATER)                                                                        ) end, -- Quest: Trial by Water
+        [ 609] = function() return ( mjob == JOBS.SMN and mlvl >= 20                                                                                ) end, -- Quest: Trial-size Trial by Water
+        [ 611] = function() return ( asa == SUGAR_COATED_DIRECTIVE and player:hasKeyItem(DOMINAS_CERULEAN_SEAL)                                     ) end, -- ASA4: Sugar-coated Directive
+        [ 640] = function() return ( cop == THREE_PATHS and player:getVar("COP_Ulmia_s_Path") == 6                                                  ) end, -- PM5-3 U3: Flames for the Dead
+        [ 641] = function() return ( player:hasKeyItem(ZEPHYR_FAN)                                                                                  ) end, -- ENM: Follow the White Rabbit
+        [ 642] = function() return ( player:hasKeyItem(ZEPHYR_FAN)                                                                                  ) end, -- ENM: When Hell Freezes Over
+        [ 643] = function() return ( player:hasKeyItem(ZEPHYR_FAN)                                                                                  ) end, -- ENM: Brothers
+        [ 644] = function() return ( player:hasKeyItem(ZEPHYR_FAN)                                                                                  ) end, -- ENM: Holy Cow
+        [ 672] = function() return ( cop == THREE_PATHS and player:getVar("COP_Ulmia_s_Path") == 5                                                  ) end, -- PM5-3 U2: Head Wind
+        [ 673] = function() return ( player:hasKeyItem(MIASMA_FILTER)                                                                               ) end, -- ENM: Like the Wind
+        [ 674] = function() return ( player:hasKeyItem(MIASMA_FILTER)                                                                               ) end, -- ENM: Sheep in Antlion's Clothing
+        [ 675] = function() return ( player:hasKeyItem(MIASMA_FILTER)                                                                               ) end, -- ENM: Shell We Dance?
+        [ 676] = function() return ( player:hasKeyItem(MIASMA_FILTER)                                                                               ) end, -- ENM: Totentanz
+        [ 677] = function() return ( player:hasKeyItem(LETTER_FROM_SHIKAREE_X)                                                                      ) end, -- Quest: Tango with a Tracker
+        [ 678] = function() return ( player:hasKeyItem(LETTER_FROM_SHIKAREE_Y)                                                                      ) end, -- Quest: Requiem of Sin
+        [ 704] = function() return ( cop == DARKNESS_NAMED and copStat == 2                                                                         ) end, -- PM3-5: Darkness Named
+        [ 705] = function() return ( player:hasKeyItem(ASTRAL_COVENANT)                                                                             ) end, -- ENM: Test Your Mite
+        [ 706] = function() return ( player:hasKeyItem(VIAL_OF_DREAM_INCENSE)                                                                       ) end, -- Quest: Waking Dreams
+        [ 736] = function() return ( cop == THREE_PATHS and player:getVar("COP_Louverance_s_Path") == 5                                             ) end, -- PM5-3 L3: A Century of Hardship
+        [ 738] = function() return ( player:hasKeyItem(SHAFT_2716_OPERATING_LEVER)                                                                  ) end, -- ENM: Bionic Bug
+        [ 739] = function() return ( player:hasKeyItem(SHAFT_GATE_OPERATING_DIAL)                                                                   ) end, -- ENM: Pulling Your Strings
+        [ 740] = function() return ( player:hasKeyItem(SHAFT_GATE_OPERATING_DIAL)                                                                   ) end, -- ENM: Automaton Assault
+        [ 768] = function() return ( (cop==BELOW_THE_ARKS and copStat==1) or (cop==THE_MOTHERCRYSTALS and not player:hasKeyItem(LIGHT_OF_HOLLA))    ) end, -- PM1-3: The Mothercrystals
+        [ 769] = function() return ( player:hasKeyItem(CENSER_OF_ABANDONMENT)                                                                       ) end, -- ENM: Simulant
+        [ 800] = function() return ( (cop==BELOW_THE_ARKS and copStat==1) or (cop==THE_MOTHERCRYSTALS and not player:hasKeyItem(LIGHT_OF_DEM))      ) end, -- PM1-3: The Mothercrystals
+        [ 801] = function() return ( player:hasKeyItem(CENSER_OF_ANTIPATHY)                                                                         ) end, -- ENM: You Are What You Eat
+        [ 832] = function() return ( (cop==BELOW_THE_ARKS and copStat==1) or (cop==THE_MOTHERCRYSTALS and not player:hasKeyItem(LIGHT_OF_MEA))      ) end, -- PM1-3: The Mothercrystals
+        [ 833] = function() return ( player:hasKeyItem(CENSER_OF_ANIMUS)                                                                            ) end, -- ENM: Playing Host
+        [ 864] = function() return ( cop == DESIRES_OF_EMPTINESS and copStat == 8                                                                   ) end, -- PM5-2: Desires of Emptiness
+        [ 865] = function() return ( player:hasKeyItem(CENSER_OF_ACRIMONY)                                                                          ) end, -- ENM: Pulling the Plug
+        [ 896] = function() return ( player:getQuestStatus(JEUNO,STORMS_OF_FATE) == QUEST_ACCEPTED and player:getVar('StormsOfFate') == 2           ) end, -- Quest: Storms of Fate
+        [ 960] = function() return ( cop == ANCIENT_VOWS and copStat == 2                                                                           ) end, -- PM2-5: Ancient Vows
+        [ 961] = function() return ( cop == THE_SAVAGE and copStat == 1                                                                             ) end, -- PM4-2: The Savage
+        [ 962] = function() return ( player:hasKeyItem(MONARCH_BEARD)                                                                               ) end, -- ENM: Fire in the Sky
+        [ 963] = function() return ( player:hasKeyItem(MONARCH_BEARD)                                                                               ) end, -- ENM: Bad Seed
+        [ 964] = function() return ( player:hasKeyItem(MONARCH_BEARD)                                                                               ) end, -- ENM: Bugard in the Clouds
+        [ 965] = function() return ( player:hasKeyItem(MONARCH_BEARD)                                                                               ) end, -- ENM: Beloved of Atlantes
+        [ 992] = function() return ( cop == ONE_TO_BE_FEARED and copStat == 2                                                                       ) end, -- PM6-4: One to be Feared
+        [ 993] = function() return ( cop == THE_WARRIOR_S_PATH                                                                                      ) end, -- PM7-5: The Warrior's Path
+        [1024] = function() return ( cop == WHEN_ANGELS_FALL and copStat == 4                                                                       ) end, -- PM8-3: When Angels Fall
+        [1056] = function() return ( cop == DAWN and copStat == 2                                                                                   ) end, -- PM8-4: Dawn
+        [1090] = function() return ( player:hasKeyItem(TOGGLE_SWITCH)                                                                               ) end, -- Quest: Puppetmaster Blues
+        [1091] = function() return ( mjob == JOBS.COR and mlvl >= 66                                                                                ) end, -- Quest: Breaking the Bonds of Fate (COR LB5)
+        [1092] = function() return ( toau == LEGACY_OF_THE_LOST                                                                                     ) end, -- TOAU35: Legacy of the Lost
+        [1123] = function() return ( mjob == JOBS.PUP and mlvl >= 66                                                                                ) end, -- Quest: Achieving True Power (PUP LB5)
+        [1124] = function() return ( toau == SHIELD_OF_DIPLOMACY and toauStat == 2                                                                  ) end, -- TOAU22: Shield of Diplomacy
+        [1154] = function() return ( mjob == JOBS.BLU and mlvl >= 66                                                                                ) end, -- Quest: The Beast Within (BLU LB5)
+        [1156] = function() return ( toau == PUPPET_IN_PERIL and toauStat == 1                                                                      ) end, -- TOAU29: Puppet in Peril
+        [1290] = function() return ( player:hasKeyItem(COSMOCLEANSE) and player:hasKeyItem(RED_CARD)                                                ) end, -- NW Apollyon
+        [1291] = function() return ( player:hasKeyItem(COSMOCLEANSE) and player:hasKeyItem(RED_CARD)                                                ) end, -- SW Apollyon
+        [1292] = function() return ( player:hasKeyItem(COSMOCLEANSE) and player:hasKeyItem(BLACK_CARD)                                              ) end, -- NE Apollyon
+        [1293] = function() return ( player:hasKeyItem(COSMOCLEANSE) and player:hasKeyItem(BLACK_CARD)                                              ) end, -- SE Apollyon
+        [1294] = function() return ( player:hasKeyItem(COSMOCLEANSE)                                                                                ) end, -- CS Apollyon
+        [1296] = function() return ( player:hasKeyItem(COSMOCLEANSE)                                                                                ) end, -- Central Apollyon
+        [1298] = function() return ( player:hasKeyItem(COSMOCLEANSE) and player:hasKeyItem(WHITE_CARD)                                              ) end, -- Temenos Western Tower
+        [1299] = function() return ( player:hasKeyItem(COSMOCLEANSE) and player:hasKeyItem(WHITE_CARD)                                              ) end, -- Temenos Northern Tower 
+        [1300] = function() return ( player:hasKeyItem(COSMOCLEANSE) and player:hasKeyItem(WHITE_CARD)                                              ) end, -- Temenos Eastern Tower
+        [1301] = function() return ( player:hasKeyItem(COSMOCLEANSE) and player:hasKeyItem(WHITE_CARD)                                              ) end, -- Central Temenos Basement
+        [1303] = function() return ( player:hasKeyItem(COSMOCLEANSE) and player:hasKeyItem(WHITE_CARD)                                              ) end, -- Central Temenos 1st Floor
+        [1304] = function() return ( player:hasKeyItem(COSMOCLEANSE) and player:hasKeyItem(WHITE_CARD)                                              ) end, -- Central Temenos 2nd Floor
+        [1305] = function() return ( player:hasKeyItem(COSMOCLEANSE) and player:hasKeyItem(WHITE_CARD)                                              ) end, -- Central Temenos 3rd Floor
+        [1306] = function() return ( player:hasKeyItem(COSMOCLEANSE) and player:hasKeyItem(WHITE_CARD)                                              ) end, -- Central Temenos 4th Floor
+    };
+
+    -- requirements to enter a battlefield already registered by a party member
+    local enterReqs = {
+        [ 897] = function() return ( player:hasKeyItem(WHISPER_OF_THE_WYRMKING)                                                                     ) end, -- Quest: The Wyrmking Descends
+        [ 928] = function() return ( cop >= ANCIENT_VOWS                                                                                            ) end, -- Quest: Ouryu Cometh
+        [1290] = function() return ( player:hasKeyItem(COSMOCLEANSE) and player:hasKeyItem(RED_CARD)                                                ) end, -- NW Apollyon
+        [1291] = function() return ( player:hasKeyItem(COSMOCLEANSE) and player:hasKeyItem(RED_CARD)                                                ) end, -- SW Apollyon
+        [1292] = function() return ( player:hasKeyItem(COSMOCLEANSE) and player:hasKeyItem(BLACK_CARD)                                              ) end, -- NE Apollyon
+        [1293] = function() return ( player:hasKeyItem(COSMOCLEANSE)                                                                                ) end, -- SE Apollyon
+        [1294] = function() return ( player:hasKeyItem(COSMOCLEANSE)                                                                                ) end, -- CS Apollyon
+        [1296] = function() return ( player:hasKeyItem(COSMOCLEANSE)                                                                                ) end, -- Central Apollyon
+        [1298] = function() return ( player:hasKeyItem(COSMOCLEANSE) and player:hasKeyItem(WHITE_CARD)                                              ) end, -- Temenos Western Tower
+        [1299] = function() return ( player:hasKeyItem(COSMOCLEANSE) and player:hasKeyItem(WHITE_CARD)                                              ) end, -- Temenos Northern Tower 
+        [1300] = function() return ( player:hasKeyItem(COSMOCLEANSE) and player:hasKeyItem(WHITE_CARD)                                              ) end, -- Temenos Eastern Tower
+        [1301] = function() return ( player:hasKeyItem(COSMOCLEANSE) and player:hasKeyItem(WHITE_CARD)                                              ) end, -- Central Temenos Basement
+        [1303] = function() return ( player:hasKeyItem(COSMOCLEANSE) and player:hasKeyItem(WHITE_CARD)                                              ) end, -- Central Temenos 1st Floor
+        [1304] = function() return ( player:hasKeyItem(COSMOCLEANSE) and player:hasKeyItem(WHITE_CARD)                                              ) end, -- Central Temenos 2nd Floor
+        [1305] = function() return ( player:hasKeyItem(COSMOCLEANSE) and player:hasKeyItem(WHITE_CARD)                                              ) end, -- Central Temenos 3rd Floor
+        [1306] = function() return ( player:hasKeyItem(COSMOCLEANSE) and player:hasKeyItem(WHITE_CARD)                                              ) end, -- Central Temenos 4th Floor
+    };
+
+    -- determine whether player meets battlefield requirements
+    local req = (registrant == true) and registerReqs[bfid] or enterReqs[bfid];
+    if (req == nil) then
+        return true;
+    elseif (req()) then
+        return true;
     else
-        if (checkNonTradeBCNM(player, npc)) then
-            return true
-        end
+        return false;
     end
-
-    return false
 end
 
-function EventUpdateBCNM(player, csid, option, entrance)
-    -- return false
-    local id = player:getVar("trade_bcnmid") -- this is 0 if the bcnm isnt handled by new functions
-    local skip = CutsceneSkip(player, npc)
+-----------------------------------------------
+-- check ability to skip a cutscene
+-----------------------------------------------
 
-    print("UPDATE csid "..csid.." option "..option)
-    -- seen: option 2, 3, 0 in that order
-    if (csid == 0x7d03 and option == 2) then -- leaving a BCNM the player is currently in.
-        player:updateEvent(3)
-        return true
-    elseif (csid == 0x7d03 and option == 3) then -- leaving a BCNM the player is currently in.
-        player:updateEvent(0)
-        return true
-    end
-    if (option == 255 and csid == 0x7d00) then -- Clicked yes, try to register bcnmid
-        if (player:hasStatusEffect(EFFECT_BATTLEFIELD)) then
-            -- You're entering a bcnm but you already had the battlefield effect, so you want to go to the
-            -- instance that your battlefield effect represents.
-            player:setVar("bcnm_instanceid_tick", 0)
-            player:setVar("bcnm_instanceid", player:getBattlefieldID()) -- returns 255 if non-existent.
-            return true
-        end
+function checkSkip(player, bfid)
+    local nat       = fix255(player:getCurrentMission(player:getNation()));
+    local sandy     = fix255(player:getCurrentMission(SANDORIA));
+    local basty     = fix255(player:getCurrentMission(BASTOK));
+    local windy     = fix255(player:getCurrentMission(WINDURST));
+    local roz       = fix255(player:getCurrentMission(ZILART));
+    local cop       = fix255(player:getCurrentMission(COP));
+    local toau      = fix255(player:getCurrentMission(TOAU));
+    local asa       = fix255(player:getCurrentMission(ASA));
+    local natStat   = player:getVar("MissionStatus");
+    local rozStat   = player:getVar("ZilartStatus");
+    local copStat   = player:getVar("PromathiaStatus");
+    local toauStat  = player:getVar("AhtUrganStatus");
+    local sofStat   = player:getQuestStatus(JEUNO,STORMS_OF_FATE);
+    local mission2_3a = (basty > THE_EMISSARY_SANDORIA2 or windy > THE_THREE_KINGDOMS_SANDORIA2) or ((basty == THE_EMISSARY_SANDORIA2 or windy == THE_THREE_KINGDOMS_SANDORIA2) and natStat > 9);
+    local mission2_3b = (sandy > JOURNEY_TO_BASTOK2 or windy > THE_THREE_KINGDOMS_BASTOK2) or ((sandy == JOURNEY_TO_BASTOK2 or windy == THE_THREE_KINGDOMS_BASTOK2) and natStat > 10);
+    local mission2_3c = (sandy > JOURNEY_TO_WINDURST2 or basty > THE_EMISSARY_WINDURST2) or ((sandy == JOURNEY_TO_WINDURST2 or basty == THE_EMISSARY_WINDURST2) and natStat > 8);
 
-        inst = player:bcnmRegister(id)
-        if (inst > 0) then
-            player:setVar("bcnm_instanceid", inst)
-            player:setVar("bcnm_instanceid_tick", 0)
-            player:updateEvent(0, GetBattleBitmask(id, player:getZoneID(), 1), 0, 0, 5, 0)
+    -- requirements to skip a battlefield
+    local skipReqs = {
+        [   0] = function() return ( mission2_3a                                                                                                    ) end, -- Mission 2-3
+        [   3] = function() return ( sandy > THE_SECRET_WEAPON or (sandy == THE_SECRET_WEAPON and player:getVar("SecretWeaponStatus") > 2)          ) end, -- Sandy 7-2: The Secret Weapon
+        [  32] = function() return ( sandy > SAVE_THE_CHILDREN or (sandy == SAVE_THE_CHILDREN and natStat > 2)                                      ) end, -- Sandy 1-3: Save the Children
+        [  33] = function() return ( player:hasCompleteQuest(SANDORIA, THE_HOLY_CREST)                                                              ) end, -- Quest: The Holy Crest
+        [  64] = function() return ( mission2_3b                                                                                                    ) end, -- Mission 2-3
+        [  67] = function() return ( basty > ON_MY_WAY or (basty == ON_MY_WAY and natStat > 2)                                                      ) end, -- Basty 7-2: On My Way
+        [  96] = function() return ( mission2_3c                                                                                                    ) end, -- Mission 2-3
+        [  99] = function() return ( windy > SAINTLY_INVITATION or (windy == SAINTLY_INVITATION and natStat > 1)                                    ) end, -- Windy 6-2: A Saintly Invitation
+        [ 160] = function() return ( nat > 15 or (nat == 15 and natStat > 3)                                                                        ) end, -- Mission 5-2
+        [ 161] = function() return ( basty > WHERE_TWO_PATHS_CONVERGE or (basty == WHERE_TWO_PATHS_CONVERGE and natStat > 4)                        ) end, -- Basty 9-2: Where Two Paths Converge
+        [ 192] = function() return ( roz > THROUGH_THE_QUICKSAND_CAVES                                                                              ) end, -- ZM6: Through the Quicksand Caves
+        [ 224] = function() return ( player:hasCompleteQuest(WINDURST, THE_MOONLIT_PATH) or player:hasKeyItem(WHISPER_OF_THE_MOON)                  ) end, -- Quest: The Moonlit Path
+        [ 225] = function() return ( windy > MOON_READING or (windy == MOON_READING and natStat > 4)                                                ) end, -- Windy 9-2: Moon Reading
+        [ 256] = function() return ( roz > RETURN_TO_DELKFUTTS_TOWER                                                                                ) end, -- ZM8: Return to Delkfutt's Tower
+        [ 288] = function() return ( roz > ARK_ANGELS                                                                                               ) end, -- ZM14: Ark Angels (Hume)
+        [ 289] = function() return ( roz > ARK_ANGELS                                                                                               ) end, -- ZM14: Ark Angels (Tarutaru)
+        [ 290] = function() return ( roz > ARK_ANGELS                                                                                               ) end, -- ZM14: Ark Angels (Mithra)
+        [ 291] = function() return ( roz > ARK_ANGELS                                                                                               ) end, -- ZM14: Ark Angels (Elvaan)
+        [ 292] = function() return ( roz > ARK_ANGELS                                                                                               ) end, -- ZM14: Ark Angels (Galka)
+        [ 320] = function() return ( roz > THE_CELESTIAL_NEXUS                                                                                      ) end, -- ZM16: The Celestial Nexus
+        [ 416] = function() return ( player:hasCompleteQuest(OUTLANDS, TRIAL_BY_WIND) or player:hasKeyItem(WHISPER_OF_GALES)                        ) end, -- Quest: Trial by Wind
+        [ 448] = function() return ( player:hasCompleteQuest(OTHER_AREAS, TRIAL_BY_LIGHTNING) or player:hasKeyItem(WHISPER_OF_STORMS)               ) end, -- Quest: Trial by Lightning
+        [ 480] = function() return ( player:hasCompleteQuest(SANDORIA, TRIAL_BY_ICE) or player:hasKeyItem(WHISPER_OF_FROST)                         ) end, -- Quest: Trial by Ice
+        [ 512] = function() return ( nat > 14 or (nat == 14 and natStat > 11)                                                                       ) end, -- Mission 5-1
+        [ 516] = function() return ( sandy > THE_HEIR_TO_THE_LIGHT or (sandy == THE_HEIR_TO_THE_LIGHT and natStat > 4)                              ) end, -- Sandy 9-2: The Heir to the Light
+        [ 544] = function() return ( player:hasCompleteQuest(OUTLANDS, TRIAL_BY_FIRE) or player:hasKeyItem(WHISPER_OF_FLAMES)                       ) end, -- Quest: Trial by Fire
+        [ 576] = function() return ( player:hasCompleteQuest(BASTOK, TRIAL_BY_EARTH) or player:hasKeyItem(WHISPER_OF_TREMORS)                       ) end, -- Quest: Trial by Earth
+        [ 608] = function() return ( player:hasCompleteQuest(OUTLANDS, TRIAL_BY_WATER) or player:hasKeyItem(WHISPER_OF_TIDES)                       ) end, -- Quest: Trial by Water
+        [ 640] = function() return ( cop > THREE_PATHS or (cop == THREE_PATHS and player:getVar("COP_Ulmia_s_Path") > 6)                            ) end, -- PM5-3 U3: Flames for the Dead
+        [ 672] = function() return ( cop > THREE_PATHS or (cop == THREE_PATHS and player:getVar("COP_Ulmia_s_Path") > 5)                            ) end, -- PM5-3 U2: Head Wind
+        [ 704] = function() return ( cop > DARKNESS_NAMED or (cop == DARKNESS_NAMED and copStat > 2)                                                ) end, -- PM3-5: Darkness Named
+        [ 706] = function() return ( player:hasCompleteQuest(WINDURST, WAKING_DREAMS) or player:hasKeyItem(WHISPER_OF_DREAMS)                       ) end, -- Quest: Waking Dreams
+        [ 736] = function() return ( cop > THREE_PATHS or (cop == THREE_PATHS and player:getVar("COP_Louverance_s_Path") > 5)                       ) end, -- PM5-3 L3: A Century of Hardship
+        [ 768] = function() return ( cop > THE_MOTHERCRYSTALS or player:hasKeyItem(LIGHT_OF_HOLLA)                                                  ) end, -- PM1-3: The Mothercrystals
+        [ 800] = function() return ( cop > THE_MOTHERCRYSTALS or player:hasKeyItem(LIGHT_OF_DEM)                                                    ) end, -- PM1-3: The Mothercrystals
+        [ 832] = function() return ( cop > THE_MOTHERCRYSTALS or player:hasKeyItem(LIGHT_OF_MEA)                                                    ) end, -- PM1-3: The Mothercrystals
+        [ 864] = function() return ( cop > DESIRES_OF_EMPTINESS (cop == DESIRES_OF_EMPTINESS and copStat > 8)                                       ) end, -- PM5-2: Desires of Emptiness
+        [ 896] = function() return ( sofStat == QUEST_COMPLETED or (sofStat == QUEST_ACCEPTED and player:getVar("StormsOfFate") > 2)                ) end, -- Quest: Storms of Fate
+        [ 960] = function() return ( cop > ANCIENT_VOWS                                                                                             ) end, -- PM2-5: Ancient Vows
+        [ 961] = function() return ( cop > THE_SAVAGE or (cop == THE_SAVAGE and copStat > 1)                                                        ) end, -- PM4-2: The Savage
+        [ 992] = function() return ( cop > ONE_TO_BE_FEARED                                                                                         ) end, -- PM6-4: One to be Feared
+        [ 993] = function() return ( cop > THE_WARRIOR_S_PATH                                                                                       ) end, -- PM7-5: The Warrior's Path
+        [1024] = function() return ( cop > WHEN_ANGELS_FALL or (cop == WHEN_ANGELS_FALL and copStat > 4)                                            ) end, -- PM8-3: When Angels Fall
+        [1056] = function() return ( cop > DAWN or (cop == DAWN and copStat > 2)                                                                    ) end, -- PM8-4: Dawn
+    };
 
-            if (entrance ~= nil and player:getBattlefield() ~= nil) then
-                player:getBattlefield():setEntrance(entrance)
-            end
-            -- player:tradeComplete()
-        else
-            -- no free battlefields at the moment!
-            print("no free instances")
-            player:setVar("bcnm_instanceid", 255)
-            player:setVar("bcnm_instanceid_tick", 0)
-        end
-    elseif (option == 0 and csid == 0x7d00) then -- Requesting an Instance
-        -- Increment the instance ticker.
-        -- The client will send a total of THREE EventUpdate packets for each one of the free instances.
-        -- If the first instance is free, it should respond to the first packet
-        -- If the second instance is free, it should respond to the second packet, etc
-        local instance = player:getVar("bcnm_instanceid_tick")
-        instance = instance + 1
-        player:setVar("bcnm_instanceid_tick", instance)
-
-        if (instance == player:getVar("bcnm_instanceid")) then
-            -- respond to this packet
-            local mask = GetBattleBitmask(id, player:getZoneID(), 2)
-            local status = player:getStatusEffect(EFFECT_BATTLEFIELD)
-            local playerbcnmid = status:getPower()
-            local battlefield = player:getBattlefield()
-            local name = 'Meme';
-            local partySize = 5;
-            local clearTime = 260;
-            
-            if battlefield then
-                local record = battlefield:getRecord()
-                name = record.name
-                partySize = record.partySize
-                clearTime = record.clearTime
-            end
-            print("aaaaaaaaaaaaaaaaasssssssssssss " ..partySize)
-            print("shiiiiiiiiiiiiiiiiiiiiiiiiiiit "..clearTime)
-            if (mask < playerbcnmid) then
-                mask = GetBattleBitmask(playerbcnmid, player:getZoneID(), 2)
-                player:updateEvent(2, mask, 0, clearTime, partySize, skip) -- Add mask number for the correct entering CS
-                player:updateEventString(name);
-                player:bcnmEnter(id)
-                player:setVar("bcnm_instanceid_tick", 0)
-                -- print("mask is "..mask)
-                -- print("playerbcnmid is "..playerbcnmid)
-
-            elseif (mask >= playerbcnmid) then
-                mask = GetBattleBitmask(id, player:getZoneID(), 2)
-                player:updateEvent(2, mask, 0, clearTime, partySize, skip) -- Add mask number for the correct entering CS
-                player:updateEventString(name);
-                player:bcnmEnter(id)
-                player:setVar("bcnm_instanceid_tick", 0)
-                -- print("mask2 is "..mask)
-                -- print("playerbcnmid2 is "..playerbcnmid)
-            end
-
-            if (entrance ~= nil and player:getBattlefield() ~= nil) then
-                player:getBattlefield():setEntrance(entrance)
-            end
-
-        elseif (player:getVar("bcnm_instanceid") == 255) then -- none free
-            -- print("nfa")
-            -- player:updateEvent(2, 5, 0, 0, 1, 0)  -- @cs 32000 0 0 0 0 0 0 0 2
-            -- param1
-            -- 2=generic enter cs
-            -- 3=spam increment instance requests
-            -- 4=cleared to enter but cant while ppl engaged
-            -- 5=dont meet req, access denied.
-            -- 6=room max cap
-            -- param2 alters the eventfinish option (offset)
-            -- param7/8 = does nothing??
-        end
-        -- !pos -517 159 -209
-        -- !pos -316 112 -103
-        -- player:updateEvent(msgid, bcnmFight, 0, record, numadventurers, skip) skip=1 to skip anim
-        -- msgid 1=wait a little longer, 2=enters
-    end
-
-    return true
-end
-
-function EventFinishBCNM(player, csid, option)
-    print("FINISH csid "..csid.." option "..option)
-
-    if (player:hasStatusEffect(EFFECT_BATTLEFIELD) == false) then -- Temp condition for normal bcnm (started with onTrigger)
-        return false
+    -- determine whether player meets cutscene skip requirements
+    local req = skipReqs[bfid];
+    if (req == nil) then
+        return false;
+    elseif (req()) then
+        return true;
     else
-        local id = player:getVar("trade_bcnmid")
-        local item = player:getVar("trade_itemid")
-
-        if (id == 68 or id == 418 or id == 450 or id == 482 or id == 545 or id == 578 or id == 609 or id == 293) then
-            player:tradeComplete() -- Removes the item
-        elseif ((item >= 1426 and item <= 1440) or item == 1130 or item == 1131 or item == 1175 or item == 1177 or item == 1180 or item == 1178 or item == 1551 or item == 1552 or item == 1553) then -- Orb and Testimony (one time item)
-            player:createWornItem(item)
-        end
-
-        if csid == 0x7d03 and option == 4 then
-            if player:getBattlefield() then
-                player:bcnmLeave(1);
-            end
-        end
-        return true
+        return false;
     end
-
 end
 
--- Returns TRUE if you're trying to do a maat fight, regardless of outcome e.g. if you trade testimony on wrong job, this will return true in order to prevent further execution of TradeBCNM. Returns FALSE if you're not doing a maat fight (in other words, not trading a testimony!!)
-function CheckMaatFights(player, zone, trade, npc)
-    player:setVar("trade_bcnmid", 0)
-    player:setVar("trade_itemid", 0)
-    -- check for maat fights (one maat fight per zone in the db, but >1 mask entries depending on job, so we
-    -- need to choose the right one depending on the players job, and make sure the right testimony is traded,
-    -- and make sure the level is right!
-    local itemid = trade:getItemId()
-    local job = player:getMainJob()
-    local lvl = player:getMainLvl()
+-----------------------------------------------
+-- which battlefields are valid for registrant?
+-----------------------------------------------
 
-    if (itemid >= 1426 and itemid <= 1440) then -- The traded item IS A TESTIMONY
-        if (lvl < 66) then
-            return true
-        end
-
-        if (player:isBcnmsFull() == 1) then -- temp measure, this will precheck the instances
-            print("all bcnm instances are currently occupied.")
-            npc:messageBasic(246, 0, 0)
-            return true
-        end
-
-        -- Zone, {item, job, menu, bcnmid, ...}
-        maatList =
-        {
-            139, {1426, 1, 32, 5, 1429, 4, 64, 6, 1436, 11, 128, 7},       -- Horlais Peak [WAR BLM RNG]
-            144, {1430, 5, 64, 70, 1431, 6, 128, 71, 1434, 9, 256, 72},    -- Waughroon Shrine [RDM THF BST]
-            146, {1427, 2, 32, 101, 1428, 3, 64, 102, 1440, 15, 128, 103}, -- Balga's Dais [MNK WHM SMN]
-            168, {1437, 12, 4, 194, 1438, 13, 8, 195, 1439, 14, 16, 196},  -- Chamber of Oracles [SAM NIN DRG]
-            206, {1432, 7, 32, 517, 1433, 8, 64, 518, 1435, 10, 128, 519}  -- Qu'Bia Arena [PLD DRK BRD]
-        }
-
-        for nb = 1, #maatList, 2 do
-            if (maatList[nb] == zone) then
-                for nbi = 1, #maatList[nb + 1], 4 do
-                    if (itemid == maatList[nb + 1][nbi] and job == maatList[nb + 1][nbi + 1]) then
-                        player:startEvent(0x7d00, 0, 0, 0, maatList[nb + 1][nbi + 2], 0, 0, 0, 0)
-                        player:setVar("trade_bcnmid", maatList[nb + 1][nbi + 3])
-                        player:setVar("trade_itemid", maatList[nb + 1][nbi])
-                        break
-                    end
-                end
-            end
-        end
-
-        return true
-    end
-    -- if it got this far then its not a testimony
-    return false
-end
-
-function GetBattleBitmask(id, zone, mode)
-    -- normal sweep for NON MAAT FIGHTS
-    local ret = -1;
+function findBattlefields(player, npc, itemId)
     local mask = 0;
-
-    local battlefieldlist = battlefield_bitmask_map[zone]
-
-    if battlefieldlist then
-        for index, battlefield in ipairs(battlefield_bitmask_map[zone]) do
-            if id == battlefield then
-                if mode == 1 then
-                    ret = mask + bit.lshift(index + 1, 2);
-                else
-                    ret = mask + index;
-                end
-            end
-        end
-    else
-        printf("[bcnm] unable to get bitmask for battlefield: %u, zone: %u", id, zone);
+    local zbfs = battlefields[player:getZoneID()];
+    if (zbfs == nil) then
+        return 0;
     end
-    
-    return ret
-end
-
-function ItemToBCNMID(player, zone, trade)
-    for zoneindex = 1, #itemid_bcnmid_map, 2 do
-        if (zone==itemid_bcnmid_map[zoneindex]) then -- matched zone
-            for bcnmindex = 1, #itemid_bcnmid_map[zoneindex + 1], 2 do -- loop bcnms in this zone
-                if (trade:getItemId()==itemid_bcnmid_map[zoneindex+1][bcnmindex]) then
-                    local item = trade:getItemId()
-                    local questTimelineOK = 0
-
-                    -- Job/lvl condition for smn battle lvl20
-                    if (item >= 1544 and item <= 1549 and player:getMainJob() == JOBS.SMN and player:getMainLvl() >= 20) then
-                        questTimelineOK = 1
-                    elseif (item == 1166 and player:getVar("aThiefinNorgCS") == 6) then -- AF3 SAM condition
-                        questTimelineOK = 1
-                    elseif (item == 1551) then -- BCNM20
-                        questTimelineOK = 1
-                    elseif (item == 1552) then -- BCNM30
-                        questTimelineOK = 1
-                    elseif (item == 1131) then -- BCNM40
-                        questTimelineOK = 1
-                    elseif (item == 1177) then -- BCNM50
-                        questTimelineOK = 1
-                    elseif (item == 1130) then -- BCNM60
-                        questTimelineOK = 1
-                    elseif (item == 1175) then -- KSNM30
-                        questTimelineOK = 1
-                    elseif (item == 1178) then -- KSNM30
-                        questTimelineOK = 1
-                    elseif (item == 1180) then -- KSNM30
-                        questTimelineOK = 1
-                    elseif (item == 1553) then -- KSNM99
-                        questTimelineOK = 1
-                    elseif (item == 1550 and (player:getQuestStatus(OUTLANDS, DIVINE_MIGHT) == QUEST_ACCEPTED or player:getQuestStatus(OUTLANDS, DIVINE_MIGHT_REPEAT) == QUEST_ACCEPTED)) then -- Divine Might
-                        questTimelineOK = 1
-                    elseif (item == 1169 and player:getVar("ThePuppetMasterProgress") == 2) then -- The Puppet Master
-                        questTimelineOK = 1
-                    elseif (item == 1171 and player:getVar("ClassReunionProgress") == 5) then -- Class Reunion
-                        questTimelineOK = 1
-                    elseif (item == 1172 and player:getVar("CarbuncleDebacleProgress") == 3) then -- Carbuncle Debacle (Gremlims)
-                        questTimelineOK = 1
-                    elseif (item == 1174 and player:getVar("CarbuncleDebacleProgress") == 6) then -- Carbuncle Debacle (Ogmios)
-                        questTimelineOK = 1
-                    end
-
-                    if (questTimelineOK == 1) then
-                        player:setVar("trade_bcnmid", itemid_bcnmid_map[zoneindex+1][bcnmindex+1])
-                        player:setVar("trade_itemid", itemid_bcnmid_map[zoneindex+1][bcnmindex])
-                        return itemid_bcnmid_map[zoneindex+1][bcnmindex+1]
-                    end
-
-                end
-            end
+    for k, v in pairs(zbfs) do
+        if (v[3] == itemId and checkReqs(player, npc, v[2], true)) then
+            mask = bit.bor(mask,math.pow(2,v[1]));
         end
-    end
-    return -1
-end
-
-
--- E.g. mission checks go here, you must know the right bcnmid for the mission you want to code.
---      You also need to know the bitmask (event param) which should be put in bcnmid_param_map
-
-function checkNonTradeBCNM(player, npc, mode)
-    local mask = 0
-    local Zone = player:getZoneID()
-    mode = mode or 2;
-
-    local checks = 
-    {
-        [6] =   {
-                    [640] = function() return (player:getCurrentMission(COP) == THREE_PATHS  and  player:getVar("COP_Ulmia_s_Path") == 6)  end, -- flames_for_the_dead
-                    [643] = function() return (player:hasKeyItem(ZEPHYR_FAN))  end, -- Brothers ENM
-                },
-        [8] =   {
-                    [672] = function() return (player:getCurrentMission(COP) == THREE_PATHS  and  player:getVar("COP_Ulmia_s_Path") == 5)  end, -- head_wind
-                    [673] = function() return (player:hasKeyItem(MIASMA_FILTER)==true)  end,
-                },
-        [10] =  {
-                    [704] = function() return (player:getCurrentMission(COP) == DARKNESS_NAMED  and  player:getVar("PromathiaStatus") == 2)  end,-- DARKNESS_NAMED
-                    [706] = function() return (player:hasKeyItem(VIAL_OF_DREAM_INCENSE)==true)  end, -- waking_dreams (diabolos avatar quest)
-                },
-        [13] =  {
-                    [736] = function() return (player:getCurrentMission(COP) == THREE_PATHS  and  player:getVar("COP_Louverance_s_Path") == 5)  end, -- century_of_hardship
-                },
-        [17] = {
-                    [768] = function()
-                                return (player:getCurrentMission(COP) == BELOW_THE_ARKS and player:getVar("PromathiaStatus") ==1 )  or
-                                       (player:getCurrentMission(COP) == THE_MOTHERCRYSTALS and player:hasKeyItem(LIGHT_OF_HOLLA) == false)
-                            end, -- light of holla
-               },
-        [19] = {
-                    [800] = function() return (player:getCurrentMission(COP) == BELOW_THE_ARKS and player:getVar("PromathiaStatus") ==1 )  end,
-                    [800] = function() return (player:getCurrentMission(COP) == THE_MOTHERCRYSTALS and player:hasKeyItem(LIGHT_OF_DEM) == false)  end, -- light of dem
-               },
-        [21] = {
-                    [832] = function() return (player:getCurrentMission(COP) == BELOW_THE_ARKS and player:getVar("PromathiaStatus") ==1 )  end,
-                    [832] = function() return (player:getCurrentMission(COP) == THE_MOTHERCRYSTALS and player:hasKeyItem(LIGHT_OF_MEA) == false)  end, -- light of mea
-               },
-        [23] = {
-                    [864] = function() return (player:getCurrentMission(COP) == DESIRES_OF_EMPTINESS and player:getVar("PromathiaStatus")==8)  end, -- desires of emptiness
-               },
-        [29] = {
-                    [896] = function() return (player:getQuestStatus(JEUNO,STORMS_OF_FATE) == QUEST_ACCEPTED and player:getVar('StormsOfFate') == 2)  end,  -- Storms of Fate BCNM
-               },
-        [31] = {
-                    [960] = function() return (player:getCurrentMission(COP) == ANCIENT_VOWS and player:getVar("PromathiaStatus") == 2)  end,  -- Ancient Vows bcnm
-                    [961] = function() return (player:getCurrentMission(COP) == THE_SAVAGE and player:getVar("PromathiaStatus") == 1)  end,
-               },
-        [32] = {
-                    [992] = function() return (player:getCurrentMission(COP) == ONE_TO_BE_FEARED and player:getVar("PromathiaStatus")==2)  end, -- one_to_be_feared
-                    [993] = function() return (player:getCurrentMission(COP) == THE_WARRIOR_S_PATH)  end, -- warriors_path
-               },
-        [35] = {
-                    [1024] = function() return (player:getCurrentMission(COP) == WHEN_ANGELS_FALL and player:getVar("PromathiaStatus")==4)  end, -- when_angels_fall
-               },
-        [36] = {
-                    [1056] = function() return (player:getCurrentMission(COP) ==  DAWN and player:getVar("PromathiaStatus")==2)  end, -- dawn
-               },
-        [57] = {
-                    [1092] = function() return (player:getCurrentMission(TOAU) ==  LEGACY_OF_THE_LOST)  end, -- TOAU-35 Legacy of the Lost
-               },
-        [64] =  {
-                    [1124] = function() return (player:getCurrentMission(TOAU) ==  SHIELD_OF_DIPLOMACY and player:getVar("AhtUrganStatus")==2)  end, -- TOAU-22 shield of diplomacy
-                },
-        [67] =  {
-                    [1156] = function() return (player:getCurrentMission(TOAU) ==  PUPPET_IN_PERIL and player:getVar("AhtUrganStatus")==1)  end, -- TOAU-29 Puppet in Peril
-                },
-        [139] = {
-                    [0] = function()
-                              return ((player:getCurrentMission(BASTOK) == THE_EMISSARY_SANDORIA2 or 
-                                  player:getCurrentMission(WINDURST) == THE_THREE_KINGDOMS_SANDORIA2) and player:getVar("MissionStatus") == 9)
-                          end, -- Mission 2-3
-                    [3] = function() return (player:getCurrentMission(SANDORIA) == THE_SECRET_WEAPON and player:getVar("SecretWeaponStatus") == 2)  end,
-                },
-        [140] = {
-                    [32] = function()
-                                local MissionStatus = player:getVar("MissionStatus");
-                                local sTcCompleted = player:hasCompletedMission(SANDORIA, SAVE_THE_CHILDREN);
-                                return (player:getCurrentMission(SANDORIA) == SAVE_THE_CHILDREN and (sTcCompleted and MissionStatus <= 2 or sTcCompleted == false and MissionStatus == 2))
-                           end, -- Sandy Mission 1-3
-                    [33] = function() return (player:hasKeyItem(DRAGON_CURSE_REMEDY))  end, -- DRG Flag Quest
-                },
-        [144] = {
-                    [64] = function() return ((player:getCurrentMission(SANDORIA) == JOURNEY_TO_BASTOK2 or
-                        player:getCurrentMission(WINDURST) == THE_THREE_KINGDOMS_BASTOK2) and player:getVar("MissionStatus") == 10) end, -- Mission 2-3
-                    [67] = function() return ((player:getCurrentMission(BASTOK) == ON_MY_WAY) and (player:getVar("MissionStatus") == 2))  end,
-                },
-        [146] = {
-                    [96] = function() return (player:hasKeyItem(DARK_KEY))  end, -- Mission 2-3
-                    [99] = function() return ((player:getCurrentMission(WINDURST) == SAINTLY_INVITATION) and (player:getVar("MissionStatus") == 1))  end, -- Mission 6-2
-                },
-        [163] = {
-                    [128] = function() return (player:getCurrentMission(ZILART) == THE_TEMPLE_OF_UGGALEPIH)  end, -- Zilart Mission 4
-                },
-        [165] = {
-                    [160] = function() return (player:getCurrentMission(player:getNation()) == 15 and player:getVar("MissionStatus") == 3)  end, -- Mission 5-2
-                    [161] = function() return (player:getCurrentMission(BASTOK) == WHERE_TWO_PATHS_CONVERGE and player:getVar("BASTOK92") == 1)  end, -- bastok 9-2
-                },
-        [168] = {
-                    [192] = function() return (player:getCurrentMission(ZILART) == THROUGH_THE_QUICKSAND_CAVES or player:getCurrentMission(ZILART) == THE_CHAMBER_OF_ORACLES)  end, -- Zilart Mission 6
-                },
-        [170] = {
-                    [224] = function() return (player:hasKeyItem(MOON_BAUBLE))  end, -- The Moonlit Path
-                    [225] = function() return ((player:getCurrentMission(WINDURST) == MOON_READING) and player:getVar("WINDURST92") == 2)  end, -- Moon reading
-                },
-        [179] = {
-                    [256] = function() return (player:getCurrentMission(ZILART) == RETURN_TO_DELKFUTTS_TOWER and player:getVar("ZilartStatus") == 3)  end, -- Zilart Mission 8
-                },
-        [180] = {
-                    [288] = function() return (player:getCurrentMission(ZILART) == ARK_ANGELS and player:getVar("ZilartStatus") == 1 and qmid == 17514791 and player:hasKeyItem(SHARD_OF_APATHY) == false)  end, -- Hume, Ark Angels 1
-                    [289] = function() return (player:getCurrentMission(ZILART) == ARK_ANGELS and player:getVar("ZilartStatus") == 1 and qmid == 17514792 and player:hasKeyItem(SHARD_OF_COWARDICE) == false)  end, -- Tarutaru, Ark Angels 2
-                    [290] = function() return (player:getCurrentMission(ZILART) == ARK_ANGELS and player:getVar("ZilartStatus") == 1 and qmid == 17514793 and player:hasKeyItem(SHARD_OF_ENVY) == false)  end, -- Mithra, Ark Angels 3
-                    [291] = function() return (player:getCurrentMission(ZILART) == ARK_ANGELS and player:getVar("ZilartStatus") == 1 and qmid == 17514794 and player:hasKeyItem(SHARD_OF_ARROGANCE) == false)  end, -- Elvaan, Ark Angels 4
-                    [292] = function() return (player:getCurrentMission(ZILART) == ARK_ANGELS and player:getVar("ZilartStatus") == 1 and qmid == 17514795 and player:hasKeyItem(SHARD_OF_RAGE) == false)  end, -- Galka, Ark Angels 5
-                },
-        [181] = {
-                    [320] = function() return (player:getCurrentMission(ZILART) == THE_CELESTIAL_NEXUS)  end, -- Zilart Mission 16
-                },
-        [201] = {
-                    [416] = function() return (player:hasKeyItem(TUNING_FORK_OF_WIND))  end, -- Trial by Wind
-                    [420] = function() return (player:getCurrentMission(ASA) == SUGAR_COATED_DIRECTIVE and player:hasKeyItem(DOMINAS_EMERALD_SEAL))  end,
-                },
-        [202] = {
-                    [448] = function() return (player:hasKeyItem(TUNING_FORK_OF_LIGHTNING))  end, -- Trial by Lightning
-                    [452] = function() return (player:getCurrentMission(ASA) == SUGAR_COATED_DIRECTIVE and player:hasKeyItem(DOMINAS_VIOLET_SEAL))  end,
-               },
-        [203] = {
-                    [480] = function() return (player:hasKeyItem(TUNING_FORK_OF_ICE))  end, -- Trial by Ice
-                    [484] = function() return (player:getCurrentMission(ASA) == SUGAR_COATED_DIRECTIVE and player:hasKeyItem(DOMINAS_AZURE_SEAL))  end,
-                },
-        [206] = {
-                    [512] = function() return (player:getCurrentMission(player:getNation()) == 14 and player:getVar("MissionStatus") == 11)  end, -- Mission 5-1
-                    [516] = function() return (player:getCurrentMission(SANDORIA) == THE_HEIR_TO_THE_LIGHT and player:getVar("MissionStatus") == 3)  end, -- sando 9-2
-                --[[ 
-                    Temp disabled pending BCNM mob fixes
-                    [532] = function() return (player:getCurrentMission(ACP) >= THOSE_WHO_LURK_IN_SHADOWS_III and player:hasKeyItem(MARK_OF_SEED))  end, -- ACP Mission 7
-                ]]
-                },
-        [207] = {
-                    [544] = function() return (player:hasKeyItem(TUNING_FORK_OF_FIRE))  end, -- Trial by Fire
-                    [547] = function() return (player:getCurrentMission(ASA) == SUGAR_COATED_DIRECTIVE and player:hasKeyItem(DOMINAS_SCARLET_SEAL))  end,
-                },
-        [209] = {
-                    [576] = function() return (player:hasKeyItem(TUNING_FORK_OF_EARTH))  end, -- Trial by Earth
-                    [580] = function() return (player:getCurrentMission(ASA) == SUGAR_COATED_DIRECTIVE and player:hasKeyItem(DOMINAS_AMBER_SEAL))  end,
-               },
-        [211] = {
-                    [608] = function() return (player:hasKeyItem(TUNING_FORK_OF_WATER))  end, -- Trial by Water
-                    [611] = function() return (player:getCurrentMission(ASA) == SUGAR_COATED_DIRECTIVE and player:hasKeyItem(DOMINAS_CERULEAN_SEAL))  end,
-                },
-    }
-    
-    for keyid, condition in pairs(checks[Zone]) do
-        if condition() and GetBattleBitmask(keyid, Zone, mode) ~= -1 then
-            mask = mask + GetBattleBitmask(keyid, Zone, mode);
-            if mode == 2 then
-                player:setVar("trade_bcnmid", keyid);
-            end
-            -- todo: multiple choice bcnms
-            break;
-        end;
-    end;
-    
-    if mode == 2 then
-        player:startEvent(0x7d00, 0, 0, 0, mask, 0, 0, 0, 0);
     end
     return mask;
 end
 
-function CutsceneSkip(player, npc)
+-----------------------------------------------
+-- get battlefield id for a given zone and bit
+-----------------------------------------------
 
-    local skip = 0
-    local Zone = player:getZoneID()
-
-    if (Zone == 6) then -- Bearclaw Pinnacle
-           if ((player:hasCompletedMission(COP, THREE_PATHS)) or (player:getCurrentMission(COP) == THREE_PATHS and player:getVar("COP_Ulmia_s_Path") > 6)) then -- flames_for_the_dead
-            skip = 1
-        end
-    elseif (Zone == 8) then -- Boneyard Gully
-           if ((player:hasCompletedMission(COP, THREE_PATHS)) or (player:getCurrentMission(COP) == THREE_PATHS and player:getVar("COP_Ulmia_s_Path") > 5)) then -- head_wind
-            skip = 1
-        end
-    elseif (Zone == 10) then -- The_Shrouded_Maw
-        if ((player:hasCompletedMission(COP, DARKNESS_NAMED)) or (player:getCurrentMission(COP) == DARKNESS_NAMED and player:getVar("PromathiaStatus") > 2)) then -- DARKNESS_NAMED
-            skip = 1
-        elseif ((player:hasCompleteQuest(WINDURST, WAKING_DREAMS)) or (player:hasKeyItem(WHISPER_OF_DREAMS))) then -- waking_dreams (diabolos avatar quest)
-            skip = 1
-        end
-    elseif (Zone == 13) then -- Mine Shaft 2716
-        if ((player:hasCompletedMission(COP, THREE_PATHS)) or (player:getCurrentMission(COP) == THREE_PATHS and player:getVar("COP_Louverance_s_Path") > 5)) then -- century_of_hardship
-            skip = 1
-        end
-    elseif (Zone == 17) then -- Spire of Holla
-        if ((player:hasCompletedMission(COP, THE_MOTHERCRYSTALS)) or (player:hasKeyItem(LIGHT_OF_HOLLA))) then -- light of holla
-            skip = 1
-        end
-    elseif (Zone == 19) then -- Spire of Dem
-        if ((player:hasCompletedMission(COP, THE_MOTHERCRYSTALS)) or (player:hasKeyItem(LIGHT_OF_DEM))) then -- light of dem
-            skip = 1
-        end
-    elseif (Zone == 21) then -- Spire of Mea
-        if ((player:hasCompletedMission(COP, THE_MOTHERCRYSTALS)) or (player:hasKeyItem(LIGHT_OF_MEA))) then -- light of mea
-            skip = 1
-        end
-    elseif (Zone == 23) then -- Spire of Vahzl
-        if ((player:hasCompletedMission(COP, DESIRES_OF_EMPTINESS)) or (player:getCurrentMission(COP) == DESIRES_OF_EMPTINESS and player:getVar("PromathiaStatus") > 8)) then -- desires of emptiness
-            skip = 1
-        end
-    elseif (Zone == 29) then -- Riverne Site #B01
-        if ((player:getQuestStatus(JEUNO,STORMS_OF_FATE) == QUEST_COMPLETED) or (player:getQuestStatus(JEUNO,STORMS_OF_FATE) == QUEST_ACCEPTED and player:getVar("StormsOfFate") > 2)) then -- Storms of Fate
-            skip = 1
-        end
-    elseif (Zone == 31) then -- Monarch Linn
-        if (player:hasCompletedMission(COP, ANCIENT_VOWS)) then -- Ancient Vows
-            skip = 1
-        elseif ((player:hasCompletedMission(COP, THE_SAVAGE)) or (player:getCurrentMission(COP) == THE_SAVAGE and player:getVar("PromathiaStatus") > 1)) then
-            skip = 1
-        end
-    elseif (Zone == 32) then -- Sealion's Den
-        if (player:hasCompletedMission(COP, ONE_TO_BE_FEARED)) then -- one_to_be_feared
-            skip = 1
-        elseif (player:hasCompletedMission(COP, THE_WARRIOR_S_PATH)) then -- warriors_path
-            skip = 1
-        end
-    elseif (Zone == 35) then -- The Garden of RuHmet
-        if ((player:hasCompletedMission(COP, WHEN_ANGELS_FALL)) or (player:getCurrentMission(COP) == WHEN_ANGELS_FALL and player:getVar("PromathiaStatus") > 4)) then -- when_angels_fall
-            skip = 1
-        end
-    elseif (Zone == 36) then -- Empyreal Paradox
-        if ((player:hasCompletedMission(COP, DAWN)) or (player:getCurrentMission(COP) == DAWN and player:getVar("PromathiaStatus") > 2)) then -- dawn
-            skip = 1
-        end
-    elseif (Zone == 139) then -- Horlais Peak
-        if ((player:hasCompletedMission(BASTOK, THE_EMISSARY_SANDORIA2) or player:hasCompletedMission(WINDURST, THE_THREE_KINGDOMS_SANDORIA2)) or
-        ((player:getCurrentMission(BASTOK) == THE_EMISSARY_SANDORIA2 or player:getCurrentMission(WINDURST) == THE_THREE_KINGDOMS_SANDORIA2) and player:getVar("MissionStatus") > 9)) then -- Mission 2-3
-            skip = 1
-        elseif ((player:hasCompletedMission(SANDORIA, THE_SECRET_WEAPON)) or (player:getCurrentMission(SANDORIA) == THE_SECRET_WEAPON and player:getVar("SecretWeaponStatus") > 2)) then
-            skip = 1
-        end
-    elseif (Zone == 140) then -- Ghelsba Outpost
-        if ((player:hasCompletedMission(SANDORIA, SAVE_THE_CHILDREN)) or (player:getCurrentMission(SANDORIA) == SAVE_THE_CHILDREN and player:getVar("MissionStatus") > 2)) then -- Sandy Mission 1-3
-            skip = 1
-        elseif (player:hasCompleteQuest(SANDORIA, THE_HOLY_CREST)) then -- DRG Flag Quest
-            skip = 1
-        end
-    elseif (Zone == 144) then -- Waughroon Shrine
-        if ((player:hasCompletedMission(SANDORIA, JOURNEY_TO_BASTOK2) or player:hasCompletedMission(WINDURST, THE_THREE_KINGDOMS_BASTOK2)) or
-        ((player:getCurrentMission(SANDORIA) == JOURNEY_TO_BASTOK2 or player:getCurrentMission(WINDURST) == THE_THREE_KINGDOMS_BASTOK2) and player:getVar("MissionStatus") > 10)) then -- Mission 2-3
-            skip = 1
-        elseif ((player:hasCompletedMission(BASTOK, ON_MY_WAY)) or (player:getCurrentMission(BASTOK) == ON_MY_WAY and player:getVar("MissionStatus") > 2)) then
-            skip = 1
-        end
-    elseif (Zone == 146) then -- Balga's Dais
-        if ((player:hasCompletedMission(SANDORIA, JOURNEY_TO_WINDURST2) or player:hasCompletedMission(BASTOK, THE_EMISSARY_WINDURST2)) or
-        ((player:getCurrentMission(SANDORIA) == JOURNEY_TO_WINDURST2 or player:getCurrentMission(BASTOK) == THE_EMISSARY_WINDURST2) and player:getVar("MissionStatus") > 8)) then -- Mission 2-3
-            skip = 1
-        elseif ((player:hasCompletedMission(WINDURST, SAINTLY_INVITATION)) or (player:getCurrentMission(WINDURST) == SAINTLY_INVITATION and player:getVar("MissionStatus") > 1)) then -- Mission 6-2
-            skip = 1
-        end
-    elseif (Zone == 165) then -- Throne Room
-        if ((player:hasCompletedMission(player:getNation(), 15)) or (player:getCurrentMission(player:getNation()) == 15 and player:getVar("MissionStatus") > 3)) then -- Mission 5-2
-            skip = 1
-        end
-    elseif (Zone == 168) then -- Chamber of Oracles
-        if (player:hasCompletedMission(ZILART, THROUGH_THE_QUICKSAND_CAVES)) then -- Zilart Mission 6
-            skip = 1
-        end
-    elseif (Zone == 170) then -- Full Moon Fountain
-        if ((player:hasCompleteQuest(WINDURST, THE_MOONLIT_PATH)) or (player:hasKeyItem(WHISPER_OF_THE_MOON))) then -- The Moonlit Path
-            skip = 1
-        end
-    elseif (Zone == 179) then -- Stellar Fulcrum
-        if (player:hasCompletedMission(ZILART, RETURN_TO_DELKFUTTS_TOWER)) then -- Zilart Mission 8
-            skip = 1
-        end
-    elseif (Zone == 180) then -- La'Loff Amphitheater
-        if (player:hasCompletedMission(ZILART, ARK_ANGELS)) then
-            skip = 1
-        end
-    elseif (Zone == 181) then -- The Celestial Nexus
-        if (player:hasCompletedMission(ZILART, THE_CELESTIAL_NEXUS)) then -- Zilart Mission 16
-            skip = 1
-        end
-    elseif (Zone == 201) then -- Cloister of Gales
-        if ((player:hasCompleteQuest(OUTLANDS, TRIAL_BY_WIND)) or (player:hasKeyItem(WHISPER_OF_GALES))) then -- Trial by Wind
-            skip = 1
-        end
-    elseif (Zone == 202) then -- Cloister of Storms
-        if ((player:hasCompleteQuest(OTHER_AREAS, TRIAL_BY_LIGHTNING)) or (player:hasKeyItem(WHISPER_OF_STORMS))) then -- Trial by Lightning
-            skip = 1
-        end
-    elseif (Zone == 203) then -- Cloister of Frost
-        if ((player:hasCompleteQuest(SANDORIA, TRIAL_BY_ICE)) or (player:hasKeyItem(WHISPER_OF_FROST))) then -- Trial by Ice
-            skip = 1
-        end
-    elseif (Zone == 206) then -- Qu'Bia Arena
-        if ((player:hasCompletedMission(player:getNation(), 14)) or (player:getCurrentMission(player:getNation()) == 14 and player:getVar("MissionStatus") > 11)) then -- Mission 5-1
-            skip = 1
-        elseif ((player:hasCompletedMission(player:getNation(), 23)) or (player:getCurrentMission(player:getNation()) == 23 and player:getVar("MissionStatus") > 4)) then -- Mission 9-2
-            skip = 1
-        end
-    elseif (Zone == 207) then -- Cloister of Flames
-        if ((player:hasCompleteQuest(OUTLANDS, TRIAL_BY_FIRE)) or (player:hasKeyItem(WHISPER_OF_FLAMES))) then -- Trial by Fire
-            skip = 1
-        end
-    elseif (Zone == 209) then -- Cloister of Tremors
-        if ((player:hasCompleteQuest(BASTOK, TRIAL_BY_EARTH)) or (player:hasKeyItem(WHISPER_OF_TREMORS))) then -- Trial by Earth
-            skip = 1
-        end
-    elseif (Zone == 211) then -- Cloister of Tides
-        if ((player:hasCompleteQuest(OUTLANDS, TRIAL_BY_WATER)) or (player:hasKeyItem(WHISPER_OF_TIDES))) then -- Trial by Water
-            skip = 1
+function getBattlefieldIdByBit(player, bit)
+    local zbfs = battlefields[player:getZoneID()];
+    if (zbfs == nil) then
+        return false;
+    end
+    for k, v in pairs(zbfs) do
+        if (v[1] == bit) then
+            return v[2];
         end
     end
-    return skip
+    return false;
+end
+
+-----------------------------------------------
+-- get battlefield bit for a given zone and id
+-----------------------------------------------
+
+function getBattlefieldMaskById(player, bfid)
+    local zbfs = battlefields[player:getZoneID()];
+    if (zbfs ~= nil) then
+        for k, v in pairs(zbfs) do
+            if (v[2] == bfid) then
+                return math.pow(2,v[1]);
+            end
+        end
+    end
+    return 0;
+end
+
+-----------------------------------------------
+-- get battlefield bit for a given zone and id
+-----------------------------------------------
+
+function getItemById(player, bfid)
+    local zbfs = battlefields[player:getZoneID()];
+    if (zbfs ~= nil) then
+        for k, v in pairs(zbfs) do
+            if (v[2] == bfid) then
+                return v[3];
+            end
+        end
+    end
+    return 0;
+end
+
+-----------------------------------------------
+-- onTrade Action
+-----------------------------------------------
+
+function TradeBCNM(player, npc, trade)
+    -- validate trade
+    local itemId;
+    if (trade == nil) then
+        return false;
+    elseif (trade:getItemCount()==3 and trade:hasItemQty(1907,1) and trade:hasItemQty(1908,1) and trade:hasItemQty(1986,1)) then
+        itemId = -1;
+    elseif (trade:getItemCount()==4 and trade:hasItemQty(1909,1) and trade:hasItemQty(1910,1) and trade:hasItemQty(1987,1) and trade:hasItemQty(1988,1)) then
+        itemId = -2;
+    else
+        itemId = trade:getItemId(0);
+        if (itemId == nil or itemId < 1 or itemId > 65535 or trade:getItemCount() ~= 1 or trade:getSlotQty(0) ~= 1) then
+            return false;
+        elseif (player:hasWornItem(itemId)) then
+            player:messageBasic(56, 0, 0); -- Unable to use item.
+            return false;
+        end
+    end
+
+    -- validate battlefield status
+    if (player:hasStatusEffect(EFFECT_BATTLEFIELD)) then
+        player:messageBasic(94, 0, 0); -- You must wait longer to perform that action.
+        return false;
+    end
+
+    -- open menu of valid battlefields
+    local validBattlefields = findBattlefields(player, npc, itemId);
+    if (validBattlefields ~= 0) then
+        player:startEvent(32000, 0, 0, 0, validBattlefields, 0, 0, 0, 0);
+        return true;
+    end
+    
+    return false;
+end
+
+-----------------------------------------------
+-- onTrigger Action
+-----------------------------------------------
+
+function EventTriggerBCNM(player, npc)
+
+    -- player is in battlefield and clicks to leave
+    if (player:isInBcnm() == 1) then
+        player:startEvent(32003);
+        return true;
+
+    -- player wants to register a new battlefield
+    elseif (not player:hasStatusEffect(EFFECT_BATTLEFIELD)) then
+        local mask = findBattlefields(player, npc, 0);
+        -- mask = 268435455; -- uncomment to open menu with all possible battlefields
+        if (mask ~= 0) then
+            player:startEvent(32000, 0, 0, 0, mask, 0, 0, 0, 0);
+            return true;
+        end
+
+    -- player is allied with a registrant and wants to enter their instance
+    else
+        local stat = player:getStatusEffect(EFFECT_BATTLEFIELD);
+        local bfid = stat:getSubPower();
+        local mask = getBattlefieldMaskById(player, bfid);
+        if (mask ~= 0 and checkReqs(player, npc, bfid, false)) then
+            player:startEvent(32000, 0, 0, 0, mask, 0, 0, 0, 0);
+            return true;
+        end
+
+    end
+
+    return false;
+end
+
+-----------------------------------------------
+-- onEventUpdate
+-----------------------------------------------
+
+function EventUpdateBCNM(player, csid, option, extras, entrance)
+    if (tonumber(extras) == nil) then extras = 0; end
+    if (tonumber(entrance) == nil) then entrance = 0; end
+    -- player:PrintToPlayer(string.format("EventUpdateBCNM csid=%i option=%i extras=%i", csid, option, extras));
+
+    -- requesting a battlefield
+    if (csid == 32000 and option == 0) then
+        local bit = math.floor(extras / 16);
+        local bfid = getBattlefieldIdByBit(player,bit);
+        local bnum = (extras % 16);
+        local reply = false;
+        
+        -- registrant
+        if (not player:hasStatusEffect(EFFECT_BATTLEFIELD) and player:isBattlefieldFree(bnum)) then
+            player:registerBattlefield(bnum, bfid);
+            reply = true;
+            if (entrance > 0 and player:getBattlefield() ~= nil) then
+                 player:getBattlefield():setEntrance(entrance);
+            end
+        -- ally
+        elseif (player:hasStatusEffect(EFFECT_BATTLEFIELD)) then
+            local stat = player:getStatusEffect(EFFECT_BATTLEFIELD);
+            if (stat:getPower() == bnum) then
+                reply = true;
+            end
+
+        end
+
+        -- found a battlefield, respond to this packet
+        if (reply) then
+            local battlefield = player:getBattlefield();
+            
+            if (battlefield) then
+                local mask = math.pow(2, bit);
+                local record = battlefield:getRecord();
+                local clearTime = record.clearTime;
+                local partySize = record.partySize;
+                local name = record.name;
+                local skip = checkSkip(player, bfid) and 1 or 0;
+                player:updateEvent(2, bit, 0, clearTime, partySize, skip);
+                player:updateEventString(name);
+                player:bcnmEnter(bnum);
+            else
+                printf("BCNM.LUA ERROR: No Battlefield found for arena %u bfid %u", bnum, bfid);
+            end
+        end
+
+    -- leaving a battlefield
+    elseif (csid == 32003 and option == 2) then
+        player:updateEvent(3)
+        return true
+    elseif (csid == 32003 and option == 3) then
+        player:updateEvent(0)
+        return true
+        
+    end
+
+    return false;
+end
+
+-----------------------------------------------
+-- onEventFinish Action
+-----------------------------------------------
+
+function EventFinishBCNM(player, csid, option)
+    -- player:PrintToPlayer(string.format("EventFinishBCNM csid=%i option=%i", csid, option));
+
+    if (player:hasStatusEffect(EFFECT_BATTLEFIELD)) then
+        if (csid == 32000 and option ~= 0) then
+            local zone = player:getZoneID();
+            local stat = player:getStatusEffect(EFFECT_BATTLEFIELD);
+            local bfid = stat:getSubPower();
+            local item = getItemById(player, bfid);
+            if (item ~= 0) then
+                -- remove limbus chips
+                if (zone == 37 or zone == 38) then
+                    player:tradeComplete();
+                    
+                -- set other traded item to worn
+                else
+                    if (player:hasItem(item)) then
+                        player:createWornItem(item);
+                    end
+                end
+            end
+
+        elseif (csid == 32003 and option == 4) then
+            if (player:getBattlefield()) then
+                player:bcnmLeave(1);
+            end
+        end
+
+        return true;
+    end
+
+    return false;
 end

--- a/scripts/globals/bcnm.lua
+++ b/scripts/globals/bcnm.lua
@@ -1,6 +1,3 @@
---[[
-
---]]
 
 require("scripts/globals/keyitems")
 require("scripts/globals/missions")
@@ -438,17 +435,6 @@ local battlefields = {
 };
 
 -----------------------------------------------
--- for checks, mission 255 is mission -1
------------------------------------------------
-
-function fix255(n)
-    if (n == 255) then
-        return -1;
-    end
-    return n;
-end
-
------------------------------------------------
 -- check requirements for registrant and allies
 -----------------------------------------------
 
@@ -456,14 +442,14 @@ function checkReqs(player, npc, bfid, registrant)
     local npcid   = npc:getID();
     local mjob    = player:getMainJob();
     local mlvl    = player:getMainLvl();
-    local nat     = fix255(player:getCurrentMission(player:getNation()));
-    local sandy   = fix255(player:getCurrentMission(SANDORIA));
-    local basty   = fix255(player:getCurrentMission(BASTOK));
-    local windy   = fix255(player:getCurrentMission(WINDURST));
-    local roz     = fix255(player:getCurrentMission(ZILART));
-    local cop     = fix255(player:getCurrentMission(COP));
-    local toau    = fix255(player:getCurrentMission(TOAU));
-    local asa     = fix255(player:getCurrentMission(ASA));
+    local nat     = player:getCurrentMission(player:getNation());
+    local sandy   = player:getCurrentMission(SANDORIA);
+    local basty   = player:getCurrentMission(BASTOK);
+    local windy   = player:getCurrentMission(WINDURST);
+    local roz     = player:getCurrentMission(ZILART);
+    local cop     = player:getCurrentMission(COP);
+    local toau    = player:getCurrentMission(TOAU);
+    local asa     = player:getCurrentMission(ASA);
     local natStat  = player:getVar("MissionStatus");
     local rozStat  = player:getVar("ZilartStatus");
     local copStat  = player:getVar("PromathiaStatus");
@@ -603,7 +589,7 @@ function checkReqs(player, npc, bfid, registrant)
     -- requirements to enter a battlefield already registered by a party member
     local enterReqs = {
         [ 897] = function() return ( player:hasKeyItem(WHISPER_OF_THE_WYRMKING)                                                                     ) end, -- Quest: The Wyrmking Descends
-        [ 928] = function() return ( cop >= ANCIENT_VOWS                                                                                            ) end, -- Quest: Ouryu Cometh
+        [ 928] = function() return ( player:hasCompletedMission(COP, ANCIENT_VOWS) or (cop == ANCIENT_VOWS and copStat >= 2)                        ) end, -- Quest: Ouryu Cometh
         [1290] = function() return ( player:hasKeyItem(COSMOCLEANSE) and player:hasKeyItem(RED_CARD)                                                ) end, -- NW Apollyon
         [1291] = function() return ( player:hasKeyItem(COSMOCLEANSE) and player:hasKeyItem(RED_CARD)                                                ) end, -- SW Apollyon
         [1292] = function() return ( player:hasKeyItem(COSMOCLEANSE) and player:hasKeyItem(BLACK_CARD)                                              ) end, -- NE Apollyon
@@ -636,14 +622,14 @@ end
 -----------------------------------------------
 
 function checkSkip(player, bfid)
-    local nat       = fix255(player:getCurrentMission(player:getNation()));
-    local sandy     = fix255(player:getCurrentMission(SANDORIA));
-    local basty     = fix255(player:getCurrentMission(BASTOK));
-    local windy     = fix255(player:getCurrentMission(WINDURST));
-    local roz       = fix255(player:getCurrentMission(ZILART));
-    local cop       = fix255(player:getCurrentMission(COP));
-    local toau      = fix255(player:getCurrentMission(TOAU));
-    local asa       = fix255(player:getCurrentMission(ASA));
+    local nat       = player:getCurrentMission(player:getNation());
+    local sandy     = player:getCurrentMission(SANDORIA);
+    local basty     = player:getCurrentMission(BASTOK);
+    local windy     = player:getCurrentMission(WINDURST);
+    local roz       = player:getCurrentMission(ZILART);
+    local cop       = player:getCurrentMission(COP);
+    local toau      = player:getCurrentMission(TOAU);
+    local asa       = player:getCurrentMission(ASA);
     local natStat   = player:getVar("MissionStatus");
     local rozStat   = player:getVar("ZilartStatus");
     local copStat   = player:getVar("PromathiaStatus");
@@ -655,50 +641,50 @@ function checkSkip(player, bfid)
 
     -- requirements to skip a battlefield
     local skipReqs = {
-        [   0] = function() return ( mission2_3a                                                                                                    ) end, -- Mission 2-3
-        [   3] = function() return ( sandy > THE_SECRET_WEAPON or (sandy == THE_SECRET_WEAPON and player:getVar("SecretWeaponStatus") > 2)          ) end, -- Sandy 7-2: The Secret Weapon
-        [  32] = function() return ( sandy > SAVE_THE_CHILDREN or (sandy == SAVE_THE_CHILDREN and natStat > 2)                                      ) end, -- Sandy 1-3: Save the Children
-        [  33] = function() return ( player:hasCompleteQuest(SANDORIA, THE_HOLY_CREST)                                                              ) end, -- Quest: The Holy Crest
-        [  64] = function() return ( mission2_3b                                                                                                    ) end, -- Mission 2-3
-        [  67] = function() return ( basty > ON_MY_WAY or (basty == ON_MY_WAY and natStat > 2)                                                      ) end, -- Basty 7-2: On My Way
-        [  96] = function() return ( mission2_3c                                                                                                    ) end, -- Mission 2-3
-        [  99] = function() return ( windy > SAINTLY_INVITATION or (windy == SAINTLY_INVITATION and natStat > 1)                                    ) end, -- Windy 6-2: A Saintly Invitation
-        [ 160] = function() return ( nat > 15 or (nat == 15 and natStat > 3)                                                                        ) end, -- Mission 5-2
-        [ 161] = function() return ( basty > WHERE_TWO_PATHS_CONVERGE or (basty == WHERE_TWO_PATHS_CONVERGE and natStat > 4)                        ) end, -- Basty 9-2: Where Two Paths Converge
-        [ 192] = function() return ( roz > THROUGH_THE_QUICKSAND_CAVES                                                                              ) end, -- ZM6: Through the Quicksand Caves
-        [ 224] = function() return ( player:hasCompleteQuest(WINDURST, THE_MOONLIT_PATH) or player:hasKeyItem(WHISPER_OF_THE_MOON)                  ) end, -- Quest: The Moonlit Path
-        [ 225] = function() return ( windy > MOON_READING or (windy == MOON_READING and natStat > 4)                                                ) end, -- Windy 9-2: Moon Reading
-        [ 256] = function() return ( roz > RETURN_TO_DELKFUTTS_TOWER                                                                                ) end, -- ZM8: Return to Delkfutt's Tower
-        [ 288] = function() return ( roz > ARK_ANGELS                                                                                               ) end, -- ZM14: Ark Angels (Hume)
-        [ 289] = function() return ( roz > ARK_ANGELS                                                                                               ) end, -- ZM14: Ark Angels (Tarutaru)
-        [ 290] = function() return ( roz > ARK_ANGELS                                                                                               ) end, -- ZM14: Ark Angels (Mithra)
-        [ 291] = function() return ( roz > ARK_ANGELS                                                                                               ) end, -- ZM14: Ark Angels (Elvaan)
-        [ 292] = function() return ( roz > ARK_ANGELS                                                                                               ) end, -- ZM14: Ark Angels (Galka)
-        [ 320] = function() return ( roz > THE_CELESTIAL_NEXUS                                                                                      ) end, -- ZM16: The Celestial Nexus
-        [ 416] = function() return ( player:hasCompleteQuest(OUTLANDS, TRIAL_BY_WIND) or player:hasKeyItem(WHISPER_OF_GALES)                        ) end, -- Quest: Trial by Wind
-        [ 448] = function() return ( player:hasCompleteQuest(OTHER_AREAS, TRIAL_BY_LIGHTNING) or player:hasKeyItem(WHISPER_OF_STORMS)               ) end, -- Quest: Trial by Lightning
-        [ 480] = function() return ( player:hasCompleteQuest(SANDORIA, TRIAL_BY_ICE) or player:hasKeyItem(WHISPER_OF_FROST)                         ) end, -- Quest: Trial by Ice
-        [ 512] = function() return ( nat > 14 or (nat == 14 and natStat > 11)                                                                       ) end, -- Mission 5-1
-        [ 516] = function() return ( sandy > THE_HEIR_TO_THE_LIGHT or (sandy == THE_HEIR_TO_THE_LIGHT and natStat > 4)                              ) end, -- Sandy 9-2: The Heir to the Light
-        [ 544] = function() return ( player:hasCompleteQuest(OUTLANDS, TRIAL_BY_FIRE) or player:hasKeyItem(WHISPER_OF_FLAMES)                       ) end, -- Quest: Trial by Fire
-        [ 576] = function() return ( player:hasCompleteQuest(BASTOK, TRIAL_BY_EARTH) or player:hasKeyItem(WHISPER_OF_TREMORS)                       ) end, -- Quest: Trial by Earth
-        [ 608] = function() return ( player:hasCompleteQuest(OUTLANDS, TRIAL_BY_WATER) or player:hasKeyItem(WHISPER_OF_TIDES)                       ) end, -- Quest: Trial by Water
-        [ 640] = function() return ( cop > THREE_PATHS or (cop == THREE_PATHS and player:getVar("COP_Ulmia_s_Path") > 6)                            ) end, -- PM5-3 U3: Flames for the Dead
-        [ 672] = function() return ( cop > THREE_PATHS or (cop == THREE_PATHS and player:getVar("COP_Ulmia_s_Path") > 5)                            ) end, -- PM5-3 U2: Head Wind
-        [ 704] = function() return ( cop > DARKNESS_NAMED or (cop == DARKNESS_NAMED and copStat > 2)                                                ) end, -- PM3-5: Darkness Named
-        [ 706] = function() return ( player:hasCompleteQuest(WINDURST, WAKING_DREAMS) or player:hasKeyItem(WHISPER_OF_DREAMS)                       ) end, -- Quest: Waking Dreams
-        [ 736] = function() return ( cop > THREE_PATHS or (cop == THREE_PATHS and player:getVar("COP_Louverance_s_Path") > 5)                       ) end, -- PM5-3 L3: A Century of Hardship
-        [ 768] = function() return ( cop > THE_MOTHERCRYSTALS or player:hasKeyItem(LIGHT_OF_HOLLA)                                                  ) end, -- PM1-3: The Mothercrystals
-        [ 800] = function() return ( cop > THE_MOTHERCRYSTALS or player:hasKeyItem(LIGHT_OF_DEM)                                                    ) end, -- PM1-3: The Mothercrystals
-        [ 832] = function() return ( cop > THE_MOTHERCRYSTALS or player:hasKeyItem(LIGHT_OF_MEA)                                                    ) end, -- PM1-3: The Mothercrystals
-        [ 864] = function() return ( cop > DESIRES_OF_EMPTINESS (cop == DESIRES_OF_EMPTINESS and copStat > 8)                                       ) end, -- PM5-2: Desires of Emptiness
-        [ 896] = function() return ( sofStat == QUEST_COMPLETED or (sofStat == QUEST_ACCEPTED and player:getVar("StormsOfFate") > 2)                ) end, -- Quest: Storms of Fate
-        [ 960] = function() return ( cop > ANCIENT_VOWS                                                                                             ) end, -- PM2-5: Ancient Vows
-        [ 961] = function() return ( cop > THE_SAVAGE or (cop == THE_SAVAGE and copStat > 1)                                                        ) end, -- PM4-2: The Savage
-        [ 992] = function() return ( cop > ONE_TO_BE_FEARED                                                                                         ) end, -- PM6-4: One to be Feared
-        [ 993] = function() return ( cop > THE_WARRIOR_S_PATH                                                                                       ) end, -- PM7-5: The Warrior's Path
-        [1024] = function() return ( cop > WHEN_ANGELS_FALL or (cop == WHEN_ANGELS_FALL and copStat > 4)                                            ) end, -- PM8-3: When Angels Fall
-        [1056] = function() return ( cop > DAWN or (cop == DAWN and copStat > 2)                                                                    ) end, -- PM8-4: Dawn
+        [   0] = function() return ( mission2_3a                                                                                                                            ) end, -- Mission 2-3
+        [   3] = function() return ( player:hasCompletedMission(SANDORIA, THE_SECRET_WEAPON) or (sandy == THE_SECRET_WEAPON and player:getVar("SecretWeaponStatus") > 2)    ) end, -- Sandy 7-2: The Secret Weapon
+        [  32] = function() return ( player:hasCompletedMission(SANDORIA, SAVE_THE_CHILDREN) or (sandy == SAVE_THE_CHILDREN and natStat > 2)                                ) end, -- Sandy 1-3: Save the Children
+        [  33] = function() return ( player:hasCompleteQuest(SANDORIA, THE_HOLY_CREST)                                                                                      ) end, -- Quest: The Holy Crest
+        [  64] = function() return ( mission2_3b                                                                                                                            ) end, -- Mission 2-3
+        [  67] = function() return ( player:hasCompletedMission(BASTOK, ON_MY_WAY) or (basty == ON_MY_WAY and natStat > 2)                                                  ) end, -- Basty 7-2: On My Way
+        [  96] = function() return ( mission2_3c                                                                                                                            ) end, -- Mission 2-3
+        [  99] = function() return ( player:hasCompletedMission(WINDURST, SAINTLY_INVITATION) or (windy == SAINTLY_INVITATION and natStat > 1)                              ) end, -- Windy 6-2: A Saintly Invitation
+        [ 160] = function() return ( player:hasCompletedMission(player:getNation(), 15) or (nat == 15 and natStat > 3)                                                      ) end, -- Mission 5-2
+        [ 161] = function() return ( player:hasCompletedMission(BASTOK, WHERE_TWO_PATHS_CONVERGE) or (basty == WHERE_TWO_PATHS_CONVERGE and natStat > 4)                    ) end, -- Basty 9-2: Where Two Paths Converge
+        [ 192] = function() return ( player:hasCompletedMission(ZILART, THROUGH_THE_QUICKSAND_CAVES)                                                                        ) end, -- ZM6: Through the Quicksand Caves
+        [ 224] = function() return ( player:hasCompleteQuest(WINDURST, THE_MOONLIT_PATH) or player:hasKeyItem(WHISPER_OF_THE_MOON)                                          ) end, -- Quest: The Moonlit Path
+        [ 225] = function() return ( player:hasCompletedMission(WINDURST, MOON_READING) or (windy == MOON_READING and natStat > 4)                                          ) end, -- Windy 9-2: Moon Reading
+        [ 256] = function() return ( player:hasCompletedMission(ZILART, RETURN_TO_DELKFUTTS_TOWER)                                                                          ) end, -- ZM8: Return to Delkfutt's Tower
+        [ 288] = function() return ( player:hasCompletedMission(ZILART, ARK_ANGELS)                                                                                         ) end, -- ZM14: Ark Angels (Hume)
+        [ 289] = function() return ( player:hasCompletedMission(ZILART, ARK_ANGELS)                                                                                         ) end, -- ZM14: Ark Angels (Tarutaru)
+        [ 290] = function() return ( player:hasCompletedMission(ZILART, ARK_ANGELS)                                                                                         ) end, -- ZM14: Ark Angels (Mithra)
+        [ 291] = function() return ( player:hasCompletedMission(ZILART, ARK_ANGELS)                                                                                         ) end, -- ZM14: Ark Angels (Elvaan)
+        [ 292] = function() return ( player:hasCompletedMission(ZILART, ARK_ANGELS)                                                                                         ) end, -- ZM14: Ark Angels (Galka)
+        [ 320] = function() return ( player:hasCompletedMission(ZILART, THE_CELESTIAL_NEXUS)                                                                                ) end, -- ZM16: The Celestial Nexus
+        [ 416] = function() return ( player:hasCompleteQuest(OUTLANDS, TRIAL_BY_WIND) or player:hasKeyItem(WHISPER_OF_GALES)                                                ) end, -- Quest: Trial by Wind
+        [ 448] = function() return ( player:hasCompleteQuest(OTHER_AREAS, TRIAL_BY_LIGHTNING) or player:hasKeyItem(WHISPER_OF_STORMS)                                       ) end, -- Quest: Trial by Lightning
+        [ 480] = function() return ( player:hasCompleteQuest(SANDORIA, TRIAL_BY_ICE) or player:hasKeyItem(WHISPER_OF_FROST)                                                 ) end, -- Quest: Trial by Ice
+        [ 512] = function() return ( player:hasCompletedMission(player:getNation(), 14) or (nat == 14 and natStat > 11)                                                     ) end, -- Mission 5-1
+        [ 516] = function() return ( player:hasCompletedMission(SANDORIA, THE_HEIR_TO_THE_LIGHT) or (sandy == THE_HEIR_TO_THE_LIGHT and natStat > 4)                        ) end, -- Sandy 9-2: The Heir to the Light
+        [ 544] = function() return ( player:hasCompleteQuest(OUTLANDS, TRIAL_BY_FIRE) or player:hasKeyItem(WHISPER_OF_FLAMES)                                               ) end, -- Quest: Trial by Fire
+        [ 576] = function() return ( player:hasCompleteQuest(BASTOK, TRIAL_BY_EARTH) or player:hasKeyItem(WHISPER_OF_TREMORS)                                               ) end, -- Quest: Trial by Earth
+        [ 608] = function() return ( player:hasCompleteQuest(OUTLANDS, TRIAL_BY_WATER) or player:hasKeyItem(WHISPER_OF_TIDES)                                               ) end, -- Quest: Trial by Water
+        [ 640] = function() return ( player:hasCompletedMission(COP, THREE_PATHS) or (cop == THREE_PATHS and player:getVar("COP_Ulmia_s_Path") > 6)                         ) end, -- PM5-3 U3: Flames for the Dead
+        [ 672] = function() return ( player:hasCompletedMission(COP, THREE_PATHS) or (cop == THREE_PATHS and player:getVar("COP_Ulmia_s_Path") > 5)                         ) end, -- PM5-3 U2: Head Wind
+        [ 704] = function() return ( player:hasCompletedMission(COP, DARKNESS_NAMED) or (cop == DARKNESS_NAMED and copStat > 2)                                             ) end, -- PM3-5: Darkness Named
+        [ 706] = function() return ( player:hasCompleteQuest(WINDURST, WAKING_DREAMS) or player:hasKeyItem(WHISPER_OF_DREAMS)                                               ) end, -- Quest: Waking Dreams
+        [ 736] = function() return ( player:hasCompletedMission(COP, THREE_PATHS) or (cop == THREE_PATHS and player:getVar("COP_Louverance_s_Path") > 5)                    ) end, -- PM5-3 L3: A Century of Hardship
+        [ 768] = function() return ( player:hasCompletedMission(COP, THE_MOTHERCRYSTALS) or player:hasKeyItem(LIGHT_OF_HOLLA)                                               ) end, -- PM1-3: The Mothercrystals
+        [ 800] = function() return ( player:hasCompletedMission(COP, THE_MOTHERCRYSTALS) or player:hasKeyItem(LIGHT_OF_DEM)                                                 ) end, -- PM1-3: The Mothercrystals
+        [ 832] = function() return ( player:hasCompletedMission(COP, THE_MOTHERCRYSTALS) or player:hasKeyItem(LIGHT_OF_MEA)                                                 ) end, -- PM1-3: The Mothercrystals
+        [ 864] = function() return ( player:hasCompletedMission(COP, DESIRES_OF_EMPTINESS) (cop == DESIRES_OF_EMPTINESS and copStat > 8)                                    ) end, -- PM5-2: Desires of Emptiness
+        [ 896] = function() return ( sofStat == QUEST_COMPLETED or (sofStat == QUEST_ACCEPTED and player:getVar("StormsOfFate") > 2)                                        ) end, -- Quest: Storms of Fate
+        [ 960] = function() return ( player:hasCompletedMission(COP, ANCIENT_VOWS)                                                                                          ) end, -- PM2-5: Ancient Vows
+        [ 961] = function() return ( player:hasCompletedMission(COP, THE_SAVAGE) or (cop == THE_SAVAGE and copStat > 1)                                                     ) end, -- PM4-2: The Savage
+        [ 992] = function() return ( player:hasCompletedMission(COP, ONE_TO_BE_FEARED)                                                                                      ) end, -- PM6-4: One to be Feared
+        [ 993] = function() return ( player:hasCompletedMission(COP, THE_WARRIOR_S_PATH)                                                                                    ) end, -- PM7-5: The Warrior's Path
+        [1024] = function() return ( player:hasCompletedMission(COP, WHEN_ANGELS_FALL) or (cop == WHEN_ANGELS_FALL and copStat > 4)                                         ) end, -- PM8-3: When Angels Fall
+        [1056] = function() return ( player:hasCompletedMission(COP, DAWN) or (cop == DAWN and copStat > 2)                                                                 ) end, -- PM8-4: Dawn
     };
 
     -- determine whether player meets cutscene skip requirements

--- a/scripts/globals/limbus.lua
+++ b/scripts/globals/limbus.lua
@@ -2,31 +2,33 @@
 require("scripts/globals/keyitems")
 --------------------------------------
 
-APPOLLYON_SE_NE = 1 -- out 557 -1 441 128
-APPOLLYON_NW_SW = 2 -- out -561 0 443 242
+APOLLYON_SE_NE = 1 -- out 557 -1 441 128
+APOLLYON_NW_SW = 2 -- out -561 0 443 242
 TEMENOS = 3
 -- WHITE_CARD = 349
 -- RED_CARD = 350
 -- BLACK_CARD = 351
 -- COSMOCLEANSE = 734
 
- --  REGION
-NW_Apollyon = 1
-SW_Apollyon = 2
-NE_Apollyon = 3
-SE_Apollyon = 4
-CS_Apollyon = 5
-Central_Apollyon = 6
-Temenos_Western_Tower = 1
-Temenos_Northern_Tower = 2
-Temenos_Eastern_Tower = 3
-Central_Temenos_Basement = 4
-Central_Temenos_1st_Floor = 5
-Central_Temenos_2nd_Floor = 6
-Central_Temenos_3rd_Floor = 7
-Central_Temenos_4th_Floor = 8
+GATE_OFFSET = 16929221;
 
-APPOLLYON_SE_NE_BCNM_LIST =
+ --  REGION
+Temenos_Northern_Tower = 1
+Temenos_Eastern_Tower = 2
+Temenos_Western_Tower = 3
+Central_Temenos_4th_Floor = 4
+Central_Temenos_3rd_Floor = 5
+Central_Temenos_2nd_Floor = 6
+Central_Temenos_1st_Floor = 7
+Central_Temenos_Basement = 8
+SW_Apollyon = 1
+NW_Apollyon = 2
+SE_Apollyon = 3
+NE_Apollyon = 4
+Central_Apollyon = 5
+CS_Apollyon = 6
+
+APOLLYON_SE_NE_BCNM_LIST =
 {
     -- instanceID, white, red, black, bitmap, bit, instanceRegion
     1292, {false, false, true, 8, NE_Apollyon}, --  'NE_Apollyon'  region 3  438 0 -89
@@ -37,7 +39,7 @@ APPOLLYON_SE_NE_BCNM_LIST =
     1297, {false, false, false, 128, Central_Apollyon}  --  'Central_Apollyon_II'  0   0 210
 }
 
-APPOLLYON_NW_SW_BCNM_LIST =
+APOLLYON_NW_SW_BCNM_LIST =
 {
     1290, {false, true, false, 2, NW_Apollyon}, --  'NW_Apollyon'    -439  0 -89
     1291, {false, true, false, 1, SW_Apollyon}, --  'SW_Apollyon'    -468  0 -626
@@ -80,16 +82,16 @@ cITEM = 2
 cRESTORE = 3
 cMIMIC = 4
 
-ARMOURY_CRATES_LIST_APPOLLYON =
+ARMOURY_CRATES_LIST_APOLLYON =
 {
     -- armoryID, (type, regionID, time, despawnothercoffer, mimicID, lootID)
-    1, {cTIME, SE_Apollyon, 5, false, 0, 0}, --  time    SE_Appollyon floor 1
-    2, {cITEM, SE_Apollyon, 0, false, 0, 110}, --  items    SE_Appollyon floor 1
-    3, {cRESTORE, SE_Apollyon, 0, false, 0, 0}, --  restore    SE_Appollyon floor 1
+    1, {cTIME, SE_Apollyon, 5, false, 0, 0}, --  time    SE_Apollyon floor 1
+    2, {cITEM, SE_Apollyon, 0, false, 0, 110}, --  items    SE_Apollyon floor 1
+    3, {cRESTORE, SE_Apollyon, 0, false, 0, 0}, --  restore    SE_Apollyon floor 1
 
-    14, {cTIME, SW_Apollyon, 10, false, 0, 0}, --  time    SW_Appollyon floor 1
-    15, {cITEM, SW_Apollyon, 0, false, 0, 119}, --  items    SW_Appollyon floor 1
-    16, {cRESTORE, SW_Apollyon, 0, false, 0, 0}, --  restore    SW_Appollyon floor 1
+    14, {cTIME, SW_Apollyon, 10, true, 0, 0}, --  time    SW_Apollyon floor 1
+    15, {cITEM, SW_Apollyon, 0, true, 0, 119}, --  items    SW_Apollyon floor 1
+    16, {cRESTORE, SW_Apollyon, 0, true, 0, 0}, --  restore    SW_Apollyon floor 1
 
     -- 32, {}, -- mimic
     -- 33, {}, -- mimic
@@ -99,64 +101,64 @@ ARMOURY_CRATES_LIST_APPOLLYON =
     -- 37, {}, -- mimic
     -- 38, {}, -- mimic
     39, {cITEM, Central_Apollyon, 0, false, 0, 128}, --  omega
-    40, {cTIME, NW_Apollyon, 5, false, 0, 0}, --  time   NW_Appollyon floor 1 T1
-    41, {cTIME, NW_Apollyon, 5, false, 0, 0}, --  time   NW_Appollyon floor 1 T2
-    42, {cTIME, NW_Apollyon, 5, false, 0, 0}, --  time   NW_Appollyon floor 1 T3
-    43, {cTIME, NW_Apollyon, 5, false, 0, 0}, --  time   NW_Appollyon floor 2 T1
-    44, {cTIME, NW_Apollyon, 5, false, 0, 0}, --  time   NW_Appollyon floor 2 T2
-    45, {cTIME, NW_Apollyon, 5, false, 0, 0}, --  time   NW_Appollyon floor 2 T3
+    40, {cTIME, NW_Apollyon, 5, false, 0, 0}, --  time   NW_Apollyon floor 1 T1
+    41, {cTIME, NW_Apollyon, 5, false, 0, 0}, --  time   NW_Apollyon floor 1 T2
+    42, {cTIME, NW_Apollyon, 5, false, 0, 0}, --  time   NW_Apollyon floor 1 T3
+    43, {cTIME, NW_Apollyon, 5, false, 0, 0}, --  time   NW_Apollyon floor 2 T1
+    44, {cTIME, NW_Apollyon, 5, false, 0, 0}, --  time   NW_Apollyon floor 2 T2
+    45, {cTIME, NW_Apollyon, 5, false, 0, 0}, --  time   NW_Apollyon floor 2 T3
 
-    70, {cTIME, SW_Apollyon, 10, true, 0, 0}, --  time    SW_Appollyon floor 2
-    71, {cITEM, SW_Apollyon, 0, true, 0, 120}, --  items    SW_Appollyon floor 2
-    72, {cRESTORE, SW_Apollyon, 0, true, 0, 0}, --  restore    SW_Appollyon floor 2
+    70, {cTIME, SW_Apollyon, 10, true, 0, 0}, --  time    SW_Apollyon floor 2
+    71, {cITEM, SW_Apollyon, 0, true, 0, 120}, --  items    SW_Apollyon floor 2
+    72, {cRESTORE, SW_Apollyon, 0, true, 0, 0}, --  restore    SW_Apollyon floor 2
 
-    81, {cTIME, NE_Apollyon, 5, false, 0, 0}, --  time    NE_Appollyon floor 1 T2
-    82, {cTIME, NE_Apollyon, 5, false, 0, 0}, --  time    NE_Appollyon floor 1 T3
+    81, {cTIME, NE_Apollyon, 5, false, 0, 0}, --  time    NE_Apollyon floor 1 T2
+    82, {cTIME, NE_Apollyon, 5, false, 0, 0}, --  time    NE_Apollyon floor 1 T3
 
-    83, {cTIME, NE_Apollyon, 5, false, 0, 0}, --  time    NE_Appollyon floor 2 T2
-    84, {cTIME, NE_Apollyon, 5, false, 0, 0}, --  time    NE_Appollyon floor 2 T3
+    83, {cTIME, NE_Apollyon, 5, false, 0, 0}, --  time    NE_Apollyon floor 2 T2
+    84, {cTIME, NE_Apollyon, 5, false, 0, 0}, --  time    NE_Apollyon floor 2 T3
 
-    85, {cTIME, NE_Apollyon, 5, false, 0, 0}, --  time    NE_Appollyon floor 3 T2
-    94, {cTIME, NE_Apollyon, 5, false, 0, 0}, --  time    NE_Appollyon floor 3 T3
+    85, {cTIME, NE_Apollyon, 5, false, 0, 0}, --  time    NE_Apollyon floor 3 T2
+    94, {cTIME, NE_Apollyon, 5, false, 0, 0}, --  time    NE_Apollyon floor 3 T3
 
-    95, {cTIME, NE_Apollyon, 5, false, 0, 0}, --  time    NE_Appollyon floor 4 T2
-    96, {cTIME, NE_Apollyon, 5, false, 0, 0}, --  time    NE_Appollyon floor 4 T3
+    95, {cTIME, NE_Apollyon, 5, false, 0, 0}, --  time    NE_Apollyon floor 4 T2
+    96, {cTIME, NE_Apollyon, 5, false, 0, 0}, --  time    NE_Apollyon floor 4 T3
 
-    97, {cTIME, NW_Apollyon, 5, false, 0, 0}, --  time    NW_Appollyon floor 4 T2
-    98, {cTIME, NW_Apollyon, 5, false, 0, 0}, --  time    NW_Appollyon floor 4  T3
+    97, {cTIME, NW_Apollyon, 5, false, 0, 0}, --  time    NW_Apollyon floor 4 T2
+    98, {cTIME, NW_Apollyon, 5, false, 0, 0}, --  time    NW_Apollyon floor 4  T3
 
-    107, {cITEM, NW_Apollyon, 0, false, 0, 123}, --  item    NW_Appollyon floor 1
-    108, {cITEM, NW_Apollyon, 0, false, 0, 124}, --  item    NW_Appollyon floor 2
-    109, {cITEM, NW_Apollyon, 0, false, 0, 125}, --  item    NW_Appollyon floor 3
-    110, {cITEM, NW_Apollyon, 0, false, 0, 126}, --  item    NW_Appollyon floor 4
-    111, {cITEM, NW_Apollyon, 0, false, 0, 127}, --  item    NW_Appollyon floor 5
+    107, {cITEM, NW_Apollyon, 0, false, 0, 123}, --  item    NW_Apollyon floor 1
+    108, {cITEM, NW_Apollyon, 0, false, 0, 124}, --  item    NW_Apollyon floor 2
+    109, {cITEM, NW_Apollyon, 0, false, 0, 125}, --  item    NW_Apollyon floor 3
+    110, {cITEM, NW_Apollyon, 0, false, 0, 126}, --  item    NW_Apollyon floor 4
+    111, {cITEM, NW_Apollyon, 0, false, 0, 127}, --  item    NW_Apollyon floor 5
 
-    118, {cTIME, NE_Apollyon, 5, false, 0, 0}, --  time    NE_Appollyon floor 1 T1
-    119, {cITEM, NE_Apollyon, 0, false, 0, 114}, --  items    NE_Appollyon floor 1
-    120, {cRESTORE, NE_Apollyon, 0, false, 0, 0}, --  restore    NE_Appollyon floor 1
+    118, {cTIME, NE_Apollyon, 5, false, 0, 0}, --  time    NE_Apollyon floor 1 T1
+    119, {cITEM, NE_Apollyon, 0, false, 0, 114}, --  items    NE_Apollyon floor 1
+    120, {cRESTORE, NE_Apollyon, 0, false, 0, 0}, --  restore    NE_Apollyon floor 1
 
-    125, {cTIME, NE_Apollyon, 5, false, 0, 10}, --  time    NE_Appollyon floor 2 T1
-    126, {cITEM, NE_Apollyon, 0, false, 0, 115}, --  items    NE_Appollyon floor 2
-    127, {cRESTORE, NE_Apollyon, 0, false, 0, 0}, --  restore    NE_Appollyon floor 2
+    125, {cTIME, NE_Apollyon, 5, false, 0, 10}, --  time    NE_Apollyon floor 2 T1
+    126, {cITEM, NE_Apollyon, 0, false, 0, 115}, --  items    NE_Apollyon floor 2
+    127, {cRESTORE, NE_Apollyon, 0, false, 0, 0}, --  restore    NE_Apollyon floor 2
 
-    139, {cTIME, NE_Apollyon, 5, false, 0, 0}, --  time    NE_Appollyon floor 3 T1
-    140, {cITEM, NE_Apollyon, 0, false, 0, 116}, --  items    NE_Appollyon floor 3
-    141, {cRESTORE, NE_Apollyon, 0, false, 0, 0}, --  restore    NE_Appollyon floor 3
+    139, {cTIME, NE_Apollyon, 5, false, 0, 0}, --  time    NE_Apollyon floor 3 T1
+    140, {cITEM, NE_Apollyon, 0, false, 0, 116}, --  items    NE_Apollyon floor 3
+    141, {cRESTORE, NE_Apollyon, 0, false, 0, 0}, --  restore    NE_Apollyon floor 3
 
-    153, {cTIME, NE_Apollyon, 5, false, 0, 0}, --  time    NE_Appollyon floor 4 T1
-    154, {cITEM, NE_Apollyon, 0, false, 0, 117}, --  items    NE_Appollyon floor 4
-    155, {cRESTORE, NE_Apollyon, 0, false, 0, 0}, --  restore    NE_Appollyon floor 4
+    153, {cTIME, NE_Apollyon, 5, false, 0, 0}, --  time    NE_Apollyon floor 4 T1
+    154, {cITEM, NE_Apollyon, 0, false, 0, 117}, --  items    NE_Apollyon floor 4
+    155, {cRESTORE, NE_Apollyon, 0, false, 0, 0}, --  restore    NE_Apollyon floor 4
 
     177, {cTIME, NW_Apollyon, 5, false, 0, 0}, --  time    NW_Apollyon floor 3 T1
-    178, {cITEM, NE_Apollyon, 0, false, 0, 118}, --  items    NE_Appollyon floor 5
+    178, {cITEM, NE_Apollyon, 0, false, 0, 118}, --  items    NE_Apollyon floor 5
     179, {cRESTORE, NW_Apollyon, 0, false, 0, 0}, --  restore    NW_Apollyon floor 4
 
-    189, {cTIME, NW_Apollyon, 5, false, 0, 0}, --  time    NW_Appollyon floor 3 T2
-    190, {cTIME, NW_Apollyon, 5, false, 0, 0}, --  time    NW_Appollyon floor 3 T3
+    189, {cTIME, NW_Apollyon, 5, false, 0, 0}, --  time    NW_Apollyon floor 3 T2
+    190, {cTIME, NW_Apollyon, 5, false, 0, 0}, --  time    NW_Apollyon floor 3 T3
 
-    195, {cTIME, SW_Apollyon, 10, false, 0, 0}, --  time    SW_Appollyon floor 3
-    196, {cITEM, SW_Apollyon, 5, false, 0, 121}, --  items    SW_Appollyon floor 3
-    197, {cRESTORE, SW_Apollyon, 0, false, 0, 0}, --  restore    SW_Appollyon floor 3
+    195, {cTIME, SW_Apollyon, 10, false, 0, 0}, --  time    SW_Apollyon floor 3
+    196, {cITEM, SW_Apollyon, 5, false, 0, 121}, --  items    SW_Apollyon floor 3
+    197, {cRESTORE, SW_Apollyon, 0, false, 0, 0}, --  restore    SW_Apollyon floor 3
 
     210, {cMIMIC, SW_Apollyon, 0, false, 0, 0}, -- PH for mimic
     211, {cMIMIC, SW_Apollyon, 0, false, 0, 0}, -- PH for mimic
@@ -166,23 +168,23 @@ ARMOURY_CRATES_LIST_APPOLLYON =
     215, {cMIMIC, SW_Apollyon, 0, false, 0, 0}, -- PH for mimic
     216, {cMIMIC, SW_Apollyon, 0, false, 0, 0}, -- PH for mimic
 
-    232, {cTIME, SE_Apollyon, 5, false, 0, 0}, --  time    SE_Appollyon floor 2
-    233, {cITEM, SE_Apollyon, 0, false, 0, 111}, --  items    SE_Appollyon floor 2
-    234, {cRESTORE, SE_Apollyon, 0, false, 0, 0}, --  restore  SE_Appollyon floor 2
+    232, {cTIME, SE_Apollyon, 5, false, 0, 0}, --  time    SE_Apollyon floor 2
+    233, {cITEM, SE_Apollyon, 0, false, 0, 111}, --  items    SE_Apollyon floor 2
+    234, {cRESTORE, SE_Apollyon, 0, false, 0, 0}, --  restore  SE_Apollyon floor 2
 
-    246, {cTIME, SE_Apollyon, 10, false, 0, 0}, --  time    SE_Appollyon floor 3
-    247, {cITEM, SE_Apollyon, 0, false, 0, 112}, --  items    SE_Appollyon floor 3
-    248, {cRESTORE, SE_Apollyon, 0, false, 0, 0}, --  restore  SE_Appollyon floor 3
+    246, {cTIME, SE_Apollyon, 10, false, 0, 0}, --  time    SE_Apollyon floor 3
+    247, {cITEM, SE_Apollyon, 0, false, 0, 112}, --  items    SE_Apollyon floor 3
+    248, {cRESTORE, SE_Apollyon, 0, false, 0, 0}, --  restore  SE_Apollyon floor 3
 
     259, {cITEM, Central_Apollyon, 0, false, 0, 129}, --  Pod
 
-    262, {cTIME, NW_Apollyon, 5, false, 0, 0}, --  time    NW_Appollyon floor 4 T1
-    263, {cITEM, SE_Apollyon, 0, false, 0, 113}, --  items    SE_Appollyon floor 4
+    262, {cTIME, NW_Apollyon, 5, false, 0, 0}, --  time    NW_Apollyon floor 4 T1
+    263, {cITEM, SE_Apollyon, 0, false, 0, 113}, --  items    SE_Apollyon floor 4
     264, {cRESTORE, NW_Apollyon, 0, false, 0, 0}, --  restore    NW_Apollyon floor 1
 
     289, {cRESTORE, NW_Apollyon, 0, false, 0, 0}, --  restore    NW_Apollyon floor 2
 
-    313, {cITEM, SW_Apollyon, 0, false, 0, 122}, --  items    SW_Appollyon floor 4
+    313, {cITEM, SW_Apollyon, 0, false, 0, 122}, --  items    SW_Apollyon floor 4
 
     327, {cRESTORE, NW_Apollyon, 0, false, 0, 0}, --  restore    NW_Apollyon floor 3
 }
@@ -222,7 +224,7 @@ ARMOURY_CRATES_LIST_TEMENOS =
 
 
     --  central 4eme floor -------------------------------
-    79, {cITEM, Central_Temenos_4th_Floor, 0, false, 0, 154},
+    79, {cITEM, Central_Temenos_4th_Floor, 0, true, 0, 154},
     --
     80, {cITEM, Central_Temenos_4th_Floor, 0, false, 1, 155},
     86, {cITEM, Central_Temenos_4th_Floor, 0, false, 1, 155},
@@ -275,7 +277,7 @@ ARMOURY_CRATES_LIST_TEMENOS =
     199, {cTIME, Central_Temenos_Basement, 5, false, 0, 0},
     200, {cTIME, Central_Temenos_Basement, 5, false, 0, 0},
     201, {cTIME, Central_Temenos_Basement, 5, false, 0, 0},
-    202, {cTIME, Central_Temenos_Basement, 5, false, 0, 0},
+    202, {cTIME, Central_Temenos_Basement, 0, false, 0, 181},
 
 
     203, {cRESTORE, Temenos_Western_Tower, 0, false, 0, 0},
@@ -306,38 +308,23 @@ ARMOURY_CRATES_LIST_TEMENOS =
     393, {cMIMIC, Temenos_Eastern_Tower, 0, true, 0, 0}
 }
 
-function LimbusEntrance(player, entrance)
+function enterApollyon(player, entrance)
     switch (entrance): caseof
     {
-        [1] = function (x)
+        [APOLLYON_SE_NE] = function (x)
             player:setPos(643, 0.1, -600, 124, 0x26)  --  instance entrer 600 1 -600
         end, --  sortiezone  637, -4, -642, 642, 4, -637
-        [2] = function (x)
+        [APOLLYON_NW_SW] = function (x)
             player:setPos(-668, 0.1, -666, 209, 0x26)  --  instance entrer -599 0 -600
         end, --  sortiezone -642, -4, -642, -637, 4, -637
     }
 end
 
-function ResetPlayerLimbusVariable(player)
-    player:setVar("characterLimbusKey", 0)
-    player:setVar("LimbusID", 0)
-end
-
-function GenerateLimbusKey()
-    local Key = math.random(1, 1000000)
-
-    while (IsKeyExist(Key) == true) do
-        Key = math.random(1, 1000000)
-    end
-
-    return Key
-end
-
 function HideArmouryCrates(Region, Zone)
-    if (Zone == APPOLLYON_SE_NE or Zone == APPOLLYON_NW_SW) then
-        for X = 1, #ARMOURY_CRATES_LIST_APPOLLYON, 2 do
-            if (ARMOURY_CRATES_LIST_APPOLLYON[X+1][2] == Region) then
-                GetNPCByID((ARMOURY_CRATES_LIST_APPOLLYON[X])+16932864):setStatus(STATUS_DISAPPEAR)
+    if (Zone == APOLLYON_SE_NE or Zone == APOLLYON_NW_SW) then
+        for X = 1, #ARMOURY_CRATES_LIST_APOLLYON, 2 do
+            if (ARMOURY_CRATES_LIST_APOLLYON[X+1][2] == Region) then
+                GetNPCByID((ARMOURY_CRATES_LIST_APOLLYON[X])+16932864):setStatus(STATUS_DISAPPEAR)
             end
         end
     elseif (Zone == TEMENOS) then
@@ -350,40 +337,41 @@ function HideArmouryCrates(Region, Zone)
 end
 
 function HideTemenosDoor(Region)
+
     if (Region == Temenos_Northern_Tower) then
-        GetNPCByID((450)+16928770):setStatus(STATUS_DISAPPEAR)
-        GetNPCByID((451)+16928770):setStatus(STATUS_DISAPPEAR)
-        GetNPCByID((452)+16928770):setStatus(STATUS_DISAPPEAR)
-        GetNPCByID((453)+16928770):setStatus(STATUS_DISAPPEAR)
-        GetNPCByID((454)+16928770):setStatus(STATUS_DISAPPEAR)
-        GetNPCByID((455)+16928770):setStatus(STATUS_DISAPPEAR)
-        GetNPCByID((456)+16928770):setStatus(STATUS_DISAPPEAR)
+        GetNPCByID(GATE_OFFSET +  0):setStatus(STATUS_DISAPPEAR)
+        GetNPCByID(GATE_OFFSET +  1):setStatus(STATUS_DISAPPEAR)
+        GetNPCByID(GATE_OFFSET +  2):setStatus(STATUS_DISAPPEAR)
+        GetNPCByID(GATE_OFFSET +  3):setStatus(STATUS_DISAPPEAR)
+        GetNPCByID(GATE_OFFSET +  4):setStatus(STATUS_DISAPPEAR)
+        GetNPCByID(GATE_OFFSET +  5):setStatus(STATUS_DISAPPEAR)
+        GetNPCByID(GATE_OFFSET +  6):setStatus(STATUS_DISAPPEAR)
     elseif (Region == Temenos_Eastern_Tower) then
-        GetNPCByID((457)+16928770):setStatus(STATUS_DISAPPEAR)
-        GetNPCByID((458)+16928770):setStatus(STATUS_DISAPPEAR)
-        GetNPCByID((459)+16928770):setStatus(STATUS_DISAPPEAR)
-        GetNPCByID((460)+16928770):setStatus(STATUS_DISAPPEAR)
-        GetNPCByID((461)+16928770):setStatus(STATUS_DISAPPEAR)
-        GetNPCByID((462)+16928770):setStatus(STATUS_DISAPPEAR)
-        GetNPCByID((463)+16928770):setStatus(STATUS_DISAPPEAR)
+        GetNPCByID(GATE_OFFSET +  7):setStatus(STATUS_DISAPPEAR)
+        GetNPCByID(GATE_OFFSET +  8):setStatus(STATUS_DISAPPEAR)
+        GetNPCByID(GATE_OFFSET +  9):setStatus(STATUS_DISAPPEAR)
+        GetNPCByID(GATE_OFFSET + 10):setStatus(STATUS_DISAPPEAR)
+        GetNPCByID(GATE_OFFSET + 11):setStatus(STATUS_DISAPPEAR)
+        GetNPCByID(GATE_OFFSET + 12):setStatus(STATUS_DISAPPEAR)
+        GetNPCByID(GATE_OFFSET + 13):setStatus(STATUS_DISAPPEAR)
     elseif (Region == Temenos_Western_Tower) then
-        GetNPCByID((464)+16928770):setStatus(STATUS_DISAPPEAR)
-        GetNPCByID((465)+16928770):setStatus(STATUS_DISAPPEAR)
-        GetNPCByID((466)+16928770):setStatus(STATUS_DISAPPEAR)
-        GetNPCByID((467)+16928770):setStatus(STATUS_DISAPPEAR)
-        GetNPCByID((468)+16928770):setStatus(STATUS_DISAPPEAR)
-        GetNPCByID((469)+16928770):setStatus(STATUS_DISAPPEAR)
-        GetNPCByID((470)+16928770):setStatus(STATUS_DISAPPEAR)
+        GetNPCByID(GATE_OFFSET + 14):setStatus(STATUS_DISAPPEAR)
+        GetNPCByID(GATE_OFFSET + 15):setStatus(STATUS_DISAPPEAR)
+        GetNPCByID(GATE_OFFSET + 16):setStatus(STATUS_DISAPPEAR)
+        GetNPCByID(GATE_OFFSET + 17):setStatus(STATUS_DISAPPEAR)
+        GetNPCByID(GATE_OFFSET + 18):setStatus(STATUS_DISAPPEAR)
+        GetNPCByID(GATE_OFFSET + 19):setStatus(STATUS_DISAPPEAR)
+        GetNPCByID(GATE_OFFSET + 20):setStatus(STATUS_DISAPPEAR)
     elseif (Region == Central_Temenos_1st_Floor) then
-        GetNPCByID((471)+16928770):setStatus(STATUS_DISAPPEAR)
+        GetNPCByID(GATE_OFFSET + 21):setStatus(STATUS_DISAPPEAR)
     elseif (Region == Central_Temenos_2nd_Floor) then
-        GetNPCByID((472)+16928770):setStatus(STATUS_DISAPPEAR)
+        GetNPCByID(GATE_OFFSET + 22):setStatus(STATUS_DISAPPEAR)
     elseif (Region == Central_Temenos_3rd_Floor) then
-        GetNPCByID((473)+16928770):setStatus(STATUS_DISAPPEAR)
+        GetNPCByID(GATE_OFFSET + 23):setStatus(STATUS_DISAPPEAR)
     elseif (Region == Central_Temenos_4th_Floor) then
-        GetNPCByID((474)+16928770):setStatus(STATUS_DISAPPEAR)
+        GetNPCByID(GATE_OFFSET + 24):setStatus(STATUS_DISAPPEAR)
     elseif (Region == Central_Temenos_Basement) then
-        GetNPCByID((475)+16928770):setStatus(STATUS_DISAPPEAR)
+        GetNPCByID(GATE_OFFSET + 25):setStatus(STATUS_DISAPPEAR)
     end
 end
 
@@ -391,35 +379,35 @@ function IselementalDayAreDead()
     local day = GetServerVariable("[SW_Apollyon]ElementalTrigger") - 1
     local daykill=false
     if (day == 0) then  --  fire
-        if (IsMobDead(16932913) == true and IsMobDead(16932921) == true and IsMobDead(16932929) == true) then
+        if (GetMobByID(16932913):isDead() and GetMobByID(16932921):isDead() and GetMobByID(16932929):isDead()) then
             daykill = true
         end
     elseif (day == 1) then --  earth
-        if (IsMobDead(16932912) == true and IsMobDead(16932920) == true and IsMobDead(16932928) == true) then
+        if (GetMobByID(16932912):isDead() and GetMobByID(16932920):isDead() and GetMobByID(16932928):isDead()) then
             daykill = true
         end
     elseif (day == 2) then --  water
-        if (IsMobDead(16932916) == true and IsMobDead(16932924) == true and IsMobDead(16932932) == true) then
+        if (GetMobByID(16932916):isDead() and GetMobByID(16932924):isDead() and GetMobByID(16932932):isDead()) then
             daykill = true
         end
     elseif (day == 3) then --  wind
-        if (IsMobDead(16932910) == true and IsMobDead(16932918) == true and IsMobDead(16932926) == true) then
+        if (GetMobByID(16932910):isDead() and GetMobByID(16932918):isDead() and GetMobByID(16932926):isDead()) then
             daykill = true
         end
     elseif (day == 4) then --  ice
-        if (IsMobDead(16932914) == true and IsMobDead(16932922) == true and IsMobDead(16932930) == true) then
+        if (GetMobByID(16932914):isDead() and GetMobByID(16932922):isDead() and GetMobByID(16932930):isDead()) then
             daykill = true
         end
     elseif (day == 5) then --  lightning
-        if (IsMobDead(16932917) == true and IsMobDead(16932925) == true and IsMobDead(16932933) == true) then
+        if (GetMobByID(16932917):isDead() and GetMobByID(16932925):isDead() and GetMobByID(16932933):isDead()) then
             daykill = true
         end
-    elseif (day == 6) then --  ligth
-        if (IsMobDead(16932931) == true and IsMobDead(16932915) == true and IsMobDead(16932923) == true) then
+    elseif (day == 6) then --  light
+        if (GetMobByID(16932931):isDead() and GetMobByID(16932915):isDead() and GetMobByID(16932923):isDead()) then
             daykill = true
         end
     elseif (day == 7) then  --  dark
-        if (IsMobDead(16932911) == true and IsMobDead(16932919) == true and IsMobDead(16932927) == true) then
+        if (GetMobByID(16932911):isDead() and GetMobByID(16932919):isDead() and GetMobByID(16932927):isDead()) then
             daykill = true
         end
     end
@@ -470,130 +458,83 @@ function addLimbusList(player, number, Region)
     end
 end
 
-function IsKeyExist(Key)  --  return true if Key already exist for another linbus
-    local H = false
-    local KeyAlreadyExist =
-    {
-        GetServerVariable("[NW_Apollyon]UniqueID"),
-        GetServerVariable("[SW_Apollyon]UniqueID"),
-        GetServerVariable("[NE_Apollyon]UniqueID"),
-        GetServerVariable("[SE_Apollyon]UniqueID"),
-        GetServerVariable("[CS_Apollyon]UniqueID"),
-        GetServerVariable("[CS_Apollyon_II]UniqueID"),
-        GetServerVariable("[Central_Apollyon]UniqueID"),
-        GetServerVariable("[Central_Apollyon_II]UniqueID"),
-        GetServerVariable("[Temenos_W_Tower]UniqueID"),
-        GetServerVariable("[Temenos_N_Tower"),
-        GetServerVariable("[Temenos_E_Tower]UniqueID"),
-        GetServerVariable("[C_Temenos_Base]UniqueID"),
-        GetServerVariable("[C_Temenos_Base_II]UniqueID"),
-        GetServerVariable("[C_Temenos_1st]UniqueID"),
-        GetServerVariable("[C_Temenos_2nd]UniqueID"),
-        GetServerVariable("[C_Temenos_3rd]UniqueID"),
-        GetServerVariable("[C_Temenos_4th]UniqueID"),
-        GetServerVariable("[C_Temenos_4th_II]UniqueID"),
-    }
+function getBattlefieldEntrance(player, inst)
+    local zone = player:getZoneID();
 
-    for nl = 1, #KeyAlreadyExist, 1 do
-        if (KeyAlreadyExist[nl] == Key) then
-            H = true
-            break
+    -- Temenos
+    if (zone == 37) then
+        if     (inst == 1) then return  380,   71.0,  376;
+        elseif (inst == 2) then return  380,   -2.5,   96;
+        elseif (inst == 3) then return  380,   71.5, -184;
+        elseif (inst == 4) then return -540,   -2.5, -584;
+        elseif (inst == 5) then return -296, -162.5, -500;
+        elseif (inst == 6) then return   20,   -2.5, -544;
+        elseif (inst == 7) then return  260, -162.5, -504;
+        elseif (inst == 8) then return  580,   -2.5, -544;
+        else                    return  580,   -1.5,    5;
         end
-    end
+    
+    -- Apollyon
+    elseif (zone == 38) then
+        if     (inst == 1) then return -468, 0, -626;
+        elseif (inst == 2) then return -439, 0,  -89;
+        elseif (inst == 3) then return  468, 0, -625;
+        elseif (inst == 4) then return  438, 0,  -89;
+        elseif (inst == 5) then return    0, 0,  210;
+        elseif (inst == 6) then return    0, 0, -210;
+        else                    return  643, 0, -600;
+        end
 
-    return H
+    end
 end
 
-function GetLimbusKeyFromInstance(instanceID)
-    local Instancekey = 0
+function belongsInBattlefield(player)
+    local zone = player:getZoneID();
+    local key = player:getVar("characterLimbusKey");
+    
+    -- Temenos
+    if (zone == 37) then
+        if (key == GetServerVariable("[Temenos_N_Tower]UniqueID")   ) then return 1; end
+        if (key == GetServerVariable("[Temenos_E_Tower]UniqueID")   ) then return 2; end
+        if (key == GetServerVariable("[Temenos_W_Tower]UniqueID")   ) then return 3; end
+        if (key == GetServerVariable("[C_Temenos_4th]UniqueID")     ) then return 4; end
+        if (key == GetServerVariable("[C_Temenos_3rd]UniqueID")     ) then return 5; end
+        if (key == GetServerVariable("[C_Temenos_2nd]UniqueID")     ) then return 6; end
+        if (key == GetServerVariable("[C_Temenos_1st]UniqueID")     ) then return 7; end
+        if (key == GetServerVariable("[C_Temenos_Base]UniqueID")    ) then return 8; end
+        if (key == GetServerVariable("[C_Temenos_Base_II]UniqueID") ) then return 8; end
+        if (key == GetServerVariable("[C_Temenos_4th_II]UniqueID")  ) then return 4; end
+    
+    -- Apollyon
+    elseif (zone == 38) then
+        if (key == GetServerVariable("[SW_Apollyon]UniqueID")           ) then return 1; end
+        if (key == GetServerVariable("[NW_Apollyon]UniqueID")           ) then return 2; end
+        if (key == GetServerVariable("[SE_Apollyon]UniqueID")           ) then return 3; end
+        if (key == GetServerVariable("[NE_Apollyon]UniqueID")           ) then return 4; end
+        if (key == GetServerVariable("[Central_Apollyon]UniqueID")      ) then return 5; end
+        if (key == GetServerVariable("[CS_Apollyon]UniqueID")           ) then return 6; end
+        if (key == GetServerVariable("[CS_Apollyon_II]UniqueID")        ) then return 6; end
+        if (key == GetServerVariable("[Central_Apollyon_II]UniqueID")   ) then return 5; end
 
-    switch (instanceID): caseof
-    {
-        [1290] = function (x)
-            Instancekey = GetServerVariable("[NW_Apollyon]UniqueID")
-        end,
-        [1291] = function (x)
-            Instancekey = GetServerVariable("[SW_Apollyon]UniqueID")
-        end,
-        [1292] = function (x)
-            Instancekey = GetServerVariable("[NE_Apollyon]UniqueID")
-        end,
-        [1293] = function (x)
-            Instancekey = GetServerVariable("[SE_Apollyon]UniqueID")
-        end,
-        [1294] = function (x)
-            Instancekey = GetServerVariable("[CS_Apollyon]UniqueID")
-        end,
-        [1295] = function (x)
-            Instancekey = GetServerVariable("[CS_Apollyon_II]UniqueID")
-        end,
-        [1296] = function (x)
-            Instancekey = GetServerVariable("[Central_Apollyon]UniqueID")
-        end,
-        [1297] = function (x)
-            Instancekey = GetServerVariable("[Central_Apollyon_II]UniqueID")
-        end,
-        [1298] = function (x)
-            Instancekey = GetServerVariable("[Temenos_W_Tower]UniqueID")
-        end,
-        [1299] = function (x)
-            Instancekey = GetServerVariable("[Temenos_N_Tower")
-        end,
-        [1300] = function (x)
-            Instancekey = GetServerVariable("[Temenos_E_Tower]UniqueID")
-        end,
-        [1301] = function (x)
-            Instancekey = GetServerVariable("[C_Temenos_Base]UniqueID")
-        end,
-        [1302] = function (x)
-            Instancekey = GetServerVariable("[C_Temenos_Base_II]UniqueID")
-        end,
-        [1303] = function (x)
-            Instancekey = GetServerVariable("[C_Temenos_1st]UniqueID")
-        end,
-        [1304] = function (x)
-            Instancekey =  GetServerVariable("[C_Temenos_2nd]UniqueID")
-        end,
-        [1305] = function (x)
-            Instancekey = GetServerVariable("[C_Temenos_3rd]UniqueID")
-        end,
-        [1306] = function (x)
-            Instancekey = GetServerVariable("[C_Temenos_4th]UniqueID")
-        end,
-        [1307] = function (x)
-            Instancekey = GetServerVariable("[C_Temenos_4th_II]UniqueID")
-        end,
-    }
-    --   print("Server__instanceID "..instanceID.." Serverkey "..Instancekey)
-
-    return Instancekey
-end
-
-function IsMobDead(mobID)
-    local ActionValue = GetMobAction(mobID)
-    --  Todo: replace this
-    if (ActionValue == 0 or ActionValue == 21 or ActionValue == 22 or ActionValue == 23) then
-        return true
-    else
-        return false
     end
+    return -1;
 end
 
 function despawnLimbusCS()
     for n = 16933130, 16933136, 1 do
-        if (IsMobDead(n) == false) then
+        if (GetMobByID(n):isSpawned()) then
             DespawnMob(n)
         end
     end
 
     for n = 16933138, 16933143, 1 do
-        if (IsMobDead(n) == false) then
+        if (GetMobByID(n):isSpawned()) then
             DespawnMob(n)
         end
     end
 
     for n = 16933145, 16933152, 1 do
-        if (IsMobDead(n) == false) then
+        if (GetMobByID(n):isSpawned()) then
             DespawnMob(n)
         end
     end
@@ -616,6 +557,45 @@ function SpawnCofferSWfloor3()
     GetNPCByID(16932864+216):setPos(MIMICPOSITION[14][1], MIMICPOSITION[14][2], MIMICPOSITION[14][3])
     GetNPCByID(16932864+216):setStatus(STATUS_NORMAL)
     SetServerVariable("[SW_Apollyon]MimicTrigger", 1)
+end
+
+function SpawnCofferNEfloor1()
+    --print ("spawn_coffer")
+    GetNPCByID(16932864+81):setPos(453,0,31)
+    GetNPCByID(16932864+81):setStatus(STATUS_NORMAL)
+    GetNPCByID(16932864+82):setPos(459,0,29)
+    GetNPCByID(16932864+82):setStatus(STATUS_NORMAL)
+    GetNPCByID(16932864+118):setPos(452,0,15)
+    GetNPCByID(16932864+118):setStatus(STATUS_NORMAL)
+    GetNPCByID(16932864+120):setPos(470,0,32)
+    GetNPCByID(16932864+120):setStatus(STATUS_NORMAL)
+
+    GetNPCByID(16932864+83):setPos(333,0,228)
+    GetNPCByID(16932864+83):setStatus(STATUS_NORMAL)
+    GetNPCByID(16932864+84):setPos(410,0,279)
+    GetNPCByID(16932864+84):setStatus(STATUS_NORMAL)
+    GetNPCByID(16932864+125):setPos(316,0,363)
+    GetNPCByID(16932864+125):setStatus(STATUS_NORMAL)
+    GetNPCByID(16932864+127):setPos(369,0,325)
+    GetNPCByID(16932864+127):setStatus(STATUS_NORMAL)
+
+    GetNPCByID(16932864+85):setPos(211,0,554)
+    GetNPCByID(16932864+85):setStatus(STATUS_NORMAL)
+    GetNPCByID(16932864+94):setPos(307,0,530)
+    GetNPCByID(16932864+94):setStatus(STATUS_NORMAL)
+    GetNPCByID(16932864+139):setPos(362,0,556)
+    GetNPCByID(16932864+139):setStatus(STATUS_NORMAL)
+    GetNPCByID(16932864+141):setPos(363,0,538)
+    GetNPCByID(16932864+141):setStatus(STATUS_NORMAL)
+
+    GetNPCByID(16932864+95):setPos(587,0,536)
+    GetNPCByID(16932864+95):setStatus(STATUS_NORMAL) 
+    GetNPCByID(16932864+96):setPos(560,0,580)
+    GetNPCByID(16932864+96):setStatus(STATUS_NORMAL)
+    GetNPCByID(16932864+153):setPos(558,0,644)
+    GetNPCByID(16932864+153):setStatus(STATUS_NORMAL)
+    GetNPCByID(16932864+155):setPos(585,0,597)
+    GetNPCByID(16932864+155):setStatus(STATUS_NORMAL)
 end
 
 function SpawnCofferTemenosCFloor4()
@@ -748,170 +728,4 @@ function Randomcoffer(Floor, region)
     end
     --  print("cofferID" ..cofferID)
     return cofferID
-end
-
-function ResetKeyForEmptyLimbus(player, instanceID)
-    local instancestatus = player:isSpecialBattlefieldEmpty(GetInstanceRegion(instanceID))
-
-    --  print("instancestatus"..instancestatus)
-
-    if (instancestatus == 0) then
-        switch (instanceID): caseof
-        {
-            [1290] = function (x)
-                SetServerVariable("[NW_Apollyon]UniqueID", 0)
-                print("[NW_Apollyon]KeyDelete")
-            end,
-            [1291] = function (x)
-                SetServerVariable("[SW_Apollyon]UniqueID", 0)
-                print("[SW_Apollyon]KeyDelete")
-            end,
-            [1292] = function (x)
-                SetServerVariable("[NE_Apollyon]UniqueID", 0)
-                print("[NE_Apollyon]KeyDelete")
-            end,
-            [1293] = function (x)
-                SetServerVariable("[SE_Apollyon]UniqueID", 0)
-                print("[SE_Apollyon]KeyDelete")
-            end,
-            [1294] = function (x)
-                SetServerVariable("[CS_Apollyon]UniqueID", 0)
-                print("[CS_Apollyon]KeyDelete")
-            end,
-            [1295] = function (x)
-                SetServerVariable("[CS_Apollyon_II]UniqueID", 0)
-                print("[CS_Apollyon_II]KeyDelete")
-            end,
-            [1296] = function (x)
-                SetServerVariable("[Central_Apollyon]UniqueID", 0)
-                print("[Central_Apollyon]KeyDelete")
-            end,
-            [1297] = function (x)
-                SetServerVariable("[Central_Apollyon_II]UniqueID", 0)
-                print("[Central_Apollyon_II]KeyDelete")
-            end,
-            [1298] = function (x)
-                SetServerVariable("[Temenos_W_Tower]UniqueID", 0)
-                print("[Temenos_W_Tower]KeyDelete")
-            end,
-            [1299] = function (x)
-                SetServerVariable("[Temenos_N_Tower]UniqueID", 0)
-                print("[Temenos_N_Tower]KeyDelete")
-            end,
-            [1300] = function (x)
-                SetServerVariable("[Temenos_E_Tower]UniqueID", 0)
-                print("[Temenos_E_Tower]KeyDelete")
-            end,
-            [1301] = function (x)
-                SetServerVariable("[C_Temenos_Base]UniqueID", 0)
-                print("[C_Temenos_Base]KeyDelete")
-            end,
-            [1302] = function (x)
-                SetServerVariable("[C_Temenos_Base_II]UniqueID", 0)
-                print("[C_Temenos_Base_II]KeyDelete")
-            end,
-            [1303] = function (x)
-                SetServerVariable("[C_Temenos_1st]UniqueID", 0)
-                print("[C_Temenos_1st]KeyDelete")
-            end,
-            [1304] = function (x)
-                SetServerVariable("[C_Temenos_2nd]UniqueID", 0)
-                print("[C_Temenos_2nd]KeyDelete")
-            end,
-            [1305] = function (x)
-                SetServerVariable("[C_Temenos_3rd]UniqueID", 0)
-                print("[C_Temenos_3rd]KeyDelete")
-            end,
-            [1306] = function (x)
-                SetServerVariable("[C_Temenos_4th]UniqueID", 0)
-                print("[C_Temenos_4th]KeyDelete")
-            end,
-            [1307] = function (x)
-                SetServerVariable("[C_Temenos_4th_II]UniqueID", 0)
-                print("[C_Temenos_4th_II]KeyDelete")
-            end,
-        }
-    end
-end
-
-function GetInstanceRegion(instanceID)
-    local region = 0
-
-    for K = 1, #APPOLLYON_SE_NE_BCNM_LIST, 2 do
-        if (APPOLLYON_SE_NE_BCNM_LIST[K] == instanceID) then
-            region =APPOLLYON_SE_NE_BCNM_LIST[K+1][5]
-        end
-    end
-
-    for L = 1, #APPOLLYON_NW_SW_BCNM_LIST, 2 do
-        if (APPOLLYON_NW_SW_BCNM_LIST[L] == instanceID) then
-            region =APPOLLYON_NW_SW_BCNM_LIST[L+1][5]
-        end
-    end
-
-    for M = 1, #TEMENOS_LIST, 2 do
-        if (TEMENOS_LIST[M] == instanceID) then
-            region = TEMENOS_LIST[M+1][5]
-        end
-    end
-
-    return region
-end
-
-function RegisterLimbusInstance(player, instanceID)
-    local playerLimbusKeyID  = player:getVar("characterLimbusKey")
-    local playerLimbusID  = player:getVar("LimbusID")
-    local inst = 0
-
-    ResetKeyForEmptyLimbus(player, instanceID)  --  instancekey will be reset if this instance is empty
-
-    if (playerLimbusID == 0) then
-        playerLimbusID = instanceID
-    end
-    --    print("Player_:_instanceID_"..playerLimbusID.." Playerkey "..playerLimbusKeyID)
-    if (playerLimbusID ~= 0) then
-        if (GetLimbusKeyFromInstance(playerLimbusID) == 0 and playerLimbusKeyID == 0) then
-            inst = player:bcnmRegister(playerLimbusID)    --  Build Limbus
-            printf("Regionfound: %u", inst)
-
-            if (inst == GetInstanceRegion(playerLimbusID)) then
-                player:bcnmEnter(playerLimbusID)
-                printf("BCNM_CREATE_WITH_REGION: %u", inst)
-            else
-                if (playerLimbusID == 1290 or playerLimbusID == 1291
-                or playerLimbusID == 1294 or playerLimbusID == 1295
-                or playerLimbusID == 1296 or playerLimbusID == 1297) then
-                    player:setPos(-668, 0.1, -666)
-                else
-                    player:setPos(643, 0.1, -600)
-                end
-
-                player:messageSpecial(7006)
-                ResetPlayerLimbusVariable(player)
-                print("BCNM_cant_be _created")
-            end
-        end
-    end
-end
-
-function TryTobackOnCurrentLimbus(player)
-    local currentlimbus = 0
-    local playerLimbusID = player:getVar("LimbusID")
-    local playerLimbusKeyID = player:getVar("characterLimbusKey")
-    --  print("Player_:_instanceID_"..playerLimbusID.." Playerkey "..playerLimbusKeyID)
-    if (GetLimbusKeyFromInstance(playerLimbusID) == playerLimbusKeyID
-    and player:isSpecialBattlefieldEmpty(GetInstanceRegion(playerLimbusID)) == 1) then   --  player deco and back
-        currentlimbus = playerLimbusID
-        print("trying_to_add_player_on_the_current_bcnm")
-
-        local registration = player:addPlayerToSpecialBattlefield(playerLimbusID)
-
-        if (registration ~= 1) then
-            currentlimbus = 0
-        end
-    else
-        currentlimbus = 0
-    end
-
-    return currentlimbus
 end

--- a/scripts/zones/AlTaieu/npcs/Swirling_Vortex.lua
+++ b/scripts/zones/AlTaieu/npcs/Swirling_Vortex.lua
@@ -45,10 +45,8 @@ function onEventFinish(player,csid,option)
     -- printf("CSID: %u",csid);
     -- printf("RESULT: %u",option);
     if (csid == 0x00A0 and option == 1 ) then
-        ResetPlayerLimbusVariable(player);
-        LimbusEntrance(player,APPOLLYON_NW_SW);
+        enterApollyon(player,APOLLYON_NW_SW);
     elseif (csid == 0x009F and option == 1 ) then
-        ResetPlayerLimbusVariable(player);
-        LimbusEntrance(player,APPOLLYON_SE_NE);
+        enterApollyon(player,APOLLYON_SE_NE);
     end
 end;

--- a/scripts/zones/Apollyon/Zone.lua
+++ b/scripts/zones/Apollyon/Zone.lua
@@ -1,60 +1,53 @@
 -----------------------------------
 -- 
--- Zone: Apollyon
+-- Zone: Apollyon (38)
 -- 
+-----------------------------------
+package.loaded["scripts/zones/Apollyon/TextIDs"] = nil;
 -----------------------------------
 
 require("scripts/globals/settings");
-package.loaded["scripts/zones/Apollyon/TextIDs"] = nil;
-require("scripts/zones/Apollyon/TextIDs");
 require("scripts/globals/limbus");
+require("scripts/zones/Apollyon/TextIDs");
+
 -----------------------------------
 --  onInitialize
 -----------------------------------
 
 function onInitialize(zone)
-            SetServerVariable("[NW_Apollyon]UniqueID",0);       
-            SetServerVariable("[SW_Apollyon]UniqueID",0);       
-            SetServerVariable("[NE_Apollyon]UniqueID",0) ;  
-            SetServerVariable("[SE_Apollyon]UniqueID",0);       
-            SetServerVariable("[CS_Apollyon]UniqueID",0);       
-            SetServerVariable("[CS_Apollyon_II]UniqueID",0);        
-            SetServerVariable("[Central_Apollyon]UniqueID",0);      
-            SetServerVariable("[Central_Apollyon_II]UniqueID",0); 
+    SetServerVariable("[NW_Apollyon]UniqueID",0);
+    SetServerVariable("[SW_Apollyon]UniqueID",0);
+    SetServerVariable("[NE_Apollyon]UniqueID",0);
+    SetServerVariable("[SE_Apollyon]UniqueID",0);
+    SetServerVariable("[CS_Apollyon]UniqueID",0);
+    SetServerVariable("[CS_Apollyon_II]UniqueID",0);
+    SetServerVariable("[Central_Apollyon]UniqueID",0);
+    SetServerVariable("[Central_Apollyon_II]UniqueID",0);
 
+    zone:registerRegion( 1,  637, -4, -642,  642, 4, -637); -- APOLLYON_SE_NE exit
+    zone:registerRegion( 2, -642, -4, -642, -637, 4, -637); -- APOLLYON_NW_SW exit
 
-zone:registerRegion(1,  637,-4,-642,642,4,-637);  -- APPOLLYON_SE_NE exit
-zone:registerRegion(2, -642,-4,-642,-637,4,-637);  -- APPOLLYON_NW_SW exit
+    zone:registerRegion(20,  396, -4, -522,  403, 4, -516); -- Apollyon SE telporter floor1 to floor2
+    zone:registerRegion(21,  116, -4, -443,  123, 4, -436); -- Apollyon SE telporter floor2 to floor3
+    zone:registerRegion(22,  276, -4, -283,  283, 4, -276); -- Apollyon SE telporter floor3 to floor4
+    zone:registerRegion(23,  517, -4, -323,  523, 4, -316); -- Apollyon SE telporter floor4 to entrance
 
-zone:registerRegion(3, 468,-4,-637,  478,4,-622); -- appolyon SE register
-zone:registerRegion(4, 421,-4,-98,   455,4,-78); -- appolyon NE register
-zone:registerRegion(5, -470,-4,-629,  -459,4,-620); -- appolyon SW register
-zone:registerRegion(6, -455,-4,-95,   -425,4,-67); -- appolyon NW register
+    zone:registerRegion(24,  396, -4,   76,  403, 4,   83); -- Apollyon NE telporter floor1 to floor2
+    zone:registerRegion(25,  276, -4,  356,  283, 4,  363); -- Apollyon NE telporter floor2 to floor3
+    zone:registerRegion(26,  236, -4,  517,  243, 4,  523); -- Apollyon NE telporter floor3 to floor4
+    zone:registerRegion(27,  517, -4,  637,  523, 4,  643); -- Apollyon NE telporter floor4 to floor5
+    zone:registerRegion(28,  557, -4,  356,  563, 4,  363); -- Apollyon NE telporter floor5 to entrance
 
-zone:registerRegion(7, -3,-4,-214,   3,4,-210); -- appolyon CS register
-zone:registerRegion(8, -3,-4, 207,   3,4, 215); -- appolyon Center register
+    zone:registerRegion(29, -403, -4, -523, -396, 4, -516); -- Apollyon SW telporter floor1 to floor2   
+    zone:registerRegion(30, -123, -4, -443, -116, 4, -436); -- Apollyon SW telporter floor2 to floor3  
+    zone:registerRegion(31, -283, -4, -283, -276, 4, -276); -- Apollyon SW telporter floor3 to floor4 
+    zone:registerRegion(32, -523, -4, -323, -517, 4, -316); -- Apollyon SW telporter floor4 to entrance 
 
-zone:registerRegion(20,   396,-4,-522,   403,4,-516); -- appolyon SE telporter floor1 to floor2
-zone:registerRegion(21,   116,-4,-443,   123,4,-436); -- appolyon SE telporter floor2 to floor3
-zone:registerRegion(22,   276,-4,-283,   283,4,-276); -- appolyon SE telporter floor3 to floor4
-zone:registerRegion(23,   517,-4,-323,   523,4,-316); -- appolyon SE telporter floor4 to entrance
-
-zone:registerRegion(24,   396,-4,76,   403,4,83); -- appolyon NE telporter floor1 to floor2
-zone:registerRegion(25,   276,-4,356,   283,4,363); -- appolyon NE telporter floor2 to floor3
-zone:registerRegion(26,   236,-4,517,   243,4,523); -- appolyon NE telporter floor3 to floor4
-zone:registerRegion(27,   517,-4,637,   523,4,643); -- appolyon NE telporter floor4 to floor5
-zone:registerRegion(28,   557,-4,356,   563,4,363); -- appolyon NE telporter floor5 to entrance
-
-zone:registerRegion(29, -403,-4,-523,  -396,4,-516); -- appolyon SW telporter floor1 to floor2   
-zone:registerRegion(30, -123,-4,-443,  -116,4,-436); -- appolyon SW telporter floor2 to floor3  
-zone:registerRegion(31, -283,-4,-283,  -276,4,-276); -- appolyon SW telporter floor3 to floor4 
-zone:registerRegion(32, -523,-4,-323,  -517,4,-316); -- appolyon SW telporter floor4 to entrance 
-
-zone:registerRegion(33, -403,-4,76,   -396,4,83); -- appolyon NW telporter floor1 to floor2 
-zone:registerRegion(34, -283,-4,356,  -276,4,363); -- appolyon NW telporter floor2 to floor3 
-zone:registerRegion(35, -243,-4,516,  -236,4,523); -- appolyon NW telporter floor3 to floor4 
-zone:registerRegion(36, -523,-4,636,  -516,4,643); -- appolyon NW telporter floor4 to floor5 
-zone:registerRegion(37, -563,-4,356,  -556,4,363); -- appolyon NW telporter floor5 to entrance 
+    zone:registerRegion(33, -403, -4,   76, -396, 4,   83); -- Apollyon NW telporter floor1 to floor2 
+    zone:registerRegion(34, -283, -4,  356, -276, 4,  363); -- Apollyon NW telporter floor2 to floor3 
+    zone:registerRegion(35, -243, -4,  516, -236, 4,  523); -- Apollyon NW telporter floor3 to floor4 
+    zone:registerRegion(36, -523, -4,  636, -516, 4,  643); -- Apollyon NW telporter floor4 to floor5 
+    zone:registerRegion(37, -563, -4,  356, -556, 4,  363); -- Apollyon NW telporter floor5 to entrance 
                                                                 
 end;
 
@@ -76,20 +69,32 @@ end;
 -----------------------------------
 
 function onZoneIn(player,prevZone)
-cs = -1;
-    if (prevZone~=33) then
-      local playerLimbusID = player:getVar("LimbusID");
-        if (playerLimbusID== 1290 or playerLimbusID== 1291 or playerLimbusID== 1294 or playerLimbusID== 1295 or playerLimbusID== 1296 or playerLimbusID== 1297) then
-        player:setPos(-668,0.1,-666);
-        else
-        player:setPos(643,0.1,-600);
-        end
- 
-    elseif ((player:getXPos() == 0) and (player:getYPos() == 0) and (player:getZPos() == 0)) then    
-        player:setPos(643,0.1,-600);        
-    end 
+    local cs = 0;
     
-return cs;
+    player:delStatusEffect(EFFECT_LIMBUS);
+    local inst = belongsInBattlefield(player);
+    
+    -- player is returning from disconnect, so add them to matching run in progress
+    if (inst > 0 and not player:isBattlefieldFree(inst)) then
+        player:addPlayerToBattlefield(inst);
+        local x, y, z = getBattlefieldEntrance(player, inst);
+        printf("%s reconnected to battlefield. Moving to x=%f y=%f z=%f",player:getName(),x,y,z);
+        player:setPos(x,y,z);
+        cs = -1;
+    
+    -- GM can goto players in battlefield, and should not be set to entrance
+    elseif (player:getGMLevel() > 0) then
+        if ((player:getXPos() == 0) and (player:getYPos() == 0) and (player:getZPos() == 0)) then
+            player:setPos(643,0.1,-600);
+        end
+
+    -- everyone else should be put at the entrance        
+    else
+        player:setPos(643,0.1,-600);
+        
+    end
+    
+    return cs;
 end;
 
 -----------------------------------
@@ -100,117 +105,88 @@ function onRegionEnter(player,region)
   local regionID = region:GetRegionID();
    switch (regionID): caseof {
         [1] = function (x) 
-             player:startEvent(0x0064); -- APPOLLYON_SE_NE exit
+             player:startEvent(0x0064); -- APOLLYON_SE_NE exit
         end,
         [2] = function (x) 
-             player:startEvent(0x0065); -- APPOLLYON_NW_SW exit
-            -- print("APPOLLYON_NW_SW");
+             player:startEvent(0x0065); -- APOLLYON_NW_SW exit
+            -- print("APOLLYON_NW_SW");
         end,
-        [3] = function (x) 
-              if (player:hasStatusEffect(EFFECT_BATTLEFIELD) == false) then 
-                  RegisterLimbusInstance(player,1293);
-              end   --create instance appolyon SE     
-        end,
-        [4] = function (x) 
-              if (player:hasStatusEffect(EFFECT_BATTLEFIELD) == false) then 
-                  RegisterLimbusInstance(player,1292);
-              end   --create instance appolyon NE     
-        end,
-        [5] = function (x) 
-              if (player:hasStatusEffect(EFFECT_BATTLEFIELD) == false) then 
-                  RegisterLimbusInstance(player,1291);
-              end   --create instance appolyon SW     
-        end,
-        [6] = function (x) 
-              if (player:hasStatusEffect(EFFECT_BATTLEFIELD) == false) then 
-                  RegisterLimbusInstance(player,1290);
-              end   --create instance appolyon NW     
-        end,
-        [7] = function (x) 
-              if (player:hasStatusEffect(EFFECT_BATTLEFIELD) == false) then 
-                  RegisterLimbusInstance(player,1294);
-              end   --create instance appolyon CS     
-        end,        
-        [8] = function (x) 
-              if (player:hasStatusEffect(EFFECT_BATTLEFIELD) == false) then 
-                  RegisterLimbusInstance(player,1296);
-              end   --create instance appolyon CENTER     
-        end,    
         
-        -- ///////////////////////APPOLLYON SE TELEPORTER///////////////////////////////////////////
+        -- ///////////////////////APOLLYON SE TELEPORTER///////////////////////////////////////////
         [20] = function (x) 
              -- print("SE_telporter_f1_to_f2");
-             if (IsMobDead(16932992)==true and player:getAnimation()==0) then player:startEvent(0x00DB);end
+             if (GetMobByID(16932992):isDead() and player:getAnimation()==0) then player:startEvent(0x00DB);end
         end,
         [21] = function (x) 
              -- print("SE_telporter_f2_to_f3");
-              if (IsMobDead(16933006)==true and player:getAnimation()==0) then player:startEvent(0x00DA);end
+              if (GetMobByID(16933006):isDead() and player:getAnimation()==0) then player:startEvent(0x00DA);end
         end,    
         [22] = function (x) 
             --  print("SE_telporter_f3_to_f4");
-              if (IsMobDead(16933020)==true and player:getAnimation()==0) then player:startEvent(0x00D8);end
+              if (GetMobByID(16933020):isDead() and player:getAnimation()==0) then player:startEvent(0x00D8);end
          end,       
         [23] = function (x) 
              -- print("SE_telporter_f3_to_entrance");
-              if (IsMobDead(16933032)==true and player:getAnimation()==0) then player:startEvent(0x00D9);end
+              if (GetMobByID(16933032):isDead() and player:getAnimation()==0) then player:startEvent(0x00D9);end
          end,
          -- ///////////////////////////////////////////////////////////////////////////////////////////      
-         -- /////////////////////    APPOLLYON NE TELEPORTER           ////////////////////////////////
+         -- /////////////////////    APOLLYON NE TELEPORTER           ////////////////////////////////
         [24] = function (x) 
              -- print("NE_telporter_f1_to_f2");
-              if (IsMobDead(16933044)==true and player:getAnimation()==0) then player:startEvent(0x00D6);end 
+              if (GetMobByID(16933044):isDead() and player:getAnimation()==0) then player:startEvent(0x00D6);end 
          end,
          [25] = function (x) 
              -- print("NE_telporter_f2_to_f3");
-              if (IsMobDead(16933064)==true and player:getAnimation()==0) then player:startEvent(0x00D4);end  --212
+              if (GetMobByID(16933064):isDead() and player:getAnimation()==0) then player:startEvent(0x00D4);end  --212
          end,
          [26] = function (x) 
             --  print("NE_telporter_f3_to_f4");
-              if (IsMobDead(16933086)==true and player:getAnimation()==0) then player:startEvent(0x00D2);end  --210
+              if (GetMobByID(16933086):isDead() and player:getAnimation()==0) then player:startEvent(0x00D2);end  --210
          end,
          [27] = function (x) 
             --  print("NE_telporter_f4_to_f5");
-              if (IsMobDead(16933101)==true and player:getAnimation()==0) then player:startEvent(0x00D7);end    --215
+              if (GetMobByID(16933101):isDead() and player:getAnimation()==0) then player:startEvent(0x00D7);end    --215
          end,
          [28] = function (x) 
             --  print("NE_telporter_f5_to_entrance");
-              if ( (IsMobDead(16933114)==true or IsMobDead(16933113)==true) and player:getAnimation()==0) then player:startEvent(0x00D5);end --213
+              if ( (GetMobByID(16933114):isDead() or GetMobByID(16933113):isDead()) and player:getAnimation()==0) then player:startEvent(0x00D5);end --213
          end,
          -- //////////////////////////////////////////////////////////////////////////////////////////////////
-         -- /////////////////////    APPOLLYON SW TELEPORTER           //////////////////////////////// 
+         -- /////////////////////    APOLLYON SW TELEPORTER           //////////////////////////////// 
          [29] = function (x) 
-              if (IsMobDead(16932873)==true and player:getAnimation()==0) then player:startEvent(0x00D0);end --208
+              if (GetMobByID(16932873):isDead() and player:getAnimation()==0) then player:startEvent(0x00D0);end --208
          end,
          [30] = function (x) 
-              if (IsMobDead(16932885)==true and player:getAnimation()==0) then player:startEvent(0x00D1);end --209
+              if (GetMobByID(16932885):isDead() and player:getAnimation()==0) then player:startEvent(0x00D1);end --209
               --printf("Mimics should be 0: %u",GetServerVariable("[SW_Apollyon]MimicTrigger"));
          end,
          [31] = function (x)        
-              if (( IsMobDead(16932896)==true or IsMobDead(16932897)==true or IsMobDead(16932898)==true or  IsMobDead(16932899)==true )and player:getAnimation()==0) then player:startEvent(0x00CF);end -- 207
+              if (( GetMobByID(16932896):isDead() or GetMobByID(16932897):isDead() or GetMobByID(16932898):isDead() or  GetMobByID(16932899):isDead() )and player:getAnimation()==0) then player:startEvent(0x00CF);end -- 207
          end,
          [32] = function (x) 
               if (IselementalDayAreDead()==true and player:getAnimation()==0) then player:startEvent(0x00CE);end -- 206
          end,        
              -- //////////////////////////////////////////////////////////////////////////////////////////////////
-         -- /////////////////////    APPOLLYON NW TELEPORTER           //////////////////////////////// 
+         -- /////////////////////    APOLLYON NW TELEPORTER           //////////////////////////////// 
          [33] = function (x) 
-              if (IsMobDead(16932937)==true and player:getAnimation()==0) then player:startEvent(0x00CD);end --205
+              if (GetMobByID(16932937):isDead() and player:getAnimation()==0) then player:startEvent(0x00CD);end --205
          end,
          [34] = function (x) 
-              if (IsMobDead(16932950)==true and player:getAnimation()==0) then player:startEvent(0x00CB);end --203
+              if (GetMobByID(16932950):isDead() and player:getAnimation()==0) then player:startEvent(0x00CB);end --203
          end,
          [35] = function (x) 
-              if (IsMobDead(16932963)==true and player:getAnimation()==0) then player:startEvent(0x00C9);end --201
+              if (GetMobByID(16932963):isDead() and player:getAnimation()==0) then player:startEvent(0x00C9);end --201
          end,
          [36] = function (x) 
-              if (IsMobDead(16932976)==true and player:getAnimation()==0) then player:startEvent(0x00C8);end --200
+              if (GetMobByID(16932976):isDead() and player:getAnimation()==0) then player:startEvent(0x00C8);end --200
          end,
          [37] = function (x) 
-              if (IsMobDead(16932985)==true and player:getAnimation()==0) then player:startEvent(0x00CA);end --202
+              if (GetMobByID(16932985):isDead() and player:getAnimation()==0) then player:startEvent(0x00CA);end --202
          end,
     }
     
 end;
+
 ----------------------------------- 
 -- onRegionLeave    
 -----------------------------------
@@ -223,15 +199,15 @@ end;
 -----------------------------------
 
 function onEventUpdate(player,csid,option)
--- printf("CSID: %u",csid);
--- printf("RESULT: %u",option);
-   if (csid == 0x00D1 and option == 0 and GetServerVariable("[SW_Apollyon]MimicTrigger")==0) then
-    SpawnCofferSWfloor3();
-    --printf("Mimics should be 1: %u",GetServerVariable("[SW_Apollyon]MimicTrigger"));
-   elseif (csid == 0x00CF and option == 0 and GetServerVariable("[SW_Apollyon]ElementalTrigger")==0) then 
-    SetServerVariable("[SW_Apollyon]ElementalTrigger",VanadielDayElement()+1);
-    -- printf("Elementals should be 1: %u",GetServerVariable("[SW_Apollyon]ElementalTrigger"));
-   end
+    -- printf("CSID: %u",csid);
+    -- printf("RESULT: %u",option);
+    if (csid == 0x00D1 and option == 0 and GetServerVariable("[SW_Apollyon]MimicTrigger")==0) then
+        SpawnCofferSWfloor3();
+        --printf("Mimics should be 1: %u",GetServerVariable("[SW_Apollyon]MimicTrigger"));
+    elseif (csid == 0x00CF and option == 0 and GetServerVariable("[SW_Apollyon]ElementalTrigger")==0) then 
+        SetServerVariable("[SW_Apollyon]ElementalTrigger",VanadielDayElement()+1);
+        -- printf("Elementals should be 1: %u",GetServerVariable("[SW_Apollyon]ElementalTrigger"));
+    end
 end;
 
 -----------------------------------
@@ -239,13 +215,13 @@ end;
 -----------------------------------
 
 function onEventFinish(player,csid,option)
--- printf("CSID: %u",csid);
--- printf("RESULT: %u",option);
-   if (csid == 0x0064 and option == 1) then
-    player:setPos(557,-1,441,128,0x21);  -- APPOLLYON_SE_NE exit
-   elseif (csid == 0x0065 and option == 1) then
-    player:setPos(-561,0,443,242,0x21); -- APPOLLYON_NW_SW exit
-   end   
+    -- printf("CSID: %u",csid);
+    -- printf("RESULT: %u",option);
+    if (csid == 0x0064 and option == 1) then
+        player:setPos(557,-1,441,128,0x21);  -- APOLLYON_SE_NE exit
+    elseif (csid == 0x0065 and option == 1) then
+        player:setPos(-561,0,443,242,0x21); -- APOLLYON_NW_SW exit
+    end
 end;
 
 

--- a/scripts/zones/Apollyon/bcnms/central_apollyon.lua
+++ b/scripts/zones/Apollyon/bcnms/central_apollyon.lua
@@ -1,24 +1,21 @@
 -----------------------------------
 -- Area: Appolyon
--- Name: 
+-- Name: Central Apollyon
 -----------------------------------
 require("scripts/globals/limbus");
 require("scripts/globals/keyitems");
 
 -- After registering the BCNM via bcnmRegister(bcnmid)
 function onBcnmRegister(player,instance)        
-    SetServerVariable("[Central_Apollyon]UniqueID",GenerateLimbusKey());
-    HideArmouryCrates(GetInstanceRegion(1296),APPOLLYON_SE_NE);    
+    SetServerVariable("[Central_Apollyon]UniqueID",os.time());
+    HideArmouryCrates(Central_Apollyon,APOLLYON_SE_NE);    
     GetNPCByID(16933248):setAnimation(8);
-    if (IsMobDead(16933125)==false) then DespawnMob(16933125);end        
-     player:setVar("Limbus_Trade_Item",0);    
+    if (GetMobByID():isSpawned(16933125)) then DespawnMob(16933125);end        
 end;
 
 -- Physically entering the BCNM via bcnmEnter(bcnmid)
 function onBcnmEnter(player,instance)
-    player:setVar("limbusbitmap",0);
     player:setVar("characterLimbusKey",GetServerVariable("[Central_Apollyon]UniqueID"));
-    player:setVar("LimbusID",1296);    
     player:delKeyItem(COSMOCLEANSE);
 end;
 
@@ -27,10 +24,9 @@ end;
 -- 4=Finish 
 
 function onBcnmLeave(player,instance,leavecode)
---print("leave code "..leavecode);
+    --print("leave code "..leavecode);
     if (leavecode == 4) then
+        SetServerVariable("[Central_Apollyon]UniqueID",0);
         player:setPos(-668,0.1,-666);
-        ResetPlayerLimbusVariable(player)
     end
-    
 end;

--- a/scripts/zones/Apollyon/bcnms/cs_apollyon.lua
+++ b/scripts/zones/Apollyon/bcnms/cs_apollyon.lua
@@ -8,21 +8,18 @@ require("scripts/globals/keyitems");
 
 -- After registering the BCNM via bcnmRegister(bcnmid)
 function onBcnmRegister(player,instance)
-    SetServerVariable("[CS_Apollyon]UniqueID",GenerateLimbusKey());
-    HideArmouryCrates(GetInstanceRegion(1294),APPOLLYON_SE_NE);    
+    SetServerVariable("[CS_Apollyon]UniqueID",os.time());
+    HideArmouryCrates(CS_Apollyon,APOLLYON_SE_NE);    
     SetServerVariable("[CS_Apollyon]Already_Received",0);
     GetNPCByID(16933245):setAnimation(8);
     GetNPCByID(16933246):setAnimation(8);
     GetNPCByID(16933247):setAnimation(8);
-        despawnLimbusCS();
-    player:setVar("Limbus_Trade_Item",0);    
+    despawnLimbusCS();
 end;
 
 -- Physically entering the BCNM via bcnmEnter(bcnmid)
 function onBcnmEnter(player,instance)
-    player:setVar("limbusbitmap",0);
     player:setVar("characterLimbusKey",GetServerVariable("[CS_Apollyon]UniqueID"));
-    player:setVar("LimbusID",1294);    
     player:delKeyItem(COSMOCLEANSE);
 end;
 
@@ -30,12 +27,9 @@ end;
 -- 3=Disconnected or warped out (if dyna is empty: launch 4 after 3)
 -- 4=Finish
 function onBcnmLeave(player,instance,leavecode)
---print("leave code "..leavecode);
-    
-
+    --print("leave code "..leavecode);
     if (leavecode == 4) then
+        SetServerVariable("[CS_Apollyon]UniqueID",0);
         player:setPos(-668,0.1,-666);
-        ResetPlayerLimbusVariable(player)
     end
-    
 end;

--- a/scripts/zones/Apollyon/bcnms/ne_apollyon.lua
+++ b/scripts/zones/Apollyon/bcnms/ne_apollyon.lua
@@ -1,21 +1,20 @@
 -----------------------------------
 -- Area: Appolyon
--- Name: NE_Apollyon
+-- Name: NE Apollyon
 -----------------------------------
 require("scripts/globals/limbus");
 require("scripts/globals/keyitems");
 
 -- After registering the BCNM via bcnmRegister(bcnmid)
 function onBcnmRegister(player,instance)    
-    SetServerVariable("[NE_Apollyon]UniqueID",GenerateLimbusKey());
-    HideArmouryCrates(GetInstanceRegion(1292),APPOLLYON_SE_NE);    
+    SetServerVariable("[NE_Apollyon]UniqueID",os.time());
+    HideArmouryCrates(NE_Apollyon,APOLLYON_SE_NE);
+    SpawnCofferNEfloor1();
 end;
 
 -- Physically entering the BCNM via bcnmEnter(bcnmid)
 function onBcnmEnter(player,instance)
-    player:setVar("limbusbitmap",0);
     player:setVar("characterLimbusKey",GetServerVariable("[NE_Apollyon]UniqueID"));
-    player:setVar("LimbusID",1292);    
     player:delKeyItem(COSMOCLEANSE);
     player:delKeyItem(BLACK_CARD);
 end;
@@ -25,11 +24,9 @@ end;
 -- 4=Finish 
 
 function onBcnmLeave(player,instance,leavecode)
---print("leave code "..leavecode);
-    
+    --print("leave code "..leavecode);
     if (leavecode == 4) then
-         player:setPos(643,0.1,-600);
-        ResetPlayerLimbusVariable(player)
+        SetServerVariable("[NE_Apollyon]UniqueID",0);
+        player:setPos(643,0.1,-600);
     end
-    
 end;

--- a/scripts/zones/Apollyon/bcnms/nw_apollyon.lua
+++ b/scripts/zones/Apollyon/bcnms/nw_apollyon.lua
@@ -1,22 +1,19 @@
 -----------------------------------
 -- Area: Appolyon
--- Name: 
+-- Name: NW Apollyon
 -----------------------------------
 require("scripts/globals/limbus");
 require("scripts/globals/keyitems");
 
 -- After registering the BCNM via bcnmRegister(bcnmid)
 function onBcnmRegister(player,instance)        
-    SetServerVariable("[NW_Apollyon]UniqueID",GenerateLimbusKey());
-    HideArmouryCrates(GetInstanceRegion(1290),APPOLLYON_NW_SW);
-    
+    SetServerVariable("[NW_Apollyon]UniqueID",os.time());
+    HideArmouryCrates(NW_Apollyon,APOLLYON_NW_SW);
 end;
 
 -- Physically entering the BCNM via bcnmEnter(bcnmid)
 function onBcnmEnter(player,instance)
-    player:setVar("limbusbitmap",0);
     player:setVar("characterLimbusKey",GetServerVariable("[NW_Apollyon]UniqueID"));
-    player:setVar("LimbusID",1290);    
     player:delKeyItem(COSMOCLEANSE);
     player:delKeyItem(RED_CARD);
 end;
@@ -26,11 +23,9 @@ end;
 -- 4=Finish 
 
 function onBcnmLeave(player,instance,leavecode)
---print("leave code "..leavecode);
-    
+    --print("leave code "..leavecode);
     if (leavecode == 4) then
+        SetServerVariable("[NW_Apollyon]UniqueID",0);
         player:setPos(-668,0.1,-666);
-        ResetPlayerLimbusVariable(player)
     end
-    
 end;

--- a/scripts/zones/Apollyon/bcnms/se_apollyon.lua
+++ b/scripts/zones/Apollyon/bcnms/se_apollyon.lua
@@ -1,21 +1,19 @@
 -----------------------------------
 -- Area: Appolyon
--- Name: SE_Apollyon
+-- Name: SE Apollyon
 -----------------------------------
 require("scripts/globals/limbus");
 require("scripts/globals/keyitems");
 
 -- After registering the BCNM via bcnmRegister(bcnmid)
 function onBcnmRegister(player,instance)
-    SetServerVariable("[SE_Apollyon]UniqueID",GenerateLimbusKey());
-    HideArmouryCrates(GetInstanceRegion(1293),APPOLLYON_SE_NE);
+    SetServerVariable("[SE_Apollyon]UniqueID",os.time());
+    HideArmouryCrates(SE_Apollyon,APOLLYON_SE_NE);
 end;
 
 -- Physically entering the BCNM via bcnmEnter(bcnmid)
 function onBcnmEnter(player,instance)
-    player:setVar("limbusbitmap",0);
     player:setVar("characterLimbusKey",GetServerVariable("[SE_Apollyon]UniqueID"));
-    player:setVar("LimbusID",1293);    
     player:delKeyItem(COSMOCLEANSE);
     player:delKeyItem(BLACK_CARD);
 end;
@@ -23,28 +21,9 @@ end;
 -- 4=Finish 
 
 function onBcnmLeave(player,instance,leavecode)
-  -- print("leave code "..leavecode);
-   
+    -- print("leave code "..leavecode);
     if (leavecode == 4) then
-         player:setPos(643,0.1,-600);
-        ResetPlayerLimbusVariable(player)
+        SetServerVariable("[SE_Apollyon]UniqueID",0);
+        player:setPos(643,0.1,-600);
     end
-end;
-
------------------------------------
--- onEventUpdate
------------------------------------
-
-function onEventUpdate(player,csid,option)
-    -- printf("CSID: %u",csid);
-    -- printf("RESULT: %u",option);
-end;
-
------------------------------------
--- onEventFinish
------------------------------------
-
-function onEventFinish(player,csid,option)
-    -- printf("CSID: %u",csid);
-    -- printf("RESULT: %u",option);
 end;

--- a/scripts/zones/Apollyon/bcnms/sw_apollyon.lua
+++ b/scripts/zones/Apollyon/bcnms/sw_apollyon.lua
@@ -1,23 +1,21 @@
 -----------------------------------
 -- Area: Appolyon
--- Name: 
+-- Name: SW Apollyon
 -----------------------------------
 require("scripts/globals/limbus");
 require("scripts/globals/keyitems");
 
 -- After registering the BCNM via bcnmRegister(bcnmid)
 function onBcnmRegister(player,instance)
-    SetServerVariable("[SW_Apollyon]UniqueID",GenerateLimbusKey());
-    HideArmouryCrates(GetInstanceRegion(1291),APPOLLYON_NW_SW);
+    SetServerVariable("[SW_Apollyon]UniqueID",os.time());
+    HideArmouryCrates(SW_Apollyon,APOLLYON_NW_SW);
     SetServerVariable("[SW_Apollyon]MimicTrigger",0);    
     SetServerVariable("[SW_Apollyon]ElementalTrigger",0);
 end;
 
 -- Physically entering the BCNM via bcnmEnter(bcnmid)
 function onBcnmEnter(player,instance)
-    player:setVar("limbusbitmap",0);
     player:setVar("characterLimbusKey",GetServerVariable("[SW_Apollyon]UniqueID"));
-    player:setVar("LimbusID",1291);    
     player:delKeyItem(COSMOCLEANSE);
     player:delKeyItem(RED_CARD);
 end;
@@ -28,7 +26,7 @@ end;
 
 function onBcnmLeave(player,instance,leavecode)
     if (leavecode == 4) then
+        SetServerVariable("[SW_Apollyon]UniqueID",0);
         player:setPos(-668,0.1,-666);
-        ResetPlayerLimbusVariable(player)
     end
 end;

--- a/scripts/zones/Apollyon/mobs/Carnagechief_Jackbodokk.lua
+++ b/scripts/zones/Apollyon/mobs/Carnagechief_Jackbodokk.lua
@@ -39,7 +39,7 @@ function onMobFight(mob,target)
     local Y = mob:getYPos();
     local Z = mob:getZPos();
     local lifepourcent= ((mob:getHP()/mob:getMaxHP())*100);
-    local instancetime = target:getSpecialBattlefieldLeftTime(5);
+    local instancetime = target:getBattlefieldTimeLeft(Central_Temenos_2nd_Floor);
 
 
     if (lifepourcent < 50 and GetNPCByID(16933245):getAnimation() == 8) then
@@ -51,13 +51,12 @@ function onMobFight(mob,target)
     end
 
     if (instancetime < 13) then
-        if (IsMobDead(16933144) == false) then  --link  dee wapa
+        if (GetMobByID(16933144):isAlive()) then  
             GetMobByID(16933144):updateEnmity(target);
-        elseif (IsMobDead(16933137) == false) then  --link na qba
+        elseif (GetMobByID(16933137):isAlive()) then 
             GetMobByID(16933137):updateEnmity(target);
         end
     end
-
 end;
 
 -----------------------------------
@@ -65,8 +64,8 @@ end;
 -----------------------------------
 
 function onMobDeath(mob, player, isKiller)
-    if ((IsMobDead(16933144) == false or IsMobDead(16933137) == false) and alreadyReceived(player,1,GetInstanceRegion(1294)) == false) then
-        player:addTimeToSpecialBattlefield(5,5);
-        addLimbusList(player,1,GetInstanceRegion(1294));
+    if ( ( GetMobByID(16933144):isAlive() or GetMobByID(16933137):isAlive() ) and alreadyReceived(player,1,Central_Temenos_2nd_Floor) == false) then          
+        player:addTimeToBattlefield(Central_Temenos_2nd_Floor,5);
+        addLimbusList(player,1,Central_Temenos_2nd_Floor);
     end
 end;

--- a/scripts/zones/Apollyon/mobs/Dee_Wapa_the_Desolator.lua
+++ b/scripts/zones/Apollyon/mobs/Dee_Wapa_the_Desolator.lua
@@ -40,7 +40,7 @@ function onMobFight(mob,target)
     local Y = mob:getYPos();
     local Z = mob:getZPos();
     local lifepourcent= ((mob:getHP()/mob:getMaxHP())*100); 
-    local instancetime = target:getSpecialBattlefieldLeftTime(5);
+    local instancetime = target:getBattlefieldTimeLeft(Central_Temenos_2nd_Floor);
 
     if (lifepourcent < 50 and GetNPCByID(16933247):getAnimation() == 8) then
         SpawnMob(16933151):setMobMod(MOBMOD_SUPERLINK, mob:getShortID());
@@ -50,9 +50,9 @@ function onMobFight(mob,target)
     end
 
     if (instancetime < 13) then
-        if (IsMobDead(16933129)==false) then  
+        if (GetMobByID(16933129):isAlive()) then  
             GetMobByID(16933129):updateEnmity(target);
-        elseif (IsMobDead(16933137)==false) then 
+        elseif (GetMobByID(16933137):isAlive()) then 
             GetMobByID(16933137):updateEnmity(target);
         end
     end
@@ -63,9 +63,8 @@ end;
 -----------------------------------
 
 function onMobDeath(mob, player, isKiller)
-    if ((IsMobDead(16933129) == false or IsMobDead(16933137) == false)
-    and alreadyReceived(player,3,GetInstanceRegion(1294)) == false) then          
-        player:addTimeToSpecialBattlefield(5,5);
-        addLimbusList(player,4,GetInstanceRegion(1294));
+    if ( ( GetMobByID(16933129):isAlive() or GetMobByID(16933137):isAlive() ) and alreadyReceived(player,3,Central_Temenos_2nd_Floor) == false) then          
+        player:addTimeToBattlefield(Central_Temenos_2nd_Floor,5);
+        addLimbusList(player,3,Central_Temenos_2nd_Floor);
     end
 end;

--- a/scripts/zones/Apollyon/mobs/Jidra.lua
+++ b/scripts/zones/Apollyon/mobs/Jidra.lua
@@ -60,36 +60,29 @@ end;
 -----------------------------------
 
 function onMobDespawn(mob)
- local mobID = mob:getID();    
- -- print(mobID);
-      local mobX = mob:getXPos();
+    local mobID = mob:getID();    
+    -- print(mobID);
+    local mobX = mob:getXPos();
     local mobY = mob:getYPos();
     local mobZ = mob:getZPos();
- 
- 
- if (
-IsMobDead(16932882)==true and
-IsMobDead(16932883)==true and
-IsMobDead(16932884)==true and
-IsMobDead(16932885)==true and
-IsMobDead(16932886)==true and
-IsMobDead(16932887)==true and
-IsMobDead(16932888)==true 
- 
- ) then
- 
--- time
-       GetNPCByID(16932864+70):setPos(mobX+3,mobY,mobZ);
-    GetNPCByID(16932864+70):setStatus(STATUS_NORMAL);
--- recover
-       GetNPCByID(16932864+71):setPos(mobX+4,mobY,mobZ+4);
-    GetNPCByID(16932864+71):setStatus(STATUS_NORMAL);
--- item
-      GetNPCByID(16932864+72):setPos(mobX,mobY,mobZ-3);
-    GetNPCByID(16932864+72):setStatus(STATUS_NORMAL);
 
- 
- end
- 
-
+    if (
+        GetMobByID(16932882):isDead() and
+        GetMobByID(16932883):isDead() and
+        GetMobByID(16932884):isDead() and
+        GetMobByID(16932885):isDead() and
+        GetMobByID(16932886):isDead() and
+        GetMobByID(16932887):isDead() and
+        GetMobByID(16932888):isDead()
+    ) then
+        -- time
+        GetNPCByID(16932864+70):setPos(mobX+3,mobY,mobZ);
+        GetNPCByID(16932864+70):setStatus(STATUS_NORMAL);
+        -- recover
+        GetNPCByID(16932864+71):setPos(mobX+4,mobY,mobZ+4);
+        GetNPCByID(16932864+71):setStatus(STATUS_NORMAL);
+        -- item
+        GetNPCByID(16932864+72):setPos(mobX,mobY,mobZ-3);
+        GetNPCByID(16932864+72):setStatus(STATUS_NORMAL);
+    end
 end;

--- a/scripts/zones/Apollyon/mobs/Na_Qba_Chirurgeon.lua
+++ b/scripts/zones/Apollyon/mobs/Na_Qba_Chirurgeon.lua
@@ -38,7 +38,7 @@ function onMobFight(mob,target)
     local Y = mob:getYPos();
     local Z = mob:getZPos();
     local lifepourcent= ((mob:getHP()/mob:getMaxHP())*100); 
-    local instancetime = target:getSpecialBattlefieldLeftTime(5);
+    local instancetime = target:getBattlefieldTimeLeft(Central_Temenos_2nd_Floor);
 
     if (lifepourcent < 50 and GetNPCByID(16933246):getAnimation() == 8) then
         SpawnMob(16933142):setMobMod(MOBMOD_SUPERLINK, mob:getShortID());
@@ -48,21 +48,21 @@ function onMobFight(mob,target)
     end
     
     if (instancetime < 13) then
-        if (IsMobDead(16933129) == false) then  
+        if (GetMobByID(16933129):isAlive()) then  
             GetMobByID(16933129):updateEnmity(target);
-        elseif (IsMobDead(16933144) == false) then  
+        elseif (GetMobByID(16933144):isAlive()) then 
             GetMobByID(16933144):updateEnmity(target);
         end
     end
 end;
+
 -----------------------------------
 -- onMobDeath
 -----------------------------------
 
 function onMobDeath(mob, player, isKiller)
-    if ((IsMobDead(16933129) == false or IsMobDead(16933144) == false)
-    and alreadyReceived(player,2,GetInstanceRegion(1294)) == false) then          
-        player:addTimeToSpecialBattlefield(5,5);
-        addLimbusList(player,2,GetInstanceRegion(1294));
+    if ( ( GetMobByID(16933129):isAlive() or GetMobByID(16933144):isAlive() ) and alreadyReceived(player,2,Central_Temenos_2nd_Floor) == false) then          
+        player:addTimeToBattlefield(Central_Temenos_2nd_Floor,5);
+        addLimbusList(player,2,Central_Temenos_2nd_Floor);
     end
 end;

--- a/scripts/zones/Apollyon/mobs/Troglodyte_Dhalmel.lua
+++ b/scripts/zones/Apollyon/mobs/Troglodyte_Dhalmel.lua
@@ -35,24 +35,23 @@ end;
 -----------------------------------
 
 function onMobDespawn(mob)
- local mobID = mob:getID();    
- -- print(mobID);
-      local mobX = mob:getXPos();
+    local mobID = mob:getID();    
+    -- print(mobID);
+    local mobX = mob:getXPos();
     local mobY = mob:getYPos();
     local mobZ = mob:getZPos();
- 
- 
-  if (IsMobDead(16933115)==true and 
-     IsMobDead(16933116)==true and   
-     IsMobDead(16933117)==true and
-     IsMobDead(16933118)==true and
-     IsMobDead(16933119)==true and
-     IsMobDead(16933120)==true and
-     IsMobDead(16933121)==true and
-     IsMobDead(16933122)==true 
+
+    if (
+        GetMobByID(16933115):isDead() and 
+        GetMobByID(16933116):isDead() and   
+        GetMobByID(16933117):isDead() and
+        GetMobByID(16933118):isDead() and
+        GetMobByID(16933119):isDead() and
+        GetMobByID(16933120):isDead() and
+        GetMobByID(16933121):isDead() and
+        GetMobByID(16933122):isDead() 
     ) then
-     -- item
-       GetNPCByID(16932864+178):setPos(mobX,mobY,mobZ);
-    GetNPCByID(16932864+178):setStatus(STATUS_NORMAL);
-   end
+        GetNPCByID(16932864+178):setPos(mobX,mobY,mobZ);
+        GetNPCByID(16932864+178):setStatus(STATUS_NORMAL);
+    end
 end;

--- a/scripts/zones/Apollyon/npcs/Armoury_Crate.lua
+++ b/scripts/zones/Apollyon/npcs/Armoury_Crate.lua
@@ -31,14 +31,14 @@ function onTrigger(player,npc)
  local  DespawnOtherCoffer=false;
  local  MimicID=0;
  
-  for coffer = 1,#ARMOURY_CRATES_LIST_APPOLLYON,2 do
-      if (ARMOURY_CRATES_LIST_APPOLLYON[coffer]== CofferID-16932864) then      
-         CofferType=ARMOURY_CRATES_LIST_APPOLLYON[coffer+1][1];
-         InstanceRegion=ARMOURY_CRATES_LIST_APPOLLYON[coffer+1][2];
-         addtime=ARMOURY_CRATES_LIST_APPOLLYON[coffer+1][3];
-         DespawnOtherCoffer=ARMOURY_CRATES_LIST_APPOLLYON[coffer+1][4];
-         MimicID=ARMOURY_CRATES_LIST_APPOLLYON[coffer+1][5];
-         lootID=ARMOURY_CRATES_LIST_APPOLLYON[coffer+1][6];                          
+  for coffer = 1,#ARMOURY_CRATES_LIST_APOLLYON,2 do
+      if (ARMOURY_CRATES_LIST_APOLLYON[coffer]== CofferID-16932864) then      
+         CofferType=ARMOURY_CRATES_LIST_APOLLYON[coffer+1][1];
+         InstanceRegion=ARMOURY_CRATES_LIST_APOLLYON[coffer+1][2];
+         addtime=ARMOURY_CRATES_LIST_APOLLYON[coffer+1][3];
+         DespawnOtherCoffer=ARMOURY_CRATES_LIST_APOLLYON[coffer+1][4];
+         MimicID=ARMOURY_CRATES_LIST_APOLLYON[coffer+1][5];
+         lootID=ARMOURY_CRATES_LIST_APOLLYON[coffer+1][6];                          
       end      
   end
   
@@ -51,7 +51,7 @@ function onTrigger(player,npc)
  
  
     if (CofferType == cTIME) then 
-            player:addTimeToSpecialBattlefield(InstanceRegion,addtime);
+            player:addTimeToBattlefield(InstanceRegion,addtime);
     elseif (CofferType == cITEM) then
             player:BCNMSetLoot(lootID,InstanceRegion,CofferID);
             player:getBCNMloot();
@@ -86,7 +86,7 @@ function onTrigger(player,npc)
          end        
     end  
     if (DespawnOtherCoffer==true) then
-        HideArmouryCrates(InstanceRegion,APPOLLYON_SE_NE);
+        HideArmouryCrates(InstanceRegion,APOLLYON_SE_NE);
     end
     
    npc:setStatus(STATUS_DISAPPEAR);

--- a/scripts/zones/Apollyon/npcs/Radiant_Aureole.lua
+++ b/scripts/zones/Apollyon/npcs/Radiant_Aureole.lua
@@ -1,39 +1,17 @@
 -----------------------------------
 -- Area: Appolyon
 -- NPC:  Radiant_Aureole
--- !pos
------------------------------------
-require("scripts/globals/limbus");
-require("scripts/globals/keyitems");
-package.loaded["scripts/zones/Apollyon/TextIDs"] = nil;
+-- !pos 606 -0.1 -599 38
 -----------------------------------
 
-require("scripts/zones/Apollyon/TextIDs");
+require("scripts/globals/bcnm");
+
 -----------------------------------
 -- onTrade Action
 -----------------------------------
 
 function onTrade(player,npc,trade)
-local count = trade:getItemCount();
-if (player:hasKeyItem(COSMOCLEANSE)) then
-  if (count==1 and trade:hasItemQty(2127,1)) then-- metal chip
-     player:setVar("Limbus_Trade_Item",32);
-     player:tradeComplete();
-     player:messageSpecial(CHIP_TRADE);
-         player:startEvent(0x7d00,0,0,0,32,0,0,0,0);
-        player:setVar("limbusbitmap",32);
-  elseif (count==4 and trade:hasItemQty(1988,1) and trade:hasItemQty(1987,1) and trade:hasItemQty(1910,1) and trade:hasItemQty(1909,1)) then
-    player:setVar("Limbus_Trade_Item",16);
-    player:tradeComplete();
-    player:messageSpecial(CHIP_TRADE);
-    player:startEvent(0x7d00,0,0,0,16,0,0,0,0);
-    player:setVar("limbusbitmap",16);
-  end
- else
-       player:messageSpecial(CONDITION_FOR_LIMBUS);
-     print("error player  don't have cosmo clean");
- end
-
+    TradeBCNM(player,npc,trade);
 end;
 
 -----------------------------------
@@ -41,119 +19,15 @@ end;
 -----------------------------------
 
 function onTrigger(player,npc)
- local instancelist ={};
- local limbusbitmap = 0 ;
- local AllowLimbusToPlayer = true ;
- local currentlimbus= TryTobackOnCurrentLimbus(player);
-
-  if ( npc:getID() == 16933242) then
-         instancelist = APPOLLYON_SE_NE_BCNM_LIST;
-  else
-         instancelist = APPOLLYON_NW_SW_BCNM_LIST;
- end
-printf("currentlimbus: %u",currentlimbus);
-
-
-   if (player:hasKeyItem(COSMOCLEANSE)) then
-       if (player:hasStatusEffect(EFFECT_BATTLEFIELD) == false) then
-         local LimbusTradeItem = player:getVar("Limbus_Trade_Item");
-           for nt = 1,#instancelist,2 do
-                 --   printf("list d'instance: %u",instancelist[nt]);
-               if (instancelist[nt+1][1]==true and player:hasKeyItem(WHITE_CARD)) then
-                --   print("player_have_white_card");
-                   limbusbitmap = limbusbitmap + instancelist[nt+1][4];
-                --   printf("bitmapadd: %u",instancelist[nt+1][4]);
-               end
-               if (instancelist[nt+1][2]==true and player:hasKeyItem(RED_CARD)) then
-                --   print("player_have_red_card");
-                    limbusbitmap = limbusbitmap + instancelist[nt+1][4];
-               --     printf("bitmapadd: %u",instancelist[nt+1][4]);
-               end
-               if (instancelist[nt+1][3]==true and player:hasKeyItem(BLACK_CARD)) then
-                --   print("player_have_black_card");
-                    limbusbitmap = limbusbitmap + instancelist[nt+1][4];
-                 --   printf("bitmapadd: %u",instancelist[nt+1][4]);
-               end
-           end
-        limbusbitmap= limbusbitmap + LimbusTradeItem;
-      ----- /////////////////////////////////////////////on doit ajouter le mipmap pour l'item trade ici
-       else
-             local    status = player:getStatusEffect(EFFECT_BATTLEFIELD);
-            local    playerbcnmid = status:getPower();
-           -- check if the player has the key item for the current battlefield
-           for nt = 1,#instancelist,2 do
-               --     printf("list d'instance: %u",instancelist[nt]);
-                    if (instancelist[nt] == playerbcnmid) then
-                        if (instancelist[nt+1][1]== true and player:hasKeyItem(WHITE_CARD) == false) then
-                           AllowLimbusToPlayer = false;
-                        end
-                        if (instancelist[nt+1][2]== true  and player:hasKeyItem(RED_CARD) == false ) then
-                           AllowLimbusToPlayer = false;
-                        end
-                        if (instancelist[nt+1][3]== true and player:hasKeyItem(BLACK_CARD) == false ) then
-                           AllowLimbusToPlayer = false;
-                        end
-                        if (AllowLimbusToPlayer == true) then --player have the correct key item for the current battflield
-                           limbusbitmap = instancelist[nt+1][4];
-                        end
-
-                    end
-           end
-
-
-
-       end
-
-
-
-
-       if (limbusbitmap~= 0 ) then
-           player:startEvent(0x7d00,0,0,0,limbusbitmap,0,0,0,0);
-        player:setVar("limbusbitmap",limbusbitmap);
-       else
-       player:messageSpecial(CONDITION_FOR_LIMBUS);
-        print("player need a card for basic limbus");
-        end
-
-  elseif (currentlimbus~=0) then
-           for nt = 1,#instancelist,2 do
-               --     printf("list d'instance: %u",instancelist[nt]);
-                    if (instancelist[nt] == currentlimbus) then
-                           limbusbitmap = instancelist[nt+1][4];
-                    end
-           end
-        player:startEvent(0x7d00,0,0,0,limbusbitmap,0,0,0,0);
-        player:setVar("limbusbitmap",limbusbitmap);
-
-  else
-       player:messageSpecial(CONDITION_FOR_LIMBUS);
-    print("error player  don't have cosmo clean");
-  end
-
+    EventTriggerBCNM(player,npc);
 end;
 
 -----------------------------------
 -- onEventUpdate
 -----------------------------------
 
-function onEventUpdate(player,csid,option)
-
-
-     if (csid == 0x7d00) then
-       if (player:hasStatusEffect(EFFECT_BATTLEFIELD) == false) then
-           ResetPlayerLimbusVariable(player);
-           player:setVar("characterLimbusKey",0);
-       else
-               local status = player:getStatusEffect(EFFECT_BATTLEFIELD);
-            player:setVar("LimbusID",status:getPower());
-             player:setVar("characterLimbusKey",GetLimbusKeyFromInstance(status:getPower()));
-       end
-     player:updateEvent(2,player:getVar("limbusbitmap"),0,1,1,0);
-     player:setVar("limbusbitmap",0);
-
-
-     end
-
+function onEventUpdate(player,csid,option,extras)
+    EventUpdateBCNM(player,csid,option,extras);
 end;
 
 -----------------------------------
@@ -161,9 +35,5 @@ end;
 -----------------------------------
 
 function onEventFinish(player,csid,option)
-    -- printf("CSID: %u",csid);
-    -- printf("RESULT: %u",option);
-   if (csid == 0x7d00) then
-
-   end
+    EventFinishBCNM(player,csid,option);
 end;

--- a/scripts/zones/Apollyon/npcs/Sentinel_Column.lua
+++ b/scripts/zones/Apollyon/npcs/Sentinel_Column.lua
@@ -1,9 +1,10 @@
 -----------------------------------
 -- Area: Appolyon
 -- NPC:  Sentinel_Column
--- !pos
+-- !pos 643 0 -609 38
 -----------------------------------
 require("scripts/globals/limbus");
+
 -----------------------------------
 -- onTrade Action
 -----------------------------------
@@ -16,10 +17,7 @@ end;
 -----------------------------------
 
 function onTrigger(player,npc)
-
-   player:startEvent(0x00DD,127);
-
-
+    player:startEvent(0x00DD, 127);
 end;
 
 -----------------------------------
@@ -27,9 +25,15 @@ end;
 -----------------------------------
 
 function onEventUpdate(player,csid,option)
-  -- printf("CSID: %u",csid);
-   --printf("RESULT: %u",option);
- player:updateEvent(0,player:getSpecialBattlefieldLeftTime(2),player:getSpecialBattlefieldLeftTime(1),player:getSpecialBattlefieldLeftTime(4),player:getSpecialBattlefieldLeftTime(3),player:getSpecialBattlefieldLeftTime(6),player:getSpecialBattlefieldLeftTime(5));
+    player:updateEvent(
+        0,
+        player:getBattlefieldTimeLeft(1), -- SW Apollyon
+        player:getBattlefieldTimeLeft(2), -- NW Apollyon
+        player:getBattlefieldTimeLeft(3), -- SE Apollyon
+        player:getBattlefieldTimeLeft(4), -- NE Apollyon
+        player:getBattlefieldTimeLeft(5), -- Central Apollyon
+        player:getBattlefieldTimeLeft(6)  -- CS Apollyon
+    );
 end;
 
 -----------------------------------
@@ -37,9 +41,4 @@ end;
 -----------------------------------
 
 function onEventFinish(player,csid,option)
-    -- printf("CSID: %u",csid);
-    -- printf("RESULT: %u",option);
-   if (csid == 0) then
-
-   end
 end;

--- a/scripts/zones/Balgas_Dais/npcs/Armoury_Crate.lua
+++ b/scripts/zones/Balgas_Dais/npcs/Armoury_Crate.lua
@@ -25,6 +25,7 @@ end;
 
 function onTrigger(player,npc)
     player:getBCNMloot();
+    npc:setStatus(STATUS_DISAPPEAR);
 end;
 
 -----------------------------------

--- a/scripts/zones/Balgas_Dais/npcs/Burning_Circle.lua
+++ b/scripts/zones/Balgas_Dais/npcs/Burning_Circle.lua
@@ -4,42 +4,15 @@
 -- Balga's Dais Burning Circle
 -- !pos 299 -123 345 146
 -------------------------------------
-package.loaded["scripts/zones/Balgas_Dais/TextIDs"] = nil;
--------------------------------------
 
-require("scripts/globals/keyitems");
 require("scripts/globals/bcnm");
-require("scripts/zones/Balgas_Dais/TextIDs");
-
-    ---- 0: Rank 2 Final Mission for Bastok "The Emissary" and Sandy "Journey Abroad"
-    ---- 1: Steamed Sprouts (BCNM 40, Star Orb)
-    ---- 2: Divine Punishers (BCNM 60, Moon Orb)
-    ---- 3: Saintly Invitation (Windurst mission 6-2)
-    ---- 4: Treasure and Tribulations (BCNM 50, Comet Orb)
-    ---- 5: Shattering Stars (MNK)
-    ---- 6: Shattering Stars (WHM)
-    ---- 7: Shattering Stars (SMN)
-    ---- 8: Creeping Doom (BCNM 30, Sky Orb)
-    ---- 9: Charming Trio (BCNM 20, Cloudy Orb)
-    ---- 10: Harem Scarem (BCNM 30, Sky Orb)
-    ---- 11: Early Bird Catches the Wyrm (KSNM 99, Themis Orb)
-    ---- 12: Royal Succession (BCNM 40, Star Orb)
-    ---- 13: Rapid Raptors (BCNM 50, Comet Orb)
-    ---- 14: Wild Wild Whiskers (BCNM 60, Moon Orb)
-    ---- 15: Season's Greetings (KSNM 30, Clotho Orb)
-    ---- 16: Royale Ramble (KSNM 30, Lachesis Orb)
-    ---- 17: Moa Constrictors (KSNM 30, Atropos Orb
 
 -----------------------------------
 -- onTrade Action
 -----------------------------------
 
 function onTrade(player,npc,trade)
-
-    if (TradeBCNM(player,player:getZoneID(),trade,npc)) then
-        return;
-    end
-
+    TradeBCNM(player,npc,trade);
 end;
 
 -----------------------------------
@@ -47,25 +20,15 @@ end;
 -----------------------------------
 
 function onTrigger(player,npc)
-
-    if (EventTriggerBCNM(player,npc)) then
-        return;
-    end
-
+    EventTriggerBCNM(player,npc);
 end;
 
 -----------------------------------
 -- onEventUpdate
 -----------------------------------
 
-function onEventUpdate(player,csid,option)
-    -- printf("onUpdate CSID: %u",csid);
-    -- printf("onUpdate RESULT: %u",option);
-
-    if (EventUpdateBCNM(player,csid,option)) then
-        return;
-    end
-
+function onEventUpdate(player,csid,option,extras)
+    EventUpdateBCNM(player,csid,option,extras);
 end;
 
 -----------------------------------
@@ -73,11 +36,5 @@ end;
 -----------------------------------
 
 function onEventFinish(player,csid,option)
-    -- printf("onFinish CSID: %u",csid);
-    -- printf("onFinish RESULT: %u",option);
-
-    if (EventFinishBCNM(player,csid,option)) then
-        return;
-    end
-
+    EventFinishBCNM(player,csid,option);
 end;

--- a/scripts/zones/Bearclaw_Pinnacle/npcs/Armoury_Crate.lua
+++ b/scripts/zones/Bearclaw_Pinnacle/npcs/Armoury_Crate.lua
@@ -23,6 +23,7 @@ end;
 
 function onTrigger(player,npc)
     player:getBCNMloot();
+    npc:setStatus(STATUS_DISAPPEAR);
 end;
 
 -----------------------------------

--- a/scripts/zones/Bearclaw_Pinnacle/npcs/Wind_Pillar.lua
+++ b/scripts/zones/Bearclaw_Pinnacle/npcs/Wind_Pillar.lua
@@ -2,23 +2,15 @@
 -- Area: Bearclaw Pinnacle
 -- NPC:  Wind Pillar
 -----------------------------------
-package.loaded["scripts/zones/Bearclaw_Pinnacle/TextIDs"] = nil;
------------------------------------
 
 require("scripts/globals/bcnm");
-require("scripts/globals/quests");
-require("scripts/globals/missions");
-require("scripts/zones/Bearclaw_Pinnacle/TextIDs");
 
 -----------------------------------
 -- onTrade Action
 -----------------------------------
 
 function onTrade(player,npc,trade)
-    if (TradeBCNM(player,player:getZoneID(),trade,npc)) then
-        return;
-    end
-    
+    TradeBCNM(player,npc,trade);
 end;
 
 -----------------------------------
@@ -26,27 +18,15 @@ end;
 -----------------------------------
 
 function onTrigger(player,npc)
-    
-    if (EventTriggerBCNM(player,npc)) then
-        return 1;
-        else
-        return 1;
-    end
-    
+    EventTriggerBCNM(player,npc);
 end;
 
 -----------------------------------
 -- onEventUpdate
 -----------------------------------
 
-function onEventUpdate(player,csid,option)
-    -- printf("onUpdate CSID: %u",csid);
-    -- printf("onUpdate RESULT: %u",option);
-
-    if (EventUpdateBCNM(player,csid,option)) then
-        return;
-    end
-    
+function onEventUpdate(player,csid,option,extras)
+    EventUpdateBCNM(player,csid,option,extras);
 end;
 
 -----------------------------------
@@ -54,10 +34,5 @@ end;
 -----------------------------------
 
 function onEventFinish(player,csid,option)
-    -- printf("onFinish CSID: %u",csid);
-    -- printf("onFinish RESULT: %u",option);
-    if (EventFinishBCNM(player,csid,option)) then
-        return;
-    end
-    
+    EventFinishBCNM(player,csid,option);
 end;

--- a/scripts/zones/Boneyard_Gully/npcs/Armoury_Crate.lua
+++ b/scripts/zones/Boneyard_Gully/npcs/Armoury_Crate.lua
@@ -24,6 +24,7 @@ end;
 
 function onTrigger(player,npc)
     player:getBCNMloot();
+    npc:setStatus(STATUS_DISAPPEAR);
 end;
 
 -----------------------------------

--- a/scripts/zones/Boneyard_Gully/npcs/_081.lua
+++ b/scripts/zones/Boneyard_Gully/npcs/_081.lua
@@ -2,23 +2,15 @@
 -- Area: Boneyard_Gully
 -- NPC:  _081 (Dark Miasma)
 -----------------------------------
-package.loaded["scripts/zones/Boneyard_Gully/TextIDs"] = nil;
------------------------------------
 
 require("scripts/globals/bcnm");
-require("scripts/globals/quests");
-require("scripts/globals/missions");
-require("scripts/zones/Boneyard_Gully/TextIDs");
 
 -----------------------------------
 -- onTrade Action
 -----------------------------------
 
 function onTrade(player,npc,trade)
-    if (TradeBCNM(player,player:getZoneID(),trade,npc)) then
-        return;
-    end
-    
+    TradeBCNM(player,npc,trade);
 end;
 
 -----------------------------------
@@ -26,27 +18,15 @@ end;
 -----------------------------------
 
 function onTrigger(player,npc)
-    
-    if (EventTriggerBCNM(player,npc)) then
-        return 1;
-        else
-        return 1;
-   end
-    
+    EventTriggerBCNM(player,npc);
 end;
 
 -----------------------------------
 -- onEventUpdate
 -----------------------------------
 
-function onEventUpdate(player,csid,option)
-    -- printf("onUpdate CSID: %u",csid);
-    -- printf("onUpdate RESULT: %u",option);
-
-    if (EventUpdateBCNM(player,csid,option)) then
-        return;
-    end
-    
+function onEventUpdate(player,csid,option,extras)
+    EventUpdateBCNM(player,csid,option,extras);
 end;
 
 -----------------------------------
@@ -54,10 +34,5 @@ end;
 -----------------------------------
 
 function onEventFinish(player,csid,option)
-    -- printf("onFinish CSID: %u",csid);
-    -- printf("onFinish RESULT: %u",option);
-    if (EventFinishBCNM(player,csid,option)) then
-        return;
-    end
-    
+    EventFinishBCNM(player,csid,option);
 end;

--- a/scripts/zones/Chamber_of_Oracles/npcs/Shimmering_Circle.lua
+++ b/scripts/zones/Chamber_of_Oracles/npcs/Shimmering_Circle.lua
@@ -3,35 +3,15 @@
 -- NPC:  Shimmering Circle
 -- !pos -220 0 12 168
 -------------------------------------
-package.loaded["scripts/zones/Chamber_of_Oracles/TextIDs"] = nil;
--------------------------------------
 
 require("scripts/globals/bcnm");
-require("scripts/globals/missions");
-require("scripts/zones/Chamber_of_Oracles/TextIDs");
-
--------------------------------------
-
-    --- 1/0: Through the Quicksand Caves
-    --- 2/1: Legion XI Comitatensis
-    --- 4/2: Shattering Stars (Samurai)
-    --- 8/3: Shattering Stars (Ninja)
-    --- 16/4: Shattering Stars (Dragoon)
-    --- Cactuar Suave
-    --- Eye of the Storm
-    --- The Scarlet King
-    --- Roar! A Cat Burglar Bares Her Fangs
 
 -----------------------------------
 -- onTrade Action
 -----------------------------------
 
 function onTrade(player,npc,trade)
-
-    if (TradeBCNM(player,player:getZoneID(),trade,npc)) then
-        return;
-    end
-
+    TradeBCNM(player,npc,trade);
 end;
 
 -----------------------------------
@@ -39,25 +19,15 @@ end;
 -----------------------------------
 
 function onTrigger(player,npc)
-
-    if (EventTriggerBCNM(player,npc)) then
-        return;
-    end
-
+    EventTriggerBCNM(player,npc);
 end;
 
 -----------------------------------
 -- onEventUpdate
 -----------------------------------
 
-function onEventUpdate(player,csid,option)
-    -- printf("onUpdate CSID: %u",csid);
-    -- printf("onUpdate RESULT: %u",option);
-
-    if (EventUpdateBCNM(player,csid,option)) then
-        return;
-    end
-
+function onEventUpdate(player,csid,option,extras)
+    EventUpdateBCNM(player,csid,option,extras);
 end;
 
 -----------------------------------
@@ -65,11 +35,5 @@ end;
 -----------------------------------
 
 function onEventFinish(player,csid,option)
-    -- printf("onFinish CSID: %u",csid);
-    -- printf("onFinish RESULT: %u",option);
-
-    if (EventFinishBCNM(player,csid,option)) then
-        return;
-    end
-
+    EventFinishBCNM(player,csid,option);
 end;

--- a/scripts/zones/Cloister_of_Flames/npcs/Fire_Protocrystal.lua
+++ b/scripts/zones/Cloister_of_Flames/npcs/Fire_Protocrystal.lua
@@ -16,11 +16,7 @@ require("scripts/zones/Cloister_of_Flames/TextIDs");
 -----------------------------------
 
 function onTrade(player,npc,trade)
-
-    if (TradeBCNM(player,player:getZoneID(),trade,npc)) then
-        return;
-    end
-
+    TradeBCNM(player,npc,trade);
 end;
 
 -----------------------------------
@@ -43,14 +39,8 @@ end;
 -- onEventUpdate
 -----------------------------------
 
-function onEventUpdate(player,csid,option)
-    --printf("onUpdate CSID: %u",csid);
-    --printf("onUpdate RESULT: %u",option);
-
-    if (EventUpdateBCNM(player,csid,option)) then
-        return;
-    end
-
+function onEventUpdate(player,csid,option,extras)
+    EventUpdateBCNM(player,csid,option,extras);
 end;
 
 -----------------------------------

--- a/scripts/zones/Cloister_of_Frost/npcs/Ice_Protocrystal.lua
+++ b/scripts/zones/Cloister_of_Frost/npcs/Ice_Protocrystal.lua
@@ -16,11 +16,7 @@ require("scripts/zones/Cloister_of_Frost/TextIDs");
 -----------------------------------
 
 function onTrade(player,npc,trade)
-
-    if (TradeBCNM(player,player:getZoneID(),trade,npc)) then
-        return;
-    end
-
+    TradeBCNM(player,npc,trade);
 end;
 
 -----------------------------------
@@ -43,14 +39,8 @@ end;
 -- onEventUpdate
 -----------------------------------
 
-function onEventUpdate(player,csid,option)
-    -- printf("onUpdate CSID: %u",csid);
-    -- printf("onUpdate RESULT: %u",option);
-
-    if (EventUpdateBCNM(player,csid,option)) then
-        return;
-    end
-
+function onEventUpdate(player,csid,option,extras)
+    EventUpdateBCNM(player,csid,option,extras);
 end;
 
 -----------------------------------

--- a/scripts/zones/Cloister_of_Gales/npcs/Wind_Protocrystal.lua
+++ b/scripts/zones/Cloister_of_Gales/npcs/Wind_Protocrystal.lua
@@ -16,12 +16,8 @@ require("scripts/zones/Cloister_of_Gales/TextIDs");
 -----------------------------------
 
 function onTrade(player,npc,trade)
-    
-    if (TradeBCNM(player,player:getZoneID(),trade,npc)) then
-        return;
-    end
-    
-end; 
+    TradeBCNM(player,npc,trade);
+end;
 
 -----------------------------------
 -- onTrigger Action
@@ -43,14 +39,8 @@ end;
 -- onEventUpdate
 -----------------------------------
 
-function onEventUpdate(player,csid,option)
-    -- printf("onUpdate CSID: %u",csid);
-    -- printf("onUpdate RESULT: %u",option);
-    
-    if (EventUpdateBCNM(player,csid,option)) then
-        return;
-    end
-    
+function onEventUpdate(player,csid,option,extras)
+    EventUpdateBCNM(player,csid,option,extras);
 end;
 
 -----------------------------------

--- a/scripts/zones/Cloister_of_Storms/npcs/Lightning_Protocrystal.lua
+++ b/scripts/zones/Cloister_of_Storms/npcs/Lightning_Protocrystal.lua
@@ -18,10 +18,7 @@ require("scripts/zones/Cloister_of_Storms/TextIDs");
 -----------------------------------
 
 function onTrade(player,npc,trade)
-
-    if (TradeBCNM(player,player:getZoneID(),trade,npc)) then
-        return;
-    end
+    TradeBCNM(player,npc,trade);
 end;
 
 -----------------------------------
@@ -43,13 +40,8 @@ end;
 -- onEventUpdate
 -----------------------------------
 
-function onEventUpdate(player,csid,option)
-    --printf("onUpdate CSID: %u",csid);
-    --printf("onUpdate RESULT: %u",option);
-
-    if (EventUpdateBCNM(player,csid,option)) then
-        return;
-    end
+function onEventUpdate(player,csid,option,extras)
+    EventUpdateBCNM(player,csid,option,extras);
 end;
 
 -----------------------------------

--- a/scripts/zones/Cloister_of_Tides/npcs/Water_Protocrystal.lua
+++ b/scripts/zones/Cloister_of_Tides/npcs/Water_Protocrystal.lua
@@ -16,11 +16,7 @@ require("scripts/zones/Cloister_of_Tides/TextIDs");
 -----------------------------------
 
 function onTrade(player,npc,trade)
-
-    if (TradeBCNM(player,player:getZoneID(),trade,npc)) then
-        return;
-    end
-
+    TradeBCNM(player,npc,trade);
 end;
 
 -----------------------------------
@@ -43,14 +39,8 @@ end;
 -- onEventUpdate
 -----------------------------------
 
-function onEventUpdate(player,csid,option)
-    -- printf("onUpdate CSID: %u",csid);
-    -- printf("onUpdate RESULT: %u",option);
-
-    if (EventUpdateBCNM(player,csid,option)) then
-        return;
-    end
-
+function onEventUpdate(player,csid,option,extras)
+    EventUpdateBCNM(player,csid,option,extras);
 end;
 
 -----------------------------------

--- a/scripts/zones/Cloister_of_Tremors/npcs/Earth_Protocrystal.lua
+++ b/scripts/zones/Cloister_of_Tremors/npcs/Earth_Protocrystal.lua
@@ -16,11 +16,7 @@ require("scripts/zones/Cloister_of_Tremors/TextIDs");
 -----------------------------------
 
 function onTrade(player,npc,trade)
-
-    if (TradeBCNM(player,player:getZoneID(),trade,npc)) then
-        return;
-    end
-
+    TradeBCNM(player,npc,trade);
 end;
 
 -----------------------------------
@@ -43,14 +39,8 @@ end;
 -- onEventUpdate
 -----------------------------------
 
-function onEventUpdate(player,csid,option)
-    -- printf("onUpdate CSID: %u",csid);
-    -- printf("onUpdate RESULT: %u",option);
-
-    if (EventUpdateBCNM(player,csid,option)) then
-        return;
-    end
-
+function onEventUpdate(player,csid,option,extras)
+    EventUpdateBCNM(player,csid,option,extras);
 end;
 
 -----------------------------------

--- a/scripts/zones/Dynamis-Bastok/Zone.lua
+++ b/scripts/zones/Dynamis-Bastok/Zone.lua
@@ -14,6 +14,7 @@ require("scripts/zones/Dynamis-Bastok/TextIDs");
 -----------------------------------
 
 function onInitialize(zone)
+    SetServerVariable("[DynaBastok]UniqueID", 0);
 end;
 
 -----------------------------------
@@ -41,19 +42,19 @@ function onZoneIn(player,prevZone)
         -- add player to the run if they entered via markings, or if they reconnected to a run they were previously in
         -- gms will be automatically registered
         if player:getVar("enteringDynamis") == 1 or player:getVar("DynamisID") == GetServerVariable("[DynaBastok]UniqueID") or player:getGMLevel() > 0 then
-            inst = player:addPlayerToDynamis(1280);
+            inst = player:addPlayerToBattlefield(1);
         end
     else
         -- no run yet in progress
         -- register run by player if they entered via markings
         -- gms will be automatically registered
         if player:getVar("enteringDynamis") == 1 or player:getGMLevel() > 0 then
-            inst = player:bcnmRegister(1280);
+            inst = player:registerBattlefield(1, 1280);
         end
     end
 
     if inst == 1 then
-        player:bcnmEnter(1280);
+        player:bcnmEnter(1);
         cs = -1;
         if ((player:getXPos() == 0) and (player:getYPos() == 0) and (player:getZPos() == 0)) then
             player:setPos(116.482,0.994,-72.121,128);

--- a/scripts/zones/Dynamis-Beaucedine/Zone.lua
+++ b/scripts/zones/Dynamis-Beaucedine/Zone.lua
@@ -14,6 +14,7 @@ require("scripts/zones/Dynamis-Beaucedine/TextIDs");
 -----------------------------------
 
 function onInitialize(zone)
+    SetServerVariable("[DynaBeaucedine]UniqueID", 0);
 end;
 
 -----------------------------------
@@ -41,19 +42,19 @@ function onZoneIn(player,prevZone)
         -- add player to the run if they entered via markings, or if they reconnected to a run they were previously in
         -- gms will be automatically registered
         if player:getVar("enteringDynamis") == 1 or player:getVar("DynamisID") == GetServerVariable("[DynaBeaucedine]UniqueID") or player:getGMLevel() > 0 then
-            inst = player:addPlayerToDynamis(1284);
+            inst = player:addPlayerToBattlefield(1);
         end
     else
         -- no run yet in progress
         -- register run by player if they entered via markings
         -- gms will be automatically registered
         if player:getVar("enteringDynamis") == 1 or player:getGMLevel() > 0 then
-            inst = player:bcnmRegister(1284);
+            inst = player:registerBattlefield(1, 1284);
         end
     end
 
     if inst == 1 then
-        player:bcnmEnter(1284);
+        player:bcnmEnter(1);
         cs = -1;
         if ((player:getXPos() == 0) and (player:getYPos() == 0) and (player:getZPos() == 0)) then
             player:setPos(-284.751,-39.923,-422.948,235);

--- a/scripts/zones/Dynamis-Buburimu/Zone.lua
+++ b/scripts/zones/Dynamis-Buburimu/Zone.lua
@@ -13,6 +13,7 @@ require("scripts/zones/Dynamis-Buburimu/TextIDs");
 -----------------------------------
 
 function onInitialize(zone)
+    SetServerVariable("[DynaBuburimu]UniqueID", 0);
 end;
 
 -----------------------------------
@@ -40,19 +41,19 @@ function onZoneIn(player,prevZone)
         -- add player to the run if they entered via markings, or if they reconnected to a run they were previously in
         -- gms will be automatically registered
         if player:getVar("enteringDynamis") == 1 or player:getVar("DynamisID") == GetServerVariable("[DynaBuburimu]UniqueID") or player:getGMLevel() > 0 then
-            inst = player:addPlayerToDynamis(1287);
+            inst = player:addPlayerToBattlefield(1);
         end
     else
         -- no run yet in progress
         -- register run by player if they entered via markings
         -- gms will be automatically registered
         if player:getVar("enteringDynamis") == 1 or player:getGMLevel() > 0 then
-            inst = player:bcnmRegister(1287);
+            inst = player:registerBattlefield(1, 1287);
         end
     end
 
     if inst == 1 then
-        player:bcnmEnter(1287);
+        player:bcnmEnter(1);
         cs = -1;
         if ((player:getXPos() == 0) and (player:getYPos() == 0) and (player:getZPos() == 0)) then
             player:setPos(155,-1,-169,170);

--- a/scripts/zones/Dynamis-Jeuno/Zone.lua
+++ b/scripts/zones/Dynamis-Jeuno/Zone.lua
@@ -14,6 +14,7 @@ require("scripts/zones/Dynamis-Jeuno/TextIDs");
 -----------------------------------
 
 function onInitialize(zone)
+    SetServerVariable("[DynaJeuno]UniqueID", 0);
 end;
 
 -----------------------------------
@@ -41,19 +42,19 @@ function onZoneIn(player,prevZone)
         -- add player to the run if they entered via markings, or if they reconnected to a run they were previously in
         -- gms will be automatically registered
         if player:getVar("enteringDynamis") == 1 or player:getVar("DynamisID") == GetServerVariable("[DynaJeuno]UniqueID") or player:getGMLevel() > 0 then
-            inst = player:addPlayerToDynamis(1283);
+            inst = player:addPlayerToBattlefield(1);
         end
     else
         -- no run yet in progress
         -- register run by player if they entered via markings
         -- gms will be automatically registered
         if player:getVar("enteringDynamis") == 1 or player:getGMLevel() > 0 then
-            inst = player:bcnmRegister(1283);
+            inst = player:registerBattlefield(1, 1283);
         end
     end
 
     if inst == 1 then
-        player:bcnmEnter(1283);
+        player:bcnmEnter(1);
         cs = -1;
         if ((player:getXPos() == 0) and (player:getYPos() == 0) and (player:getZPos() == 0)) then
             player:setPos(48.930,10.002,-71.032,195);

--- a/scripts/zones/Dynamis-Qufim/Zone.lua
+++ b/scripts/zones/Dynamis-Qufim/Zone.lua
@@ -13,6 +13,7 @@ require("scripts/zones/Dynamis-Qufim/TextIDs");
 -----------------------------------
 
 function onInitialize(zone)
+    SetServerVariable("[DynaQufim]UniqueID", 0);
 end;
 
 -----------------------------------
@@ -40,19 +41,19 @@ function onZoneIn(player,prevZone)
         -- add player to the run if they entered via markings, or if they reconnected to a run they were previously in
         -- gms will be automatically registered
         if player:getVar("enteringDynamis") == 1 or player:getVar("DynamisID") == GetServerVariable("[DynaQufim]UniqueID") or player:getGMLevel() > 0 then
-            inst = player:addPlayerToDynamis(1288);
+            inst = player:addPlayerToBattlefield(1);
         end
     else
         -- no run yet in progress
         -- register run by player if they entered via markings
         -- gms will be automatically registered
         if player:getVar("enteringDynamis") == 1 or player:getGMLevel() > 0 then
-            inst = player:bcnmRegister(1288);
+            inst = player:registerBattlefield(1, 1288);
         end
     end
 
     if inst == 1 then
-        player:bcnmEnter(1288);
+        player:bcnmEnter(1);
         cs = -1;
         if ((player:getXPos() == 0) and (player:getYPos() == 0) and (player:getZPos() == 0)) then
             player:setPos(-19,-17,104,253);

--- a/scripts/zones/Dynamis-San_dOria/Zone.lua
+++ b/scripts/zones/Dynamis-San_dOria/Zone.lua
@@ -14,6 +14,7 @@ require("scripts/zones/Dynamis-San_dOria/TextIDs");
 -----------------------------------
 
 function onInitialize(zone)
+    SetServerVariable("[DynaSandoria]UniqueID", 0);
 end;
 
 -----------------------------------
@@ -41,19 +42,19 @@ function onZoneIn(player,prevZone)
         -- add player to the run if they entered via markings, or if they reconnected to a run they were previously in
         -- gms will be automatically registered
         if player:getVar("enteringDynamis") == 1 or player:getVar("DynamisID") == GetServerVariable("[DynaSandoria]UniqueID") or player:getGMLevel() > 0 then
-            inst = player:addPlayerToDynamis(1281);
+            inst = player:addPlayerToBattlefield(1);
         end
     else
         -- no run yet in progress
         -- register run by player if they entered via markings
         -- gms will be automatically registered
         if player:getVar("enteringDynamis") == 1 or player:getGMLevel() > 0 then
-            inst = player:bcnmRegister(1281);
+            inst = player:registerBattlefield(1, 1281);
         end
     end
 
     if inst == 1 then
-        player:bcnmEnter(1281);
+        player:bcnmEnter(1);
         cs = -1;
         if ((player:getXPos() == 0) and (player:getYPos() == 0) and (player:getZPos() == 0)) then
             player:setPos(161.838,-2.000,161.673,93);

--- a/scripts/zones/Dynamis-Tavnazia/Zone.lua
+++ b/scripts/zones/Dynamis-Tavnazia/Zone.lua
@@ -13,6 +13,7 @@ require("scripts/zones/Dynamis-Tavnazia/TextIDs");
 -----------------------------------
 
 function onInitialize(zone)
+    SetServerVariable("[DynaTavnazia]UniqueID", 0);
 end;
 
 -----------------------------------
@@ -40,19 +41,19 @@ function onZoneIn(player,prevZone)
         -- add player to the run if they entered via markings, or if they reconnected to a run they were previously in
         -- gms will be automatically registered
         if player:getVar("enteringDynamis") == 1 or player:getVar("DynamisID") == GetServerVariable("[DynaTavnazia]UniqueID") or player:getGMLevel() > 0 then
-            inst = player:addPlayerToDynamis(1289);
+            inst = player:addPlayerToBattlefield(1);
         end
     else
         -- no run yet in progress
         -- register run by player if they entered via markings
         -- gms will be automatically registered
         if player:getVar("enteringDynamis") == 1 or player:getGMLevel() > 0 then
-            inst = player:bcnmRegister(1289);
+            inst = player:registerBattlefield(1, 1289);
         end
     end
 
     if inst == 1 then
-        player:bcnmEnter(1289);
+        player:bcnmEnter(1);
         cs = -1;
         if ((player:getXPos() == 0) and (player:getYPos() == 0) and (player:getZPos() == 0)) then
             player:setPos(0.1,-7,-21,190);

--- a/scripts/zones/Dynamis-Valkurm/Zone.lua
+++ b/scripts/zones/Dynamis-Valkurm/Zone.lua
@@ -14,6 +14,7 @@ require("scripts/zones/Dynamis-Valkurm/TextIDs");
 -----------------------------------
 
 function onInitialize(zone)
+    SetServerVariable("[DynaValkurm]UniqueID", 0);
 end;
 
 -----------------------------------
@@ -41,19 +42,19 @@ function onZoneIn(player,prevZone)
         -- add player to the run if they entered via markings, or if they reconnected to a run they were previously in
         -- gms will be automatically registered
         if player:getVar("enteringDynamis") == 1 or player:getVar("DynamisID") == GetServerVariable("[DynaValkurm]UniqueID") or player:getGMLevel() > 0 then
-            inst = player:addPlayerToDynamis(1286);
+            inst = player:addPlayerToBattlefield(1);
         end
     else
         -- no run yet in progress
         -- register run by player if they entered via markings
         -- gms will be automatically registered
         if player:getVar("enteringDynamis") == 1 or player:getGMLevel() > 0 then
-            inst = player:bcnmRegister(1286);
+            inst = player:registerBattlefield(1, 1286);
         end
     end
 
     if inst == 1 then
-        player:bcnmEnter(1286);
+        player:bcnmEnter(1);
         cs = -1;
         if ((player:getXPos() == 0) and (player:getYPos() == 0) and (player:getZPos() == 0)) then
             player:setPos(100,-8,131,47);

--- a/scripts/zones/Dynamis-Windurst/Zone.lua
+++ b/scripts/zones/Dynamis-Windurst/Zone.lua
@@ -14,6 +14,7 @@ require("scripts/zones/Dynamis-Windurst/TextIDs");
 -----------------------------------
 
 function onInitialize(zone)
+    SetServerVariable("[DynaWindurst]UniqueID", 0);
 end;
 
 -----------------------------------
@@ -41,19 +42,19 @@ function onZoneIn(player,prevZone)
         -- add player to the run if they entered via markings, or if they reconnected to a run they were previously in
         -- gms will be automatically registered
         if player:getVar("enteringDynamis") == 1 or player:getVar("DynamisID") == GetServerVariable("[DynaWindurst]UniqueID") or player:getGMLevel() > 0 then
-            inst = player:addPlayerToDynamis(1282);
+            inst = player:addPlayerToBattlefield(1);
         end
     else
         -- no run yet in progress
         -- register run by player if they entered via markings
         -- gms will be automatically registered
         if player:getVar("enteringDynamis") == 1 or player:getGMLevel() > 0 then
-            inst = player:bcnmRegister(1282);
+            inst = player:registerBattlefield(1, 1282);
         end
     end
 
     if inst == 1 then
-        player:bcnmEnter(1282);
+        player:bcnmEnter(1);
         cs = -1;
         if ((player:getXPos() == 0) and (player:getYPos() == 0) and (player:getZPos() == 0)) then
             player:setPos(-221.988,1.000,-120.184,0);

--- a/scripts/zones/Dynamis-Xarcabard/Zone.lua
+++ b/scripts/zones/Dynamis-Xarcabard/Zone.lua
@@ -14,6 +14,7 @@ require("scripts/zones/Dynamis-Xarcabard/TextIDs");
 -----------------------------------
 
 function onInitialize(zone)
+    SetServerVariable("[DynaXarcabard]UniqueID", 0);
 end;
 
 -----------------------------------
@@ -41,19 +42,19 @@ function onZoneIn(player,prevZone)
         -- add player to the run if they entered via markings, or if they reconnected to a run they were previously in
         -- gms will be automatically registered
         if player:getVar("enteringDynamis") == 1 or player:getVar("DynamisID") == GetServerVariable("[DynaXarcabard]UniqueID") or player:getGMLevel() > 0 then
-            inst = player:addPlayerToDynamis(1285);
+            inst = player:addPlayerToBattlefield(1);
         end
     else
         -- no run yet in progress
         -- register run by player if they entered via markings
         -- gms will be automatically registered
         if player:getVar("enteringDynamis") == 1 or player:getGMLevel() > 0 then
-            inst = player:bcnmRegister(1285);
+            inst = player:registerBattlefield(1, 1285);
         end
     end
 
     if inst == 1 then
-        player:bcnmEnter(1285);
+        player:bcnmEnter(1);
         cs = -1;
         if ((player:getXPos() == 0) and (player:getYPos() == 0) and (player:getZPos() == 0)) then
             player:setPos(569.312,-0.098,-270.158,90);

--- a/scripts/zones/Empyreal_Paradox/npcs/Transcendental.lua
+++ b/scripts/zones/Empyreal_Paradox/npcs/Transcendental.lua
@@ -17,7 +17,7 @@ require("scripts/globals/bcnm");
 
 function onTrade(player,npc,trade)
     
-    if (TradeBCNM(player,player:getZoneID(),trade,npc)) then
+    if (TradeBCNM(player,npc,trade)) then
         return;
     end
 
@@ -40,11 +40,8 @@ end;
 -- onEventUpdate
 -----------------------------------
 
-function onEventUpdate(player,csid,option)
-    -- printf("onUpdate CSID: %u",csid);
-    -- printf("onUpdate RESULT: %u",option);
-    
-    EventUpdateBCNM(player,csid,option)
+function onEventUpdate(player,csid,option,extras)
+    EventUpdateBCNM(player,csid,option,extras);
 end;
 
 -----------------------------------
@@ -55,9 +52,8 @@ function onEventFinish(player,csid,option)
     -- printf("onFinish CSID: %u",csid);
     -- printf("onFinish RESULT: %u",option);
     if ( csid == 0x0002) then
-     player:setVar("PromathiaStatus",2);
+        player:setVar("PromathiaStatus",2);
     elseif (EventFinishBCNM(player,csid,option)) then
         return;
     end
-
-    end;
+end;

--- a/scripts/zones/Full_Moon_Fountain/npcs/Moon_Spiral.lua
+++ b/scripts/zones/Full_Moon_Fountain/npcs/Moon_Spiral.lua
@@ -4,23 +4,15 @@
 -- Involved in Quests: The Moonlit Path
 -- !pos -302 9 -260 170
 -----------------------------------
-package.loaded["scripts/zones/Full_Moon_Fountain/TextIDs"] = nil;
--------------------------------------
 
 require("scripts/globals/bcnm");
-require("scripts/globals/quests");
-require("scripts/globals/missions");
-require("scripts/zones/Full_Moon_Fountain/TextIDs");
 
 -----------------------------------
 -- onTrade Action
 -----------------------------------
 
 function onTrade(player,npc,trade)
-
-    if (TradeBCNM(player,player:getZoneID(),trade,npc)) then
-        return;
-    end
+    TradeBCNM(player,npc,trade);
 end;
 
 -----------------------------------
@@ -28,23 +20,15 @@ end;
 -----------------------------------
 
 function onTrigger(player,npc)
-
-    if (EventTriggerBCNM(player,npc)) then
-        return;
-    end
+    EventTriggerBCNM(player,npc);
 end;
 
 -----------------------------------
 -- onEventUpdate
 -----------------------------------
 
-function onEventUpdate(player,csid,option)
-printf("onUpdate CSID: %u",csid);
-printf("onUpdate RESULT: %u",option);
-
-    if (EventUpdateBCNM(player,csid,option)) then
-        return;
-    end
+function onEventUpdate(player,csid,option,extras)
+    EventUpdateBCNM(player,csid,option,extras);
 end;
 
 -----------------------------------
@@ -52,10 +36,5 @@ end;
 -----------------------------------
 
 function onEventFinish(player,csid,option)
-printf("onFinish CSID: %u",csid);
-printf("onFinish RESULT: %u",option);
-
-    if (EventFinishBCNM(player,csid,option)) then
-        return;
-    end
+    EventFinishBCNM(player,csid,option);
 end;

--- a/scripts/zones/Ghelsba_Outpost/npcs/Armoury_Crate.lua
+++ b/scripts/zones/Ghelsba_Outpost/npcs/Armoury_Crate.lua
@@ -24,6 +24,7 @@ end;
 
 function onTrigger(player,npc)
     player:getBCNMloot();
+    npc:setStatus(STATUS_DISAPPEAR);
 end;
 
 -----------------------------------

--- a/scripts/zones/Ghelsba_Outpost/npcs/Hut_Door.lua
+++ b/scripts/zones/Ghelsba_Outpost/npcs/Hut_Door.lua
@@ -14,24 +14,12 @@ require("scripts/globals/quests");
 require("scripts/globals/missions");
 require("scripts/zones/Ghelsba_Outpost/TextIDs");
 
-    ---- 0:
-    ---- 1:
-    ---- 2:
-    ---- 3:
-    ---- 4:
-    ---- 5:
-    ---- 6:
-
 -----------------------------------
 -- onTrade Action
 -----------------------------------
 
 function onTrade(player,npc,trade)
-
-  if (TradeBCNM(player,player:getZoneID(),trade,npc)) then
-        return;
-    end
-
+    TradeBCNM(player,npc,trade);
 end;
 
 -----------------------------------
@@ -39,33 +27,25 @@ end;
 -----------------------------------
 
 function onTrigger(player,npc)
-
-  if (player:hasKeyItem(ORCISH_HUT_KEY)) then
+    if (player:hasKeyItem(ORCISH_HUT_KEY)) then
         if (player:hasCompletedMission(SANDORIA,SAVE_THE_CHILDREN)) then
             player:startEvent(0x0003);
         else
             player:startEvent(0x0037);
         end
-  else
-         if (EventTriggerBCNM(player,npc)) then
+    else
+        if (EventTriggerBCNM(player,npc)) then
             return;
+        end
     end
-  end
-
 end;
 
 -----------------------------------
 -- onEventUpdate
 -----------------------------------
 
-function onEventUpdate(player,csid,option)
-    -- printf("onUpdate CSID: %u",csid);
-    -- printf("onUpdate RESULT: %u",option);
-
-    if (EventUpdateBCNM(player,csid,option)) then
-        return;
-    end
-
+function onEventUpdate(player,csid,option,extras)
+    EventUpdateBCNM(player,csid,option,extras);
 end;
 
 -----------------------------------

--- a/scripts/zones/Horlais_Peak/npcs/Armoury_Crate.lua
+++ b/scripts/zones/Horlais_Peak/npcs/Armoury_Crate.lua
@@ -21,6 +21,7 @@ end;
 
 function onTrigger(player,npc)
     player:getBCNMloot();
+    npc:setStatus(STATUS_DISAPPEAR);
 end;
 
 -----------------------------------

--- a/scripts/zones/Horlais_Peak/npcs/Burning_Circle.lua
+++ b/scripts/zones/Horlais_Peak/npcs/Burning_Circle.lua
@@ -4,43 +4,15 @@
 -- Horlais Peak Burning Circle
 -- !pos -509 158 -211 139
 -------------------------------------
-package.loaded["scripts/zones/Horlais_Peak/TextIDs"] = nil;
--------------------------------------
 
 require("scripts/globals/bcnm");
-require("scripts/globals/quests");
-require("scripts/globals/missions");
-require("scripts/zones/Horlais_Peak/TextIDs");
-
-    --- 0: The Rank 2 Final Mission
-    --- 1: Tails of Woe
-    --- 2: Dismemberment Brigade
-    --- 3: The Secret Weapon (Sandy Mission 7-2)
-    --- 4: Hostile Herbivores
-    --- 5: Shattering Stars (WAR)
-    --- 6: Shattering Stars (BLM)
-    --- 7: Shattering Stars (RNG)
-    --- 8: Carapace Combatants
-    --- 9: Shooting Fish
-    --- 10: Dropping like Flies
-    --- 11: Horns of War
-    --- 12: Under Observation
-    --- 13: Eye of the Tiger
-    --- 14: Shots in the Dark
-    --- 15: Double Dragonian
-    --- 16: Today's Horoscope
-    --- 17: Contaminated Colosseum
 
 -----------------------------------
 -- onTrade Action
 -----------------------------------
 
 function onTrade(player,npc,trade)
-
-    if (TradeBCNM(player,player:getZoneID(),trade,npc)) then
-        return;
-    end
-
+    TradeBCNM(player,npc,trade);
 end;
 
 -----------------------------------
@@ -48,25 +20,15 @@ end;
 -----------------------------------
 
 function onTrigger(player,npc)
-
-    if (EventTriggerBCNM(player,npc)) then
-        return;
-    end
-
+    EventTriggerBCNM(player,npc);
 end;
 
 -----------------------------------
 -- onEventUpdate
 -----------------------------------
 
-function onEventUpdate(player,csid,option)
-    -- printf("onUpdate CSID: %u",csid);
-    -- printf("onUpdate RESULT: %u",option);
-
-    if (EventUpdateBCNM(player,csid,option)) then
-        return;
-    end
-
+function onEventUpdate(player,csid,option,extras)
+    EventUpdateBCNM(player,csid,option,extras);
 end;
 
 -----------------------------------
@@ -74,11 +36,5 @@ end;
 -----------------------------------
 
 function onEventFinish(player,csid,option)
-    -- printf("onFinish CSID: %u",csid);
-    -- printf("onFinish RESULT: %u",option);
-
-    if (EventFinishBCNM(player,csid,option)) then
-        return;
-    end
-
+    EventFinishBCNM(player,csid,option);
 end;

--- a/scripts/zones/Jade_Sepulcher/npcs/_1v0.lua
+++ b/scripts/zones/Jade_Sepulcher/npcs/_1v0.lua
@@ -38,14 +38,8 @@ end;
 -- onEventUpdate
 -----------------------------------
 
-function onEventUpdate(player,csid,option)
-    -- printf("onUpdate CSID: %u",csid);
-    -- printf("onUpdate RESULT: %u",option);
-    
-    if (EventUpdateBCNM(player,csid,option)) then
-        return;
-    end
-    
+function onEventUpdate(player,csid,option,extras)
+    EventUpdateBCNM(player,csid,option,extras);
 end;
 
 -----------------------------------

--- a/scripts/zones/LaLoff_Amphitheater/bcnms/ark_angels_1.lua
+++ b/scripts/zones/LaLoff_Amphitheater/bcnms/ark_angels_1.lua
@@ -42,11 +42,13 @@ function onBcnmLeave(player,instance,leavecode)
 --print("leave code "..leavecode);
 
     if (leavecode == 2) then -- play end CS. Need time and battle id for record keeping + storage
-    
+        local record = instance:getRecord();
+        local clearTime = record.clearTime;
+
         if (player:hasCompletedMission(ZILART,ARK_ANGELS)) then
-            player:startEvent(0x7d01,instance:getEntrance(),instance:getFastestTime(),1,instance:getTimeInside(),180,0,1);        -- winning CS (allow player to skip)
+            player:startEvent(0x7d01,instance:getEntrance(),clearTime,1,instance:getTimeInside(),180,0,1);        -- winning CS (allow player to skip)
         else
-            player:startEvent(0x7d01,instance:getEntrance(),instance:getFastestTime(),1,instance:getTimeInside(),180,0,0);        -- winning CS (allow player to skip)
+            player:startEvent(0x7d01,instance:getEntrance(),clearTime,1,instance:getTimeInside(),180,0,0);        -- winning CS (allow player to skip)
         end
         
     elseif (leavecode == 4) then

--- a/scripts/zones/LaLoff_Amphitheater/bcnms/ark_angels_2.lua
+++ b/scripts/zones/LaLoff_Amphitheater/bcnms/ark_angels_2.lua
@@ -42,10 +42,13 @@ function onBcnmLeave(player,instance,leavecode)
 --print("leave code "..leavecode);
 
     if (leavecode == 2) then -- play end CS. Need time and battle id for record keeping + storage
+        local record = instance:getRecord();
+        local clearTime = record.clearTime;
+
         if (player:hasCompletedMission(ZILART,ARK_ANGELS)) then
-            player:startEvent(0x7d01,instance:getEntrance(),instance:getFastestTime(),1,instance:getTimeInside(),180,1,1);        -- winning CS (allow player to skip)
+            player:startEvent(0x7d01,instance:getEntrance(),clearTime,1,instance:getTimeInside(),180,1,1);        -- winning CS (allow player to skip)
         else
-            player:startEvent(0x7d01,instance:getEntrance(),instance:getFastestTime(),1,instance:getTimeInside(),180,1,0);        -- winning CS (allow player to skip)
+            player:startEvent(0x7d01,instance:getEntrance(),clearTime,1,instance:getTimeInside(),180,1,0);        -- winning CS (allow player to skip)
         end
         
     elseif (leavecode == 4) then

--- a/scripts/zones/LaLoff_Amphitheater/bcnms/ark_angels_3.lua
+++ b/scripts/zones/LaLoff_Amphitheater/bcnms/ark_angels_3.lua
@@ -42,11 +42,13 @@ function onBcnmLeave(player,instance,leavecode)
 --print("leave code "..leavecode);
 
     if (leavecode == 2) then -- play end CS. Need time and battle id for record keeping + storage
+        local record = instance:getRecord();
+        local clearTime = record.clearTime;
     
         if (player:hasCompletedMission(ZILART,ARK_ANGELS)) then
-            player:startEvent(0x7d01,instance:getEntrance(),instance:getFastestTime(),1,instance:getTimeInside(),180,2,1);        -- winning CS (allow player to skip)
+            player:startEvent(0x7d01,instance:getEntrance(),clearTime,1,instance:getTimeInside(),180,2,1);        -- winning CS (allow player to skip)
         else
-            player:startEvent(0x7d01,instance:getEntrance(),instance:getFastestTime(),1,instance:getTimeInside(),180,2,0);        -- winning CS (allow player to skip)
+            player:startEvent(0x7d01,instance:getEntrance(),clearTime,1,instance:getTimeInside(),180,2,0);        -- winning CS (allow player to skip)
         end
         
     elseif (leavecode == 4) then

--- a/scripts/zones/LaLoff_Amphitheater/bcnms/ark_angels_4.lua
+++ b/scripts/zones/LaLoff_Amphitheater/bcnms/ark_angels_4.lua
@@ -42,11 +42,13 @@ function onBcnmLeave(player,instance,leavecode)
 --print("leave code "..leavecode);
 
     if (leavecode == 2) then -- play end CS. Need time and battle id for record keeping + storage
+        local record = instance:getRecord();
+        local clearTime = record.clearTime;
     
         if (player:hasCompletedMission(ZILART,ARK_ANGELS)) then
-            player:startEvent(0x7d01,instance:getEntrance(),instance:getFastestTime(),1,instance:getTimeInside(),180,3,1);        -- winning CS (allow player to skip)
+            player:startEvent(0x7d01,instance:getEntrance(),clearTime,1,instance:getTimeInside(),180,3,1);        -- winning CS (allow player to skip)
         else
-            player:startEvent(0x7d01,instance:getEntrance(),instance:getFastestTime(),1,instance:getTimeInside(),180,3,0);        -- winning CS (allow player to skip)
+            player:startEvent(0x7d01,instance:getEntrance(),clearTime,1,instance:getTimeInside(),180,3,0);        -- winning CS (allow player to skip)
         end
         
     elseif (leavecode == 4) then

--- a/scripts/zones/LaLoff_Amphitheater/bcnms/ark_angels_5.lua
+++ b/scripts/zones/LaLoff_Amphitheater/bcnms/ark_angels_5.lua
@@ -42,11 +42,13 @@ function onBcnmLeave(player,instance,leavecode)
 --print("leave code "..leavecode);
 
     if (leavecode == 2) then -- play end CS. Need time and battle id for record keeping + storage
+        local record = instance:getRecord();
+        local clearTime = record.clearTime;
     
         if (player:hasCompletedMission(ZILART,ARK_ANGELS)) then
-            player:startEvent(0x7d01,instance:getEntrance(),instance:getFastestTime(),1,instance:getTimeInside(),180,4,1);        -- winning CS (allow player to skip)
+            player:startEvent(0x7d01,instance:getEntrance(),clearTime,1,instance:getTimeInside(),180,4,1);        -- winning CS (allow player to skip)
         else
-            player:startEvent(0x7d01,instance:getEntrance(),instance:getFastestTime(),1,instance:getTimeInside(),180,4,0);        -- winning CS (allow player to skip)
+            player:startEvent(0x7d01,instance:getEntrance(),clearTime,1,instance:getTimeInside(),180,4,0);        -- winning CS (allow player to skip)
         end
         
     elseif (leavecode == 4) then

--- a/scripts/zones/LaLoff_Amphitheater/bcnms/divine_might.lua
+++ b/scripts/zones/LaLoff_Amphitheater/bcnms/divine_might.lua
@@ -44,10 +44,13 @@ function onBcnmLeave(player,instance,leavecode)
 --print("leave code "..leavecode);
 
     if (leavecode == 2) then -- play end CS. Need time and battle id for record keeping + storage
+        local record = instance:getRecord();
+        local clearTime = record.clearTime;
+    
         if (player:hasCompletedMission(ZILART,ARK_ANGELS)) then
-            player:startEvent(0x7d01,instance:getEntrance(),instance:getFastestTime(),1,instance:getTimeInside(),180,5,1);        -- winning CS (allow player to skip)
+            player:startEvent(0x7d01,instance:getEntrance(),clearTime,1,instance:getTimeInside(),180,5,1);        -- winning CS (allow player to skip)
         else
-            player:startEvent(0x7d01,instance:getEntrance(),instance:getFastestTime(),1,instance:getTimeInside(),180,5,0);        -- winning CS (allow player to skip)
+            player:startEvent(0x7d01,instance:getEntrance(),clearTime,1,instance:getTimeInside(),180,5,0);        -- winning CS (allow player to skip)
         end
 
     --[[ caps:

--- a/scripts/zones/LaLoff_Amphitheater/npcs/qm1_1.lua
+++ b/scripts/zones/LaLoff_Amphitheater/npcs/qm1_1.lua
@@ -2,38 +2,15 @@
 -- Area: LaLoff_Amphitheater
 -- NPC:  Shimmering Circle (BCNM Entrances)
 -------------------------------------
-package.loaded["scripts/zones/LaLoff_Amphitheater/TextIDs"] = nil;
-package.loaded["scripts/globals/bcnm"] = nil;
--------------------------------------
 
 require("scripts/globals/bcnm");
-require("scripts/globals/titles");
-require("scripts/globals/keyitems");
-require("scripts/globals/quests");
-require("scripts/globals/missions");
-require("scripts/zones/LaLoff_Amphitheater/TextIDs");
-
--- Death cutscenes:
-
--- param 1: entrance #
--- param 2: fastest time
--- param 3: unknown
--- param 4: clear time
--- param 5: zoneid
--- param 6: exit cs (0-4 AA, 5 DM, 6-10 neo AA, 11 neo DM)
--- param 7: skip (0 - no skip, 1 - prompt, 2 - force)
--- param 8: 0
 
 -----------------------------------
 -- onTrade Action
 -----------------------------------
 
 function onTrade(player,npc,trade)
-
-    if (TradeBCNM(player,player:getZoneID(),trade,npc)) then
-        return;
-    end
-
+    TradeBCNM(player,npc,trade);
 end;
 
 -----------------------------------
@@ -41,25 +18,15 @@ end;
 -----------------------------------
 
 function onTrigger(player,npc)
-
-    if (EventTriggerBCNM(player,npc)) then
-        return;
-    end
-    
+    EventTriggerBCNM(player,npc);
 end;
 
 -----------------------------------
 -- onEventUpdate
 -----------------------------------
 
-function onEventUpdate(player,csid,option)
--- printf("onUpdate CSID: %u",csid);
--- printf("onUpdate RESULT: %u",option);
-
-    if (EventUpdateBCNM(player,csid,option,1)) then
-        return;
-    end
-    
+function onEventUpdate(player,csid,option,extras)
+    EventUpdateBCNM(player,csid,option,extras,1);
 end;
 
 -----------------------------------
@@ -67,11 +34,5 @@ end;
 -----------------------------------
 
 function onEventFinish(player,csid,option)
-    -- printf("onFinish CSID: %u",csid);
-    -- printf("onFinish RESULT: %u",option);
-    
-    if (EventFinishBCNM(player,csid,option)) then
-        return;
-    end
-    
+    EventFinishBCNM(player,csid,option);
 end;

--- a/scripts/zones/LaLoff_Amphitheater/npcs/qm1_1.lua
+++ b/scripts/zones/LaLoff_Amphitheater/npcs/qm1_1.lua
@@ -15,13 +15,6 @@ require("scripts/zones/LaLoff_Amphitheater/TextIDs");
 
 -- Death cutscenes:
 
---    player:startEvent(0x7d01,1,instance:getFastestTime(),1,instance:getTimeInside(),1,0,0); -- hume
---    player:startEvent(0x7d01,1,instance:getFastestTime(),1,instance:getTimeInside(),1,1,0); -- taru
---    player:startEvent(0x7d01,1,instance:getFastestTime(),1,instance:getTimeInside(),1,2,0); -- mithra
---    player:startEvent(0x7d01,1,instance:getFastestTime(),1,instance:getTimeInside(),1,3,0); -- elvaan
---    player:startEvent(0x7d01,1,instance:getFastestTime(),1,instance:getTimeInside(),1,4,0); -- galka
---    player:startEvent(0x7d01,1,instance:getFastestTime(),1,instance:getTimeInside(),1,5,0); -- divine might
-
 -- param 1: entrance #
 -- param 2: fastest time
 -- param 3: unknown

--- a/scripts/zones/LaLoff_Amphitheater/npcs/qm1_2.lua
+++ b/scripts/zones/LaLoff_Amphitheater/npcs/qm1_2.lua
@@ -15,13 +15,6 @@ require("scripts/zones/LaLoff_Amphitheater/TextIDs");
 
 -- Death cutscenes:
 
---    player:startEvent(0x7d01,1,instance:getFastestTime(),1,instance:getTimeInside(),1,0,0); -- hume
---    player:startEvent(0x7d01,1,instance:getFastestTime(),1,instance:getTimeInside(),1,1,0); -- taru
---    player:startEvent(0x7d01,1,instance:getFastestTime(),1,instance:getTimeInside(),1,2,0); -- mithra
---    player:startEvent(0x7d01,1,instance:getFastestTime(),1,instance:getTimeInside(),1,3,0); -- elvaan
---    player:startEvent(0x7d01,1,instance:getFastestTime(),1,instance:getTimeInside(),1,4,0); -- galka
---    player:startEvent(0x7d01,1,instance:getFastestTime(),1,instance:getTimeInside(),1,5,0); -- divine might
-
 -- param 1: entrance #
 -- param 2: fastest time
 -- param 3: unknown

--- a/scripts/zones/LaLoff_Amphitheater/npcs/qm1_2.lua
+++ b/scripts/zones/LaLoff_Amphitheater/npcs/qm1_2.lua
@@ -2,38 +2,15 @@
 -- Area: LaLoff_Amphitheater
 -- NPC:  Shimmering Circle (BCNM Entrances)
 -------------------------------------
-package.loaded["scripts/zones/LaLoff_Amphitheater/TextIDs"] = nil;
-package.loaded["scripts/globals/bcnm"] = nil;
--------------------------------------
 
 require("scripts/globals/bcnm");
-require("scripts/globals/titles");
-require("scripts/globals/keyitems");
-require("scripts/globals/quests");
-require("scripts/globals/missions");
-require("scripts/zones/LaLoff_Amphitheater/TextIDs");
-
--- Death cutscenes:
-
--- param 1: entrance #
--- param 2: fastest time
--- param 3: unknown
--- param 4: clear time
--- param 5: zoneid
--- param 6: exit cs (0-4 AA, 5 DM, 6-10 neo AA, 11 neo DM)
--- param 7: skip (0 - no skip, 1 - prompt, 2 - force)
--- param 8: 0
 
 -----------------------------------
 -- onTrade Action
 -----------------------------------
 
 function onTrade(player,npc,trade)
-
-    if (TradeBCNM(player,player:getZoneID(),trade,npc)) then
-        return;
-    end
-
+    TradeBCNM(player,npc,trade);
 end;
 
 -----------------------------------
@@ -41,24 +18,15 @@ end;
 -----------------------------------
 
 function onTrigger(player,npc)
-    if (EventTriggerBCNM(player,npc)) then
-        return;
-    end
-    
+    EventTriggerBCNM(player,npc);
 end;
 
 -----------------------------------
 -- onEventUpdate
 -----------------------------------
 
-function onEventUpdate(player,csid,option)
--- printf("onUpdate CSID: %u",csid);
--- printf("onUpdate RESULT: %u",option);
-
-    if (EventUpdateBCNM(player,csid,option,2)) then
-        return;
-    end
-    
+function onEventUpdate(player,csid,option,extras)
+    EventUpdateBCNM(player,csid,option,extras,2);
 end;
 
 -----------------------------------
@@ -66,11 +34,5 @@ end;
 -----------------------------------
 
 function onEventFinish(player,csid,option)
-    -- printf("onFinish CSID: %u",csid);
-    -- printf("onFinish RESULT: %u",option);
-    
-    if (EventFinishBCNM(player,csid,option)) then
-        return;
-    end
-    
+    EventFinishBCNM(player,csid,option);
 end;

--- a/scripts/zones/LaLoff_Amphitheater/npcs/qm1_3.lua
+++ b/scripts/zones/LaLoff_Amphitheater/npcs/qm1_3.lua
@@ -2,38 +2,15 @@
 -- Area: LaLoff_Amphitheater
 -- NPC:  Shimmering Circle (BCNM Entrances)
 -------------------------------------
-package.loaded["scripts/zones/LaLoff_Amphitheater/TextIDs"] = nil;
-package.loaded["scripts/globals/bcnm"] = nil;
--------------------------------------
 
 require("scripts/globals/bcnm");
-require("scripts/globals/titles");
-require("scripts/globals/keyitems");
-require("scripts/globals/quests");
-require("scripts/globals/missions");
-require("scripts/zones/LaLoff_Amphitheater/TextIDs");
-
--- Death cutscenes:
-
--- param 1: entrance #
--- param 2: fastest time
--- param 3: unknown
--- param 4: clear time
--- param 5: zoneid
--- param 6: exit cs (0-4 AA, 5 DM, 6-10 neo AA, 11 neo DM)
--- param 7: skip (0 - no skip, 1 - prompt, 2 - force)
--- param 8: 0
 
 -----------------------------------
 -- onTrade Action
 -----------------------------------
 
 function onTrade(player,npc,trade)
-
-    if (TradeBCNM(player,player:getZoneID(),trade,npc)) then
-        return;
-    end
-
+    TradeBCNM(player,npc,trade);
 end;
 
 -----------------------------------
@@ -41,24 +18,15 @@ end;
 -----------------------------------
 
 function onTrigger(player,npc)
-    if (EventTriggerBCNM(player,npc)) then
-        return;
-    end
-    
+    EventTriggerBCNM(player,npc);
 end;
 
 -----------------------------------
 -- onEventUpdate
 -----------------------------------
 
-function onEventUpdate(player,csid,option)
--- printf("onUpdate CSID: %u",csid);
--- printf("onUpdate RESULT: %u",option);
-
-    if (EventUpdateBCNM(player,csid,option,3)) then
-        return;
-    end
-    
+function onEventUpdate(player,csid,option,extras)
+    EventUpdateBCNM(player,csid,option,extras,3);
 end;
 
 -----------------------------------
@@ -66,11 +34,5 @@ end;
 -----------------------------------
 
 function onEventFinish(player,csid,option)
-    -- printf("onFinish CSID: %u",csid);
-    -- printf("onFinish RESULT: %u",option);
-    
-    if (EventFinishBCNM(player,csid,option)) then
-        return;
-    end
-    
+    EventFinishBCNM(player,csid,option);
 end;

--- a/scripts/zones/LaLoff_Amphitheater/npcs/qm1_3.lua
+++ b/scripts/zones/LaLoff_Amphitheater/npcs/qm1_3.lua
@@ -15,13 +15,6 @@ require("scripts/zones/LaLoff_Amphitheater/TextIDs");
 
 -- Death cutscenes:
 
---    player:startEvent(0x7d01,1,instance:getFastestTime(),1,instance:getTimeInside(),1,0,0); -- hume
---    player:startEvent(0x7d01,1,instance:getFastestTime(),1,instance:getTimeInside(),1,1,0); -- taru
---    player:startEvent(0x7d01,1,instance:getFastestTime(),1,instance:getTimeInside(),1,2,0); -- mithra
---    player:startEvent(0x7d01,1,instance:getFastestTime(),1,instance:getTimeInside(),1,3,0); -- elvaan
---    player:startEvent(0x7d01,1,instance:getFastestTime(),1,instance:getTimeInside(),1,4,0); -- galka
---    player:startEvent(0x7d01,1,instance:getFastestTime(),1,instance:getTimeInside(),1,5,0); -- divine might
-
 -- param 1: entrance #
 -- param 2: fastest time
 -- param 3: unknown

--- a/scripts/zones/LaLoff_Amphitheater/npcs/qm1_4.lua
+++ b/scripts/zones/LaLoff_Amphitheater/npcs/qm1_4.lua
@@ -15,13 +15,6 @@ require("scripts/zones/LaLoff_Amphitheater/TextIDs");
 
 -- Death cutscenes:
 
---    player:startEvent(0x7d01,1,instance:getFastestTime(),1,instance:getTimeInside(),1,0,0); -- hume
---    player:startEvent(0x7d01,1,instance:getFastestTime(),1,instance:getTimeInside(),1,1,0); -- taru
---    player:startEvent(0x7d01,1,instance:getFastestTime(),1,instance:getTimeInside(),1,2,0); -- mithra
---    player:startEvent(0x7d01,1,instance:getFastestTime(),1,instance:getTimeInside(),1,3,0); -- elvaan
---    player:startEvent(0x7d01,1,instance:getFastestTime(),1,instance:getTimeInside(),1,4,0); -- galka
---    player:startEvent(0x7d01,1,instance:getFastestTime(),1,instance:getTimeInside(),1,5,0); -- divine might
-
 -- param 1: entrance #
 -- param 2: fastest time
 -- param 3: unknown

--- a/scripts/zones/LaLoff_Amphitheater/npcs/qm1_4.lua
+++ b/scripts/zones/LaLoff_Amphitheater/npcs/qm1_4.lua
@@ -2,38 +2,15 @@
 -- Area: LaLoff_Amphitheater
 -- NPC:  Shimmering Circle (BCNM Entrances)
 -------------------------------------
-package.loaded["scripts/zones/LaLoff_Amphitheater/TextIDs"] = nil;
-package.loaded["scripts/globals/bcnm"] = nil;
--------------------------------------
 
 require("scripts/globals/bcnm");
-require("scripts/globals/titles");
-require("scripts/globals/keyitems");
-require("scripts/globals/quests");
-require("scripts/globals/missions");
-require("scripts/zones/LaLoff_Amphitheater/TextIDs");
-
--- Death cutscenes:
-
--- param 1: entrance #
--- param 2: fastest time
--- param 3: unknown
--- param 4: clear time
--- param 5: zoneid
--- param 6: exit cs (0-4 AA, 5 DM, 6-10 neo AA, 11 neo DM)
--- param 7: skip (0 - no skip, 1 - prompt, 2 - force)
--- param 8: 0
 
 -----------------------------------
 -- onTrade Action
 -----------------------------------
 
 function onTrade(player,npc,trade)
-
-    if (TradeBCNM(player,player:getZoneID(),trade,npc)) then
-        return;
-    end
-
+    TradeBCNM(player,npc,trade);
 end;
 
 -----------------------------------
@@ -41,24 +18,15 @@ end;
 -----------------------------------
 
 function onTrigger(player,npc)
-    if (EventTriggerBCNM(player,npc)) then
-        return;
-    end
-    
+    EventTriggerBCNM(player,npc);
 end;
 
 -----------------------------------
 -- onEventUpdate
 -----------------------------------
 
-function onEventUpdate(player,csid,option)
--- printf("onUpdate CSID: %u",csid);
--- printf("onUpdate RESULT: %u",option);
-
-    if (EventUpdateBCNM(player,csid,option,4)) then
-        return;
-    end
-    
+function onEventUpdate(player,csid,option,extras)
+    EventUpdateBCNM(player,csid,option,extras,4);
 end;
 
 -----------------------------------
@@ -66,11 +34,5 @@ end;
 -----------------------------------
 
 function onEventFinish(player,csid,option)
-    -- printf("onFinish CSID: %u",csid);
-    -- printf("onFinish RESULT: %u",option);
-    
-    if (EventFinishBCNM(player,csid,option)) then
-        return;
-    end
-    
+    EventFinishBCNM(player,csid,option);
 end;

--- a/scripts/zones/LaLoff_Amphitheater/npcs/qm1_5.lua
+++ b/scripts/zones/LaLoff_Amphitheater/npcs/qm1_5.lua
@@ -15,13 +15,6 @@ require("scripts/zones/LaLoff_Amphitheater/TextIDs");
 
 -- Death cutscenes:
 
---    player:startEvent(0x7d01,1,instance:getFastestTime(),1,instance:getTimeInside(),1,0,0); -- hume
---    player:startEvent(0x7d01,1,instance:getFastestTime(),1,instance:getTimeInside(),1,1,0); -- taru
---    player:startEvent(0x7d01,1,instance:getFastestTime(),1,instance:getTimeInside(),1,2,0); -- mithra
---    player:startEvent(0x7d01,1,instance:getFastestTime(),1,instance:getTimeInside(),1,3,0); -- elvaan
---    player:startEvent(0x7d01,1,instance:getFastestTime(),1,instance:getTimeInside(),1,4,0); -- galka
---    player:startEvent(0x7d01,1,instance:getFastestTime(),1,instance:getTimeInside(),1,5,0); -- divine might
-
 -- param 1: entrance #
 -- param 2: fastest time
 -- param 3: unknown

--- a/scripts/zones/LaLoff_Amphitheater/npcs/qm1_5.lua
+++ b/scripts/zones/LaLoff_Amphitheater/npcs/qm1_5.lua
@@ -2,38 +2,15 @@
 -- Area: LaLoff_Amphitheater
 -- NPC:  Shimmering Circle (BCNM Entrances)
 -------------------------------------
-package.loaded["scripts/zones/LaLoff_Amphitheater/TextIDs"] = nil;
-package.loaded["scripts/globals/bcnm"] = nil;
--------------------------------------
 
 require("scripts/globals/bcnm");
-require("scripts/globals/titles");
-require("scripts/globals/keyitems");
-require("scripts/globals/quests");
-require("scripts/globals/missions");
-require("scripts/zones/LaLoff_Amphitheater/TextIDs");
-
--- Death cutscenes:
-
--- param 1: entrance #
--- param 2: fastest time
--- param 3: unknown
--- param 4: clear time
--- param 5: zoneid
--- param 6: exit cs (0-4 AA, 5 DM, 6-10 neo AA, 11 neo DM)
--- param 7: skip (0 - no skip, 1 - prompt, 2 - force)
--- param 8: 0
 
 -----------------------------------
 -- onTrade Action
 -----------------------------------
 
 function onTrade(player,npc,trade)
-
-    if (TradeBCNM(player,player:getZoneID(),trade,npc)) then
-        return;
-    end
-
+    TradeBCNM(player,npc,trade);
 end;
 
 -----------------------------------
@@ -41,24 +18,15 @@ end;
 -----------------------------------
 
 function onTrigger(player,npc)
-    if (EventTriggerBCNM(player,npc)) then
-        return;
-    end
-    
+    EventTriggerBCNM(player,npc);
 end;
 
 -----------------------------------
 -- onEventUpdate
 -----------------------------------
 
-function onEventUpdate(player,csid,option)
--- printf("onUpdate CSID: %u",csid);
--- printf("onUpdate RESULT: %u",option);
-
-    if (EventUpdateBCNM(player,csid,option,5)) then
-        return;
-    end
-    
+function onEventUpdate(player,csid,option,extras)
+    EventUpdateBCNM(player,csid,option,extras,5);
 end;
 
 -----------------------------------
@@ -66,11 +34,5 @@ end;
 -----------------------------------
 
 function onEventFinish(player,csid,option)
-    -- printf("onFinish CSID: %u",csid);
-    -- printf("onFinish RESULT: %u",option);
-    
-    if (EventFinishBCNM(player,csid,option)) then
-        return;
-    end
-    
+    EventFinishBCNM(player,csid,option);
 end;

--- a/scripts/zones/LaLoff_Amphitheater/npcs/qm2.lua
+++ b/scripts/zones/LaLoff_Amphitheater/npcs/qm2.lua
@@ -2,46 +2,15 @@
 -- Area: LaLoff_Amphitheater
 -- NPC:  Shimmering Circle (BCNM Exits)
 -------------------------------------
-package.loaded["scripts/zones/LaLoff_Amphitheater/TextIDs"] = nil;
--------------------------------------
 
 require("scripts/globals/bcnm");
-require("scripts/globals/titles");
-require("scripts/globals/keyitems");
-require("scripts/globals/quests");
-require("scripts/globals/missions");
-require("scripts/zones/LaLoff_Amphitheater/TextIDs");
-
-    ---- 0: 
-    ---- 1: 
-    ---- 2: 
-    ---- 3: 
-    ---- 4: 
-    ---- 5: 
-    ---- 6: 
-    ---- 7: 
-    ---- 8: 
-    ---- 9: 
--- Death cutscenes:
-
---    player:startEvent(0x7d01,1,1,1,instance:getTimeInside(),1,0,0); -- hume
---    player:startEvent(0x7d01,1,1,1,instance:getTimeInside(),1,1,0); -- taru
---    player:startEvent(0x7d01,1,1,1,instance:getTimeInside(),1,2,0); -- mithra
---    player:startEvent(0x7d01,1,1,1,instance:getTimeInside(),1,3,0); -- elvaan
---    player:startEvent(0x7d01,1,1,1,instance:getTimeInside(),1,4,0); -- galka
---    player:startEvent(0x7d01,1,1,1,instance:getTimeInside(),1,5,0); -- divine might
---    player:startEvent(0x7d01,1,1,1,instance:getTimeInside(),1,6,0); -- skip ending cs
 
 -----------------------------------
 -- onTrade Action
 -----------------------------------
 
 function onTrade(player,npc,trade)
-
-    if (TradeBCNM(player,player:getZoneID(),trade,npc)) then
-        return;
-    end
-
+    TradeBCNM(player,npc,trade);
 end;
 
 -----------------------------------
@@ -49,24 +18,15 @@ end;
 -----------------------------------
 
 function onTrigger(player,npc)
-    if (EventTriggerBCNM(player,npc)) then
-        return;
-    end
-    
+    EventTriggerBCNM(player,npc);
 end;
 
 -----------------------------------
 -- onEventUpdate
 -----------------------------------
 
-function onEventUpdate(player,csid,option)
--- printf("onUpdate CSID: %u",csid);
--- printf("onUpdate RESULT: %u",option);
-
-    if (EventUpdateBCNM(player,csid,option)) then
-        return;
-    end
-    
+function onEventUpdate(player,csid,option,extras)
+    EventUpdateBCNM(player,csid,option,extras);
 end;
 
 -----------------------------------
@@ -74,11 +34,5 @@ end;
 -----------------------------------
 
 function onEventFinish(player,csid,option)
-    -- printf("onFinish CSID: %u",csid);
-    -- printf("onFinish RESULT: %u",option);
-    
-    if (EventFinishBCNM(player,csid,option)) then
-        return;
-    end
-    
+    EventFinishBCNM(player,csid,option);
 end;

--- a/scripts/zones/Mine_Shaft_2716/npcs/_0d0.lua
+++ b/scripts/zones/Mine_Shaft_2716/npcs/_0d0.lua
@@ -6,7 +6,6 @@ package.loaded["scripts/zones/Mine_Shaft_2716/TextIDs"] = nil;
 -----------------------------------
 
 require("scripts/globals/bcnm");
-require("scripts/globals/quests");
 require("scripts/globals/missions");
 require("scripts/zones/Mine_Shaft_2716/TextIDs");
 
@@ -19,10 +18,9 @@ function onTrade(player,npc,trade)
         if (trade:getItemCount() == 1 and trade:hasItemQty(1684,1)) then            
             player:startEvent(0x0003);
         end
-    elseif (TradeBCNM(player,player:getZoneID(),trade,npc)) then
-        return;
+    else
+        TradeBCNM(player,npc,trade);
     end
-    
 end;
 
 -----------------------------------
@@ -30,26 +28,19 @@ end;
 -----------------------------------
 
 function onTrigger(player,npc)
-
     if (player:getCurrentMission(COP) ==FIRE_IN_THE_EYES_OF_MEN and player:getVar("PromathiaStatus")==0) then
-          player:startEvent(0x0004);
-    elseif (EventTriggerBCNM(player,npc)) then
-   end
-    return 1;
+        player:startEvent(0x0004);
+    else
+        EventTriggerBCNM(player,npc);
+    end
 end;
 
 -----------------------------------
 -- onEventUpdate
 -----------------------------------
 
-function onEventUpdate(player,csid,option)
-    -- printf("onUpdate CSID: %u",csid);
-    -- printf("onUpdate RESULT: %u",option);
-
-    if (EventUpdateBCNM(player,csid,option)) then
-        return;
-    end
-    
+function onEventUpdate(player,csid,option,extras)
+    EventUpdateBCNM(player,csid,option,extras);
 end;
 
 -----------------------------------
@@ -57,15 +48,12 @@ end;
 -----------------------------------
 
 function onEventFinish(player,csid,option)
-    -- printf("onFinish CSID: %u",csid);
-    -- printf("onFinish RESULT: %u",option);
     if (csid ==0x0003) then
-      player:setVar("COP_Louverance_s_Path",9);
-      player:tradeComplete();
-     elseif (csid ==0x0004) then 
-      player:setVar("PromathiaStatus",1);
-    elseif (EventFinishBCNM(player,csid,option)) then
-        return;
+        player:setVar("COP_Louverance_s_Path",9);
+        player:tradeComplete();
+    elseif (csid ==0x0004) then 
+        player:setVar("PromathiaStatus",1);
+    else
+        EventFinishBCNM(player,csid,option);
     end
-    
 end;

--- a/scripts/zones/Monarch_Linn/npcs/Spatial_Displacement.lua
+++ b/scripts/zones/Monarch_Linn/npcs/Spatial_Displacement.lua
@@ -17,7 +17,7 @@ require("scripts/zones/Monarch_Linn/TextIDs");
 
 function onTrade(player,npc,trade)
 
-    if (TradeBCNM(player,player:getZoneID(),trade,npc)) then
+    if (TradeBCNM(player,npc,trade)) then
         return;
     end
 
@@ -57,14 +57,8 @@ end;
 -- onEventUpdate
 -----------------------------------
 
-function onEventUpdate(player,csid,option)
-    -- printf("onUpdate CSID: %u",csid);
-    -- printf("onUpdate RESULT: %u",option);
-
-    if (EventUpdateBCNM(player,csid,option)) then
-        return;
-    end
-
+function onEventUpdate(player,csid,option,extras)
+    EventUpdateBCNM(player,csid,option,extras);
 end;
 
 -----------------------------------

--- a/scripts/zones/Navukgo_Execution_Chamber/npcs/_1s0.lua
+++ b/scripts/zones/Navukgo_Execution_Chamber/npcs/_1s0.lua
@@ -35,14 +35,8 @@ end;
 -- onEventUpdate
 -----------------------------------
 
-function onEventUpdate(player,csid,option)
-    -- printf("onUpdate CSID: %u",csid);
-    -- printf("onUpdate RESULT: %u",option);
-
-    if (EventUpdateBCNM(player,csid,option)) then
-        return;
-    end
-
+function onEventUpdate(player,csid,option,extras)
+    EventUpdateBCNM(player,csid,option,extras);
 end;
 
 -----------------------------------

--- a/scripts/zones/Navukgo_Execution_Chamber/npcs/_1s1.lua
+++ b/scripts/zones/Navukgo_Execution_Chamber/npcs/_1s1.lua
@@ -32,14 +32,8 @@ end;
 -- onEventUpdate
 -----------------------------------
 
-function onEventUpdate(player,csid,option)
-    -- printf("onUpdate CSID: %u",csid);
-    -- printf("onUpdate RESULT: %u",option);
-
-    if (EventUpdateBCNM(player,csid,option)) then
-        return;
-    end
-
+function onEventUpdate(player,csid,option,extras)
+    EventUpdateBCNM(player,csid,option,extras);
 end;
 
 -----------------------------------

--- a/scripts/zones/QuBia_Arena/npcs/Burning_Circle.lua
+++ b/scripts/zones/QuBia_Arena/npcs/Burning_Circle.lua
@@ -3,49 +3,15 @@
 -- NPC:  Burning Circle
 -- !pos -221 -24 19 206
 -------------------------------------
-package.loaded["scripts/zones/QuBia_Arena/TextIDs"] = nil;
--------------------------------------
 
 require("scripts/globals/bcnm");
-require("scripts/globals/missions");
-require("scripts/globals/keyitems");
-require("scripts/zones/QuBia_Arena/TextIDs");
-
--------------------------------------
-
-    -- 0: The Ruins of Fei'Yin, Darkness Rising, The Final Seal (Rank 5 Mission)
-    -- 1: Come Into My Parlor
-    -- 2: E-vase-ive Action
-    -- 3: Infernal Swarm
-    -- 4: The Heir to the Light
-    -- 5: Shattering Stars (Paladin)
-    -- 6: Shattering Stars (Dark Knight)
-    -- 7: Shattering Stars (Bard)
-    -- 8: Demolition Squad
-    -- 9: Die By the Sword
-    -- 10: Let Sleeping Dogs Die
-    -- 11: Brothers D'Aurphe
-    -- 12: Undying Promise
-    -- 13: Factory Rejects
-    -- 14: Idol Thoughts
-    -- 15: An Awful Autopsy
-    -- 16: Celery
-    -- 17: Mirror Images
-    -- 18: A Furious Finale (Dancer)
-    -- 19: Clash of the Comrades
-    -- 20: Those Who Lurk in the Shadows (III)
-    -- 21: Beyond Infinity
 
 -----------------------------------
 -- onTrade Action
 -----------------------------------
 
 function onTrade(player,npc,trade)
-
-    if (TradeBCNM(player,player:getZoneID(),trade,npc)) then
-        return;
-    end
-
+    TradeBCNM(player,npc,trade);
 end;
 
 -----------------------------------
@@ -53,30 +19,15 @@ end;
 -----------------------------------
 
 function onTrigger(player,npc)
-
-    -- if (player:hasKeyItem(MARK_OF_SEED) and player:getCurrentMission(ACP) == THOSE_WHO_LURK_IN_SHADOWS_II) then
-        --player:startEvent(0x005);
-    --elseif (EventTriggerBCNM(player,npc)) then
-    -- Temp disabled pending fixes for the BCNM mobs.
-
-    if (EventTriggerBCNM(player,npc)) then
-        return;
-    end
-
+    EventTriggerBCNM(player,npc);
 end;
 
 -----------------------------------
 -- onEventUpdate
 -----------------------------------
 
-function onEventUpdate(player,csid,option)
-    -- printf("onUpdate CSID: %u",csid);
-    -- printf("onUpdate RESULT: %u",option);
-
-    if (EventUpdateBCNM(player,csid,option)) then
-        return;
-    end
-
+function onEventUpdate(player,csid,option,extras)
+    EventUpdateBCNM(player,csid,option,extras);
 end;
 
 -----------------------------------
@@ -84,14 +35,5 @@ end;
 -----------------------------------
 
 function onEventFinish(player,csid,option)
-    -- printf("onFinish CSID: %u",csid);
-    -- printf("onFinish RESULT: %u",option);
-
-    if (csid == 0x005) then
-        player:completeMission(ACP,THOSE_WHO_LURK_IN_SHADOWS_II);
-        player:addMission(ACP,THOSE_WHO_LURK_IN_SHADOWS_III);
-    elseif (EventFinishBCNM(player,csid,option)) then
-        return;
-    end
-
+    EventFinishBCNM(player,csid,option);
 end;

--- a/scripts/zones/Riverne-Site_B01/npcs/Unstable_Displacement.lua
+++ b/scripts/zones/Riverne-Site_B01/npcs/Unstable_Displacement.lua
@@ -7,39 +7,16 @@
 package.loaded["scripts/zones/Riverne-Site_B01/TextIDs"] = nil;
 -----------------------------------
 
-require("scripts/globals/missions");
 require("scripts/zones/Riverne-Site_B01/TextIDs");
 require("scripts/globals/quests");
-require("scripts/globals/status");
 require("scripts/globals/bcnm");
-
-    -- events:
-    -- 7D00 : BC menu
-    -- Param 4 is a bitmask for the choice of battlefields in the menu:
-
-    -- 0:
-    -- 1:
-    -- 2:
-    -- 3:
-    -- 4:
-    -- 5:
-
-    -- Param 8 is a flag: 0 : menu, >0 : automatically enter and exit
-
-    -- 7D01 : final BC event.
-    -- param 2: #time record for this mission
-    -- param 3: #clear time in seconds
-    -- param 6: #which mission (linear numbering as above)
-    -- 7D03 : stay/run away
 
 -----------------------------------
 -- onTrade
 -----------------------------------
 
 function onTrade(player,npc,trade)
-    if (TradeBCNM(player,player:getZoneID(),trade,npc)) then
-        return;
-    end
+    TradeBCNM(player,npc,trade);
 end;
 
 -----------------------------------
@@ -60,13 +37,8 @@ end;
 -- onEventUpdate
 -----------------------------------
 
-function onEventUpdate(player,csid,option)
-    -- printf("CSID: %u",csid);
-    -- printf("RESULT: %u",option);
-
-    if (EventUpdateBCNM(player,csid,option)) then
-        return;
-    end
+function onEventUpdate(player,csid,option,extras)
+    EventUpdateBCNM(player,csid,option,extras);
 end;
 
 -----------------------------------

--- a/scripts/zones/Sacrificial_Chamber/npcs/Armoury_Crate.lua
+++ b/scripts/zones/Sacrificial_Chamber/npcs/Armoury_Crate.lua
@@ -21,6 +21,7 @@ end;
 
 function onTrigger(player,npc)
     player:getBCNMloot();
+    npc:setStatus(STATUS_DISAPPEAR);
 end;
 
 -----------------------------------

--- a/scripts/zones/Sacrificial_Chamber/npcs/_4j0.lua
+++ b/scripts/zones/Sacrificial_Chamber/npcs/_4j0.lua
@@ -15,11 +15,7 @@ require("scripts/zones/Sacrificial_Chamber/TextIDs");
 -----------------------------------
 
 function onTrade(player,npc,trade)
-
-    if (TradeBCNM(player,player:getZoneID(),trade,npc)) then
-        return;
-    end
-
+    TradeBCNM(player,npc,trade);
 end;
 
 -----------------------------------
@@ -40,14 +36,8 @@ end;
 -- onEventUpdate
 -----------------------------------
 
-function onEventUpdate(player,csid,option)
-    -- printf("onUpdate CSID: %u",csid);
-    -- printf("onUpdate RESULT: %u",option);
-
-    if (EventUpdateBCNM(player,csid,option)) then
-        return;
-    end
-
+function onEventUpdate(player,csid,option,extras)
+    EventUpdateBCNM(player,csid,option,extras);
 end;
 
 -----------------------------------

--- a/scripts/zones/Sacrificial_Chamber/npcs/_4j2.lua
+++ b/scripts/zones/Sacrificial_Chamber/npcs/_4j2.lua
@@ -15,11 +15,7 @@ require("scripts/zones/Sacrificial_Chamber/TextIDs");
 -----------------------------------
 
 function onTrade(player,npc,trade)
-
-    if (TradeBCNM(player,player:getZoneID(),trade,npc)) then
-        return;
-    end
-
+    TradeBCNM(player,npc,trade);
 end;
 
 -----------------------------------
@@ -38,14 +34,8 @@ end;
 -- onEventUpdate
 -----------------------------------
 
-function onEventUpdate(player,csid,option)
-    -- printf("onUpdate CSID: %u",csid);
-    -- printf("onUpdate RESULT: %u",option);
-
-    if (EventUpdateBCNM(player,csid,option)) then
-        return;
-    end
-
+function onEventUpdate(player,csid,option,extras)
+    EventUpdateBCNM(player,csid,option,extras);
 end;
 
 -----------------------------------

--- a/scripts/zones/Sacrificial_Chamber/npcs/_4j3.lua
+++ b/scripts/zones/Sacrificial_Chamber/npcs/_4j3.lua
@@ -15,11 +15,7 @@ require("scripts/zones/Sacrificial_Chamber/TextIDs");
 -----------------------------------
 
 function onTrade(player,npc,trade)
-
-    if (TradeBCNM(player,player:getZoneID(),trade,npc)) then
-        return;
-    end
-
+    TradeBCNM(player,npc,trade);
 end;
 
 -----------------------------------
@@ -38,14 +34,8 @@ end;
 -- onEventUpdate
 -----------------------------------
 
-function onEventUpdate(player,csid,option)
-    -- printf("onUpdate CSID: %u",csid);
-    -- printf("onUpdate RESULT: %u",option);
-
-    if (EventUpdateBCNM(player,csid,option)) then
-        return;
-    end
-
+function onEventUpdate(player,csid,option,extras)
+    EventUpdateBCNM(player,csid,option,extras);
 end;
 
 -----------------------------------

--- a/scripts/zones/Sacrificial_Chamber/npcs/_4j4.lua
+++ b/scripts/zones/Sacrificial_Chamber/npcs/_4j4.lua
@@ -15,11 +15,7 @@ require("scripts/zones/Sacrificial_Chamber/TextIDs");
 -----------------------------------
 
 function onTrade(player,npc,trade)
-
-    if (TradeBCNM(player,player:getZoneID(),trade,npc)) then
-        return;
-    end
-
+    TradeBCNM(player,npc,trade);
 end;
 
 -----------------------------------
@@ -38,14 +34,8 @@ end;
 -- onEventUpdate
 -----------------------------------
 
-function onEventUpdate(player,csid,option)
-    -- printf("onUpdate CSID: %u",csid);
-    -- printf("onUpdate RESULT: %u",option);
-
-    if (EventUpdateBCNM(player,csid,option)) then
-        return;
-    end
-
+function onEventUpdate(player,csid,option,extras)
+    EventUpdateBCNM(player,csid,option,extras);
 end;
 
 -----------------------------------

--- a/scripts/zones/Sealions_Den/npcs/_0w0.lua
+++ b/scripts/zones/Sealions_Den/npcs/_0w0.lua
@@ -17,11 +17,7 @@ require("scripts/zones/Sealions_Den/TextIDs");
 -----------------------------------
 
 function onTrade(player,npc,trade)
-
-    if (TradeBCNM(player,player:getZoneID(),trade,npc)) then
-        return;
-    end
-
+    TradeBCNM(player,npc,trade);
 end;
 
 -----------------------------------
@@ -42,10 +38,8 @@ end;
 -- onEventUpdate
 -----------------------------------
 
-function onEventUpdate(player,csid,option)
-    -- printf("onUpdate CSID: %u",csid);
-    -- printf("onUpdate RESULT: %u",option);
-    EventUpdateBCNM(player,csid,option)
+function onEventUpdate(player,csid,option,extras)
+    EventUpdateBCNM(player,csid,option,extras);
 end;
 
 -----------------------------------

--- a/scripts/zones/Spire_of_Dem/npcs/_0j0.lua
+++ b/scripts/zones/Spire_of_Dem/npcs/_0j0.lua
@@ -3,24 +3,15 @@
 -- NPC:  Web of Recollections
 -- !pos 0.000 -2.0 247.992 19
 -----------------------------------
-package.loaded["scripts/zones/Spire_of_Dem/TextIDs"] = nil;
------------------------------------
 
 require("scripts/globals/bcnm");
-require("scripts/globals/quests");
-require("scripts/globals/missions");
-require("scripts/zones/Spire_of_Dem/TextIDs");
 
 -----------------------------------
 -- onTrade Action
 -----------------------------------
 
 function onTrade(player,npc,trade)
-
-    if (TradeBCNM(player,player:getZoneID(),trade,npc)) then
-        return;
-    end
-
+    TradeBCNM(player,npc,trade);
 end;
 
 -----------------------------------
@@ -28,28 +19,15 @@ end;
 -----------------------------------
 
 function onTrigger(player,npc)
-
-    if (EventTriggerBCNM(player,npc)) then
-        return 1;
-    else
-        player:messageSpecial(FAINT_SCRAPING);
-        return 1;
-    end
-
+    EventTriggerBCNM(player,npc);
 end;
 
 -----------------------------------
 -- onEventUpdate
 -----------------------------------
 
-function onEventUpdate(player,csid,option)
-    -- printf("onUpdate CSID: %u",csid);
-    -- printf("onUpdate RESULT: %u",option);
-
-    if (EventUpdateBCNM(player,csid,option)) then
-        return;
-    end
-
+function onEventUpdate(player,csid,option,extras)
+    EventUpdateBCNM(player,csid,option,extras);
 end;
 
 -----------------------------------
@@ -57,11 +35,5 @@ end;
 -----------------------------------
 
 function onEventFinish(player,csid,option)
-    -- printf("onFinish CSID: %u",csid);
-    -- printf("onFinish RESULT: %u",option);
-
-    if (EventFinishBCNM(player,csid,option)) then
-        return;
-    end
-
+    EventFinishBCNM(player,csid,option);
 end;

--- a/scripts/zones/Spire_of_Dem/npcs/_0j1.lua
+++ b/scripts/zones/Spire_of_Dem/npcs/_0j1.lua
@@ -2,22 +2,15 @@
 -- Area: Spire_of_Dem
 -- NPC:  web of regret
 -----------------------------------
-package.loaded["scripts/zones/Spire_of_Dem/TextIDs"] = nil;
------------------------------------
 
 require("scripts/globals/bcnm");
-require("scripts/zones/Spire_of_Dem/TextIDs");
 
 -----------------------------------
 -- onTrade Action
 -----------------------------------
 
 function onTrade(player,npc,trade)
-    
-    if (TradeBCNM(player,player:getZoneID(),trade,npc)) then
-        return;
-    end
-    
+    TradeBCNM(player,npc,trade);
 end;
 
 -----------------------------------
@@ -25,25 +18,15 @@ end;
 -----------------------------------
 
 function onTrigger(player,npc)
-    
-    if (EventTriggerBCNM(player,npc)) then
-        return 1;
-    end
-    
+    EventTriggerBCNM(player,npc);
 end;
 
 -----------------------------------
 -- onEventUpdate
 -----------------------------------
 
-function onEventUpdate(player,csid,option)
-    -- printf("onUpdate CSID: %u",csid);
-    -- printf("onUpdate RESULT: %u",option);
-
-    if (EventUpdateBCNM(player,csid,option)) then
-        return;
-    end
-    
+function onEventUpdate(player,csid,option,extras)
+    EventUpdateBCNM(player,csid,option,extras);
 end;
 
 -----------------------------------
@@ -51,11 +34,5 @@ end;
 -----------------------------------
 
 function onEventFinish(player,csid,option)
-    -- printf("onFinish CSID: %u",csid);
-    -- printf("onFinish RESULT: %u",option);
-    
-    if (EventFinishBCNM(player,csid,option)) then
-        return;
-    end
-    
+    EventFinishBCNM(player,csid,option);
 end;

--- a/scripts/zones/Spire_of_Dem/npcs/_0j2.lua
+++ b/scripts/zones/Spire_of_Dem/npcs/_0j2.lua
@@ -2,22 +2,15 @@
 -- Area: Spire_of_Dem
 -- NPC:  web of regret
 -----------------------------------
-package.loaded["scripts/zones/Spire_of_Dem/TextIDs"] = nil;
------------------------------------
 
 require("scripts/globals/bcnm");
-require("scripts/zones/Spire_of_Dem/TextIDs");
 
 -----------------------------------
 -- onTrade Action
 -----------------------------------
 
 function onTrade(player,npc,trade)
-    
-    if (TradeBCNM(player,player:getZoneID(),trade,npc)) then
-        return;
-    end
-    
+    TradeBCNM(player,npc,trade);
 end;
 
 -----------------------------------
@@ -25,25 +18,15 @@ end;
 -----------------------------------
 
 function onTrigger(player,npc)
-    
-    if (EventTriggerBCNM(player,npc)) then
-        return 1;
-    end
-    
+    EventTriggerBCNM(player,npc);
 end;
 
 -----------------------------------
 -- onEventUpdate
 -----------------------------------
 
-function onEventUpdate(player,csid,option)
-    -- printf("onUpdate CSID: %u",csid);
-    -- printf("onUpdate RESULT: %u",option);
-
-    if (EventUpdateBCNM(player,csid,option)) then
-        return;
-    end
-    
+function onEventUpdate(player,csid,option,extras)
+    EventUpdateBCNM(player,csid,option,extras);
 end;
 
 -----------------------------------
@@ -51,11 +34,5 @@ end;
 -----------------------------------
 
 function onEventFinish(player,csid,option)
-    -- printf("onFinish CSID: %u",csid);
-    -- printf("onFinish RESULT: %u",option);
-    
-    if (EventFinishBCNM(player,csid,option)) then
-        return;
-    end
-    
+    EventFinishBCNM(player,csid,option);
 end;

--- a/scripts/zones/Spire_of_Dem/npcs/_0j3.lua
+++ b/scripts/zones/Spire_of_Dem/npcs/_0j3.lua
@@ -2,22 +2,15 @@
 -- Area: Spire_of_Dem
 -- NPC:  web of regret
 -----------------------------------
-package.loaded["scripts/zones/Spire_of_Dem/TextIDs"] = nil;
------------------------------------
 
 require("scripts/globals/bcnm");
-require("scripts/zones/Spire_of_Dem/TextIDs");
 
 -----------------------------------
 -- onTrade Action
 -----------------------------------
 
 function onTrade(player,npc,trade)
-    
-    if (TradeBCNM(player,player:getZoneID(),trade,npc)) then
-        return;
-    end
-    
+    TradeBCNM(player,npc,trade);
 end;
 
 -----------------------------------
@@ -25,25 +18,15 @@ end;
 -----------------------------------
 
 function onTrigger(player,npc)
-    
-    if (EventTriggerBCNM(player,npc)) then
-        return 1;
-    end
-    
+    EventTriggerBCNM(player,npc);
 end;
 
 -----------------------------------
 -- onEventUpdate
 -----------------------------------
 
-function onEventUpdate(player,csid,option)
-    -- printf("onUpdate CSID: %u",csid);
-    -- printf("onUpdate RESULT: %u",option);
-
-    if (EventUpdateBCNM(player,csid,option)) then
-        return;
-    end
-    
+function onEventUpdate(player,csid,option,extras)
+    EventUpdateBCNM(player,csid,option,extras);
 end;
 
 -----------------------------------
@@ -51,11 +34,5 @@ end;
 -----------------------------------
 
 function onEventFinish(player,csid,option)
-    -- printf("onFinish CSID: %u",csid);
-    -- printf("onFinish RESULT: %u",option);
-    
-    if (EventFinishBCNM(player,csid,option)) then
-        return;
-    end
-    
+    EventFinishBCNM(player,csid,option);
 end;

--- a/scripts/zones/Spire_of_Holla/npcs/_0h0.lua
+++ b/scripts/zones/Spire_of_Holla/npcs/_0h0.lua
@@ -2,24 +2,15 @@
 -- Area: Spire of Holla
 -- NPC:  Web of Recollection
 -----------------------------------
-package.loaded["scripts/zones/Spire_of_Holla/TextIDs"] = nil;
------------------------------------
 
 require("scripts/globals/bcnm");
-require("scripts/globals/quests");
-require("scripts/globals/missions");
-require("scripts/zones/Spire_of_Holla/TextIDs");
 
 -----------------------------------
 -- onTrade Action
 -----------------------------------
 
 function onTrade(player,npc,trade)
-    
-    if (TradeBCNM(player,player:getZoneID(),trade,npc)) then
-        return;
-    end
-    
+    TradeBCNM(player,npc,trade);
 end;
 
 -----------------------------------
@@ -27,28 +18,15 @@ end;
 -----------------------------------
 
 function onTrigger(player,npc)
-    
-    if (EventTriggerBCNM(player,npc)) then
-        return 1;
-    else
-        player:messageSpecial(FAINT_SCRAPING);
-        return 1;
-    end
-    
+    EventTriggerBCNM(player,npc);
 end;
 
 -----------------------------------
 -- onEventUpdate
 -----------------------------------
 
-function onEventUpdate(player,csid,option)
-    -- printf("onUpdate CSID: %u",csid);
-    -- printf("onUpdate RESULT: %u",option);
-
-    if (EventUpdateBCNM(player,csid,option)) then
-        return;
-    end
-    
+function onEventUpdate(player,csid,option,extras)
+    EventUpdateBCNM(player,csid,option,extras);
 end;
 
 -----------------------------------
@@ -56,11 +34,5 @@ end;
 -----------------------------------
 
 function onEventFinish(player,csid,option)
-    -- printf("onFinish CSID: %u",csid);
-    -- printf("onFinish RESULT: %u",option);
-    
-    if (EventFinishBCNM(player,csid,option)) then
-        return;
-    end
-    
+    EventFinishBCNM(player,csid,option);
 end;

--- a/scripts/zones/Spire_of_Holla/npcs/_0h1.lua
+++ b/scripts/zones/Spire_of_Holla/npcs/_0h1.lua
@@ -2,22 +2,15 @@
 -- Area: Spire_of_Holla
 -- NPC:  web of regret
 -----------------------------------
-package.loaded["scripts/zones/Spire_of_Holla/TextIDs"] = nil;
------------------------------------
 
 require("scripts/globals/bcnm");
-require("scripts/zones/Spire_of_Holla/TextIDs");
 
 -----------------------------------
 -- onTrade Action
 -----------------------------------
 
 function onTrade(player,npc,trade)
-    
-    if (TradeBCNM(player,player:getZoneID(),trade,npc)) then
-        return;
-    end
-    
+    TradeBCNM(player,npc,trade);
 end;
 
 -----------------------------------
@@ -25,25 +18,15 @@ end;
 -----------------------------------
 
 function onTrigger(player,npc)
-    
-    if (EventTriggerBCNM(player,npc)) then
-        return 1;
-    end
-    
+    EventTriggerBCNM(player,npc);
 end;
 
 -----------------------------------
 -- onEventUpdate
 -----------------------------------
 
-function onEventUpdate(player,csid,option)
-    -- printf("onUpdate CSID: %u",csid);
-    -- printf("onUpdate RESULT: %u",option);
-
-    if (EventUpdateBCNM(player,csid,option)) then
-        return;
-    end
-    
+function onEventUpdate(player,csid,option,extras)
+    EventUpdateBCNM(player,csid,option,extras);
 end;
 
 -----------------------------------
@@ -51,11 +34,5 @@ end;
 -----------------------------------
 
 function onEventFinish(player,csid,option)
-    -- printf("onFinish CSID: %u",csid);
-    -- printf("onFinish RESULT: %u",option);
-    
-    if (EventFinishBCNM(player,csid,option)) then
-        return;
-    end
-    
+    EventFinishBCNM(player,csid,option);
 end;

--- a/scripts/zones/Spire_of_Holla/npcs/_0h2.lua
+++ b/scripts/zones/Spire_of_Holla/npcs/_0h2.lua
@@ -2,22 +2,15 @@
 -- Area: Spire_of_Holla
 -- NPC:  web of regret
 -----------------------------------
-package.loaded["scripts/zones/Spire_of_Holla/TextIDs"] = nil;
------------------------------------
 
 require("scripts/globals/bcnm");
-require("scripts/zones/Spire_of_Holla/TextIDs");
 
 -----------------------------------
 -- onTrade Action
 -----------------------------------
 
 function onTrade(player,npc,trade)
-    
-    if (TradeBCNM(player,player:getZoneID(),trade,npc)) then
-        return;
-    end
-    
+    TradeBCNM(player,npc,trade);
 end;
 
 -----------------------------------
@@ -25,25 +18,15 @@ end;
 -----------------------------------
 
 function onTrigger(player,npc)
-    
-    if (EventTriggerBCNM(player,npc)) then
-        return 1;
-    end
-    
+    EventTriggerBCNM(player,npc);
 end;
 
 -----------------------------------
 -- onEventUpdate
 -----------------------------------
 
-function onEventUpdate(player,csid,option)
-    -- printf("onUpdate CSID: %u",csid);
-    -- printf("onUpdate RESULT: %u",option);
-
-    if (EventUpdateBCNM(player,csid,option)) then
-        return;
-    end
-    
+function onEventUpdate(player,csid,option,extras)
+    EventUpdateBCNM(player,csid,option,extras);
 end;
 
 -----------------------------------
@@ -51,11 +34,5 @@ end;
 -----------------------------------
 
 function onEventFinish(player,csid,option)
-    -- printf("onFinish CSID: %u",csid);
-    -- printf("onFinish RESULT: %u",option);
-    
-    if (EventFinishBCNM(player,csid,option)) then
-        return;
-    end
-    
+    EventFinishBCNM(player,csid,option);
 end;

--- a/scripts/zones/Spire_of_Holla/npcs/_0h3.lua
+++ b/scripts/zones/Spire_of_Holla/npcs/_0h3.lua
@@ -2,22 +2,15 @@
 -- Area: Spire_of_Holla
 -- NPC:  web of regret
 -----------------------------------
-package.loaded["scripts/zones/Spire_of_Holla/TextIDs"] = nil;
------------------------------------
 
 require("scripts/globals/bcnm");
-require("scripts/zones/Spire_of_Holla/TextIDs");
 
 -----------------------------------
 -- onTrade Action
 -----------------------------------
 
 function onTrade(player,npc,trade)
-    
-    if (TradeBCNM(player,player:getZoneID(),trade,npc)) then
-        return;
-    end
-    
+    TradeBCNM(player,npc,trade);
 end;
 
 -----------------------------------
@@ -25,25 +18,15 @@ end;
 -----------------------------------
 
 function onTrigger(player,npc)
-    
-    if (EventTriggerBCNM(player,npc)) then
-        return 1;
-    end
-    
+    EventTriggerBCNM(player,npc);
 end;
 
 -----------------------------------
 -- onEventUpdate
 -----------------------------------
 
-function onEventUpdate(player,csid,option)
-    -- printf("onUpdate CSID: %u",csid);
-    -- printf("onUpdate RESULT: %u",option);
-
-    if (EventUpdateBCNM(player,csid,option)) then
-        return;
-    end
-    
+function onEventUpdate(player,csid,option,extras)
+    EventUpdateBCNM(player,csid,option,extras);
 end;
 
 -----------------------------------
@@ -51,11 +34,5 @@ end;
 -----------------------------------
 
 function onEventFinish(player,csid,option)
-    -- printf("onFinish CSID: %u",csid);
-    -- printf("onFinish RESULT: %u",option);
-    
-    if (EventFinishBCNM(player,csid,option)) then
-        return;
-    end
-    
+    EventFinishBCNM(player,csid,option);
 end;

--- a/scripts/zones/Spire_of_Mea/npcs/_0l0.lua
+++ b/scripts/zones/Spire_of_Mea/npcs/_0l0.lua
@@ -2,24 +2,15 @@
 -- Area: Spire of Mea
 -- NPC:  Web of Recollection
 -----------------------------------
-package.loaded["scripts/zones/Spire_of_Mea/TextIDs"] = nil;
------------------------------------
 
 require("scripts/globals/bcnm");
-require("scripts/globals/quests");
-require("scripts/globals/missions");
-require("scripts/zones/Spire_of_Mea/TextIDs");
 
 -----------------------------------
 -- onTrade Action
 -----------------------------------
 
 function onTrade(player,npc,trade)
-    
-    if (TradeBCNM(player,player:getZoneID(),trade,npc)) then
-        return;
-    end
-    
+    TradeBCNM(player,npc,trade);
 end;
 
 -----------------------------------
@@ -27,28 +18,15 @@ end;
 -----------------------------------
 
 function onTrigger(player,npc)
-    
-    if (EventTriggerBCNM(player,npc)) then
-        return 1;
-    else
-        player:messageSpecial(FAINT_SCRAPING);
-        return 1;
-    end
-    
+    EventTriggerBCNM(player,npc);
 end;
 
 -----------------------------------
 -- onEventUpdate
 -----------------------------------
 
-function onEventUpdate(player,csid,option)
-    -- printf("onUpdate CSID: %u",csid);
-    -- printf("onUpdate RESULT: %u",option);
-
-    if (EventUpdateBCNM(player,csid,option)) then
-        return;
-    end
-    
+function onEventUpdate(player,csid,option,extras)
+    EventUpdateBCNM(player,csid,option,extras);
 end;
 
 -----------------------------------
@@ -56,11 +34,5 @@ end;
 -----------------------------------
 
 function onEventFinish(player,csid,option)
-    -- printf("onFinish CSID: %u",csid);
-    -- printf("onFinish RESULT: %u",option);
-    
-    if (EventFinishBCNM(player,csid,option)) then
-        return;
-    end
-    
+    EventFinishBCNM(player,csid,option);
 end;

--- a/scripts/zones/Spire_of_Mea/npcs/_0l1.lua
+++ b/scripts/zones/Spire_of_Mea/npcs/_0l1.lua
@@ -2,22 +2,15 @@
 -- Area: Spire_of_Mea
 -- NPC:  web of regret
 -----------------------------------
-package.loaded["scripts/zones/Spire_of_Mea/TextIDs"] = nil;
------------------------------------
 
 require("scripts/globals/bcnm");
-require("scripts/zones/Spire_of_Mea/TextIDs");
 
 -----------------------------------
 -- onTrade Action
 -----------------------------------
 
 function onTrade(player,npc,trade)
-    
-    if (TradeBCNM(player,player:getZoneID(),trade,npc)) then
-        return;
-    end
-    
+    TradeBCNM(player,npc,trade);
 end;
 
 -----------------------------------
@@ -25,25 +18,15 @@ end;
 -----------------------------------
 
 function onTrigger(player,npc)
-    
-    if (EventTriggerBCNM(player,npc)) then
-        return 1;
-    end
-    
+    EventTriggerBCNM(player,npc);
 end;
 
 -----------------------------------
 -- onEventUpdate
 -----------------------------------
 
-function onEventUpdate(player,csid,option)
-    -- printf("onUpdate CSID: %u",csid);
-    -- printf("onUpdate RESULT: %u",option);
-
-    if (EventUpdateBCNM(player,csid,option)) then
-        return;
-    end
-    
+function onEventUpdate(player,csid,option,extras)
+    EventUpdateBCNM(player,csid,option,extras);
 end;
 
 -----------------------------------
@@ -51,11 +34,5 @@ end;
 -----------------------------------
 
 function onEventFinish(player,csid,option)
-    -- printf("onFinish CSID: %u",csid);
-    -- printf("onFinish RESULT: %u",option);
-    
-    if (EventFinishBCNM(player,csid,option)) then
-        return;
-    end
-    
+    EventFinishBCNM(player,csid,option);
 end;

--- a/scripts/zones/Spire_of_Mea/npcs/_0l2.lua
+++ b/scripts/zones/Spire_of_Mea/npcs/_0l2.lua
@@ -2,22 +2,15 @@
 -- Area: Spire_of_Mea
 -- NPC:  web of regret
 -----------------------------------
-package.loaded["scripts/zones/Spire_of_Mea/TextIDs"] = nil;
------------------------------------
 
 require("scripts/globals/bcnm");
-require("scripts/zones/Spire_of_Mea/TextIDs");
 
 -----------------------------------
 -- onTrade Action
 -----------------------------------
 
 function onTrade(player,npc,trade)
-    
-    if (TradeBCNM(player,player:getZoneID(),trade,npc)) then
-        return;
-    end
-    
+    TradeBCNM(player,npc,trade);
 end;
 
 -----------------------------------
@@ -25,25 +18,15 @@ end;
 -----------------------------------
 
 function onTrigger(player,npc)
-    
-    if (EventTriggerBCNM(player,npc)) then
-        return 1;
-    end
-    
+    EventTriggerBCNM(player,npc);
 end;
 
 -----------------------------------
 -- onEventUpdate
 -----------------------------------
 
-function onEventUpdate(player,csid,option)
-    -- printf("onUpdate CSID: %u",csid);
-    -- printf("onUpdate RESULT: %u",option);
-
-    if (EventUpdateBCNM(player,csid,option)) then
-        return;
-    end
-    
+function onEventUpdate(player,csid,option,extras)
+    EventUpdateBCNM(player,csid,option,extras);
 end;
 
 -----------------------------------
@@ -51,11 +34,5 @@ end;
 -----------------------------------
 
 function onEventFinish(player,csid,option)
-    -- printf("onFinish CSID: %u",csid);
-    -- printf("onFinish RESULT: %u",option);
-    
-    if (EventFinishBCNM(player,csid,option)) then
-        return;
-    end
-    
+    EventFinishBCNM(player,csid,option);
 end;

--- a/scripts/zones/Spire_of_Mea/npcs/_0l3.lua
+++ b/scripts/zones/Spire_of_Mea/npcs/_0l3.lua
@@ -2,22 +2,15 @@
 -- Area: Spire_of_Mea
 -- NPC:  web of regret
 -----------------------------------
-package.loaded["scripts/zones/Spire_of_Mea/TextIDs"] = nil;
------------------------------------
 
 require("scripts/globals/bcnm");
-require("scripts/zones/Spire_of_Mea/TextIDs");
 
 -----------------------------------
 -- onTrade Action
 -----------------------------------
 
 function onTrade(player,npc,trade)
-    
-    if (TradeBCNM(player,player:getZoneID(),trade,npc)) then
-        return;
-    end
-    
+    TradeBCNM(player,npc,trade);
 end;
 
 -----------------------------------
@@ -25,25 +18,15 @@ end;
 -----------------------------------
 
 function onTrigger(player,npc)
-    
-    if (EventTriggerBCNM(player,npc)) then
-        return 1;
-    end
-    
+    EventTriggerBCNM(player,npc);
 end;
 
 -----------------------------------
 -- onEventUpdate
 -----------------------------------
 
-function onEventUpdate(player,csid,option)
-    -- printf("onUpdate CSID: %u",csid);
-    -- printf("onUpdate RESULT: %u",option);
-
-    if (EventUpdateBCNM(player,csid,option)) then
-        return;
-    end
-    
+function onEventUpdate(player,csid,option,extras)
+    EventUpdateBCNM(player,csid,option,extras);
 end;
 
 -----------------------------------
@@ -51,11 +34,5 @@ end;
 -----------------------------------
 
 function onEventFinish(player,csid,option)
-    -- printf("onFinish CSID: %u",csid);
-    -- printf("onFinish RESULT: %u",option);
-    
-    if (EventFinishBCNM(player,csid,option)) then
-        return;
-    end
-    
+    EventFinishBCNM(player,csid,option);
 end;

--- a/scripts/zones/Spire_of_Vahzl/npcs/_0n0.lua
+++ b/scripts/zones/Spire_of_Vahzl/npcs/_0n0.lua
@@ -2,27 +2,15 @@
 -- Area: Spire of Vahzl
 -- NPC:  Web of Recollection
 -----------------------------------
-package.loaded["scripts/zones/Spire_of_Vahzl/TextIDs"] = nil;
------------------------------------
 
 require("scripts/globals/bcnm");
-require("scripts/globals/quests");
-require("scripts/globals/missions");
-require("scripts/zones/Spire_of_Vahzl/TextIDs");
 
 -----------------------------------
 -- onTrade Action
 -----------------------------------
 
 function onTrade(player,npc,trade)
-    
-    if (TradeBCNM(player,player:getZoneID(),trade,npc)) then
-        return;
-    else
-        player:messageSpecial(FAINT_SCRAPING);
-        return 1;
-    end
-    
+    TradeBCNM(player,npc,trade);
 end;
 
 -----------------------------------
@@ -30,27 +18,15 @@ end;
 -----------------------------------
 
 function onTrigger(player,npc)
-    
-    if (EventTriggerBCNM(player,npc)) then
-        return 1;
-    else
-        return 1;
-   end
-    
+    EventTriggerBCNM(player,npc);
 end;
 
 -----------------------------------
 -- onEventUpdate
 -----------------------------------
 
-function onEventUpdate(player,csid,option)
-    -- printf("onUpdate CSID: %u",csid);
-    -- printf("onUpdate RESULT: %u",option);
-
-    if (EventUpdateBCNM(player,csid,option)) then
-        return;
-    end
-    
+function onEventUpdate(player,csid,option,extras)
+    EventUpdateBCNM(player,csid,option,extras);
 end;
 
 -----------------------------------
@@ -58,11 +34,5 @@ end;
 -----------------------------------
 
 function onEventFinish(player,csid,option)
-    -- printf("onFinish CSID: %u",csid);
-    -- printf("onFinish RESULT: %u",option);
-    
-    if (EventFinishBCNM(player,csid,option)) then
-        return;
-    end
-    
+    EventFinishBCNM(player,csid,option);
 end;

--- a/scripts/zones/Spire_of_Vahzl/npcs/_0n1.lua
+++ b/scripts/zones/Spire_of_Vahzl/npcs/_0n1.lua
@@ -2,22 +2,15 @@
 -- Area: Spire_of_vahlz
 -- NPC:  web of regret
 -----------------------------------
-package.loaded["scripts/zones/Spire_of_Vahzl/TextIDs"] = nil;
------------------------------------
 
 require("scripts/globals/bcnm");
-require("scripts/zones/Spire_of_Vahzl/TextIDs");
 
 -----------------------------------
 -- onTrade Action
 -----------------------------------
 
 function onTrade(player,npc,trade)
-    
-    if (TradeBCNM(player,player:getZoneID(),trade,npc)) then
-        return;
-    end
-    
+    TradeBCNM(player,npc,trade);
 end;
 
 -----------------------------------
@@ -25,25 +18,15 @@ end;
 -----------------------------------
 
 function onTrigger(player,npc)
-    
-    if (EventTriggerBCNM(player,npc)) then
-        return 1;
-    end
-    
+    EventTriggerBCNM(player,npc);
 end;
 
 -----------------------------------
 -- onEventUpdate
 -----------------------------------
 
-function onEventUpdate(player,csid,option)
-    -- printf("onUpdate CSID: %u",csid);
-    -- printf("onUpdate RESULT: %u",option);
-
-    if (EventUpdateBCNM(player,csid,option)) then
-        return;
-    end
-    
+function onEventUpdate(player,csid,option,extras)
+    EventUpdateBCNM(player,csid,option,extras);
 end;
 
 -----------------------------------
@@ -51,11 +34,5 @@ end;
 -----------------------------------
 
 function onEventFinish(player,csid,option)
-    -- printf("onFinish CSID: %u",csid);
-    -- printf("onFinish RESULT: %u",option);
-    
-    if (EventFinishBCNM(player,csid,option)) then
-        return;
-    end
-    
+    EventFinishBCNM(player,csid,option);
 end;

--- a/scripts/zones/Spire_of_Vahzl/npcs/_0n2.lua
+++ b/scripts/zones/Spire_of_Vahzl/npcs/_0n2.lua
@@ -2,22 +2,15 @@
 -- Area: Spire_of_vahlz
 -- NPC:  web of regret
 -----------------------------------
-package.loaded["scripts/zones/Spire_of_Vahzl/TextIDs"] = nil;
------------------------------------
 
 require("scripts/globals/bcnm");
-require("scripts/zones/Spire_of_Vahzl/TextIDs");
 
 -----------------------------------
 -- onTrade Action
 -----------------------------------
 
 function onTrade(player,npc,trade)
-    
-    if (TradeBCNM(player,player:getZoneID(),trade,npc)) then
-        return;
-    end
-    
+    TradeBCNM(player,npc,trade);
 end;
 
 -----------------------------------
@@ -25,25 +18,15 @@ end;
 -----------------------------------
 
 function onTrigger(player,npc)
-    
-    if (EventTriggerBCNM(player,npc)) then
-        return 1;
-    end
-    
+    EventTriggerBCNM(player,npc);
 end;
 
 -----------------------------------
 -- onEventUpdate
 -----------------------------------
 
-function onEventUpdate(player,csid,option)
-    -- printf("onUpdate CSID: %u",csid);
-    -- printf("onUpdate RESULT: %u",option);
-
-    if (EventUpdateBCNM(player,csid,option)) then
-        return;
-    end
-    
+function onEventUpdate(player,csid,option,extras)
+    EventUpdateBCNM(player,csid,option,extras);
 end;
 
 -----------------------------------
@@ -51,11 +34,5 @@ end;
 -----------------------------------
 
 function onEventFinish(player,csid,option)
-    -- printf("onFinish CSID: %u",csid);
-    -- printf("onFinish RESULT: %u",option);
-    
-    if (EventFinishBCNM(player,csid,option)) then
-        return;
-    end
-    
+    EventFinishBCNM(player,csid,option);
 end;

--- a/scripts/zones/Spire_of_Vahzl/npcs/_0n3.lua
+++ b/scripts/zones/Spire_of_Vahzl/npcs/_0n3.lua
@@ -2,22 +2,15 @@
 -- Area: Spire_of_vahlz
 -- NPC:  web of regret
 -----------------------------------
-package.loaded["scripts/zones/Spire_of_Vahzl/TextIDs"] = nil;
------------------------------------
 
 require("scripts/globals/bcnm");
-require("scripts/zones/Spire_of_Vahzl/TextIDs");
 
 -----------------------------------
 -- onTrade Action
 -----------------------------------
 
 function onTrade(player,npc,trade)
-    
-    if (TradeBCNM(player,player:getZoneID(),trade,npc)) then
-        return;
-    end
-    
+    TradeBCNM(player,npc,trade);
 end;
 
 -----------------------------------
@@ -25,25 +18,15 @@ end;
 -----------------------------------
 
 function onTrigger(player,npc)
-    
-    if (EventTriggerBCNM(player,npc)) then
-        return 1;
-    end
-    
+    EventTriggerBCNM(player,npc);
 end;
 
 -----------------------------------
 -- onEventUpdate
 -----------------------------------
 
-function onEventUpdate(player,csid,option)
-    -- printf("onUpdate CSID: %u",csid);
-    -- printf("onUpdate RESULT: %u",option);
-
-    if (EventUpdateBCNM(player,csid,option)) then
-        return;
-    end
-    
+function onEventUpdate(player,csid,option,extras)
+    EventUpdateBCNM(player,csid,option,extras);
 end;
 
 -----------------------------------
@@ -51,11 +34,5 @@ end;
 -----------------------------------
 
 function onEventFinish(player,csid,option)
-    -- printf("onFinish CSID: %u",csid);
-    -- printf("onFinish RESULT: %u",option);
-    
-    if (EventFinishBCNM(player,csid,option)) then
-        return;
-    end
-    
+    EventFinishBCNM(player,csid,option);
 end;

--- a/scripts/zones/Stellar_Fulcrum/npcs/_4z0.lua
+++ b/scripts/zones/Stellar_Fulcrum/npcs/_4z0.lua
@@ -3,32 +3,15 @@
 -- Door: Qe'Lov Gate
 -- !pos -520 -4 17 179
 -------------------------------------
-package.loaded["scripts/zones/Stellar_Fulcrum/TextIDs"] = nil;
-package.loaded["scripts/globals/bcnm"] = nil;
--------------------------------------
 
 require("scripts/globals/bcnm");
-require("scripts/globals/missions");
-require("scripts/zones/Stellar_Fulcrum/TextIDs");
-
-    -- events:
-    -- 7D00 : BC menu
-    -- Param 4 is a bitmask for the choice of battlefields in the menu:
-
-    -- 1/0: Zilart Mission 8
-    -- 2/1:
-    -- 3/2:
 
 -----------------------------------
--- onTrigger Action
+-- onTrade Action
 -----------------------------------
 
 function onTrade(player,npc,trade)
-
-    if (TradeBCNM(player,player:getZoneID(),trade,npc)) then
-        return;
-    end
-
+    TradeBCNM(player,npc,trade);
 end;
 
 -----------------------------------
@@ -36,25 +19,15 @@ end;
 -----------------------------------
 
 function onTrigger(player,npc)
-
-    if (EventTriggerBCNM(player,npc)) then
-        return 1;
-    end
-
+    EventTriggerBCNM(player,npc);
 end;
 
 -----------------------------------
 -- onEventUpdate
 -----------------------------------
 
-function onEventUpdate(player,csid,option)
-    -- printf("onUpdate CSID: %u",csid);
-    -- printf("onUpdate RESULT: %u",option);
-
-    if (EventUpdateBCNM(player,csid,option)) then
-        return;
-    end
-
+function onEventUpdate(player,csid,option,extras)
+    EventUpdateBCNM(player,csid,option,extras);
 end;
 
 -----------------------------------
@@ -62,11 +35,5 @@ end;
 -----------------------------------
 
 function onEventFinish(player,csid,option)
-    -- printf("onFinish CSID: %u",csid);
-    -- printf("onFinish RESULT: %u",option);
-
-    if (EventFinishBCNM(player,csid,option)) then
-        return;
-    end
-
+    EventFinishBCNM(player,csid,option);
 end;

--- a/scripts/zones/Talacca_Cove/npcs/_1l0.lua
+++ b/scripts/zones/Talacca_Cove/npcs/_1l0.lua
@@ -16,6 +16,7 @@ require("scripts/globals/keyitems");
 -----------------------------------
 
 function onTrade(player,npc,trade)
+    TradeBCNM(player,npc,trade);
 end;
 
 -----------------------------------
@@ -38,14 +39,8 @@ end;
 -- onEventUpdate
 -----------------------------------
 
-function onEventUpdate(player,csid,option)
--- printf("CSID: %u",csid);
--- printf("RESULT: %u",option);
-
-    if (EventUpdateBCNM(player,csid,option)) then
-        return;
-    end
-
+function onEventUpdate(player,csid,option,extras)
+    EventUpdateBCNM(player,csid,option,extras);
 end;
 
 -----------------------------------

--- a/scripts/zones/Temenos/Zone.lua
+++ b/scripts/zones/Temenos/Zone.lua
@@ -7,8 +7,8 @@ package.loaded["scripts/zones/Temenos/TextIDs"] = nil;
 -----------------------------------
 
 require("scripts/globals/settings");
-require("scripts/zones/Temenos/TextIDs");
 require("scripts/globals/limbus");
+require("scripts/zones/Temenos/TextIDs");
 
 -----------------------------------
 -- onInitialize
@@ -25,17 +25,7 @@ function onInitialize(zone)
     SetServerVariable("[C_Temenos_3rd]UniqueID",0);
     SetServerVariable("[C_Temenos_4th]UniqueID",0);
     SetServerVariable("[C_Temenos_4th_II]UniqueID",0);
-
-    zone:registerRegion(1,  378,70,-186    ,382,72,-182); -- 'Temenos_Western_Tower'    380 71 -184
-    zone:registerRegion(2,  378,70,373    ,382,72,377); -- 'Temenos_Northern_Tower'   380 71 375
-    zone:registerRegion(3,  378,-4,93    ,382,4,98); -- 'Temenos_Eastern_Tower'    380 -2 96
-    zone:registerRegion(4,  578,-4,-546    ,582,4,-542); -- 'Central_Temenos_Basement' 580 -2 -544
-    zone:registerRegion(5,  258,-164,-506    ,262,-160,-502); -- 'Central_Temenos_1st_Floor' 260 -162 -504
-    zone:registerRegion(6,  18,-4,-546    ,22,4,-542); -- 'Central_Temenos_2nd_Floor' 20 -2 -544
-    zone:registerRegion(7,  -298,-164,-502    ,-294,-160,-498); -- 'Central_Temenos_3rd_Floor' -296 -162 -500
-    zone:registerRegion(8,  -542,-4,-586    ,-538,4,-582); -- 'Central_Temenos_4th_Floor'  -540 -2  -584
 end;
-
 
 -----------------------------------
 -- onConquestUpdate
@@ -54,8 +44,31 @@ end;
 -----------------------------------
 
 function onZoneIn(player,prevZone)
-    local cs = -1;
+    local cs = 0;
+
+    player:delStatusEffect(EFFECT_LIMBUS);
+    local inst = belongsInBattlefield(player);
+    
+    -- player is returning from disconnect, so add them to matching run in progress
+    if (inst > 0 and not player:isBattlefieldFree(inst)) then
+        player:addPlayerToBattlefield(inst);
+        local x, y, z = getBattlefieldEntrance(player, inst);
+        printf("%s reconnected to battlefield. Moving to x=%f y=%f z=%f",player:getName(),x,y,z);
+        player:setPos(x,y,z);
+        cs = -1;
+    
+    -- GM can goto players in battlefield, and should not be set to entrance
+    elseif (player:getGMLevel() > 0) then
+        if ((player:getXPos() == 0) and (player:getYPos() == 0) and (player:getZPos() == 0)) then
+            player:setPos(580,-1.5,4.452,192);
+        end
+
+    -- everyone else should be put at the entrance        
+    else
         player:setPos(580,-1.5,4.452,192);
+        
+    end
+    
     return cs;
 end;
 
@@ -64,64 +77,15 @@ end;
 -----------------------------------
 
 function onRegionEnter(player,region)
-    local regionID = region:GetRegionID();
-
-    switch (regionID): caseof
-    {
-        [1] = function (x)
-            if (player:hasStatusEffect(EFFECT_BATTLEFIELD) == false) then
-                -- create instance   Temenos_Western_Tower
-                RegisterLimbusInstance(player,1298);
-            end
-        end,
-        [2] = function (x)
-            if (player:hasStatusEffect(EFFECT_BATTLEFIELD) == false) then
-                -- create instance Temenos_Northern_Tower
-                RegisterLimbusInstance(player,1299);
-            end
-        end,
-        [3] = function (x)
-            if (player:hasStatusEffect(EFFECT_BATTLEFIELD) == false) then
-                -- create instance Temenos_Eastern_Tower
-                RegisterLimbusInstance(player,1300);
-            end
-        end,
-        [4] = function (x)
-            if (player:hasStatusEffect(EFFECT_BATTLEFIELD) == false) then
-                -- create instance  Central_Temenos_Basement
-                RegisterLimbusInstance(player,1301);
-            end
-        end,
-        [5] = function (x)
-            if (player:hasStatusEffect(EFFECT_BATTLEFIELD) == false) then
-                -- create instance Central_Temenos_1st_Floor
-                RegisterLimbusInstance(player,1303);
-            end
-        end,
-        [6] = function (x)
-            if (player:hasStatusEffect(EFFECT_BATTLEFIELD) == false) then
-                -- create instance   Central_Temenos_2nd_Floor
-                RegisterLimbusInstance(player,1304);
-            end
-        end,
-        [7] = function (x)
-            if (player:hasStatusEffect(EFFECT_BATTLEFIELD) == false) then
-                -- create instance Central_Temenos_3rd_Floor
-                RegisterLimbusInstance(player,1305);
-            end
-        end,
-        [8] = function (x)
-            if (player:hasStatusEffect(EFFECT_BATTLEFIELD) == false) then
-                -- create instance Central_Temenos_4th_Floor
-                RegisterLimbusInstance(player,1306);
-            end
-        end,
-    }
 end;
 
+-----------------------------------
+-- onRegionLeave
+-----------------------------------
 
 function onRegionLeave(player,region)
 end;
+
 -----------------------------------
 -- onEventUpdate
 -----------------------------------

--- a/scripts/zones/Temenos/bcnms/central_temenos_1st_floor.lua
+++ b/scripts/zones/Temenos/bcnms/central_temenos_1st_floor.lua
@@ -1,23 +1,20 @@
 -----------------------------------
 -- Area: Temenos
--- Name: 
+-- Name: Central Temenos 1st Floor
 -----------------------------------
-
-
+require("scripts/globals/limbus");
+require("scripts/globals/keyitems");
 
 -- After registering the BCNM via bcnmRegister(bcnmid)
 function onBcnmRegister(player,instance)        
-    SetServerVariable("[C_Temenos_1st]UniqueID",GenerateLimbusKey());
-    HideArmouryCrates(GetInstanceRegion(1303),TEMENOS);        
-    HideTemenosDoor(GetInstanceRegion(1303));
-    player:setVar("Limbus_Trade_Item-T",0);
+    SetServerVariable("[C_Temenos_1st]UniqueID",os.time());
+    HideArmouryCrates(Central_Temenos_1st_Floor,TEMENOS);        
+    HideTemenosDoor(Central_Temenos_1st_Floor);
 end;
 
 -- Physically entering the BCNM via bcnmEnter(bcnmid)
 function onBcnmEnter(player,instance)
-    player:setVar("limbusbitmap",0);
     player:setVar("characterLimbusKey",GetServerVariable("[C_Temenos_1st]UniqueID"));
-    player:setVar("LimbusID",1303);    
     player:delKeyItem(COSMOCLEANSE);
     player:delKeyItem(WHITE_CARD);
 end;
@@ -27,10 +24,9 @@ end;
 -- 4=Finish he dynamis
 
 function onBcnmLeave(player,instance,leavecode)
---print("leave code "..leavecode);
+    --print("leave code "..leavecode);
     if (leavecode == 4) then
-         player:setPos(580,-1.5,4.452,192);
-        ResetPlayerLimbusVariable(player)
+        SetServerVariable("[C_Temenos_1st]UniqueID",0);
+        player:setPos(580,-1.5,4.452,192);
     end
-    
 end;

--- a/scripts/zones/Temenos/bcnms/central_temenos_2nd_floor.lua
+++ b/scripts/zones/Temenos/bcnms/central_temenos_2nd_floor.lua
@@ -1,29 +1,26 @@
 -----------------------------------
 -- Area: Temenos
--- Name: 
+-- Name: Central Temenos 2nd Floor
 -----------------------------------
-
-
+require("scripts/globals/limbus");
+require("scripts/globals/keyitems");
 
 -- After registering the BCNM via bcnmRegister(bcnmid)
 function onBcnmRegister(player,instance)
-if (GetMobAction(16929039) > 0) then DespawnMob(16929039);end
-if (GetMobAction(16929040) > 0) then DespawnMob(16929040);end
-if (GetMobAction(16929041) > 0) then DespawnMob(16929041);end
-if (GetMobAction(16929042) > 0) then DespawnMob(16929042);end
-if (GetMobAction(16929043) > 0) then DespawnMob(16929043);end
-if (GetMobAction(16929044) > 0) then DespawnMob(16929044);end
-    SetServerVariable("[C_Temenos_2nd]UniqueID",GenerateLimbusKey());
-    HideArmouryCrates(GetInstanceRegion(1304),TEMENOS);        
-    HideTemenosDoor(GetInstanceRegion(1304));
-    player:setVar("Limbus_Trade_Item-T",0);        
+    if (GetMobByID(16929039):isSpawned()) then DespawnMob(16929039); end
+    if (GetMobByID(16929040):isSpawned()) then DespawnMob(16929040); end
+    if (GetMobByID(16929041):isSpawned()) then DespawnMob(16929041); end
+    if (GetMobByID(16929042):isSpawned()) then DespawnMob(16929042); end
+    if (GetMobByID(16929043):isSpawned()) then DespawnMob(16929043); end
+    if (GetMobByID(16929044):isSpawned()) then DespawnMob(16929044); end
+    SetServerVariable("[C_Temenos_2nd]UniqueID",os.time());
+    HideArmouryCrates(Central_Temenos_2nd_Floor,TEMENOS);        
+    HideTemenosDoor(Central_Temenos_2nd_Floor);
 end;
 
 -- Physically entering the BCNM via bcnmEnter(bcnmid)
 function onBcnmEnter(player,instance)
-    player:setVar("limbusbitmap",0);
     player:setVar("characterLimbusKey",GetServerVariable("[C_Temenos_2nd]UniqueID"));
-    player:setVar("LimbusID",1304);    
     player:delKeyItem(COSMOCLEANSE);
     player:delKeyItem(WHITE_CARD);
 end;
@@ -33,9 +30,9 @@ end;
 -- 4=Finish he dynamis
 
 function onBcnmLeave(player,instance,leavecode)
---print("leave code "..leavecode);
+    --print("leave code "..leavecode);
     if (leavecode == 4) then
-         player:setPos(580,-1.5,4.452,192);
-        ResetPlayerLimbusVariable(player)
+        SetServerVariable("[C_Temenos_2nd]UniqueID",0);
+        player:setPos(580,-1.5,4.452,192);
     end
 end;

--- a/scripts/zones/Temenos/bcnms/central_temenos_3rd_floor.lua
+++ b/scripts/zones/Temenos/bcnms/central_temenos_3rd_floor.lua
@@ -1,23 +1,20 @@
 -----------------------------------
 -- Area: Temenos
--- Name: 
+-- Name: Central Temenos 3rd Floor
 -----------------------------------
-
-
+require("scripts/globals/limbus");
+require("scripts/globals/keyitems");
 
 -- After registering the BCNM via bcnmRegister(bcnmid)
 function onBcnmRegister(player,instance)    
-    SetServerVariable("[C_Temenos_3rd]UniqueID",GenerateLimbusKey());
-    HideArmouryCrates(GetInstanceRegion(1305),TEMENOS);        
-    HideTemenosDoor(GetInstanceRegion(1305));
-    player:setVar("Limbus_Trade_Item-T",0);        
+    SetServerVariable("[C_Temenos_3rd]UniqueID",os.time());
+    HideArmouryCrates(Central_Temenos_3rd_Floor,TEMENOS);        
+    HideTemenosDoor(Central_Temenos_3rd_Floor);
 end;
 
 -- Physically entering the BCNM via bcnmEnter(bcnmid)
 function onBcnmEnter(player,instance)
-    player:setVar("limbusbitmap",0);
     player:setVar("characterLimbusKey",GetServerVariable("[C_Temenos_3rd]UniqueID"));
-    player:setVar("LimbusID",1305);    
     player:delKeyItem(COSMOCLEANSE);
     player:delKeyItem(WHITE_CARD);
 end;
@@ -27,9 +24,9 @@ end;
 -- 4=Finish he dynamis
 
 function onBcnmLeave(player,instance,leavecode)
---print("leave code "..leavecode);
+    --print("leave code "..leavecode);
     if (leavecode == 4) then
-         player:setPos(580,-1.5,4.452,192);
-        ResetPlayerLimbusVariable(player)
+        SetServerVariable("[C_Temenos_3rd]UniqueID",0);
+        player:setPos(580,-1.5,4.452,192);
     end    
 end;

--- a/scripts/zones/Temenos/bcnms/central_temenos_4th_floor.lua
+++ b/scripts/zones/Temenos/bcnms/central_temenos_4th_floor.lua
@@ -1,31 +1,27 @@
 -----------------------------------
 -- Area: Temenos
--- Name: 
+-- Name: Central Temenos 4th Floor
 -----------------------------------
-
-
+require("scripts/globals/limbus");
+require("scripts/globals/keyitems");
 
 -- After registering the BCNM via bcnmRegister(bcnmid)
 function onBcnmRegister(player,instance)    
-    SetServerVariable("[C_Temenos_4th]UniqueID",GenerateLimbusKey());
-    HideArmouryCrates(GetInstanceRegion(1306),TEMENOS);        
-    HideTemenosDoor(GetInstanceRegion(1306));
-    player:setVar("Limbus_Trade_Item-T",0);
-if (GetMobAction(16928986) > 0) then DespawnMob(16928986);end
-if (GetMobAction(16928987) > 0) then DespawnMob(16928987);end
-if (GetMobAction(16928988) > 0) then DespawnMob(16928988);end    
-    for n=16928991,16929003,1 do      
-        if (GetMobAction(n) > 0) then DespawnMob(n);end
-    end    
---print("spawn_coffer");
-  SpawnCofferTemenosCFloor4();
+    SetServerVariable("[C_Temenos_4th]UniqueID",os.time());
+    HideArmouryCrates(Central_Temenos_4th_Floor,TEMENOS);
+    HideTemenosDoor(Central_Temenos_4th_Floor);
+    for n=16928986,16928988,1 do
+        if (GetMobByID(n):isSpawned()) then DespawnMob(n); end
+    end
+    for n=16928991,16929003,1 do
+        if (GetMobByID(n):isSpawned()) then DespawnMob(n); end
+    end
+    SpawnCofferTemenosCFloor4();
 end;
 
 -- Physically entering the BCNM via bcnmEnter(bcnmid)
 function onBcnmEnter(player,instance)
-    player:setVar("limbusbitmap",0);
     player:setVar("characterLimbusKey",GetServerVariable("[C_Temenos_4th]UniqueID"));
-    player:setVar("LimbusID",1306);    
     player:delKeyItem(COSMOCLEANSE);
     player:delKeyItem(WHITE_CARD);
 end;
@@ -35,9 +31,9 @@ end;
 -- 4=Finish he dynamis
 
 function onBcnmLeave(player,instance,leavecode)
---print("leave code "..leavecode);
+    --print("leave code "..leavecode);
     if (leavecode == 4) then
-         player:setPos(580,-1.5,4.452,192);
-        ResetPlayerLimbusVariable(player)
+        SetServerVariable("[C_Temenos_4th]UniqueID",0);
+        player:setPos(580,-1.5,4.452,192);
     end
 end;

--- a/scripts/zones/Temenos/bcnms/central_temenos_basement.lua
+++ b/scripts/zones/Temenos/bcnms/central_temenos_basement.lua
@@ -1,24 +1,21 @@
 -----------------------------------
 -- Area: Temenos
--- Name: 
+-- Name: Central Temenos Basement
 -----------------------------------
-
-
+require("scripts/globals/limbus");
+require("scripts/globals/keyitems");
 
 -- After registering the BCNM via bcnmRegister(bcnmid)
 function onBcnmRegister(player,instance)    
-    SetServerVariable("[C_Temenos_Base]UniqueID",GenerateLimbusKey());
-    HideArmouryCrates(GetInstanceRegion(1301),TEMENOS);        
-    HideTemenosDoor(GetInstanceRegion(1301));
-    player:setVar("Limbus_Trade_Item-T",0);
-    if (GetMobAction(16929088) > 0) then DespawnMob(16928988);end    
+    SetServerVariable("[C_Temenos_Base]UniqueID",os.time());
+    HideArmouryCrates(Central_Temenos_Basement,TEMENOS);        
+    HideTemenosDoor(Central_Temenos_Basement);
+    if (GetMobByID(16929088):isSpawned()) then DespawnMob(16929088); end
 end;
 
 -- Physically entering the BCNM via bcnmEnter(bcnmid)
 function onBcnmEnter(player,instance)
-    player:setVar("limbusbitmap",0);
     player:setVar("characterLimbusKey",GetServerVariable("[C_Temenos_Base]UniqueID"));
-    player:setVar("LimbusID",1301);    
     player:delKeyItem(COSMOCLEANSE);
     player:delKeyItem(WHITE_CARD);
 end;
@@ -28,9 +25,9 @@ end;
 -- 4=Finish he dynamis
 
 function onBcnmLeave(player,instance,leavecode)
---print("leave code "..leavecode);
+    --print("leave code "..leavecode);
     if (leavecode == 4) then
-         player:setPos(580,-1.5,4.452,192);
-        ResetPlayerLimbusVariable(player)
-    end    
+        SetServerVariable("[C_Temenos_Base]UniqueID",0);
+        player:setPos(580,-1.5,4.452,192);
+    end
 end;

--- a/scripts/zones/Temenos/bcnms/temenos_eastern_tower.lua
+++ b/scripts/zones/Temenos/bcnms/temenos_eastern_tower.lua
@@ -1,30 +1,27 @@
 -----------------------------------
 -- Area: Temenos
--- Name: 
+-- Name: Temenos Eastern Tower
 -----------------------------------
-
-
+require("scripts/globals/limbus");
+require("scripts/globals/keyitems");
 
 -- After registering the BCNM via bcnmRegister(bcnmid)
 function onBcnmRegister(player,instance)
-if (GetMobAction(16928844) > 0) then DespawnMob(16928844);end
-if (GetMobAction(16928853) > 0) then DespawnMob(16928853);end
-if (GetMobAction(16928862) > 0) then DespawnMob(16928862);end
-if (GetMobAction(16928871) > 0) then DespawnMob(16928871);end
-if (GetMobAction(16928880) > 0) then DespawnMob(16928880);end
-if (GetMobAction(16928889) > 0) then DespawnMob(16928889);end
-if (GetMobAction(16928894) > 0) then DespawnMob(16928894);end
-    SetServerVariable("[Temenos_E_Tower]UniqueID",GenerateLimbusKey());
-    HideArmouryCrates(GetInstanceRegion(1300),TEMENOS);        
-    HideTemenosDoor(GetInstanceRegion(1300));
-                        
+    if (GetMobByID(16928844):isSpawned()) then DespawnMob(16928844); end
+    if (GetMobByID(16928853):isSpawned()) then DespawnMob(16928853); end
+    if (GetMobByID(16928862):isSpawned()) then DespawnMob(16928862); end
+    if (GetMobByID(16928871):isSpawned()) then DespawnMob(16928871); end
+    if (GetMobByID(16928880):isSpawned()) then DespawnMob(16928880); end
+    if (GetMobByID(16928889):isSpawned()) then DespawnMob(16928889); end
+    if (GetMobByID(16928894):isSpawned()) then DespawnMob(16928894); end
+    SetServerVariable("[Temenos_E_Tower]UniqueID",os.time());
+    HideArmouryCrates(Temenos_Eastern_Tower,TEMENOS);        
+    HideTemenosDoor(Temenos_Eastern_Tower);
 end;
 
 -- Physically entering the BCNM via bcnmEnter(bcnmid)
 function onBcnmEnter(player,instance)
-    player:setVar("limbusbitmap",0);
     player:setVar("characterLimbusKey",GetServerVariable("[Temenos_E_Tower]UniqueID"));
-    player:setVar("LimbusID",1300);    
     player:delKeyItem(COSMOCLEANSE);
     player:delKeyItem(WHITE_CARD);
 end;
@@ -34,9 +31,9 @@ end;
 -- 4=Finish he dynamis
 
 function onBcnmLeave(player,instance,leavecode)
---print("leave code "..leavecode);
+    --print("leave code "..leavecode);
     if (leavecode == 4) then
-         player:setPos(580,-1.5,4.452,192);
-        ResetPlayerLimbusVariable(player)
+        SetServerVariable("[Temenos_E_Tower]UniqueID",0);
+        player:setPos(580,-1.5,4.452,192);
     end
 end;

--- a/scripts/zones/Temenos/bcnms/temenos_northern_tower.lua
+++ b/scripts/zones/Temenos/bcnms/temenos_northern_tower.lua
@@ -1,23 +1,20 @@
 -----------------------------------
 -- Area: Temenos
--- Name: 
+-- Name: Temenos Northern Tower
 -----------------------------------
 require("scripts/globals/limbus");
 require("scripts/globals/keyitems");
 
-
 -- After registering the BCNM via bcnmRegister(bcnmid)
 function onBcnmRegister(player,instance)
-    SetServerVariable("[Temenos_N_Tower]UniqueID",GenerateLimbusKey());
-    HideArmouryCrates(GetInstanceRegion(1299),TEMENOS);        
-    HideTemenosDoor(GetInstanceRegion(1299));    
+    SetServerVariable("[Temenos_N_Tower]UniqueID",os.time());
+    HideArmouryCrates(Temenos_Northern_Tower,TEMENOS);        
+    HideTemenosDoor(Temenos_Northern_Tower);    
 end;
 
 -- Physically entering the BCNM via bcnmEnter(bcnmid)
 function onBcnmEnter(player,instance)
-    player:setVar("limbusbitmap",0);
     player:setVar("characterLimbusKey",GetServerVariable("[Temenos_N_Tower]UniqueID"));
-    player:setVar("LimbusID",1299);    
     player:delKeyItem(COSMOCLEANSE);
     player:delKeyItem(WHITE_CARD);
 end;
@@ -27,9 +24,10 @@ end;
 -- 4=Finish he dynamis
 
 function onBcnmLeave(player,instance,leavecode)
---print("leave code "..leavecode);
+    -- player:PrintToPlayer(leavecode);
+    print("leave code "..leavecode);
     if (leavecode == 4) then
-             player:setPos(580,-1.5,4.452,192);
-        ResetPlayerLimbusVariable(player)
+        SetServerVariable("[Temenos_N_Tower]UniqueID",0);
+        player:setPos(580,-1.5,4.452,192);
     end
 end;

--- a/scripts/zones/Temenos/bcnms/temenos_western_tower.lua
+++ b/scripts/zones/Temenos/bcnms/temenos_western_tower.lua
@@ -1,22 +1,20 @@
 -----------------------------------
 -- Area: Temenos
--- Name: 
+-- Name: Temenos Western Tower
 -----------------------------------
-
-
+require("scripts/globals/limbus");
+require("scripts/globals/keyitems");
 
 -- After registering the BCNM via bcnmRegister(bcnmid)
 function onBcnmRegister(player,instance)    
-    SetServerVariable("[Temenos_W_Tower]UniqueID",GenerateLimbusKey());
-    HideArmouryCrates(GetInstanceRegion(1298),TEMENOS);        
-    HideTemenosDoor(GetInstanceRegion(1298));        
+    SetServerVariable("[Temenos_W_Tower]UniqueID",os.time());
+    HideArmouryCrates(Temenos_Western_Tower,TEMENOS);        
+    HideTemenosDoor(Temenos_Western_Tower);        
 end;
 
 -- Physically entering the BCNM via bcnmEnter(bcnmid)
 function onBcnmEnter(player,instance)
-    player:setVar("limbusbitmap",0);
     player:setVar("characterLimbusKey",GetServerVariable("[Temenos_W_Tower]UniqueID"));
-    player:setVar("LimbusID",1298);    
     player:delKeyItem(COSMOCLEANSE);
     player:delKeyItem(WHITE_CARD);
 end;
@@ -26,10 +24,9 @@ end;
 -- 4=Finish he dynamis
 
 function onBcnmLeave(player,instance,leavecode)
---print("leave code "..leavecode);
-
+    --print("leave code "..leavecode);
     if (leavecode == 4) then
-         player:setPos(580,-1.5,4.452,192);
-        ResetPlayerLimbusVariable(player)
+        SetServerVariable("[Temenos_W_Tower]UniqueID",0);
+        player:setPos(580,-1.5,4.452,192);
     end
 end;

--- a/scripts/zones/Temenos/mobs/Abyssdweller_Jhabdebb.lua
+++ b/scripts/zones/Temenos/mobs/Abyssdweller_Jhabdebb.lua
@@ -20,21 +20,26 @@ end;
 -----------------------------------
 
 function onMobEngaged(mob,target)
-  if   (IsMobDead(16929010)==true and IsMobDead(16929011)==true and IsMobDead(16929012)==true and
-        IsMobDead(16929013)==true and IsMobDead(16929014)==true and IsMobDead(16929015)==true 
-    ) then
-       mob:setMod(MOD_SLASHRES,1400);
-       mob:setMod(MOD_PIERCERES,1400);
-       mob:setMod(MOD_IMPACTRES,1400);
-       mob:setMod(MOD_HTHRES,1400);       
-  else
-      mob:setMod(MOD_SLASHRES,300);
-      mob:setMod(MOD_PIERCERES,300);
-      mob:setMod(MOD_IMPACTRES,300);
-      mob:setMod(MOD_HTHRES,300);
-  end   
-  GetMobByID(16929006):updateEnmity(target);
-  GetMobByID(16929007):updateEnmity(target);
+    if (
+        GetMobByID(16929010):isDead() and
+        GetMobByID(16929011):isDead() and
+        GetMobByID(16929012):isDead() and
+        GetMobByID(16929013):isDead() and
+        GetMobByID(16929014):isDead() and
+        GetMobByID(16929015):isDead()
+    ) then  
+        mob:setMod(MOD_SLASHRES,1400);
+        mob:setMod(MOD_PIERCERES,1400);
+        mob:setMod(MOD_IMPACTRES,1400);
+        mob:setMod(MOD_HTHRES,1400);
+    else
+        mob:setMod(MOD_SLASHRES,300);
+        mob:setMod(MOD_PIERCERES,300);
+        mob:setMod(MOD_IMPACTRES,300);
+        mob:setMod(MOD_HTHRES,300);
+    end
+    GetMobByID(16929006):updateEnmity(target);
+    GetMobByID(16929007):updateEnmity(target);
 end;
 
 -----------------------------------
@@ -42,9 +47,13 @@ end;
 -----------------------------------
 
 function onMobDeath(mob, player, isKiller)
-          if (IsMobDead(16929005)==true and IsMobDead(16929006)==true and IsMobDead(16929007)==true) then
-            GetNPCByID(16928768+78):setPos(-280,-161,-440);
-            GetNPCByID(16928768+78):setStatus(STATUS_NORMAL);
-            GetNPCByID(16928768+473):setStatus(STATUS_NORMAL);        
-          end
+    if (
+        GetMobByID(16929005):isDead() and
+        GetMobByID(16929006):isDead() and
+        GetMobByID(16929007):isDead()
+    ) then
+        GetNPCByID(16928768+78):setPos(-280,-161,-440);
+        GetNPCByID(16928768+78):setStatus(STATUS_NORMAL);
+        GetNPCByID(16928768+473):setStatus(STATUS_NORMAL);
+    end
 end;

--- a/scripts/zones/Temenos/mobs/Air_Elemental.lua
+++ b/scripts/zones/Temenos/mobs/Air_Elemental.lua
@@ -27,33 +27,34 @@ end;
 -----------------------------------
 
 function onMobDeath(mob, player, isKiller)
-   local mobID = mob:getID();    
-   local mobX = mob:getXPos();
-   local mobY = mob:getYPos();
-   local mobZ = mob:getZPos();        
-     switch (mobID): caseof {
-         -- 100 a 106 inclut (Temenos -Northern Tower )
+    local mobID = mob:getID();    
+    local mobX = mob:getXPos();
+    local mobY = mob:getYPos();
+    local mobZ = mob:getZPos();        
+
+    switch (mobID): caseof {
+        -- 100 a 106 inclut (Temenos -Northern Tower )
         [16928858] = function (x)
-           GetNPCByID(16928768+181):setPos(mobX,mobY,mobZ);
-           GetNPCByID(16928768+181):setStatus(STATUS_NORMAL);
-        end    , 
+            GetNPCByID(16928768+181):setPos(mobX,mobY,mobZ);
+            GetNPCByID(16928768+181):setStatus(STATUS_NORMAL);
+        end, 
         [16928859] = function (x)
-           GetNPCByID(16928768+217):setPos(mobX,mobY,mobZ);
-           GetNPCByID(16928768+217):setStatus(STATUS_NORMAL);
-        end    , 
+            GetNPCByID(16928768+217):setPos(mobX,mobY,mobZ);
+            GetNPCByID(16928768+217):setStatus(STATUS_NORMAL);
+        end, 
         [16928860] = function (x)
-           GetNPCByID(16928768+348):setPos(mobX,mobY,mobZ);
-           GetNPCByID(16928768+348):setStatus(STATUS_NORMAL);
-        end    , 
+            GetNPCByID(16928768+348):setPos(mobX,mobY,mobZ);
+            GetNPCByID(16928768+348):setStatus(STATUS_NORMAL);
+        end, 
         [16928861] = function (x)   
-           GetNPCByID(16928768+46):setPos(mobX,mobY,mobZ);
-           GetNPCByID(16928768+46):setStatus(STATUS_NORMAL);
-        end    , 
+            GetNPCByID(16928768+46):setPos(mobX,mobY,mobZ);
+            GetNPCByID(16928768+46):setStatus(STATUS_NORMAL);
+        end, 
         [16929035] = function (x)   
-           if (IsMobDead(16929036)==false) then
-             DespawnMob(16929036);
-             SpawnMob(16929042);
-           end
-        end    ,
-     }
+            if (GetMobByID(16929036):isSpawned()) then
+                DespawnMob(16929036);
+                SpawnMob(16929042);
+            end
+        end
+    }
 end;

--- a/scripts/zones/Temenos/mobs/Airi.lua
+++ b/scripts/zones/Temenos/mobs/Airi.lua
@@ -20,10 +20,10 @@ end;
 -----------------------------------
 
 function onMobEngaged(mob,target)
-  if (IsMobDead(16929047)==true) then
-     mob:addStatusEffect(EFFECT_REGAIN,7,3,0);
-     mob:addStatusEffect(EFFECT_REGEN,50,3,0);
-  end
+    if (GetMobByID(16929047):isDead()) then
+        mob:addStatusEffect(EFFECT_REGAIN,7,3,0);
+        mob:addStatusEffect(EFFECT_REGEN,50,3,0);
+    end
 end;
 
 -----------------------------------
@@ -35,9 +35,16 @@ function onMobDeath(mob, player, isKiller)
     local mobY = mob:getYPos();
     local mobZ = mob:getZPos();
 
-  if (IsMobDead(16929046)==true and IsMobDead(16929047)==true and IsMobDead(16929048)==true and IsMobDead(16929049)==true and IsMobDead(16929050)==true and IsMobDead(16929051)==true) then
-       GetNPCByID(16928768+71):setPos(mobX,mobY,mobZ);
-    GetNPCByID(16928768+71):setStatus(STATUS_NORMAL);
-    GetNPCByID(16928770+471):setStatus(STATUS_NORMAL);
-  end
+    if (
+        GetMobByID(16929046):isDead() and
+        GetMobByID(16929047):isDead() and
+        GetMobByID(16929048):isDead() and
+        GetMobByID(16929049):isDead() and
+        GetMobByID(16929050):isDead() and
+        GetMobByID(16929051):isDead()
+    ) then
+        GetNPCByID(16928768+71):setPos(mobX,mobY,mobZ);
+        GetNPCByID(16928768+71):setStatus(STATUS_NORMAL);
+        GetNPCByID(16928770+471):setStatus(STATUS_NORMAL);
+    end
 end;

--- a/scripts/zones/Temenos/mobs/Beli.lua
+++ b/scripts/zones/Temenos/mobs/Beli.lua
@@ -29,12 +29,16 @@ end;
 -----------------------------------
 
 function onMobDeath(mob, player, isKiller)
- if (IsMobDead(16928781)==true and IsMobDead(16928782)==true  and IsMobDead(16928783)==true ) then
-       GetNPCByID(16928768+19):setPos(200,-82,495);
-    GetNPCByID(16928768+19):setStatus(STATUS_NORMAL);
-    GetNPCByID(16928768+153):setPos(206,-82,495);
-    GetNPCByID(16928768+153):setStatus(STATUS_NORMAL);
-    GetNPCByID(16928768+210):setPos(196,-82,495);
-    GetNPCByID(16928768+210):setStatus(STATUS_NORMAL);
- end
+    if (
+        GetMobByID(16928781):isDead() and
+        GetMobByID(16928782):isDead() and
+        GetMobByID(16928783):isDead()
+    ) then
+        GetNPCByID(16928768+19):setPos(200,-82,495);
+        GetNPCByID(16928768+19):setStatus(STATUS_NORMAL);
+        GetNPCByID(16928768+153):setPos(206,-82,495);
+        GetNPCByID(16928768+153):setStatus(STATUS_NORMAL);
+        GetNPCByID(16928768+210):setPos(196,-82,495);
+        GetNPCByID(16928768+210):setStatus(STATUS_NORMAL);
+    end
 end;

--- a/scripts/zones/Temenos/mobs/Cryptonberry_Charmer.lua
+++ b/scripts/zones/Temenos/mobs/Cryptonberry_Charmer.lua
@@ -28,13 +28,16 @@ end;
 -----------------------------------
 
 function onMobDeath(mob, player, isKiller)
- if (IsMobDead(16928816)==true and IsMobDead(16928817)==true ) then
-       GetNPCByID(16928768+38):setPos(-412,-78,426);
-    GetNPCByID(16928768+38):setStatus(STATUS_NORMAL);
-    GetNPCByID(16928768+172):setPos(-415,-78,427);
-    GetNPCByID(16928768+172):setStatus(STATUS_NORMAL);
-    GetNPCByID(16928768+214):setPos(-412,-78,422);
-    GetNPCByID(16928768+214):setStatus(STATUS_NORMAL);
-    GetNPCByID(16928770+455):setStatus(STATUS_NORMAL);
- end
+    if (
+        GetMobByID(16928816):isDead() and
+        GetMobByID(16928817):isDead()
+    ) then
+        GetNPCByID(16928768+38):setPos(-412,-78,426);
+        GetNPCByID(16928768+38):setStatus(STATUS_NORMAL);
+        GetNPCByID(16928768+172):setPos(-415,-78,427);
+        GetNPCByID(16928768+172):setStatus(STATUS_NORMAL);
+        GetNPCByID(16928768+214):setPos(-412,-78,422);
+        GetNPCByID(16928768+214):setStatus(STATUS_NORMAL);
+        GetNPCByID(16928770+455):setStatus(STATUS_NORMAL);
+    end
 end;

--- a/scripts/zones/Temenos/mobs/Cryptonberry_Skulker.lua
+++ b/scripts/zones/Temenos/mobs/Cryptonberry_Skulker.lua
@@ -28,13 +28,16 @@ end;
 -----------------------------------
 
 function onMobDeath(mob, player, isKiller)
- if (IsMobDead(16928816)==true and IsMobDead(16928817)==true ) then
-       GetNPCByID(16928768+38):setPos(-412,-78,426);
-    GetNPCByID(16928768+38):setStatus(STATUS_NORMAL);
-    GetNPCByID(16928768+172):setPos(-415,-78,427);
-    GetNPCByID(16928768+172):setStatus(STATUS_NORMAL);
-    GetNPCByID(16928768+214):setPos(-412,-78,422);
-    GetNPCByID(16928768+214):setStatus(STATUS_NORMAL);
-    GetNPCByID(16928770+455):setStatus(STATUS_NORMAL);
- end
+    if (
+        GetMobByID(16928816):isDead() and
+        GetMobByID(16928817):isDead()
+    ) then
+        GetNPCByID(16928768+38):setPos(-412,-78,426);
+        GetNPCByID(16928768+38):setStatus(STATUS_NORMAL);
+        GetNPCByID(16928768+172):setPos(-415,-78,427);
+        GetNPCByID(16928768+172):setStatus(STATUS_NORMAL);
+        GetNPCByID(16928768+214):setPos(-412,-78,422);
+        GetNPCByID(16928768+214):setStatus(STATUS_NORMAL);
+        GetNPCByID(16928770+455):setStatus(STATUS_NORMAL);
+    end
 end;

--- a/scripts/zones/Temenos/mobs/Earth_Elemental.lua
+++ b/scripts/zones/Temenos/mobs/Earth_Elemental.lua
@@ -28,33 +28,34 @@ end;
 -----------------------------------
 
 function onMobDeath(mob, player, isKiller)
-   local mobID = mob:getID();    
-   local mobX = mob:getXPos();
-   local mobY = mob:getYPos();
-   local mobZ = mob:getZPos();        
-     switch (mobID): caseof {
-         -- 100 a 106 inclut (Temenos -Northern Tower )
+    local mobID = mob:getID();    
+    local mobX = mob:getXPos();
+    local mobY = mob:getYPos();
+    local mobZ = mob:getZPos();        
+
+    switch (mobID): caseof {
+        -- 100 a 106 inclut (Temenos -Northern Tower )
         [16928867] = function (x)
-           GetNPCByID(16928768+182):setPos(mobX,mobY,mobZ);
-           GetNPCByID(16928768+182):setStatus(STATUS_NORMAL);
-        end    , 
+            GetNPCByID(16928768+182):setPos(mobX,mobY,mobZ);
+            GetNPCByID(16928768+182):setStatus(STATUS_NORMAL);
+        end, 
         [16928868] = function (x)
-           GetNPCByID(16928768+236):setPos(mobX,mobY,mobZ);
-           GetNPCByID(16928768+236):setStatus(STATUS_NORMAL);
-        end    , 
+            GetNPCByID(16928768+236):setPos(mobX,mobY,mobZ);
+            GetNPCByID(16928768+236):setStatus(STATUS_NORMAL);
+        end, 
         [16928869] = function (x)
-           GetNPCByID(16928768+360):setPos(mobX,mobY,mobZ);
-           GetNPCByID(16928768+360):setStatus(STATUS_NORMAL);
-        end    , 
+            GetNPCByID(16928768+360):setPos(mobX,mobY,mobZ);
+            GetNPCByID(16928768+360):setStatus(STATUS_NORMAL);
+        end, 
         [16928870] = function (x)   
-           GetNPCByID(16928768+47):setPos(mobX,mobY,mobZ);
-           GetNPCByID(16928768+47):setStatus(STATUS_NORMAL);
-        end    , 
+            GetNPCByID(16928768+47):setPos(mobX,mobY,mobZ);
+            GetNPCByID(16928768+47):setStatus(STATUS_NORMAL);
+        end, 
         [16929036] = function (x)   
-           if (IsMobDead(16929037)==false) then
-             DespawnMob(16929037);
-             SpawnMob(16929043);
-           end
-        end    ,
-     }
+            if (GetMobByID(16929037):isSpawned()) then
+                DespawnMob(16929037);
+                SpawnMob(16929043);
+            end
+        end
+    }
 end;

--- a/scripts/zones/Temenos/mobs/Enhanced_Ahriman.lua
+++ b/scripts/zones/Temenos/mobs/Enhanced_Ahriman.lua
@@ -20,10 +20,10 @@ end;
 -----------------------------------
 
 function onMobEngaged(mob,target)
-  if (IsMobDead(16929050)==true) then
-     mob:addStatusEffect(EFFECT_REGAIN,7,3,0);
-     mob:addStatusEffect(EFFECT_REGEN,50,3,0);
-  end
+    if (GetMobByID(16929050):isDead()) then
+        mob:addStatusEffect(EFFECT_REGAIN,7,3,0);
+        mob:addStatusEffect(EFFECT_REGEN,50,3,0);
+    end
 end;
 
 -----------------------------------
@@ -34,9 +34,16 @@ function onMobDeath(mob, player, isKiller)
     local mobX = mob:getXPos();
     local mobY = mob:getYPos();
     local mobZ = mob:getZPos();
-  if (IsMobDead(16929046)==true and IsMobDead(16929047)==true and IsMobDead(16929048)==true and IsMobDead(16929049)==true and IsMobDead(16929050)==true and IsMobDead(16929051)==true) then
-       GetNPCByID(16928768+71):setPos(mobX,mobY,mobZ);
-    GetNPCByID(16928768+71):setStatus(STATUS_NORMAL);
-    GetNPCByID(16928770+471):setStatus(STATUS_NORMAL);
-  end
+    if (
+        GetMobByID(16929046):isDead() and
+        GetMobByID(16929047):isDead() and
+        GetMobByID(16929048):isDead() and
+        GetMobByID(16929049):isDead() and
+        GetMobByID(16929050):isDead() and
+        GetMobByID(16929051):isDead()
+    ) then
+        GetNPCByID(16928768+71):setPos(mobX,mobY,mobZ);
+        GetNPCByID(16928768+71):setStatus(STATUS_NORMAL);
+        GetNPCByID(16928770+471):setStatus(STATUS_NORMAL);
+    end
 end;

--- a/scripts/zones/Temenos/mobs/Enhanced_Beetle.lua
+++ b/scripts/zones/Temenos/mobs/Enhanced_Beetle.lua
@@ -28,7 +28,7 @@ end;
 -----------------------------------
 
 function onMobDeath(mob, player, isKiller)
-local cofferID=Randomcoffer(3,GetInstanceRegion(1298));
+local cofferID=Randomcoffer(3,Temenos_Western_Tower);
     local mobX = mob:getXPos();
     local mobY = mob:getYPos();
     local mobZ = mob:getZPos();

--- a/scripts/zones/Temenos/mobs/Enhanced_Dragon.lua
+++ b/scripts/zones/Temenos/mobs/Enhanced_Dragon.lua
@@ -20,10 +20,10 @@ end;
 -----------------------------------
 
 function onMobEngaged(mob,target)
-  if (IsMobDead(16929051)==true) then
-     mob:addStatusEffect(EFFECT_REGAIN,7,3,0);
-     mob:addStatusEffect(EFFECT_REGEN,50,3,0);
-  end
+    if (GetMobByID(16929051):isDead()) then
+        mob:addStatusEffect(EFFECT_REGAIN,7,3,0);
+        mob:addStatusEffect(EFFECT_REGEN,50,3,0);
+    end
 end;
 
 -----------------------------------
@@ -34,9 +34,16 @@ function onMobDeath(mob, player, isKiller)
     local mobX = mob:getXPos();
     local mobY = mob:getYPos();
     local mobZ = mob:getZPos();
-  if (IsMobDead(16929046)==true and IsMobDead(16929047)==true and IsMobDead(16929048)==true and IsMobDead(16929049)==true and IsMobDead(16929050)==true and IsMobDead(16929051)==true) then
-       GetNPCByID(16928768+71):setPos(mobX,mobY,mobZ);
-    GetNPCByID(16928768+71):setStatus(STATUS_NORMAL);
-    GetNPCByID(16928770+471):setStatus(STATUS_NORMAL);
-  end
+    if (
+        GetMobByID(16929046):isDead() and
+        GetMobByID(16929047):isDead() and
+        GetMobByID(16929048):isDead() and
+        GetMobByID(16929049):isDead() and
+        GetMobByID(16929050):isDead() and
+        GetMobByID(16929051):isDead()
+    ) then
+        GetNPCByID(16928768+71):setPos(mobX,mobY,mobZ);
+        GetNPCByID(16928768+71):setStatus(STATUS_NORMAL);
+        GetNPCByID(16928770+471):setStatus(STATUS_NORMAL);
+    end
 end;

--- a/scripts/zones/Temenos/mobs/Enhanced_Lizard.lua
+++ b/scripts/zones/Temenos/mobs/Enhanced_Lizard.lua
@@ -28,7 +28,7 @@ end;
 -----------------------------------
 
 function onMobDeath(mob, player, isKiller)
-local cofferID=Randomcoffer(4,GetInstanceRegion(1298));
+local cofferID=Randomcoffer(4,Temenos_Western_Tower);
     local mobX = mob:getXPos();
     local mobY = mob:getYPos();
     local mobZ = mob:getZPos();

--- a/scripts/zones/Temenos/mobs/Enhanced_Mandragora.lua
+++ b/scripts/zones/Temenos/mobs/Enhanced_Mandragora.lua
@@ -28,7 +28,7 @@ end;
 -----------------------------------
 
 function onMobDeath(mob, player, isKiller)
-local cofferID=Randomcoffer(2,GetInstanceRegion(1298));
+local cofferID=Randomcoffer(2,Temenos_Western_Tower);
     local mobX = mob:getXPos();
     local mobY = mob:getYPos();
     local mobZ = mob:getZPos();

--- a/scripts/zones/Temenos/mobs/Enhanced_Pugil.lua
+++ b/scripts/zones/Temenos/mobs/Enhanced_Pugil.lua
@@ -28,7 +28,7 @@ end;
 -----------------------------------
 
 function onMobDeath(mob, player, isKiller)
-local cofferID=Randomcoffer(6,GetInstanceRegion(1298));
+local cofferID=Randomcoffer(6,Temenos_Western_Tower);
     local mobX = mob:getXPos();
     local mobY = mob:getYPos();
     local mobZ = mob:getZPos();

--- a/scripts/zones/Temenos/mobs/Enhanced_Slime.lua
+++ b/scripts/zones/Temenos/mobs/Enhanced_Slime.lua
@@ -28,7 +28,7 @@ end;
 -----------------------------------
 
 function onMobDeath(mob, player, isKiller)
-local cofferID=Randomcoffer(5,GetInstanceRegion(1298));
+local cofferID=Randomcoffer(5,Temenos_Western_Tower);
     local mobX = mob:getXPos();
     local mobY = mob:getYPos();
     local mobZ = mob:getZPos();

--- a/scripts/zones/Temenos/mobs/Enhanced_Tiger.lua
+++ b/scripts/zones/Temenos/mobs/Enhanced_Tiger.lua
@@ -28,7 +28,7 @@ end;
 -----------------------------------
 
 function onMobDeath(mob, player, isKiller)
-local cofferID=Randomcoffer(1,GetInstanceRegion(1298));
+local cofferID=Randomcoffer(1,Temenos_Western_Tower);
     local mobX = mob:getXPos();
     local mobY = mob:getYPos();
     local mobZ = mob:getZPos();

--- a/scripts/zones/Temenos/mobs/Enhanced_Vulture.lua
+++ b/scripts/zones/Temenos/mobs/Enhanced_Vulture.lua
@@ -20,12 +20,12 @@ end;
 -----------------------------------
 
 function onMobEngaged(mob,target)
-        GetMobByID(16928959):updateEnmity(target);
-        GetMobByID(16928960):updateEnmity(target);
-        GetMobByID(16928961):updateEnmity(target);
-        GetMobByID(16928962):updateEnmity(target);
-        GetMobByID(16928963):updateEnmity(target);
-        GetMobByID(16928964):updateEnmity(target);
+    GetMobByID(16928959):updateEnmity(target);
+    GetMobByID(16928960):updateEnmity(target);
+    GetMobByID(16928961):updateEnmity(target);
+    GetMobByID(16928962):updateEnmity(target);
+    GetMobByID(16928963):updateEnmity(target);
+    GetMobByID(16928964):updateEnmity(target);
 end;
 
 -----------------------------------
@@ -33,14 +33,19 @@ end;
 -----------------------------------
 
 function onMobDeath(mob, player, isKiller)
-
     local mobX = mob:getXPos();
     local mobY = mob:getYPos();
     local mobZ = mob:getZPos();
-   if (IsMobDead(16928959)==true and IsMobDead(16928960)==true  and IsMobDead(16928961)==true
-   and IsMobDead(16928962)==true  and IsMobDead(16928963)==true and IsMobDead(16928964)==true) then
-       GetNPCByID(16928768+17):setPos(mobX,mobY,mobZ);
-    GetNPCByID(16928768+17):setStatus(STATUS_NORMAL);
-    GetNPCByID(16928770+470):setStatus(STATUS_NORMAL);
-  end
+    if (
+        GetMobByID(16928959):isDead() and
+        GetMobByID(16928960):isDead() and
+        GetMobByID(16928961):isDead() and
+        GetMobByID(16928962):isDead() and
+        GetMobByID(16928963):isDead() and
+        GetMobByID(16928964):isDead()
+    ) then
+        GetNPCByID(16928768+17):setPos(mobX,mobY,mobZ);
+        GetNPCByID(16928768+17):setStatus(STATUS_NORMAL);
+        GetNPCByID(16928770+470):setStatus(STATUS_NORMAL);
+    end
 end;

--- a/scripts/zones/Temenos/mobs/Fire_Elemental.lua
+++ b/scripts/zones/Temenos/mobs/Fire_Elemental.lua
@@ -28,32 +28,33 @@ end;
 -----------------------------------
 
 function onMobDeath(mob, player, isKiller)
-   local mobID = mob:getID();    
-   local mobX = mob:getXPos();
-   local mobY = mob:getYPos();
-   local mobZ = mob:getZPos();        
-     switch (mobID): caseof {
+    local mobID = mob:getID();    
+    local mobX = mob:getXPos();
+    local mobY = mob:getYPos();
+    local mobZ = mob:getZPos();        
+
+    switch (mobID): caseof {
         [16928840] = function (x)
-           GetNPCByID(16928768+173):setPos(mobX,mobY,mobZ);
-           GetNPCByID(16928768+173):setStatus(STATUS_NORMAL);
-        end    , 
+            GetNPCByID(16928768+173):setPos(mobX,mobY,mobZ);
+            GetNPCByID(16928768+173):setStatus(STATUS_NORMAL);
+        end, 
         [16928841] = function (x)
-           GetNPCByID(16928768+215):setPos(mobX,mobY,mobZ);
-           GetNPCByID(16928768+215):setStatus(STATUS_NORMAL);
-        end    , 
+            GetNPCByID(16928768+215):setPos(mobX,mobY,mobZ);
+            GetNPCByID(16928768+215):setStatus(STATUS_NORMAL);
+        end, 
         [16928842] = function (x)
-           GetNPCByID(16928768+284):setPos(mobX,mobY,mobZ);
-           GetNPCByID(16928768+284):setStatus(STATUS_NORMAL);
-        end    , 
+            GetNPCByID(16928768+284):setPos(mobX,mobY,mobZ);
+            GetNPCByID(16928768+284):setStatus(STATUS_NORMAL);
+        end, 
         [16928843] = function (x)   
-           GetNPCByID(16928768+40):setPos(mobX,mobY,mobZ);
-           GetNPCByID(16928768+40):setStatus(STATUS_NORMAL);
-        end    , 
+            GetNPCByID(16928768+40):setPos(mobX,mobY,mobZ);
+            GetNPCByID(16928768+40):setStatus(STATUS_NORMAL);
+        end, 
         [16929033] = function (x)   
-           if (IsMobDead(16929034)==false) then -- ice
-             DespawnMob(16929034);
-             SpawnMob(16929040);
-           end
-        end    ,
-     }
+            if (GetMobByID(16929034):isSpawned()) then -- ice
+                DespawnMob(16929034);
+                SpawnMob(16929040);
+            end
+        end
+    }
 end;

--- a/scripts/zones/Temenos/mobs/Goblin_Fencer.lua
+++ b/scripts/zones/Temenos/mobs/Goblin_Fencer.lua
@@ -20,10 +20,9 @@ end;
 -----------------------------------
 
 function onMobEngaged(mob,target)
-GetMobByID(16928831):updateEnmity(target);
-GetMobByID(16928833):updateEnmity(target);
-GetMobByID(16928835):updateEnmity(target);
-
+    GetMobByID(16928831):updateEnmity(target);
+    GetMobByID(16928833):updateEnmity(target);
+    GetMobByID(16928835):updateEnmity(target);
 end;
 
 -----------------------------------
@@ -31,10 +30,15 @@ end;
 -----------------------------------
 
 function onMobDeath(mob, player, isKiller)
- if (IsMobDead(16928831)==true and IsMobDead(16928832)==true and IsMobDead(16928833)==true and IsMobDead(16928834)==true and IsMobDead(16928835)==true ) then
-       GetNPCByID(16928768+39):setPos(-599,85,438);
-    GetNPCByID(16928768+39):setStatus(STATUS_NORMAL);
-
-    GetNPCByID(16928768+456):setStatus(STATUS_NORMAL);
- end
+    if (
+        GetMobByID(16928831):isDead() and
+        GetMobByID(16928832):isDead() and
+        GetMobByID(16928833):isDead() and
+        GetMobByID(16928834):isDead() and
+        GetMobByID(16928835):isDead()
+    ) then
+        GetNPCByID(16928768+39):setPos(-599,85,438);
+        GetNPCByID(16928768+39):setStatus(STATUS_NORMAL);
+        GetNPCByID(16928768+456):setStatus(STATUS_NORMAL);
+    end
 end;

--- a/scripts/zones/Temenos/mobs/Goblin_Theurgist.lua
+++ b/scripts/zones/Temenos/mobs/Goblin_Theurgist.lua
@@ -20,10 +20,9 @@ end;
 -----------------------------------
 
 function onMobEngaged(mob,target)
-GetMobByID(16928831):updateEnmity(target);
-GetMobByID(16928832):updateEnmity(target);
-GetMobByID(16928834):updateEnmity(target);
-
+    GetMobByID(16928831):updateEnmity(target);
+    GetMobByID(16928832):updateEnmity(target);
+    GetMobByID(16928834):updateEnmity(target);
 end;
 
 -----------------------------------
@@ -31,10 +30,15 @@ end;
 -----------------------------------
 
 function onMobDeath(mob, player, isKiller)
- if (IsMobDead(16928831)==true and IsMobDead(16928832)==true and IsMobDead(16928833)==true and IsMobDead(16928834)==true and IsMobDead(16928835)==true ) then
-       GetNPCByID(16928768+39):setPos(-599,85,438);
-    GetNPCByID(16928768+39):setStatus(STATUS_NORMAL);
-
-    GetNPCByID(16928768+456):setStatus(STATUS_NORMAL);
- end
+    if (
+        GetMobByID(16928831):isDead() and
+        GetMobByID(16928832):isDead() and
+        GetMobByID(16928833):isDead() and
+        GetMobByID(16928834):isDead() and
+        GetMobByID(16928835):isDead()
+    ) then
+        GetNPCByID(16928768+39):setPos(-599,85,438);
+        GetNPCByID(16928768+39):setStatus(STATUS_NORMAL);
+        GetNPCByID(16928768+456):setStatus(STATUS_NORMAL);
+    end
 end;

--- a/scripts/zones/Temenos/mobs/Goblin_Warlord.lua
+++ b/scripts/zones/Temenos/mobs/Goblin_Warlord.lua
@@ -19,10 +19,10 @@ end;
 -----------------------------------
 
 function onMobEngaged(mob,target)
-GetMobByID(16928831):updateEnmity(target);
-GetMobByID(16928832):updateEnmity(target);
-GetMobByID(16928833):updateEnmity(target);
-GetMobByID(16928834):updateEnmity(target);
+    GetMobByID(16928831):updateEnmity(target);
+    GetMobByID(16928832):updateEnmity(target);
+    GetMobByID(16928833):updateEnmity(target);
+    GetMobByID(16928834):updateEnmity(target);
 end;
 
 -----------------------------------
@@ -30,10 +30,15 @@ end;
 -----------------------------------
 
 function onMobDeath(mob, player, isKiller)
- if (IsMobDead(16928831)==true and IsMobDead(16928832)==true and IsMobDead(16928833)==true and IsMobDead(16928834)==true and IsMobDead(16928835)==true ) then
-       GetNPCByID(16928768+39):setPos(-599,85,438);
-    GetNPCByID(16928768+39):setStatus(STATUS_NORMAL);
-
-    GetNPCByID(16928768+456):setStatus(STATUS_NORMAL);
- end
+    if (
+        GetMobByID(16928831):isDead() and
+        GetMobByID(16928832):isDead() and
+        GetMobByID(16928833):isDead() and
+        GetMobByID(16928834):isDead() and
+        GetMobByID(16928835):isDead()
+    ) then
+        GetNPCByID(16928768+39):setPos(-599,85,438);
+        GetNPCByID(16928768+39):setStatus(STATUS_NORMAL);
+        GetNPCByID(16928768+456):setStatus(STATUS_NORMAL);
+    end
 end;

--- a/scripts/zones/Temenos/mobs/Ice_Elemental.lua
+++ b/scripts/zones/Temenos/mobs/Ice_Elemental.lua
@@ -28,35 +28,34 @@ end;
 -----------------------------------
 
 function onMobDeath(mob, player, isKiller)
-   local mobID = mob:getID();    
-   local mobX = mob:getXPos();
-   local mobY = mob:getYPos();
-   local mobZ = mob:getZPos();        
-     switch (mobID): caseof {
-         -- 100 a 106 inclut (Temenos -Northern Tower )
-        [16928849] = function (x)
-           GetNPCByID(16928768+174):setPos(mobX,mobY,mobZ);
-           GetNPCByID(16928768+174):setStatus(STATUS_NORMAL);
-        end    , 
-        [16928850] = function (x)
-           GetNPCByID(16928768+216):setPos(mobX,mobY,mobZ);
-           GetNPCByID(16928768+216):setStatus(STATUS_NORMAL);
-        end    , 
-        [16928851] = function (x)
-           GetNPCByID(16928768+321):setPos(mobX,mobY,mobZ);
-           GetNPCByID(16928768+321):setStatus(STATUS_NORMAL);
-        end    , 
-        [16928852] = function (x)   
-           GetNPCByID(16928768+45):setPos(mobX,mobY,mobZ);
-           GetNPCByID(16928768+45):setStatus(STATUS_NORMAL);
-        end    ,
-        [16929034] = function (x)   
-           if (IsMobDead(16929035)==false) then -- wind
-             DespawnMob(16929035);
-             SpawnMob(16929041);
-           end
-        end    ,
+    local mobID = mob:getID();    
+    local mobX = mob:getXPos();
+    local mobY = mob:getYPos();
+    local mobZ = mob:getZPos();        
 
-        
-     }
+    switch (mobID): caseof {
+        -- 100 a 106 inclut (Temenos -Northern Tower )
+        [16928849] = function (x)
+            GetNPCByID(16928768+174):setPos(mobX,mobY,mobZ);
+            GetNPCByID(16928768+174):setStatus(STATUS_NORMAL);
+        end, 
+        [16928850] = function (x)
+            GetNPCByID(16928768+216):setPos(mobX,mobY,mobZ);
+            GetNPCByID(16928768+216):setStatus(STATUS_NORMAL);
+        end, 
+        [16928851] = function (x)
+            GetNPCByID(16928768+321):setPos(mobX,mobY,mobZ);
+            GetNPCByID(16928768+321):setStatus(STATUS_NORMAL);
+        end, 
+        [16928852] = function (x)   
+            GetNPCByID(16928768+45):setPos(mobX,mobY,mobZ);
+            GetNPCByID(16928768+45):setStatus(STATUS_NORMAL);
+        end,
+        [16929034] = function (x)   
+            if (GetMobByID(16929035):isSpawned()) then -- wind
+                DespawnMob(16929035);
+                SpawnMob(16929041);
+            end
+        end
+    }
 end;

--- a/scripts/zones/Temenos/mobs/Iruci.lua
+++ b/scripts/zones/Temenos/mobs/Iruci.lua
@@ -20,10 +20,10 @@ end;
 -----------------------------------
 
 function onMobEngaged(mob,target)
- if (IsMobDead(16929049)==true) then
-     mob:addStatusEffect(EFFECT_REGAIN,7,3,0);
-     mob:addStatusEffect(EFFECT_REGEN,50,3,0);
- end     
+    if (GetMobByID(16929049):isDead()) then
+        mob:addStatusEffect(EFFECT_REGAIN,7,3,0);
+        mob:addStatusEffect(EFFECT_REGEN,50,3,0);
+    end     
 end;
 
 -----------------------------------
@@ -34,10 +34,17 @@ function onMobDeath(mob, player, isKiller)
     local mobX = mob:getXPos();
     local mobY = mob:getYPos();
     local mobZ = mob:getZPos();
- 
-  if (IsMobDead(16929046)==true and IsMobDead(16929047)==true and IsMobDead(16929048)==true and IsMobDead(16929049)==true and IsMobDead(16929050)==true and IsMobDead(16929051)==true) then
-       GetNPCByID(16928768+71):setPos(mobX,mobY,mobZ);
-    GetNPCByID(16928768+71):setStatus(STATUS_NORMAL);
-    GetNPCByID(16928770+471):setStatus(STATUS_NORMAL);
-  end
+
+    if (
+        GetMobByID(16929046):isDead() and
+        GetMobByID(16929047):isDead() and
+        GetMobByID(16929048):isDead() and
+        GetMobByID(16929049):isDead() and
+        GetMobByID(16929050):isDead() and
+        GetMobByID(16929051):isDead()
+    ) then
+        GetNPCByID(16928768+71):setPos(mobX,mobY,mobZ);
+        GetNPCByID(16928768+71):setStatus(STATUS_NORMAL);
+        GetNPCByID(16928770+471):setStatus(STATUS_NORMAL);
+    end
 end;

--- a/scripts/zones/Temenos/mobs/Kindred_Dark_Knight.lua
+++ b/scripts/zones/Temenos/mobs/Kindred_Dark_Knight.lua
@@ -28,12 +28,16 @@ end;
 -----------------------------------
 
 function onMobDeath(mob, player, isKiller)
- if (IsMobDead(16928797)==true and IsMobDead(16928798)==true  and IsMobDead(16928799)==true ) then
-       GetNPCByID(16928768+27):setPos(-120,-80,429);
-    GetNPCByID(16928768+27):setStatus(STATUS_NORMAL);
-    GetNPCByID(16928768+161):setPos(-123,-80,429);
-    GetNPCByID(16928768+161):setStatus(STATUS_NORMAL);
-    GetNPCByID(16928768+212):setPos(-117,-80,429);
-    GetNPCByID(16928768+212):setStatus(STATUS_NORMAL);
- end
+    if (
+        GetMobByID(16928797):isDead() and
+        GetMobByID(16928798):isDead() and
+        GetMobByID(16928799):isDead()
+    ) then
+        GetNPCByID(16928768+27):setPos(-120,-80,429);
+        GetNPCByID(16928768+27):setStatus(STATUS_NORMAL);
+        GetNPCByID(16928768+161):setPos(-123,-80,429);
+        GetNPCByID(16928768+161):setStatus(STATUS_NORMAL);
+        GetNPCByID(16928768+212):setPos(-117,-80,429);
+        GetNPCByID(16928768+212):setStatus(STATUS_NORMAL);
+    end
 end;

--- a/scripts/zones/Temenos/mobs/Kindred_Summoner.lua
+++ b/scripts/zones/Temenos/mobs/Kindred_Summoner.lua
@@ -28,12 +28,16 @@ end;
 -----------------------------------
 
 function onMobDeath(mob, player, isKiller)
- if (IsMobDead(16928797)==true and IsMobDead(16928798)==true  and IsMobDead(16928799)==true ) then
-       GetNPCByID(16928768+27):setPos(-120,-80,429);
-    GetNPCByID(16928768+27):setStatus(STATUS_NORMAL);
-    GetNPCByID(16928768+161):setPos(-123,-80,429);
-    GetNPCByID(16928768+161):setStatus(STATUS_NORMAL);
-    GetNPCByID(16928768+212):setPos(-117,-80,429);
-    GetNPCByID(16928768+212):setStatus(STATUS_NORMAL);
- end
+    if (
+        GetMobByID(16928797):isDead() and
+        GetMobByID(16928798):isDead() and
+        GetMobByID(16928799):isDead()
+    ) then
+        GetNPCByID(16928768+27):setPos(-120,-80,429);
+        GetNPCByID(16928768+27):setStatus(STATUS_NORMAL);
+        GetNPCByID(16928768+161):setPos(-123,-80,429);
+        GetNPCByID(16928768+161):setStatus(STATUS_NORMAL);
+        GetNPCByID(16928768+212):setPos(-117,-80,429);
+        GetNPCByID(16928768+212):setStatus(STATUS_NORMAL);
+    end
 end;

--- a/scripts/zones/Temenos/mobs/Kindred_Warrior.lua
+++ b/scripts/zones/Temenos/mobs/Kindred_Warrior.lua
@@ -28,12 +28,16 @@ end;
 -----------------------------------
 
 function onMobDeath(mob, player, isKiller)
- if (IsMobDead(16928797)==true and IsMobDead(16928798)==true  and IsMobDead(16928799)==true ) then
-       GetNPCByID(16928768+27):setPos(-120,-80,429);
-    GetNPCByID(16928768+27):setStatus(STATUS_NORMAL);
-    GetNPCByID(16928768+161):setPos(-123,-80,429);
-    GetNPCByID(16928768+161):setStatus(STATUS_NORMAL);
-    GetNPCByID(16928768+212):setPos(-117,-80,429);
-    GetNPCByID(16928768+212):setStatus(STATUS_NORMAL);
- end
+    if (
+        GetMobByID(16928797):isDead() and
+        GetMobByID(16928798):isDead() and
+        GetMobByID(16928799):isDead()
+    ) then
+        GetNPCByID(16928768+27):setPos(-120,-80,429);
+        GetNPCByID(16928768+27):setStatus(STATUS_NORMAL);
+        GetNPCByID(16928768+161):setPos(-123,-80,429);
+        GetNPCByID(16928768+161):setStatus(STATUS_NORMAL);
+        GetNPCByID(16928768+212):setPos(-117,-80,429);
+        GetNPCByID(16928768+212):setStatus(STATUS_NORMAL);
+    end
 end;

--- a/scripts/zones/Temenos/mobs/Light_Elemental.lua
+++ b/scripts/zones/Temenos/mobs/Light_Elemental.lua
@@ -35,22 +35,22 @@ end;
 -----------------------------------
 
 function onMobDeath(mob, player, isKiller)
-   local mobID = mob:getID();    
-    
-     switch (mobID): caseof {
+    local mobID = mob:getID();    
+
+    switch (mobID): caseof {
         [16929031] = function (x)   
-          if (IsMobDead(16929030)==true and IsMobDead(16929032)==true ) then
-            GetNPCByID(16928768+77):setPos(0.5,-6,-459);
-            GetNPCByID(16928768+77):setStatus(STATUS_NORMAL);
-            GetNPCByID(16928768+472):setStatus(STATUS_NORMAL);
-          end
-        end    , 
+            if (GetMobByID(16929030):isDead() and GetMobByID(16929032):isDead()) then
+                GetNPCByID(16928768+77):setPos(0.5,-6,-459);
+                GetNPCByID(16928768+77):setStatus(STATUS_NORMAL);
+                GetNPCByID(16928768+472):setStatus(STATUS_NORMAL);
+            end
+        end, 
         [16929032] = function (x)   
-          if (IsMobDead(16929030)==true and IsMobDead(16929031)==true ) then
-            GetNPCByID(16928768+77):setPos(0.5,-6,-459);
-            GetNPCByID(16928768+77):setStatus(STATUS_NORMAL);
-            GetNPCByID(16928768+472):setStatus(STATUS_NORMAL);
-          end
-        end    , 
-     }
+            if (GetMobByID(16929030):isDead() and GetMobByID(16929031):isDead()) then
+                GetNPCByID(16928768+77):setPos(0.5,-6,-459);
+                GetNPCByID(16928768+77):setStatus(STATUS_NORMAL);
+                GetNPCByID(16928768+472):setStatus(STATUS_NORMAL);
+            end
+        end
+    }
 end;

--- a/scripts/zones/Temenos/mobs/Mystic_Avatar.lua
+++ b/scripts/zones/Temenos/mobs/Mystic_Avatar.lua
@@ -24,37 +24,37 @@ function onMobEngaged(mob,target)
     if (mobID==16929030) then --Carbuncle (Central Temenos 2nd Floor)
         GetMobByID(16929032):updateEnmity(target);
         GetMobByID(16929031):updateEnmity(target);
-        if (IsMobDead(16929033)==true and IsMobDead(16929039)==true) then
+        if (GetMobByID(16929033):isDead() and GetMobByID(16929039):isDead()) then
             mob:setMod(MOD_FIREDEF,-128);    
         else
             mob:setMod(MOD_FIREDEF,256);
         end
     
-        if (IsMobDead(16929034)==true and IsMobDead(16929040)==true) then
+        if (GetMobByID(16929034):isDead() and GetMobByID(16929040):isDead()) then
             mob:setMod(MOD_ICEDEF,-128);
         else    
             mob:setMod(MOD_ICEDEF,256);
         end
 
-        if (IsMobDead(16929035)==true and IsMobDead(16929041)==true) then
+        if (GetMobByID(16929035):isDead() and GetMobByID(16929041):isDead()) then
             mob:setMod(MOD_WINDDEF,-128);
         else
             mob:setMod(MOD_WINDDEF,256);
         end
 
-        if (IsMobDead(16929036)==true and IsMobDead(16929042)==true) then
+        if (GetMobByID(16929036):isDead() and GetMobByID(16929042):isDead()) then
             mob:setMod(MOD_EARTHDEF,-128);    
         else
             mob:setMod(MOD_EARTHDEF,256);
         end
 
-        if (IsMobDead(16929037)==true and IsMobDead(16929043)==true) then
+        if (GetMobByID(16929037):isDead() and GetMobByID(16929043):isDead()) then
             mob:setMod(MOD_THUNDERDEF,-128);
         else    
             mob:setMod(MOD_THUNDERDEF,256);
         end
 
-        if (IsMobDead(16929038)==true and IsMobDead(16929044)==true) then
+        if (GetMobByID(16929038):isDead() and GetMobByID(16929044):isDead()) then
             mob:setMod(MOD_WATERDEF,-128);
         else
             mob:setMod(MOD_WATERDEF,256);    
@@ -97,7 +97,7 @@ function onMobDeath(mob, player, isKiller)
         GetNPCByID(16928768+70):setPos(mobX,mobY,mobZ);
         GetNPCByID(16928768+70):setStatus(STATUS_NORMAL);
     elseif (mobID==16929030) then --Carbuncle (Central Temenos 2nd Floor)
-        if (IsMobDead(16929031)==true and IsMobDead(16929032)==true ) then
+        if (GetMobByID(16929031):isDead() and GetMobByID(16929032):isDead() ) then
             GetNPCByID(16928768+77):setPos(0.5,-6,-459);
             GetNPCByID(16928768+77):setStatus(STATUS_NORMAL);
             GetNPCByID(16928768+472):setStatus(STATUS_NORMAL);

--- a/scripts/zones/Temenos/mobs/Orichalcum_Quadav.lua
+++ b/scripts/zones/Temenos/mobs/Orichalcum_Quadav.lua
@@ -20,21 +20,26 @@ end;
 -----------------------------------
 
 function onMobEngaged(mob,target)
-  if   (IsMobDead(16929017)==true and IsMobDead(16929018)==true and IsMobDead(16929019)==true and
-        IsMobDead(16929020)==true and IsMobDead(16929021)==true and IsMobDead(16929022)==true 
-    ) then
-       mob:setMod(MOD_SLASHRES,1400);
-       mob:setMod(MOD_PIERCERES,1400);
-       mob:setMod(MOD_IMPACTRES,1400);
-       mob:setMod(MOD_HTHRES,1400);       
-  else
-      mob:setMod(MOD_SLASHRES,300);
-      mob:setMod(MOD_PIERCERES,300);
-      mob:setMod(MOD_IMPACTRES,300);
-      mob:setMod(MOD_HTHRES,300);
-  end 
-  GetMobByID(16929005):updateEnmity(target);
-  GetMobByID(16929007):updateEnmity(target);
+    if (
+        GetMobByID(16929017):isDead() and
+        GetMobByID(16929018):isDead() and
+        GetMobByID(16929019):isDead() and
+        GetMobByID(16929020):isDead() and
+        GetMobByID(16929021):isDead() and
+        GetMobByID(16929022):isDead()
+    ) then  
+        mob:setMod(MOD_SLASHRES,1400);
+        mob:setMod(MOD_PIERCERES,1400);
+        mob:setMod(MOD_IMPACTRES,1400);
+        mob:setMod(MOD_HTHRES,1400);
+    else
+        mob:setMod(MOD_SLASHRES,300);
+        mob:setMod(MOD_PIERCERES,300);
+        mob:setMod(MOD_IMPACTRES,300);
+        mob:setMod(MOD_HTHRES,300);
+    end
+    GetMobByID(16929005):updateEnmity(target);
+    GetMobByID(16929007):updateEnmity(target);
 end;
 
 -----------------------------------
@@ -42,9 +47,13 @@ end;
 -----------------------------------
 
 function onMobDeath(mob, player, isKiller)
-          if (IsMobDead(16929005)==true and IsMobDead(16929006)==true and IsMobDead(16929007)==true) then
-            GetNPCByID(16928768+78):setPos(-280,-161,-440);
-            GetNPCByID(16928768+78):setStatus(STATUS_NORMAL);
-            GetNPCByID(16928768+473):setStatus(STATUS_NORMAL);        
-          end
+    if (
+        GetMobByID(16929005):isDead() and
+        GetMobByID(16929006):isDead() and
+        GetMobByID(16929007):isDead()
+    ) then
+        GetNPCByID(16928768+78):setPos(-280,-161,-440);
+        GetNPCByID(16928768+78):setStatus(STATUS_NORMAL);
+        GetNPCByID(16928768+473):setStatus(STATUS_NORMAL);
+    end
 end;

--- a/scripts/zones/Temenos/mobs/Pee_Qoho_the_Python.lua
+++ b/scripts/zones/Temenos/mobs/Pee_Qoho_the_Python.lua
@@ -20,21 +20,26 @@ end;
 -----------------------------------
 
 function onMobEngaged(mob,target)
-  if   (IsMobDead(16929023)==true and IsMobDead(16929024)==true and IsMobDead(16929025)==true and
-        IsMobDead(16929026)==true and IsMobDead(16929027)==true and IsMobDead(16929028)==true 
-    ) then
-       mob:setMod(MOD_SLASHRES,1400);
-       mob:setMod(MOD_PIERCERES,1400);
-       mob:setMod(MOD_IMPACTRES,1400);
-       mob:setMod(MOD_HTHRES,1400);       
-  else
-      mob:setMod(MOD_SLASHRES,300);
-      mob:setMod(MOD_PIERCERES,300);
-      mob:setMod(MOD_IMPACTRES,300);
-      mob:setMod(MOD_HTHRES,300);
-  end 
-  GetMobByID(16929005):updateEnmity(target);
-  GetMobByID(16929006):updateEnmity(target);
+    if (
+        GetMobByID(16929023):isDead() and
+        GetMobByID(16929024):isDead() and
+        GetMobByID(16929025):isDead() and
+        GetMobByID(16929026):isDead() and
+        GetMobByID(16929027):isDead() and
+        GetMobByID(16929028):isDead()
+    ) then  
+        mob:setMod(MOD_SLASHRES,1400);
+        mob:setMod(MOD_PIERCERES,1400);
+        mob:setMod(MOD_IMPACTRES,1400);
+        mob:setMod(MOD_HTHRES,1400);
+    else
+        mob:setMod(MOD_SLASHRES,300);
+        mob:setMod(MOD_PIERCERES,300);
+        mob:setMod(MOD_IMPACTRES,300);
+        mob:setMod(MOD_HTHRES,300);
+    end
+    GetMobByID(16929005):updateEnmity(target);
+    GetMobByID(16929006):updateEnmity(target);
 end;
 
 -----------------------------------
@@ -42,9 +47,13 @@ end;
 -----------------------------------
 
 function onMobDeath(mob, player, isKiller)
-          if (IsMobDead(16929005)==true and IsMobDead(16929006)==true and IsMobDead(16929007)==true) then
-            GetNPCByID(16928768+78):setPos(-280,-161,-440);
-            GetNPCByID(16928768+78):setStatus(STATUS_NORMAL);
-            GetNPCByID(16928768+473):setStatus(STATUS_NORMAL);        
-          end
+    if (
+        GetMobByID(16929005):isDead() and
+        GetMobByID(16929006):isDead() and
+        GetMobByID(16929007):isDead()
+    ) then
+        GetNPCByID(16928768+78):setPos(-280,-161,-440);
+        GetNPCByID(16928768+78):setStatus(STATUS_NORMAL);
+        GetNPCByID(16928768+473):setStatus(STATUS_NORMAL);
+    end
 end;

--- a/scripts/zones/Temenos/mobs/Praetorian_Guard_CCCXI.lua
+++ b/scripts/zones/Temenos/mobs/Praetorian_Guard_CCCXI.lua
@@ -28,13 +28,18 @@ end;
 -----------------------------------
 
 function onMobDeath(mob, player, isKiller)
- if (IsMobDead(16928809)==true and IsMobDead(16928810)==true  and IsMobDead(16928811)==true and IsMobDead(16928812)==true ) then
-       GetNPCByID(16928768+28):setPos(-311,80,419);
-    GetNPCByID(16928768+28):setStatus(STATUS_NORMAL);
-    GetNPCByID(16928768+162):setPos(-311,80,417);
-    GetNPCByID(16928768+162):setStatus(STATUS_NORMAL);
-    GetNPCByID(16928768+213):setPos(-311,80,421);
-    GetNPCByID(16928768+213):setStatus(STATUS_NORMAL);
-    GetNPCByID(16928770+454):setStatus(STATUS_NORMAL);
- end
+    if (
+        GetMobByID(16928809):isDead() and
+        GetMobByID(16928810):isDead() and
+        GetMobByID(16928811):isDead() and
+        GetMobByID(16928812):isDead()
+    ) then
+        GetNPCByID(16928768+28):setPos(-311,80,419);
+        GetNPCByID(16928768+28):setStatus(STATUS_NORMAL);
+        GetNPCByID(16928768+162):setPos(-311,80,417);
+        GetNPCByID(16928768+162):setStatus(STATUS_NORMAL);
+        GetNPCByID(16928768+213):setPos(-311,80,421);
+        GetNPCByID(16928768+213):setStatus(STATUS_NORMAL);
+        GetNPCByID(16928770+454):setStatus(STATUS_NORMAL);
+    end
 end;

--- a/scripts/zones/Temenos/mobs/Skadi.lua
+++ b/scripts/zones/Temenos/mobs/Skadi.lua
@@ -29,12 +29,16 @@ end;
 -----------------------------------
 
 function onMobDeath(mob, player, isKiller)
- if (IsMobDead(16928781)==true and IsMobDead(16928782)==true  and IsMobDead(16928783)==true ) then
-       GetNPCByID(16928768+19):setPos(200,-82,495);
-    GetNPCByID(16928768+19):setStatus(STATUS_NORMAL);
-    GetNPCByID(16928768+153):setPos(206,-82,495);
-    GetNPCByID(16928768+153):setStatus(STATUS_NORMAL);
-    GetNPCByID(16928768+210):setPos(196,-82,495);
-    GetNPCByID(16928768+210):setStatus(STATUS_NORMAL);
- end
+    if (
+        GetMobByID(16928781):isDead() and
+        GetMobByID(16928782):isDead() and
+        GetMobByID(16928783):isDead()
+    ) then
+        GetNPCByID(16928768+19):setPos(200,-82,495);
+        GetNPCByID(16928768+19):setStatus(STATUS_NORMAL);
+        GetNPCByID(16928768+153):setPos(206,-82,495);
+        GetNPCByID(16928768+153):setStatus(STATUS_NORMAL);
+        GetNPCByID(16928768+210):setPos(196,-82,495);
+        GetNPCByID(16928768+210):setStatus(STATUS_NORMAL);
+    end
 end;

--- a/scripts/zones/Temenos/mobs/Telchines_Bard.lua
+++ b/scripts/zones/Temenos/mobs/Telchines_Bard.lua
@@ -28,12 +28,17 @@ end;
 -----------------------------------
 
 function onMobDeath(mob, player, isKiller)
- if (IsMobDead(16928788)==true and IsMobDead(16928789)==true  and IsMobDead(16928792)==true   and IsMobDead(16928793)==true ) then
-       GetNPCByID(16928768+26):setPos(19,80,430);
-    GetNPCByID(16928768+26):setStatus(STATUS_NORMAL);
-    GetNPCByID(16928768+160):setPos(16,80,430);
-    GetNPCByID(16928768+160):setStatus(STATUS_NORMAL);
-    GetNPCByID(16928768+211):setPos(22,80,430);
-    GetNPCByID(16928768+211):setStatus(STATUS_NORMAL);
- end
+    if (
+        GetMobByID(16928788):isDead() and
+        GetMobByID(16928789):isDead() and
+        GetMobByID(16928792):isDead() and
+        GetMobByID(16928793):isDead()
+    ) then
+        GetNPCByID(16928768+26):setPos(19,80,430);
+        GetNPCByID(16928768+26):setStatus(STATUS_NORMAL);
+        GetNPCByID(16928768+160):setPos(16,80,430);
+        GetNPCByID(16928768+160):setStatus(STATUS_NORMAL);
+        GetNPCByID(16928768+211):setPos(22,80,430);
+        GetNPCByID(16928768+211):setStatus(STATUS_NORMAL);
+    end
 end;

--- a/scripts/zones/Temenos/mobs/Telchines_Monk.lua
+++ b/scripts/zones/Temenos/mobs/Telchines_Monk.lua
@@ -28,12 +28,17 @@ end;
 -----------------------------------
 
 function onMobDeath(mob, player, isKiller)
- if (IsMobDead(16928788)==true and IsMobDead(16928789)==true  and IsMobDead(16928792)==true   and IsMobDead(16928793)==true ) then
-       GetNPCByID(16928768+26):setPos(19,80,430);
-    GetNPCByID(16928768+26):setStatus(STATUS_NORMAL);
-    GetNPCByID(16928768+160):setPos(16,80,430);
-    GetNPCByID(16928768+160):setStatus(STATUS_NORMAL);
-    GetNPCByID(16928768+211):setPos(22,80,430);
-    GetNPCByID(16928768+211):setStatus(STATUS_NORMAL);
- end
+    if (
+        GetMobByID(16928788):isDead() and
+        GetMobByID(16928789):isDead() and
+        GetMobByID(16928792):isDead() and
+        GetMobByID(16928793):isDead()
+    ) then
+        GetNPCByID(16928768+26):setPos(19,80,430);
+        GetNPCByID(16928768+26):setStatus(STATUS_NORMAL);
+        GetNPCByID(16928768+160):setPos(16,80,430);
+        GetNPCByID(16928768+160):setStatus(STATUS_NORMAL);
+        GetNPCByID(16928768+211):setPos(22,80,430);
+        GetNPCByID(16928768+211):setStatus(STATUS_NORMAL);
+    end
 end;

--- a/scripts/zones/Temenos/mobs/Telchines_White_Mage.lua
+++ b/scripts/zones/Temenos/mobs/Telchines_White_Mage.lua
@@ -28,12 +28,17 @@ end;
 -----------------------------------
 
 function onMobDeath(mob, player, isKiller)
- if (IsMobDead(16928788)==true and IsMobDead(16928789)==true  and IsMobDead(16928792)==true   and IsMobDead(16928793)==true ) then
-       GetNPCByID(16928768+26):setPos(19,80,430);
-    GetNPCByID(16928768+26):setStatus(STATUS_NORMAL);
-    GetNPCByID(16928768+160):setPos(16,80,430);
-    GetNPCByID(16928768+160):setStatus(STATUS_NORMAL);
-    GetNPCByID(16928768+211):setPos(22,80,430);
-    GetNPCByID(16928768+211):setStatus(STATUS_NORMAL);
- end
+    if (
+        GetMobByID(16928788):isDead() and
+        GetMobByID(16928789):isDead() and
+        GetMobByID(16928792):isDead() and
+        GetMobByID(16928793):isDead()
+    ) then
+        GetNPCByID(16928768+26):setPos(19,80,430);
+        GetNPCByID(16928768+26):setStatus(STATUS_NORMAL);
+        GetNPCByID(16928768+160):setPos(16,80,430);
+        GetNPCByID(16928768+160):setStatus(STATUS_NORMAL);
+        GetNPCByID(16928768+211):setPos(22,80,430);
+        GetNPCByID(16928768+211):setStatus(STATUS_NORMAL);
+    end
 end;

--- a/scripts/zones/Temenos/mobs/Temenos_Aern.lua
+++ b/scripts/zones/Temenos/mobs/Temenos_Aern.lua
@@ -60,7 +60,7 @@ local AernList = {16929053,16929054,16929055,16929057,16929058,16929060,16929061
                   16929077,16929078,16929079,16929082,16929083,16929084,16929085,16929086,16929087};
 
     for n=1,27,1 do
-      if ( IsMobDead(AernList[n]) == false) then
+      if ( GetMobByID(AernList[n]):isAlive() ) then
         leftAern=leftAern+1;
       end      
     end

--- a/scripts/zones/Temenos/mobs/Temenos_Cleaner.lua
+++ b/scripts/zones/Temenos/mobs/Temenos_Cleaner.lua
@@ -20,10 +20,10 @@ end;
 -----------------------------------
 
 function onMobEngaged(mob,target)
- if (IsMobDead(16929046)==true) then
-     mob:addStatusEffect(EFFECT_REGAIN,7,3,0);
-     mob:addStatusEffect(EFFECT_REGEN,50,3,0);
-  end
+    if (GetMobByID(16929046):isDead()) then
+        mob:addStatusEffect(EFFECT_REGAIN,7,3,0);
+        mob:addStatusEffect(EFFECT_REGEN,50,3,0);
+    end
 end;
 
 -----------------------------------
@@ -34,9 +34,16 @@ function onMobDeath(mob, player, isKiller)
     local mobX = mob:getXPos();
     local mobY = mob:getYPos();
     local mobZ = mob:getZPos();
-  if (IsMobDead(16929046)==true and IsMobDead(16929047)==true and IsMobDead(16929048)==true and IsMobDead(16929049)==true and IsMobDead(16929050)==true and IsMobDead(16929051)==true) then
-       GetNPCByID(16928768+71):setPos(mobX,mobY,mobZ);
-    GetNPCByID(16928768+71):setStatus(STATUS_NORMAL);
-    GetNPCByID(16928770+471):setStatus(STATUS_NORMAL);
-  end
+    if (
+        GetMobByID(16929046):isDead() and
+        GetMobByID(16929047):isDead() and
+        GetMobByID(16929048):isDead() and
+        GetMobByID(16929049):isDead() and
+        GetMobByID(16929050):isDead() and
+        GetMobByID(16929051):isDead()
+    ) then
+        GetNPCByID(16928768+71):setPos(mobX,mobY,mobZ);
+        GetNPCByID(16928768+71):setStatus(STATUS_NORMAL);
+        GetNPCByID(16928770+471):setStatus(STATUS_NORMAL);
+    end
 end;

--- a/scripts/zones/Temenos/mobs/Temenos_Weapon.lua
+++ b/scripts/zones/Temenos/mobs/Temenos_Weapon.lua
@@ -20,10 +20,10 @@ end;
 -----------------------------------
 
 function onMobEngaged(mob,target)
-  if (IsMobDead(16929048)==true) then
-     mob:addStatusEffect(EFFECT_REGAIN,7,3,0);
-     mob:addStatusEffect(EFFECT_REGEN,50,3,0);
-  end
+    if (GetMobByID(16929048):isDead()) then
+        mob:addStatusEffect(EFFECT_REGAIN,7,3,0);
+        mob:addStatusEffect(EFFECT_REGEN,50,3,0);
+    end
 end;
 
 -----------------------------------
@@ -34,9 +34,16 @@ function onMobDeath(mob, player, isKiller)
     local mobX = mob:getXPos();
     local mobY = mob:getYPos();
     local mobZ = mob:getZPos();
-  if (IsMobDead(16929046)==true and IsMobDead(16929047)==true and IsMobDead(16929048)==true and IsMobDead(16929049)==true and IsMobDead(16929050)==true and IsMobDead(16929051)==true) then
-       GetNPCByID(16928768+71):setPos(mobX,mobY,mobZ);
-    GetNPCByID(16928768+71):setStatus(STATUS_NORMAL);
-    GetNPCByID(16928770+471):setStatus(STATUS_NORMAL);
-  end
+    if (
+        GetMobByID(16929046):isDead() and 
+        GetMobByID(16929047):isDead() and 
+        GetMobByID(16929048):isDead() and 
+        GetMobByID(16929049):isDead() and 
+        GetMobByID(16929050):isDead() and 
+        GetMobByID(16929051):isDead()
+    ) then
+        GetNPCByID(16928768+71):setPos(mobX,mobY,mobZ);
+        GetNPCByID(16928768+71):setStatus(STATUS_NORMAL);
+        GetNPCByID(16928770+471):setStatus(STATUS_NORMAL);
+    end
 end;

--- a/scripts/zones/Temenos/mobs/Thrym.lua
+++ b/scripts/zones/Temenos/mobs/Thrym.lua
@@ -21,7 +21,7 @@ end;
 
 function onMobEngaged(mob,target)
     GetMobByID(16928781):updateEnmity(target);
-        GetMobByID(16928783):updateEnmity(target);
+    GetMobByID(16928783):updateEnmity(target);
 end;
 
 -----------------------------------
@@ -29,13 +29,16 @@ end;
 -----------------------------------
 
 function onMobDeath(mob, player, isKiller)
-
- if (IsMobDead(16928781)==true and IsMobDead(16928782)==true  and IsMobDead(16928783)==true ) then
-       GetNPCByID(16928768+19):setPos(200,-82,495);
-    GetNPCByID(16928768+19):setStatus(STATUS_NORMAL);
-    GetNPCByID(16928768+153):setPos(206,-82,495);
-    GetNPCByID(16928768+153):setStatus(STATUS_NORMAL);
-    GetNPCByID(16928768+210):setPos(196,-82,495);
-    GetNPCByID(16928768+210):setStatus(STATUS_NORMAL);
- end
+    if (
+        GetMobByID(16928781):isDead() and
+        GetMobByID(16928782):isDead() and
+        GetMobByID(16928783):isDead()
+    ) then
+        GetNPCByID(16928768+19):setPos(200,-82,495);
+        GetNPCByID(16928768+19):setStatus(STATUS_NORMAL);
+        GetNPCByID(16928768+153):setPos(206,-82,495);
+        GetNPCByID(16928768+153):setStatus(STATUS_NORMAL);
+        GetNPCByID(16928768+210):setPos(196,-82,495);
+        GetNPCByID(16928768+210):setStatus(STATUS_NORMAL);
+    end
 end;

--- a/scripts/zones/Temenos/mobs/Thunder_Elemental.lua
+++ b/scripts/zones/Temenos/mobs/Thunder_Elemental.lua
@@ -28,33 +28,34 @@ end;
 -----------------------------------
 
 function onMobDeath(mob, player, isKiller)
-   local mobID = mob:getID();    
-   local mobX = mob:getXPos();
-   local mobY = mob:getYPos();
-   local mobZ = mob:getZPos();        
-     switch (mobID): caseof {
-         -- 100 a 106 inclut (Temenos -Northern Tower )
+    local mobID = mob:getID();
+    local mobX = mob:getXPos();
+    local mobY = mob:getYPos();
+    local mobZ = mob:getZPos();
+
+    switch (mobID): caseof {
+        -- 100 a 106 inclut (Temenos -Northern Tower )
         [16928876] = function (x)
-           GetNPCByID(16928768+183):setPos(mobX,mobY,mobZ);
-           GetNPCByID(16928768+183):setStatus(STATUS_NORMAL);
-        end    , 
+            GetNPCByID(16928768+183):setPos(mobX,mobY,mobZ);
+            GetNPCByID(16928768+183):setStatus(STATUS_NORMAL);
+        end, 
         [16928877] = function (x)
-           GetNPCByID(16928768+261):setPos(mobX,mobY,mobZ);
-           GetNPCByID(16928768+261):setStatus(STATUS_NORMAL);
-        end    , 
+            GetNPCByID(16928768+261):setPos(mobX,mobY,mobZ);
+            GetNPCByID(16928768+261):setStatus(STATUS_NORMAL);
+        end, 
         [16928878] = function (x)
-           GetNPCByID(16928768+393):setPos(mobX,mobY,mobZ);
-           GetNPCByID(16928768+393):setStatus(STATUS_NORMAL);
-        end    , 
-        [16928879] = function (x)   
-           GetNPCByID(16928768+68):setPos(mobX,mobY,mobZ);
-           GetNPCByID(16928768+68):setStatus(STATUS_NORMAL);
-        end    , 
-        [16929037] = function (x)   
-           if (IsMobDead(16929038)==false) then
-             DespawnMob(16929038);
-             SpawnMob(16929044);
-           end
-        end    ,
-     }
+            GetNPCByID(16928768+393):setPos(mobX,mobY,mobZ);
+            GetNPCByID(16928768+393):setStatus(STATUS_NORMAL);
+        end, 
+        [16928879] = function (x)
+            GetNPCByID(16928768+68):setPos(mobX,mobY,mobZ);
+            GetNPCByID(16928768+68):setStatus(STATUS_NORMAL);
+        end, 
+        [16929037] = function (x)
+            if (GetMobByID(16929038):isSpawned()) then
+                DespawnMob(16929038);
+                SpawnMob(16929044);
+            end
+        end
+    }
 end;

--- a/scripts/zones/Temenos/mobs/Water_Elemental.lua
+++ b/scripts/zones/Temenos/mobs/Water_Elemental.lua
@@ -28,33 +28,34 @@ end;
 -----------------------------------
 
 function onMobDeath(mob, player, isKiller)
-   local mobID = mob:getID();    
-   local mobX = mob:getXPos();
-   local mobY = mob:getYPos();
-   local mobZ = mob:getZPos();        
-     switch (mobID): caseof {
-         -- 100 a 106 inclut (Temenos -Northern Tower )
+    local mobID = mob:getID();
+    local mobX = mob:getXPos();
+    local mobY = mob:getYPos();
+    local mobZ = mob:getZPos();
+
+    switch (mobID): caseof {
+        -- 100 a 106 inclut (Temenos -Northern Tower )
         [16928885] = function (x)
-           GetNPCByID(16928768+277):setPos(mobX,mobY,mobZ);
-           GetNPCByID(16928768+277):setStatus(STATUS_NORMAL);
-        end    , 
+            GetNPCByID(16928768+277):setPos(mobX,mobY,mobZ);
+            GetNPCByID(16928768+277):setStatus(STATUS_NORMAL);
+        end, 
         [16928886] = function (x)
-           GetNPCByID(16928768+190):setPos(mobX,mobY,mobZ);
-           GetNPCByID(16928768+190):setStatus(STATUS_NORMAL);
-        end    , 
+            GetNPCByID(16928768+190):setPos(mobX,mobY,mobZ);
+            GetNPCByID(16928768+190):setStatus(STATUS_NORMAL);
+        end, 
         [16928887] = function (x)
-           GetNPCByID(16928768+127):setPos(mobX,mobY,mobZ);
-           GetNPCByID(16928768+127):setStatus(STATUS_NORMAL);
-        end    , 
+            GetNPCByID(16928768+127):setPos(mobX,mobY,mobZ);
+            GetNPCByID(16928768+127):setStatus(STATUS_NORMAL);
+        end, 
         [16928888] = function (x)   
-           GetNPCByID(16928768+69):setPos(mobX,mobY,mobZ);
-           GetNPCByID(16928768+69):setStatus(STATUS_NORMAL);
-        end    ,
+            GetNPCByID(16928768+69):setPos(mobX,mobY,mobZ);
+            GetNPCByID(16928768+69):setStatus(STATUS_NORMAL);
+        end,
         [16929038] = function (x)   
-           if (IsMobDead(16929033)==false) then  
-             DespawnMob(16929033);
-             SpawnMob(16929039);
-           end
-        end    ,
-     }
+            if (GetMobByID(16929033):isSpawned()) then  
+                DespawnMob(16929033);
+                SpawnMob(16929039);
+            end
+        end
+    }
 end;

--- a/scripts/zones/Temenos/npcs/Armoury_Crate.lua
+++ b/scripts/zones/Temenos/npcs/Armoury_Crate.lua
@@ -55,7 +55,7 @@ function onTrigger(player,npc)
     local coffer = CofferID-16928768;
 
     if (CofferType == cTIME) then 
-        player:addTimeToSpecialBattlefield(InstanceRegion,addtime);
+        player:addTimeToBattlefield(InstanceRegion,addtime);
     elseif (CofferType == cITEM) then
         if (InstanceRegion == Central_Temenos_4th_Floor and coffer~=79) then
             local randmimic = math.random(1,24)

--- a/scripts/zones/Temenos/npcs/Matter_Diffusion_Module.lua
+++ b/scripts/zones/Temenos/npcs/Matter_Diffusion_Module.lua
@@ -1,51 +1,17 @@
 -----------------------------------
 -- Area: temenos
 -- NPC:  Matter diffusion module
--- !pos
------------------------------------
-package.loaded["scripts/zones/Temenos/TextIDs"] = nil;
+-- !pos 580 -3 100 37
 -----------------------------------
 
-require("scripts/globals/limbus");
-require("scripts/globals/keyitems");
-require("scripts/zones/Temenos/TextIDs");
+require("scripts/globals/bcnm");
 
 -----------------------------------
 -- onTrade Action
 -----------------------------------
 
 function onTrade(player,npc,trade)
-local count = trade:getItemCount();
-local InstanceTrade=0;
-if (player:hasKeyItem(COSMOCLEANSE) and player:hasKeyItem(WHITE_CARD) ) then
-
-
-     if (count==1 and trade:hasItemQty(2127,1)) then -- Central Temenos - Basement 1
-       InstanceTrade=128;
-     elseif (count==1 and trade:hasItemQty(1906,1)) then -- Central Temenos - 1st Floor
-       InstanceTrade=64;
-     elseif (count==1 and trade:hasItemQty(1905,1)) then -- Central Temenos - 2st Floor
-       InstanceTrade=32;
-     elseif (count==1 and trade:hasItemQty(1904,1)) then -- Central Temenos - 3st Floor
-       InstanceTrade=16;
-     elseif (count==3 and trade:hasItemQty(1986,1) and trade:hasItemQty(1908,1) and trade:hasItemQty(1907,1)) then --proto-ultima
-       InstanceTrade=8;
-     end
-  else
-       player:messageSpecial(CONDITION_FOR_LIMBUS_T);
-     print("error player  don't have cosmo clean");
-  end
-
-   if (InstanceTrade~=0) then
-   player:setVar("Limbus_Trade_Item-T",InstanceTrade);
-   player:tradeComplete();
-   player:messageSpecial(CHIP_TRADE_T);
-   player:startEvent(0x7d00,0,0,0,InstanceTrade,0,0,0,0);
-   player:setVar("limbusbitmap",InstanceTrade);
-   end
-
-
-
+    TradeBCNM(player,npc,trade);
 end;
 
 -----------------------------------
@@ -53,117 +19,15 @@ end;
 -----------------------------------
 
 function onTrigger(player,npc)
- local instancelist ={};
- local limbusbitmap = 0 ;
- local AllowLimbusToPlayer = true ;
- local currentlimbus= TryTobackOnCurrentLimbus(player);
-
-
-         instancelist = TEMENOS_LIST;
-
-  printf("currentlimbus: %u",currentlimbus);
-
-
-   if (player:hasKeyItem(COSMOCLEANSE)) then
-       if (player:hasStatusEffect(EFFECT_BATTLEFIELD) == false) then
-         local LimbusTradeItem = player:getVar("Limbus_Trade_Item-T");
-           for nt = 1,#instancelist,2 do
-                --    printf("list d'instance: %u",instancelist[nt]);
-               if (instancelist[nt+1][1]==true and player:hasKeyItem(WHITE_CARD)) then
-               --    print("player_have_white_card");
-                   limbusbitmap = limbusbitmap + instancelist[nt+1][4];
-               --   printf("bitmapadd: %u",instancelist[nt+1][4]);
-               end
-               if (instancelist[nt+1][2]==true and player:hasKeyItem(RED_CARD)) then
-                --  print("player_have_red_card");
-                    limbusbitmap = limbusbitmap + instancelist[nt+1][4];
-                --   printf("bitmapadd: %u",instancelist[nt+1][4]);
-               end
-               if (instancelist[nt+1][3]==true and player:hasKeyItem(BLACK_CARD)) then
-                 -- print("player_have_black_card");
-                    limbusbitmap = limbusbitmap + instancelist[nt+1][4];
-                 --  printf("bitmapadd: %u",instancelist[nt+1][4]);
-               end
-           end
-        limbusbitmap= limbusbitmap + LimbusTradeItem;
-      ----- /////////////////////////////////////////////on doit ajouter le mipmap pour l'item trade ici
-       else
-             local    status = player:getStatusEffect(EFFECT_BATTLEFIELD);
-            local    playerbcnmid = status:getPower();
-           -- check if the player has the key item for the current battlefield
-           for nt = 1,#instancelist,2 do
-               --     printf("list d'instance: %u",instancelist[nt]);
-                    if (instancelist[nt] == playerbcnmid) then
-                        if (instancelist[nt+1][1]== true and player:hasKeyItem(WHITE_CARD) == false) then
-                           AllowLimbusToPlayer = false;
-                        end
-                        if (instancelist[nt+1][2]== true  and player:hasKeyItem(RED_CARD) == false ) then
-                           AllowLimbusToPlayer = false;
-                        end
-                        if (instancelist[nt+1][3]== true and player:hasKeyItem(BLACK_CARD) == false ) then
-                           AllowLimbusToPlayer = false;
-                        end
-                        if (AllowLimbusToPlayer == true) then --player have the correct key item for the current battflield
-                           limbusbitmap = instancelist[nt+1][4];
-                        end
-
-                    end
-           end
-
-
-
-       end
-
-
-
-
-       if (limbusbitmap~= 0 ) then
-           player:startEvent(0x7d00,0,0,0,limbusbitmap,0,0,0,0);
-        player:setVar("limbusbitmap",limbusbitmap);
-       else
-       player:messageSpecial(CONDITION_FOR_LIMBUS_T);
-        print("player need a card for basic limbus");
-        end
-
-  elseif (currentlimbus~=0) then
-           for nt = 1,#instancelist,2 do
-               --     printf("list d'instance: %u",instancelist[nt]);
-                    if (instancelist[nt] == currentlimbus) then
-                           limbusbitmap = instancelist[nt+1][4];
-                    end
-           end
-        player:startEvent(0x7d00,0,0,0,limbusbitmap,0,0,0,0);
-        player:setVar("limbusbitmap",limbusbitmap);
-
-  else
-       player:messageSpecial(CONDITION_FOR_LIMBUS_T);
-    print("error player  don't have cosmo clean");
-  end
-
+    EventTriggerBCNM(player,npc);
 end;
 
 -----------------------------------
 -- onEventUpdate
 -----------------------------------
 
-function onEventUpdate(player,csid,option)
-
-
-     if (csid == 0x7d00) then
-       if (player:hasStatusEffect(EFFECT_BATTLEFIELD) == false) then
-           ResetPlayerLimbusVariable(player);
-           player:setVar("characterLimbusKey",0);
-       else
-               local status = player:getStatusEffect(EFFECT_BATTLEFIELD);
-            player:setVar("LimbusID",status:getPower());
-             player:setVar("characterLimbusKey",GetLimbusKeyFromInstance(status:getPower()));
-       end
-     player:updateEvent(2,player:getVar("limbusbitmap"),0,1,1,0);
-     player:setVar("limbusbitmap",0);
-
-
-     end
-
+function onEventUpdate(player,csid,option,extras)
+    EventUpdateBCNM(player,csid,option,extras);
 end;
 
 -----------------------------------
@@ -171,9 +35,5 @@ end;
 -----------------------------------
 
 function onEventFinish(player,csid,option)
-    -- printf("CSID: %u",csid);
-    -- printf("RESULT: %u",option);
-   if (csid == 0x7d00) then
-
-   end
+    EventFinishBCNM(player,csid,option);
 end;

--- a/scripts/zones/Temenos/npcs/Particle_Gate.lua
+++ b/scripts/zones/Temenos/npcs/Particle_Gate.lua
@@ -22,92 +22,92 @@ end;
 
 function onTrigger(player,npc)
     local GateID =  npc:getID();  
-    local GateOffset = 16929221;
+
     -- print("GateID " ..GateID);
     -- player:PrintToPlayer(npc:getID());
     
     switch (GateID): caseof 
     {
          -- 100-106 : Northern Tower
-        [GateOffset] = function (x)
+        [GATE_OFFSET] = function (x)
              player:startEvent(100);
         end,
-        [GateOffset+1] = function (x)
+        [GATE_OFFSET+1] = function (x)
              player:startEvent(101);
         end,
-        [GateOffset+2] = function (x)
+        [GATE_OFFSET+2] = function (x)
              player:startEvent(102);
         end,
-        [GateOffset+3] = function (x)
+        [GATE_OFFSET+3] = function (x)
              player:startEvent(103);
         end,
-        [GateOffset+4] = function (x)
+        [GATE_OFFSET+4] = function (x)
              player:startEvent(104);
         end,
-        [GateOffset+5] = function (x)
+        [GATE_OFFSET+5] = function (x)
              player:startEvent(105);
         end,
-        [GateOffset+6] = function (x)
+        [GATE_OFFSET+6] = function (x)
              player:startEvent(106);
         end,
         -- 107-113 : Eastern Tower
-        [GateOffset+7] = function (x)
+        [GATE_OFFSET+7] = function (x)
              player:startEvent(107);
         end,
-        [GateOffset+8] = function (x)
+        [GATE_OFFSET+8] = function (x)
              player:startEvent(108);
         end,
-        [GateOffset+9] = function (x)
+        [GATE_OFFSET+9] = function (x)
              player:startEvent(109);
         end,
-        [GateOffset+10] = function (x)
+        [GATE_OFFSET+10] = function (x)
              player:startEvent(110);
         end,
-        [GateOffset+11] = function (x)
+        [GATE_OFFSET+11] = function (x)
              player:startEvent(111);
         end,
-        [GateOffset+12] = function (x)
+        [GATE_OFFSET+12] = function (x)
              player:startEvent(112);
         end,
-        [GateOffset+13] = function (x)
+        [GATE_OFFSET+13] = function (x)
              player:startEvent(113);
         end,
         -- 114-120 Western Tower
-        [GateOffset+14] = function (x)
+        [GATE_OFFSET+14] = function (x)
              player:startEvent(114);
         end,
-        [GateOffset+15] = function (x)
+        [GATE_OFFSET+15] = function (x)
              player:startEvent(115);
         end,
-        [GateOffset+16] = function (x)
+        [GATE_OFFSET+16] = function (x)
              player:startEvent(116);
         end,
-        [GateOffset+17] = function (x)
+        [GATE_OFFSET+17] = function (x)
              player:startEvent(117);
         end,
-        [GateOffset+18] = function (x)
+        [GATE_OFFSET+18] = function (x)
              player:startEvent(118);
         end,
-        [GateOffset+19] = function (x)
+        [GATE_OFFSET+19] = function (x)
              player:startEvent(119);
         end,
-        [GateOffset+20] = function (x)
+        [GATE_OFFSET+20] = function (x)
              player:startEvent(120);
         end,
         -- The rest of Temenos
-        [GateOffset+21] = function (x)
+        [GATE_OFFSET+21] = function (x)
              player:startEvent(120);
         end,
-        [GateOffset+22] = function (x)
+        [GATE_OFFSET+22] = function (x)
              player:startEvent(120);
         end,
-        [GateOffset+23] = function (x)
+        [GATE_OFFSET+23] = function (x)
              player:startEvent(120);
         end,
-        [GateOffset+24] = function (x)
+        [GATE_OFFSET+24] = function (x)
              player:startEvent(120);
         end,
-        [GateOffset+25] = function (x)
+        [GATE_OFFSET+25] = function (x)
              player:startEvent(120);
         end,
     }

--- a/scripts/zones/Temenos/npcs/Scanning_Device.lua
+++ b/scripts/zones/Temenos/npcs/Scanning_Device.lua
@@ -1,9 +1,10 @@
 -----------------------------------
 -- Area: Temenos
 -- NPC:  Scanning_Device
--- !pos
+-- !pos 586 0 66 37
 -----------------------------------
 require("scripts/globals/limbus");
+
 -----------------------------------
 -- onTrade Action
 -----------------------------------
@@ -16,9 +17,7 @@ end;
 -----------------------------------
 
 function onTrigger(player,npc)
-
-   player:startEvent(0x0079,511);
-
+    player:startEvent(0x0079, 511);
 end;
 
 -----------------------------------
@@ -26,37 +25,18 @@ end;
 -----------------------------------
 
 function onEventUpdate(player,csid,option)
-  -- printf("CSID: %u",csid);
-   printf("RESULT: %u",option);
-   Xtime=0;
---=player:getSpecialBattlefieldLeftTime();
- switch (option): caseof {
-        [1] = function (x) -- N
-Xtime=player:getSpecialBattlefieldLeftTime(2);
-        end,
-        [2] = function (x) -- E
-Xtime=player:getSpecialBattlefieldLeftTime(1);
-        end,
-        [3] = function (x) -- O
-Xtime=player:getSpecialBattlefieldLeftTime(3);
-        end,
-        [4] = function (x) -- 4E
-Xtime=player:getSpecialBattlefieldLeftTime(8);
-        end,
-        [5] = function (x) -- 3E
-Xtime=player:getSpecialBattlefieldLeftTime(7);
-        end,
-        [6] = function (x) -- 2E
-Xtime=player:getSpecialBattlefieldLeftTime(6);
-        end,
-        [7] = function (x) -- 1E
-Xtime=player:getSpecialBattlefieldLeftTime(5);
-        end,
-        [8] = function (x) -- SS
-Xtime=player:getSpecialBattlefieldLeftTime(4);
-        end,
-                             }
- player:updateEvent(0,Xtime,0,0,0,0,0,0);
+    local time = 0;
+    switch (option): caseof {
+        [1] = function (x) time = player:getBattlefieldTimeLeft(1); end, -- Northern Tower
+        [2] = function (x) time = player:getBattlefieldTimeLeft(2); end, -- Eastern Tower
+        [3] = function (x) time = player:getBattlefieldTimeLeft(3); end, -- Western Tower
+        [4] = function (x) time = player:getBattlefieldTimeLeft(4); end, -- Central 4th
+        [5] = function (x) time = player:getBattlefieldTimeLeft(5); end, -- Central 3rd
+        [6] = function (x) time = player:getBattlefieldTimeLeft(6); end, -- Central 2nd
+        [7] = function (x) time = player:getBattlefieldTimeLeft(7); end, -- Central 1st
+        [8] = function (x) time = player:getBattlefieldTimeLeft(8); end, -- Central Basement
+    }
+    player:updateEvent(0,time,0,0,0,0,0,0);
 end;
 
 -----------------------------------
@@ -64,9 +44,4 @@ end;
 -----------------------------------
 
 function onEventFinish(player,csid,option)
-    -- printf("CSID: %u",csid);
-    -- printf("RESULT: %u",option);
-   if (csid == 0) then
-
-   end
 end;

--- a/scripts/zones/The_Celestial_Nexus/npcs/_513.lua
+++ b/scripts/zones/The_Celestial_Nexus/npcs/_513.lua
@@ -3,25 +3,15 @@
 -- Area: Celestial Nexus
 -- NPC:  _515
 -----------------------------------
-package.loaded["scripts/zones/The_Celestial_Nexus"] = nil;
-package.loaded["scripts/globals/bcnm"] = nil;
------------------------------------
 
 require("scripts/globals/bcnm");
-require("scripts/globals/quests");
-require("scripts/globals/missions");
-require("scripts/zones/The_Celestial_Nexus/TextIDs");
 
 -----------------------------------
--- onTrade
+-- onTrade Action
 -----------------------------------
 
 function onTrade(player,npc,trade)
-    
-    if (TradeBCNM(player,player:getZoneID(),trade,npc)) then
-        return;
-    end
-    
+    TradeBCNM(player,npc,trade);
 end;
 
 -----------------------------------
@@ -29,25 +19,15 @@ end;
 -----------------------------------
 
 function onTrigger(player,npc)
-    
-    if (EventTriggerBCNM(player,npc)) then  -- enter the battlefield
-        return 1;
-    end
-    
+    EventTriggerBCNM(player,npc);
 end;
 
 -----------------------------------
 -- onEventUpdate
 -----------------------------------
 
-function onEventUpdate(player,csid,option)
-    -- printf("onUpdate CSID: %u",csid);
-    -- printf("onUpdate RESULT: %u",option);
-
-    if (EventUpdateBCNM(player,csid,option)) then
-        return;
-    end
-    
+function onEventUpdate(player,csid,option,extras)
+    EventUpdateBCNM(player,csid,option,extras);
 end;
 
 -----------------------------------
@@ -55,11 +35,5 @@ end;
 -----------------------------------
 
 function onEventFinish(player,csid,option)
-    -- printf("onFinish CSID: %u",csid);
-    -- printf("onFinish RESULT: %u",option);
-    
-    if (EventFinishBCNM(player,csid,option)) then
-        return;
-    end
-    
+    EventFinishBCNM(player,csid,option);
 end;

--- a/scripts/zones/The_Garden_of_RuHmet/mobs/Jailer_of_Fortitude.lua
+++ b/scripts/zones/The_Garden_of_RuHmet/mobs/Jailer_of_Fortitude.lua
@@ -5,7 +5,6 @@
 
 require("scripts/globals/status");
 require("scripts/globals/magic");
-require("scripts/globals/limbus");
 
 -----------------------------------
 -- onMobSpawn Action
@@ -34,7 +33,7 @@ function onMobFight(mob, target)
         mob:setLocalVar("delay", 0);
     end;
 
-    if (IsMobDead(16921016) == false or IsMobDead(16921017) == false) then -- check for kf'ghrah
+    if ( GetMobByID(16921016):isAlive() or GetMobByID(16921017):isAlive() ) then -- check for kf'ghrah
         if (spell > 0 and mob:hasStatusEffect(EFFECT_SILENCE) == false) then
             if (delay >= 3) then
                 mob:castSpell(spell);

--- a/scripts/zones/The_Garden_of_RuHmet/npcs/_0z0.lua
+++ b/scripts/zones/The_Garden_of_RuHmet/npcs/_0z0.lua
@@ -17,7 +17,7 @@ require("scripts/globals/bcnm");
 
 function onTrade(player,npc,trade)
     
-    if (TradeBCNM(player,player:getZoneID(),trade,npc)) then
+    if (TradeBCNM(player,npc,trade)) then
         return;
     end
 
@@ -43,14 +43,9 @@ end;
 -- onEventUpdate
 -----------------------------------
 
-function onEventUpdate(player,csid,option)
-    -- printf("onUpdate CSID: %u",csid);
-    -- printf("onUpdate RESULT: %u",option);
-    
-    if (EventUpdateBCNM(player,csid,option)) then
-        return 1;
-    end
-    end;
+function onEventUpdate(player,csid,option,extras)
+    EventUpdateBCNM(player,csid,option,extras);
+end;
 
 -----------------------------------
 -- onEventFinish Action 
@@ -60,9 +55,8 @@ function onEventFinish(player,csid,option)
     -- printf("onFinish CSID: %u",csid);
     -- printf("onFinish RESULT: %u",option);
     if ( csid == 0x00CB) then
-     player:setVar("PromathiaStatus",4);
+        player:setVar("PromathiaStatus",4);
     elseif (EventFinishBCNM(player,csid,option)) then
         return;
     end
-
-    end;
+end;

--- a/scripts/zones/The_Shrouded_Maw/bcnms/darkness_named.lua
+++ b/scripts/zones/The_Shrouded_Maw/bcnms/darkness_named.lua
@@ -15,7 +15,7 @@ require("scripts/globals/missions");
 -- After registering the BCNM via bcnmRegister(bcnmid)
 function onBcnmRegister(player,instance)
 
-    local inst = player:getBattlefieldID();
+    local inst = player:getBattlefield():getBattlefieldNumber();
 
     if (inst == 1) then
     

--- a/scripts/zones/The_Shrouded_Maw/bcnms/waking_dreams.lua
+++ b/scripts/zones/The_Shrouded_Maw/bcnms/waking_dreams.lua
@@ -16,7 +16,7 @@ require("scripts/globals/missions");
 -- After registering the BCNM via bcnmRegister(bcnmid)
 function onBcnmRegister(player,instance)
 
-    local inst = player:getBattlefieldID();
+    local inst = player:getBattlefield():getBattlefieldNumber();
 
     if (inst == 1) then
     

--- a/scripts/zones/The_Shrouded_Maw/npcs/MementoCircle.lua
+++ b/scripts/zones/The_Shrouded_Maw/npcs/MementoCircle.lua
@@ -2,24 +2,15 @@
 -- Area: The_Shrouded_Maw
 -- NPC:  MementoCircle
 -----------------------------------
-package.loaded["scripts/zones/The_Shrouded_Maw/TextIDs"] = nil;
------------------------------------
 
 require("scripts/globals/bcnm");
-require("scripts/globals/quests");
-require("scripts/globals/missions");
-require("scripts/zones/The_Shrouded_Maw/TextIDs");
 
 -----------------------------------
 -- onTrade Action
 -----------------------------------
 
 function onTrade(player,npc,trade)
-    
-    if (TradeBCNM(player,player:getZoneID(),trade,npc)) then
-        return;
-    end
-    
+    TradeBCNM(player,npc,trade);
 end;
 
 -----------------------------------
@@ -27,27 +18,15 @@ end;
 -----------------------------------
 
 function onTrigger(player,npc)
-
-    if (EventTriggerBCNM(player,npc)) then
-        return 1;
-        else
-        return 1;
-    end
-    
+    EventTriggerBCNM(player,npc);
 end;
 
 -----------------------------------
 -- onEventUpdate
 -----------------------------------
 
-function onEventUpdate(player,csid,option)
-    -- printf("onUpdate CSID: %u",csid);
-    -- printf("onUpdate RESULT: %u",option);
-
-    if (EventUpdateBCNM(player,csid,option)) then
-        return;
-    end
-    
+function onEventUpdate(player,csid,option,extras)
+    EventUpdateBCNM(player,csid,option,extras);
 end;
 
 -----------------------------------
@@ -55,11 +34,5 @@ end;
 -----------------------------------
 
 function onEventFinish(player,csid,option)
-    -- printf("onFinish CSID: %u",csid);
-    -- printf("onFinish RESULT: %u",option);
-    
-    if (EventFinishBCNM(player,csid,option)) then
-        return;
-    end
-    
+    EventFinishBCNM(player,csid,option);
 end;

--- a/scripts/zones/Throne_Room/npcs/_4l1.lua
+++ b/scripts/zones/Throne_Room/npcs/_4l1.lua
@@ -36,11 +36,7 @@ require("scripts/zones/Throne_Room/TextIDs");
 -----------------------------------
 
 function onTrade(player,npc,trade)
-
-    if (TradeBCNM(player,player:getZoneID(),trade,npc)) then
-        return;
-    end
-
+    TradeBCNM(player,npc,trade);
 end;
 
 -----------------------------------
@@ -61,14 +57,8 @@ end;
 -- onEventUpdate
 -----------------------------------
 
-function onEventUpdate(player,csid,option)
-    -- printf("onUpdate CSID: %u",csid);
-    -- printf("onUpdate RESULT: %u",option);
-
-    if (EventUpdateBCNM(player,csid,option)) then
-        return;
-    end
-
+function onEventUpdate(player,csid,option,extras)
+    EventUpdateBCNM(player,csid,option,extras);
 end;
 
 -----------------------------------

--- a/scripts/zones/Throne_Room/npcs/_4l2.lua
+++ b/scripts/zones/Throne_Room/npcs/_4l2.lua
@@ -10,23 +10,15 @@ require("scripts/globals/bcnm");
 -----------------------------------
 
 function onTrade(player,npc,trade)
-    
-    if (TradeBCNM(player,player:getZoneID(),trade,npc)) then
-        return;
-    end
-    
+    TradeBCNM(player,npc,trade);
 end;
 
 -----------------------------------
 -- onTrigger Action
 -----------------------------------
 
-function onTrigger(player,npc)
-    
-    if (EventTriggerBCNM(player,npc)) then
-        return 1;
-    end
-    
+function onEventUpdate(player,csid,option,extras)
+    EventUpdateBCNM(player,csid,option,extras);
 end;
 
 -----------------------------------

--- a/scripts/zones/Throne_Room/npcs/_4l3.lua
+++ b/scripts/zones/Throne_Room/npcs/_4l3.lua
@@ -10,11 +10,7 @@ require("scripts/globals/bcnm");
 -----------------------------------
 
 function onTrade(player,npc,trade)
-    
-    if (TradeBCNM(player,player:getZoneID(),trade,npc)) then
-        return;
-    end
-    
+    TradeBCNM(player,npc,trade);
 end;
 
 -----------------------------------
@@ -33,14 +29,8 @@ end;
 -- onEventUpdate
 -----------------------------------
 
-function onEventUpdate(player,csid,option)
-    -- printf("onUpdate CSID: %u",csid);
-    -- printf("onUpdate RESULT: %u",option);
-    
-    if (EventUpdateBCNM(player,csid,option)) then
-        return;
-    end
-    
+function onEventUpdate(player,csid,option,extras)
+    EventUpdateBCNM(player,csid,option,extras);
 end;
 
 -----------------------------------

--- a/scripts/zones/Throne_Room/npcs/_4l4.lua
+++ b/scripts/zones/Throne_Room/npcs/_4l4.lua
@@ -10,11 +10,7 @@ require("scripts/globals/bcnm");
 -----------------------------------
 
 function onTrade(player,npc,trade)
-    
-    if (TradeBCNM(player,player:getZoneID(),trade,npc)) then
-        return;
-    end
-    
+    TradeBCNM(player,npc,trade);
 end;
 
 -----------------------------------
@@ -33,14 +29,8 @@ end;
 -- onEventUpdate
 -----------------------------------
 
-function onEventUpdate(player,csid,option)
-    -- printf("onUpdate CSID: %u",csid);
-    -- printf("onUpdate RESULT: %u",option);
-    
-    if (EventUpdateBCNM(player,csid,option)) then
-        return;
-    end
-    
+function onEventUpdate(player,csid,option,extras)
+    EventUpdateBCNM(player,csid,option,extras);
 end;
 
 -----------------------------------

--- a/scripts/zones/Waughroon_Shrine/npcs/Armoury_Crate.lua
+++ b/scripts/zones/Waughroon_Shrine/npcs/Armoury_Crate.lua
@@ -23,6 +23,7 @@ end;
 
 function onTrigger(player,npc)
     player:getBCNMloot();
+    npc:setStatus(STATUS_DISAPPEAR);
 end;
 
 -----------------------------------

--- a/scripts/zones/Waughroon_Shrine/npcs/Burning_Circle.lua
+++ b/scripts/zones/Waughroon_Shrine/npcs/Burning_Circle.lua
@@ -4,48 +4,15 @@
 -- Waughroon Shrine Burning Circle
 -- !pos -345 104 -260 144
 -------------------------------------
-package.loaded["scripts/zones/Waughroon_Shrine/TextIDs"] = nil;
--------------------------------------
 
 require("scripts/globals/bcnm");
-require("scripts/globals/titles");
-require("scripts/globals/keyitems");
-require("scripts/globals/quests");
-require("scripts/globals/missions");
-require("scripts/zones/Waughroon_Shrine/TextIDs");
 
-    ---- 0: Rank 2 Final Mission for Bastok "The Emissary" and Sandy "Journey Abroad"
-    ---- 1: Worms Turn
-    ---- 2: Grimshell Shocktroopers
-    ---- 3: On my Way
-    ---- 4: Thief in Norg
-    ---- 5: 3, 2, 1
-    ---- 6: Shattering Stars (RDM)
-    ---- 7: Shattering Stars (THF)
-    ---- 8: Shattering Stars (BST)
-    ---- 9: Birds of the feather
-    ---- 10: Crustacean Conundrum
-    ---- 11: Grove Gardians
-    ---- 12: The Hills are alive
-    ---- 13: Royal Jelly
-    ---- 14: The Final Bout
-    ---- 15: Up in arms
-    ---- 16: Copy Cat
-    ---- 17: Operation Desert Swarm
-    ---- 18: Prehistoric Pigeons
-    ---- 19: The Palborough Project
-    ---- 20: Shell Shocked
-    ---- 21: Beyond infinity
 -----------------------------------
 -- onTrade Action
 -----------------------------------
 
 function onTrade(player,npc,trade)
-
-    if (TradeBCNM(player,player:getZoneID(),trade,npc)) then
-        return;
-    end
-
+    TradeBCNM(player,npc,trade);
 end;
 
 -----------------------------------
@@ -53,26 +20,15 @@ end;
 -----------------------------------
 
 function onTrigger(player,npc)
-
-
-    if (EventTriggerBCNM(player,npc)) then
-        return;
-    end
-
+    EventTriggerBCNM(player,npc);
 end;
 
 -----------------------------------
 -- onEventUpdate
 -----------------------------------
 
-function onEventUpdate(player,csid,option)
-    -- printf("onUpdate CSID: %u",csid);
-    -- printf("onUpdate RESULT: %u",option);
-
-    if (EventUpdateBCNM(player,csid,option)) then
-        return;
-    end
-
+function onEventUpdate(player,csid,option,extras)
+    EventUpdateBCNM(player,csid,option,extras);
 end;
 
 -----------------------------------
@@ -80,11 +36,5 @@ end;
 -----------------------------------
 
 function onEventFinish(player,csid,option)
-    -- printf("onFinish CSID: %u",csid);
-    -- printf("onFinish RESULT: %u",option);
-
-    if (EventFinishBCNM(player,csid,option)) then
-        return;
-    end
-
+    EventFinishBCNM(player,csid,option);
 end;

--- a/sql/bcnm_battlefield.sql
+++ b/sql/bcnm_battlefield.sql
@@ -2,7 +2,7 @@
 --
 -- Host: localhost    Database: dspdb
 -- ------------------------------------------------------
--- Server version	5.5.5-10.0.20-MariaDB
+-- Server version   5.5.5-10.0.20-MariaDB
 
 --
 -- Table structure for table `bcnm_battlefield`
@@ -593,7 +593,7 @@ INSERT INTO `bcnm_battlefield` VALUES (672,3,16809996,3);
 INSERT INTO `bcnm_battlefield` VALUES (672,3,16809995,3);
 INSERT INTO `bcnm_battlefield` VALUES (672,3,16809999,0);
 INSERT INTO `bcnm_battlefield` VALUES (672,3,16809998,0);
-INSERT INTO `bcnm_battlefield` VALUES (673,1,16810018,3);	-- Race Runner
+INSERT INTO `bcnm_battlefield` VALUES (673,1,16810018,3);   -- Race Runner
 INSERT INTO `bcnm_battlefield` VALUES (736,1,16830466,3);
 INSERT INTO `bcnm_battlefield` VALUES (736,1,16830465,3);
 INSERT INTO `bcnm_battlefield` VALUES (736,1,16830468,3);
@@ -1803,16 +1803,16 @@ INSERT INTO `bcnm_battlefield` VALUES (1287,1,16941057,3); -- Apocalyptic_Beast
 -- statue
 INSERT INTO `bcnm_battlefield` VALUES (1287,1,16941190,3); 
 INSERT INTO `bcnm_battlefield` VALUES (1287,1,16941191,3);  -- Ree_Nata_the_Melomanic
-INSERT INTO `bcnm_battlefield` VALUES (1287,1,16941192,3);  -- Koo_Rahi_the_Levinblade			
+INSERT INTO `bcnm_battlefield` VALUES (1287,1,16941192,3);  -- Koo_Rahi_the_Levinblade          
 INSERT INTO `bcnm_battlefield` VALUES (1287,1,16941208,3); 
 INSERT INTO `bcnm_battlefield` VALUES (1287,1,16941209,3);  -- Doo_Peku_the_Fleetfoot
 INSERT INTO `bcnm_battlefield` VALUES (1287,1,16941210,3);  -- Baa_Dava_the_Bibliophage
 INSERT INTO `bcnm_battlefield` VALUES (1287,1,16941471,3); 
 INSERT INTO `bcnm_battlefield` VALUES (1287,1,16941472,3);  -- Va_Rhu_Bodysnatcher
-INSERT INTO `bcnm_battlefield` VALUES (1287,1,16941473,3);  -- Te_Zha_Ironclad											
+INSERT INTO `bcnm_battlefield` VALUES (1287,1,16941473,3);  -- Te_Zha_Ironclad                                          
 INSERT INTO `bcnm_battlefield` VALUES (1287,1,16941485,3); 
 INSERT INTO `bcnm_battlefield` VALUES (1287,1,16941486,3); 
-INSERT INTO `bcnm_battlefield` VALUES (1287,1,16941487,3); 		
+INSERT INTO `bcnm_battlefield` VALUES (1287,1,16941487,3);      
 INSERT INTO `bcnm_battlefield` VALUES (1287,1,16941068,3); 
 INSERT INTO `bcnm_battlefield` VALUES (1287,1,16941069,3); 
 INSERT INTO `bcnm_battlefield` VALUES (1287,1,16941070,3);  -- Woodnix_Shrillwhistle
@@ -1821,25 +1821,25 @@ INSERT INTO `bcnm_battlefield` VALUES (1287,1,16941084,3);
 INSERT INTO `bcnm_battlefield` VALUES (1287,1,16941085,3);  -- Shamblix_Rottenheart
 INSERT INTO `bcnm_battlefield` VALUES (1287,1,16941098,3); 
 INSERT INTO `bcnm_battlefield` VALUES (1287,1,16941099,3); 
-INSERT INTO `bcnm_battlefield` VALUES (1287,1,16941100,3);  -- Gosspix_Blabberlips				
+INSERT INTO `bcnm_battlefield` VALUES (1287,1,16941100,3);  -- Gosspix_Blabberlips              
 INSERT INTO `bcnm_battlefield` VALUES (1287,1,16941381,3); 
 INSERT INTO `bcnm_battlefield` VALUES (1287,1,16941382,3); 
-INSERT INTO `bcnm_battlefield` VALUES (1287,1,16941383,3); 						
+INSERT INTO `bcnm_battlefield` VALUES (1287,1,16941383,3);                      
 INSERT INTO `bcnm_battlefield` VALUES (1287,1,16941395,3); 
 INSERT INTO `bcnm_battlefield` VALUES (1287,1,16941396,3); 
-INSERT INTO `bcnm_battlefield` VALUES (1287,1,16941397,3); 					
+INSERT INTO `bcnm_battlefield` VALUES (1287,1,16941397,3);                  
 INSERT INTO `bcnm_battlefield` VALUES (1287,1,16941118,3); 
 INSERT INTO `bcnm_battlefield` VALUES (1287,1,16941119,3); -- Flamecaller_Zoeqdoq
 INSERT INTO `bcnm_battlefield` VALUES (1287,1,16941120,3);  -- Elvaansticker_Bxafraff
 INSERT INTO `bcnm_battlefield` VALUES (1287,1,16941135,3); 
 INSERT INTO `bcnm_battlefield` VALUES (1287,1,16941136,3);  -- Hamfist_Gukhbuk
-INSERT INTO `bcnm_battlefield` VALUES (1287,1,16941137,3);  -- Lyncean_Juwgneg				
+INSERT INTO `bcnm_battlefield` VALUES (1287,1,16941137,3);  -- Lyncean_Juwgneg              
 INSERT INTO `bcnm_battlefield` VALUES (1287,1,16941411,3); 
 INSERT INTO `bcnm_battlefield` VALUES (1287,1,16941412,3); 
-INSERT INTO `bcnm_battlefield` VALUES (1287,1,16941413,3); 				
+INSERT INTO `bcnm_battlefield` VALUES (1287,1,16941413,3);              
 INSERT INTO `bcnm_battlefield` VALUES (1287,1,16941425,3); 
 INSERT INTO `bcnm_battlefield` VALUES (1287,1,16941426,3); 
-INSERT INTO `bcnm_battlefield` VALUES (1287,1,16941427,3); 	 
+INSERT INTO `bcnm_battlefield` VALUES (1287,1,16941427,3);   
 INSERT INTO `bcnm_battlefield` VALUES (1287,1,16941153,3); 
 INSERT INTO `bcnm_battlefield` VALUES (1287,1,16941154,3); 
 INSERT INTO `bcnm_battlefield` VALUES (1287,1,16941155,3); 
@@ -1848,7 +1848,7 @@ INSERT INTO `bcnm_battlefield` VALUES (1287,1,16941172,3);
 INSERT INTO `bcnm_battlefield` VALUES (1287,1,16941173,3); 
 INSERT INTO `bcnm_battlefield` VALUES (1287,1,16941440,3); 
 INSERT INTO `bcnm_battlefield` VALUES (1287,1,16941441,3); 
-INSERT INTO `bcnm_battlefield` VALUES (1287,1,16941442,3); 					
+INSERT INTO `bcnm_battlefield` VALUES (1287,1,16941442,3);                  
 INSERT INTO `bcnm_battlefield` VALUES (1287,1,16941455,3); 
 INSERT INTO `bcnm_battlefield` VALUES (1287,1,16941456,3); 
 INSERT INTO `bcnm_battlefield` VALUES (1287,1,16941457,3); 
@@ -2290,384 +2290,384 @@ INSERT INTO `bcnm_battlefield` VALUES (1289,1,16949494,3);
 --               APPOLYON  SE
 -- //////////////////////////////////////////////////////////////
 -- FIRST FLOOR
-INSERT INTO `bcnm_battlefield` VALUES (1293,4,16932993,1);-- 'Metalloid_Amoeba'
-INSERT INTO `bcnm_battlefield` VALUES (1293,4,16932994,1);-- 'Metalloid_Amoeba'
-INSERT INTO `bcnm_battlefield` VALUES (1293,4,16932995,1);-- 'Metalloid_Amoeba'
-INSERT INTO `bcnm_battlefield` VALUES (1293,4,16932996,1);-- 'Metalloid_Amoeba'
-INSERT INTO `bcnm_battlefield` VALUES (1293,4,16932997,1);-- 'Metalloid_Amoeba'
-INSERT INTO `bcnm_battlefield` VALUES (1293,4,16932998,1);-- 'Metalloid_Amoeba'
-INSERT INTO `bcnm_battlefield` VALUES (1293,4,16932999,1);-- 'Metalloid_Amoeba'
-INSERT INTO `bcnm_battlefield` VALUES (1293,4,16933000,1);-- 'Metalloid_Amoeba'
-INSERT INTO `bcnm_battlefield` VALUES (1293,4,16932992,1);-- 'Ghost_Clot'
+INSERT INTO `bcnm_battlefield` VALUES (1293,3,16932993,1);-- 'Metalloid_Amoeba'
+INSERT INTO `bcnm_battlefield` VALUES (1293,3,16932994,1);-- 'Metalloid_Amoeba'
+INSERT INTO `bcnm_battlefield` VALUES (1293,3,16932995,1);-- 'Metalloid_Amoeba'
+INSERT INTO `bcnm_battlefield` VALUES (1293,3,16932996,1);-- 'Metalloid_Amoeba'
+INSERT INTO `bcnm_battlefield` VALUES (1293,3,16932997,1);-- 'Metalloid_Amoeba'
+INSERT INTO `bcnm_battlefield` VALUES (1293,3,16932998,1);-- 'Metalloid_Amoeba'
+INSERT INTO `bcnm_battlefield` VALUES (1293,3,16932999,1);-- 'Metalloid_Amoeba'
+INSERT INTO `bcnm_battlefield` VALUES (1293,3,16933000,1);-- 'Metalloid_Amoeba'
+INSERT INTO `bcnm_battlefield` VALUES (1293,3,16932992,1);-- 'Ghost_Clot'
 -- Second Floor
-INSERT INTO `bcnm_battlefield` VALUES (1293,4,16933007,1);-- 'Adamantshell'
-INSERT INTO `bcnm_battlefield` VALUES (1293,4,16933008,1);-- 'Adamantshell'
-INSERT INTO `bcnm_battlefield` VALUES (1293,4,16933009,1);-- 'Adamantshell'
-INSERT INTO `bcnm_battlefield` VALUES (1293,4,16933010,1);-- 'Adamantshell'
-INSERT INTO `bcnm_battlefield` VALUES (1293,4,16933011,1);-- 'Adamantshell'
-INSERT INTO `bcnm_battlefield` VALUES (1293,4,16933012,1);-- 'Adamantshell'
-INSERT INTO `bcnm_battlefield` VALUES (1293,4,16933013,1);-- 'Adamantshell'
-INSERT INTO `bcnm_battlefield` VALUES (1293,4,16933014,1);-- 'Adamantshell'
-INSERT INTO `bcnm_battlefield` VALUES (1293,4,16933006,1);-- 'Tieholtsodi'
+INSERT INTO `bcnm_battlefield` VALUES (1293,3,16933007,1);-- 'Adamantshell'
+INSERT INTO `bcnm_battlefield` VALUES (1293,3,16933008,1);-- 'Adamantshell'
+INSERT INTO `bcnm_battlefield` VALUES (1293,3,16933009,1);-- 'Adamantshell'
+INSERT INTO `bcnm_battlefield` VALUES (1293,3,16933010,1);-- 'Adamantshell'
+INSERT INTO `bcnm_battlefield` VALUES (1293,3,16933011,1);-- 'Adamantshell'
+INSERT INTO `bcnm_battlefield` VALUES (1293,3,16933012,1);-- 'Adamantshell'
+INSERT INTO `bcnm_battlefield` VALUES (1293,3,16933013,1);-- 'Adamantshell'
+INSERT INTO `bcnm_battlefield` VALUES (1293,3,16933014,1);-- 'Adamantshell'
+INSERT INTO `bcnm_battlefield` VALUES (1293,3,16933006,1);-- 'Tieholtsodi'
 -- Third Floor
-INSERT INTO `bcnm_battlefield` VALUES (1293,4,16933021,1);-- 'Inhumer'
-INSERT INTO `bcnm_battlefield` VALUES (1293,4,16933022,1);-- 'Inhumer'
-INSERT INTO `bcnm_battlefield` VALUES (1293,4,16933023,1);-- 'Inhumer'
-INSERT INTO `bcnm_battlefield` VALUES (1293,4,16933024,1);-- 'Inhumer'
-INSERT INTO `bcnm_battlefield` VALUES (1293,4,16933025,1);-- 'Inhumer'
-INSERT INTO `bcnm_battlefield` VALUES (1293,4,16933026,1);-- 'Inhumer'
-INSERT INTO `bcnm_battlefield` VALUES (1293,4,16933027,1);-- 'Inhumer'
-INSERT INTO `bcnm_battlefield` VALUES (1293,4,16933028,1);-- 'Inhumer'
-INSERT INTO `bcnm_battlefield` VALUES (1293,4,16933020,1);-- 'Grave_Digger'
+INSERT INTO `bcnm_battlefield` VALUES (1293,3,16933021,1);-- 'Inhumer'
+INSERT INTO `bcnm_battlefield` VALUES (1293,3,16933022,1);-- 'Inhumer'
+INSERT INTO `bcnm_battlefield` VALUES (1293,3,16933023,1);-- 'Inhumer'
+INSERT INTO `bcnm_battlefield` VALUES (1293,3,16933024,1);-- 'Inhumer'
+INSERT INTO `bcnm_battlefield` VALUES (1293,3,16933025,1);-- 'Inhumer'
+INSERT INTO `bcnm_battlefield` VALUES (1293,3,16933026,1);-- 'Inhumer'
+INSERT INTO `bcnm_battlefield` VALUES (1293,3,16933027,1);-- 'Inhumer'
+INSERT INTO `bcnm_battlefield` VALUES (1293,3,16933028,1);-- 'Inhumer'
+INSERT INTO `bcnm_battlefield` VALUES (1293,3,16933020,1);-- 'Grave_Digger'
 -- Fourth Floor
-INSERT INTO `bcnm_battlefield` VALUES (1293,4,16933032,1);-- 'Evil_Armory'
-INSERT INTO `bcnm_battlefield` VALUES (1293,4,16933033,1);-- 'Flying_Spear'
-INSERT INTO `bcnm_battlefield` VALUES (1293,4,16933034,1);-- 'Flying_Spear'
-INSERT INTO `bcnm_battlefield` VALUES (1293,4,16933035,1);-- 'Flying_Spear'
-INSERT INTO `bcnm_battlefield` VALUES (1293,4,16933036,1);-- 'Flying_Spear'
-INSERT INTO `bcnm_battlefield` VALUES (1293,4,16933037,1);-- 'Flying_Spear'
-INSERT INTO `bcnm_battlefield` VALUES (1293,4,16933038,1);-- 'Flying_Spear'
-INSERT INTO `bcnm_battlefield` VALUES (1293,4,16933039,1);-- 'Flying_Spear'
-INSERT INTO `bcnm_battlefield` VALUES (1293,4,16933040,1);-- 'Flying_Spear'
+INSERT INTO `bcnm_battlefield` VALUES (1293,3,16933032,1);-- 'Evil_Armory'
+INSERT INTO `bcnm_battlefield` VALUES (1293,3,16933033,1);-- 'Flying_Spear'
+INSERT INTO `bcnm_battlefield` VALUES (1293,3,16933034,1);-- 'Flying_Spear'
+INSERT INTO `bcnm_battlefield` VALUES (1293,3,16933035,1);-- 'Flying_Spear'
+INSERT INTO `bcnm_battlefield` VALUES (1293,3,16933036,1);-- 'Flying_Spear'
+INSERT INTO `bcnm_battlefield` VALUES (1293,3,16933037,1);-- 'Flying_Spear'
+INSERT INTO `bcnm_battlefield` VALUES (1293,3,16933038,1);-- 'Flying_Spear'
+INSERT INTO `bcnm_battlefield` VALUES (1293,3,16933039,1);-- 'Flying_Spear'
+INSERT INTO `bcnm_battlefield` VALUES (1293,3,16933040,1);-- 'Flying_Spear'
 
 -- ----------------------------------------------------------------
 -- //////////////////////////////////////////////////////////////
 --               APPOLYON  NE
 -- //////////////////////////////////////////////////////////////
-INSERT INTO `bcnm_battlefield` VALUES (1292,3,16933044,1);-- 'Goobbue_Harvestet'
-INSERT INTO `bcnm_battlefield` VALUES (1292,3,16933045,1);-- 'Barometz'
-INSERT INTO `bcnm_battlefield` VALUES (1292,3,16933046,1);-- 'Borametz'
-INSERT INTO `bcnm_battlefield` VALUES (1292,3,16933047,1);-- 'Barometz'
-INSERT INTO `bcnm_battlefield` VALUES (1292,3,16933048,1);-- 'Borametz'
-INSERT INTO `bcnm_battlefield` VALUES (1292,3,16933049,1);-- 'Barometz'
-INSERT INTO `bcnm_battlefield` VALUES (1292,3,16933050,1);-- 'Borametz'
-INSERT INTO `bcnm_battlefield` VALUES (1292,3,16933051,1);-- 'Barometz'
-INSERT INTO `bcnm_battlefield` VALUES (1292,3,16933052,1);-- 'Borametz'
-INSERT INTO `bcnm_battlefield` VALUES (1292,3,16933055,1);-- 'Barometz'
-INSERT INTO `bcnm_battlefield` VALUES (1292,3,16933056,1);-- 'Borametz'
-INSERT INTO `bcnm_battlefield` VALUES (1292,3,16933057,1);-- 'Barometz'
-INSERT INTO `bcnm_battlefield` VALUES (1292,3,16933058,1);-- 'Borametz'
+INSERT INTO `bcnm_battlefield` VALUES (1292,4,16933044,1);-- 'Goobbue_Harvestet'
+INSERT INTO `bcnm_battlefield` VALUES (1292,4,16933045,1);-- 'Barometz'
+INSERT INTO `bcnm_battlefield` VALUES (1292,4,16933046,1);-- 'Borametz'
+INSERT INTO `bcnm_battlefield` VALUES (1292,4,16933047,1);-- 'Barometz'
+INSERT INTO `bcnm_battlefield` VALUES (1292,4,16933048,1);-- 'Borametz'
+INSERT INTO `bcnm_battlefield` VALUES (1292,4,16933049,1);-- 'Barometz'
+INSERT INTO `bcnm_battlefield` VALUES (1292,4,16933050,1);-- 'Borametz'
+INSERT INTO `bcnm_battlefield` VALUES (1292,4,16933051,1);-- 'Barometz'
+INSERT INTO `bcnm_battlefield` VALUES (1292,4,16933052,1);-- 'Borametz'
+INSERT INTO `bcnm_battlefield` VALUES (1292,4,16933055,1);-- 'Barometz'
+INSERT INTO `bcnm_battlefield` VALUES (1292,4,16933056,1);-- 'Borametz'
+INSERT INTO `bcnm_battlefield` VALUES (1292,4,16933057,1);-- 'Barometz'
+INSERT INTO `bcnm_battlefield` VALUES (1292,4,16933058,1);-- 'Borametz'
 
-INSERT INTO `bcnm_battlefield` VALUES (1292,3,16933062,1);-- 'Thiazi'
-INSERT INTO `bcnm_battlefield` VALUES (1292,3,16933063,1);-- 'Thiazi'
-INSERT INTO `bcnm_battlefield` VALUES (1292,3,16933064,1);-- 'Bialozar'
-INSERT INTO `bcnm_battlefield` VALUES (1292,3,16933065,1);-- 'Bialozar'
-INSERT INTO `bcnm_battlefield` VALUES (1292,3,16933066,1);-- 'Cornu'
-INSERT INTO `bcnm_battlefield` VALUES (1292,3,16933067,1);-- 'Cornu'
-INSERT INTO `bcnm_battlefield` VALUES (1292,3,16933068,1);-- 'Cornu'
-INSERT INTO `bcnm_battlefield` VALUES (1292,3,16933069,1);-- 'Cornu'
-INSERT INTO `bcnm_battlefield` VALUES (1292,3,16933070,1);-- 'Sirin'
-INSERT INTO `bcnm_battlefield` VALUES (1292,3,16933071,1);-- 'Sirin'
-INSERT INTO `bcnm_battlefield` VALUES (1292,3,16933072,1);-- 'Sirin'
-INSERT INTO `bcnm_battlefield` VALUES (1292,3,16933073,1);-- 'Sirin'
+INSERT INTO `bcnm_battlefield` VALUES (1292,4,16933062,1);-- 'Thiazi'
+INSERT INTO `bcnm_battlefield` VALUES (1292,4,16933063,1);-- 'Thiazi'
+INSERT INTO `bcnm_battlefield` VALUES (1292,4,16933064,1);-- 'Bialozar'
+INSERT INTO `bcnm_battlefield` VALUES (1292,4,16933065,1);-- 'Bialozar'
+INSERT INTO `bcnm_battlefield` VALUES (1292,4,16933066,1);-- 'Cornu'
+INSERT INTO `bcnm_battlefield` VALUES (1292,4,16933067,1);-- 'Cornu'
+INSERT INTO `bcnm_battlefield` VALUES (1292,4,16933068,1);-- 'Cornu'
+INSERT INTO `bcnm_battlefield` VALUES (1292,4,16933069,1);-- 'Cornu'
+INSERT INTO `bcnm_battlefield` VALUES (1292,4,16933070,1);-- 'Sirin'
+INSERT INTO `bcnm_battlefield` VALUES (1292,4,16933071,1);-- 'Sirin'
+INSERT INTO `bcnm_battlefield` VALUES (1292,4,16933072,1);-- 'Sirin'
+INSERT INTO `bcnm_battlefield` VALUES (1292,4,16933073,1);-- 'Sirin'
 
-INSERT INTO `bcnm_battlefield` VALUES (1292,3,16933081,1);-- 'Apollyon_Sweeper'
-INSERT INTO `bcnm_battlefield` VALUES (1292,3,16933082,1);-- 'Apollyon_Cleaner'
-INSERT INTO `bcnm_battlefield` VALUES (1292,3,16933083,1);-- 'Apollyon_Cleaner'
-INSERT INTO `bcnm_battlefield` VALUES (1292,3,16933084,1);-- 'Apollyon_Cleaner'
-INSERT INTO `bcnm_battlefield` VALUES (1292,3,16933085,1);-- 'Apollyon_Cleaner'
-INSERT INTO `bcnm_battlefield` VALUES (1292,3,16933086,1);-- 'Apollyon_Sweeper'
-INSERT INTO `bcnm_battlefield` VALUES (1292,3,16933087,1);-- 'Apollyon_Cleaner'
-INSERT INTO `bcnm_battlefield` VALUES (1292,3,16933088,1);--  'Apollyon_Cleaner'
-INSERT INTO `bcnm_battlefield` VALUES (1292,3,16933090,1);-- 'Apollyon_Cleaner'
-INSERT INTO `bcnm_battlefield` VALUES (1292,3,16933091,1);-- 'Apollyon_Sweeper'
-INSERT INTO `bcnm_battlefield` VALUES (1292,3,16933092,1);-- 'Apollyon_Cleaner'
-INSERT INTO `bcnm_battlefield` VALUES (1292,3,16933093,1);-- 'Apollyon_Cleaner'
-INSERT INTO `bcnm_battlefield` VALUES (1292,3,16933094,1);-- 'Apollyon_Cleaner'
-INSERT INTO `bcnm_battlefield` VALUES (1292,3,16933095,1);-- 'Apollyon_Cleaner'
+INSERT INTO `bcnm_battlefield` VALUES (1292,4,16933081,1);-- 'Apollyon_Sweeper'
+INSERT INTO `bcnm_battlefield` VALUES (1292,4,16933082,1);-- 'Apollyon_Cleaner'
+INSERT INTO `bcnm_battlefield` VALUES (1292,4,16933083,1);-- 'Apollyon_Cleaner'
+INSERT INTO `bcnm_battlefield` VALUES (1292,4,16933084,1);-- 'Apollyon_Cleaner'
+INSERT INTO `bcnm_battlefield` VALUES (1292,4,16933085,1);-- 'Apollyon_Cleaner'
+INSERT INTO `bcnm_battlefield` VALUES (1292,4,16933086,1);-- 'Apollyon_Sweeper'
+INSERT INTO `bcnm_battlefield` VALUES (1292,4,16933087,1);-- 'Apollyon_Cleaner'
+INSERT INTO `bcnm_battlefield` VALUES (1292,4,16933088,1);--  'Apollyon_Cleaner'
+INSERT INTO `bcnm_battlefield` VALUES (1292,4,16933090,1);-- 'Apollyon_Cleaner'
+INSERT INTO `bcnm_battlefield` VALUES (1292,4,16933091,1);-- 'Apollyon_Sweeper'
+INSERT INTO `bcnm_battlefield` VALUES (1292,4,16933092,1);-- 'Apollyon_Cleaner'
+INSERT INTO `bcnm_battlefield` VALUES (1292,4,16933093,1);-- 'Apollyon_Cleaner'
+INSERT INTO `bcnm_battlefield` VALUES (1292,4,16933094,1);-- 'Apollyon_Cleaner'
+INSERT INTO `bcnm_battlefield` VALUES (1292,4,16933095,1);-- 'Apollyon_Cleaner'
 
-INSERT INTO `bcnm_battlefield` VALUES (1292,3,16933099,1);-- 'Hyperion'
-INSERT INTO `bcnm_battlefield` VALUES (1292,3,16933100,1);-- 'Okeanos'
-INSERT INTO `bcnm_battlefield` VALUES (1292,3,16933101,1);-- 'Cronos'
-INSERT INTO `bcnm_battlefield` VALUES (1292,3,16933102,1);-- 'Kerkopes'
-INSERT INTO `bcnm_battlefield` VALUES (1292,3,16933103,1);-- 'Kerkopes'
-INSERT INTO `bcnm_battlefield` VALUES (1292,3,16933104,1);-- 'Kerkopes'
-INSERT INTO `bcnm_battlefield` VALUES (1292,3,16933105,1);-- 'Kerkopes'
-INSERT INTO `bcnm_battlefield` VALUES (1292,3,16933106,1);-- 'Kerkopes'
-INSERT INTO `bcnm_battlefield` VALUES (1292,3,16933107,1);-- 'Kerkopes'
-INSERT INTO `bcnm_battlefield` VALUES (1292,3,16933108,1);-- 'Kerkopes'
-INSERT INTO `bcnm_battlefield` VALUES (1292,3,16933109,1);-- 'Kerkopes'
+INSERT INTO `bcnm_battlefield` VALUES (1292,4,16933099,1);-- 'Hyperion'
+INSERT INTO `bcnm_battlefield` VALUES (1292,4,16933100,1);-- 'Okeanos'
+INSERT INTO `bcnm_battlefield` VALUES (1292,4,16933101,1);-- 'Cronos'
+INSERT INTO `bcnm_battlefield` VALUES (1292,4,16933102,1);-- 'Kerkopes'
+INSERT INTO `bcnm_battlefield` VALUES (1292,4,16933103,1);-- 'Kerkopes'
+INSERT INTO `bcnm_battlefield` VALUES (1292,4,16933104,1);-- 'Kerkopes'
+INSERT INTO `bcnm_battlefield` VALUES (1292,4,16933105,1);-- 'Kerkopes'
+INSERT INTO `bcnm_battlefield` VALUES (1292,4,16933106,1);-- 'Kerkopes'
+INSERT INTO `bcnm_battlefield` VALUES (1292,4,16933107,1);-- 'Kerkopes'
+INSERT INTO `bcnm_battlefield` VALUES (1292,4,16933108,1);-- 'Kerkopes'
+INSERT INTO `bcnm_battlefield` VALUES (1292,4,16933109,1);-- 'Kerkopes'
 
-INSERT INTO `bcnm_battlefield` VALUES (1292,3,16933113,1);-- 'Criosphinx'
-INSERT INTO `bcnm_battlefield` VALUES (1292,3,16933114,1);-- 'Hieracosphinx'
-INSERT INTO `bcnm_battlefield` VALUES (1292,3,16933115,1);-- 'Troglodyte_Dhalmel'
-INSERT INTO `bcnm_battlefield` VALUES (1292,3,16933116,1);-- 'Troglodyte_Dhalmel'
-INSERT INTO `bcnm_battlefield` VALUES (1292,3,16933117,1);-- 'Troglodyte_Dhalmel'
-INSERT INTO `bcnm_battlefield` VALUES (1292,3,16933118,1);-- 'Troglodyte_Dhalmel'
-INSERT INTO `bcnm_battlefield` VALUES (1292,3,16933119,1);-- 'Troglodyte_Dhalmel'
-INSERT INTO `bcnm_battlefield` VALUES (1292,3,16933120,1);-- 'Troglodyte_Dhalmel'
-INSERT INTO `bcnm_battlefield` VALUES (1292,3,16933121,1);-- 'Troglodyte_Dhalmel'
-INSERT INTO `bcnm_battlefield` VALUES (1292,3,16933122,1);-- 'Troglodyte_Dhalmel'
+INSERT INTO `bcnm_battlefield` VALUES (1292,4,16933113,1);-- 'Criosphinx'
+INSERT INTO `bcnm_battlefield` VALUES (1292,4,16933114,1);-- 'Hieracosphinx'
+INSERT INTO `bcnm_battlefield` VALUES (1292,4,16933115,1);-- 'Troglodyte_Dhalmel'
+INSERT INTO `bcnm_battlefield` VALUES (1292,4,16933116,1);-- 'Troglodyte_Dhalmel'
+INSERT INTO `bcnm_battlefield` VALUES (1292,4,16933117,1);-- 'Troglodyte_Dhalmel'
+INSERT INTO `bcnm_battlefield` VALUES (1292,4,16933118,1);-- 'Troglodyte_Dhalmel'
+INSERT INTO `bcnm_battlefield` VALUES (1292,4,16933119,1);-- 'Troglodyte_Dhalmel'
+INSERT INTO `bcnm_battlefield` VALUES (1292,4,16933120,1);-- 'Troglodyte_Dhalmel'
+INSERT INTO `bcnm_battlefield` VALUES (1292,4,16933121,1);-- 'Troglodyte_Dhalmel'
+INSERT INTO `bcnm_battlefield` VALUES (1292,4,16933122,1);-- 'Troglodyte_Dhalmel'
 -- //////////////////////////////////////////////////////////////
---               APPOLYON  NW
+--               APPOLYON  SW
 -- //////////////////////////////////////////////////////////////
-INSERT INTO `bcnm_battlefield` VALUES (1291,2,16932868,1);-- 'FirBholg'
-INSERT INTO `bcnm_battlefield` VALUES (1291,2,16932869,1);-- 'FirBholg'
-INSERT INTO `bcnm_battlefield` VALUES (1291,2,16932870,1);-- 'FirBholg'
-INSERT INTO `bcnm_battlefield` VALUES (1291,2,16932871,1);-- 'FirBholg'
-INSERT INTO `bcnm_battlefield` VALUES (1291,2,16932872,1);-- 'FirBholg'
-INSERT INTO `bcnm_battlefield` VALUES (1291,2,16932873,1);-- 'FirBholg'
-INSERT INTO `bcnm_battlefield` VALUES (1291,2,16932874,1);-- 'FirBholg'
-INSERT INTO `bcnm_battlefield` VALUES (1291,2,16932875,1);-- 'FirBholg'
-INSERT INTO `bcnm_battlefield` VALUES (1291,2,16932876,1);-- 'FirBholg'
-INSERT INTO `bcnm_battlefield` VALUES (1291,2,16932877,1);-- 'FirBholg'
+INSERT INTO `bcnm_battlefield` VALUES (1291,1,16932868,1);-- 'FirBholg'
+INSERT INTO `bcnm_battlefield` VALUES (1291,1,16932869,1);-- 'FirBholg'
+INSERT INTO `bcnm_battlefield` VALUES (1291,1,16932870,1);-- 'FirBholg'
+INSERT INTO `bcnm_battlefield` VALUES (1291,1,16932871,1);-- 'FirBholg'
+INSERT INTO `bcnm_battlefield` VALUES (1291,1,16932872,1);-- 'FirBholg'
+INSERT INTO `bcnm_battlefield` VALUES (1291,1,16932873,1);-- 'FirBholg'
+INSERT INTO `bcnm_battlefield` VALUES (1291,1,16932874,1);-- 'FirBholg'
+INSERT INTO `bcnm_battlefield` VALUES (1291,1,16932875,1);-- 'FirBholg'
+INSERT INTO `bcnm_battlefield` VALUES (1291,1,16932876,1);-- 'FirBholg'
+INSERT INTO `bcnm_battlefield` VALUES (1291,1,16932877,1);-- 'FirBholg'
 
-INSERT INTO `bcnm_battlefield` VALUES (1291,2,16932882,1);-- 'Jidra'
-INSERT INTO `bcnm_battlefield` VALUES (1291,2,16932883,1);-- 'Jidra'
-INSERT INTO `bcnm_battlefield` VALUES (1291,2,16932884,1);-- 'Jidra'
-INSERT INTO `bcnm_battlefield` VALUES (1291,2,16932885,1);-- 'Jidra'
-INSERT INTO `bcnm_battlefield` VALUES (1291,2,16932886,1);-- 'Jidra'
-INSERT INTO `bcnm_battlefield` VALUES (1291,2,16932887,1);-- 'Jidra'
-INSERT INTO `bcnm_battlefield` VALUES (1291,2,16932888,1);-- 'Jidra'
+INSERT INTO `bcnm_battlefield` VALUES (1291,1,16932882,1);-- 'Jidra'
+INSERT INTO `bcnm_battlefield` VALUES (1291,1,16932883,1);-- 'Jidra'
+INSERT INTO `bcnm_battlefield` VALUES (1291,1,16932884,1);-- 'Jidra'
+INSERT INTO `bcnm_battlefield` VALUES (1291,1,16932885,1);-- 'Jidra'
+INSERT INTO `bcnm_battlefield` VALUES (1291,1,16932886,1);-- 'Jidra'
+INSERT INTO `bcnm_battlefield` VALUES (1291,1,16932887,1);-- 'Jidra'
+INSERT INTO `bcnm_battlefield` VALUES (1291,1,16932888,1);-- 'Jidra'
 
--- INSERT INTO `bcnm_battlefield` VALUES (1291,2,16932889,1);-- 'Arboricole_Hornet'
--- INSERT INTO `bcnm_battlefield` VALUES (1291,2,16932890,1);-- 'Arboricole_Raven'
--- INSERT INTO `bcnm_battlefield` VALUES (1291,2,16932891,1);-- 'Arboricole_Opo-opo'
--- INSERT INTO `bcnm_battlefield` VALUES (1291,2,16932892,1);-- 'Arboricole_Spider'
--- INSERT INTO `bcnm_battlefield` VALUES (1291,2,16932893,1);-- 'Arboricole_Beetle'
--- INSERT INTO `bcnm_battlefield` VALUES (1291,2,16932894,1);-- 'Arboricole_Crawler'
--- INSERT INTO `bcnm_battlefield` VALUES (1291,2,16932895,1);-- 'Apollyon_Sapling'
+-- INSERT INTO `bcnm_battlefield` VALUES (1291,1,16932889,1);-- 'Arboricole_Hornet'
+-- INSERT INTO `bcnm_battlefield` VALUES (1291,1,16932890,1);-- 'Arboricole_Raven'
+-- INSERT INTO `bcnm_battlefield` VALUES (1291,1,16932891,1);-- 'Arboricole_Opo-opo'
+-- INSERT INTO `bcnm_battlefield` VALUES (1291,1,16932892,1);-- 'Arboricole_Spider'
+-- INSERT INTO `bcnm_battlefield` VALUES (1291,1,16932893,1);-- 'Arboricole_Beetle'
+-- INSERT INTO `bcnm_battlefield` VALUES (1291,1,16932894,1);-- 'Arboricole_Crawler'
+-- INSERT INTO `bcnm_battlefield` VALUES (1291,1,16932895,1);-- 'Apollyon_Sapling'
 
-INSERT INTO `bcnm_battlefield` VALUES (1291,2,16932896,1);-- 'Armoury_Crate'
-INSERT INTO `bcnm_battlefield` VALUES (1291,2,16932897,1);-- 'Armoury_Crate'
-INSERT INTO `bcnm_battlefield` VALUES (1291,2,16932898,1);-- 'Armoury_Crate'
-INSERT INTO `bcnm_battlefield` VALUES (1291,2,16932899,1);-- 'Armoury_Crate'
-INSERT INTO `bcnm_battlefield` VALUES (1291,2,16932900,1);-- 'Armoury_Crate'
-INSERT INTO `bcnm_battlefield` VALUES (1291,2,16932901,1);-- 'Armoury_Crate'
-INSERT INTO `bcnm_battlefield` VALUES (1291,2,16932902,1);-- 'Armoury_Crate'
+INSERT INTO `bcnm_battlefield` VALUES (1291,1,16932896,1);-- 'Armoury_Crate'
+INSERT INTO `bcnm_battlefield` VALUES (1291,1,16932897,1);-- 'Armoury_Crate'
+INSERT INTO `bcnm_battlefield` VALUES (1291,1,16932898,1);-- 'Armoury_Crate'
+INSERT INTO `bcnm_battlefield` VALUES (1291,1,16932899,1);-- 'Armoury_Crate'
+INSERT INTO `bcnm_battlefield` VALUES (1291,1,16932900,1);-- 'Armoury_Crate'
+INSERT INTO `bcnm_battlefield` VALUES (1291,1,16932901,1);-- 'Armoury_Crate'
+INSERT INTO `bcnm_battlefield` VALUES (1291,1,16932902,1);-- 'Armoury_Crate'
 
 
-INSERT INTO `bcnm_battlefield` VALUES (1291,2,16932910,1);-- 'Air_Elemental'
-INSERT INTO `bcnm_battlefield` VALUES (1291,2,16932911,1);-- 'Dark_Elemental'
-INSERT INTO `bcnm_battlefield` VALUES (1291,2,16932912,1);-- 'Earth_Elemental'
-INSERT INTO `bcnm_battlefield` VALUES (1291,2,16932913,1);-- 'Fire_Elemental'
-INSERT INTO `bcnm_battlefield` VALUES (1291,2,16932914,1);-- 'Ice_Elemental'
-INSERT INTO `bcnm_battlefield` VALUES (1291,2,16932915,1);-- 'Light_Elemental'
-INSERT INTO `bcnm_battlefield` VALUES (1291,2,16932916,1);-- 'Water_Elemental'
-INSERT INTO `bcnm_battlefield` VALUES (1291,2,16932917,1);-- 'ThunderElement'
-INSERT INTO `bcnm_battlefield` VALUES (1291,2,16932918,1);-- 'Air_Elemental'
-INSERT INTO `bcnm_battlefield` VALUES (1291,2,16932919,1);-- 'Dark_Elemental'
-INSERT INTO `bcnm_battlefield` VALUES (1291,2,16932920,1);-- 'Earth_Elemental'
-INSERT INTO `bcnm_battlefield` VALUES (1291,2,16932921,1);-- 'Fire_Elemental'
-INSERT INTO `bcnm_battlefield` VALUES (1291,2,16932922,1);-- 'Ice_Elemental'
-INSERT INTO `bcnm_battlefield` VALUES (1291,2,16932923,1);-- 'Light_Elemental'
-INSERT INTO `bcnm_battlefield` VALUES (1291,2,16932924,1);-- 'Water_Elemental'
-INSERT INTO `bcnm_battlefield` VALUES (1291,2,16932925,1);-- 'ThunderElement'
-INSERT INTO `bcnm_battlefield` VALUES (1291,2,16932926,1);-- 'Air_Elemental'
-INSERT INTO `bcnm_battlefield` VALUES (1291,2,16932927,1);-- 'Dark_Elemental'
-INSERT INTO `bcnm_battlefield` VALUES (1291,2,16932928,1);-- 'Earth_Elemental'
-INSERT INTO `bcnm_battlefield` VALUES (1291,2,16932929,1);-- 'Fire_Elemental'
-INSERT INTO `bcnm_battlefield` VALUES (1291,2,16932930,1);-- 'Ice_Elemental'
-INSERT INTO `bcnm_battlefield` VALUES (1291,2,16932931,1);-- 'Light_Elemental'
-INSERT INTO `bcnm_battlefield` VALUES (1291,2,16932932,1);-- 'Water_Elemental'
-INSERT INTO `bcnm_battlefield` VALUES (1291,2,16932933,1);-- 'Thunder_Elemental'
+INSERT INTO `bcnm_battlefield` VALUES (1291,1,16932910,1);-- 'Air_Elemental'
+INSERT INTO `bcnm_battlefield` VALUES (1291,1,16932911,1);-- 'Dark_Elemental'
+INSERT INTO `bcnm_battlefield` VALUES (1291,1,16932912,1);-- 'Earth_Elemental'
+INSERT INTO `bcnm_battlefield` VALUES (1291,1,16932913,1);-- 'Fire_Elemental'
+INSERT INTO `bcnm_battlefield` VALUES (1291,1,16932914,1);-- 'Ice_Elemental'
+INSERT INTO `bcnm_battlefield` VALUES (1291,1,16932915,1);-- 'Light_Elemental'
+INSERT INTO `bcnm_battlefield` VALUES (1291,1,16932916,1);-- 'Water_Elemental'
+INSERT INTO `bcnm_battlefield` VALUES (1291,1,16932917,1);-- 'ThunderElement'
+INSERT INTO `bcnm_battlefield` VALUES (1291,1,16932918,1);-- 'Air_Elemental'
+INSERT INTO `bcnm_battlefield` VALUES (1291,1,16932919,1);-- 'Dark_Elemental'
+INSERT INTO `bcnm_battlefield` VALUES (1291,1,16932920,1);-- 'Earth_Elemental'
+INSERT INTO `bcnm_battlefield` VALUES (1291,1,16932921,1);-- 'Fire_Elemental'
+INSERT INTO `bcnm_battlefield` VALUES (1291,1,16932922,1);-- 'Ice_Elemental'
+INSERT INTO `bcnm_battlefield` VALUES (1291,1,16932923,1);-- 'Light_Elemental'
+INSERT INTO `bcnm_battlefield` VALUES (1291,1,16932924,1);-- 'Water_Elemental'
+INSERT INTO `bcnm_battlefield` VALUES (1291,1,16932925,1);-- 'ThunderElement'
+INSERT INTO `bcnm_battlefield` VALUES (1291,1,16932926,1);-- 'Air_Elemental'
+INSERT INTO `bcnm_battlefield` VALUES (1291,1,16932927,1);-- 'Dark_Elemental'
+INSERT INTO `bcnm_battlefield` VALUES (1291,1,16932928,1);-- 'Earth_Elemental'
+INSERT INTO `bcnm_battlefield` VALUES (1291,1,16932929,1);-- 'Fire_Elemental'
+INSERT INTO `bcnm_battlefield` VALUES (1291,1,16932930,1);-- 'Ice_Elemental'
+INSERT INTO `bcnm_battlefield` VALUES (1291,1,16932931,1);-- 'Light_Elemental'
+INSERT INTO `bcnm_battlefield` VALUES (1291,1,16932932,1);-- 'Water_Elemental'
+INSERT INTO `bcnm_battlefield` VALUES (1291,1,16932933,1);-- 'Thunder_Elemental'
 -- //////////////////////////////////////////////////////////////
---               APPOLYON SW
+--               APPOLYON NW
 -- //////////////////////////////////////////////////////////////
-INSERT INTO `bcnm_battlefield` VALUES (1290,1,16932937,1);-- 'Pluto'
-INSERT INTO `bcnm_battlefield` VALUES (1290,1,16932938,1);-- 'Bardha'
-INSERT INTO `bcnm_battlefield` VALUES (1290,1,16932939,1);-- 'Bardha'
-INSERT INTO `bcnm_battlefield` VALUES (1290,1,16932940,1);-- 'Bardha'
-INSERT INTO `bcnm_battlefield` VALUES (1290,1,16932941,1);-- 'Bardha'
-INSERT INTO `bcnm_battlefield` VALUES (1290,1,16932942,1);-- 'Bardha'
-INSERT INTO `bcnm_battlefield` VALUES (1290,1,16932943,1);-- 'Bardha'
-INSERT INTO `bcnm_battlefield` VALUES (1290,1,16932944,1);-- 'Bardha'
-INSERT INTO `bcnm_battlefield` VALUES (1290,1,16932950,1);-- 'Zlatorog'
-INSERT INTO `bcnm_battlefield` VALUES (1290,1,16932951,1);-- 'Mountain_Buffalo'
-INSERT INTO `bcnm_battlefield` VALUES (1290,1,16932952,1);-- 'Mountain_Buffalo'
-INSERT INTO `bcnm_battlefield` VALUES (1290,1,16932953,1);-- 'Mountain_Buffalo'
-INSERT INTO `bcnm_battlefield` VALUES (1290,1,16932954,1);-- 'Mountain_Buffalo'
-INSERT INTO `bcnm_battlefield` VALUES (1290,1,16932955,1);-- 'Mountain_Buffalo'
-INSERT INTO `bcnm_battlefield` VALUES (1290,1,16932956,1);-- 'Mountain_Buffalo'
-INSERT INTO `bcnm_battlefield` VALUES (1290,1,16932957,1);-- 'Mountain_Buffalo'
-INSERT INTO `bcnm_battlefield` VALUES (1290,1,16932963,1);-- 'Millenary_Mossback'
-INSERT INTO `bcnm_battlefield` VALUES (1290,1,16932964,1);-- 'Apollyon_Scavenger'
-INSERT INTO `bcnm_battlefield` VALUES (1290,1,16932965,1);-- 'Apollyon_Scavenger'
-INSERT INTO `bcnm_battlefield` VALUES (1290,1,16932966,1);-- 'Apollyon_Scavenger'
-INSERT INTO `bcnm_battlefield` VALUES (1290,1,16932967,1);-- 'Apollyon_Scavenger'
-INSERT INTO `bcnm_battlefield` VALUES (1290,1,16932968,1);-- 'Apollyon_Scavenger'
-INSERT INTO `bcnm_battlefield` VALUES (1290,1,16932969,1);-- 'Apollyon_Scavenger'
-INSERT INTO `bcnm_battlefield` VALUES (1290,1,16932970,1);-- 'Apollyon_Scavenger'
-INSERT INTO `bcnm_battlefield` VALUES (1290,1,16932976,1);-- 'Cynoprosopi'
-INSERT INTO `bcnm_battlefield` VALUES (1290,1,16932977,1);-- 'Gorynich'
-INSERT INTO `bcnm_battlefield` VALUES (1290,1,16932978,1);-- 'Gorynich'
-INSERT INTO `bcnm_battlefield` VALUES (1290,1,16932979,1);-- 'Gorynich'
-INSERT INTO `bcnm_battlefield` VALUES (1290,1,16932980,1);-- 'Gorynich'
-INSERT INTO `bcnm_battlefield` VALUES (1290,1,16932981,1);-- 'Gorynich'
-INSERT INTO `bcnm_battlefield` VALUES (1290,1,16932985,1);-- 'Kaiser_Behemoth'
-INSERT INTO `bcnm_battlefield` VALUES (1290,1,16932986,1);-- 'Kronprinz_Behemoth'
-INSERT INTO `bcnm_battlefield` VALUES (1290,1,16932987,1);-- 'Kronprinz_Behemoth'
-INSERT INTO `bcnm_battlefield` VALUES (1290,1,16932988,1);-- 'Kronprinz_Behemoth'
+INSERT INTO `bcnm_battlefield` VALUES (1290,2,16932937,1);-- 'Pluto'
+INSERT INTO `bcnm_battlefield` VALUES (1290,2,16932938,1);-- 'Bardha'
+INSERT INTO `bcnm_battlefield` VALUES (1290,2,16932939,1);-- 'Bardha'
+INSERT INTO `bcnm_battlefield` VALUES (1290,2,16932940,1);-- 'Bardha'
+INSERT INTO `bcnm_battlefield` VALUES (1290,2,16932941,1);-- 'Bardha'
+INSERT INTO `bcnm_battlefield` VALUES (1290,2,16932942,1);-- 'Bardha'
+INSERT INTO `bcnm_battlefield` VALUES (1290,2,16932943,1);-- 'Bardha'
+INSERT INTO `bcnm_battlefield` VALUES (1290,2,16932944,1);-- 'Bardha'
+INSERT INTO `bcnm_battlefield` VALUES (1290,2,16932950,1);-- 'Zlatorog'
+INSERT INTO `bcnm_battlefield` VALUES (1290,2,16932951,1);-- 'Mountain_Buffalo'
+INSERT INTO `bcnm_battlefield` VALUES (1290,2,16932952,1);-- 'Mountain_Buffalo'
+INSERT INTO `bcnm_battlefield` VALUES (1290,2,16932953,1);-- 'Mountain_Buffalo'
+INSERT INTO `bcnm_battlefield` VALUES (1290,2,16932954,1);-- 'Mountain_Buffalo'
+INSERT INTO `bcnm_battlefield` VALUES (1290,2,16932955,1);-- 'Mountain_Buffalo'
+INSERT INTO `bcnm_battlefield` VALUES (1290,2,16932956,1);-- 'Mountain_Buffalo'
+INSERT INTO `bcnm_battlefield` VALUES (1290,2,16932957,1);-- 'Mountain_Buffalo'
+INSERT INTO `bcnm_battlefield` VALUES (1290,2,16932963,1);-- 'Millenary_Mossback'
+INSERT INTO `bcnm_battlefield` VALUES (1290,2,16932964,1);-- 'Apollyon_Scavenger'
+INSERT INTO `bcnm_battlefield` VALUES (1290,2,16932965,1);-- 'Apollyon_Scavenger'
+INSERT INTO `bcnm_battlefield` VALUES (1290,2,16932966,1);-- 'Apollyon_Scavenger'
+INSERT INTO `bcnm_battlefield` VALUES (1290,2,16932967,1);-- 'Apollyon_Scavenger'
+INSERT INTO `bcnm_battlefield` VALUES (1290,2,16932968,1);-- 'Apollyon_Scavenger'
+INSERT INTO `bcnm_battlefield` VALUES (1290,2,16932969,1);-- 'Apollyon_Scavenger'
+INSERT INTO `bcnm_battlefield` VALUES (1290,2,16932970,1);-- 'Apollyon_Scavenger'
+INSERT INTO `bcnm_battlefield` VALUES (1290,2,16932976,1);-- 'Cynoprosopi'
+INSERT INTO `bcnm_battlefield` VALUES (1290,2,16932977,1);-- 'Gorynich'
+INSERT INTO `bcnm_battlefield` VALUES (1290,2,16932978,1);-- 'Gorynich'
+INSERT INTO `bcnm_battlefield` VALUES (1290,2,16932979,1);-- 'Gorynich'
+INSERT INTO `bcnm_battlefield` VALUES (1290,2,16932980,1);-- 'Gorynich'
+INSERT INTO `bcnm_battlefield` VALUES (1290,2,16932981,1);-- 'Gorynich'
+INSERT INTO `bcnm_battlefield` VALUES (1290,2,16932985,1);-- 'Kaiser_Behemoth'
+INSERT INTO `bcnm_battlefield` VALUES (1290,2,16932986,1);-- 'Kronprinz_Behemoth'
+INSERT INTO `bcnm_battlefield` VALUES (1290,2,16932987,1);-- 'Kronprinz_Behemoth'
+INSERT INTO `bcnm_battlefield` VALUES (1290,2,16932988,1);-- 'Kronprinz_Behemoth'
 -- //////////////////////////////////////////////////////////////
 --               APPOLYON CS
 -- //////////////////////////////////////////////////////////////
-INSERT INTO `bcnm_battlefield` VALUES (1294,5,16933129,1);-- 'Carnagechief_Jackbodokk'
-INSERT INTO `bcnm_battlefield` VALUES (1294,5,16933137,1);-- 'Na QbaChirurge'
-INSERT INTO `bcnm_battlefield` VALUES (1294,5,16933144,1);-- 'DeeWapatheDe'
+INSERT INTO `bcnm_battlefield` VALUES (1294,6,16933129,1);-- 'Carnagechief_Jackbodokk'
+INSERT INTO `bcnm_battlefield` VALUES (1294,6,16933137,1);-- 'Na QbaChirurge'
+INSERT INTO `bcnm_battlefield` VALUES (1294,6,16933144,1);-- 'DeeWapatheDe'
 -- //////////////////////////////////////////////////////////////
 --               APPOLYON CENTRAL
 -- //////////////////////////////////////////////////////////////
-INSERT INTO `bcnm_battlefield` VALUES (1296,6,16933124,1);-- 'Proto-Omega'
+INSERT INTO `bcnm_battlefield` VALUES (1296,5,16933124,1);-- 'Proto-Omega'
 -- ------------------------------------
 -- ------Temenos - Northern Tower
 -- ------------------------------------
-INSERT INTO `bcnm_battlefield` VALUES (1299,2,16928772,1);-- Goblin Slaughterman
-INSERT INTO `bcnm_battlefield` VALUES (1299,2,16928773,1);-- Goblin Slaughterman
-INSERT INTO `bcnm_battlefield` VALUES (1299,2,16928774,1);-- Moblin Dustman
-INSERT INTO `bcnm_battlefield` VALUES (1299,2,16928775,1);-- Moblin Dustman
-INSERT INTO `bcnm_battlefield` VALUES (1299,2,16928776,1);-- Moblin Dustman
-INSERT INTO `bcnm_battlefield` VALUES (1299,2,16928777,1);-- Moblin Dustman
-INSERT INTO `bcnm_battlefield` VALUES (1299,2,16928781,1);-- Skadi
-INSERT INTO `bcnm_battlefield` VALUES (1299,2,16928782,1);-- Thrym
-INSERT INTO `bcnm_battlefield` VALUES (1299,2,16928783,1);-- Beli
-INSERT INTO `bcnm_battlefield` VALUES (1299,2,16928784,1);-- Kari
-INSERT INTO `bcnm_battlefield` VALUES (1299,2,16928788,1);-- Telchines Bard
-INSERT INTO `bcnm_battlefield` VALUES (1299,2,16928789,1);-- Telchines White Mage
-INSERT INTO `bcnm_battlefield` VALUES (1299,2,16928790,1);-- Telchines Dragoon
-INSERT INTO `bcnm_battlefield` VALUES (1299,2,16928791,1);-- Telchines's Wyvern
-INSERT INTO `bcnm_battlefield` VALUES (1299,2,16928792,1);-- Telchines Monk
-INSERT INTO `bcnm_battlefield` VALUES (1299,2,16928793,1);-- Telchines Monk
-INSERT INTO `bcnm_battlefield` VALUES (1299,2,16928797,1);-- Kindred Warrior
-INSERT INTO `bcnm_battlefield` VALUES (1299,2,16928798,1);-- Kindred Dark Knight
-INSERT INTO `bcnm_battlefield` VALUES (1299,2,16928799,1);-- Kindred Summoner
-INSERT INTO `bcnm_battlefield` VALUES (1299,2,16928800,1);-- Kindred's Elemental
-INSERT INTO `bcnm_battlefield` VALUES (1299,2,16928802,1);-- Kindred Black Mage
-INSERT INTO `bcnm_battlefield` VALUES (1299,2,16928803,1);-- Kindred Black Mage
-INSERT INTO `bcnm_battlefield` VALUES (1299,2,16928804,1);-- Kindred Black Mage
-INSERT INTO `bcnm_battlefield` VALUES (1299,2,16928805,1);-- Kindred Black Mage
-INSERT INTO `bcnm_battlefield` VALUES (1299,2,16928809,1);-- Praetorian Guard CCXX
-INSERT INTO `bcnm_battlefield` VALUES (1299,2,16928810,1);-- Praetorian Guard LXXIII
-INSERT INTO `bcnm_battlefield` VALUES (1299,2,16928811,1);-- Praetorian Guard CXLVIII
-INSERT INTO `bcnm_battlefield` VALUES (1299,2,16928812,1);-- Praetorian Guard CCCXI
-INSERT INTO `bcnm_battlefield` VALUES (1299,2,16928816,1);-- Cryptonberry Charmer
-INSERT INTO `bcnm_battlefield` VALUES (1299,2,16928817,1);-- Cryptonberry Skulker
-INSERT INTO `bcnm_battlefield` VALUES (1299,2,16928818,1);-- Cryptonberry Abductor
-INSERT INTO `bcnm_battlefield` VALUES (1299,2,16928819,1);-- Cryptonberry Designator
-INSERT INTO `bcnm_battlefield` VALUES (1299,2,16928820,1);-- Tonberry's Elemental
-INSERT INTO `bcnm_battlefield` VALUES (1299,2,16928822,1);-- Cryptonberry Abductor
-INSERT INTO `bcnm_battlefield` VALUES (1299,2,16928823,1);-- Cryptonberry Designator
-INSERT INTO `bcnm_battlefield` VALUES (1299,2,16928824,1);-- Tonberry's Elemental
-INSERT INTO `bcnm_battlefield` VALUES (1299,2,16928826,1);-- Cryptonberry Abductor
-INSERT INTO `bcnm_battlefield` VALUES (1299,2,16928827,1);-- Cryptonberry Designator
-INSERT INTO `bcnm_battlefield` VALUES (1299,2,16928828,1);-- Tonberry's Elemental
-INSERT INTO `bcnm_battlefield` VALUES (1299,2,16928831,1);-- Goblin Warlord
-INSERT INTO `bcnm_battlefield` VALUES (1299,2,16928832,1);-- Goblin Fencer
-INSERT INTO `bcnm_battlefield` VALUES (1299,2,16928833,1);-- Goblin Theurgist
-INSERT INTO `bcnm_battlefield` VALUES (1299,2,16928834,1);-- Goblin Fencer
-INSERT INTO `bcnm_battlefield` VALUES (1299,2,16928835,1);-- Goblin Theurgist
+INSERT INTO `bcnm_battlefield` VALUES (1299,1,16928772,1);-- Goblin Slaughterman
+INSERT INTO `bcnm_battlefield` VALUES (1299,1,16928773,1);-- Goblin Slaughterman
+INSERT INTO `bcnm_battlefield` VALUES (1299,1,16928774,1);-- Moblin Dustman
+INSERT INTO `bcnm_battlefield` VALUES (1299,1,16928775,1);-- Moblin Dustman
+INSERT INTO `bcnm_battlefield` VALUES (1299,1,16928776,1);-- Moblin Dustman
+INSERT INTO `bcnm_battlefield` VALUES (1299,1,16928777,1);-- Moblin Dustman
+INSERT INTO `bcnm_battlefield` VALUES (1299,1,16928781,1);-- Skadi
+INSERT INTO `bcnm_battlefield` VALUES (1299,1,16928782,1);-- Thrym
+INSERT INTO `bcnm_battlefield` VALUES (1299,1,16928783,1);-- Beli
+INSERT INTO `bcnm_battlefield` VALUES (1299,1,16928784,1);-- Kari
+INSERT INTO `bcnm_battlefield` VALUES (1299,1,16928788,1);-- Telchines Bard
+INSERT INTO `bcnm_battlefield` VALUES (1299,1,16928789,1);-- Telchines White Mage
+INSERT INTO `bcnm_battlefield` VALUES (1299,1,16928790,1);-- Telchines Dragoon
+INSERT INTO `bcnm_battlefield` VALUES (1299,1,16928791,1);-- Telchines's Wyvern
+INSERT INTO `bcnm_battlefield` VALUES (1299,1,16928792,1);-- Telchines Monk
+INSERT INTO `bcnm_battlefield` VALUES (1299,1,16928793,1);-- Telchines Monk
+INSERT INTO `bcnm_battlefield` VALUES (1299,1,16928797,1);-- Kindred Warrior
+INSERT INTO `bcnm_battlefield` VALUES (1299,1,16928798,1);-- Kindred Dark Knight
+INSERT INTO `bcnm_battlefield` VALUES (1299,1,16928799,1);-- Kindred Summoner
+INSERT INTO `bcnm_battlefield` VALUES (1299,1,16928800,1);-- Kindred's Elemental
+INSERT INTO `bcnm_battlefield` VALUES (1299,1,16928802,1);-- Kindred Black Mage
+INSERT INTO `bcnm_battlefield` VALUES (1299,1,16928803,1);-- Kindred Black Mage
+INSERT INTO `bcnm_battlefield` VALUES (1299,1,16928804,1);-- Kindred Black Mage
+INSERT INTO `bcnm_battlefield` VALUES (1299,1,16928805,1);-- Kindred Black Mage
+INSERT INTO `bcnm_battlefield` VALUES (1299,1,16928809,1);-- Praetorian Guard CCXX
+INSERT INTO `bcnm_battlefield` VALUES (1299,1,16928810,1);-- Praetorian Guard LXXIII
+INSERT INTO `bcnm_battlefield` VALUES (1299,1,16928811,1);-- Praetorian Guard CXLVIII
+INSERT INTO `bcnm_battlefield` VALUES (1299,1,16928812,1);-- Praetorian Guard CCCXI
+INSERT INTO `bcnm_battlefield` VALUES (1299,1,16928816,1);-- Cryptonberry Charmer
+INSERT INTO `bcnm_battlefield` VALUES (1299,1,16928817,1);-- Cryptonberry Skulker
+INSERT INTO `bcnm_battlefield` VALUES (1299,1,16928818,1);-- Cryptonberry Abductor
+INSERT INTO `bcnm_battlefield` VALUES (1299,1,16928819,1);-- Cryptonberry Designator
+INSERT INTO `bcnm_battlefield` VALUES (1299,1,16928820,1);-- Tonberry's Elemental
+INSERT INTO `bcnm_battlefield` VALUES (1299,1,16928822,1);-- Cryptonberry Abductor
+INSERT INTO `bcnm_battlefield` VALUES (1299,1,16928823,1);-- Cryptonberry Designator
+INSERT INTO `bcnm_battlefield` VALUES (1299,1,16928824,1);-- Tonberry's Elemental
+INSERT INTO `bcnm_battlefield` VALUES (1299,1,16928826,1);-- Cryptonberry Abductor
+INSERT INTO `bcnm_battlefield` VALUES (1299,1,16928827,1);-- Cryptonberry Designator
+INSERT INTO `bcnm_battlefield` VALUES (1299,1,16928828,1);-- Tonberry's Elemental
+INSERT INTO `bcnm_battlefield` VALUES (1299,1,16928831,1);-- Goblin Warlord
+INSERT INTO `bcnm_battlefield` VALUES (1299,1,16928832,1);-- Goblin Fencer
+INSERT INTO `bcnm_battlefield` VALUES (1299,1,16928833,1);-- Goblin Theurgist
+INSERT INTO `bcnm_battlefield` VALUES (1299,1,16928834,1);-- Goblin Fencer
+INSERT INTO `bcnm_battlefield` VALUES (1299,1,16928835,1);-- Goblin Theurgist
 -- ------------------------
 -- --Temenos - Eastern Tower
 -- ------------------------
-INSERT INTO `bcnm_battlefield` VALUES (1300,3,16928840,1);-- Fire Elemental
-INSERT INTO `bcnm_battlefield` VALUES (1300,3,16928841,1);-- Fire Elemental
-INSERT INTO `bcnm_battlefield` VALUES (1300,3,16928842,1);-- Fire Elemental
-INSERT INTO `bcnm_battlefield` VALUES (1300,3,16928843,1);-- Fire Elemental
-INSERT INTO `bcnm_battlefield` VALUES (1300,3,16928849,1);-- Ice Elemental
-INSERT INTO `bcnm_battlefield` VALUES (1300,3,16928850,1);-- Ice Elemental
-INSERT INTO `bcnm_battlefield` VALUES (1300,3,16928851,1);-- Ice Elemental
-INSERT INTO `bcnm_battlefield` VALUES (1300,3,16928852,1);-- Ice Elemental
-INSERT INTO `bcnm_battlefield` VALUES (1300,3,16928858,1);-- Air Elemental
-INSERT INTO `bcnm_battlefield` VALUES (1300,3,16928859,1);-- Air Elemental
-INSERT INTO `bcnm_battlefield` VALUES (1300,3,16928860,1);-- Air Elemental
-INSERT INTO `bcnm_battlefield` VALUES (1300,3,16928861,1);-- Air Elemental
-INSERT INTO `bcnm_battlefield` VALUES (1300,3,16928867,1);-- Earth Elemental
-INSERT INTO `bcnm_battlefield` VALUES (1300,3,16928868,1);-- Earth Elemental
-INSERT INTO `bcnm_battlefield` VALUES (1300,3,16928869,1);-- Earth Elemental
-INSERT INTO `bcnm_battlefield` VALUES (1300,3,16928870,1);-- Earth Elemental
-INSERT INTO `bcnm_battlefield` VALUES (1300,3,16928876,1);-- Thunder Elemental
-INSERT INTO `bcnm_battlefield` VALUES (1300,3,16928877,1);-- Thunder Elemental
-INSERT INTO `bcnm_battlefield` VALUES (1300,3,16928878,1);-- Thunder Elemental
-INSERT INTO `bcnm_battlefield` VALUES (1300,3,16928879,1);-- Thunder Elemental
-INSERT INTO `bcnm_battlefield` VALUES (1300,3,16928885,1);-- Water Elemental
-INSERT INTO `bcnm_battlefield` VALUES (1300,3,16928886,1);-- Water Elemental
-INSERT INTO `bcnm_battlefield` VALUES (1300,3,16928887,1);-- Water Elemental
-INSERT INTO `bcnm_battlefield` VALUES (1300,3,16928888,1);-- Water Elemental
-INSERT INTO `bcnm_battlefield` VALUES (1300,3,16928892,1);-- Dark Elemental
-INSERT INTO `bcnm_battlefield` VALUES (1300,3,16928893,1);-- Dark Elemental
+INSERT INTO `bcnm_battlefield` VALUES (1300,2,16928840,1);-- Fire Elemental
+INSERT INTO `bcnm_battlefield` VALUES (1300,2,16928841,1);-- Fire Elemental
+INSERT INTO `bcnm_battlefield` VALUES (1300,2,16928842,1);-- Fire Elemental
+INSERT INTO `bcnm_battlefield` VALUES (1300,2,16928843,1);-- Fire Elemental
+INSERT INTO `bcnm_battlefield` VALUES (1300,2,16928849,1);-- Ice Elemental
+INSERT INTO `bcnm_battlefield` VALUES (1300,2,16928850,1);-- Ice Elemental
+INSERT INTO `bcnm_battlefield` VALUES (1300,2,16928851,1);-- Ice Elemental
+INSERT INTO `bcnm_battlefield` VALUES (1300,2,16928852,1);-- Ice Elemental
+INSERT INTO `bcnm_battlefield` VALUES (1300,2,16928858,1);-- Air Elemental
+INSERT INTO `bcnm_battlefield` VALUES (1300,2,16928859,1);-- Air Elemental
+INSERT INTO `bcnm_battlefield` VALUES (1300,2,16928860,1);-- Air Elemental
+INSERT INTO `bcnm_battlefield` VALUES (1300,2,16928861,1);-- Air Elemental
+INSERT INTO `bcnm_battlefield` VALUES (1300,2,16928867,1);-- Earth Elemental
+INSERT INTO `bcnm_battlefield` VALUES (1300,2,16928868,1);-- Earth Elemental
+INSERT INTO `bcnm_battlefield` VALUES (1300,2,16928869,1);-- Earth Elemental
+INSERT INTO `bcnm_battlefield` VALUES (1300,2,16928870,1);-- Earth Elemental
+INSERT INTO `bcnm_battlefield` VALUES (1300,2,16928876,1);-- Thunder Elemental
+INSERT INTO `bcnm_battlefield` VALUES (1300,2,16928877,1);-- Thunder Elemental
+INSERT INTO `bcnm_battlefield` VALUES (1300,2,16928878,1);-- Thunder Elemental
+INSERT INTO `bcnm_battlefield` VALUES (1300,2,16928879,1);-- Thunder Elemental
+INSERT INTO `bcnm_battlefield` VALUES (1300,2,16928885,1);-- Water Elemental
+INSERT INTO `bcnm_battlefield` VALUES (1300,2,16928886,1);-- Water Elemental
+INSERT INTO `bcnm_battlefield` VALUES (1300,2,16928887,1);-- Water Elemental
+INSERT INTO `bcnm_battlefield` VALUES (1300,2,16928888,1);-- Water Elemental
+INSERT INTO `bcnm_battlefield` VALUES (1300,2,16928892,1);-- Dark Elemental
+INSERT INTO `bcnm_battlefield` VALUES (1300,2,16928893,1);-- Dark Elemental
 -- ------------------------
 -- Temenos - Western Tower
 -- ------------------------
-INSERT INTO `bcnm_battlefield` VALUES (1298,1,16928898,1);-- Enhanced Tiger
-INSERT INTO `bcnm_battlefield` VALUES (1298,1,16928899,1);-- Enhanced Tiger
-INSERT INTO `bcnm_battlefield` VALUES (1298,1,16928900,1);-- Enhanced Tiger
-INSERT INTO `bcnm_battlefield` VALUES (1298,1,16928901,1);-- Enhanced Tiger
-INSERT INTO `bcnm_battlefield` VALUES (1298,1,16928902,1);-- Enhanced Tiger
-INSERT INTO `bcnm_battlefield` VALUES (1298,1,16928903,1);-- Enhanced Tiger
-INSERT INTO `bcnm_battlefield` VALUES (1298,1,16928904,1);-- Enhanced Tiger
-INSERT INTO `bcnm_battlefield` VALUES (1298,1,16928905,1);-- Enhanced Tiger
-INSERT INTO `bcnm_battlefield` VALUES (1298,1,16928906,1);-- Enhanced Tiger
-INSERT INTO `bcnm_battlefield` VALUES (1298,1,16928910,1);-- Enhanced Mandragora
-INSERT INTO `bcnm_battlefield` VALUES (1298,1,16928911,1);-- Enhanced Mandragora
-INSERT INTO `bcnm_battlefield` VALUES (1298,1,16928912,1);-- Enhanced Mandragora
-INSERT INTO `bcnm_battlefield` VALUES (1298,1,16928913,1);-- Enhanced Mandragora
-INSERT INTO `bcnm_battlefield` VALUES (1298,1,16928914,1);-- Enhanced Mandragora
-INSERT INTO `bcnm_battlefield` VALUES (1298,1,16928915,1);-- Enhanced Mandragora
-INSERT INTO `bcnm_battlefield` VALUES (1298,1,16928916,1);-- Enhanced Mandragora
-INSERT INTO `bcnm_battlefield` VALUES (1298,1,16928917,1);-- Enhanced Mandragora
-INSERT INTO `bcnm_battlefield` VALUES (1298,1,16928918,1);-- Enhanced Mandragora
-INSERT INTO `bcnm_battlefield` VALUES (1298,1,16928922,1);-- Enhanced Beetle
-INSERT INTO `bcnm_battlefield` VALUES (1298,1,16928923,1);-- Enhanced Beetle
-INSERT INTO `bcnm_battlefield` VALUES (1298,1,16928924,1);-- Enhanced Beetle
-INSERT INTO `bcnm_battlefield` VALUES (1298,1,16928925,1);-- Enhanced Beetle
-INSERT INTO `bcnm_battlefield` VALUES (1298,1,16928926,1);-- Enhanced Beetle
-INSERT INTO `bcnm_battlefield` VALUES (1298,1,16928927,1);-- Enhanced Beetle
-INSERT INTO `bcnm_battlefield` VALUES (1298,1,16928931,1);-- Enhanced Lizard
-INSERT INTO `bcnm_battlefield` VALUES (1298,1,16928932,1);-- Enhanced Lizard
-INSERT INTO `bcnm_battlefield` VALUES (1298,1,16928933,1);-- Enhanced Lizard
-INSERT INTO `bcnm_battlefield` VALUES (1298,1,16928934,1);-- Enhanced Lizard
-INSERT INTO `bcnm_battlefield` VALUES (1298,1,16928935,1);-- Enhanced Lizard
-INSERT INTO `bcnm_battlefield` VALUES (1298,1,16928936,1);-- Enhanced Lizard
-INSERT INTO `bcnm_battlefield` VALUES (1298,1,16928937,1);-- Enhanced Lizard
-INSERT INTO `bcnm_battlefield` VALUES (1298,1,16928938,1);-- Enhanced Lizard
-INSERT INTO `bcnm_battlefield` VALUES (1298,1,16928939,1);-- Enhanced Lizard
-INSERT INTO `bcnm_battlefield` VALUES (1298,1,16928943,1);-- Enhanced Slime
-INSERT INTO `bcnm_battlefield` VALUES (1298,1,16928944,1);-- Enhanced Slime
-INSERT INTO `bcnm_battlefield` VALUES (1298,1,16928945,1);-- Enhanced Slime
-INSERT INTO `bcnm_battlefield` VALUES (1298,1,16928946,1);-- Enhanced Slime
-INSERT INTO `bcnm_battlefield` VALUES (1298,1,16928947,1);-- Enhanced Slime
-INSERT INTO `bcnm_battlefield` VALUES (1298,1,16928948,1);-- Enhanced Slime
-INSERT INTO `bcnm_battlefield` VALUES (1298,1,16928952,1);-- Enhanced Pugil
-INSERT INTO `bcnm_battlefield` VALUES (1298,1,16928953,1);-- Enhanced Pugil
-INSERT INTO `bcnm_battlefield` VALUES (1298,1,16928954,1);-- Enhanced Pugil
-INSERT INTO `bcnm_battlefield` VALUES (1298,1,16928955,1);-- Enhanced Pugil
-INSERT INTO `bcnm_battlefield` VALUES (1298,1,16928956,1);-- Enhanced Pugil
-INSERT INTO `bcnm_battlefield` VALUES (1298,1,16928957,1);-- Enhanced Pugil
-INSERT INTO `bcnm_battlefield` VALUES (1298,1,16928959,1);-- Enhanced Vulture
-INSERT INTO `bcnm_battlefield` VALUES (1298,1,16928960,1);-- Enhanced Vulture
-INSERT INTO `bcnm_battlefield` VALUES (1298,1,16928961,1);-- Enhanced Vulture
-INSERT INTO `bcnm_battlefield` VALUES (1298,1,16928962,1);-- Enhanced Vulture
-INSERT INTO `bcnm_battlefield` VALUES (1298,1,16928963,1);-- Enhanced Vulture
-INSERT INTO `bcnm_battlefield` VALUES (1298,1,16928964,1);-- Enhanced Vulture
+INSERT INTO `bcnm_battlefield` VALUES (1298,3,16928898,1);-- Enhanced Tiger
+INSERT INTO `bcnm_battlefield` VALUES (1298,3,16928899,1);-- Enhanced Tiger
+INSERT INTO `bcnm_battlefield` VALUES (1298,3,16928900,1);-- Enhanced Tiger
+INSERT INTO `bcnm_battlefield` VALUES (1298,3,16928901,1);-- Enhanced Tiger
+INSERT INTO `bcnm_battlefield` VALUES (1298,3,16928902,1);-- Enhanced Tiger
+INSERT INTO `bcnm_battlefield` VALUES (1298,3,16928903,1);-- Enhanced Tiger
+INSERT INTO `bcnm_battlefield` VALUES (1298,3,16928904,1);-- Enhanced Tiger
+INSERT INTO `bcnm_battlefield` VALUES (1298,3,16928905,1);-- Enhanced Tiger
+INSERT INTO `bcnm_battlefield` VALUES (1298,3,16928906,1);-- Enhanced Tiger
+INSERT INTO `bcnm_battlefield` VALUES (1298,3,16928910,1);-- Enhanced Mandragora
+INSERT INTO `bcnm_battlefield` VALUES (1298,3,16928911,1);-- Enhanced Mandragora
+INSERT INTO `bcnm_battlefield` VALUES (1298,3,16928912,1);-- Enhanced Mandragora
+INSERT INTO `bcnm_battlefield` VALUES (1298,3,16928913,1);-- Enhanced Mandragora
+INSERT INTO `bcnm_battlefield` VALUES (1298,3,16928914,1);-- Enhanced Mandragora
+INSERT INTO `bcnm_battlefield` VALUES (1298,3,16928915,1);-- Enhanced Mandragora
+INSERT INTO `bcnm_battlefield` VALUES (1298,3,16928916,1);-- Enhanced Mandragora
+INSERT INTO `bcnm_battlefield` VALUES (1298,3,16928917,1);-- Enhanced Mandragora
+INSERT INTO `bcnm_battlefield` VALUES (1298,3,16928918,1);-- Enhanced Mandragora
+INSERT INTO `bcnm_battlefield` VALUES (1298,3,16928922,1);-- Enhanced Beetle
+INSERT INTO `bcnm_battlefield` VALUES (1298,3,16928923,1);-- Enhanced Beetle
+INSERT INTO `bcnm_battlefield` VALUES (1298,3,16928924,1);-- Enhanced Beetle
+INSERT INTO `bcnm_battlefield` VALUES (1298,3,16928925,1);-- Enhanced Beetle
+INSERT INTO `bcnm_battlefield` VALUES (1298,3,16928926,1);-- Enhanced Beetle
+INSERT INTO `bcnm_battlefield` VALUES (1298,3,16928927,1);-- Enhanced Beetle
+INSERT INTO `bcnm_battlefield` VALUES (1298,3,16928931,1);-- Enhanced Lizard
+INSERT INTO `bcnm_battlefield` VALUES (1298,3,16928932,1);-- Enhanced Lizard
+INSERT INTO `bcnm_battlefield` VALUES (1298,3,16928933,1);-- Enhanced Lizard
+INSERT INTO `bcnm_battlefield` VALUES (1298,3,16928934,1);-- Enhanced Lizard
+INSERT INTO `bcnm_battlefield` VALUES (1298,3,16928935,1);-- Enhanced Lizard
+INSERT INTO `bcnm_battlefield` VALUES (1298,3,16928936,1);-- Enhanced Lizard
+INSERT INTO `bcnm_battlefield` VALUES (1298,3,16928937,1);-- Enhanced Lizard
+INSERT INTO `bcnm_battlefield` VALUES (1298,3,16928938,1);-- Enhanced Lizard
+INSERT INTO `bcnm_battlefield` VALUES (1298,3,16928939,1);-- Enhanced Lizard
+INSERT INTO `bcnm_battlefield` VALUES (1298,3,16928943,1);-- Enhanced Slime
+INSERT INTO `bcnm_battlefield` VALUES (1298,3,16928944,1);-- Enhanced Slime
+INSERT INTO `bcnm_battlefield` VALUES (1298,3,16928945,1);-- Enhanced Slime
+INSERT INTO `bcnm_battlefield` VALUES (1298,3,16928946,1);-- Enhanced Slime
+INSERT INTO `bcnm_battlefield` VALUES (1298,3,16928947,1);-- Enhanced Slime
+INSERT INTO `bcnm_battlefield` VALUES (1298,3,16928948,1);-- Enhanced Slime
+INSERT INTO `bcnm_battlefield` VALUES (1298,3,16928952,1);-- Enhanced Pugil
+INSERT INTO `bcnm_battlefield` VALUES (1298,3,16928953,1);-- Enhanced Pugil
+INSERT INTO `bcnm_battlefield` VALUES (1298,3,16928954,1);-- Enhanced Pugil
+INSERT INTO `bcnm_battlefield` VALUES (1298,3,16928955,1);-- Enhanced Pugil
+INSERT INTO `bcnm_battlefield` VALUES (1298,3,16928956,1);-- Enhanced Pugil
+INSERT INTO `bcnm_battlefield` VALUES (1298,3,16928957,1);-- Enhanced Pugil
+INSERT INTO `bcnm_battlefield` VALUES (1298,3,16928959,1);-- Enhanced Vulture
+INSERT INTO `bcnm_battlefield` VALUES (1298,3,16928960,1);-- Enhanced Vulture
+INSERT INTO `bcnm_battlefield` VALUES (1298,3,16928961,1);-- Enhanced Vulture
+INSERT INTO `bcnm_battlefield` VALUES (1298,3,16928962,1);-- Enhanced Vulture
+INSERT INTO `bcnm_battlefield` VALUES (1298,3,16928963,1);-- Enhanced Vulture
+INSERT INTO `bcnm_battlefield` VALUES (1298,3,16928964,1);-- Enhanced Vulture
 -- ----------------------------
 -- Central Temenos - 4th Floor
 -- ----------------------------
-INSERT INTO `bcnm_battlefield` VALUES (1306,8,16928966,1);-- Proto-Ultima
+INSERT INTO `bcnm_battlefield` VALUES (1306,4,16928966,1);-- Proto-Ultima
 -- --------------------------------
 -- Central Temenos - 3rd Floor
 -- --------------------------------
-INSERT INTO `bcnm_battlefield` VALUES (1305,7,16929005,1);-- Abyssdweller Jhabdebb
-INSERT INTO `bcnm_battlefield` VALUES (1305,7,16929006,1);-- Orichalcum Quadav
-INSERT INTO `bcnm_battlefield` VALUES (1305,7,16929007,1);-- Pee Qoho the Python
-INSERT INTO `bcnm_battlefield` VALUES (1305,7,16929009,1);-- Yagudo's Avatar
-INSERT INTO `bcnm_battlefield` VALUES (1305,7,16929010,1);-- Grognard Mesmerizer
-INSERT INTO `bcnm_battlefield` VALUES (1305,7,16929011,1);-- Grognard Footsoldier
-INSERT INTO `bcnm_battlefield` VALUES (1305,7,16929012,1);-- Grognard Predator
-INSERT INTO `bcnm_battlefield` VALUES (1305,7,16929013,1);-- Grognard Neckchopper
-INSERT INTO `bcnm_battlefield` VALUES (1305,7,16929014,1);-- Grognard Grappler
-INSERT INTO `bcnm_battlefield` VALUES (1305,7,16929015,1);-- Grognard Impaler
-INSERT INTO `bcnm_battlefield` VALUES (1305,7,16929016,1);-- Orc's Wyvern
-INSERT INTO `bcnm_battlefield` VALUES (1305,7,16929017,1);-- Star Ruby Quadav
-INSERT INTO `bcnm_battlefield` VALUES (1305,7,16929018,1);-- Fossil Quadav
-INSERT INTO `bcnm_battlefield` VALUES (1305,7,16929019,1);-- Whitegold Quadav
-INSERT INTO `bcnm_battlefield` VALUES (1305,7,16929020,1);-- Wootz Quadav
-INSERT INTO `bcnm_battlefield` VALUES (1305,7,16929021,1);-- Star Sapphire Quadav
-INSERT INTO `bcnm_battlefield` VALUES (1305,7,16929022,1);-- Lightsteel Quadav
-INSERT INTO `bcnm_battlefield` VALUES (1305,7,16929023,1);-- Yagudo Archpriest
-INSERT INTO `bcnm_battlefield` VALUES (1305,7,16929024,1);-- Yagudo Disciplinant
-INSERT INTO `bcnm_battlefield` VALUES (1305,7,16929025,1);-- Yagudo Kapellmeister
-INSERT INTO `bcnm_battlefield` VALUES (1305,7,16929026,1);-- Yagudo Knight Templar
-INSERT INTO `bcnm_battlefield` VALUES (1305,7,16929027,1);-- Yagudo Prelatess
-INSERT INTO `bcnm_battlefield` VALUES (1305,7,16929028,1);-- Yagudo Eradicator
+INSERT INTO `bcnm_battlefield` VALUES (1305,5,16929005,1);-- Abyssdweller Jhabdebb
+INSERT INTO `bcnm_battlefield` VALUES (1305,5,16929006,1);-- Orichalcum Quadav
+INSERT INTO `bcnm_battlefield` VALUES (1305,5,16929007,1);-- Pee Qoho the Python
+INSERT INTO `bcnm_battlefield` VALUES (1305,5,16929009,1);-- Yagudo's Avatar
+INSERT INTO `bcnm_battlefield` VALUES (1305,5,16929010,1);-- Grognard Mesmerizer
+INSERT INTO `bcnm_battlefield` VALUES (1305,5,16929011,1);-- Grognard Footsoldier
+INSERT INTO `bcnm_battlefield` VALUES (1305,5,16929012,1);-- Grognard Predator
+INSERT INTO `bcnm_battlefield` VALUES (1305,5,16929013,1);-- Grognard Neckchopper
+INSERT INTO `bcnm_battlefield` VALUES (1305,5,16929014,1);-- Grognard Grappler
+INSERT INTO `bcnm_battlefield` VALUES (1305,5,16929015,1);-- Grognard Impaler
+INSERT INTO `bcnm_battlefield` VALUES (1305,5,16929016,1);-- Orc's Wyvern
+INSERT INTO `bcnm_battlefield` VALUES (1305,5,16929017,1);-- Star Ruby Quadav
+INSERT INTO `bcnm_battlefield` VALUES (1305,5,16929018,1);-- Fossil Quadav
+INSERT INTO `bcnm_battlefield` VALUES (1305,5,16929019,1);-- Whitegold Quadav
+INSERT INTO `bcnm_battlefield` VALUES (1305,5,16929020,1);-- Wootz Quadav
+INSERT INTO `bcnm_battlefield` VALUES (1305,5,16929021,1);-- Star Sapphire Quadav
+INSERT INTO `bcnm_battlefield` VALUES (1305,5,16929022,1);-- Lightsteel Quadav
+INSERT INTO `bcnm_battlefield` VALUES (1305,5,16929023,1);-- Yagudo Archpriest
+INSERT INTO `bcnm_battlefield` VALUES (1305,5,16929024,1);-- Yagudo Disciplinant
+INSERT INTO `bcnm_battlefield` VALUES (1305,5,16929025,1);-- Yagudo Kapellmeister
+INSERT INTO `bcnm_battlefield` VALUES (1305,5,16929026,1);-- Yagudo Knight Templar
+INSERT INTO `bcnm_battlefield` VALUES (1305,5,16929027,1);-- Yagudo Prelatess
+INSERT INTO `bcnm_battlefield` VALUES (1305,5,16929028,1);-- Yagudo Eradicator
 -- -----------------------------
 -- Central Temenos - 2nd Floor
 -- ------------------------------
@@ -2683,47 +2683,47 @@ INSERT INTO `bcnm_battlefield` VALUES (1304,6,16929038,1);-- Water Elemental
 -- -----------------------------
 -- Central Temenos - 1st Floor
 -- -----------------------------
-INSERT INTO `bcnm_battlefield` VALUES (1303,5,16929046,1);-- Airi
-INSERT INTO `bcnm_battlefield` VALUES (1303,5,16929047,1);-- Temenos Cleaner
-INSERT INTO `bcnm_battlefield` VALUES (1303,5,16929048,1);-- Iruci
-INSERT INTO `bcnm_battlefield` VALUES (1303,5,16929049,1);-- Temenos Weapon
-INSERT INTO `bcnm_battlefield` VALUES (1303,5,16929050,1);-- Enhanced Dragon
-INSERT INTO `bcnm_battlefield` VALUES (1303,5,16929051,1);-- Enhanced Ahriman
+INSERT INTO `bcnm_battlefield` VALUES (1303,7,16929046,1);-- Airi
+INSERT INTO `bcnm_battlefield` VALUES (1303,7,16929047,1);-- Temenos Cleaner
+INSERT INTO `bcnm_battlefield` VALUES (1303,7,16929048,1);-- Iruci
+INSERT INTO `bcnm_battlefield` VALUES (1303,7,16929049,1);-- Temenos Weapon
+INSERT INTO `bcnm_battlefield` VALUES (1303,7,16929050,1);-- Enhanced Dragon
+INSERT INTO `bcnm_battlefield` VALUES (1303,7,16929051,1);-- Enhanced Ahriman
 -- -------------------------------
 -- Central Temenos - Basement 1
 -- ------------------------------
-INSERT INTO `bcnm_battlefield` VALUES (1301,4,16929053,1);-- Temenos Aern
-INSERT INTO `bcnm_battlefield` VALUES (1301,4,16929054,1);-- Temenos Aern
-INSERT INTO `bcnm_battlefield` VALUES (1301,4,16929055,1);-- Temenos Aern
-INSERT INTO `bcnm_battlefield` VALUES (1301,4,16929056,1);-- Aern's Wynav
-INSERT INTO `bcnm_battlefield` VALUES (1301,4,16929057,1);-- Temenos Aern
-INSERT INTO `bcnm_battlefield` VALUES (1301,4,16929058,1);-- Temenos Aern
-INSERT INTO `bcnm_battlefield` VALUES (1301,4,16929059,1);-- Aern's Euvhi
-INSERT INTO `bcnm_battlefield` VALUES (1301,4,16929060,1);-- Temenos Aern
-INSERT INTO `bcnm_battlefield` VALUES (1301,4,16929061,1);-- Temenos Aern
-INSERT INTO `bcnm_battlefield` VALUES (1301,4,16929062,1);-- Temenos Aern
-INSERT INTO `bcnm_battlefield` VALUES (1301,4,16929063,1);-- Temenos Aern
-INSERT INTO `bcnm_battlefield` VALUES (1301,4,16929064,1);-- Temenos Aern
-INSERT INTO `bcnm_battlefield` VALUES (1301,4,16929065,1);-- Temenos Aern
-INSERT INTO `bcnm_battlefield` VALUES (1301,4,16929066,1);-- Temenos Aern
-INSERT INTO `bcnm_battlefield` VALUES (1301,4,16929067,1);-- Aern's Elemental
-INSERT INTO `bcnm_battlefield` VALUES (1301,4,16929069,1);-- Temenos Aern
-INSERT INTO `bcnm_battlefield` VALUES (1301,4,16929070,1);-- Aern's Wynav
-INSERT INTO `bcnm_battlefield` VALUES (1301,4,16929071,1);-- Temenos Aern
-INSERT INTO `bcnm_battlefield` VALUES (1301,4,16929072,1);-- Temenos Aern
-INSERT INTO `bcnm_battlefield` VALUES (1301,4,16929073,1);-- Temenos Aern
-INSERT INTO `bcnm_battlefield` VALUES (1301,4,16929074,1);-- Aern's Euvhi
-INSERT INTO `bcnm_battlefield` VALUES (1301,4,16929075,1);-- Temenos Aern
-INSERT INTO `bcnm_battlefield` VALUES (1301,4,16929076,1);-- Temenos Aern
-INSERT INTO `bcnm_battlefield` VALUES (1301,4,16929077,1);-- Temenos Aern
-INSERT INTO `bcnm_battlefield` VALUES (1301,4,16929078,1);-- Temenos Aern
-INSERT INTO `bcnm_battlefield` VALUES (1301,4,16929079,1);-- Temenos Aern
-INSERT INTO `bcnm_battlefield` VALUES (1301,4,16929080,1);-- Aern's Elemental
-INSERT INTO `bcnm_battlefield` VALUES (1301,4,16929082,1);-- Temenos Aern
-INSERT INTO `bcnm_battlefield` VALUES (1301,4,16929083,1);-- Temenos Aern
-INSERT INTO `bcnm_battlefield` VALUES (1301,4,16929084,1);-- Temenos Aern
-INSERT INTO `bcnm_battlefield` VALUES (1301,4,16929085,1);-- Temenos Aern
-INSERT INTO `bcnm_battlefield` VALUES (1301,4,16929086,1);-- Temenos Aern
-INSERT INTO `bcnm_battlefield` VALUES (1301,4,16929087,1);-- Temenos Aern
+INSERT INTO `bcnm_battlefield` VALUES (1301,8,16929053,1);-- Temenos Aern
+INSERT INTO `bcnm_battlefield` VALUES (1301,8,16929054,1);-- Temenos Aern
+INSERT INTO `bcnm_battlefield` VALUES (1301,8,16929055,1);-- Temenos Aern
+INSERT INTO `bcnm_battlefield` VALUES (1301,8,16929056,1);-- Aern's Wynav
+INSERT INTO `bcnm_battlefield` VALUES (1301,8,16929057,1);-- Temenos Aern
+INSERT INTO `bcnm_battlefield` VALUES (1301,8,16929058,1);-- Temenos Aern
+INSERT INTO `bcnm_battlefield` VALUES (1301,8,16929059,1);-- Aern's Euvhi
+INSERT INTO `bcnm_battlefield` VALUES (1301,8,16929060,1);-- Temenos Aern
+INSERT INTO `bcnm_battlefield` VALUES (1301,8,16929061,1);-- Temenos Aern
+INSERT INTO `bcnm_battlefield` VALUES (1301,8,16929062,1);-- Temenos Aern
+INSERT INTO `bcnm_battlefield` VALUES (1301,8,16929063,1);-- Temenos Aern
+INSERT INTO `bcnm_battlefield` VALUES (1301,8,16929064,1);-- Temenos Aern
+INSERT INTO `bcnm_battlefield` VALUES (1301,8,16929065,1);-- Temenos Aern
+INSERT INTO `bcnm_battlefield` VALUES (1301,8,16929066,1);-- Temenos Aern
+INSERT INTO `bcnm_battlefield` VALUES (1301,8,16929067,1);-- Aern's Elemental
+INSERT INTO `bcnm_battlefield` VALUES (1301,8,16929069,1);-- Temenos Aern
+INSERT INTO `bcnm_battlefield` VALUES (1301,8,16929070,1);-- Aern's Wynav
+INSERT INTO `bcnm_battlefield` VALUES (1301,8,16929071,1);-- Temenos Aern
+INSERT INTO `bcnm_battlefield` VALUES (1301,8,16929072,1);-- Temenos Aern
+INSERT INTO `bcnm_battlefield` VALUES (1301,8,16929073,1);-- Temenos Aern
+INSERT INTO `bcnm_battlefield` VALUES (1301,8,16929074,1);-- Aern's Euvhi
+INSERT INTO `bcnm_battlefield` VALUES (1301,8,16929075,1);-- Temenos Aern
+INSERT INTO `bcnm_battlefield` VALUES (1301,8,16929076,1);-- Temenos Aern
+INSERT INTO `bcnm_battlefield` VALUES (1301,8,16929077,1);-- Temenos Aern
+INSERT INTO `bcnm_battlefield` VALUES (1301,8,16929078,1);-- Temenos Aern
+INSERT INTO `bcnm_battlefield` VALUES (1301,8,16929079,1);-- Temenos Aern
+INSERT INTO `bcnm_battlefield` VALUES (1301,8,16929080,1);-- Aern's Elemental
+INSERT INTO `bcnm_battlefield` VALUES (1301,8,16929082,1);-- Temenos Aern
+INSERT INTO `bcnm_battlefield` VALUES (1301,8,16929083,1);-- Temenos Aern
+INSERT INTO `bcnm_battlefield` VALUES (1301,8,16929084,1);-- Temenos Aern
+INSERT INTO `bcnm_battlefield` VALUES (1301,8,16929085,1);-- Temenos Aern
+INSERT INTO `bcnm_battlefield` VALUES (1301,8,16929086,1);-- Temenos Aern
+INSERT INTO `bcnm_battlefield` VALUES (1301,8,16929087,1);-- Temenos Aern
 
 -- Dump completed on 2017-01-31 10:38:38

--- a/sql/bcnm_loot.sql
+++ b/sql/bcnm_loot.sql
@@ -842,7 +842,7 @@ INSERT INTO `bcnm_loot` VALUES ('35', '744', '79', '7');
 INSERT INTO `bcnm_loot` VALUES ('35', '806', '131', '7');
 INSERT INTO `bcnm_loot` VALUES ('35', '0', '600', '7');
 -- limbus                      lootID,ItemID,Roll,lootgroup
--- SE Appollyon first floor
+-- SE Apollyon first floor
 INSERT INTO `bcnm_loot` VALUES ('110', '1875', '1000', '0'); -- ancient beastcoin*4
 INSERT INTO `bcnm_loot` VALUES ('110', '1875', '1000', '1'); 
 INSERT INTO `bcnm_loot` VALUES ('110', '1875', '1000', '2'); 
@@ -857,7 +857,7 @@ INSERT INTO `bcnm_loot` VALUES ('110', '1955', '200', '5');  --  NIN,
 INSERT INTO `bcnm_loot` VALUES ('110', '2659', '62', '5');  --  COR,
 INSERT INTO `bcnm_loot` VALUES ('110', '2715', '407', '5');  --  DNC
 -- -------------------------------------
--- SE Appollyon Second floor
+-- SE Apollyon Second floor
 -- -------------------------------------
 INSERT INTO `bcnm_loot` VALUES ('111', '1875', '1000', '0'); -- ancient beastcoin*4
 INSERT INTO `bcnm_loot` VALUES ('111', '1875', '1000', '1'); 
@@ -873,7 +873,7 @@ INSERT INTO `bcnm_loot` VALUES ('111', '1955', '80', '5');  --  NIN,
 INSERT INTO `bcnm_loot` VALUES ('111', '1945', '90', '5');  --  DRK,
 INSERT INTO `bcnm_loot` VALUES ('111', '2659', '100', '5');  --  COR,
 INSERT INTO `bcnm_loot` VALUES ('111', '2715', '120', '5');  --  DNC
--- SE Appollyon Third floor
+-- SE Apollyon Third floor
 -- -------------------------------------
 INSERT INTO `bcnm_loot` VALUES ('112', '1875', '1000', '0'); -- ancient beastcoin*4
 INSERT INTO `bcnm_loot` VALUES ('112', '1875', '1000', '1'); 
@@ -891,7 +891,7 @@ INSERT INTO `bcnm_loot` VALUES ('112', '2659', '39', '5');  --  COR,
 INSERT INTO `bcnm_loot` VALUES ('112', '664', '20', '5');  --  Darksteel Sheet
 INSERT INTO `bcnm_loot` VALUES ('112', '646', '20', '5');  --   Adaman Ore
 INSERT INTO `bcnm_loot` VALUES ('112', '1931', '200', '5'); --  WAR,
--- ---SE Appollyon fourth floor-------------------------
+-- ---SE Apollyon fourth floor-------------------------
 INSERT INTO `bcnm_loot` VALUES ('113', '1875', '1000', '0'); -- ancient beastcoin*5
 INSERT INTO `bcnm_loot` VALUES ('113', '1875', '1000', '1'); 
 INSERT INTO `bcnm_loot` VALUES ('113', '1875', '1000', '2'); 
@@ -1736,3 +1736,11 @@ INSERT INTO `bcnm_loot` VALUES ('180','17277','163','2');
 INSERT INTO `bcnm_loot` VALUES ('180','17707','167','2');
 INSERT INTO `bcnm_loot` VALUES ('180','18098','153','2');
 INSERT INTO `bcnm_loot` VALUES ('180','4748','271','2');
+
+-- Central Temenos Basement final chest
+INSERT INTO `bcnm_loot` VALUES ('181','1875','1000','0');
+INSERT INTO `bcnm_loot` VALUES ('181','1875','1000','1');
+INSERT INTO `bcnm_loot` VALUES ('181','1875','1000','2');
+INSERT INTO `bcnm_loot` VALUES ('181','1875','1000','3');
+INSERT INTO `bcnm_loot` VALUES ('181','1875','1000','4');
+INSERT INTO `bcnm_loot` VALUES ('181','1875','1000','5');

--- a/src/map/battlefield.h
+++ b/src/map/battlefield.h
@@ -27,6 +27,7 @@
 #include "../common/cbasetypes.h"
 #include "../common/mmo.h"
 #include <vector>
+#include "status_effect.h"
 #include "utils/battlefieldutils.h"
 
 enum BCRULES {
@@ -79,8 +80,8 @@ struct BattlefieldRecord
 
 typedef struct
 {
-    CMobEntity* MobEntity;	// BCNM Target
-    bool killed;			// whether it has died or not
+    CMobEntity* MobEntity;  // BCNM Target
+    bool killed;            // whether it has died or not
 } MobVictoryCondition_t;
 
 
@@ -91,94 +92,84 @@ public:
     CBattlefield(CBattlefieldHandler* hand, uint16 bcnmid, BATTLEFIELDTYPE type);
 
     //bcnm related functions
-    uint16		getID();
-    duration		getTimeLimit();
-    BATTLEFIELDTYPE		getType();
-    const int8* getBcnmName();
-    uint16		getZoneId();
-    uint8       getBattlefieldNumber();
-    uint8       getMaxParticipants();
-    uint8		getMaxPlayerInBCNM();
-    uint8		getLevelCap();
-    uint16		getLootId();
-    time_point		getStartTime();
-    time_point		getWinTime();
-    time_point		getDeadTime();
-    uint8		getEntrance();
+    uint16          getID();
+    duration        getTimeLimit();
+    BATTLEFIELDTYPE getType();
+    EFFECT          getEffect();
+    const int8*     getBcnmName();
+    uint16          getZoneId();
+    uint8           getBattlefieldNumber();
+    uint8           getMaxParticipants();
+    uint8           getMaxPlayerInBCNM();
+    uint8           getLevelCap();
+    uint16          getLootId();
+    time_point      getStartTime();
+    time_point      getWinTime();
+    time_point      getDeadTime();
+    uint8           getEntrance();
     const BattlefieldRecord& getRecord() const;
 
-    void		setTimeLimit(duration time);
-    void		setBcnmName(int8* name);
-    void		setZoneId(uint16 zone);
-    void		setBattlefieldNumber(uint8 battlefield);
-    void		setMaxParticipants(uint8 max);
-    void		setLevelCap(uint8 cap);
-    void		setLootId(uint16 id);
-    void		setDeadTime(time_point time);
-    void		setEntrance(uint8 entrance);
+    void        setTimeLimit(duration time);
+    void        setBcnmName(int8* name);
+    void        setZoneId(uint16 zone);
+    void        setBattlefieldNumber(uint8 battlefield);
+    void        setMaxParticipants(uint8 max);
+    void        setLevelCap(uint8 cap);
+    void        setLootId(uint16 id);
+    void        setDeadTime(time_point time);
+    void        setEntrance(uint8 entrance);
     void        setRecord(const std::string& name, uint8 partySize, duration clearTime);
+    void        addTimeLimit(duration time);
 
     //player related functions
-    bool		isValidPlayerForBcnm(CCharEntity* PChar);
-    bool		isPlayerInBcnm(CCharEntity* PChar);
-    bool		enterBcnm(CCharEntity* PChar);
-    bool		addPlayerToBcnm(CCharEntity* PChar);					// true if added
-    bool		delPlayerFromBcnm(CCharEntity* PChar);					// true if deleted
-    bool		allPlayersDead();										// true if all players in the bcnm are dead.
-    uint8		getPlayerMainJob();										// used for Maat fights
-    uint8		getPlayerMainLevel();									// used for Maat fights
-    void		capPlayerToBCNM();										// adjust player's level to the appropriate cap and remove buffs
-    void		disableSubJob();										// disable all players subjobs
-    void		enableSubJob();											// enable all players subjobs
-    void		pushMessageToAllInBcnm(uint16 msg, uint16 param);
+    bool        isValidPlayerForBcnm(CCharEntity* PChar);
+    bool        isPlayerInBcnm(CCharEntity* PChar);
+    bool        enterBcnm(CCharEntity* PChar);
+    bool        addPlayer(CCharEntity* PChar);                          // add player to m_Playerlist
+    bool        delPlayer(CCharEntity* PChar);                          // delete player from m_Playerlist
+    bool        allPlayersDead();                                       // true if all players in the bcnm are dead.
+    uint8       getPlayerMainJob();                                     // used for Maat fights
+    uint8       getPlayerMainLevel();                                   // used for Maat fights
+    void        capPlayerToBCNM();                                      // adjust player's level to the appropriate cap and remove buffs
+    void        disableSubJob();                                        // disable all players subjobs
+    void        enableSubJob();                                         // enable all players subjobs
+    void        pushMessageToAllInBcnm(uint16 msg, uint16 param);
+    void        clearPlayerEnmity(CCharEntity* PChar);                  // erase chars enmity
 
     //spawning chests + loot
-    void		addNpc(CBaseEntity* PNpc);
-    bool		spawnTreasureChest();
-    bool		treasureChestSpawned;
-    void		OpenChestinBcnm();
+    void        addNpc(CBaseEntity* PNpc);
+    void        spawnChest();
+    void        openChest();
+    bool        m_chestSpawned;
 
     //mob related functions
-    //bool		spawnAllEnemies();
-    //bool		resetAllEnemySpawnPositions();
-    void		addEnemy(CMobEntity* PMob, uint8 condition);
-    bool		allEnemiesDefeated();
-    bool		isEnemyBelowHPP(uint8 hpp);
-    void		addMonsterInList(CMobEntity* PMob);						// add monster to the list
-    bool		isMonsterInList(CMobEntity* PMob);						// check if monster is in the list
+    //bool      spawnAllEnemies();
+    //bool      resetAllEnemySpawnPositions();
+    void        addEnemy(CMobEntity* PMob, uint8 condition);
+    bool        allEnemiesDefeated();
+    bool        isEnemyBelowHPP(uint8 hpp);
+    bool        isEnemyInList(CMobEntity* PMob);
 
     //handler functions (time/multiple rounds/etc)
-    void		lockBcnm();												// removes valid players if they arent inside the BCNM. Called when fighting.
-    void		init();													// prepares new BCNM
-    void 		beforeCleanup();										// called before players are removed
-    void		cleanup();												// cleans up the existing active BCNM
+    void        init();                                                 // prepares new BCNM
+    void        lock();                                                 // happens when enemy is engaged. prevents allies from entering the arena.
+    bool        isLocked();
+    void        beforeCleanup();                                        // called before players are removed
+    void        cleanup();                                              // remove players, mobs, npcs. update record. wipe from handler.
     void        removePlayers();
-    bool		isPlayersFighting();									// true if mob has aggression, used for locking the BCNM
-    bool		winBcnm();
-    bool		loseBcnm();
-    bool		isReserved();											// true if someone has a valid entry for this bcnm
+    bool        isPlayersFighting();                                    // true if mob has aggression, used for locking the BCNM
+    bool        winBcnm();
+    bool        loseBcnm();
+    bool        isReserved();                                           // true if someone has a valid entry for this bcnm
 
-    //Dynamis functions
-    void		setDynaUniqueID();										// set unique ID in dynamis battlefield
-    uint16		getDynaUniqueID();										// get unique ID in dynamis battlefield
-    bool		addPlayerToDynamis(CCharEntity* PChar);					// add player to the dynamis
-    void		addTimeLimit(duration time);								// add time in dynamis
-    bool		finishDynamis();										// finish dynamis
-    void		cleanupDynamis();										// cleanup all mobs in dynamis
-    bool		delPlayerFromDynamis(CCharEntity* PChar);				// delete player in m_PlayerList
-    void		clearPlayerEnmity(CCharEntity* PChar); 					// erase chars enmity
+    uint16      m_RuleMask;
+    time_point  lastTick;
+    time_point  fightTick;
 
-    uint16		m_RuleMask;
-    bool		locked;
-    string_t	m_FastestName;
-    uint32		m_FastestTime;
-    time_point		lastTick;
-    time_point      fightTick;
-
-    bool		lost();
-    bool		won();
-    void		lose();
-    void		win(time_point tick);
+    bool        lost();
+    bool        won();
+    void        lose();
+    void        win(time_point tick);
     bool        cleared();
 
     std::vector<CCharEntity*> m_PlayerList;
@@ -189,23 +180,25 @@ public:
 
 private:
     CBattlefieldHandler* m_Handler;
-    uint16			m_BcnmID;
-    string_t		m_name;
-    uint16			m_ZoneID;
+    uint16          m_BcnmID;
+    string_t        m_name;
+    uint16          m_ZoneID;
     BATTLEFIELDTYPE m_Type;
-    uint8			m_BattlefieldNumber;
-    time_point			m_StartTime;
-    time_point 			m_WinTime;
-    time_point			m_AllDeadTime;											// time when every pt member has fallen
-    duration			m_TimeLimit;
-    uint32			m_LootId;
-    uint8			m_LevelCap;
-    uint8			m_MaxParticipants;										// 1,3,6,12,18,zone
-    uint16			m_DynaUniqueID;											// unique ID for dynamis battlefield
-    uint8			m_entrance;
-    CCharEntity*	m_CurrentBattlefieldLeader;
-    bool			m_lost;
-    bool			m_won;
+    EFFECT          m_Effect;
+    uint8           m_BattlefieldNumber;
+    time_point      m_StartTime;
+    time_point      m_WinTime;
+    time_point      m_AllDeadTime;                                          // time when every pt member has fallen
+    duration        m_TimeLimit;
+    uint32          m_LootId;
+    uint8           m_LevelCap;
+    uint8           m_MaxParticipants;                                      // 1,3,6,12,18,zone
+    uint16          m_DynaUniqueID;                                         // unique ID for dynamis battlefield
+    uint8           m_entrance;
+    CCharEntity*    m_CurrentBattlefieldLeader;
+    bool            m_lost;
+    bool            m_won;
+    bool            m_locked;
     bool            m_cleared {false}; // set when the BCNM has ended and the players have started the end cutscene
 
     BattlefieldRecord m_record;

--- a/src/map/battlefield_handler.cpp
+++ b/src/map/battlefield_handler.cpp
@@ -36,31 +36,37 @@
 #include "recast_container.h"
 #include "status_effect_container.h"
 
-CBattlefieldHandler::CBattlefieldHandler(uint16 zoneid)
-{
+CBattlefieldHandler::CBattlefieldHandler(uint16 zoneid) {
     m_ZoneId = zoneid;
 
-    //Dynamis zone (need to add COP dyna zone)
-    //added ghelsba outpost here, 1 battlefield only
-    if (m_ZoneId > 184 && m_ZoneId < 189 || m_ZoneId > 133 && m_ZoneId < 136 || m_ZoneId == 140 || m_ZoneId == 35 || m_ZoneId > 38 && m_ZoneId < 43)
-    {
+    // The Garden of RuHmet, Dynamis zones, and Ghelsba Outpost
+    if (m_ZoneId == 35 || m_ZoneId > 38 && m_ZoneId < 43 || m_ZoneId > 133 && m_ZoneId < 136 || m_ZoneId == 140 || m_ZoneId > 184 && m_ZoneId < 189 ) {
         m_MaxBattlefields = 1;
+
+    // Temenos
+    } else if (m_ZoneId == 37) {
+        m_MaxBattlefields = 8;
+
+    // Apollyon
+    } else if (m_ZoneId == 38) {
+        m_MaxBattlefields = 6;
+
+    // All other battlefield zones
+    } else {
+        m_MaxBattlefields = 3;
     }
-    else
-        if (m_ZoneId == 37)
-        {
-            m_MaxBattlefields = 8;
-        }
-        else
-            if (m_ZoneId == 38)
-            {
-                m_MaxBattlefields = 6;
-            }
-            else
-            {
-                m_MaxBattlefields = 3;
-            }
+
     memset(&m_Battlefields, 0, sizeof(m_Battlefields));
+}
+
+/***********************************************************
+ is battlefield bnum free
+ ***********************************************************/
+bool CBattlefieldHandler::isBattlefieldFree(uint16 bnum) {
+    if (m_Battlefields[bnum-1] == nullptr)
+        return true;
+    else
+        return false;
 }
 
 void CBattlefieldHandler::handleBattlefields(time_point tick) {
@@ -69,150 +75,83 @@ void CBattlefieldHandler::handleBattlefields(time_point tick) {
             CBattlefield* PBattlefield = m_Battlefields[i];
             int instzone = PBattlefield->getZoneId();
 
-            //handle time remaining prompts (since its useful!) Prompts every minute
+            // update timers
             auto time_elapsed = std::chrono::duration_cast<std::chrono::seconds>(tick - PBattlefield->getStartTime());
             auto time_remaining = std::chrono::duration_cast<std::chrono::seconds>(PBattlefield->getTimeLimit() - time_elapsed).count();
 
-            //Dynamis zone (need to add COP Dyna)
-            if (instzone > 184 && instzone < 189 || instzone > 133 && instzone < 136 || instzone > 38 && instzone < 43) {
-                //handle death time
-                if (PBattlefield->allPlayersDead()) {//set dead time
-                    if (PBattlefield->getDeadTime() == time_point::min()) {
-                        PBattlefield->setDeadTime(tick);
-                        ShowDebug("Dynamis %i battlefield %i : All players have fallen.\n", PBattlefield->getID(), PBattlefield->getBattlefieldNumber());
-                    }
-                }
-                else {
-                    if (PBattlefield->getDeadTime() != time_point::min()) {
-                        PBattlefield->setDeadTime(time_point::min()); //reset dead time when people are alive
-                        ShowDebug("Dynamis %i battlefield %i : Death counter reset as a player is now alive.\n", PBattlefield->getID(), PBattlefield->getBattlefieldNumber());
-                    }
-                }
+            //handle locking of bcnm when engaged
+            if (PBattlefield->getType() == BATTLEFIELDTYPE_BCNM && !PBattlefield->isLocked() && PBattlefield->isPlayersFighting()) {
+                PBattlefield->lock();
+                PBattlefield->fightTick = tick;
+                ShowDebug("Zone %i battlefield %i with bfid %i: Battlefield locked \n", PBattlefield->getZoneId(), PBattlefield->getBattlefieldNumber(), PBattlefield->getID());
+            }
 
-
-                //New message (in yellow) at the end of dynamis (5min before the end)
-                if ((time_elapsed % 60) == 0s && (PBattlefield->getTimeLimit() - time_elapsed) <= 5min) {
-                    PBattlefield->pushMessageToAllInBcnm(449, (time_remaining) / 60);
-                }
-                else {
-                    if (time_elapsed % 60 == 0s) {
-                        PBattlefield->pushMessageToAllInBcnm(202, time_remaining);
-                    }
-                }
-
-                //if the time is finished, exiting dynamis
-                if (battlefieldutils::meetsLosingConditions(PBattlefield, tick)) {
-                    ShowDebug("Dynamis %i battlefield %i : Dynamis is finished. Exiting battlefield.\n", PBattlefield->getID(), PBattlefield->getBattlefieldNumber());
-                    PBattlefield->finishDynamis();
+            // handle death time
+            if (PBattlefield->allPlayersDead()) {
+                if (PBattlefield->getDeadTime() == time_point::min()) {
+                    PBattlefield->setDeadTime(tick);
+                    ShowDebug("Zone %i battlefield %i with bfid %i: All players have fallen \n", PBattlefield->getZoneId(), PBattlefield->getBattlefieldNumber(), PBattlefield->getID());
                 }
             }
-            else
-                if (instzone == 37 || instzone == 38) { //limbus ///////////////////////////////////////////////////////////
-                                //handle death time
-                    if (PBattlefield->allPlayersDead()) {//set dead time
-                        if (PBattlefield->getDeadTime() == time_point::min()) {
-                            PBattlefield->setDeadTime(tick);
-                            ShowDebug("Limbus %i battlefield %i : All players have fallen.\n", PBattlefield->getID(), PBattlefield->getBattlefieldNumber());
-                        }
-                    }
-                    else {
-                        if (PBattlefield->getDeadTime() != time_point::min()) {
-                            PBattlefield->setDeadTime(time_point::min()); //reset dead time when people are alive
-                            ShowDebug("Limbus %i battlefield %i : Death counter reset as a player is now alive.\n", PBattlefield->getID(), PBattlefield->getBattlefieldNumber());
-                        }
-                    }
+            else {
+                if (PBattlefield->getDeadTime() != time_point::min()) {
+                    PBattlefield->setDeadTime(time_point::min()); //reset dead time when people are alive
+                    ShowDebug("Zone %i battlefield %i with bfid %i: Death counter reset as a player is now alive \n", PBattlefield->getZoneId(), PBattlefield->getBattlefieldNumber(), PBattlefield->getID());
+                }
+            }
 
-                    if (time_elapsed % 60 == 0s) {
-                        PBattlefield->pushMessageToAllInBcnm(202, time_remaining);
-                    }
+            // time remaining messages
+            if (PBattlefield->getType() == BATTLEFIELDTYPE_DYNAMIS && (time_elapsed % 60) == 0s && (PBattlefield->getTimeLimit() - time_elapsed) <= 5min) {
+                PBattlefield->pushMessageToAllInBcnm(449, (time_remaining) / 60);
+            } else if (time_elapsed % 60 == 0s) {
+                PBattlefield->pushMessageToAllInBcnm(202, time_remaining);
+            }
 
-                    //if the time is finished, exiting Limbus
-                    if (battlefieldutils::meetsLosingConditions(PBattlefield, tick)) {
+            // handle win conditions
+            if (PBattlefield->getType() == BATTLEFIELDTYPE_BCNM && battlefieldutils::meetsWinningConditions(PBattlefield, tick)) {
 
-                        ShowDebug("Limbus %i battlefield %i : Limbus is finished. Exiting battlefield.\n", PBattlefield->getID(), PBattlefield->getBattlefieldNumber());
-                        PBattlefield->loseBcnm();
+                //check rule mask to see if warp immediately or pop a chest
+                if (PBattlefield->m_RuleMask & RULES_SPAWN_TREASURE_ON_WIN) {
+                    //spawn chest
+                    if (!PBattlefield->m_chestSpawned)
+                    {
+                        ShowDebug("Zone %i battlefield %i with bfid %i: Winning conditions met. Spawning chest. \n", PBattlefield->getZoneId(), PBattlefield->getBattlefieldNumber(), PBattlefield->getID());
+                        PBattlefield->spawnChest();
                     }
-                    ///////////////////////////////////////////////////////////////////////////////////////////////////////////////
                 }
                 else {
-                    //handle locking of bcnm when engaged
-                    if (!PBattlefield->locked && PBattlefield->isPlayersFighting()) {
-                        PBattlefield->lockBcnm();
-                        PBattlefield->fightTick = tick;
-                        PBattlefield->locked = true;
-                        ShowDebug("BCNM %i battlefield %i : Battlefield has been locked. No more players can enter.\n", PBattlefield->getID(), PBattlefield->getBattlefieldNumber());
+                    // BCNMs that ends before killing mobs exits immediately.
+                    if (!PBattlefield->allEnemiesDefeated() && !PBattlefield->cleared()) {
+                        ShowDebug("Zone %i battlefield %i with bfid %i: Winning conditions met. \n", PBattlefield->getZoneId(), PBattlefield->getBattlefieldNumber(), PBattlefield->getID());
+                        PBattlefield->winBcnm();
                     }
-                    //handle death time
-                    if (PBattlefield->allPlayersDead()) {//set dead time
-                        if (PBattlefield->getDeadTime() == time_point::min()) {
-                            PBattlefield->setDeadTime(tick);
-                            ShowDebug("BCNM %i battlefield %i : All players have fallen.\n", PBattlefield->getID(), PBattlefield->getBattlefieldNumber());
-                        }
+                    // BCNMs with no treasure chest ends around 7 seconds after winning.
+                    else if (!PBattlefield->won()) {
+                        ShowDebug("Zone %i battlefield %i with bfid %i: Winning conditions met. Waiting 7 seconds before exiting battlefield. \n", PBattlefield->getZoneId(), PBattlefield->getBattlefieldNumber(), PBattlefield->getID());
+                        PBattlefield->win(tick);
                     }
                     else {
-                        if (PBattlefield->getDeadTime() != time_point::min()) {
-                            PBattlefield->setDeadTime(time_point::min()); //reset dead time when people are alive
-                            ShowDebug("BCNM %i battlefield %i : Death counter reset as a player is now alive.\n", PBattlefield->getID(), PBattlefield->getBattlefieldNumber());
+                        if (!PBattlefield->cleared() && (tick - PBattlefield->getWinTime()) > 6s) {
+                            ShowDebug("Zone %i battlefield %i with bfid %i: Winning conditions met. \n", PBattlefield->getZoneId(), PBattlefield->getBattlefieldNumber(), PBattlefield->getID());
+                            PBattlefield->winBcnm();
                         }
-                    }
-                    //handle time remaining prompts (since its useful!) Prompts every minute
-                    if (time_elapsed % 60 == 0s) {
-                        PBattlefield->pushMessageToAllInBcnm(202, time_remaining);
-                    }
-
-                    //handle win conditions
-                    if (battlefieldutils::meetsWinningConditions(PBattlefield, tick)) {
-                        //check rule mask to see if warp immediately or pop a chest
-                        if (PBattlefield->m_RuleMask & RULES_SPAWN_TREASURE_ON_WIN) {
-                            //spawn chest
-                            if (PBattlefield->treasureChestSpawned == false)
-                            {
-                                ShowDebug("BCNM %i battlefield %i : Winning conditions met. Spawning chest.\n", PBattlefield->getID(), PBattlefield->getBattlefieldNumber());
-                                PBattlefield->spawnTreasureChest();
-                                //PBattlefield->getHighestTHforBcnm(); apparently not used in bcnm
-                                PBattlefield->treasureChestSpawned = true;
-                            }
-                        }
-                        else {
-                            // BCNMs that ends before killing mobs exits immediately.
-                            if (!PBattlefield->allEnemiesDefeated() && !PBattlefield->cleared()) {
-                                ShowDebug("BCNM %i battlefield %i : Winning conditions met.\n",
-                                    PBattlefield->getID(), PBattlefield->getBattlefieldNumber());
-                                PBattlefield->winBcnm();
-                            }
-                            // BCNMs with no treasure chest ends around 7 seconds after winning.
-                            else if (!PBattlefield->won()) {
-                                ShowDebug("BCNM %i battlefield %i : Winning conditions met. Waiting 7 seconds before exiting battlefield.\n",
-                                    PBattlefield->getID(), PBattlefield->getBattlefieldNumber());
-                                PBattlefield->win(tick);
-                            }
-                            else {
-                                if (!PBattlefield->cleared() && (tick - PBattlefield->getWinTime()) > 6s) {
-                                    ShowDebug("BCNM %i battlefield %i : Exiting battlefield.\n",
-                                        PBattlefield->getID(), PBattlefield->getBattlefieldNumber());
-                                    PBattlefield->winBcnm();
-                                }
-                            }
-                        }
-                    }
-                    //handle lose conditions
-                    else if (!PBattlefield->cleared() && battlefieldutils::meetsLosingConditions(PBattlefield, tick)) {
-                        ShowDebug("BCNM %i battlefield %i : Losing conditions met. Exiting battlefield.\n", PBattlefield->getID(), PBattlefield->getBattlefieldNumber());
-                        PBattlefield->loseBcnm();
                     }
                 }
+
+            // handle lose conditions
+            } else if (!PBattlefield->cleared() && battlefieldutils::meetsLosingConditions(PBattlefield, tick)) {
+                ShowDebug("Zone %i battlefield %i with bfid %i: Losing conditions met. \n", PBattlefield->getZoneId(), PBattlefield->getBattlefieldNumber(), PBattlefield->getID());
+                PBattlefield->loseBcnm();
+            }
+
         }
     }
-
-    //send 246 with bunrning circle as target (bcnm is full. followed by time remaining)
-
 }
 
-void CBattlefieldHandler::wipeBattlefield(CBattlefield* inst) {
-    if (inst->getBattlefieldNumber() <= m_MaxBattlefields && inst->getBattlefieldNumber() > 0 &&
-        m_Battlefields[inst->getBattlefieldNumber() - 1] != nullptr) {
-        ShowDebug("Wiping battlefield BCNMID: %i Battlefield %i \n", inst->getID(), inst->getBattlefieldNumber());
-        m_Battlefields[inst->getBattlefieldNumber() - 1] = nullptr;
+void CBattlefieldHandler::wipeBattlefield(CBattlefield* PBattlefield) {
+    if (PBattlefield->getBattlefieldNumber() <= m_MaxBattlefields && PBattlefield->getBattlefieldNumber() > 0 && m_Battlefields[PBattlefield->getBattlefieldNumber() - 1] != nullptr) {
+        ShowDebug("Zone %i battlefield %i with bfid %i: Wiping battlefield from handler. \n", PBattlefield->getZoneId(), PBattlefield->getBattlefieldNumber(), PBattlefield->getID());
+        m_Battlefields[PBattlefield->getBattlefieldNumber() - 1] = nullptr;
     }
 }
 
@@ -221,225 +160,158 @@ This removes the player from the active list and calls the warp/dc callback. Mus
 that this will be called if you warp BEFORE entering the bcnm (but still have battleifeld status)
 hence it doesn't check if you're "in" the BCNM, it just tries to remove you from the list.
 */
-bool CBattlefieldHandler::disconnectFromBcnm(CCharEntity* PChar) //includes warping
-{
-    if (!PChar->StatusEffectContainer->HasStatusEffect(EFFECT_BATTLEFIELD))
+bool CBattlefieldHandler::disconnectFromBattlefield(CCharEntity* PChar) {
+    uint16 bnum = 0;
+
+    if (PChar->StatusEffectContainer->HasStatusEffect(EFFECT_BATTLEFIELD))
+        bnum = PChar->StatusEffectContainer->GetStatusEffect(EFFECT_BATTLEFIELD)->GetPower();
+    else if (PChar->StatusEffectContainer->HasStatusEffect(EFFECT_DYNAMIS))
+        bnum = PChar->StatusEffectContainer->GetStatusEffect(EFFECT_DYNAMIS)->GetPower();
+
+    if (bnum == 0)
         return false;
-    
-    uint16 effectid = PChar->StatusEffectContainer->GetStatusEffect(EFFECT_BATTLEFIELD)->GetPower();
 
-    for (int i = 0; i < m_MaxBattlefields; i++)
-    {
-        if (m_Battlefields[i] != nullptr)
-        {
-            if (m_Battlefields[i]->getID() == effectid)
-            //PChar->PBCNM will be nullptr if the player has not yet entered so we check their status effect instead
-            { 
-                luautils::OnBcnmLeave(PChar, m_Battlefields[i], LEAVE_WARPDC);
-                m_Battlefields[i]->delPlayerFromBcnm(PChar);
-                return true;
+    if (m_Battlefields[bnum-1] != nullptr) {
+        CBattlefield* PBattlefield = m_Battlefields[bnum-1];
+        if (PBattlefield->delPlayer(PChar)) {
+            luautils::OnBcnmLeave(PChar, PBattlefield, LEAVE_WARPDC);
+            if (!PBattlefield->isReserved()) {//no more players in BCNM
+                ShowDebug("Zone %i battlefield %i with bfid %i: No more players detected. \n", PBattlefield->getZoneId(), PBattlefield->getBattlefieldNumber(), PBattlefield->getID());
+                luautils::OnBcnmLeave(PChar, PBattlefield, LEAVE_LOSE);
+                PBattlefield->cleanup();
             }
+            return true;
+        }
+
+    }
+
+    return false;
+}
+
+bool CBattlefieldHandler::leaveBcnm(uint16 bnum, CCharEntity* PChar) {
+    if (m_Battlefields[bnum-1] != nullptr && m_Battlefields[bnum-1]->isPlayerInBcnm(PChar) && m_Battlefields[bnum-1] == PChar->PBCNM) {
+        luautils::OnBcnmLeave(PChar, m_Battlefields[bnum-1], LEAVE_EXIT);
+        m_Battlefields[bnum-1]->delPlayer(PChar);
+        return true;
+    }
+    return false;
+}
+
+bool CBattlefieldHandler::winBcnm(uint16 bnum, CCharEntity* PChar) {
+    if (m_Battlefields[bnum-1] != nullptr && m_Battlefields[bnum-1]->isPlayerInBcnm(PChar)) {
+        m_Battlefields[bnum-1]->winBcnm();
+        return true;
+    }
+    return false;
+}
+
+bool CBattlefieldHandler::enterBcnm(uint16 bnum, CCharEntity* PChar) {
+    if (m_Battlefields[bnum-1] != nullptr && m_Battlefields[bnum-1]->isValidPlayerForBcnm(PChar)) {
+        if (m_Battlefields[bnum-1]->enterBcnm(PChar)) {
+            return true;
         }
     }
     return false;
 }
 
-bool CBattlefieldHandler::leaveBcnm(uint16 bcnmid, CCharEntity* PChar) {
-    for (int i = 0; i < m_MaxBattlefields; i++) {
-        if (m_Battlefields[i] != nullptr && m_Battlefields[i]->getID() == bcnmid) {
-            if (m_Battlefields[i]->isPlayerInBcnm(PChar)) {
-                if (m_Battlefields[i] == PChar->PBCNM) {
-                    luautils::OnBcnmLeave(PChar, m_Battlefields[i], LEAVE_EXIT);
-                    m_Battlefields[i]->delPlayerFromBcnm(PChar);
-                    return true;
-                }
-            }
-        }
-    }
-    return false;
-}
-
-bool CBattlefieldHandler::winBcnm(uint16 bcnmid, CCharEntity* PChar) {
-    for (int i = 0; i < m_MaxBattlefields; i++) {
-        if (m_Battlefields[i] != nullptr && m_Battlefields[i]->getID() == bcnmid) {
-            if (m_Battlefields[i]->isPlayerInBcnm(PChar)) {
-                m_Battlefields[i]->winBcnm();
-                return true;
-            }
-        }
-    }
-    return false;
-}
-
-bool CBattlefieldHandler::enterBcnm(uint16 bcnmid, CCharEntity* PChar) {
-    for (int i = 0; i < m_MaxBattlefields; i++) {
-        if (m_Battlefields[i] != nullptr && m_Battlefields[i]->getID() == bcnmid) {
-            if (m_Battlefields[i]->isValidPlayerForBcnm(PChar)) {
-                if (m_Battlefields[i]->enterBcnm(PChar)) {
-                    return true;
-                }
-            }
-        }
-    }
-    return false;
-}
-
-int CBattlefieldHandler::registerBcnm(uint16 id, CCharEntity* PChar) {
-    if (!hasFreeBattlefield()) {
+int CBattlefieldHandler::registerBattlefield(uint16 bnum, uint16 id, CCharEntity* PChar) {
+    if (!isBattlefieldFree(bnum)) {
         return -1;
     }
-    CBattlefield* PBattlefield = battlefieldutils::loadBattlefield(this, id, BATTLEFIELDTYPE_BCNM);
+
+    CZone* PZone = PChar->loc.zone == nullptr ? zoneutils::GetZone(PChar->loc.destination) : PChar->loc.zone;
+    int ZoneID = PZone->GetID();
+
+    BATTLEFIELDTYPE type;
+    if (ZoneID == 37 || ZoneID == 38)
+        type = BATTLEFIELDTYPE_LIMBUS;
+    else if ((ZoneID >= 39 && ZoneID <= 42) || ZoneID == 134 || ZoneID == 135 || (ZoneID >= 185 && ZoneID <= 188))
+        type = BATTLEFIELDTYPE_DYNAMIS;
+    else
+        type = BATTLEFIELDTYPE_BCNM;
+
+    CBattlefield* PBattlefield = battlefieldutils::loadBattlefield(this, id, type);
     if (PBattlefield == nullptr) {
         return -1;
     }
-    if (id > 1289 && id < 1308) {
+    PBattlefield->setBattlefieldNumber(bnum);
 
-        switch (id)
-        {
-            case 1290:
-            {PBattlefield->setBattlefieldNumber(1); }
-            break;
-            case 1291:
-            {PBattlefield->setBattlefieldNumber(2); }
-            break;
-            case 1292:
-            {PBattlefield->setBattlefieldNumber(3); }
-            break;
-            case 1293:
-            {PBattlefield->setBattlefieldNumber(4); }
-            break;
-            case 1294:
-            {PBattlefield->setBattlefieldNumber(5); }
-            break;
-            case 1295:
-            {PBattlefield->setBattlefieldNumber(5); }
-            break;
-            case 1296:
-            {PBattlefield->setBattlefieldNumber(6); }
-            break;
-            case 1297:
-            {PBattlefield->setBattlefieldNumber(6); }
-            break;
-            case 1298:
-            {PBattlefield->setBattlefieldNumber(1); }
-            break;
-            case 1299:
-            {PBattlefield->setBattlefieldNumber(2); }
-            break;
-            case 1300:
-            {PBattlefield->setBattlefieldNumber(3); }
-            break;
-            case 1301:
-            {PBattlefield->setBattlefieldNumber(4); }
-            break;
-            case 1302:
-            {PBattlefield->setBattlefieldNumber(4); }
-            break;
-            case 1303:
-            {PBattlefield->setBattlefieldNumber(5); }
-            break;
-            case 1304:
-            {PBattlefield->setBattlefieldNumber(6); }
-            break;
-            case 1305:
-            {PBattlefield->setBattlefieldNumber(7); }
-            break;
-            case 1306:
-            {PBattlefield->setBattlefieldNumber(8); }
-            break;
-            case 1307:
-            {PBattlefield->setBattlefieldNumber(8); }
-            break;
-        }
-    }
-    else {
-        for (int i = 0; i < m_MaxBattlefields; i++) {
-            if (m_Battlefields[i] == nullptr) {
-                PBattlefield->setBattlefieldNumber(i + 1);
+    if (type == BATTLEFIELDTYPE_DYNAMIS) {
+        PBattlefield->addPlayer(PChar);
+    } else {
+        switch (PBattlefield->getMaxParticipants()) {
+            case 1:
+                if (PBattlefield->addPlayer(PChar)) {
+                    ShowDebug("Zone %i battlefield %i with bfid %i: Added %s. \n", PBattlefield->getZoneId(), PBattlefield->getBattlefieldNumber(), PBattlefield->getID(), PChar->GetName());
+                }
                 break;
-            }
-        }
-    }
-    switch (PBattlefield->getMaxParticipants()) {
-        case 1:
-            if (PBattlefield->addPlayerToBcnm(PChar)) {
-                ShowDebug("BattlefieldHandler ::1 Added %s to the valid players list for BCNM %i Battlefield %i \n",
-                    PChar->GetName(), id, PBattlefield->getBattlefieldNumber());
-            }
-            break;
-        case 3:
-            if (PChar->PParty == nullptr) {//just add the initiator
-                if (PBattlefield->addPlayerToBcnm(PChar)) {
-                    ShowDebug("BattlefieldHandler ::3 Added %s to the valid players list for BCNM %i Battlefield %i \n",
-                        PChar->GetName(), id, PBattlefield->getBattlefieldNumber());
-                }
-            }
-            else {
-                int numRegistered = 0;
-                for (int j = 0; j < PChar->PParty->members.size(); j++) {
-                    if (PBattlefield->addPlayerToBcnm((CCharEntity*)PChar->PParty->members.at(j))) {
-                        ShowDebug("BattlefieldHandler ::3 Added %s to the valid players list for BCNM %i Battlefield %i \n",
-                            PChar->PParty->members.at(j)->GetName(), id, PBattlefield->getBattlefieldNumber());
-                        numRegistered++;
-                    }
-                    if (numRegistered >= 3) { break; }
-                }
-            }
-            break;
-        case 6:
-            if (PChar->PParty == nullptr) {//just add the initiator
-                if (PBattlefield->addPlayerToBcnm(PChar)) {
-                    ShowDebug("BattlefieldHandler ::6 Added %s to the valid players list for BCNM %i Battlefield %i \n",
-                        PChar->GetName(), id, PBattlefield->getBattlefieldNumber());
-                }
-            }
-            else {
-                for (int j = 0; j < PChar->PParty->members.size(); j++) {
-                    if (PBattlefield->addPlayerToBcnm((CCharEntity*)PChar->PParty->members.at(j))) {
-                        ShowDebug("BattlefieldHandler ::6 Added %s to the valid players list for BCNM %i Battlefield %i \n",
-                            PChar->PParty->members.at(j)->GetName(), id, PBattlefield->getBattlefieldNumber());
+            case 3:
+                if (PChar->PParty == nullptr) {//just add the initiator
+                    if (PBattlefield->addPlayer(PChar)) {
+                        ShowDebug("Zone %i battlefield %i with bfid %i: Added %s. \n", PBattlefield->getZoneId(), PBattlefield->getBattlefieldNumber(), PBattlefield->getID(), PChar->GetName());
                     }
                 }
-            }
-            break;
-        case 12: ShowDebug("BCNMs for 12 people are not implemented yet.\n"); break;
+                else {
+                    int numRegistered = 0;
+                    for (int j = 0; j < PChar->PParty->members.size(); j++) {
+                        if (PBattlefield->addPlayer((CCharEntity*)PChar->PParty->members.at(j))) {
+                            ShowDebug("Zone %i battlefield %i with bfid %i: Added %s. \n", PBattlefield->getZoneId(), PBattlefield->getBattlefieldNumber(), PBattlefield->getID(), PChar->PParty->members.at(j)->GetName());
+                            numRegistered++;
+                        }
+                        if (numRegistered >= 3) { break; }
+                    }
+                }
+                break;
+            case 6:
+                if (PChar->PParty == nullptr) {//just add the initiator
+                    if (PBattlefield->addPlayer(PChar)) {
+                        ShowDebug("Zone %i battlefield %i with bfid %i: Added %s. \n", PBattlefield->getZoneId(), PBattlefield->getBattlefieldNumber(), PBattlefield->getID(), PChar->GetName());
+                    }
+                }
+                else {
+                    for (int j = 0; j < PChar->PParty->members.size(); j++) {
+                        if (PBattlefield->addPlayer((CCharEntity*)PChar->PParty->members.at(j))) {
+                            ShowDebug("Zone %i battlefield %i with bfid %i: Added %s. \n", PBattlefield->getZoneId(), PBattlefield->getBattlefieldNumber(), PBattlefield->getID(), PChar->PParty->members.at(j)->GetName());
+                        }
+                    }
+                }
+                break;
+            case 12: ShowDebug("BCNMs for 12 people are not implemented yet.\n"); break;
 
-        case 18:
-            if (PChar->PParty == nullptr) {//1 player entering 18 man bcnm
-                if (PBattlefield->addPlayerToBcnm(PChar)) {
-                    ShowDebug("BattlefieldHandler ::18 Added %s to the valid players list for BCNM %i Battlefield %i \n",
-                        PChar->GetName(), id, PBattlefield->getBattlefieldNumber());
+            case 18:
+                if (PChar->PParty == nullptr) {//1 player entering 18 man bcnm
+                    if (PBattlefield->addPlayer(PChar)) {
+                        ShowDebug("Zone %i battlefield %i with bfid %i: Added %s. \n", PBattlefield->getZoneId(), PBattlefield->getBattlefieldNumber(), PBattlefield->getID(), PChar->GetName());
+                    }
                 }
-            }
-            else {//alliance entering 18 man bcnm
-                if (PChar->PParty->m_PAlliance != nullptr)
-                {
-                    for (uint8 a = 0; a < PChar->PParty->m_PAlliance->partyList.size(); ++a)
+                else {//alliance entering 18 man bcnm
+                    if (PChar->PParty->m_PAlliance != nullptr)
                     {
-                        for (uint8 j = 0; j < PChar->PParty->m_PAlliance->partyList.at(a)->members.size(); j++) {
-                            if (PBattlefield->addPlayerToBcnm((CCharEntity*)PChar->PParty->m_PAlliance->partyList.at(a)->members.at(j))) {
-                                ShowDebug("BattlefieldHandler ::18 Added %s to the valid players list for BCNM %i Battlefield %i \n",
-                                    PChar->PParty->m_PAlliance->partyList.at(a)->members.at(j)->GetName(), id, PBattlefield->getBattlefieldNumber());
+                        for (uint8 a = 0; a < PChar->PParty->m_PAlliance->partyList.size(); ++a)
+                        {
+                            for (uint8 j = 0; j < PChar->PParty->m_PAlliance->partyList.at(a)->members.size(); j++) {
+                                if (PBattlefield->addPlayer((CCharEntity*)PChar->PParty->m_PAlliance->partyList.at(a)->members.at(j))) {
+                                    ShowDebug("Zone %i battlefield %i with bfid %i: Added %s. \n", PBattlefield->getZoneId(), PBattlefield->getBattlefieldNumber(), PBattlefield->getID(), PChar->PParty->m_PAlliance->partyList.at(a)->members.at(j)->GetName());
+                                }
+                            }
+                        }
+                    }
+                    else {//single party entering 18 man bcnm
+                        for (uint8 j = 0; j < PChar->PParty->members.size(); j++) {
+                            if (PBattlefield->addPlayer((CCharEntity*)PChar->PParty->members.at(j))) {
+                                ShowDebug("Zone %i battlefield %i with bfid %i: Added %s. \n", PBattlefield->getZoneId(), PBattlefield->getBattlefieldNumber(), PBattlefield->getID(), PChar->PParty->members.at(j)->GetName());
                             }
                         }
                     }
                 }
-                else {//single party entering 18 man bcnm
-                    for (uint8 j = 0; j < PChar->PParty->members.size(); j++) {
-                        if (PBattlefield->addPlayerToBcnm((CCharEntity*)PChar->PParty->members.at(j))) {
-                            ShowDebug("BattlefieldHandler ::18 Added %s to the valid players list for BCNM %i Battlefield %i \n",
-                                PChar->PParty->members.at(j)->GetName(), id, PBattlefield->getBattlefieldNumber());
-                        }
-                    }
-                }
-            }
-            break;
+                break;
 
-        default: ShowDebug("Unknown max participants value %i \n", PBattlefield->getMaxParticipants());
+            default: ShowDebug("Unknown max participants value %i \n", PBattlefield->getMaxParticipants());
+        }
     }
 
     if (!PBattlefield->isReserved()) {//no player met the criteria for entering, so revoke the previous permission.
-        ShowDebug("No player has met the requirements for entering the BCNM.\n");
+        ShowDebug("Zone %i battlefield %i with bfid %i: No player has met the requirements for entering the battlefield. \n", PBattlefield->getZoneId(), PBattlefield->getBattlefieldNumber(), PBattlefield->getID());
         delete PBattlefield;
         return -1;
     }
@@ -450,89 +322,17 @@ int CBattlefieldHandler::registerBcnm(uint16 id, CCharEntity* PChar) {
     return PBattlefield->getBattlefieldNumber();
 }
 
-bool CBattlefieldHandler::hasFreeSpecialBattlefield(uint16 id) { //reserved for special battlefield like limbus
-
-    switch (id)
-    {
-        case 1290:
-        { if (m_Battlefields[0] == nullptr) { return true; }}
-        break;
-        case 1291:
-        { if (m_Battlefields[1] == nullptr) { return true; }}
-        break;
-        case 1292:
-        { if (m_Battlefields[2] == nullptr) { return true; }}
-        break;
-        case 1293:
-        { if (m_Battlefields[3] == nullptr) { return true; }}
-        break;
-        case 1294:
-        { if (m_Battlefields[4] == nullptr) { return true; }}
-        break;
-        case 1295:
-        { if (m_Battlefields[4] == nullptr) { return true; }}
-        break;
-        case 1296:
-        { if (m_Battlefields[5] == nullptr) { return true; }}
-        break;
-        case 1297:
-        { if (m_Battlefields[5] == nullptr) { return true; }}
-        break;
-        case 1298:
-        { if (m_Battlefields[0] == nullptr) { return true; }}
-        break;
-        case 1299:
-        {if (m_Battlefields[1] == nullptr) { return true; }}
-        break;
-        case 1300:
-        {if (m_Battlefields[2] == nullptr) { return true; }}
-        break;
-        case 1301:
-        {if (m_Battlefields[3] == nullptr) { return true; }}
-        break;
-        case 1302:
-        {if (m_Battlefields[3] == nullptr) { return true; }}
-        break;
-        case 1303:
-        {if (m_Battlefields[4] == nullptr) { return true; }}
-        break;
-        case 1304:
-        {if (m_Battlefields[5] == nullptr) { return true; }}
-        break;
-        case 1305:
-        {if (m_Battlefields[6] == nullptr) { return true; }}
-        break;
-        case 1306:
-        {if (m_Battlefields[7] == nullptr) { return true; }}
-        break;
-        case 1307:
-        {if (m_Battlefields[7] == nullptr) { return true; }}
-        break;
-        default:
-            return false;
-            break;
-    }
-    return false;
-}
-
-bool CBattlefieldHandler::hasSpecialBattlefieldEmpty(uint16 id) { //reserved for special battlefield like limbus
-    if (id <= m_MaxBattlefields &&  id != 0) {
-        if (m_Battlefields[id - 1] != nullptr) {
-            return false;
-        }
-    }
-    return true;
-}
-void CBattlefieldHandler::SetLootToBCNM(uint16 LootID, uint16 id, uint32 npcID) {
-    m_Battlefields[id - 1]->setLootId(LootID);
+void CBattlefieldHandler::SetLootToBCNM(uint16 LootID, uint16 bnum, uint32 npcID) {
+    m_Battlefields[bnum - 1]->setLootId(LootID);
     CBaseEntity* PNpc = (CBaseEntity*)zoneutils::GetEntity(npcID, TYPE_NPC);
-    m_Battlefields[id - 1]->addNpc(PNpc);
+    m_Battlefields[bnum - 1]->addNpc(PNpc);
 }
-void CBattlefieldHandler::RestoreOnBattlefield(uint16 id) {
+
+void CBattlefieldHandler::RestoreOnBattlefield(uint16 bnum) {
     int playermaxMP = 0;
     int playermaxHP = 0;
-    if (id <= m_MaxBattlefields &&  id > 0) {
-        CBattlefield* PBattlefield = m_Battlefields[id - 1];
+    if (bnum <= m_MaxBattlefields &&  bnum > 0) {
+        CBattlefield* PBattlefield = m_Battlefields[bnum - 1];
         for (int i = 0; i < PBattlefield->m_PlayerList.size(); i++) {
             if (PBattlefield->m_PlayerList.at(i)->animation != ANIMATION_DEATH) {
 
@@ -560,27 +360,30 @@ void CBattlefieldHandler::RestoreOnBattlefield(uint16 id) {
         }
     }
 }
-duration CBattlefieldHandler::SpecialBattlefieldLeftTime(uint16 id, time_point tick) { //reserved for special battlefield like limbus
 
-    if (id <= m_MaxBattlefields &&  id > 0) {
+duration CBattlefieldHandler::getBattlefieldTimeLeft(uint16 bnum, time_point tick) {
 
-        if (m_Battlefields[id - 1] != nullptr) {
-            auto Tremaining = (tick - m_Battlefields[id - 1]->getStartTime());  //66
-            auto timelimit = m_Battlefields[id - 1]->getTimeLimit();		  	 ///3600
+    if (bnum <= m_MaxBattlefields &&  bnum > 0) {
+
+        if (m_Battlefields[bnum - 1] != nullptr) {
+            auto Tremaining = (tick - m_Battlefields[bnum - 1]->getStartTime());  //66
+            auto timelimit = m_Battlefields[bnum - 1]->getTimeLimit();             ///3600
             return (timelimit - Tremaining);
         }
     }
     return 0s;
 }
-int CBattlefieldHandler::GiveTimeToBattlefield(uint16 id, duration Time) {
-    if (id <= m_MaxBattlefields &&  id > 0) {
-        if (m_Battlefields[id - 1] != nullptr) {
-            CBattlefield* PBattlefield = m_Battlefields[id - 1];
+
+int CBattlefieldHandler::GiveTimeToBattlefield(uint16 bnum, duration Time) {
+    if (bnum <= m_MaxBattlefields &&  bnum > 0) {
+        if (m_Battlefields[bnum - 1] != nullptr) {
+            CBattlefield* PBattlefield = m_Battlefields[bnum - 1];
             PBattlefield->addTimeLimit(Time);
         }
     }
     return 1;
 }
+
 bool CBattlefieldHandler::hasFreeBattlefield() {
 
     for (int i = 0; i < m_MaxBattlefields; i++) {
@@ -602,104 +405,43 @@ uint8 CBattlefieldHandler::findBattlefieldIDFor(CCharEntity* PChar) {
     return 255;
 }
 
-CBattlefield* CBattlefieldHandler::getBattlefield(CCharEntity* PChar)
+CBattlefield* CBattlefieldHandler::getBattlefield(uint16 bnum)
 {
-    for (int i = 0; i < m_MaxBattlefields; i++)
-        if (m_Battlefields[i] != nullptr)
-            if (m_Battlefields[i]->isValidPlayerForBcnm(PChar))
-                return m_Battlefields[i];
-    return nullptr;
+    return m_Battlefields[bnum-1];
 }
 
-uint32 CBattlefieldHandler::pollTimeLeft(uint16 id) {
-    return 0;
-}
+int CBattlefieldHandler::addPlayerToBattlefield(uint16 bnum, CCharEntity* PChar) {
 
-void CBattlefieldHandler::openTreasureChest(CCharEntity* PChar) {
-    for (int i = 0; i < m_MaxBattlefields; i++) {
-        if (m_Battlefields[i] != nullptr) {
-            if (m_Battlefields[i]->isValidPlayerForBcnm(PChar)) {
-                CBattlefield* PBattlefield = m_Battlefields[i];
-                PBattlefield->OpenChestinBcnm();
-            }
-        }
+    if (m_Battlefields[bnum-1]->addPlayer(PChar)) {
+        ShowDebug("Zone %i battlefield %i with bfid %i: Added %s \n", m_Battlefields[bnum-1]->getZoneId(), m_Battlefields[bnum-1]->getBattlefieldNumber(), m_Battlefields[bnum-1]->getID(), PChar->GetName());
     }
+
+    return 1;
 }
+
 
 //========================DYNAMIS FUNCTIONS=============================================//
 
-int CBattlefieldHandler::getUniqueDynaID(uint16 id) {
-
-    CBattlefield* PBattlefield = m_Battlefields[0];
-    return PBattlefield->getDynaUniqueID();
-}
-
-int CBattlefieldHandler::registerDynamis(uint16 id, CCharEntity* PChar) {
-    if (!hasFreeBattlefield()) {
+int CBattlefieldHandler::registerDynamis(uint16 bnum, uint16 id, CCharEntity* PChar) {
+    if (!isBattlefieldFree(bnum)) {
         return -1;
     }
     CBattlefield* PBattlefield = battlefieldutils::loadBattlefield(this, id, BATTLEFIELDTYPE_DYNAMIS);
     if (PBattlefield == nullptr) {
         return -1;
     }
-    for (int i = 0; i < m_MaxBattlefields; i++) {
-        if (m_Battlefields[i] == nullptr) {
-            PBattlefield->setBattlefieldNumber(i + 1);
-            break;
-        }
-    }
+    PBattlefield->setBattlefieldNumber(bnum);
 
-    if (PBattlefield->addPlayerToDynamis(PChar)) {
-        ShowDebug("BattlefieldHandler ::1 Added %s to the valid players list for Dynamis %i Battlefield %i \n",
-            PChar->GetName(), id, PBattlefield->getBattlefieldNumber());
+    if (PBattlefield->addPlayer(PChar)) {
+        ShowDebug("Zone %i battlefield %i with bfid %i: Added %s \n", PBattlefield->getZoneId(), PBattlefield->getBattlefieldNumber(), PBattlefield->getID(), PChar->GetName());
     }
 
     m_Battlefields[PBattlefield->getBattlefieldNumber() - 1] = PBattlefield;
     PBattlefield->init();
-    PBattlefield->setDynaUniqueID();
     luautils::OnBcnmRegister(PChar, PBattlefield);
     return PBattlefield->getBattlefieldNumber();
 }
 
-int CBattlefieldHandler::dynamisAddPlayer(uint16 dynaid, CCharEntity* PChar) {
-
-    if (m_Battlefields[0]->addPlayerToDynamis(PChar)) {
-        ShowDebug("BattlefieldHandler ::Registration for Dynamis by %s succeeded \n", PChar->GetName());
-    }
-
-    return 1;
-}
-
-int CBattlefieldHandler::SpecialBattlefieldAddPlayer(uint16 id, CCharEntity* PChar)
-{
-    short Inst = 0;
-    switch (id)
-    {
-        case 1290: Inst = 0; break;
-        case 1291: Inst = 1; break;
-        case 1292: Inst = 2; break;
-        case 1293: Inst = 3; break;
-        case 1294: Inst = 4; break;
-        case 1295: Inst = 4; break;
-        case 1296: Inst = 5; break;
-        case 1297: Inst = 5; break;
-        case 1298: Inst = 0; break;
-        case 1299: Inst = 1; break;
-        case 1300: Inst = 2; break;
-        case 1301: Inst = 3; break;
-        case 1302: Inst = 3; break;
-        case 1303: Inst = 4; break;
-        case 1304: Inst = 5; break;
-        case 1305: Inst = 6; break;
-        case 1306: Inst = 7; break;
-        case 1307: Inst = 7; break;
-    }
-
-    if (m_Battlefields[Inst]->addPlayerToBcnm(PChar)) {
-        ShowDebug("BattlefieldHandler ::Registration for Special Battlefield by %s succeeded \n", PChar->GetName());
-    }
-    return 1;
-}
 int CBattlefieldHandler::dynamisMessage(uint16 Param1, uint16 Param2) {
 
     CBattlefield* PBattlefield = m_Battlefields[0];
@@ -714,42 +456,15 @@ void CBattlefieldHandler::launchDynamisSecondPart() {
     battlefieldutils::spawnSecondPartDynamis(m_Battlefields[0]);
 }
 
-/* Disconnecting from Dynamis (including warp)
-This removes the player from the active list and calls the warp/dc callback. Must bear in mind
-that this will be called if you warp BEFORE entering the dyna (but still have dynamis status)
-hence it doesn't check if you're "in" the BCNM, it just tries to remove you from the list.
-*/
-bool CBattlefieldHandler::disconnectFromDynamis(CCharEntity* PChar) { //includes warping
-    if (m_Battlefields[0] != nullptr) {
-        if (m_Battlefields[0]->delPlayerFromDynamis(PChar)) {
-            luautils::OnBcnmLeave(PChar, m_Battlefields[0], LEAVE_WARPDC);
-            if (!m_Battlefields[0]->isReserved()) {//no more players in BCNM
-                ShowDebug("Detected no more players in Dynamis Battlefield %i. Cleaning up. \n", m_Battlefields[0]->getBattlefieldNumber());
-                luautils::OnBcnmLeave(PChar, m_Battlefields[0], LEAVE_LOSE);
-                m_Battlefields[0]->finishDynamis();
-            }
-            return true;
-        }
-    }
-    return false;
-}
-
 void CBattlefieldHandler::insertMonsterInList(CMobEntity* PMob)
 {
     CBattlefield* PBattlefield = m_Battlefields[0];
 
-    if (PBattlefield->isMonsterInList(PMob) == false)
-    {
-        PBattlefield->addMonsterInList(PMob);
-    }
+    if (!PBattlefield->isEnemyInList(PMob))
+        PBattlefield->addEnemy(PMob, 0);
 }
 
 bool CBattlefieldHandler::checkMonsterInList(CMobEntity* PMob)
 {
-    CBattlefield* PBattlefield = m_Battlefields[0];
-
-    if (PBattlefield->isMonsterInList(PMob))
-        return true;
-    else
-        return false;
+    return m_Battlefields[0]->isEnemyInList(PMob);
 }

--- a/src/map/battlefield_handler.h
+++ b/src/map/battlefield_handler.h
@@ -36,47 +36,40 @@ class CMobEntity;
 class CBattlefieldHandler
 {
 public:
-
     CBattlefieldHandler(uint16 zoneid);
-    void	handleBattlefields(time_point tick);							// called every tick to handle win/lose conditions, locking the bcnm, etc
-    int		registerBcnm(uint16 bcnmid, CCharEntity* PChar);		// returns the battlefield id of the registration, -1 if no free bcnm.
-                                                                    // also registers all people in the characters PT, etc.
 
-    bool	enterBcnm(uint16 bcnmid, CCharEntity* PChar);			// Enters the BCNM battlefield if you're registered
-    bool	leaveBcnm(uint16 bcnmid, CCharEntity* PChar);			// Leaves the BCNM battlefield if you're registered
-    bool	disconnectFromBcnm(CCharEntity* PChar);					// Disconnects/Warps you from a BCNM
-    bool	winBcnm(uint16 bcnmid, CCharEntity* PChar);				// Wins a BCNM battlefield (e.g. the player opening the chest)
+    void    handleBattlefields(time_point tick);    // called every tick to handle win/lose conditions, locking the bcnm, etc
 
-    uint8	findBattlefieldIDFor(CCharEntity* PChar);					// returns 1 2 3 or 255 if non-existent
-    bool	hasFreeBattlefield();										// returns true if there is a free battlefield available
-    bool	hasFreeSpecialBattlefield(uint16 id);
-    bool    hasSpecialBattlefieldEmpty(uint16 id);                     // return 1 if one or more player is still on the special battlefield
-    duration     SpecialBattlefieldLeftTime(uint16 id, time_point tick);         //return left Time of the specific battlefield
-    int     GiveTimeToBattlefield(uint16 id, duration Time);              // give time to specific battlefield
-    void    SetLootToBCNM(uint16 LootID, uint16 id, uint32 npcID);
-    void    RestoreOnBattlefield(uint16 id);                          //restor MP HP ability on a specific battlefield
-    uint32	pollTimeLeft(uint16 bcnmid);							// returns the shortest time left of all 3 battlefields of the given BCNM ID
-    void	openTreasureChest(CCharEntity* PChar);
-    void	wipeBattlefield(CBattlefield* inst);
-    CBattlefield* getBattlefield(CCharEntity*);                           // returns the battlefield a player is in
+    bool    isBattlefieldFree(uint16 bnum);                             // is battlefield with given number free
+    int     registerBattlefield(uint16 bnum, uint16 id, CCharEntity* PChar);   // registers to PChar and allies a battlefield in arena bnum with content id
+    bool    enterBcnm(uint16 bnum, CCharEntity* PChar);                 // enter battlefield arena bnum if you are registered
+    bool    leaveBcnm(uint16 bnum, CCharEntity* PChar);                 // leave battlefield arena bnum if you are registered
+    bool    disconnectFromBattlefield(CCharEntity* PChar);              // Disconnects/Warps you from a BCNM
+    bool    winBcnm(uint16 bcnmid, CCharEntity* PChar);                 // Wins a BCNM battlefield (e.g. the player opening the chest)
 
-    int     SpecialBattlefieldAddPlayer(uint16 id, CCharEntity* PChar);
+    uint8   findBattlefieldIDFor(CCharEntity* PChar);                   // returns 1 2 3 or 255 if non-existent
+    bool    hasFreeBattlefield();                                       // returns true if there is a free battlefield available
+    duration     getBattlefieldTimeLeft(uint16 bnum, time_point tick);  // return left Time of the specific battlefield
+    int     GiveTimeToBattlefield(uint16 bnum, duration Time);          // give time to specific battlefield
+    void    SetLootToBCNM(uint16 LootID, uint16 bnum, uint32 npcID);
+    void    RestoreOnBattlefield(uint16 bnum);                          // restore MP HP ability on a specific battlefield
+    void    wipeBattlefield(CBattlefield* inst);
+
+    CBattlefield* getBattlefield(uint16 bnum);                              // return battlefield of given arena
+    int     addPlayerToBattlefield(uint16 bnum, CCharEntity* PChar);        // add a player to given arena
+
     //Dynamis Functions
-    int		getUniqueDynaID(uint16 id);								//
-    int		registerDynamis(uint16 id, CCharEntity* PChar);			//
-    int		dynamisAddPlayer(uint16 dynaid, CCharEntity* PChar);	// Add a player to the dynamis battlefield
-    int		dynamisMessage(uint16 Param1, uint16 Param2);			// Add message on dynamis param1: messageid, param2: parameter
-    void	launchDynamisSecondPart();
-    bool	disconnectFromDynamis(CCharEntity* PChar);
+    int     registerDynamis(uint16 bnum, uint16 id, CCharEntity* PChar);    // registers to PChar a dynamis in arena bnum with content id
+    int     dynamisMessage(uint16 Param1, uint16 Param2);                   // Add message on dynamis param1: messageid, param2: parameter
+    void    launchDynamisSecondPart();
+    void    insertMonsterInList(CMobEntity* PMob);
+    bool    checkMonsterInList(CMobEntity* PMob);
 
-    void	insertMonsterInList(CMobEntity* PMob);
-    bool	checkMonsterInList(CMobEntity* PMob);
-
-    uint16					m_ZoneId;
+    uint16          m_ZoneId;
 
 private:
-    uint8					m_MaxBattlefields;							// usually 3 except dynamis, einherjar, besieged, ...
-    CBattlefield*				m_Battlefields[8];
+    uint8           m_MaxBattlefields;
+    CBattlefield*   m_Battlefields[8];
 };
 
 #endif

--- a/src/map/lua/lua_baseentity.h
+++ b/src/map/lua/lua_baseentity.h
@@ -218,26 +218,23 @@ public:
     int32 getCurrentGPItem(lua_State*);     // Gets current GP item id and max points
     int32 addGuildPoints(lua_State*);       // add guild points
 
-    int32 bcnmRegister(lua_State*);                  //Attempts to register a bcnm battlefield (used by Dynamis and BCNM)
-    int32 bcnmEnter(lua_State*);                     //Enter a bcnm battlefield (used by Dynamis and BCNM)
-    int32 bcnmLeave(lua_State*);                     //Leave a bcnm battlefield
-    int32 isInBcnm(lua_State*);                      //true if you're INSIDE the bc (not just the status)
-    int32 isBcnmsFull(lua_State*);                   //true if all 3 battlefield are full
-    int32 isSpecialBattlefieldEmpty(lua_State*);     // 1 if this battlefield is full
-    int32 getSpecialBattlefieldLeftTime(lua_State*); // return left time of the specific instance
-    int32 addTimeToSpecialBattlefield(lua_State*);   // add time of the specific instance
-    int32 BCNMSetLoot(lua_State*);                   // set a lootlist for a special inctance
-    int32 RestoreAndHealOnBattlefield(lua_State*);   // restore ability , PM and PV on the specific instance
-    int32 getBattlefieldID(lua_State*);              //returns 1 2 or 3 if the player can enter a bcnm with the instance assigned
-    int32 getBCNMloot(lua_State*);                   //triggers if the player opens the chest inside bcnm
-    int32 addPlayerToSpecialBattlefield(lua_State*); //for limbus
+    int32 isBattlefieldFree(lua_State*);            // is battlefield with given number free in current zone (returns 1, -1)
+    int32 registerBattlefield(lua_State*);          // attempt to register a battlefield (returns 1, -1)
+    int32 bcnmEnter(lua_State*);                    // enter a battlefield
+    int32 bcnmLeave(lua_State*);                    // leave a battlefield
+    int32 isInBcnm(lua_State*);                     // true if you're INSIDE the bc (not just the status)
+    int32 isBcnmsFull(lua_State*);                  // true if all 3 battlefield are full
+    int32 getBattlefieldTimeLeft(lua_State*);       // return time left in given battlefield num
+    int32 addTimeToBattlefield(lua_State*);         // add time to given battlefield num
+    int32 BCNMSetLoot(lua_State*);                  // set a lootlist for a special inctance
+    int32 RestoreAndHealOnBattlefield(lua_State*);  // restore ability , PM and PV on the specific instance
+    int32 getBCNMloot(lua_State*);                  // triggers if the player opens the chest inside bcnm
+    int32 addPlayerToBattlefield(lua_State*);       // add player to the given battlefield number and apply status
 
     int32 isSpawned(lua_State*);
     int32 setSpawn(lua_State*);                // Sets spawn point
     int32 setRespawnTime(lua_State*);          // set respawn time
     int32 getRespawnTime(lua_State*);
-    int32 getDynamisUniqueID(lua_State*);      //Get unique Dynamis ID
-    int32 addPlayerToDynamis(lua_State*);      //Add player to the Dynamis
     int32 addTimeToDynamis(lua_State*);        //Add time to the Dynamis
     int32 launchDynamisSecondPart(lua_State*); //Spawn Mob part 2 when mega boss is defeated
     int32 isInDynamis(lua_State*);             //If player is in Dynamis return true else false

--- a/src/map/lua/lua_battlefield.cpp
+++ b/src/map/lua/lua_battlefield.cpp
@@ -32,9 +32,9 @@
 
 
 /************************************************************************
-*																		*
-*  Constructor															*
-*																		*
+*                                                                       *
+*  Constructor                                                          *
+*                                                                       *
 ************************************************************************/
 
 CLuaBattlefield::CLuaBattlefield(lua_State *L)
@@ -51,9 +51,9 @@ CLuaBattlefield::CLuaBattlefield(lua_State *L)
 }
 
 /************************************************************************
-*																		*
-*  Constructor															*
-*																		*
+*                                                                       *
+*  Constructor                                                          *
+*                                                                       *
 ************************************************************************/
 
 CLuaBattlefield::CLuaBattlefield(CBattlefield* PBattlefield)
@@ -63,7 +63,7 @@ CLuaBattlefield::CLuaBattlefield(CBattlefield* PBattlefield)
 
 /************************************************************************
 *                                                                       *
-*						Get methods								        *
+*                       Get methods                                     *
 *                                                                       *
 ************************************************************************/
 
@@ -115,13 +115,6 @@ inline int32 CLuaBattlefield::getRecord(lua_State* L)
     lua_pushnumber(L, std::chrono::duration_cast<std::chrono::seconds>(record.clearTime).count());
     lua_setfield(L, newTable, "clearTime");
 
-    return 1;
-}
-
-inline int32 CLuaBattlefield::setAsFastest(lua_State* L) {
-    DSP_DEBUG_BREAK_IF(m_PLuaBattlefield == nullptr);
-
-    lua_pushinteger(L, 0);
     return 1;
 }
 
@@ -252,9 +245,9 @@ inline int32 CLuaBattlefield::win(lua_State* L)
 }
 
 /************************************************************************
-*																		*
-*  declare lua function													*
-*																		*
+*                                                                       *
+*  declare lua function                                                 *
+*                                                                       *
 ************************************************************************/
 
 const int8 CLuaBattlefield::className[] = "CBattlefield";

--- a/src/map/lua/lua_battlefield.h
+++ b/src/map/lua/lua_battlefield.h
@@ -49,7 +49,6 @@ public:
     int32 getTimeLimit(lua_State*);
     int32 getTimeInside(lua_State*);
     int32 getRecord(lua_State*);
-    int32 setAsFastest(lua_State*);
     int32 setEntrance(lua_State*);
     int32 getEntrance(lua_State*);
     int32 insertAlly(lua_State*);

--- a/src/map/lua/luautils.cpp
+++ b/src/map/lua/luautils.cpp
@@ -1551,9 +1551,47 @@ namespace luautils
     }
 
     /************************************************************************
-    *                                                                       *
     *  Запущенное событие нуждается в дополнительных параметрах             *
-    *                                                                       *
+    *  A triggered event needs additional parameters  (battlefield extras)  *
+    ************************************************************************/
+
+    int32 OnEventUpdate(CCharEntity* PChar, uint16 eventID, uint32 result, uint16 extras)
+    {
+        int32 oldtop = lua_gettop(LuaHandle);
+
+        lua_pushnil(LuaHandle);
+        lua_setglobal(LuaHandle, "onEventUpdate");
+
+        auto loadResult = LoadEventScript(PChar, "onEventUpdate");
+
+        if (!loadResult)
+        {
+            ShowError("luautils::onEventUpdate: undefined procedure onEventUpdate\n");
+            return -1;
+        }
+
+        CLuaBaseEntity LuaBaseEntity(PChar);
+        Lunar<CLuaBaseEntity>::push(LuaHandle, &LuaBaseEntity);
+
+        lua_pushinteger(LuaHandle, eventID);
+        lua_pushinteger(LuaHandle, result);
+        lua_pushinteger(LuaHandle, extras);
+
+        CLuaBaseEntity LuaTargetEntity(PChar->m_event.Target);
+        Lunar<CLuaBaseEntity>::push(LuaHandle, &LuaTargetEntity);
+
+        if (lua_pcall(LuaHandle, 5, 0, 0))
+        {
+            ShowError("luautils::onEventUpdate: %s\n", lua_tostring(LuaHandle, -1));
+            lua_pop(LuaHandle, 1);
+            return -1;
+        }
+        return 0;
+    }
+
+    /************************************************************************
+    *  Запущенное событие нуждается в дополнительных параметрах             *
+    *  A triggered event needs additional parameters                        *
     ************************************************************************/
 
     int32 OnEventUpdate(CCharEntity* PChar, uint16 eventID, uint32 result)

--- a/src/map/lua/luautils.h
+++ b/src/map/lua/luautils.h
@@ -188,6 +188,7 @@ namespace luautils
     int32 OnConquestUpdate(CZone* PZone, ConquestUpdate type);                  // hourly conquest update
 
     int32 OnTrigger(CCharEntity* PChar, CBaseEntity* PNpc);                     // triggered when user targets npc and clicks action button
+    int32 OnEventUpdate(CCharEntity* PChar, uint16 eventID, uint32 result, uint16 extras); // triggered when game triggers event update during cutscene with extra parameters (battlefield)
     int32 OnEventUpdate(CCharEntity* PChar, uint16 eventID, uint32 result);     // triggered when game triggers event update during cutscene
     int32 OnEventUpdate(CCharEntity* PChar, int8* string);                      // triggered when game triggers event update during cutscene
     int32 OnEventFinish(CCharEntity* PChar, uint16 eventID, uint32 result);     // triggered when cutscene/event is completed

--- a/src/map/packet_system.cpp
+++ b/src/map/packet_system.cpp
@@ -2631,11 +2631,12 @@ void SmallPacket0x05C(map_session_data_t* session, CCharEntity* PChar, CBasicPac
         PChar->loc.p.x = RBUFF(data, (0x04));
         PChar->loc.p.y = RBUFF(data, (0x08));
         PChar->loc.p.z = RBUFF(data, (0x0C));
+        uint16 extras = RBUFW(data, (0x14));
         PChar->loc.p.rotation = RBUFB(data, (0x1F));
 
         if (RBUFB(data, (0x1E)) != 0)
         {
-            luautils::OnEventUpdate(PChar, EventID, 0);
+            luautils::OnEventUpdate(PChar, EventID, 0, extras);
         }
         else
         {
@@ -4328,7 +4329,7 @@ void SmallPacket0x0DC(map_session_data_t* session, CCharEntity* PChar, CBasicPac
         if (PChar->nameflags.flags & FLAG_ANON)
         {
             PChar->pushPacket(new CMessageSystemPacket(0, 0, 175));
-        } 
+        }
         else
         {
             PChar->pushPacket(new CMessageSystemPacket(0, 0, 176));

--- a/src/map/utils/battlefieldutils.cpp
+++ b/src/map/utils/battlefieldutils.cpp
@@ -182,6 +182,7 @@ namespace battlefieldutils {
                     PNpc->loc.zone->PushPacket(PNpc, CHAR_INRANGE, new CEntityUpdatePacket(PNpc, ENTITY_SPAWN, UPDATE_ALL_MOB));
                     battlefield->addNpc(PNpc);
                     ShowDebug(CL_CYAN"Spawned %s id %i inst %i \n", PNpc->status, PNpc->id, battlefield->getBattlefieldNumber());
+                    battlefield->m_chestSpawned = true;
                 }
                 else
                 {

--- a/src/map/utils/battlefieldutils.h
+++ b/src/map/utils/battlefieldutils.h
@@ -32,21 +32,22 @@ class CBattlefieldHandler;
 
 enum BATTLEFIELDTYPE {
     BATTLEFIELDTYPE_DYNAMIS,
-    BATTLEFIELDTYPE_BCNM
+    BATTLEFIELDTYPE_BCNM,
+    BATTLEFIELDTYPE_LIMBUS
 };
 
 namespace battlefieldutils
 {
-    void getLosePosition(CBattlefield* battlefield, int(&pPosition)[4]);		// returns x y z rot in that order
-    void getWinPosition(CBattlefield* battlefield, int(&pPosition)[4]);		// returns x y z rot in that order
-    void getStartPosition(uint16 zoneid, int(&pPosition)[4]);			// returns lobby position
+    void getLosePosition(CBattlefield* battlefield, int(&pPosition)[4]);        // returns x y z rot in that order
+    void getWinPosition(CBattlefield* battlefield, int(&pPosition)[4]);     // returns x y z rot in that order
+    void getStartPosition(uint16 zoneid, int(&pPosition)[4]);           // returns lobby position
     bool meetsWinningConditions(CBattlefield* battlefield, time_point tick);
     bool meetsLosingConditions(CBattlefield* battlefield, time_point tick);
     bool spawnMonstersForBcnm(CBattlefield* battlefield);
     bool spawnTreasureForBcnm(CBattlefield* battlefield);
 
-    uint8 getMaxLootGroups(CBattlefield* battlefield);						// returns maximum number of loot groups for a BCNM battlefield
-    uint16 getRollsPerGroup(CBattlefield* battlefield, uint8 groupID);		// returns the maximum number of "rolls" in a given group
+    uint8 getMaxLootGroups(CBattlefield* battlefield);                      // returns maximum number of loot groups for a BCNM battlefield
+    uint16 getRollsPerGroup(CBattlefield* battlefield, uint8 groupID);      // returns the maximum number of "rolls" in a given group
     void getChestItems(CBattlefield* battlefield);
     CBattlefield* loadBattlefield(CBattlefieldHandler* hand, uint16 bcnmid, BATTLEFIELDTYPE type);
 

--- a/src/map/zone_entities.cpp
+++ b/src/map/zone_entities.cpp
@@ -305,9 +305,9 @@ void CZoneEntities::DecreaseZoneCounter(CCharEntity* PChar)
     }
 
     //remove bcnm status
-    if (m_zone->m_BattlefieldHandler != nullptr && PChar->StatusEffectContainer->HasStatusEffect(EFFECT_BATTLEFIELD))
+    if (m_zone->m_BattlefieldHandler != nullptr && (PChar->StatusEffectContainer->HasStatusEffect(EFFECT_BATTLEFIELD) || PChar->StatusEffectContainer->HasStatusEffect(EFFECT_DYNAMIS, 0)))
     {
-        if (m_zone->m_BattlefieldHandler->disconnectFromBcnm(PChar)) {
+        if (m_zone->m_BattlefieldHandler->disconnectFromBattlefield(PChar)) {
             ShowDebug("Removed %s from the BCNM they were in as they have left the zone.\n", PChar->GetName());
         }
 
@@ -324,30 +324,7 @@ void CZoneEntities::DecreaseZoneCounter(CCharEntity* PChar)
                 charutils::SaveCharPosition(PChar);
             }
             else {
-                ShowWarning("%s has disconnected from the BCNM but cannot move them to the lobby as the lobby position is unknown!\n", PChar->GetName());
-            }
-        }
-    }
-    else if (m_zone->m_BattlefieldHandler != nullptr && PChar->StatusEffectContainer->HasStatusEffect(EFFECT_DYNAMIS, 0))
-    {
-        if (m_zone->m_BattlefieldHandler->disconnectFromDynamis(PChar)) {
-            ShowDebug("Removed %s from the BCNM they were in as they have left the zone.\n", PChar->GetName());
-        }
-
-        if (PChar->loc.destination == 0) { //this player is disconnecting/logged out, so move them to the entrance
-            //move depending on zone
-            int pos[4] = {0, 0, 0, 0};
-            battlefieldutils::getStartPosition(m_zone->GetID(), pos);
-            if (!(pos[0] == 0 && pos[1] == 0 && pos[2] == 0 && pos[3] == 0)) {
-                PChar->loc.p.x = pos[0];
-                PChar->loc.p.y = pos[1];
-                PChar->loc.p.z = pos[2];
-                PChar->loc.p.rotation = pos[3];
-                PChar->updatemask |= UPDATE_POS;
-                charutils::SaveCharPosition(PChar);
-            }
-            else {
-                ShowWarning("%s has disconnected from the BCNM but cannot move them to the lobby as the lobby position is unknown!\n", PChar->GetName());
+                ShowWarning("%s has disconnected from a battlefield but cannot move to the lobby as the lobby position is unknown!\n", PChar->GetName());
             }
         }
     }


### PR DESCRIPTION
Rewrote bcnm.lua.  Battlefield registration and entry now controlled by a few LUA tables.  It is now possible to have multiple battlefields appear in the menu for any given trade.

Limbus arena instances now match client.  GMs can now !goto limbus battlefields.  Players who disconnect from limbus will automatically be readded to their run if it's still in progress.  Their position will be set to the entrance of their instance.

Removed as many of the differences between BCNMs, Dynamis, and Limbus as possible -- in many cases we had separate functions for doing the same things for different battlefield types. I condensed those.

BCNM chests now disappear after being opened.

Removed all IsMobDead() calls.

Added a where clause to the SQL query that writes battlefield record back into DB.