### PR TITLE
Re-Engage Delay Option Added to map_darkstar.conf

### DIFF
--- a/conf/map_darkstar.conf
+++ b/conf/map_darkstar.conf
@@ -92,6 +92,9 @@ disable_gear_scaling: 0
 #Enable/disable jobs other than BST and RNG having widescan
 all_jobs_widescan: 1
 
+#Enable/disable re-engage delay when acquiring new targets (1 = enabled; 0 = disabled)
+reengage_delay: 1
+
 #Modifier to apply to player speed. 0 means default speed of 40, where 20 would mean speed 60 or -10 would mean speed 30.
 speed_mod: 0
 

--- a/src/map/ai/controllers/player_controller.cpp
+++ b/src/map/ai/controllers/player_controller.cpp
@@ -69,7 +69,9 @@ bool CPlayerController::Engage(uint16 targid)
     {
         if (distance(PChar->loc.p, PTarget->loc.p) < 30)
         {
-            if (m_LastAttackTime + std::chrono::milliseconds(PChar->GetWeaponDelay(false)) < server_clock::now())
+            auto nextAttack = map_config.reengage_delay ? m_LastAttackTime + std::chrono::milliseconds(PChar->GetWeaponDelay(false)) : m_LastAttackTime;
+
+            if (nextAttack < server_clock::now())
             {
                 if (CController::Engage(targid))
                 {

--- a/src/map/map.h
+++ b/src/map/map.h
@@ -91,6 +91,7 @@ struct map_config_t
     bool   level_sync_enable;         // Enable/disable Level Sync
     bool   disable_gear_scaling;      // Disables ability to equip higher level gear when level cap/sync effect is on player.
     bool   all_jobs_widescan;         // Enable/disable jobs other than BST and RNG having widescan.
+    bool   reengage_delay;            // Enable/disable re-engage delay when acquiring new targets (1=enabled; 0=disabled)
     int8   speed_mod;                 // Modifier to add to player speed
     int8   mob_speed_mod;             // Modifier to add to monster speed
     float  skillup_chance_multiplier; // Constant used in the skillup formula that has a strong effect on skill-up rates


### PR DESCRIPTION
Added ability to set re-engage delay to on or off through the map_config. 1 = on (by default); 0 = off (no delay).