### PR TITLE
Fixed a crash when CMagicState's target was null

### DIFF
--- a/src/map/entities/battleentity.cpp
+++ b/src/map/entities/battleentity.cpp
@@ -1307,7 +1307,7 @@ void CBattleEntity::OnCastInterrupted(CMagicState& state, action_t& action, MSGB
         actionTarget.messageID = 0;
         actionTarget.animation = PSpell->getAnimationID();
 
-        loc.zone->PushPacket(this, CHAR_INRANGE_SELF, new CMessageBasicPacket(this, state.GetTarget(), 0, 0, msg));
+        loc.zone->PushPacket(this, CHAR_INRANGE_SELF, new CMessageBasicPacket(this, state.GetTarget() ? state.GetTarget() : this, 0, 0, msg));
     }
 }
 

--- a/src/map/entities/charentity.cpp
+++ b/src/map/entities/charentity.cpp
@@ -709,7 +709,7 @@ void CCharEntity::OnCastInterrupted(CMagicState& state, action_t& action, MSGBAS
 
     if (message)
     {
-        static_cast<CCharEntity*>(this)->pushPacket(message);
+        pushPacket(message);
     }
 }
 


### PR DESCRIPTION
Not sure which spells cause this, I didn't think it could ever be null