### PR TITLE
Fixes related to Dynamis currency goblin NPCs

### DIFF
--- a/scripts/globals/settings.lua
+++ b/scripts/globals/settings.lua
@@ -96,7 +96,8 @@ LandKingSystem_HQ = 0;
     BETWEEN_2DYNA_WAIT_TIME = 1;        -- wait time between 2 Dynamis (in real day) min: 1 day
         DYNA_MIDNIGHT_RESET = true;     -- if true, makes the wait time count by number of server midnights instead of full 24 hour intervals
              DYNA_LEVEL_MIN = 65;       -- level min for entering in Dynamis
-    TIMELESS_HOURGLASS_COST = 500000;   -- cost of the timeless hourglass for Dynamis.
+    TIMELESS_HOURGLASS_COST = 500000;   -- refund for the timeless hourglass for Dynamis.
+   PRISMATIC_HOURGLASS_COST = 50000;    -- cost of the prismatic hourglass for Dynamis.
      CURRENCY_EXCHANGE_RATE = 100;      -- X Tier 1 ancient currency -> 1 Tier 2, and so on.  Certain values may conflict with shop items.  Not designed to exceed 198.
 RELIC_2ND_UPGRADE_WAIT_TIME = 604800;      -- wait time for 2nd relic upgrade (stage 2 -> stage 3) in seconds. 604800s = 1 RL week.
 RELIC_3RD_UPGRADE_WAIT_TIME = 295200;      -- wait time for 3rd relic upgrade (stage 3 -> stage 4) in seconds. 295200s = 82 hours.

--- a/scripts/zones/Beadeaux/TextIDs.lua
+++ b/scripts/zones/Beadeaux/TextIDs.lua
@@ -5,6 +5,7 @@ ITEM_CANNOT_BE_OBTAINED = 6381; -- You cannot obtain the item <item>. Come back 
           ITEM_OBTAINED = 6387; -- Obtained: <item>.
            GIL_OBTAINED = 6388; -- Obtained <number> gil.
        KEYITEM_OBTAINED = 6390; -- Obtained key item: <keyitem>.
+         NOT_ENOUGH_GIL = 6392; -- You do not have enough gil.
          ITEMS_OBTAINED = 6393; -- You obtain <param2 number> <param1 item>!
 
 -- Treasure Coffer/Chest Dialog

--- a/scripts/zones/Castle_Oztroja/TextIDs.lua
+++ b/scripts/zones/Castle_Oztroja/TextIDs.lua
@@ -6,6 +6,7 @@ FULL_INVENTORY_AFTER_TRADE = 6570; -- You cannot obtain the #. Try trading again
              ITEM_OBTAINED = 6572; -- Obtained: <item>.
               GIL_OBTAINED = 6573; -- Obtained <number> gil.
           KEYITEM_OBTAINED = 6575; -- Obtained key item: <keyitem>.
+            NOT_ENOUGH_GIL = 6577; -- You do not have enough gil.
             ITEMS_OBTAINED = 6578; -- You obtain
     FISHING_MESSAGE_OFFSET = 7252; -- You can't fish here.
 

--- a/scripts/zones/Castle_Oztroja/npcs/Antiqix.lua
+++ b/scripts/zones/Castle_Oztroja/npcs/Antiqix.lua
@@ -6,171 +6,185 @@
 -----------------------------------
 package.loaded["scripts/zones/Castle_Oztroja/TextIDs"] = nil;
 -----------------------------------
-
 require("scripts/zones/Castle_Oztroja/TextIDs");
-require("scripts/globals/settings");
 require("scripts/globals/keyitems");
+require("scripts/globals/settings");
 require("scripts/globals/dynamis");
 
------------------------------------
--- onTrade Action
------------------------------------
+local TIMELESS_HOURGLASS = 4236;
+local currency = {1449,1450,1451};
+local shop = {
+     7, 1312, -- Angel Skin
+     8, 1518, -- Colossal Skull
+     9, 1464, -- Lancewood Log
+    23, 1463, -- Chronos Tooth
+    24, 1467, -- Relic Steel
+    25, 1462, -- Lancewood Lumber
+    28, 658,  -- Damascus Ingot
+}
+local maps = {
+    [MAP_OF_DYNAMIS_SANDORIA]   = 10000,
+    [MAP_OF_DYNAMIS_BASTOK]     = 10000,
+    [MAP_OF_DYNAMIS_WINDURST]   = 10000,
+    [MAP_OF_DYNAMIS_JEUNO]      = 10000,
+    [MAP_OF_DYNAMIS_BEAUCEDINE] = 15000,
+    [MAP_OF_DYNAMIS_XARCABARD]  = 20000,
+    [MAP_OF_DYNAMIS_VALKURM]    = 10000,
+    [MAP_OF_DYNAMIS_BUBURIMU]   = 10000,
+    [MAP_OF_DYNAMIS_QUFIM]      = 10000,
+    [MAP_OF_DYNAMIS_TAVNAZIA]   = 20000,
+}
 
 function onTrade(player,npc,trade)
