### PR TITLE
Temp disable "Expert" craft promotion until fully implemented

### DIFF
--- a/scripts/globals/crafting.lua
+++ b/scripts/globals/crafting.lua
@@ -148,8 +148,8 @@ function canGetNewRank(player,skillLvL,craftID)
        Rank == 6 and skillLvL >= 1861 or
        Rank == 7 and skillLvL >= 2182 or
        Rank == 8 and skillLvL >= 2503 or
-       Rank == 9 and skillLvL >= 2824 or
-       Rank == 10 and skillLvL >= 3145) then
+       Rank == 9 and skillLvL >= 2824) then
+--       Rank == 10 and skillLvL >= 3145) then
             canGet = 1;
     end
 


### PR DESCRIPTION
Just commented out the "Expert" level per discussion: https://github.com/DarkstarProject/darkstar/issues/4209
Tested with Bonecraft: raised skill to 100 cap and was not offered to go any higher.