### PR TITLE
Hopefully the last MR/Stray related PR of the year.

### DIFF
--- a/scripts/zones/Promyvion-Dem/mobs/Memory_Receptacle.lua
+++ b/scripts/zones/Promyvion-Dem/mobs/Memory_Receptacle.lua
@@ -2,10 +2,8 @@
 -- Area: Promyvion-Dem
 --  MOB: Memory Receptacle
 -----------------------------------
-package.loaded["scripts/zones/Promyvion-Dem/TextIDs"] = nil;
 package.loaded["scripts/zones/Promyvion-Dem/MobIDs"] = nil;
 -----------------------------------
-require("scripts/zones/Promyvion-Dem/TextIDs");
 require("scripts/zones/Promyvion-Dem/MobIDs");
 require("scripts/globals/status");
 
@@ -14,21 +12,15 @@ function onMobInitialize(mob)
     mob:SetAutoAttackEnabled(false); -- Recepticles only use TP moves.
 end;
 
-function onMobSpawn(mob, target)
-    mob:setLocalVar("nextStray", os.time() + 30);
-end;
-
 function checkStray(mob)
     local mobId = mob:getID();
     local numStrays = MEMORY_RECEPTACLES[mobId][2];
     
     if (os.time() > mob:getLocalVar("nextStray")) then
-        mob:setLocalVar("nextStray", os.time() + 30);
         for i = mobId + 1, mobId + numStrays do
             local stray = GetMobByID(i);
             if (not stray:isSpawned()) then
-                mob:AnimationSub(1);
-                stray:setPos(mob:getXPos() + math.random(-1,1), mob:getYPos(), mob:getZPos() + math.random(-1,1));
+                mob:setLocalVar("nextStray", os.time() + 20);
                 SpawnMob(stray:getID());
                 break;
             end
@@ -36,10 +28,6 @@ function checkStray(mob)
     else
         mob:AnimationSub(2);
     end
-end;
-
-function onMobRoam(mob)
-    checkStray(mob);
 end;
 
 function onMobFight(mob, target)
@@ -54,7 +42,6 @@ function onMobFight(mob, target)
         end
     end
     
-    -- summon a stray every 30 seconds
     checkStray(mob);
 end;
 

--- a/scripts/zones/Promyvion-Dem/mobs/Stray.lua
+++ b/scripts/zones/Promyvion-Dem/mobs/Stray.lua
@@ -1,0 +1,34 @@
+-----------------------------------
+-- Area: Promyvion-Dem
+--  MOB: Stray
+-----------------------------------
+package.loaded["scripts/zones/Promyvion-Dem/MobIDs"] = nil;
+-----------------------------------
+require("scripts/zones/Promyvion-Dem/MobIDs");
+require("scripts/globals/status");
+
+function findMother(mob)
+    local mobId = mob:getID();
+    local mother = 0;
+    for k,v in pairs(MEMORY_RECEPTACLES) do
+        if (k < mobId and k > mother) then
+            mother = k;
+        end
+    end
+    return mother;
+end;
+
+function onMobInitialize(mob)
+    mob:setMobMod(MOBMOD_GIL_MAX, -1);
+end;
+
+function onMobSpawn(mob, target)
+    local mother = GetMobByID(findMother(mob));
+    if (mother ~= nil and mother:isSpawned()) then
+        mob:setPos(mother:getXPos(), mother:getYPos()-5, mother:getZPos());
+        mother:AnimationSub(1);
+    end
+end;
+
+function onMobDeath(mob, player, isKiller)
+end;

--- a/scripts/zones/Promyvion-Holla/mobs/Memory_Receptacle.lua
+++ b/scripts/zones/Promyvion-Holla/mobs/Memory_Receptacle.lua
@@ -2,10 +2,8 @@
 -- Area: Promyvion-Holla
 --  MOB: Memory Receptacle
 -----------------------------------
-package.loaded["scripts/zones/Promyvion-Holla/TextIDs"] = nil;
 package.loaded["scripts/zones/Promyvion-Holla/MobIDs"] = nil;
 -----------------------------------
-require("scripts/zones/Promyvion-Holla/TextIDs");
 require("scripts/zones/Promyvion-Holla/MobIDs");
 require("scripts/globals/status");
 
@@ -14,21 +12,15 @@ function onMobInitialize(mob)
     mob:SetAutoAttackEnabled(false); -- Recepticles only use TP moves.
 end;
 
-function onMobSpawn(mob, target)
-    mob:setLocalVar("nextStray", os.time() + 30);
-end;
-
 function checkStray(mob)
     local mobId = mob:getID();
     local numStrays = MEMORY_RECEPTACLES[mobId][2];
     
     if (os.time() > mob:getLocalVar("nextStray")) then
