### PR TITLE
Fix -Flame spouts now despawn every 3 hrs

### DIFF
--- a/scripts/zones/Ifrits_Cauldron/Zone.lua
+++ b/scripts/zones/Ifrits_Cauldron/Zone.lua
@@ -62,10 +62,10 @@ function onGameHour(zone)
     local FlameSpout = 17617204;
 
     if (VanadielHour % 3 == 0) then -- Opens flame spouts every 3 hours Vana'diel time
-        GetNPCByID(FlameSpout):openDoor(90); -- Ifrit's Cauldron flame spout (H-6) Map 1
-        GetNPCByID(FlameSpout+1):openDoor(90); -- Ifrit's Cauldron flame spout (H-6) Map 5
-        GetNPCByID(FlameSpout+2):openDoor(90); -- Ifrit's Cauldron flame spout (I-10) Map 8
-        GetNPCByID(FlameSpout+3):openDoor(90); -- Ifrit's Cauldron flame spout (E-7) Map 8
+        GetNPCByID(FlameSpout+5):openDoor(90); -- Ifrit's Cauldron flame spout (H-6) Map 1
+        GetNPCByID(FlameSpout+6):openDoor(90); -- Ifrit's Cauldron flame spout (H-6) Map 5
+        GetNPCByID(FlameSpout+7):openDoor(90); -- Ifrit's Cauldron flame spout (I-10) Map 8
+        GetNPCByID(FlameSpout+8):openDoor(90); -- Ifrit's Cauldron flame spout (E-7) Map 8
     end
 
 end;


### PR DESCRIPTION
Adjusted the FlameSpout value indicators to correctly align with the FlameSpout NPC that allows players to pass.