-   local count = trade:getItemCount();
-   local buying = false;
-   local exchange;
-   local gil = trade:getGil();
+    local gil = trade:getGil();
+    local count = trade:getItemCount();
 
-   if (player:hasKeyItem(VIAL_OF_SHROUDED_SAND) == true) then
-      if (count == 1 and gil == TIMELESS_HOURGLASS_COST) then -- Hourglass purchase
-         player:startEvent(54);
-      elseif (gil == 0) then
-         if (count == 1 and trade:hasItemQty(4236,1)) then -- Bringing back a Timeless Hourglass
+    if (player:hasKeyItem(VIAL_OF_SHROUDED_SAND)) then
+
+        -- buy prismatic hourglass
+        if (gil == PRISMATIC_HOURGLASS_COST and count == 1 and not player:hasKeyItem(PRISMATIC_HOURGLASS)) then
+            player:startEvent(54);
+
+        -- return timeless hourglass for refund
+        elseif (count == 1 and trade:hasItemQty(TIMELESS_HOURGLASS,1)) then
             player:startEvent(97);
 
-         -- Currency Exchanges
-         elseif (count == CURRENCY_EXCHANGE_RATE and trade:hasItemQty(1449,CURRENCY_EXCHANGE_RATE)) then -- Single -> Hundred
+        -- currency exchanges
+        elseif (count == CURRENCY_EXCHANGE_RATE and trade:hasItemQty(currency[1],CURRENCY_EXCHANGE_RATE)) then
             player:startEvent(55,CURRENCY_EXCHANGE_RATE);
-         elseif (count == CURRENCY_EXCHANGE_RATE and trade:hasItemQty(1450,CURRENCY_EXCHANGE_RATE)) then -- Hundred -> Ten thousand
+        elseif (count == CURRENCY_EXCHANGE_RATE and trade:hasItemQty(currency[2],CURRENCY_EXCHANGE_RATE)) then
             player:startEvent(56,CURRENCY_EXCHANGE_RATE);
-         elseif (count == 1 and trade:hasItemQty(1451,1)) then -- Ten thousand -> 100 Hundreds
-            player:startEvent(58,1451,1450,CURRENCY_EXCHANGE_RATE);
+        elseif (count == 1 and trade:hasItemQty(currency[3],1)) then
+            player:startEvent(58,currency[3],currency[2],CURRENCY_EXCHANGE_RATE);
 
-         -- Currency Shop
-         elseif (count == 7 and trade:hasItemQty(1450,7)) then -- Angel Skin (1312)
-            buying = true;
-            exchange = {7, 1312};
-         elseif (count == 23 and trade:hasItemQty(1450,23)) then -- Chronos Tooth (1463)
-            buying = true;
-            exchange = {23,1463};
-         elseif (count == 8 and trade:hasItemQty(1450,8)) then -- Colossal Skull (1518)
-            buying = true;
-            exchange = {8, 1518};
-         elseif (count == 28 and trade:hasItemQty(1450,28)) then -- Damascus Ingot (658)
-            buying = true;
-            exchange = {28, 658};
-         elseif (count == 9 and trade:hasItemQty(1450,9)) then -- Lancewood Log (1464)
-            buying = true;
-            exchange = {9, 1464};
-         elseif (count == 25 and trade:hasItemQty(1450,25)) then -- Lancewood Lumber (1462)
-            buying = true;
-            exchange = {25, 1462};
-         elseif (count == 24 and trade:hasItemQty(1450,24)) then -- Relic Steel (1467)
-            buying = true;
-            exchange = {24, 1467};
-         end
-      end
-   end
+        -- shop
+        else
+            local item;
+            local price;
+            for i=1,13,2 do
+                price = shop[i];
+                item = shop[i+1];
+                if (count == price and trade:hasItemQty(currency[2],price)) then
+                    player:setLocalVar("hundoItemBought", item);
+                    player:startEvent(57,currency[2],price,item);
+                    break;
+                end
+            end
 
