### PR TITLE
Fixed quest commands for Other Areas log (global name conflict between log_ids.lua and zone.lua)

### DIFF
--- a/scripts/commands/addquest.lua
+++ b/scripts/commands/addquest.lua
@@ -28,7 +28,12 @@ function onTrigger(player, logId, questId, target)
         logId = QUEST_LOGS[logId];
     end
     if (logId ~= nil) then
-        logId = _G[string.upper(logId)];
+		local logTableTest = _G[string.upper(logId)];
+		if (type(logTableTest) == "table") then
+			logId = logTableTest;
+		else
+			logId = _G[string.upper(logId .. "_LOG")];
+		end
     end
     if ((type(logId) == "table") and logId.quest_log ~= nil) then
         logName = logId.full_name;

--- a/scripts/commands/checkquest.lua
+++ b/scripts/commands/checkquest.lua
@@ -28,7 +28,12 @@ function onTrigger(player,logId,questId,target)
         logId = QUEST_LOGS[logId];
     end
     if (logId ~= nil) then
-        logId = _G[string.upper(logId)];
+		local logTableTest = _G[string.upper(logId)];
+		if (type(logTableTest) == "table") then
+			logId = logTableTest;
+		else
+			logId = _G[string.upper(logId .. "_LOG")];
+		end
     end
     if ((type(logId) == "table") and logId.quest_log ~= nil) then
         logName = logId.full_name;

--- a/scripts/commands/delquest.lua
+++ b/scripts/commands/delquest.lua
@@ -28,7 +28,12 @@ function onTrigger(player, logId, questId, target)
         logId = QUEST_LOGS[logId];
     end
     if (logId ~= nil) then
-        logId = _G[string.upper(logId)];
+		local logTableTest = _G[string.upper(logId)];
+		if (type(logTableTest) == "table") then
+			logId = logTableTest;
+		else
+			logId = _G[string.upper(logId .. "_LOG")];
+		end
     end
     if ((type(logId) == "table") and logId.quest_log ~= nil) then
         logName = logId.full_name;

--- a/scripts/globals/log_ids.lua
+++ b/scripts/globals/log_ids.lua
@@ -60,7 +60,7 @@ NORG =
     ['quest_log']= 5,
     ['fame_area']= 5
 };
-OTHER_AREAS =
+OTHER_AREAS_LOG =
 {
     ['full_name'] = "Other Areas",
     ['quest_log']= 4
@@ -225,7 +225,7 @@ QUEST_LOGS = {
     [1] = "BASTOK",
     [2] = "WINDURST",
     [3] = "JEUNO",
-    [4] = "OTHER_AREAS",
+    [4] = "OTHER_AREAS_LOG",
     [5] = "OUTLANDS",
     [6] = "TOAU",
     [7] = "WOTG",


### PR DESCRIPTION
GM Commands addquest, delquest, and checkquest were broken for log id 4, other areas, due to _G["OTHER_AREAS"] evaluating to 4 upon being set by zone.lua, rather than the table set up in log_ids.lua. Because the integer value in zone.lua is a dependency for other modules, I left it alone and appended _LOG to the log_id table var, because that variable name is read dynamically from a config further down in the same file. Commands tested ok now. 
/ver 30170905_5
Revision is: Unknown (guessing branch bcnmcrap is the latest, building from 0df5b8)