### PR TITLE
Don't show player CS event about killing Quadav if they missed getting the CS at Iron Eater in Bastok that directs them here..

### DIFF
--- a/scripts/zones/Pashhow_Marshlands/Zone.lua
+++ b/scripts/zones/Pashhow_Marshlands/Zone.lua
@@ -4,45 +4,43 @@
 --
 -----------------------------------
 package.loaded[ "scripts/zones/Pashhow_Marshlands/TextIDs"] = nil;
-package.loaded[ "scripts/globals/missions"] = nil;
-package.loaded["scripts/globals/chocobo_digging"] = nil;
 -----------------------------------
-
-require("scripts/globals/zone");
-require("scripts/globals/settings");
-require("scripts/globals/missions");
-require("scripts/globals/quests");
 require("scripts/zones/Pashhow_Marshlands/TextIDs");
 require("scripts/globals/icanheararainbow");
-require("scripts/globals/conquest");
 require("scripts/globals/chocobo_digging");
+require("scripts/globals/conquest");
+require("scripts/globals/missions");
+require("scripts/globals/settings");
+require("scripts/globals/quests");
+require("scripts/globals/zone");
 
 -----------------------------------
 -- Chocobo Digging vars
 -----------------------------------
-local itemMap = {
-                    -- itemid, abundance, requirement
-                    { 846, 216, DIGREQ_NONE },
-                    { 17296, 210, DIGREQ_NONE },
-                    { 869, 198, DIGREQ_NONE },
-                    { 736, 72, DIGREQ_NONE },
-                    { 695, 102, DIGREQ_NONE },
-                    { 4448, 48, DIGREQ_NONE },
-                    { 775, 36, DIGREQ_NONE },
-                    { 749, 18, DIGREQ_NONE },
-                    { 703, 6, DIGREQ_NONE },
-                    { 885, 9, DIGREQ_NONE },
-                    { 4096, 100, DIGREQ_NONE },  -- all crystals
-                    { 2364, 120, DIGREQ_BURROW },
-                    { 2235, 42, DIGREQ_BURROW },
-                    { 1237, 24, DIGREQ_BURROW },
-                    { 1236, 12, DIGREQ_BURROW },
-                    { 4570, 10, DIGREQ_MODIFIER },
-                    { 4487, 11, DIGREQ_MODIFIER },
-                    { 4409, 12, DIGREQ_MODIFIER },
-                    { 1188, 10, DIGREQ_MODIFIER },
-                    { 4532, 12, DIGREQ_MODIFIER },
-                };
+local itemMap =
+{
+    -- itemid, abundance, requirement
+    { 846, 216, DIGREQ_NONE },
+    { 17296, 210, DIGREQ_NONE },
+    { 869, 198, DIGREQ_NONE },
+    { 736, 72, DIGREQ_NONE },
+    { 695, 102, DIGREQ_NONE },
+    { 4448, 48, DIGREQ_NONE },
+    { 775, 36, DIGREQ_NONE },
+    { 749, 18, DIGREQ_NONE },
+    { 703, 6, DIGREQ_NONE },
+    { 885, 9, DIGREQ_NONE },
+    { 4096, 100, DIGREQ_NONE },  -- all crystals
+    { 2364, 120, DIGREQ_BURROW },
+    { 2235, 42, DIGREQ_BURROW },
+    { 1237, 24, DIGREQ_BURROW },
+    { 1236, 12, DIGREQ_BURROW },
+    { 4570, 10, DIGREQ_MODIFIER },
+    { 4487, 11, DIGREQ_MODIFIER },
+    { 4409, 12, DIGREQ_MODIFIER },
+    { 1188, 10, DIGREQ_MODIFIER },
+    { 4532, 12, DIGREQ_MODIFIER },
+};
 
 local messageArray = { DIG_THROW_AWAY, FIND_NOTHING, ITEM_OBTAINED };
 
@@ -53,17 +51,9 @@ function onChocoboDig(player, precheck)
     return chocoboDig(player, itemMap, precheck, messageArray);
 end;
 
------------------------------------
--- onInitialize
------------------------------------
-
 function onInitialize(zone)
     SetRegionalConquestOverseers(zone:getRegionID())
 end;
-
------------------------------------
--- onZoneIn
------------------------------------
 
 function onZoneIn( player, prevZone)
     local cs = -1;
@@ -74,7 +64,7 @@ function onZoneIn( player, prevZone)
 
     if (prevZone == 147 and player:getCurrentMission(BASTOK) == THE_FOUR_MUSKETEERS) then
         missionStatus = player:getVar("MissionStatus");
-        if (missionStatus < 22) then
+        if (missionStatus > 0 and missionStatus < 22) then
             cs = 10;
         elseif (missionStatus == 22) then
             cs = 11;
@@ -89,10 +79,6 @@ function onZoneIn( player, prevZone)
 end;
 
 
------------------------------------
--- onConquestUpdate
------------------------------------
-
 function onConquestUpdate(zone, updatetype)
     local players = zone:getPlayers();
 
@@ -101,16 +87,8 @@ function onConquestUpdate(zone, updatetype)
     end
 end;
 
------------------------------------
--- onRegionEnter
------------------------------------
-
 function onRegionEnter( player, region)
 end;
-
------------------------------------
--- onEventUpdate
------------------------------------
 
 function onEventUpdate( player, csid, option)
     -- printf("CSID: %u",csid);
@@ -125,10 +103,6 @@ function onEventUpdate( player, csid, option)
     end
 
 end;
-
------------------------------------
--- onEventFinish
------------------------------------
 
 function onEventFinish( player, csid, option)
     -- printf("CSID: %u",csid);


### PR DESCRIPTION
1. get cs Iron Eater from metalworks
2. go kill quadavs
3. on zone out get cs telling if you killed enough or not - if not, you et sent back to kill more, this was happening despite never doing step one leading people to think the mission was broken when in reality they simply never started..