-   -- Handle the shop trades.
-   -- Item obtained dialog appears before CS.  Could be fixed with a non-local variable and onEventFinish, but meh.
-   if (buying == true) then
-      if (player:getFreeSlotsCount() == 0) then
-         player:messageSpecial(ITEM_CANNOT_BE_OBTAINED,exchange[2]);
-      else
-         player:startEvent(57,1450,exchange[1],exchange[2]);
-         player:tradeComplete();
-         player:addItem(exchange[2]);
-         player:messageSpecial(ITEM_OBTAINED,exchange[2]);
-      end
-   end
+        end
+    end
 end;
-
------------------------------------
--- onTrigger Action
------------------------------------
 
 function onTrigger(player,npc)
-   if (player:hasKeyItem(VIAL_OF_SHROUDED_SAND) == true) then
-      player:startEvent(53, 1449, CURRENCY_EXCHANGE_RATE, 1450, CURRENCY_EXCHANGE_RATE, 1451, TIMELESS_HOURGLASS_COST, 4236, TIMELESS_HOURGLASS_COST);
-   else
-      player:startEvent(50);
-   end
+    if (player:hasKeyItem(VIAL_OF_SHROUDED_SAND)) then
+        player:startEvent(53, currency[1], CURRENCY_EXCHANGE_RATE, currency[2], CURRENCY_EXCHANGE_RATE, currency[3], PRISMATIC_HOURGLASS_COST, TIMELESS_HOURGLASS, TIMELESS_HOURGLASS_COST);
+    else
+        player:startEvent(50);
+    end
 end;
-
------------------------------------
--- onEventUpdate
------------------------------------
 
 function onEventUpdate(player,csid,option)
-   -- printf("Update CSID: %u",csid);
-   -- printf("Update RESULT: %u",option);
-   if (csid == 53) then
-      if (option == 11) then -- Main menu, and many others.  Param1 = map bitmask, param2 = player's gil
-         player:updateEvent(getDynamisMapList(player), player:getGil());
-      elseif (option == 10) then -- Final line of the ancient currency explanation.  "I'll trade you param3 param2s for a param1."
-         player:updateEvent(1451, 1450, CURRENCY_EXCHANGE_RATE);
+    if (csid == 53) then
 
-      -- Map sales handling.
-      elseif (option >= MAP_OF_DYNAMIS_SANDORIA and option <= MAP_OF_DYNAMIS_TAVNAZIA) then
-         -- The returned option is actually the keyitem ID, making this much easier.
-         -- The prices are set in the menu's dialog, so they cannot be (visibly) changed.
-         if (option == MAP_OF_DYNAMIS_BEAUCEDINE) then -- 15k gil
-            player:delGil(15000);
-         elseif (option == MAP_OF_DYNAMIS_XARCABARD or option == MAP_OF_DYNAMIS_TAVNAZIA) then -- 20k gil
-            player:delGil(20000);
-         else -- All others 10k
-            player:delGil(10000);
-         end
-         player:addKeyItem(option);
-         player:updateEvent(getDynamisMapList(player),player:getGil());
+        -- asking about hourglasses
+        if (option == 1) then
+            if (not player:hasItem(TIMELESS_HOURGLASS)) then
+                -- must figure out what changes here to prevent the additional dialog
+                -- player:updateEvent(?);
+            end
 
-      -- Ancient Currency shop menu
-      elseif (option == 2) then -- Hundreds sales menu Page 1 (price1 item1 price2 item2 price3 item3 price4 item4)
-         player:updateEvent(7,1312,23,1463,8,1518,28,658);
-      elseif (option == 3) then -- Hundreds sales menu Page 2 (price1 item1 price2 item2 price3 item3)
-         player:updateEvent(9,1464,25,1462,24,1467);
-      end
-   end
+        -- shop
+        elseif (option == 2) then
+            player:updateEvent(unpack(shop,1,8));
+        elseif (option == 3) then
+            player:updateEvent(unpack(shop,9,14));
+
+        -- offer to trade down from a 10k
+        elseif (option == 10) then
+            player:updateEvent(currency[3], currency[2], CURRENCY_EXCHANGE_RATE);
+
+        -- main menu (param1 = dynamis map bitmask, param2 = gil)
+        elseif (option == 11) then
+            player:updateEvent(getDynamisMapList(player), player:getGil());
+
+        -- maps
+        elseif (maps[option] ~= nil) then
+            local price = maps[option];
+            if (price > player:getGil()) then
+                player:messageSpecial(NOT_ENOUGH_GIL);
+            else
+                player:delGil(price);
+                player:addKeyItem(option);
+                player:messageSpecial(KEYITEM_OBTAINED, option);
+            end
+            player:updateEvent(getDynamisMapList(player),player:getGil());
+
+        end
+    end
 end;
 
