### PR TITLE
Armoury Chest open animation

### DIFF
--- a/scripts/globals/battlefield.lua
+++ b/scripts/globals/battlefield.lua
@@ -186,7 +186,7 @@ function g_Battlefield.HandleLootRolls(battlefield, lootTable, players, npc)
 
     if battlefield:getStatus() == g_Battlefield.STATUS.WON and battlefield:getLocalVar("lootSeen") == 0 then
         if npc then
-            npc:setAnimation(8)
+            npc:setAnimation(90)
         end
         if lootGroup then
             for _, entry in pairs(lootGroup) do


### PR DESCRIPTION
Update animation ID to enable the Armoury Chests to open when triggered. 

Temporary solution until the Sparkly Animation is discovered.