### PR TITLE
Promy Dem map acquisition

### DIFF
--- a/scripts/zones/Promyvion-Dem/TextIDs.lua
+++ b/scripts/zones/Promyvion-Dem/TextIDs.lua
@@ -5,3 +5,6 @@ ITEM_CANNOT_BE_OBTAINED = 6380; -- You cannot obtain the item <item> come back a
           ITEM_OBTAINED = 6386; -- Obtained: <item>
            GIL_OBTAINED = 6387; -- Obtained <number> gil
        KEYITEM_OBTAINED = 6389; -- Obtained key item: <keyitem>
+
+NOTHING_OUT_OF_ORDINARY = 6400; -- There is nothing out of the ordinary here.
+        NOTHING_HAPPENS = 119;  -- Nothing happens.

--- a/scripts/zones/Promyvion-Dem/npcs/qm1.lua
+++ b/scripts/zones/Promyvion-Dem/npcs/qm1.lua
@@ -1,0 +1,38 @@
+-----------------------------------
+-- Area: Promyvion Dem
+-- ??? map acquisition
+-----------------------------------
+package.loaded["scripts/zones/Promyvion-Dem/TextIDs"] = nil;
+-----------------------------------
+
+require("scripts/globals/keyitems");
+require("scripts/zones/Promyvion-Dem/TextIDs");
+
+-----------------------------------
+-- onTrigger Action
+-----------------------------------
+
+function onTrigger(player,npc)
+    player:messageSpecial(NOTHING_OUT_OF_ORDINARY);
+end;
+
+-----------------------------------
+-- onTrade Action
+-----------------------------------
+
+function onTrade(player,npc,trade)
+    if (trade:hasItemQty(1721,1) and trade:getItemCount() == 1 and player:hasKeyItem(MAP_OF_PROMYVION_DEM) == false) then
+        player:addKeyItem(MAP_OF_PROMYVION_DEM);
+        player:tradeComplete();
+        player:messageSpecial(KEYITEM_OBTAINED,MAP_OF_PROMYVION_DEM);
+    else
+        player:messageSpecial(NOTHING_HAPPENS);
+    end
+end;
+
+-----------------------------------
+-- onEventFinish Action    
+-----------------------------------
+
+function onEventFinish(player,csid,option)
+end;


### PR DESCRIPTION
This will allow you to trade the Beryl Memosphere to obtain the Map of Promyvion-Dem. 
Basically copied from the Existing lua from Promy-Holla but greatly cleaned up because Teo taught me to indent properly and remove trailing spaces.