### PR TITLE
Synthesis Fail Patch

### DIFF
--- a/src/map/utils/synthutils.cpp
+++ b/src/map/utils/synthutils.cpp
@@ -711,8 +711,8 @@ int32 doSynthFail(CCharEntity* PChar)
 				}
 			}
 			invSlotID  = nextSlotID;
-			nextSlotID = 0;
 		}
+                nextSlotID = 0;
 		if(invSlotID == 0xFF)
 			break;
 	}

--- a/src/map/utils/synthutils.cpp
+++ b/src/map/utils/synthutils.cpp
@@ -712,7 +712,7 @@ int32 doSynthFail(CCharEntity* PChar)
 			}
 			invSlotID  = nextSlotID;
 		}
-                nextSlotID = 0;
+			nextSlotID = 0;
 		if(invSlotID == 0xFF)
 			break;
 	}

--- a/src/map/utils/synthutils.cpp
+++ b/src/map/utils/synthutils.cpp
@@ -712,7 +712,7 @@ int32 doSynthFail(CCharEntity* PChar)
 			}
 			invSlotID  = nextSlotID;
 		}
-			nextSlotID = 0;
+		nextSlotID = 0;
 		if(invSlotID == 0xFF)
 			break;
 	}


### PR DESCRIPTION
Fixes issue where failed synth would cause items to remain locked and would not remove quantity. Players would end up zoning or login/logout to resolve issue.