### PR TITLE
Chocobo digging updates for skill ups.

### DIFF
--- a/scripts/globals/chocobo_digging.lua
+++ b/scripts/globals/chocobo_digging.lua
@@ -74,12 +74,10 @@ local function calculateSkillUp(player)
             -- skill up!
             player:setSkillLevel(SKILL_DIG, RealSkill + SkillIncrement);
 
-            -- gotta update the skill rank and push packet
+            -- update the skill rank
             -- Digging does not have test items, so increment rank once player hits 10.0, 20.0, .. 100.0
-            for i = 0, 10, 1 do
-                if (SkillRank == i and (RealSkill + SkillIncrement) >= ((SkillRank * 100) + 100)) then
-                    player:setSkillRank(SKILL_DIG, SkillRank + 1);
-                end
+            if ((RealSkill + SkillIncrement) >= ((SkillRank * 100) + 100)) then
+                player:setSkillRank(SKILL_DIG, SkillRank + 1);
             end
         end
     end

--- a/scripts/globals/chocobo_digging.lua
+++ b/scripts/globals/chocobo_digging.lua
@@ -13,9 +13,6 @@ DIGREQ_BORE     = 2;
 DIGREQ_MODIFIER = 4;
 DIGREQ_NIGHT    = 8;
 
-local DIGABILITY_BURROW = 1;
-local DIGABILITY_BORE   = 2;
-
 local function canDig(player)
 
     local DigCount = player:getVar('[DIG]DigCount');
@@ -53,10 +50,13 @@ end;
 
 local function calculateSkillUp(player)
 
-    -- 59 cause we're gonna use SKILL_DIG for burrow/bore
     local SkillRank = player:getSkillRank(SKILL_DIG);
     local MaxSkill = (SkillRank + 1) * 100;
-    local RealSkill = player:getSkillLevel(SKILL_DIG);
+    local RealSkill = player:getCharSkillLevel(SKILL_DIG);
+
+    if (MaxSkill > 1000) then
+        MaxSkill = 1000;
+    end
 
     local SkillIncrement = 1;
 
@@ -75,15 +75,11 @@ local function calculateSkillUp(player)
             player:setSkillLevel(SKILL_DIG, RealSkill + SkillIncrement);
 
             -- gotta update the skill rank and push packet
+            -- Digging does not have test items, so increment rank once player hits 10.0, 20.0, .. 100.0
             for i = 0, 10, 1 do
-                if (SkillRank == i and RealSkill >= ((SkillRank * 100) + 100)) then
+                if (SkillRank == i and (RealSkill + SkillIncrement) >= ((SkillRank * 100) + 100)) then
                     player:setSkillRank(SKILL_DIG, SkillRank + 1);
                 end
-            end
-
-            if ((RealSkill / 10) < ((RealSkill + SkillIncrement) / 10)) then
-               -- todo: get this working correctly (apparently the lua binding updates RealSkills and WorkingSkills)
-               player:setSkillLevel(SKILL_DIG, player:getSkillLevel(SKILL_DIG) + 0x20);
             end
         end
     end
@@ -118,7 +114,7 @@ function updateZoneDigCount(zone, increment)
     end
 end;
 
-function getChocoboDiggingItem(itemMap, chance, digAbility, mod, totd)
+function getChocoboDiggingItem(itemMap, chance, burrowAbility, boreAbility, mod, totd)
     local accum = 0;
 
     for i = 1, #itemMap do
@@ -131,8 +127,8 @@ function getChocoboDiggingItem(itemMap, chance, digAbility, mod, totd)
             local itemReq = item[3];
 
             if ((itemReq == DIGREQ_NONE) or
-                (itemReq == DIGREQ_BURROW and digAbility == DIGABILITY_BURROW) or
-                (itemReq == DIGREQ_BORE and digAbility == DIGABILITY_BORE) or
+                (itemReq == DIGREQ_BURROW and burrowAbility == 1) or
+                (itemReq == DIGREQ_BORE and boreAbility == 1) or
                 (itemReq == DIGREQ_MODIFIER and mod == 1) or
                 (itemReq == DIGREQ_NIGHT and totd == TIME_NIGHT)) then
 