------------------------------------
--- onEventFinish
------------------------------------
-
 function onEventFinish(player,csid,option)
-   -- printf("Finish CSID: %u",csid);
-   -- printf("Finish RESULT: %u",option);
 
-   if (csid == 54) then -- Buying an Hourglass
-      if (player:getFreeSlotsCount() == 0 or player:hasItem(4236) == true) then
-         player:messageSpecial(ITEM_CANNOT_BE_OBTAINED,4236);
-      else
-         player:tradeComplete();
-         player:addItem(4236);
-         player:messageSpecial(ITEM_OBTAINED,4236);
-      end
-   elseif (csid == 97) then -- Bringing back an hourglass for gil.
-      player:tradeComplete();
-      player:addGil(TIMELESS_HOURGLASS_COST);
-      player:messageSpecial(GIL_OBTAINED,TIMELESS_HOURGLASS_COST);
-   elseif (csid == 55) then -- Trading Singles for a Hundred
-      if (player:getFreeSlotsCount() == 0) then
-         player:messageSpecial(ITEM_CANNOT_BE_OBTAINED,1450);
-      else
-         player:tradeComplete();
-         player:addItem(1450);
-         player:messageSpecial(ITEM_OBTAINED,1450);
-      end
-   elseif (csid == 56) then -- Trading 100 Hundreds for Ten thousand
-      if (player:getFreeSlotsCount() == 0) then
-         player:messageSpecial(ITEM_CANNOT_BE_OBTAINED,1451);
-      else
-         player:tradeComplete();
-         player:addItem(1451);
-         player:messageSpecial(ITEM_OBTAINED,1451);
-      end
-   elseif (csid == 58) then -- Trading Ten thousand for 100 Hundreds
-      if (player:getFreeSlotsCount() <= 1) then
-         player:messageSpecial(ITEM_CANNOT_BE_OBTAINED,1450);
-      else
-         player:tradeComplete();
-         player:addItem(1450,CURRENCY_EXCHANGE_RATE);
-         if (CURRENCY_EXCHANGE_RATE >= 100) then -- Turns out addItem cannot add > stackSize, so we need to addItem twice for quantities > 99.
-            player:addItem(1450,CURRENCY_EXCHANGE_RATE - 99);
-         end
-         player:messageSpecial(ITEMS_OBTAINED,1450,CURRENCY_EXCHANGE_RATE);
-      end
+    -- bought prismatic hourglass
+    if (csid == 54) then
+        player:tradeComplete();
+        player:addKeyItem(PRISMATIC_HOURGLASS);
+        player:messageSpecial(KEYITEM_OBTAINED,PRISMATIC_HOURGLASS);
+
+    -- refund timeless hourglass
+    elseif (csid == 97) then
+        player:tradeComplete();
+        player:addGil(TIMELESS_HOURGLASS_COST);
+        player:messageSpecial(GIL_OBTAINED,TIMELESS_HOURGLASS_COST);
+
+    -- singles to hundos
+    elseif (csid == 55) then
+        if (player:getFreeSlotsCount() == 0) then
+            player:messageSpecial(ITEM_CANNOT_BE_OBTAINED,currency[2]);
+        else
+            player:tradeComplete();
+            player:addItem(currency[2]);
+            player:messageSpecial(ITEM_OBTAINED,currency[2]);
+        end
+        
+    -- hundos to 10k pieces
+    elseif (csid == 56) then
+        if (player:getFreeSlotsCount() == 0) then
+            player:messageSpecial(ITEM_CANNOT_BE_OBTAINED,currency[3]);
+        else
+            player:tradeComplete();
+            player:addItem(currency[3]);
+            player:messageSpecial(ITEM_OBTAINED,currency[3]);
+        end
+        
+    -- 10k pieces to hundos
+    elseif (csid == 58) then
+        local slotsReq = math.ceil(CURRENCY_EXCHANGE_RATE / 99);
+        if (player:getFreeSlotsCount() < slotsReq) then
+            player:messageSpecial(ITEM_CANNOT_BE_OBTAINED,currency[2]);
+        else
+            player:tradeComplete();
+            for i=1,slotsReq do
+                if (i < slotsReq or (CURRENCY_EXCHANGE_RATE % 99) == 0) then
+                    player:addItem(currency[2],CURRENCY_EXCHANGE_RATE);
+                else
+                    player:addItem(currency[2],CURRENCY_EXCHANGE_RATE % 99);
+                end
+            end
+            player:messageSpecial(ITEMS_OBTAINED,currency[2],CURRENCY_EXCHANGE_RATE);
+        end
+
+    -- bought item from shop
+    elseif (csid == 57) then
+        local item = player:getLocalVar("hundoItemBought");
+        if (player:getFreeSlotsCount() == 0) then
+            player:messageSpecial(ITEM_CANNOT_BE_OBTAINED,item);
+        else
+            player:tradeComplete();
+            player:addItem(item);
+            player:messageSpecial(ITEM_OBTAINED,item);
+        end
+        player:setLocalVar("hundoItemBought", 0);
+
    end
 end;

