### PR TITLE
Fix gcc warnings in the login project

### DIFF
--- a/src/login/lobby.cpp
+++ b/src/login/lobby.cpp
@@ -75,7 +75,7 @@ int32 lobbydata_parse(int32 fd)
         {
             char* buff = &session[fd]->rdata[0];
 
-            int32 accid = RBUFL(buff, 1);
+            uint32 accid = RBUFL(buff, 1);
 
             sd = find_loginsd_byaccid(accid);
             if (sd == nullptr)
@@ -525,7 +525,6 @@ int32 lobbyview_parse(int32 fd)
         case 0x14:
         {
             //delete char
-            uint32 ContentID = RBUFL(session[fd]->rdata.data(), 0x1C);
             uint32 CharID = RBUFL(session[fd]->rdata.data(), 0x20);
 
             ShowInfo(CL_WHITE"lobbyview_parse" CL_RESET":attempt to delete char:<" CL_WHITE"%d" CL_RESET"> from ip:<%s>\n", CharID, ip2str(sd->client_addr, nullptr));
@@ -611,7 +610,7 @@ int32 lobbyview_parse(int32 fd)
                 do_close_lobbyview(sd, fd);
                 return -1;
             }
-            char lobbydata_code[] = { 0x15, 0x07 };
+            // char lobbydata_code[] = { 0x15, 0x07 };
             //				session[sd->login_lobbydata_fd]->wdata[0]  = 0x15;
             //				session[sd->login_lobbydata_fd]->wdata[1]  = 0x07;
             //				WFIFOSET(sd->login_lobbydata_fd,2);

--- a/src/login/login.cpp
+++ b/src/login/login.cpp
@@ -61,7 +61,6 @@ int32 do_init(int32 argc, char** argv)
     LOGIN_CONF_FILENAME = "conf/login_darkstar.conf";
     VERSION_INFO_FILENAME = "version.info";
 
-    const char *lan_cfgName = LAN_CONFIG_NAME;
     //srand(gettick());
 
     for (i = 1; i < argc; i++) {
@@ -71,14 +70,9 @@ int32 do_init(int32 argc, char** argv)
             login_versionscreen(1);
         else if (strcmp(argv[i], "--login_config") == 0 || strcmp(argv[i], "--login-config") == 0)
             LOGIN_CONF_FILENAME = argv[i + 1];
-        else if (strcmp(argv[i], "--lan_config") == 0 || strcmp(argv[i], "--lan-config") == 0)
-            lan_cfgName = argv[i + 1];
         else if (strcmp(argv[i], "--run_once") == 0)	// close the map-server as soon as its done.. for testing [Celest]
             runflag = 0;
     }
-
-    //lan_config_default(&lan_config);
-    //lan_config_read(lan_cfgName,&lan_config);
 
     login_config_default();
     login_config_read(LOGIN_CONF_FILENAME);

--- a/src/login/login_auth.cpp
+++ b/src/login/login_auth.cpp
@@ -49,7 +49,7 @@ int32 connect_client_login(int32 listenfd)
     struct sockaddr_in client_address;
     if ((fd = connect_client(listenfd, client_address)) != -1)
     {
-        int32 code = create_session(fd, recv_to_fifo, send_from_fifo, login_parse);
+        create_session(fd, recv_to_fifo, send_from_fifo, login_parse);
         session[fd]->client_addr = ntohl(client_address.sin_addr.s_addr);
         return fd;
     }

--- a/src/login/login_session.cpp
+++ b/src/login/login_session.cpp
@@ -26,7 +26,7 @@
 
 login_sd_list_t login_sd_list;
 
-login_session_data_t *find_loginsd_byaccid(int32 accid)
+login_session_data_t *find_loginsd_byaccid(uint32 accid)
 {
     for (login_sd_list_t::iterator i = login_sd_list.begin();
     i != login_sd_list.end();

--- a/src/login/login_session.h
+++ b/src/login/login_session.h
@@ -46,7 +46,7 @@ struct login_session_data_t {
 typedef std::list<login_session_data_t*> login_sd_list_t;
 extern login_sd_list_t login_sd_list;
 
-login_session_data_t* find_loginsd_byaccid(int32 accid);
+login_session_data_t* find_loginsd_byaccid(uint32 accid);
 login_session_data_t* find_loginsd_byip(uint32 ip);
 void				  erase_loginsd_byaccid(uint32 accid);
 void				  erase_loginsd(int32 loginfd);

--- a/src/login/message_server.cpp
+++ b/src/login/message_server.cpp
@@ -79,7 +79,7 @@ void message_server_send(uint64 ipp, MSGSERVTYPE type, zmq::message_t* extra, zm
 
 void message_server_parse(MSGSERVTYPE type, zmq::message_t* extra, zmq::message_t* packet, zmq::message_t* from)
 {
-    int ret;
+    int ret = SQL_ERROR;
     in_addr from_ip;
     uint16 from_port = 0;
     bool ipstring = false;
@@ -142,6 +142,16 @@ void message_server_parse(MSGSERVTYPE type, zmq::message_t* extra, zmq::message_
     {
         const char* query = "SELECT server_addr, server_port FROM accounts_sessions WHERE charid = %d; ";
         ret = Sql_Query(ChatSqlHandle, query, RBUFL(extra->data(), 0));
+        break;
+    }
+    case MSG_LOGIN:
+    {
+        // no op
+        break;
+    }
+    default:
+    {
+        ShowDebug("Message: unknown type received: %d from %s:%hu\n", type, inet_ntoa(from_ip), from_port);
         break;
     }
     }


### PR DESCRIPTION
- remove unused params/returns
- align accid to uint32
- default return to an error type
- no op MSG_LOGIN
- provide default case for logging