@@ -177,12 +173,23 @@ function chocoboDig(player, itemMap, precheck, messageArray)
             -- item and DIG_ABUNDANCE_BONUS 3 digits, dont wanna get left out
             Chance = Chance * 10;
 
-            -- rank 1 is burrow, rank 2 is bore (see DIGABILITY at the top of the file)
-            local DigAbility = player:getSkillRank(SKILL_DIG);
+            local SkillRank = player:getSkillRank(SKILL_DIG);
+
+            -- todo: learn abilities from chocobo raising
+            local burrowAbility = 0;
+            local boreAbility = 0;
+
+            if (DIG_GRANT_BURROW == 1) then
+                burrowAbility = 1;
+            end
+
+            if (DIG_GRANT_BORE == 1) then
+                boreAbility = 1;
+            end
 
             local Mod = player:getMod(MOD_EGGHELM);
 
-            ItemID = getChocoboDiggingItem(itemMap, Chance, DigAbility, Mod, VanadielTOTD());
+            ItemID = getChocoboDiggingItem(itemMap, Chance, burrowAbility, boreAbility, Mod, VanadielTOTD());
 
             -- Let's see if the item should be obtained in this zone with this weather
             local crystalMap = {

--- a/scripts/globals/settings.lua
+++ b/scripts/globals/settings.lua
@@ -163,6 +163,8 @@ NUMBER_OF_DM_EARRINGS = 1; -- Number of earrings players can simultaneously own 
 HOMEPOINT_TELEPORT = 0; -- Enables the homepoint teleport system
 DIG_ABUNDANCE_BONUS = 0; -- Increase chance of digging up an item (450  = item digup chance +45)
 DIG_FATIGUE = 1; -- Set to 0 to disable Dig Fatigue
+DIG_GRANT_BURROW = 0; -- Set to 1 to grant burrow ability
+DIG_GRANT_BORE = 0; -- Set to 1 to grant bore ability
 ENM_COOLDOWN = 120;  -- Number of hours before a player can obtain same KI for ENMs (default: 5 days)
 FORCE_SPAWN_QM_RESET_TIME = 300; -- Number of seconds the ??? remains hidden for after the despawning of the mob it force spawns.
 

--- a/src/map/lua/lua_baseentity.cpp
+++ b/src/map/lua/lua_baseentity.cpp
@@ -2151,8 +2151,8 @@ inline int32 CLuaBaseEntity::setSkillLevel(lua_State *L)
 
     CCharEntity* PChar = (CCharEntity*)m_PBaseEntity;
 
-    PChar->RealSkills.skill[SkillID] = SkillAmount * 10;
-    PChar->WorkingSkills.skill[SkillID] = SkillAmount;
+    PChar->RealSkills.skill[SkillID] = SkillAmount;
+    PChar->WorkingSkills.skill[SkillID] = (SkillAmount / 10) * 0x20 + PChar->WorkingSkills.rank[SkillID];
 
     charutils::BuildingCharSkillsTable(PChar);
     charutils::CheckWeaponSkill(PChar, SkillID);
@@ -2219,7 +2219,7 @@ inline int32 CLuaBaseEntity::setSkillRank(lua_State *L)
     auto newrank = (uint8)lua_tointeger(L, 2);
 
     PChar->WorkingSkills.rank[skillID] = newrank;
-    //PChar->WorkingSkills.skill[skillID] += 1;
+    PChar->WorkingSkills.skill[skillID] = (PChar->RealSkills.skill[skillID] / 10) * 0x20 + newrank;
     PChar->RealSkills.rank[skillID] = newrank;
     //PChar->RealSkills.skill[skillID] += 1;
 
@@ -2228,6 +2228,23 @@ inline int32 CLuaBaseEntity::setSkillRank(lua_State *L)
     PChar->pushPacket(new CCharSkillsPacket(PChar));
 
     return 0;
+}
+
+/************************************************************************
+*                                                                       *
+*  Get craft char skill level player:getCharSkillLevel(SKILLID)         *
+*                                                                       *
+************************************************************************/
+
+inline int32 CLuaBaseEntity::getCharSkillLevel(lua_State *L)
+{
+    DSP_DEBUG_BREAK_IF(m_PBaseEntity == nullptr);
+
+    CCharEntity* PChar = (CCharEntity*)m_PBaseEntity;
+    uint8 skillID = (uint8)lua_tointeger(L, 1);
+
+    lua_pushinteger(L, PChar->RealSkills.skill[skillID]);
+    return 1;
 }
 
 /************************************************************************
@@ -11382,6 +11399,7 @@ Lunar<CLuaBaseEntity>::Register_t CLuaBaseEntity::methods[] =
     LUNAR_DECLARE_METHOD(CLuaBaseEntity,getMaxSkillLevel),
     LUNAR_DECLARE_METHOD(CLuaBaseEntity,getSkillRank),
     LUNAR_DECLARE_METHOD(CLuaBaseEntity,setSkillRank),
+    LUNAR_DECLARE_METHOD(CLuaBaseEntity,getCharSkillLevel),
     LUNAR_DECLARE_METHOD(CLuaBaseEntity,getWeaponSkillLevel),
     LUNAR_DECLARE_METHOD(CLuaBaseEntity,addSpell),
     LUNAR_DECLARE_METHOD(CLuaBaseEntity,hasSpell),

--- a/src/map/lua/lua_baseentity.cpp
+++ b/src/map/lua/lua_baseentity.cpp
@@ -2240,10 +2240,18 @@ inline int32 CLuaBaseEntity::getCharSkillLevel(lua_State *L)
 {
     DSP_DEBUG_BREAK_IF(m_PBaseEntity == nullptr);
 
-    CCharEntity* PChar = (CCharEntity*)m_PBaseEntity;
-    uint8 skillID = (uint8)lua_tointeger(L, 1);
+    if (m_PBaseEntity->objtype != TYPE_PC)
+    {
+        lua_pushinteger(L, 0);
+    }
+    else
+    {
+        CCharEntity* PChar = (CCharEntity*)m_PBaseEntity;
+        uint8 skillID = (uint8)lua_tointeger(L, 1);
 
-    lua_pushinteger(L, PChar->RealSkills.skill[skillID]);
+        lua_pushinteger(L, PChar->RealSkills.skill[skillID]);
+    }
+
     return 1;
 }
 

--- a/src/map/lua/lua_baseentity.h
+++ b/src/map/lua/lua_baseentity.h
@@ -173,6 +173,7 @@ public:
     int32 getMaxSkillLevel(lua_State*);     // Get Skill Cap for skill and rank
     int32 getSkillRank(lua_State*);         // Get your current skill craft Rank
     int32 setSkillRank(lua_State*);         // Set new skill craft rank
+    int32 getCharSkillLevel(lua_State*);    // Get char skill level
     int32 getWeaponSkillLevel(lua_State*);  // Get Skill for equipped weapon
     int32 addSpell(lua_State*);             // Add spell to Entity spell list
     int32 hasSpell(lua_State*);             // Check to see if character has item in spell list


### PR DESCRIPTION
Lua bindings:
Updates how real skills and working skills are set in CLuaBaseEntity::setSkillLevel(lua_State *L). Updates CLuaBaseEntity::setSkillRank(lua_State *L) to set working skills. Adds CLuaBaseEntity::getCharSkillLevel(lua_State *L) for getting real skills (i.e., so lua can have access to the decimal place of the skill level).

Chocobo digging script:
Bugfix for value checked for current skill level (real vs working). Updates rank up to rank up on the skill up that hits 10.0, 20.0, .. 100.0 rather than after (i.e., 10.1, 20.1, .. 100.1). Removes what may have been an attempt at storing chocobo abilities in digging rank. Adds stub variables for chobobo abilities. Adds settings vars for granting chocobo abilities.

Chocobo digging skill ups were not working. The main culprit was how the skills levels/ranks were being used.
