### PR TITLE
Fixing BCNM 100% Group Drop Rate

### DIFF
--- a/src/map/utils/battlefieldutils.cpp
+++ b/src/map/utils/battlefieldutils.cpp
@@ -292,41 +292,6 @@ namespace battlefieldutils {
         }
     }
 
-
-    uint8 getMaxLootGroups(CBattlefield* battlefield) {
-        const int8* fmtQuery = "SELECT MAX(lootGroupId) \
-                        FROM bcnm_loot \
-                        JOIN bcnm_info ON bcnm_info.LootDropId = bcnm_loot.LootDropId \
-                        WHERE bcnm_info.LootDropId = %u LIMIT 1";
-
-        int32 ret = Sql_Query(SqlHandle, fmtQuery, battlefield->getLootId());
-        if (ret == SQL_ERROR || Sql_NumRows(SqlHandle) == 0 || Sql_NextRow(SqlHandle) != SQL_SUCCESS) {
-            ShowError("SQL error occured \n");
-            return 0;
-        }
-        else {
-            return (uint8)Sql_GetUIntData(SqlHandle, 0);
-        }
-    }
-
-    uint16 getRollsPerGroup(CBattlefield* battlefield, uint8 groupID) {
-        const int8* fmtQuery = "SELECT SUM(CASE \
-            WHEN LootDropID = %u \
-            AND lootGroupId = %u \
-            THEN rolls  \
-            ELSE 0 END) \
-            FROM bcnm_loot;";
-
-        int32 ret = Sql_Query(SqlHandle, fmtQuery, battlefield->getLootId(), groupID);
-        if (ret == SQL_ERROR || Sql_NumRows(SqlHandle) == 0 || Sql_NextRow(SqlHandle) != SQL_SUCCESS) {
-            ShowError("SQL error occured \n");
-            return 0;
-        }
-        else {
-            return (uint16)Sql_GetUIntData(SqlHandle, 0);
-        }
-    }
-
     /*************************************************************
     Get loot from the armoury crate
     ****************************************************************/
@@ -350,11 +315,12 @@ namespace battlefieldutils {
                 }
             }
         }
-        //getMaxLootGroups(battlefield);
-        if (maxloot != 0) {
-            for (uint8 group = 0; group <= maxloot; ++group) {
-                uint16 maxRolls = getRollsPerGroup(battlefield, group);
-                uint16 groupRoll = dsprand::GetRandomNumber(maxRolls);
+
+        if (maxloot != 0)
+        {
+            for (uint8 group = 0; group <= maxloot; ++group)
+            {
+                uint16 groupRoll = dsprand::GetRandomNumber(1000/* aka 100.0% */);
                 uint16 itemRolls = 0;
 
                 for (uint8 item = 0; item < LootList->size(); ++item)


### PR DESCRIPTION
Cleaning up code in map/utils/battlefieldutils.cpp

The bug in the code looks to be that each group's total roll will always be the sum of all of the rolls in each group.  This logic does not make sense because each group should always have a roll between 0 and 1000.  If a group only has a 5% drop rate the group should only drop an item 5% of the time, not each time.  I tested this code on the BCNM Up in Arms.  Before the code change Walkure Mask would always drop, now It does not drop all the time.