--- a/scripts/zones/Davoi/TextIDs.lua
+++ b/scripts/zones/Davoi/TextIDs.lua
@@ -5,6 +5,7 @@ ITEM_CANNOT_BE_OBTAINED = 6381; -- You cannot obtain the item <item>. Come back 
           ITEM_OBTAINED = 6387; -- Obtained: <item>.
            GIL_OBTAINED = 6388; -- Obtained <number> gil.
        KEYITEM_OBTAINED = 6390; -- Obtained key item: <keyitem>.
+         NOT_ENOUGH_GIL = 6392; -- You do not have enough gil.
          ITEMS_OBTAINED = 6393; -- You obtain
  FISHING_MESSAGE_OFFSET = 7207; -- You can't fish here.
 

--- a/scripts/zones/Davoi/npcs/Lootblox.lua
+++ b/scripts/zones/Davoi/npcs/Lootblox.lua
@@ -6,172 +6,185 @@
 -----------------------------------
 package.loaded["scripts/zones/Davoi/TextIDs"] = nil;
 -----------------------------------
-
 require("scripts/zones/Davoi/TextIDs");
-require("scripts/globals/settings");
 require("scripts/globals/keyitems");
+require("scripts/globals/settings");
 require("scripts/globals/dynamis");
 
------------------------------------
--- onTrade Action
------------------------------------
+local TIMELESS_HOURGLASS = 4236;
+local currency = {1452,1453,1454};
+local shop = {
+     5, 1295, -- Twincoon
+     6, 1466, -- Relic Iron
+     7, 1520, -- Goblin Grease
+     8, 1516, -- Griffon Hide
+    23, 1459, -- Griffon Leather
+    25, 883,  -- Behemoth Horn
+    28, 1458, -- Mammoth Tusk
+}
+local maps = {
+    [MAP_OF_DYNAMIS_SANDORIA]   = 10000,
+    [MAP_OF_DYNAMIS_BASTOK]     = 10000,
+    [MAP_OF_DYNAMIS_WINDURST]   = 10000,
+    [MAP_OF_DYNAMIS_JEUNO]      = 10000,
+    [MAP_OF_DYNAMIS_BEAUCEDINE] = 15000,
+    [MAP_OF_DYNAMIS_XARCABARD]  = 20000,
+    [MAP_OF_DYNAMIS_VALKURM]    = 10000,
+    [MAP_OF_DYNAMIS_BUBURIMU]   = 10000,
+    [MAP_OF_DYNAMIS_QUFIM]      = 10000,
+    [MAP_OF_DYNAMIS_TAVNAZIA]   = 20000,
+}
 
 function onTrade(player,npc,trade)
-   local count = trade:getItemCount();
-   local buying = false;
-   local exchange;
-   local gil = trade:getGil();
+    local gil = trade:getGil();
+    local count = trade:getItemCount();
 
-   if (player:hasKeyItem(VIAL_OF_SHROUDED_SAND) == true) then
-      if (count == 1 and gil == TIMELESS_HOURGLASS_COST) then -- Hourglass purchase
-         player:startEvent(134);
-      elseif (gil == 0) then
-         if (count == 1 and trade:hasItemQty(4236,1)) then -- Bringing back a Timeless Hourglass
+    if (player:hasKeyItem(VIAL_OF_SHROUDED_SAND)) then
+
+        -- buy prismatic hourglass
+        if (gil == PRISMATIC_HOURGLASS_COST and count == 1 and not player:hasKeyItem(PRISMATIC_HOURGLASS)) then
+            player:startEvent(134);
+
+        -- return timeless hourglass for refund
+        elseif (count == 1 and trade:hasItemQty(TIMELESS_HOURGLASS,1)) then
             player:startEvent(153);
 
