### PR TITLE
completequest command missed other_areas log update

### DIFF
--- a/scripts/commands/addmission.lua
+++ b/scripts/commands/addmission.lua
@@ -20,23 +20,13 @@ function onTrigger(player, logId, missionId, target)
 
     -- validate logId
     local logName;
-    if (logId == nil) then
-        error(player, "You must provide a logID.");
-        return;
-    elseif (tonumber(logId) ~= nil) then
-        logId = tonumber(logId);
-        logId = MISSION_LOGS[logId];
-    end
-    if (logId ~= nil) then
-        logId = _G[string.upper(logId)];
-    end
-    if ((type(logId) == "table") and logId.mission_log ~= nil) then
-        logName = logId.full_name;
-        logId = logId.mission_log;
-    else
+    local logInfo = GetMissionLogInfo(logId);
+    if (logInfo == nil) then
         error(player, "Invalid logID.");
         return;
     end
+    logName = logInfo.full_name;
+    logId = logInfo.mission_log;
     
     -- validate missionId
     if (missionId ~= nil) then

--- a/scripts/commands/addquest.lua
+++ b/scripts/commands/addquest.lua
@@ -19,29 +19,14 @@ end;
 function onTrigger(player, logId, questId, target)
 
     -- validate logId
-    local logName;
-    if (logId == nil) then
-        error(player, "You must provide a logID.");
-        return;
-    elseif (tonumber(logId) ~= nil) then
-        logId = tonumber(logId);
-        logId = QUEST_LOGS[logId];
-    end
-    if (logId ~= nil) then
-        local logTableTest = _G[string.upper(logId)];
-        if (type(logTableTest) == "table") then
-            logId = logTableTest;
-        else
-            logId = _G[string.upper(logId .. "_LOG")];
-        end
-    end
-    if ((type(logId) == "table") and logId.quest_log ~= nil) then
-        logName = logId.full_name;
-        logId = logId.quest_log;
-    else
+    local questLog = GetQuestLogInfo(logId);
+    if (questLog == nil) then 
         error(player, "Invalid logID.");
         return;
     end
+    local logName = questLog.full_name;
+    logId = questLog.quest_log;
+
 
     -- validate questId
     if (questId ~= nil) then

--- a/scripts/commands/checkmission.lua
+++ b/scripts/commands/checkmission.lua
@@ -20,23 +20,13 @@ function onTrigger(player,logId,target)
 
     -- validate logId
     local logName;
-    if (logId == nil) then
-        error(player, "You must provide a logID.");
-        return;
-    elseif (tonumber(logId) ~= nil) then
-        logId = tonumber(logId);
-        logId = MISSION_LOGS[logId];
-    end
-    if (logId ~= nil) then
-        logId = _G[string.upper(logId)];
-    end
-    if ((type(logId) == "table") and logId.mission_log ~= nil) then
-        logName = logId.full_name;
-        logId = logId.mission_log;
-    else
+    local logInfo = GetMissionLogInfo(logId);
+    if (logInfo == nil) then
         error(player, "Invalid logID.");
         return;
     end
+    logName = logInfo.full_name;
+    logId = logInfo.mission_log;
 
     -- validate target
     local targ;

--- a/scripts/commands/checkquest.lua
+++ b/scripts/commands/checkquest.lua
@@ -19,29 +19,13 @@ end;
 function onTrigger(player,logId,questId,target)
 
     -- validate logId
-    local logName;
-    if (logId == nil) then
-        error(player, "You must provide a logID.");
-        return;
-    elseif (tonumber(logId) ~= nil) then
-        logId = tonumber(logId);
-        logId = QUEST_LOGS[logId];
-    end
-    if (logId ~= nil) then
-        local logTableTest = _G[string.upper(logId)];
-        if (type(logTableTest) == "table") then
-            logId = logTableTest;
-        else
-            logId = _G[string.upper(logId .. "_LOG")];
-        end
-    end
-    if ((type(logId) == "table") and logId.quest_log ~= nil) then
-        logName = logId.full_name;
-        logId = logId.quest_log;
-    else
+    local questLog = GetQuestLogInfo(logId);
+    if (questLog == nil) then
         error(player, "Invalid logID.");
         return;
     end
+    local logName = questLog.full_name;
+    logId = questLog.quest_log;
 
     -- validate questId
     if (questId ~= nil) then

--- a/scripts/commands/completemission.lua
+++ b/scripts/commands/completemission.lua
@@ -20,23 +20,13 @@ function onTrigger(player, logId, missionId, target)
 
     -- validate logId
     local logName;
-    if (logId == nil) then
-        error(player, "You must provide a logID.");
-        return;
-    elseif (tonumber(logId) ~= nil) then
-        logId = tonumber(logId);
-        logId = MISSION_LOGS[logId];
-    end
-    if (logId ~= nil) then
-        logId = _G[string.upper(logId)];
-    end
-    if ((type(logId) == "table") and logId.mission_log ~= nil) then
-        logName = logId.full_name;
-        logId = logId.mission_log;
-    else
+    local logInfo = GetMissionLogInfo(logId);
+    if (logInfo == nil) then
         error(player, "Invalid logID.");
         return;
     end
+    logName = logInfo.full_name;
+    logId = logInfo.mission_log;
 
     -- validate missionId
     if (missionId ~= nil) then

