### PR TITLE
fix gcc warnings in search project

### DIFF
--- a/src/common/blowfish.cpp
+++ b/src/common/blowfish.cpp
@@ -503,7 +503,7 @@ uint32* blowfish_init(int8 key[], int16 keybytes, uint32* P, uint32* S)
 	uint32		 datal;
 	uint32		 datar;
 
-	const uint32 N = 16;
+	const int32 N = 16;
 	memcpy(P, subkey, 72);
 	memcpy(S, subkey+72, 4096);
 

--- a/src/common/md52.h
+++ b/src/common/md52.h
@@ -39,27 +39,4 @@ void md5_starts( md5_context *ctx );
 void md5_update( md5_context *ctx, uint8 *input, uint32 length );
 void md5_finish( md5_context *ctx, uint8 digest[16] );
 
-static const int8 *msg[] = 
-{
-    "",
-    "a",
-    "abc",
-    "message digest",
-    "abcdefghijklmnopqrstuvwxyz",
-    "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789",
-    "12345678901234567890123456789012345678901234567890123456789012" \
-    "345678901234567890"
-};
-
-static const int8 *val[] =
-{
-    "d41d8cd98f00b204e9800998ecf8427e",
-    "0cc175b9c0f1b6a831c399e269772661",
-    "900150983cd24fb0d6963f7d28e17f72",
-    "f96b697d7cb7938d525a2f31aaf161d0",
-    "c3fcd3d76192e4007dfb496cca67e13b",
-    "d174ab98d277d9f5a5611c2c9f419d9f",
-    "57edf4a22be3c955ac49da2e2107b67a"
-};
-
 #endif /* md5.h */

--- a/src/common/taskmgr.h
+++ b/src/common/taskmgr.h
@@ -93,11 +93,11 @@ public:
         TaskFunc_t InitFunc,
         duration InitInterval=1s
         ):  m_name(InitName),
-            m_tick(InitTick),
-            m_data(InitData),
             m_type(InitType),
-            m_func(InitFunc),
-            m_interval(InitInterval) {};
+            m_tick(InitTick),
+            m_interval(InitInterval),
+            m_data(InitData),
+            m_func(InitFunc) {};
 
     std::string m_name;
     TASKTYPE    m_type;

--- a/src/common/utils.cpp
+++ b/src/common/utils.cpp
@@ -525,7 +525,7 @@ int8* EncodeStringSignature(int8* signature, int8* target)
     uint8 encodedSignature[12];
     memset(encodedSignature, 0, sizeof encodedSignature);
     uint8 chars = 0;
-    uint8 leftover = 0;
+    // uint8 leftover = 0;
     for(uint8 currChar = 0; currChar < dsp_min(15, strlen((const char*)signature)); ++currChar)
     {
         uint8 tempChar = 0;

--- a/src/search/data_loader.cpp
+++ b/src/search/data_loader.cpp
@@ -253,7 +253,7 @@ std::list<SearchEntity*> CDataLoader::GetPlayersList(search_req sr, int* count)
                 continue;
 
             // filter by nation
-            if (sr.nation != 255 && !sr.nation == PPlayer->nation)
+            if (sr.nation != 255 && sr.nation != PPlayer->nation)
                 continue;
 
             // filter by race
@@ -488,7 +488,7 @@ void CDataLoader::ExpireAHItems()
 			if (ret != SQL_ERROR &&	Sql_NumRows(SqlHandle) != 0)
 			{
 				// delete the item from the auction house
-				int32 ret3 = Sql_Query(sqlH2, "DELETE FROM auction_house WHERE id= %u", saleID);
+				Sql_Query(sqlH2, "DELETE FROM auction_house WHERE id= %u", saleID);
 			}
 		}
 	}


### PR DESCRIPTION
- align types in blowfish used as iterator
- remove unused params (msg, val) from md52
- order parameter initialization for CTask
- remove unused leftover from EncodeStringSignature(...)