-         -- Currency Exchanges
-         elseif (count == CURRENCY_EXCHANGE_RATE and trade:hasItemQty(1452,CURRENCY_EXCHANGE_RATE)) then -- Single -> Hundred
+        -- currency exchanges
+        elseif (count == CURRENCY_EXCHANGE_RATE and trade:hasItemQty(currency[1],CURRENCY_EXCHANGE_RATE)) then
             player:startEvent(135,CURRENCY_EXCHANGE_RATE);
-         elseif (count == CURRENCY_EXCHANGE_RATE and trade:hasItemQty(1453,CURRENCY_EXCHANGE_RATE)) then -- Hundred -> Ten thousand
+        elseif (count == CURRENCY_EXCHANGE_RATE and trade:hasItemQty(currency[2],CURRENCY_EXCHANGE_RATE)) then
             player:startEvent(136,CURRENCY_EXCHANGE_RATE);
-         elseif (count == 1 and trade:hasItemQty(1454,1)) then -- Ten thousand -> 100 Hundreds
-            player:startEvent(138,1454,1453,CURRENCY_EXCHANGE_RATE);
+        elseif (count == 1 and trade:hasItemQty(currency[3],1)) then
+            player:startEvent(138,currency[3],currency[2],CURRENCY_EXCHANGE_RATE);
 
-         -- Currency Shop
-         elseif (count == 25 and trade:hasItemQty(1453,25)) then -- Behemoth Horn (833)
-            buying = true;
-            exchange = {25, 833};
-         elseif (count == 7 and trade:hasItemQty(1453,7)) then -- Goblin Grease (1520)
-            buying = true;
-            exchange = {7,1520};
-         elseif (count == 8 and trade:hasItemQty(1453,8)) then -- Griffon Hide (1516)
-            buying = true;
-            exchange = {8, 1516};
-         elseif (count == 23 and trade:hasItemQty(1453,23)) then -- Griffon Leather (1459)
-            buying = true;
-            exchange = {23, 1459};
-         elseif (count == 28 and trade:hasItemQty(1453,28)) then -- Mammoth Tusk (1458)
-            buying = true;
-            exchange = {28,1458};
-         elseif (count == 6 and trade:hasItemQty(1453,6)) then -- Relic Iron (1466)
-            buying = true;
-            exchange = {6, 1466};
-         elseif (count == 5 and trade:hasItemQty(1453,5)) then -- Twincoon (1295)
-            buying = true;
-            exchange = {5, 1295};
-         end
-      end
-   end
-
-   -- Handle the shop trades.
-   -- Item obtained dialog appears before CS.  Could be fixed with a non-local variable and onEventFinish, but meh.
-   if (buying == true) then
-      if (player:getFreeSlotsCount() == 0) then
-         player:messageSpecial(ITEM_CANNOT_BE_OBTAINED,exchange[2]);
-      else
-         player:startEvent(137,1453,exchange[1],exchange[2]);
-         player:tradeComplete();
-         player:addItem(exchange[2]);
-         player:messageSpecial(ITEM_OBTAINED,exchange[2]);
-      end
-   end
+        -- shop
+        else
+            local item;
+            local price;
+            for i=1,13,2 do
+                price = shop[i];
+                item = shop[i+1];
+                if (count == price and trade:hasItemQty(currency[2],price)) then
+                    player:setLocalVar("hundoItemBought", item);
+                    player:startEvent(137,currency[2],price,item);
+                    break;
+                end
+            end
+            
+        end
+    end
 end;
-
------------------------------------
--- onTrigger Action
------------------------------------
 
 function onTrigger(player,npc)
-   --if (player:hasKeyItem(VIAL_OF_SHROUDED_SAND) == true) then
-      player:startEvent(133, 1452, CURRENCY_EXCHANGE_RATE, 1453, CURRENCY_EXCHANGE_RATE, 1454, TIMELESS_HOURGLASS_COST, 4236, TIMELESS_HOURGLASS_COST);
-   --[[else
-      player:startEvent(130);
-   end]]
+    if (player:hasKeyItem(VIAL_OF_SHROUDED_SAND)) then
+        player:startEvent(133, currency[1], CURRENCY_EXCHANGE_RATE, currency[2], CURRENCY_EXCHANGE_RATE, currency[3], PRISMATIC_HOURGLASS_COST, TIMELESS_HOURGLASS, TIMELESS_HOURGLASS_COST);
+    else
+        player:startEvent(130);
+    end
 end;
