### PR TITLE
Fix extra zero's in regain on an ATMA effect

### DIFF
--- a/scripts/globals/atma.lua
+++ b/scripts/globals/atma.lua
@@ -50,7 +50,7 @@ function atmaEffectGain(target, effect)
     elseif (pwr == 11) then -- ATMA_OF_THE_VORACIOUS_VIOLET
         target:addMod(MOD_STR, 50);
         target:addMod(MOD_DOUBLE_ATTACK, 10);
-        target:addMod(MOD_REGAIN, 200);
+        target:addMod(MOD_REGAIN, 20);
     elseif (pwr == 12) then -- ATMA_OF_CLOAK_AND_DAGGER
         target:addMod(MOD_ACC, 40);
         target:addMod(MOD_EVA, 40);
@@ -454,7 +454,7 @@ function atmaEffectLose(target, effect)
     elseif (pwr == 11) then -- ATMA_OF_THE_VORACIOUS_VIOLET
         target:delMod(MOD_STR, 50);
         target:delMod(MOD_DOUBLE_ATTACK, 10);
-        target:delMod(MOD_REGAIN, 200);
+        target:delMod(MOD_REGAIN, 20);
     elseif (pwr == 12) then -- ATMA_OF_CLOAK_AND_DAGGER
         target:delMod(MOD_ACC, 40);
         target:delMod(MOD_EVA, 40);


### PR DESCRIPTION
apparently ffxiclopedia got updated but BG didn't, which is super unusual! so it got an extra zero it shouldn't have when I updated these last.

https://www.bg-wiki.com/index.php?title=Atma_of_the_Voracious_Violet&oldid=158791

http://ffxiclopedia.wikia.com/wiki/Atma_of_the_Voracious_Violet?oldid=1496976