### PR TITLE
Moved some status effect deletion logic around

### DIFF
--- a/src/map/status_effect.h
+++ b/src/map/status_effect.h
@@ -774,6 +774,7 @@ public:
     const int8* GetName();
 
     std::vector<CModifier> modList;    // список модификаторов
+    bool deleted{false};
 
     CStatusEffect(
          EFFECT id,

--- a/src/map/status_effect_container.cpp
+++ b/src/map/status_effect_container.cpp
@@ -429,18 +429,18 @@ bool CStatusEffectContainer::AddStatusEffect(CStatusEffect* PStatusEffect, bool 
 void CStatusEffectContainer::DeleteStatusEffects()
 {
     bool update_icons = false;
-    for(auto effect_iter = m_StatusEffectList.begin(); effect_iter != m_StatusEffectList.end();)
+    for (auto effect_iter = m_StatusEffectList.begin(); effect_iter != m_StatusEffectList.end();)
     {
         auto PStatusEffect = *effect_iter;
-        if(PStatusEffect->deleted)
+        if (PStatusEffect->deleted)
         {
-            if(PStatusEffect->GetStatusID() >= EFFECT_FIRE_MANEUVER &&
+            if (PStatusEffect->GetStatusID() >= EFFECT_FIRE_MANEUVER &&
                 PStatusEffect->GetStatusID() <= EFFECT_DARK_MANEUVER &&
                 m_POwner->objtype == TYPE_PC)
             {
                 puppetutils::CheckAttachmentsForManeuver((CCharEntity*)m_POwner, PStatusEffect->GetStatusID(), false);
             }
-            if(PStatusEffect->GetIcon() != 0)
+            if (PStatusEffect->GetIcon() != 0)
             {
                 update_icons = true;
             }
@@ -458,11 +458,11 @@ void CStatusEffectContainer::DeleteStatusEffects()
     }
     m_POwner->UpdateHealth();
 
-    if(m_POwner->objtype == TYPE_PC)
+    if (m_POwner->objtype == TYPE_PC)
     {
         CCharEntity* PChar = (CCharEntity*)m_POwner;
 
-        if(update_icons)
+        if (update_icons)
         {
             UpdateStatusIcons();
         }
@@ -480,11 +480,11 @@ void CStatusEffectContainer::RemoveStatusEffect(uint32 id, bool silent)
 {
     CStatusEffect* PStatusEffect = m_StatusEffectList.at(id);
     PStatusEffect->deleted = true;
-    if(m_POwner->objtype == TYPE_PC)
+    if (m_POwner->objtype == TYPE_PC)
     {
         CCharEntity* PChar = (CCharEntity*)m_POwner;
 
-        if(PStatusEffect->GetIcon() != 0)
+        if (PStatusEffect->GetIcon() != 0)
         {
             if (!silent)
             {
@@ -494,7 +494,7 @@ void CStatusEffectContainer::RemoveStatusEffect(uint32 id, bool silent)
     }
     else
     {
-        if(silent == false && PStatusEffect->GetIcon() != 0 && ((PStatusEffect->GetFlag() & EFFECTFLAG_NO_LOSS_MESSAGE) == 0) && !m_POwner->isDead())
+        if (silent == false && PStatusEffect->GetIcon() != 0 && ((PStatusEffect->GetFlag() & EFFECTFLAG_NO_LOSS_MESSAGE) == 0) && !m_POwner->isDead())
         {
             m_POwner->loc.zone->PushPacket(m_POwner, CHAR_INRANGE, new CMessageBasicPacket(m_POwner, m_POwner, PStatusEffect->GetIcon(), 0, 206));
         }

--- a/src/map/status_effect_container.h
+++ b/src/map/status_effect_container.h
@@ -116,6 +116,7 @@ private:
 
     // void ReplaceStatusEffect(EFFECT effect); //this needs to be implemented
 	void RemoveStatusEffect(uint32 id, bool silent = false);	// удаляем эффект по его номеру в контейнере
+    void DeleteStatusEffects();
 	void SetEffectParams(CStatusEffect* StatusEffect);			// устанавливаем имя эффекта
 
     void OverwriteStatusEffect(CStatusEffect* StatusEffect);

--- a/src/map/status_effect_container.h
+++ b/src/map/status_effect_container.h
@@ -41,7 +41,7 @@ class CStatusEffectContainer
 {
 public:
 
-    uint64	m_Flags {0};											// биты переполнения байтов m_StatusIcons (по два бита на каждый эффект)
+    uint64	m_Flags{0};											// биты переполнения байтов m_StatusIcons (по два бита на каждый эффект)
     uint8 m_StatusIcons[32];                  // иконки статус-эффектов
 
     bool ApplyBardEffect(CStatusEffect* PStatusEffect, uint8 maxSongs);
@@ -107,21 +107,21 @@ public:
         }
     }
 
-	CStatusEffectContainer(CBattleEntity* PEntity);
-	~CStatusEffectContainer();
+    CStatusEffectContainer(CBattleEntity* PEntity);
+    ~CStatusEffectContainer();
 
 private:
 
-	CBattleEntity* m_POwner;
+    CBattleEntity* m_POwner;
 
     // void ReplaceStatusEffect(EFFECT effect); //this needs to be implemented
-	void RemoveStatusEffect(uint32 id, bool silent = false);	// удаляем эффект по его номеру в контейнере
+    void RemoveStatusEffect(uint32 id, bool silent = false);	// удаляем эффект по его номеру в контейнере
     void DeleteStatusEffects();
-	void SetEffectParams(CStatusEffect* StatusEffect);			// устанавливаем имя эффекта
+    void SetEffectParams(CStatusEffect* StatusEffect);			// устанавливаем имя эффекта
 
     void OverwriteStatusEffect(CStatusEffect* StatusEffect);
 
-	std::vector<CStatusEffect*>	m_StatusEffectList;
+    std::vector<CStatusEffect*>	m_StatusEffectList;
 };
 
 /************************************************************************


### PR DESCRIPTION
RemovedStatusEffect only flags for deletion
New function DeleteStatusEffects actually does the deletion

Can no longer accidentally run into undefined behaviour when deleting an effect
inside OnEffectTick

Fixes #4324 

Additional information:

This technically hasn't always been an issue - must have come about when I moved some effect stuff around.  However, I think that prior to that, it was still undefined behaviour (or wrong behaviour) rather than being a crash.  If I had to guess, some effects ticks would randomly get skipped instead.  So when I changed the effect container, it just made the bug more obvious.

Also, this has a side effect of only sending the effect updating packets once per tick instead of a whole set for each expiring effect (if multiple effects expire on the same tick)