-
------------------------------------
--- onEventUpdate
------------------------------------
 
 function onEventUpdate(player,csid,option)
-    -- printf("CSID: %u",csid);
-    -- printf("RESULT: %u",option);
+    if (csid == 133) then
 
-   if (csid == 133) then
-      if (option == 11) then -- Main menu, and many others.  Param1 = map bitmask, param2 = player's gil
-         player:updateEvent(getDynamisMapList(player), player:getGil());
-      elseif (option == 10) then -- Final line of the ancient currency explanation.  "I'll trade you param3 param2s for a param1."
-         player:updateEvent(1454, 1453, CURRENCY_EXCHANGE_RATE);
+        -- asking about hourglasses
+        if (option == 1) then
+            if (not player:hasItem(TIMELESS_HOURGLASS)) then
+                -- must figure out what changes here to prevent the additional dialog
+                -- player:updateEvent(?);
+            end
 
-      -- Map sales handling.
-      elseif (option >= MAP_OF_DYNAMIS_SANDORIA and option <= MAP_OF_DYNAMIS_TAVNAZIA) then
-         -- The returned option is actually the keyitem ID, making this much easier.
-         -- The prices are set in the menu's dialog, so they cannot be (visibly) changed.
-         if (option == MAP_OF_DYNAMIS_BEAUCEDINE) then -- 15k gil
-            player:delGil(15000);
-         elseif (option == MAP_OF_DYNAMIS_XARCABARD or option == MAP_OF_DYNAMIS_TAVNAZIA) then -- 20k gil
-            player:delGil(20000);
-         else -- All others 10k
-            player:delGil(10000);
-         end
-         player:addKeyItem(option);
-         player:updateEvent(getDynamisMapList(player),player:getGil());
+        -- shop
+        elseif (option == 2) then
+            player:updateEvent(unpack(shop,1,8));
+        elseif (option == 3) then
+            player:updateEvent(unpack(shop,9,14));
+            
+        -- offer to trade down from a 10k
+        elseif (option == 10) then
+            player:updateEvent(currency[3], currency[2], CURRENCY_EXCHANGE_RATE);
+        
+        -- main menu (param1 = dynamis map bitmask, param2 = gil)
+        elseif (option == 11) then
+            player:updateEvent(getDynamisMapList(player), player:getGil());
 
-      -- Ancient Currency shop menu
-      elseif (option == 2) then -- Hundreds sales menu Page 1 (price1 item1 price2 item2 price3 item3 price4 item4)
-         player:updateEvent(25,883,7,1520,8,1516,23,1459);
-      elseif (option == 3) then -- Hundreds sales menu Page 2 (price1 item1 price2 item2 price3 item3)
-         player:updateEvent(28,1458,6,1466,5,1295);
-      end
-   end
+        -- maps
+        elseif (maps[option] ~= nil) then
+            local price = maps[option];
+            if (price > player:getGil()) then
+                player:messageSpecial(NOT_ENOUGH_GIL);
+            else
+                player:delGil(price);
+                player:addKeyItem(option);
+                player:messageSpecial(KEYITEM_OBTAINED, option);
+            end
+            player:updateEvent(getDynamisMapList(player),player:getGil());
+            
+        end
+    end
 end;
 
------------------------------------
--- onEventFinish
------------------------------------
-
 function onEventFinish(player,csid,option)
-    -- printf("CSID: %u",csid);
-    -- printf("RESULT: %u",option);
 
