### PR TITLE
avoid stl exception erasing from an empty vector

### DIFF
--- a/src/map/battlefield.cpp
+++ b/src/map/battlefield.cpp
@@ -272,7 +272,20 @@ bool CBattlefield::InsertEntity(CBaseEntity* PEntity, bool enter, BATTLEFIELDMOB
             {
                 ApplyLevelCap(static_cast<CCharEntity*>( PEntity ));
                 m_EnteredPlayers.push_back(PEntity->id);
-                m_RegisteredPlayers.erase(std::remove_if(m_RegisteredPlayers.begin(), m_RegisteredPlayers.end(), [PEntity](auto id) { return PEntity->id == id; }));
+                //m_RegisteredPlayers.erase(std::remove_if(m_RegisteredPlayers.begin(), m_RegisteredPlayers.end(), [PEntity](auto id) { return PEntity->id == id; }));
+                bool wasRegistered = false;
+                do
+                {
+                    for (auto itRegPc = m_RegisteredPlayers.begin(); itRegPc != m_RegisteredPlayers.end(); itRegPc++)
+                    {
+                        if (*itRegPc == PEntity->id)
+                        {
+                            wasRegistered = true;
+                            m_RegisteredPlayers.erase(itRegPc);
+                            break;
+                        }
+                    }
+                } while (wasRegistered);
             }
             else
             {
@@ -530,8 +543,8 @@ bool CBattlefield::LoadMobs()
 {
     //get ids from DB
     auto fmtQuery = "SELECT monsterId, conditions \
-						    FROM bcnm_battlefield \
-							WHERE bcnmId = %u AND battlefieldNumber = %u";
+                            FROM bcnm_battlefield \
+                            WHERE bcnmId = %u AND battlefieldNumber = %u";
 
     auto ret = Sql_Query(SqlHandle, fmtQuery, this->GetID(), this->GetArea());
 

--- a/src/map/battlefield.cpp
+++ b/src/map/battlefield.cpp
@@ -273,9 +273,10 @@ bool CBattlefield::InsertEntity(CBaseEntity* PEntity, bool enter, BATTLEFIELDMOB
                 ApplyLevelCap(static_cast<CCharEntity*>( PEntity ));
                 m_EnteredPlayers.push_back(PEntity->id);
                 //m_RegisteredPlayers.erase(std::remove_if(m_RegisteredPlayers.begin(), m_RegisteredPlayers.end(), [PEntity](auto id) { return PEntity->id == id; }));
-                bool wasRegistered = false;
+                bool wasRegistered;
                 do
                 {
+                    wasRegistered = false;
                     for (auto itRegPc = m_RegisteredPlayers.begin(); itRegPc != m_RegisteredPlayers.end(); itRegPc++)
                     {
                         if (*itRegPc == PEntity->id)


### PR DESCRIPTION
Added a more explicit loop to find and delete ids from CBattlefield::m_registeredPlayers. This vector was not being populated in my tests (solo), so at size 0, remove_if was initializing to past the end() of the container, which throws an out of range exception from erase().