-        mob:setLocalVar("nextStray", os.time() + 30);
         for i = mobId + 1, mobId + numStrays do
             local stray = GetMobByID(i);
             if (not stray:isSpawned()) then
-                mob:AnimationSub(1);
-                stray:setPos(mob:getXPos() + math.random(-1,1), mob:getYPos(), mob:getZPos() + math.random(-1,1));
+                mob:setLocalVar("nextStray", os.time() + 20);
                 SpawnMob(stray:getID());
                 break;
             end
@@ -36,10 +28,6 @@ function checkStray(mob)
     else
         mob:AnimationSub(2);
     end
-end;
-
-function onMobRoam(mob)
-    checkStray(mob);
 end;
 
 function onMobFight(mob, target)
@@ -54,7 +42,6 @@ function onMobFight(mob, target)
         end
     end
     
-    -- summon a stray every 30 seconds
     checkStray(mob);
 end;
 

--- a/scripts/zones/Promyvion-Holla/mobs/Stray.lua
+++ b/scripts/zones/Promyvion-Holla/mobs/Stray.lua
@@ -1,0 +1,34 @@
+-----------------------------------
+-- Area: Promyvion-Holla
+--  MOB: Stray
+-----------------------------------
+package.loaded["scripts/zones/Promyvion-Holla/MobIDs"] = nil;
+-----------------------------------
+require("scripts/zones/Promyvion-Holla/MobIDs");
+require("scripts/globals/status");
+
+function findMother(mob)
+    local mobId = mob:getID();
+    local mother = 0;
+    for k,v in pairs(MEMORY_RECEPTACLES) do
+        if (k < mobId and k > mother) then
+            mother = k;
+        end
+    end
+    return mother;
+end;
+
+function onMobInitialize(mob)
+    mob:setMobMod(MOBMOD_GIL_MAX, -1);
+end;
+
+function onMobSpawn(mob, target)
+    local mother = GetMobByID(findMother(mob));
+    if (mother ~= nil and mother:isSpawned()) then
+        mob:setPos(mother:getXPos(), mother:getYPos()-5, mother:getZPos());
+        mother:AnimationSub(1);
+    end
+end;
+
+function onMobDeath(mob, player, isKiller)
+end;

--- a/scripts/zones/Promyvion-Mea/mobs/Memory_Receptacle.lua
+++ b/scripts/zones/Promyvion-Mea/mobs/Memory_Receptacle.lua
@@ -2,10 +2,8 @@
 -- Area: Promyvion-Mea
 --  MOB: Memory Receptacle
 -----------------------------------
-package.loaded["scripts/zones/Promyvion-Mea/TextIDs"] = nil;
 package.loaded["scripts/zones/Promyvion-Mea/MobIDs"] = nil;
 -----------------------------------
-require("scripts/zones/Promyvion-Mea/TextIDs");
 require("scripts/zones/Promyvion-Mea/MobIDs");
 require("scripts/globals/status");
 
@@ -14,21 +12,15 @@ function onMobInitialize(mob)
     mob:SetAutoAttackEnabled(false); -- Recepticles only use TP moves.
 end;
 
-function onMobSpawn(mob, target)
-    mob:setLocalVar("nextStray", os.time() + 30);
-end;
-
 function checkStray(mob)
     local mobId = mob:getID();
     local numStrays = MEMORY_RECEPTACLES[mobId][2];
     
     if (os.time() > mob:getLocalVar("nextStray")) then
-        mob:setLocalVar("nextStray", os.time() + 30);
         for i = mobId + 1, mobId + numStrays do
             local stray = GetMobByID(i);
             if (not stray:isSpawned()) then
-                mob:AnimationSub(1);
-                stray:setPos(mob:getXPos() + math.random(-1,1), mob:getYPos(), mob:getZPos() + math.random(-1,1));
+                mob:setLocalVar("nextStray", os.time() + 20);
                 SpawnMob(stray:getID());
                 break;
             end
@@ -36,10 +28,6 @@ function checkStray(mob)
     else
         mob:AnimationSub(2);
     end
-end;
-
-function onMobRoam(mob)
-    checkStray(mob);
 end;
 
 function onMobFight(mob, target)
@@ -54,7 +42,6 @@ function onMobFight(mob, target)
         end
     end
     
-    -- summon a stray every 30 seconds
     checkStray(mob);
 end;
 

