### PR TITLE
Fix Pandemonium Lamp skin IDs..TODO: use skillList changes, instead of model ID checks, and NUKE duplicate skill scripts!

### DIFF
--- a/scripts/globals/mobskills/hellclap.lua
+++ b/scripts/globals/mobskills/hellclap.lua
@@ -11,7 +11,7 @@ function onMobSkillCheck(target,mob,skill)
   if(mob:getFamily() == 91) then
     local mobSkin = mob:getModelId();
 
-    if (mobSkin == 1840) then
+    if (mobSkin == 1839) then
         return 0;
     else
         return 1;

--- a/scripts/globals/mobskills/hellsnap.lua
+++ b/scripts/globals/mobskills/hellsnap.lua
@@ -11,7 +11,7 @@ function onMobSkillCheck(target,mob,skill)
   if(mob:getFamily() == 91) then
     local mobSkin = mob:getModelId();
 
-    if (mobSkin == 1840) then
+    if (mobSkin == 1839) then
         return 0;
     else
         return 1;

--- a/scripts/globals/mobskills/necrobane.lua
+++ b/scripts/globals/mobskills/necrobane.lua
@@ -19,7 +19,7 @@ function onMobSkillCheck(target,mob,skill)
   if(mob:getFamily() == 91) then
     local mobSkin = mob:getModelId();
 
-    if (mobSkin == 1840) then
+    if (mobSkin == 1839) then
         return 0;
     else
         return 1;

--- a/scripts/globals/mobskills/necropurge.lua
+++ b/scripts/globals/mobskills/necropurge.lua
@@ -21,7 +21,7 @@ function onMobSkillCheck(target,mob,skill)
   if(mob:getFamily() == 91) then
     local mobSkin = mob:getModelId();
 
-    if (mobSkin == 1840) then
+    if (mobSkin == 1839) then
         return 0;
     else
         return 1;

--- a/scripts/globals/mobskills/pl_hellclap.lua
+++ b/scripts/globals/mobskills/pl_hellclap.lua
@@ -10,7 +10,7 @@ require("scripts/globals/monstertpmoves");
 function onMobSkillCheck(target,mob,skill)
     local mobSkin = mob:getModelId();
 
-    if (mobSkin == 1840) then
+    if (mobSkin == 1839) then
         return 0;
     else
         return 1;

--- a/scripts/globals/mobskills/pl_hellsnap.lua
+++ b/scripts/globals/mobskills/pl_hellsnap.lua
@@ -10,7 +10,7 @@ require("scripts/globals/monstertpmoves");
 function onMobSkillCheck(target,mob,skill)
     local mobSkin = mob:getModelId();
 
-    if (mobSkin == 1840) then
+    if (mobSkin == 1839) then
         return 0;
     else
         return 1;

--- a/scripts/globals/mobskills/thundris_shriek.lua
+++ b/scripts/globals/mobskills/thundris_shriek.lua
@@ -27,7 +27,7 @@ function onMobSkillCheck(target,mob,skill)
   if(mob:getFamily() == 91) then
     local mobSkin = mob:getModelId();
 
-    if (mobSkin == 1840) then
+    if (mobSkin == 1839) then
         return 0;
     else
         return 1;

--- a/scripts/zones/Aydeewa_Subterrane/mobs/Pandemonium_Warden.lua
+++ b/scripts/zones/Aydeewa_Subterrane/mobs/Pandemonium_Warden.lua
@@ -70,7 +70,7 @@ function onMobFight(mob,target)
             if petStatus[i] == 0 then
                 SpawnMob(petIDs[i]):updateEnmity(target);
             end
-            GetMobByID(petIDs[i]):setModelId(1840);
+            GetMobByID(petIDs[i]):setModelId(1839);
         end
     elseif (mobHPP <= 26 and change == 12) then -- Khim and Co.
         mob:setModelId(1805);


### PR DESCRIPTION
```
TODO: use skillList changes, in stead of model ID checks, and NUKE duplicate skill scripts!
```

@dwn134 so, the existing cruddy PW implementation was written back when family ID was the skillList ID, and when we were allowed to make multiple differently named skills with the same ID. The current system requires the skill ID's to be unique (which I hate, should that table joined on name instead of ID) but anyway thought I'd tag you here to point out the todo so you are aware of it in that version you want to PR