### PR TITLE
Remove ARRAYLENGTH macro from cbasetypes

### DIFF
--- a/src/common/cbasetypes.h
+++ b/src/common/cbasetypes.h
@@ -316,10 +316,6 @@ typedef char bool;
 #define TOUPPER(c) (toupper((unsigned char)(c)))
 
 //////////////////////////////////////////////////////////////////////////
-// length of a static array
-#define ARRAYLENGTH(A) ( sizeof(A)/sizeof((A)[0]) )
-
-//////////////////////////////////////////////////////////////////////////
 // Make sure va_copy exists
 #include <stdarg.h> // va_list, va_copy(?)
 #if !defined(va_copy)

--- a/src/common/socket.cpp
+++ b/src/common/socket.cpp
@@ -92,8 +92,9 @@ int sock2newfd(SOCKET s)
 	for( fd = 1; fd < sock_arr_len; ++fd )
 		if( sock_arr[fd] == INVALID_SOCKET )
 			break;// empty position
-	if( fd == ARRAYLENGTH(sock_arr) )
-	{// too many sockets
+    if (fd == (sizeof(sock_arr) / sizeof(sock_arr[0])))
+	{
+        // too many sockets
 		closesocket(s);
 		WSASetLastError(WSAEMFILE);
 		return -1;


### PR DESCRIPTION
- Only used in socket.cpp