### PR TITLE
Fix script errors in shadowlord bcnm

### DIFF
--- a/scripts/zones/Throne_Room/bcnms/shadow_lord_battle.lua
+++ b/scripts/zones/Throne_Room/bcnms/shadow_lord_battle.lua
@@ -45,7 +45,7 @@ end;
 
 function onEventFinish(player,csid,option)
     -- print("bc finish csid "..csid.." and option "..option);
-    if (csid == 7d01) then
+    if (csid == 32001) then
         if (player:getCurrentMission(player:getNation()) == 15 and player:getVar("MissionStatus") == 3) then
             if ((not player:hasCompletedMission(ZILART, THE_NEW_FRONTIER)) and (player:getCurrentMission(ZILART) ~= THE_NEW_FRONTIER)) then
                 -- Don't add missions we already completed..Players who change nation will hit this.
@@ -54,9 +54,9 @@ function onEventFinish(player,csid,option)
             player:startEvent(7);
         end
     elseif (csid==7) then
-        player:setPos(378, -12, -20, 125, 0xA1);
         player:addKeyItem(SHADOW_FRAGMENT);
         player:messageSpecial(KEYITEM_OBTAINED,SHADOW_FRAGMENT);
         player:setVar("MissionStatus",4);
+        player:setPos(378, -12, -20, 125, 161);
     end
 end;


### PR DESCRIPTION
1. Bad number (hex to dec fail)
And drumroll:
2. ..you can't do things to a character after you've zoned them out