--- a/scripts/commands/completequest.lua
+++ b/scripts/commands/completequest.lua
@@ -19,24 +19,14 @@ end;
 function onTrigger(player, logId, questId, target)
 
     -- validate logId
-    local logName;
-    if (logId == nil) then
-        error(player, "You must provide a logID.");
-        return;
-    elseif (tonumber(logId) ~= nil) then
-        logId = tonumber(logId);
-        logId = QUEST_LOGS[logId];
-    end
-    if (logId ~= nil) then
-        logId = _G[string.upper(logId)];
-    end
-    if ((type(logId) == "table") and logId.quest_log ~= nil) then
-        logName = logId.full_name;
-        logId = logId.quest_log;
-    else
+    local questLog = GetQuestLogInfo(logId);
+    if (questLog == nil) then 
         error(player, "Invalid logID.");
         return;
     end
+    local logName = questLog.full_name;
+    logId = questLog.quest_log;
+
 
     -- validate questId
     if (questId ~= nil) then

--- a/scripts/commands/delmission.lua
+++ b/scripts/commands/delmission.lua
@@ -19,23 +19,13 @@ end;
 function onTrigger(player, logId, missionId, target)
     -- validate logId
     local logName;
-    if (logId == nil) then
-        error(player, "You must provide a logID.");
-        return;
-    elseif (tonumber(logId) ~= nil) then
-        logId = tonumber(logId);
-        logId = MISSION_LOGS[logId];
-    end
-    if (logId ~= nil) then
-        logId = _G[string.upper(logId)];
-    end
-    if ((type(logId) == "table") and logId.mission_log ~= nil) then
-        logName = logId.full_name;
-        logId = logId.mission_log;
-    else
+    local logInfo = GetMissionLogInfo(logId);
+    if (logInfo == nil) then
         error(player, "Invalid logID.");
         return;
     end
+    logName = logInfo.full_name;
+    logId = logInfo.mission_log;
     
     -- validate missionId
     if (missionId ~= nil) then

--- a/scripts/commands/delquest.lua
+++ b/scripts/commands/delquest.lua
@@ -19,29 +19,13 @@ end;
 function onTrigger(player, logId, questId, target)
 
     -- validate logId
-    local logName;
-    if (logId == nil) then
-        error(player, "You must provide a logID.");
-        return;
-    elseif (tonumber(logId) ~= nil) then
-        logId = tonumber(logId);
-        logId = QUEST_LOGS[logId];
-    end
-    if (logId ~= nil) then
-        local logTableTest = _G[string.upper(logId)];
-        if (type(logTableTest) == "table") then
-            logId = logTableTest;
-        else
-            logId = _G[string.upper(logId .. "_LOG")];
-        end
-    end
-    if ((type(logId) == "table") and logId.quest_log ~= nil) then
-        logName = logId.full_name;
-        logId = logId.quest_log;
-    else
+    local questLog = GetQuestLogInfo(logId);
+    if (questLog == nil) then 
         error(player, "Invalid logID.");
         return;
     end
+    local logName = questLog.full_name;
+    logId = questLog.quest_log;
 
     -- validate questId
     if (questId ~= nil) then

--- a/scripts/globals/log_ids.lua
+++ b/scripts/globals/log_ids.lua
@@ -250,3 +250,48 @@ MISSION_LOGS = {
     [12] = "SOA",
     [13] = "ROV",
 };
+
+function GetQMLogInfo(cmdParamText, logNameTable)
+    -- Returns the table from this file after validating
+    if (cmdParamText == nil) then return nil end
+    if (type(logNameTable) ~= "table") then return nil end
+    local logName;
+    local ret = nil;
+    local logIdNum = tonumber(cmdParamText);
+    if (logIdNum ~= nil) then
+        logName = logNameTable[logIdNum];
+    else
+        logName = string.upper(cmdParamText);
+    end
+    if (logName ~= nil) then
+        ret = _G[logName];
+        if ((type(ret) == "table") and (type(ret.full_name) == "string")) then
+            return ret;
+        else
+            logName = logName .. "_LOG";
+            ret = _G[logName];
+            if ((type(ret) == "table") and (type(ret.full_name) == "string")) then 
+                return ret;
+            end
+        end
+    end
+    return nil;
+end
+
+function GetQuestLogInfo(cmdParamText)
+    local ret = GetQMLogInfo(cmdParamText, QUEST_LOGS);
+    if ((type(ret) == "table") and (type(ret.quest_log) == "number")) then
+        return ret;
+    else
+        return nil;
+    end
+end
+
+function GetMissionLogInfo(cmdParamText)
+    local ret = GetQMLogInfo(cmdParamText, MISSION_LOGS);
+    if ((type(ret) == "table") and (type(ret.mission_log)) == "number") then
+        return ret;
+    else
+        return nil;
+    end
+end


### PR DESCRIPTION
Following the DRY principle, reduced code redundancy in commands, since completequest missed earlier changes anyway. Added functions GetQuestLogInfo and GetMissionLogInfo to log_ids.lua.
I overlooked the completequest command when fixing the other_areas log, so I decided to make things less redundant and also included missions, since the table structure is very similar. Should provide the same or greater level of validation as before. Tested each command with numerical and named log id, plus invalid inputs of both types. Oh, and I space-ified my tabs this time. ;)
/ver 30170905_5
base ref (master) c4a1f787b847f541b94d6def37ad3450bb7ce5f4