--- a/scripts/zones/Promyvion-Mea/mobs/Stray.lua
+++ b/scripts/zones/Promyvion-Mea/mobs/Stray.lua
@@ -1,0 +1,34 @@
+-----------------------------------
+-- Area: Promyvion-Mea
+--  MOB: Stray
+-----------------------------------
+package.loaded["scripts/zones/Promyvion-Mea/MobIDs"] = nil;
+-----------------------------------
+require("scripts/zones/Promyvion-Mea/MobIDs");
+require("scripts/globals/status");
+
+function findMother(mob)
+    local mobId = mob:getID();
+    local mother = 0;
+    for k,v in pairs(MEMORY_RECEPTACLES) do
+        if (k < mobId and k > mother) then
+            mother = k;
+        end
+    end
+    return mother;
+end;
+
+function onMobInitialize(mob)
+    mob:setMobMod(MOBMOD_GIL_MAX, -1);
+end;
+
+function onMobSpawn(mob, target)
+    local mother = GetMobByID(findMother(mob));
+    if (mother ~= nil and mother:isSpawned()) then
+        mob:setPos(mother:getXPos(), mother:getYPos()-5, mother:getZPos());
+        mother:AnimationSub(1);
+    end
+end;
+
+function onMobDeath(mob, player, isKiller)
+end;

--- a/scripts/zones/Promyvion-Vahzl/mobs/Memory_Receptacle.lua
+++ b/scripts/zones/Promyvion-Vahzl/mobs/Memory_Receptacle.lua
@@ -2,10 +2,8 @@
 -- Area: Promyvion-Vahzl
 --  MOB: Memory Receptacle
 -----------------------------------
-package.loaded["scripts/zones/Promyvion-Vahzl/TextIDs"] = nil;
 package.loaded["scripts/zones/Promyvion-Vahzl/MobIDs"] = nil;
 -----------------------------------
-require("scripts/zones/Promyvion-Vahzl/TextIDs");
 require("scripts/zones/Promyvion-Vahzl/MobIDs");
 require("scripts/globals/status");
 
@@ -14,21 +12,15 @@ function onMobInitialize(mob)
     mob:SetAutoAttackEnabled(false); -- Recepticles only use TP moves.
 end;
 
-function onMobSpawn(mob, target)
-    mob:setLocalVar("nextStray", os.time() + 30);
-end;
-
 function checkStray(mob)
     local mobId = mob:getID();
     local numStrays = MEMORY_RECEPTACLES[mobId][2];
     
     if (os.time() > mob:getLocalVar("nextStray")) then
-        mob:setLocalVar("nextStray", os.time() + 30);
         for i = mobId + 1, mobId + numStrays do
             local stray = GetMobByID(i);
             if (not stray:isSpawned()) then
-                mob:AnimationSub(1);
-                stray:setPos(mob:getXPos() + math.random(-1,1), mob:getYPos(), mob:getZPos() + math.random(-1,1));
+                mob:setLocalVar("nextStray", os.time() + 20);
                 SpawnMob(stray:getID());
                 break;
             end
@@ -36,10 +28,6 @@ function checkStray(mob)
     else
         mob:AnimationSub(2);
     end
-end;
-
-function onMobRoam(mob)
-    checkStray(mob);
 end;
 
 function onMobFight(mob, target)
@@ -54,7 +42,6 @@ function onMobFight(mob, target)
         end
     end
     
-    -- summon a stray every 30 seconds
     checkStray(mob);
 end;
 

--- a/scripts/zones/Promyvion-Vahzl/mobs/Stray.lua
+++ b/scripts/zones/Promyvion-Vahzl/mobs/Stray.lua
@@ -1,0 +1,34 @@
+-----------------------------------
+-- Area: Promyvion-Vahzl
+--  MOB: Stray
+-----------------------------------
+package.loaded["scripts/zones/Promyvion-Vahzl/MobIDs"] = nil;
+-----------------------------------
+require("scripts/zones/Promyvion-Vahzl/MobIDs");
+require("scripts/globals/status");
+
+function findMother(mob)
+    local mobId = mob:getID();
+    local mother = 0;
+    for k,v in pairs(MEMORY_RECEPTACLES) do
+        if (k < mobId and k > mother) then
+            mother = k;
+        end
+    end
+    return mother;
+end;
+
+function onMobInitialize(mob)
+    mob:setMobMod(MOBMOD_GIL_MAX, -1);
+end;
+
+function onMobSpawn(mob, target)
+    local mother = GetMobByID(findMother(mob));
+    if (mother ~= nil and mother:isSpawned()) then
+        mob:setPos(mother:getXPos(), mother:getYPos()-5, mother:getZPos());
+        mother:AnimationSub(1);
+    end
+end;
+
+function onMobDeath(mob, player, isKiller)
+end;

--- a/sql/mob_groups.sql
+++ b/sql/mob_groups.sql
@@ -12468,19 +12468,19 @@ INSERT INTO `mob_groups` VALUES (14581,4317,22,1056,0,4127,0,0,54,55,0);  -- Pro
 INSERT INTO `mob_groups` VALUES (14582,4317,22,1056,0,4127,0,0,56,57,0);  -- Promyvion-Vahzl Level 4/5
 
 -- Strays