-   if (csid == 134) then -- Buying an Hourglass
-      if (player:getFreeSlotsCount() == 0 or player:hasItem(4236) == true) then
-         player:messageSpecial(ITEM_CANNOT_BE_OBTAINED,4236);
-      else
-         player:tradeComplete();
-         player:addItem(4236);
-         player:messageSpecial(ITEM_OBTAINED,4236);
-      end
-   elseif (csid == 153) then -- Bringing back an hourglass for gil.
-      player:tradeComplete();
-      player:addGil(TIMELESS_HOURGLASS_COST);
-      player:messageSpecial(GIL_OBTAINED,TIMELESS_HOURGLASS_COST);
-   elseif (csid == 135) then -- Trading Singles for a Hundred
-      if (player:getFreeSlotsCount() == 0) then
-         player:messageSpecial(ITEM_CANNOT_BE_OBTAINED,1453);
-      else
-         player:tradeComplete();
-         player:addItem(1453);
-         player:messageSpecial(ITEM_OBTAINED,1453);
-      end
-   elseif (csid == 136) then -- Trading 100 Hundreds for Ten thousand
-      if (player:getFreeSlotsCount() == 0) then
-         player:messageSpecial(ITEM_CANNOT_BE_OBTAINED,1454);
-      else
-         player:tradeComplete();
-         player:addItem(1454);
-         player:messageSpecial(ITEM_OBTAINED,1454);
-      end
-   elseif (csid == 138) then -- Trading Ten thousand for 100 Hundreds
-      if (player:getFreeSlotsCount() <= 1) then
-         player:messageSpecial(ITEM_CANNOT_BE_OBTAINED,1453);
-      else
-         player:tradeComplete();
-         player:addItem(1453,CURRENCY_EXCHANGE_RATE);
-         if (CURRENCY_EXCHANGE_RATE >= 100) then -- Turns out addItem cannot add > stackSize, so we need to addItem twice for quantities > 99.
-            player:addItem(1453,CURRENCY_EXCHANGE_RATE - 99);
-         end
-         player:messageSpecial(ITEMS_OBTAINED,1453,CURRENCY_EXCHANGE_RATE);
-      end
+    -- bought prismatic hourglass
+    if (csid == 134) then
+        player:tradeComplete();
+        player:addKeyItem(PRISMATIC_HOURGLASS);
+        player:messageSpecial(KEYITEM_OBTAINED,PRISMATIC_HOURGLASS);
+
+    -- refund timeless hourglass
+    elseif (csid == 153) then
+        player:tradeComplete();
+        player:addGil(TIMELESS_HOURGLASS_COST);
+        player:messageSpecial(GIL_OBTAINED,TIMELESS_HOURGLASS_COST);
+
+    -- singles to hundos
+    elseif (csid == 135) then
+        if (player:getFreeSlotsCount() == 0) then
+            player:messageSpecial(ITEM_CANNOT_BE_OBTAINED,currency[2]);
+        else
+            player:tradeComplete();
+            player:addItem(currency[2]);
+            player:messageSpecial(ITEM_OBTAINED,currency[2]);
+        end
+        
+    -- hundos to 10k pieces
+    elseif (csid == 136) then
+        if (player:getFreeSlotsCount() == 0) then
+            player:messageSpecial(ITEM_CANNOT_BE_OBTAINED,currency[3]);
+        else
+            player:tradeComplete();
+            player:addItem(currency[3]);
+            player:messageSpecial(ITEM_OBTAINED,currency[3]);
+        end
+        
+    -- 10k pieces to hundos
+    elseif (csid == 138) then
+        local slotsReq = math.ceil(CURRENCY_EXCHANGE_RATE / 99);
+        if (player:getFreeSlotsCount() < slotsReq) then
+            player:messageSpecial(ITEM_CANNOT_BE_OBTAINED,currency[2]);
+        else
+            player:tradeComplete();
+            for i=1,slotsReq do
+                if (i < slotsReq or (CURRENCY_EXCHANGE_RATE % 99) == 0) then
+                    player:addItem(currency[2],CURRENCY_EXCHANGE_RATE);
+                else
+                    player:addItem(currency[2],CURRENCY_EXCHANGE_RATE % 99);
+                end
+            end
+            player:messageSpecial(ITEMS_OBTAINED,currency[2],CURRENCY_EXCHANGE_RATE);
+        end
+
+    -- bought item from shop
+    elseif (csid == 137) then
+        local item = player:getLocalVar("hundoItemBought");
+        if (player:getFreeSlotsCount() == 0) then
+            player:messageSpecial(ITEM_CANNOT_BE_OBTAINED,item);
+        else
+            player:tradeComplete();
+            player:addItem(item);
+            player:messageSpecial(ITEM_OBTAINED,item);
+        end
+        player:setLocalVar("hundoItemBought", 0);
+
    end
 end;


### PR DESCRIPTION
can buy prismatic hourglass rather than timeless
can still refund previously purchased timeless hourglasses
tabled shop items and maps
now handles exchange rates > 198
Lootblox no longer talks to you if you do not have shrouded sand KI
fixed Lootblox shop item ID
item obtained from hundo purchase now occurs after animation

fixes #4283 