-INSERT INTO `mob_groups` VALUES (14583,3784,16,330,128,0,0,0,19,23,0);  -- Promyvion-Holla Level 1
-INSERT INTO `mob_groups` VALUES (14584,3784,16,330,128,0,0,0,23,27,0);  -- Promyvion-Holla Level 2
-INSERT INTO `mob_groups` VALUES (14585,3784,16,330,128,0,0,0,27,31,0);  -- Promyvion-Holla Level 3
-INSERT INTO `mob_groups` VALUES (14586,3784,18,330,128,0,0,0,19,23,0);  -- Promyvion-Dem Level 1
-INSERT INTO `mob_groups` VALUES (14587,3784,18,330,128,0,0,0,23,27,0);  -- Promyvion-Dem Level 2
-INSERT INTO `mob_groups` VALUES (14588,3784,18,330,128,0,0,0,27,31,0);  -- Promyvion-Dem Level 3
-INSERT INTO `mob_groups` VALUES (14589,3784,20,330,128,0,0,0,19,23,0);  -- Promyvion-Mea Level 1
-INSERT INTO `mob_groups` VALUES (14590,3784,20,330,128,0,0,0,23,27,0);  -- Promyvion-Mea Level 2
-INSERT INTO `mob_groups` VALUES (14591,3784,20,330,128,0,0,0,27,31,0);  -- Promyvion-Mea Level 3
-INSERT INTO `mob_groups` VALUES (14592,3784,22,330,128,0,0,0,39,42,0);  -- Promyvion-Vahzl Level 1
-INSERT INTO `mob_groups` VALUES (14593,3784,22,330,128,0,0,0,42,45,0);  -- Promyvion-Vahzl Level 2
-INSERT INTO `mob_groups` VALUES (14594,3784,22,330,128,0,0,0,45,48,0);  -- Promyvion-Vahzl Level 3
-INSERT INTO `mob_groups` VALUES (14595,3784,22,330,128,0,0,0,48,51,0);  -- Promyvion-Vahzl Level 4
+INSERT INTO `mob_groups` VALUES (14583,3784,16,330,0,0,0,0,19,23,0);  -- Promyvion-Holla Level 1
+INSERT INTO `mob_groups` VALUES (14584,3784,16,330,0,0,0,0,23,27,0);  -- Promyvion-Holla Level 2
+INSERT INTO `mob_groups` VALUES (14585,3784,16,330,0,0,0,0,27,31,0);  -- Promyvion-Holla Level 3
+INSERT INTO `mob_groups` VALUES (14586,3784,18,330,0,0,0,0,19,23,0);  -- Promyvion-Dem Level 1
+INSERT INTO `mob_groups` VALUES (14587,3784,18,330,0,0,0,0,23,27,0);  -- Promyvion-Dem Level 2
+INSERT INTO `mob_groups` VALUES (14588,3784,18,330,0,0,0,0,27,31,0);  -- Promyvion-Dem Level 3
+INSERT INTO `mob_groups` VALUES (14589,3784,20,330,0,0,0,0,19,23,0);  -- Promyvion-Mea Level 1
+INSERT INTO `mob_groups` VALUES (14590,3784,20,330,0,0,0,0,23,27,0);  -- Promyvion-Mea Level 2
+INSERT INTO `mob_groups` VALUES (14591,3784,20,330,0,0,0,0,27,31,0);  -- Promyvion-Mea Level 3
+INSERT INTO `mob_groups` VALUES (14592,3784,22,330,0,0,0,0,39,42,0);  -- Promyvion-Vahzl Level 1
+INSERT INTO `mob_groups` VALUES (14593,3784,22,330,0,0,0,0,42,45,0);  -- Promyvion-Vahzl Level 2
+INSERT INTO `mob_groups` VALUES (14594,3784,22,330,0,0,0,0,45,48,0);  -- Promyvion-Vahzl Level 3
+INSERT INTO `mob_groups` VALUES (14595,3784,22,330,0,0,0,0,48,51,0);  -- Promyvion-Vahzl Level 4
 
 
 -- Seethers


### PR DESCRIPTION
Strays no longer drop gil
Strays spawn every 5.5 minutes if MR is not engaged
Strays spawn in 20 second intervals if MR is engaged
Strays spawn at MR location and move outward

Addresses #433, #4201, and #4257 .

edit: and before anyone says "why does the MR spawn a stray immediately when engaged, instead of waiting 20 seconds", I considered this, and decided that resetting the 20 second timer onMobEngaged is problematic because on DSP mobs deaggro quickly when they're not smacking you.  MRs have no autoattack, so if you aren't meleeing them, they go white quickly, which would then reset the timer when someone nukes it, and a stray would never spawn during the fight.