### PR TITLE
Fixes related to npc_utils, trade:confirmItem, and player:confirmTrade

### DIFF
--- a/scripts/globals/npc_util.lua
+++ b/scripts/globals/npc_util.lua
@@ -1,7 +1,18 @@
+--[[
+    Helper functions for common NPC tasks.
+    
+    npcUtil.pickNewPosition(npc, positionTable, allowCurrentPosition)
+    npcUtil.giveItem(player, items)
+    npcUtil.giveKeyItem(player, keyitems)
+    npcUtil.completeQuest(player, area, quest, options)
+    npcUtil.tradeHas(trade, items)
+    npcUtil.genTmask(player,title)
+    npcUtil.UpdateNPCSpawnPoint(id, minTime, maxTime, posTable, serverVar)
+    npcUtil.fishingAnimation(npc, phaseDuration, func)
+--]]
 package.loaded["scripts/globals/settings"] = nil;
 require("scripts/globals/settings");
 
--- Provides helper methods for npcs
 npcUtil = {};
 
 -- Picks a new position for an NPC and excluding the current position.
@@ -38,169 +49,217 @@ function npcUtil.pickNewPosition(npc, positionTable, allowCurrentPosition)
     return {["x"] = positionTable[newPosition][1], ["y"] = positionTable[newPosition][2], ["z"] = positionTable[newPosition][3]};
 end;
 
--- give gil to player with message and multiplied gil
--- npcUtil.giveGil(player, 200)
--- npcUtil.giveGil(player, 1000, {rate=false})
-function npcUtil.giveGil(player, amount, options)
-
-    local total = amount;
-
-    -- don't give bonus gil if rate is false
-    if (options == nil or options["rate"] == true) then
-        total = total * GIL_RATE
-    end
-
-    player:addGil(total);
-    player:messageSpecial(GIL_OBTAINED,total);
-end
-
--- give key item to player with message
--- npcUtil.giveKeyItem(player, MARK_OF_ZAHAK)
-function npcUtil.giveKeyItem(player, keyitem)
-    player:addKeyItem(keyitem);
-    player:messageSpecial(KEYITEM_OBTAINED,keyitem);
-end
-
--- give items to player with message
--- will fail if not enough slots are available
--- npcUtil.giveItem(player, {{927, 5}, 927})
----
---- Usage:
---- if (npcUtil.giveItem(player, 927)) then
----    -- player got items with message!
---- else
----    -- player did not get items and got a could not obtain msg
---- end
-function npcUtil.giveItem(player, items)
-    local freeSlots = player:getFreeSlotsCount()
-
-    if (type(items) == "number") then
-        items = {items}
-    end
-
-    if (freeSlots < #items) then
-
-        local msg = nil;
-
-        -- find right message
-        if (ITEM_CANNOT_BE_OBTAINED_2 ~= nil) then
-            msg = ITEM_CANNOT_BE_OBTAINED_2
-        elseif (ITEM_CANNOT_BE_OBTAINED_3 ~= nil) then
-            msg = ITEM_CANNOT_BE_OBTAINED_3
-        elseif (ITEM_CANNOT_BE_OBTAINED_1 ~= nil) then
-            msg = ITEM_CANNOT_BE_OBTAINED_1
-        elseif (ITEM_CANNOT_BE_OBTAINED ~= nil) then
-            msg = ITEM_CANNOT_BE_OBTAINED
-        end
-
-        player:messageSpecial(msg, items[1]);
-
-        return false;
-    end
-
-    local itemId = 0;
-
-    for k, v in pairs(items) do
-        if (type(v) == "number") then
-            itemId = v;
-            player:addItem(v, 1);
-        else
-            -- add amount
-            itemId = v[1];
-            player:addItem(itemId, v[2]);
-        end
-    end
-
-    player:messageSpecial(ITEM_OBTAINED, itemId);
-
-    return true
-end
-
--- Complete a quest
--- This can return false if player could not recieve items
--- Fame defaults to 30
--- all params in table are optional
---
--- npcUtil.completeQuest(player, SANDORIA, ROSEL_THE_ARMORER, {
---            title= ENTRANCE_DENIED,
---            gil= 200,
---            fame=120,
---            keyItem=100,
---             item={927, 927}
---            });
-function npcUtil.completeQuest(player, area, quest, options)
-    options = options or {}
-
-    if (options["item"] ~= nil) then
-        if (npcUtil.giveItem(player, options["item"]) == false) then
-            return false
-        end
-    end
-
-    if (options["title"] ~= nil) then
-        player:addTitle(options["title"])
-    end
-
-    if (options["gil"] ~= nil) then
-        npcUtil.giveGil(player, options["gil"])
-    end
-
-    if (options["keyItem"] ~= nil) then
-        npcUtil.giveKeyItem(player, options["keyItem"])
-    end
-
-    if (area["fame_area"] ~= nil) then
-        if (options["fame"] == nil) then
-            options["fame"] = 30; -- default to 30
-        end
-        player:addFame(area, options["fame"])
-    end
+--[[ *******************************************************************************
+    Give item(s) to player.
+    If player has inventory space, give items, display message, and return true.
+    If not, do not give items, display a message to indicate this, and return false.
     
-    player:completeQuest(area,quest)
-    return true
-end
+    Examples of valid items parameter:
+        640                 -- copper ore x1
+        { 640, 641 }        -- copper ore x1, tin ore x1
+        { {640,2} }         -- copper ore x2
+        { {640,2}, 641 }    -- copper ore x2, tin ore x1
+******************************************************************************* --]]
+function npcUtil.giveItem(player, items)
+    -- require zone TextIDs
+    local TextIDs = "scripts/zones/" .. player:getZoneName() .. "/TextIDs";
+    package.loaded[TextIDs] = nil;
+    require(TextIDs); 
 
--- returns true if the trade conditions are met
--- npcUtil.tradeHas(trade, 532)
--- npcUtil.tradeHas(trade, {532, 927})
--- npcUtil.tradeHas(trade, nil, 5)
-function npcUtil.tradeHas(trade, items, gil)
-    local itemCount = {};
-
-    if (gil ~= nil and trade:getGil() ~= gil) then
-        -- given wrong armound of gil
-        return false;
-    elseif (trade:getGil() ~= 0 and gil == nil) then
-        -- given gil when I don't want it
-            return false;
-    end
-
-    if (items ~= nil) then
-
-        if (type(items) == "number") then
-            items = {items}
-        end
-
-        -- given different amount of items
-        if (trade:getItemCount() ~= #items) then
-            return false;
-        end
-
+    -- create table of items, with key/val of itemId/itemQty
+    local givenItems = {};
+    local itemId;
+    local itemQty;
+    if (type(items) == "number") then
+        table.insert(givenItems, {items,1});
+    elseif (type(items) == "table") then
         for _, v in pairs(items) do
-            if (itemCount[v] == nil) then
-                itemCount[v] = 1;
+            if (type(v) == "number") then
+                table.insert(givenItems, {v,1});
+            elseif (type(v) == "table" and #v == 2 and type(v[1]) == "number" and type(v[2]) == "number") then
+                table.insert(givenItems, {v[1],v[2]});
             else
-                itemCount[v] = itemCount[v] + 1
-            end
-        end
-        for k, v in pairs(itemCount) do
-            if (trade:hasItemQty(k, v) == false) then
-                -- don't have the right amount of item
+                print(string.format("ERROR: invalid items parameter given to npcUtil.giveItem in zone %s.", player:getZoneName()));
                 return false;
             end
         end
     end
 
+    -- does player have enough inventory space?
+    if (player:getFreeSlotsCount() < #givenItems) then
+        player:messageSpecial(ITEM_CANNOT_BE_OBTAINED, givenItems[1][1]);
+        return false;
+    end
+
+    -- give items to player
+    for _, v in pairs(givenItems) do
+        player:addItem(v[1], v[2]);
+        player:messageSpecial(ITEM_OBTAINED, v[1]);
+    end
+    return true;
+end
+
+--[[ *******************************************************************************
+    Give key item(s) to player.
+    Message is displayed showing key items obtained.
+    
+    Examples of valid keyitems parameter:
+        ZERUHN_REPORT
+        {PALBOROUGH_MINES_LOGS}
+        {BLUE_ACIDITY_TESTER, RED_ACIDITY_TESTER}
+******************************************************************************* --]]
+function npcUtil.giveKeyItem(player, keyitems)
+    -- require zone TextIDs
+    local TextIDs = "scripts/zones/" .. player:getZoneName() .. "/TextIDs";
+    package.loaded[TextIDs] = nil;
+    require(TextIDs);
+    
+    -- create table of keyitems
+    local givenKeyItems = {};
+    if (type(keyitems) == "number") then
+        givenKeyItems = {keyitems};
+    elseif (type(keyitems) == "table") then
+        givenKeyItems = keyitems;
+    else
+        print(string.format("ERROR: invalid keyitems parameter given to npcUtil.giveKeyItem in zone %s.", player:getZoneName()));
+        return false;
+    end
+    
+    -- give key items to player, with message
+    for _, v in pairs(givenKeyItems) do
+        player:addKeyItem(v);
+        player:messageSpecial(KEYITEM_OBTAINED,v);
+    end
+    return true;
+end
+
+--[[ *******************************************************************************
+    Complete a quest.
+    If quest rewards items, and the player cannot carry them, return false.
+    Otherwise, return true.
+    
+    Example of usage with options parameter (all options are optional):
+        npcUtil.completeQuest(player, SANDORIA, ROSEL_THE_ARMORER, {
+            item = { {640,2}, 641 },    -- see npcUtil.giveItem for formats
+            keyItem = ZERUHN_REPORT,    -- see npcUtil.giveKeyItem for formats
+            fame = 120,                 -- fame defaults to 30 if not set
+            bayld = 500,
+            gil = 200,
+            xp = 1000,
+            title = ENTRANCE_DENIED,
+        });
+******************************************************************************* --]]
+function npcUtil.completeQuest(player, area, quest, options)
+    options = options or {};
+
+    -- load text ids
+    local TextIDs = "scripts/zones/" .. player:getZoneName() .. "/TextIDs";
+    package.loaded[TextIDs] = nil;
+    require(TextIDs); 
+
+    -- item(s) plus message. return false if player lacks inventory space.
+    if (options["item"] ~= nil) then
+        if (not npcUtil.giveItem(player, options["item"])) then
+            return false;
+        end
+    end
+
+    -- key item(s), fame, gil, bayld, xp, and title
+    if (options["keyItem"] ~= nil) then
+        npcUtil.giveKeyItem(player, options["keyItem"]);
+    end
+
+    if (options["fame"] == nil) then
+        options["fame"] = 30;
+    end
+    if (area["fame_area"] ~= nil and type(options["fame"]) == "number") then
+        player:addFame(area, options["fame"]);
+    end
+
+    if (options["gil"] ~= nil and type(options["gil"]) == "number") then
+        player:addGil(options["gil"] * GIL_RATE);
+        player:messageSpecial(GIL_OBTAINED, options["gil"] * GIL_RATE);
+    end
+
+    if (options["bayld"] ~= nil and type(options["bayld"]) == "number") then
+        player:addCurrency('bayld', options["bayld"] * BAYLD_RATE);
+        player:messageSpecial(BAYLD_OBTAINED, options["bayld"] * BAYLD_RATE);
+    end
+
+    if (options["xp"] ~= nil and type(options["xp"]) == "number") then
+        player:addExp(options["xp"] * EXP_RATE);
+    end
+
+    if (options["title"] ~= nil) then
+        player:addTitle(options["title"]);
+    end
+
+    -- successfully complete the quest
+    player:completeQuest(area,quest);
+    return true
+end
+
+--[[ *******************************************************************************
+    check whether trade has all required items
+        if yes, confirm all the items and return true
+        if no, return false
+        
+    valid examples of items:
+        640                     -- copper ore x1
+        { 640, 641 }            -- copper ore x1, tin ore x1
+        { 640, 640 }            -- copper ore x2
+        { {640,2} }             -- copper ore x2
+        { {640,2}, 641 }        -- copper ore x2, tin ore x1
+        { 640, {"gil", 200} }   -- copper ore x1, gil x200
+******************************************************************************* --]]
+function npcUtil.tradeHas(trade, items)
+
+    -- create table of traded items, with key/val of itemId/itemQty
+    local tradedItems = {};
+    local itemId;
+    local itemQty;
+    for i = 0, trade:getSlotCount()-1 do
+        itemId = trade:getItemId(i);
+        itemQty = trade:getItemQty(itemId);
+        tradedItems[itemId] = itemQty;
+    end
+    
+    -- create table of needed items, with key/val of itemId/itemQty
+    local neededItems = {};
+    if (type(items) == "number") then
+        neededItems[items] = 1;
+    elseif (type(items) == "table") then
+        local itemId;
+        local itemQty;
+        for _, v in pairs(items) do
+            if (type(v) == "number") then
+                itemId = v;
+                itemQty = 1;
+            elseif (type(v) == "table" and #v == 2 and type(v[1]) == "number" and type(v[2]) == "number") then
+                itemId = v[1];
+                itemQty = v[2];
+            elseif (type(v) == "table" and #v == 2 and type(v[1]) == "string" and type(v[2]) == "number" and string.lower(v[1]) == "gil") then
+                itemId = 65535;
+                itemQty = v[2];
+            else
+                print("ERROR: invalid value contained within items parameter given to npcUtil.tradeHas.");
+                goto continue;
+            end
+            neededItems[itemId] = (neededItems[itemId] == nil) and itemQty or neededItems[itemId] + itemQty;
+            ::continue::
+        end
+    else
+        print("ERROR: invalid items parameter given to npcUtil.tradeHas.");
+        return false;
+    end
+
+    -- determine whether all needed items have been traded, and confirm those needed. return true or false.
+    for k, v in pairs(neededItems) do
+        local tradedQty = (tradedItems[k] == nil) and 0 or tradedItems[k];
+        if (v > tradedQty or not trade:confirmItem(k,v)) then
+            return false;
+        end
+    end
     return true;
 end
 

--- a/scripts/globals/npc_util.lua
+++ b/scripts/globals/npc_util.lua
@@ -1,5 +1,5 @@
 package.loaded["scripts/globals/settings"] = nil;
-
+require("scripts/globals/settings");
 
 -- Provides helper methods for npcs
 npcUtil = {};
@@ -129,7 +129,6 @@ end
 --             item={927, 927}
 --            });
 function npcUtil.completeQuest(player, area, quest, options)
-
     options = options or {}
 
     if (options["item"] ~= nil) then
@@ -142,7 +141,6 @@ function npcUtil.completeQuest(player, area, quest, options)
         player:addTitle(options["title"])
     end
 
-
     if (options["gil"] ~= nil) then
         npcUtil.giveGil(player, options["gil"])
     end
@@ -151,15 +149,14 @@ function npcUtil.completeQuest(player, area, quest, options)
         npcUtil.giveKeyItem(player, options["keyItem"])
     end
 
-    -- default to 30
-    if (options["fame"] == nil) then
-        options["fame"] = 30;
+    if (area["fame_area"] ~= nil) then
+        if (options["fame"] == nil) then
+            options["fame"] = 30; -- default to 30
+        end
+        player:addFame(area, options["fame"])
     end
-
-    player:addFame(area, options["fame"])
-
+    
     player:completeQuest(area,quest)
-
     return true
 end
 

--- a/scripts/globals/npc_util.lua
+++ b/scripts/globals/npc_util.lua
@@ -244,10 +244,11 @@ function npcUtil.tradeHas(trade, items, exact)
                 itemQty = v[2];
             else
                 print("ERROR: invalid value contained within items parameter given to npcUtil.tradeHas.");
-                goto continue;
+                itemId = nil;
             end
-            neededItems[itemId] = (neededItems[itemId] == nil) and itemQty or neededItems[itemId] + itemQty;
-            ::continue::
+            if (itemId ~= nil) then
+                neededItems[itemId] = (neededItems[itemId] == nil) and itemQty or neededItems[itemId] + itemQty;
+            end
         end
     else
         print("ERROR: invalid items parameter given to npcUtil.tradeHas.");

--- a/scripts/globals/npc_util.lua
+++ b/scripts/globals/npc_util.lua
@@ -4,7 +4,7 @@
     npcUtil.pickNewPosition(npc, positionTable, allowCurrentPosition)
     npcUtil.giveItem(player, items)
     npcUtil.giveKeyItem(player, keyitems)
-    npcUtil.completeQuest(player, area, quest, options)
+    npcUtil.completeQuest(player, area, quest, params)
     npcUtil.tradeHas(trade, items)
     npcUtil.genTmask(player,title)
     npcUtil.UpdateNPCSpawnPoint(id, minTime, maxTime, posTable, serverVar)
@@ -138,7 +138,7 @@ end
     If quest rewards items, and the player cannot carry them, return false.
     Otherwise, return true.
     
-    Example of usage with options parameter (all options are optional):
+    Example of usage with params (all params are optional):
         npcUtil.completeQuest(player, SANDORIA, ROSEL_THE_ARMORER, {
             item = { {640,2}, 641 },    -- see npcUtil.giveItem for formats
             keyItem = ZERUHN_REPORT,    -- see npcUtil.giveKeyItem for formats
@@ -149,8 +149,8 @@ end
             title = ENTRANCE_DENIED,
         });
 ******************************************************************************* --]]
-function npcUtil.completeQuest(player, area, quest, options)
-    options = options or {};
+function npcUtil.completeQuest(player, area, quest, params)
+    params = params or {};
 
     -- load text ids
     local TextIDs = "scripts/zones/" .. player:getZoneName() .. "/TextIDs";
@@ -158,40 +158,40 @@ function npcUtil.completeQuest(player, area, quest, options)
     require(TextIDs); 
 
     -- item(s) plus message. return false if player lacks inventory space.
-    if (options["item"] ~= nil) then
-        if (not npcUtil.giveItem(player, options["item"])) then
+    if (params["item"] ~= nil) then
+        if (not npcUtil.giveItem(player, params["item"])) then
             return false;
         end
     end
 
     -- key item(s), fame, gil, bayld, xp, and title
-    if (options["keyItem"] ~= nil) then
-        npcUtil.giveKeyItem(player, options["keyItem"]);
+    if (params["keyItem"] ~= nil) then
+        npcUtil.giveKeyItem(player, params["keyItem"]);
     end
 
-    if (options["fame"] == nil) then
-        options["fame"] = 30;
+    if (params["fame"] == nil) then
+        params["fame"] = 30;
     end
-    if (area["fame_area"] ~= nil and type(options["fame"]) == "number") then
-        player:addFame(area, options["fame"]);
-    end
-
-    if (options["gil"] ~= nil and type(options["gil"]) == "number") then
-        player:addGil(options["gil"] * GIL_RATE);
-        player:messageSpecial(GIL_OBTAINED, options["gil"] * GIL_RATE);
+    if (area["fame_area"] ~= nil and type(params["fame"]) == "number") then
+        player:addFame(area, params["fame"]);
     end
 
-    if (options["bayld"] ~= nil and type(options["bayld"]) == "number") then
-        player:addCurrency('bayld', options["bayld"] * BAYLD_RATE);
-        player:messageSpecial(BAYLD_OBTAINED, options["bayld"] * BAYLD_RATE);
+    if (params["gil"] ~= nil and type(params["gil"]) == "number") then
+        player:addGil(params["gil"] * GIL_RATE);
+        player:messageSpecial(GIL_OBTAINED, params["gil"] * GIL_RATE);
     end
 
-    if (options["xp"] ~= nil and type(options["xp"]) == "number") then
-        player:addExp(options["xp"] * EXP_RATE);
+    if (params["bayld"] ~= nil and type(params["bayld"]) == "number") then
+        player:addCurrency('bayld', params["bayld"] * BAYLD_RATE);
+        player:messageSpecial(BAYLD_OBTAINED, params["bayld"] * BAYLD_RATE);
     end
 
-    if (options["title"] ~= nil) then
-        player:addTitle(options["title"]);
+    if (params["xp"] ~= nil and type(params["xp"]) == "number") then
+        player:addExp(params["xp"] * EXP_RATE);
+    end
+
+    if (params["title"] ~= nil) then
+        player:addTitle(params["title"]);
     end
 
     -- successfully complete the quest

--- a/scripts/zones/Al_Zahbi/npcs/Suldiran.lua
+++ b/scripts/zones/Al_Zahbi/npcs/Suldiran.lua
@@ -2,21 +2,18 @@
 -- Area: Al Zahbi
 --  NPC: Suldiran
 -- Type: NPC Quest
--- !pos 41.658 -6.999 -42.528 48
+-- !pos 42 -7 -43 48
 -----------------------------------
 package.loaded["scripts/zones/Al_Zahbi/TextIDs"] = nil;
 -----------------------------------
 require("scripts/zones/Al_Zahbi/TextIDs");
-require("scripts/globals/settings");
+require("scripts/globals/npc_util");
 require("scripts/globals/quests");
 require("scripts/globals/titles");
------------------------------------
 
 function onTrade(player,npc,trade)
-    if (player:getQuestStatus(AHT_URHGAN,FEAR_OF_THE_DARK_II) ~= QUEST_AVAILABLE) then
-        if (trade:hasItemQty(2163,2) and trade:getItemCount() == 2) then
-            player:startEvent(16);
-        end
+    if (player:getQuestStatus(AHT_URHGAN,FEAR_OF_THE_DARK_II) >= QUEST_AVAILABLE and npcUtil.tradeHas(trade, {2163, 2163})) then
+        player:startEvent(16);
     end
 end;
 
@@ -35,12 +32,8 @@ function onEventFinish(player,csid,option)
     if (csid == 14 and option == 1) then
         player:addQuest(AHT_URHGAN,FEAR_OF_THE_DARK_II);
     elseif (csid == 16) then
-        player:tradeComplete();
-        player:addGil(GIL_RATE*200);
-        player:addTitle(DARK_RESISTANT);
-        player:messageSpecial(GIL_OBTAINED,GIL_RATE*200);
-        if (player:getQuestStatus(AHT_URHGAN,FEAR_OF_THE_DARK_II) == QUEST_ACCEPTED) then
-            player:completeQuest(AHT_URHGAN,FEAR_OF_THE_DARK_II);
+        if (npcUtil.completeQuest(player, AHT_URHGAN, FEAR_OF_THE_DARK_II, {title=DARK_RESISTANT, gil=200})) then
+            player:tradeComplete();
         end
     end
 end;

--- a/scripts/zones/Al_Zahbi/npcs/Suldiran.lua
+++ b/scripts/zones/Al_Zahbi/npcs/Suldiran.lua
@@ -12,7 +12,7 @@ require("scripts/globals/quests");
 require("scripts/globals/titles");
 
 function onTrade(player,npc,trade)
-    if (player:getQuestStatus(AHT_URHGAN,FEAR_OF_THE_DARK_II) >= QUEST_AVAILABLE and npcUtil.tradeHas(trade, {2163, 2163})) then
+    if (player:getQuestStatus(AHT_URHGAN,FEAR_OF_THE_DARK_II) >= QUEST_AVAILABLE and npcUtil.tradeHas( trade, {{2163,2}} )) then
         player:startEvent(16);
     end
 end;
@@ -33,7 +33,7 @@ function onEventFinish(player,csid,option)
         player:addQuest(AHT_URHGAN,FEAR_OF_THE_DARK_II);
     elseif (csid == 16) then
         if (npcUtil.completeQuest(player, AHT_URHGAN, FEAR_OF_THE_DARK_II, {title=DARK_RESISTANT, gil=200})) then
-            player:tradeComplete();
+            player:confirmTrade();
         end
     end
 end;

--- a/scripts/zones/Bastok_Markets/npcs/Aquillina.lua
+++ b/scripts/zones/Bastok_Markets/npcs/Aquillina.lua
@@ -1,78 +1,47 @@
 -----------------------------------
 -- Area: Bastok Markets
---  NPC: Aquillina
+-- NPC: Aquillina
 -- Starts & Finishes Repeatable Quest: A Flash In The Pan
 -- Note: Reapeatable every 15 minutes.
+-- !pos -97 -5 -81 235
 -----------------------------------
 package.loaded["scripts/zones/Bastok_Markets/TextIDs"] = nil;
 -----------------------------------
-require("scripts/globals/quests");
-require("scripts/globals/settings");
 require("scripts/zones/Bastok_Markets/TextIDs");
------------------------------------
+require("scripts/globals/npc_util");
+require("scripts/globals/quests");
 
 function onTrade(player,npc,trade)
-
-FlashInThePan = player:getQuestStatus(BASTOK,A_FLASH_IN_THE_PAN);
-
-    if (FlashInThePan >= QUEST_ACCEPTED) then
-        PreviousTime = player:getVar("FlashInThePan");
-        CurrentTime  = os.time();
-
-        if (CurrentTime >= PreviousTime) then
-            count  = trade:getItemCount();
-            FlintStone = trade:hasItemQty(768,4);
-
-            if (FlintStone == true and count == 4) then
+    if (player:getQuestStatus(BASTOK,A_FLASH_IN_THE_PAN) >= QUEST_ACCEPTED) then
+        if (os.time() >= player:getVar("FlashInThePan")) then
+            if (npcUtil.tradeHas(trade, {768, 768, 768, 768})) then
                 player:startEvent(219);
             end
         else
             player:startEvent(218);
         end
     end
-
-end;
+end; 
 
 function onTrigger(player,npc)
-
-FlashInThePan = player:getQuestStatus(BASTOK,A_FLASH_IN_THE_PAN);
-
-    if (FlashInThePan == QUEST_AVAILABLE) then
+    if (player:getQuestStatus(BASTOK,A_FLASH_IN_THE_PAN) == QUEST_AVAILABLE) then
         player:startEvent(217);
     else
         player:startEvent(116);
     end
-
 end;
 
 function onEventUpdate(player,csid,option)
-    -- printf("CSID2: %u",csid);
-    -- printf("RESULT2: %u",option);
 end;
 
 function onEventFinish(player,csid,option)
-    -- printf("CSID: %u",csid);
-    -- printf("RESULT: %u",option);
-
     if (csid == 217) then
-        player:addQuest(BASTOK, A_FLASH_IN_THE_PAN);
+        player:addQuest(BASTOK, A_FLASH_IN_THE_PAN);        
     elseif (csid == 219) then
-        FlashInThePan = player:getQuestStatus(BASTOK,A_FLASH_IN_THE_PAN);
-        CompleteTime = os.time();
-
-        if (FlashInThePan == QUEST_ACCEPTED) then
-            player:completeQuest(BASTOK, A_FLASH_IN_THE_PAN);
-            player:addFame(BASTOK,75);
-        else
-            player:addFame(BASTOK,8);
+        local fame = player:hasCompleteQuest(BASTOK, A_FLASH_IN_THE_PAN) and 8 or 75;
+        if (npcUtil.completeQuest(player, BASTOK, A_FLASH_IN_THE_PAN, {gil=100, fame=fame})) then
+            player:tradeComplete();
+            player:setVar("FlashInThePan",os.time() + 900);
         end
-
-        player:tradeComplete();
-        player:setVar("FlashInThePan",CompleteTime + 900);
-        player:addGil(GIL_RATE*100);
-        player:messageSpecial(GIL_OBTAINED,GIL_RATE*100);
-    end
-
+    end        
 end;
-
-

--- a/scripts/zones/Bastok_Markets/npcs/Aquillina.lua
+++ b/scripts/zones/Bastok_Markets/npcs/Aquillina.lua
@@ -14,7 +14,7 @@ require("scripts/globals/quests");
 function onTrade(player,npc,trade)
     if (player:getQuestStatus(BASTOK,A_FLASH_IN_THE_PAN) >= QUEST_ACCEPTED) then
         if (os.time() >= player:getVar("FlashInThePan")) then
-            if (npcUtil.tradeHas(trade, {768, 768, 768, 768})) then
+            if (npcUtil.tradeHas( trade, {{768,4}} )) then
                 player:startEvent(219);
             end
         else
@@ -40,7 +40,7 @@ function onEventFinish(player,csid,option)
     elseif (csid == 219) then
         local fame = player:hasCompleteQuest(BASTOK, A_FLASH_IN_THE_PAN) and 8 or 75;
         if (npcUtil.completeQuest(player, BASTOK, A_FLASH_IN_THE_PAN, {gil=100, fame=fame})) then
-            player:tradeComplete();
+            player:confirmTrade();
             player:setVar("FlashInThePan",os.time() + 900);
         end
     end        

--- a/scripts/zones/Bastok_Markets/npcs/Foss.lua
+++ b/scripts/zones/Bastok_Markets/npcs/Foss.lua
@@ -1,71 +1,40 @@
 -----------------------------------
 -- Area: Bastok Markets
---  NPC: Foss
+-- NPC: Foss
 -- Starts & Finishes Repeatable Quest: Buckets of Gold
+-- !pos -283 -12 -37 235
 -----------------------------------
 package.loaded["scripts/zones/Bastok_Markets/TextIDs"] = nil;
 -----------------------------------
-require("scripts/globals/titles");
-require("scripts/globals/quests");
-require("scripts/globals/settings");
 require("scripts/zones/Bastok_Markets/TextIDs");
------------------------------------
+require("scripts/globals/npc_util");
+require("scripts/globals/quests");
+require("scripts/globals/titles");
 
 function onTrade(player,npc,trade)
-
-BucketsOfGold = player:getQuestStatus(BASTOK,BUCKETS_OF_GOLD);
-
-    if (BucketsOfGold >= QUEST_ACCEPTED) then
-        count = trade:getItemCount();
-        RustyBucket = trade:hasItemQty(90,5);
-
-        if (RustyBucket == true and count == 5) then
-            player:startEvent(272);
-        end
+    if (player:getQuestStatus(BASTOK,BUCKETS_OF_GOLD) >= QUEST_ACCEPTED and npcUtil.tradeHas(trade, {90, 90, 90, 90, 90})) then
+        player:startEvent(272);
     end
-
-end;
+end; 
 
 function onTrigger(player,npc)
-
-BucketsOfGold = player:getQuestStatus(BASTOK,BUCKETS_OF_GOLD);
-
-    if (BucketsOfGold == QUEST_AVAILABLE) then
+    if (player:getQuestStatus(BASTOK,BUCKETS_OF_GOLD) == QUEST_AVAILABLE) then
         player:startEvent(271);
     else
         player:startEvent(270);
     end
-
 end;
 
 function onEventUpdate(player,csid,option)
-    -- printf("CSID2: %u",csid);
-    -- printf("RESULT2: %u",option);
-
 end;
 
 function onEventFinish(player,csid,option)
-    -- printf("CSID: %u",csid);
-    -- printf("RESULT: %u",option);
-
     if (csid == 271 and option == 0) then
-        player:addQuest(BASTOK,BUCKETS_OF_GOLD);
+        player:addQuest(BASTOK,BUCKETS_OF_GOLD);            
     elseif (csid == 272) then
-        BucketsOfGold = player:getQuestStatus(BASTOK,BUCKETS_OF_GOLD);
-
-        if (BucketsOfGold == QUEST_ACCEPTED) then
-            player:completeQuest(BASTOK,BUCKETS_OF_GOLD);
-            player:addFame(BASTOK,75);
-            player:addTitle(BUCKET_FISHER);
-        else
-            player:addFame(BASTOK,8);
+        local fame = player:hasCompleteQuest(BASTOK, BUCKETS_OF_GOLD) and 8 or 75;
+        if (npcUtil.completeQuest(player, BASTOK, BUCKETS_OF_GOLD, {title=BUCKET_FISHER, gil=300, fame=fame})) then
+            player:tradeComplete();
         end
-
-        player:tradeComplete();
-        player:addGil(GIL_RATE*300);
-        player:messageSpecial(GIL_OBTAINED,GIL_RATE*300);
     end
-
 end;
-
-

--- a/scripts/zones/Bastok_Markets/npcs/Foss.lua
+++ b/scripts/zones/Bastok_Markets/npcs/Foss.lua
@@ -12,7 +12,7 @@ require("scripts/globals/quests");
 require("scripts/globals/titles");
 
 function onTrade(player,npc,trade)
-    if (player:getQuestStatus(BASTOK,BUCKETS_OF_GOLD) >= QUEST_ACCEPTED and npcUtil.tradeHas(trade, {90, 90, 90, 90, 90})) then
+    if (player:getQuestStatus(BASTOK,BUCKETS_OF_GOLD) >= QUEST_ACCEPTED and npcUtil.tradeHas(trade, {{90,5}})) then
         player:startEvent(272);
     end
 end; 
@@ -34,7 +34,7 @@ function onEventFinish(player,csid,option)
     elseif (csid == 272) then
         local fame = player:hasCompleteQuest(BASTOK, BUCKETS_OF_GOLD) and 8 or 75;
         if (npcUtil.completeQuest(player, BASTOK, BUCKETS_OF_GOLD, {title=BUCKET_FISHER, gil=300, fame=fame})) then
-            player:tradeComplete();
+            player:confirmTrade();
         end
     end
 end;

--- a/scripts/zones/Bastok_Markets/npcs/Horatius.lua
+++ b/scripts/zones/Bastok_Markets/npcs/Horatius.lua
@@ -12,7 +12,7 @@ require("scripts/globals/npc_util");
 require("scripts/globals/quests");
 
 function onTrade(player,npc,trade)
-    if (player:getQuestStatus(BASTOK,BREAKING_STONES) >= QUEST_AVAILABLE and npcUtil.tradeHas(trade, {553})) then
+    if (player:getQuestStatus(BASTOK,BREAKING_STONES) >= QUEST_AVAILABLE and npcUtil.tradeHas(trade, 553)) then
         player:startEvent(101);
     end
 end;
@@ -37,7 +37,7 @@ function onEventFinish(player,csid,option)
         player:addQuest(BASTOK,BREAKING_STONES);
     elseif (csid == 101) then
         if (npcUtil.completeQuest(player, BASTOK, BREAKING_STONES, {gil=400})) then
-            player:tradeComplete();
+            player:confirmTrade();
         end
     elseif (csid == 428) then
         player:setMaskBit(player:getVar("WildcatBastok"),"WildcatBastok",12,true);

--- a/scripts/zones/Bastok_Markets/npcs/Horatius.lua
+++ b/scripts/zones/Bastok_Markets/npcs/Horatius.lua
@@ -1,28 +1,23 @@
 -----------------------------------
--- Area: Bastok Markets
---  NPC: Horatius
--- Type: Quest Giver
+--  Area: Bastok Markets
+--  NPC:  Horatius
+--  Type: Quest Giver
 --  Starts and Finishes: Breaking Stones
--- !pos -158.392 -5.839 -117.061 235
+-- !pos -158 -6 -117 235
 -----------------------------------
 package.loaded["scripts/zones/Bastok_Markets/TextIDs"] = nil;
 -----------------------------------
-require("scripts/globals/settings");
-require("scripts/globals/quests");
 require("scripts/zones/Bastok_Markets/TextIDs");
------------------------------------
+require("scripts/globals/npc_util");
+require("scripts/globals/quests");
 
 function onTrade(player,npc,trade)
-
-    if (player:getQuestStatus(BASTOK,BREAKING_STONES) ~= QUEST_AVAILABLE) then
-        if (trade:hasItemQty(553,1) and trade:getItemCount() == 1) then
-            player:startEvent(101);
-        end
+    if (player:getQuestStatus(BASTOK,BREAKING_STONES) >= QUEST_AVAILABLE and npcUtil.tradeHas(trade, {553})) then
+        player:startEvent(101);
     end
 end;
 
 function onTrigger(player,npc)
-
     local WildcatBastok = player:getVar("WildcatBastok");
 
     if (player:getQuestStatus(BASTOK,LURE_OF_THE_WILDCAT_BASTOK) == QUEST_ACCEPTED and player:getMaskBit(WildcatBastok,12) == false) then
@@ -35,24 +30,16 @@ function onTrigger(player,npc)
 end;
 
 function onEventUpdate(player,csid,option)
-    -- printf("CSID: %u",csid);
-    -- printf("RESULT: %u",option);
 end;
 
 function onEventFinish(player,csid,option)
-     -- printf("CSID: %u",csid);
-     -- printf("RESULT: %u",option);
-
     if (csid == 100 and option == 0) then
         player:addQuest(BASTOK,BREAKING_STONES);
     elseif (csid == 101) then
-        player:tradeComplete();
-        player:addGil(GIL_RATE*400);
-        player:messageSpecial(GIL_OBTAINED,GIL_RATE*400);
-        player:completeQuest(BASTOK,BREAKING_STONES);
+        if (npcUtil.completeQuest(player, BASTOK, BREAKING_STONES, {gil=400})) then
+            player:tradeComplete();
+        end
     elseif (csid == 428) then
         player:setMaskBit(player:getVar("WildcatBastok"),"WildcatBastok",12,true);
     end
-
 end;
-

--- a/scripts/zones/Bastok_Markets/npcs/Malene.lua
+++ b/scripts/zones/Bastok_Markets/npcs/Malene.lua
@@ -2,21 +2,18 @@
 -- Area: Bastok Markets
 --  NPC: Malene
 -- Type: Quest NPC
--- !pos -173 -4 64 235
+-- !pos -173 -5 64 235
 -----------------------------------
 package.loaded["scripts/zones/Bastok_Markets/TextIDs"] = nil;
 -----------------------------------
 require("scripts/zones/Bastok_Markets/TextIDs");
-require("scripts/globals/settings");
-require("scripts/globals/titles");
+require("scripts/globals/npc_util");
 require("scripts/globals/quests");
------------------------------------
+require("scripts/globals/titles");
 
 function onTrade(player,npc,trade)
-      if (trade:hasItemQty(550, 1) and trade:getItemCount() == 1) then -- Quest: The Cold Light of Day - Trade Steam Clock
-        if (player:getQuestStatus(BASTOK, THE_COLD_LIGHT_OF_DAY) ~= QUEST_AVAILABLE) then
-            player:startEvent(104);
-        end
+    if (player:getQuestStatus(BASTOK, THE_COLD_LIGHT_OF_DAY) >= QUEST_AVAILABLE and npcUtil.tradeHas(trade, {550})) then
+        player:startEvent(104);
     end
 end;
 
@@ -29,31 +26,22 @@ function onTrigger(player,npc)
 end;
 
 function onEventUpdate(player,csid,option)
-    -- printf("CSID: %u",csid);
-    -- printf("RESULT: %u",option);
 end;
 
 function onEventFinish(player,csid,option)
-    -- printf("CSID: %u",csid);
-    -- printf("RESULT: %u",option);
-
-    if (csid == 102) then -- Quest: The Cold Light of Day
+    -- THE COLD LIGHT OF DAY
+    if (csid == 102) then
         if (player:getQuestStatus(BASTOK, THE_COLD_LIGHT_OF_DAY) == QUEST_AVAILABLE) then
             player:addQuest(BASTOK, THE_COLD_LIGHT_OF_DAY);
         end
-    elseif (csid == 104) then -- Quest: The Cold Light of Day - Traded Steam Clock
-        player:tradeComplete( );
-        player:addTitle(CRAB_CRUSHER);
-        player:addGil(GIL_RATE*500);
-        player:messageSpecial(GIL_OBTAINED, GIL_RATE*500);
-
-        if (player:getQuestStatus(BASTOK, THE_COLD_LIGHT_OF_DAY) == QUEST_ACCEPTED) then
-            player:addFame(BASTOK, 50);
-            player:completeQuest(BASTOK, THE_COLD_LIGHT_OF_DAY);
-        else
-            player:addFame(BASTOK, 8);
+    elseif (csid == 104) then
+        local fame = player:hasCompleteQuest(BASTOK, THE_COLD_LIGHT_OF_DAY) and 8 or 50;
+        if (npcUtil.completeQuest(player, BASTOK, THE_COLD_LIGHT_OF_DAY, {title=CRAB_CRUSHER, gil=500, fame=fame})) then
+            player:tradeComplete();
         end
-    elseif (csid == 330) then  -- Quest: Wish Upon a Star
+        
+    -- WISH UPON A STAR
+    elseif (csid == 330) then
         player:setVar("WishUponAStar_Status", 2);
     end
 end;

--- a/scripts/zones/Bastok_Markets/npcs/Malene.lua
+++ b/scripts/zones/Bastok_Markets/npcs/Malene.lua
@@ -12,7 +12,7 @@ require("scripts/globals/quests");
 require("scripts/globals/titles");
 
 function onTrade(player,npc,trade)
-    if (player:getQuestStatus(BASTOK, THE_COLD_LIGHT_OF_DAY) >= QUEST_AVAILABLE and npcUtil.tradeHas(trade, {550})) then
+    if (player:getQuestStatus(BASTOK, THE_COLD_LIGHT_OF_DAY) >= QUEST_AVAILABLE and npcUtil.tradeHas(trade, 550)) then
         player:startEvent(104);
     end
 end;
@@ -37,7 +37,7 @@ function onEventFinish(player,csid,option)
     elseif (csid == 104) then
         local fame = player:hasCompleteQuest(BASTOK, THE_COLD_LIGHT_OF_DAY) and 8 or 50;
         if (npcUtil.completeQuest(player, BASTOK, THE_COLD_LIGHT_OF_DAY, {title=CRAB_CRUSHER, gil=500, fame=fame})) then
-            player:tradeComplete();
+            player:confirmTrade();
         end
         
     -- WISH UPON A STAR

--- a/scripts/zones/Bastok_Markets/npcs/Michea.lua
+++ b/scripts/zones/Bastok_Markets/npcs/Michea.lua
@@ -1,109 +1,101 @@
 -----------------------------------
 -- Area: Bastok Markets
---  NPC: Michea
+-- NPC: Michea
 -- Quest NPC
 -- Starts: Father Figure (100%) | The Elvaan Goldsmith (100%)
--- Involed in: Fetichism | Where Two Paths Converge
+-- Involed in: Distant Loyalties
+-- !pos -298 -16 -157 235
 -----------------------------------
 package.loaded["scripts/zones/Bastok_Markets/TextIDs"] = nil;
 -----------------------------------
-require("scripts/globals/quests");
-require("scripts/globals/settings");
 require("scripts/zones/Bastok_Markets/TextIDs");
------------------------------------
+require("scripts/globals/keyitems");
+require("scripts/globals/npc_util");
+require("scripts/globals/quests");
 
 function onTrade(player,npc,trade)
+    local theElvaanGoldsmith = player:getQuestStatus(BASTOK,THE_ELVAAN_GOLDSMITH);
+    local distantLoyalties = player:getQuestStatus(SANDORIA,DISTANT_LOYALTIES);
+    local fatherFigure = player:getQuestStatus(BASTOK,FATHER_FIGURE);
 
-count = trade:getItemCount();
-CopperIngot = trade:hasItemQty(648,1);
-SilverIngot = trade:hasItemQty(744,1);
-MythrilIngot = trade:hasItemQty(653,1);
+    -- THE ELVAAN GOLDSMITH
+    if (theElvaanGoldsmith >= QUEST_ACCEPTED and npcUtil.tradeHas(trade, {648})) then
+        player:startEvent(216);
 
-    if ((CopperIngot == true) and count == 1) then
-        TheElvaanGoldsmith = player:getQuestStatus(BASTOK,THE_ELVAAN_GOLDSMITH);
-        if (TheElvaanGoldsmith == 1) then
-            player:tradeComplete();
-            player:addGil(GIL_RATE*180);
-            player:completeQuest(BASTOK,THE_ELVAAN_GOLDSMITH);
-            player:addFame(BASTOK,100);
-            player:startEvent(216);
-        end
-    elseif ((SilverIngot == true) and count == 1) then
-        FatherFigure = player:getQuestStatus(BASTOK,FATHER_FIGURE);
-        if (FatherFigure == 1) then
-            player:tradeComplete();
-            player:addGil(GIL_RATE*2200);
-            player:completeQuest(BASTOK,FATHER_FIGURE);
-            player:addFame(BASTOK,120);
-            player:startEvent(241);
-        end;
-    elseif ((MythrilIngot == true) and count == 1) then
-        DistantLoyalties = player:getQuestStatus(SANDORIA,DISTANT_LOYALTIES);
-        DistantLoyaltiesProgress = player:getVar("DistantLoyaltiesProgress");
-        if (DistantLoyalties == 1 and DistantLoyaltiesProgress == 2)        then
-            player:tradeComplete();
-            player:startEvent(317);
-        end;
+    -- DISTANT LOYALTIES
+    elseif (distantLoyalties == QUEST_ACCEPTED and player:getVar("DistantLoyaltiesProgress") == 2 and npcUtil.tradeHas(trade, {653})) then
+        player:startEvent(317);
+        
+    -- FATHER FIGURE
+    elseif (fatherFigure == QUEST_ACCEPTED and npcUtil.tradeHas(trade, {744})) then
+        player:startEvent(241);
     end;
-
-end;
+end; 
 
 function onTrigger(player,npc)
-
-pFame = player:getFameLevel(BASTOK);
-FatherFigure = player:getQuestStatus(BASTOK,FATHER_FIGURE);
-TheElvaanGoldsmith = player:getQuestStatus(BASTOK,THE_ELVAAN_GOLDSMITH);
-DistantLoyalties = player:getQuestStatus(SANDORIA,DISTANT_LOYALTIES);
-DistantLoyaltiesProgress = player:getVar("DistantLoyaltiesProgress");
-
-    if (TheElvaanGoldsmith == 0) then
+    local theElvaanGoldsmith = player:getQuestStatus(BASTOK,THE_ELVAAN_GOLDSMITH);
+    local distantLoyalties = player:getQuestStatus(SANDORIA,DISTANT_LOYALTIES);
+    local fatherFigure = player:getQuestStatus(BASTOK,FATHER_FIGURE);
+    
+    -- THE ELVAAN GOLDSMITH
+    if (theElvaanGoldsmith == QUEST_AVAILABLE) then
         player:startEvent(215);
-    elseif (DistantLoyalties ~= 1) then
-            if (FatherFigure == 0 and TheElvaanGoldsmith == 2 and pFame >= 2) then
-                player:startEvent(240);
-            else
-                player:startEvent(125);
-            end;
-    else
-        if (DistantLoyaltiesProgress == 1 and player:hasKeyItem(GOLDSMITHING_ORDER)) then
+        
+    -- DISTANT LOYALTIES
+    elseif (distantLoyalties == QUEST_ACCEPTED) then
+        local progress = player:getVar("DistantLoyaltiesProgress");
+        if (progress == 1 and player:hasKeyItem(GOLDSMITHING_ORDER)) then
             player:startEvent(315);
-        elseif (DistantLoyaltiesProgress == 2) then
+        elseif (progress == 2) then
             player:startEvent(316);
-        elseif (DistantLoyaltiesProgress == 3 and player:needToZone() == true) then
+        elseif (progress == 3 and player:needToZone() == true) then
             player:startEvent(317);
-        elseif (DistantLoyaltiesProgress == 3 and player:needToZone() == false) then
+        elseif (progress == 3 and player:needToZone() == false) then
             player:startEvent(318);
         end;
-    end;
-end;
+        
+    -- FATHER FIGURE
+    elseif (theElvaanGoldsmith == QUEST_COMPLETE and fatherFigure == QUEST_AVAILABLE and player:getFameLevel(BASTOK) >= 2) then
+        player:startEvent(240);
+
+    -- DEFAULT DIALOG
+    else
+        player:startEvent(125);
+    end;    
+end; 
 
 function onEventUpdate(player,csid,option)
-    -- printf("CSID: %u",csid);
-    -- printf("RESULT: %u",option);
 end;
 
 function onEventFinish(player,csid,option)
-    -- printf("CSID: %u",csid);
-    -- printf("RESULT: %u",option);
 
+    -- THE ELVAAN GOLDSMITH    
     if (csid == 215) then
         player:addQuest(BASTOK,THE_ELVAAN_GOLDSMITH);
-    elseif (csid == 240) then
-        player:addQuest(BASTOK,FATHER_FIGURE);
     elseif (csid == 216) then
-        player:messageSpecial(GIL_OBTAINED,GIL_RATE*180);
-    elseif (csid == 241) then
-        player:messageSpecial(GIL_OBTAINED,GIL_RATE*2200);
+        local fame = player:hasCompleteQuest(BASTOK, THE_ELVAAN_GOLDSMITH) and 8 or 100;
+        if (npcUtil.completeQuest(player, BASTOK, THE_ELVAAN_GOLDSMITH, {gil=180, fame=fame})) then
+            player:tradeComplete();
+        end
+
+    -- DISTANT LOYALTIES
     elseif (csid == 315) then
         player:delKeyItem(GOLDSMITHING_ORDER);
         player:setVar("DistantLoyaltiesProgress",2);
     elseif (csid == 317) then
+        player:tradeComplete();
         player:setVar("DistantLoyaltiesProgress",3);
         player:needToZone(true);
     elseif (csid == 318) then
         player:setVar("DistantLoyaltiesProgress",4);
-        player:addKeyItem(MYTHRIL_HEARTS);
-        player:messageSpecial(KEYITEM_OBTAINED,MYTHRIL_HEARTS);
+        npcUtil.giveKeyItem(player, MYTHRIL_HEARTS);
+        
+    -- FATHER FIGURE
+    elseif (csid == 240) then
+        player:addQuest(BASTOK,FATHER_FIGURE);
+    elseif (csid == 241) then
+        if (npcUtil.completeQuest(player, BASTOK, FATHER_FIGURE, {gil=2200, fame=120})) then
+            player:tradeComplete();
+        end
     end
-
 end;

--- a/scripts/zones/Bastok_Markets/npcs/Michea.lua
+++ b/scripts/zones/Bastok_Markets/npcs/Michea.lua
@@ -19,15 +19,15 @@ function onTrade(player,npc,trade)
     local fatherFigure = player:getQuestStatus(BASTOK,FATHER_FIGURE);
 
     -- THE ELVAAN GOLDSMITH
-    if (theElvaanGoldsmith >= QUEST_ACCEPTED and npcUtil.tradeHas(trade, {648})) then
+    if (theElvaanGoldsmith >= QUEST_ACCEPTED and npcUtil.tradeHas(trade, 648)) then
         player:startEvent(216);
 
     -- DISTANT LOYALTIES
-    elseif (distantLoyalties == QUEST_ACCEPTED and player:getVar("DistantLoyaltiesProgress") == 2 and npcUtil.tradeHas(trade, {653})) then
+    elseif (distantLoyalties == QUEST_ACCEPTED and player:getVar("DistantLoyaltiesProgress") == 2 and npcUtil.tradeHas(trade, 653)) then
         player:startEvent(317);
         
     -- FATHER FIGURE
-    elseif (fatherFigure == QUEST_ACCEPTED and npcUtil.tradeHas(trade, {744})) then
+    elseif (fatherFigure == QUEST_ACCEPTED and npcUtil.tradeHas(trade, 744)) then
         player:startEvent(241);
     end;
 end; 
@@ -35,6 +35,7 @@ end;
 function onTrigger(player,npc)
     local theElvaanGoldsmith = player:getQuestStatus(BASTOK,THE_ELVAAN_GOLDSMITH);
     local distantLoyalties = player:getQuestStatus(SANDORIA,DISTANT_LOYALTIES);
+    local distantLoyaltiesProgress = player:getVar("DistantLoyaltiesProgress");
     local fatherFigure = player:getQuestStatus(BASTOK,FATHER_FIGURE);
     
     -- THE ELVAAN GOLDSMITH
@@ -42,20 +43,19 @@ function onTrigger(player,npc)
         player:startEvent(215);
         
     -- DISTANT LOYALTIES
-    elseif (distantLoyalties == QUEST_ACCEPTED) then
-        local progress = player:getVar("DistantLoyaltiesProgress");
-        if (progress == 1 and player:hasKeyItem(GOLDSMITHING_ORDER)) then
+    elseif (distantLoyalties == QUEST_ACCEPTED and distantLoyaltiesProgress >= 1 and distantLoyaltiesProgress <= 3) then
+        if (distantLoyaltiesProgress == 1 and player:hasKeyItem(GOLDSMITHING_ORDER)) then
             player:startEvent(315);
-        elseif (progress == 2) then
+        elseif (distantLoyaltiesProgress == 2) then
             player:startEvent(316);
-        elseif (progress == 3 and player:needToZone() == true) then
+        elseif (distantLoyaltiesProgress == 3 and player:needToZone() == true) then
             player:startEvent(317);
-        elseif (progress == 3 and player:needToZone() == false) then
+        elseif (distantLoyaltiesProgress == 3 and player:needToZone() == false) then
             player:startEvent(318);
         end;
         
     -- FATHER FIGURE
-    elseif (theElvaanGoldsmith == QUEST_COMPLETE and fatherFigure == QUEST_AVAILABLE and player:getFameLevel(BASTOK) >= 2) then
+    elseif (theElvaanGoldsmith == QUEST_COMPLETED and fatherFigure == QUEST_AVAILABLE and player:getFameLevel(BASTOK) >= 2) then
         player:startEvent(240);
 
     -- DEFAULT DIALOG
@@ -75,7 +75,7 @@ function onEventFinish(player,csid,option)
     elseif (csid == 216) then
         local fame = player:hasCompleteQuest(BASTOK, THE_ELVAAN_GOLDSMITH) and 8 or 100;
         if (npcUtil.completeQuest(player, BASTOK, THE_ELVAAN_GOLDSMITH, {gil=180, fame=fame})) then
-            player:tradeComplete();
+            player:confirmTrade();
         end
 
     -- DISTANT LOYALTIES
@@ -83,7 +83,7 @@ function onEventFinish(player,csid,option)
         player:delKeyItem(GOLDSMITHING_ORDER);
         player:setVar("DistantLoyaltiesProgress",2);
     elseif (csid == 317) then
-        player:tradeComplete();
+        player:confirmTrade();
         player:setVar("DistantLoyaltiesProgress",3);
         player:needToZone(true);
     elseif (csid == 318) then
@@ -95,7 +95,7 @@ function onEventFinish(player,csid,option)
         player:addQuest(BASTOK,FATHER_FIGURE);
     elseif (csid == 241) then
         if (npcUtil.completeQuest(player, BASTOK, FATHER_FIGURE, {gil=2200, fame=120})) then
-            player:tradeComplete();
+            player:confirmTrade();
         end
     end
 end;

--- a/scripts/zones/Port_San_dOria/npcs/Miene.lua
+++ b/scripts/zones/Port_San_dOria/npcs/Miene.lua
@@ -6,6 +6,7 @@
 package.loaded["scripts/zones/Port_San_dOria/TextIDs"] = nil;
 -----------------------------------
 require("scripts/zones/Port_San_dOria/TextIDs");
+require("scripts/globals/npc_util");
 require("scripts/globals/settings");
 require("scripts/globals/quests");
 require("scripts/globals/titles");

--- a/scripts/zones/Port_San_dOria/npcs/Regine.lua
+++ b/scripts/zones/Port_San_dOria/npcs/Regine.lua
@@ -2,137 +2,136 @@
 -- Area: Port San d'Oria
 --  NPC: Regine
 -- Standard Merchant NPC
+-- !pos 68 -9 -74 232
 -----------------------------------
 package.loaded["scripts/zones/Port_San_dOria/TextIDs"] = nil;
 -----------------------------------
 require("scripts/zones/Port_San_dOria/TextIDs");
+require("scripts/globals/npc_util");
 require("scripts/globals/quests");
 require("scripts/globals/shop");
------------------------------------
 
 function onTrade(player,npc,trade)
-    -- "Flyers for Regine" conditional script
-    local count = trade:getItemCount();
+    local flyersForRegine = player:getQuestStatus(SANDORIA,FLYERS_FOR_REGINE);
+    local theBrugaireConsortium = player:getQuestStatus(SANDORIA,THE_BRUGAIRE_CONSORTIUM);
 
-    if (player:getQuestStatus(SANDORIA,FLYERS_FOR_REGINE) == QUEST_ACCEPTED and trade:getGil() == 10 and trade:getItemCount() == 1) then
-        if (player:getFreeSlotsCount() > 0) then
-            player:addItem(532,1);
-            player:tradeComplete();
-            player:messageSpecial(ITEM_OBTAINED,532);
-        else
-            player:messageSpecial(ITEM_CANNOT_BE_OBTAINED, 532); -- CANNOT_OBTAIN_ITEM
+    -- FLYERS FOR REGINE
+    if (flyersForRegine == QUEST_ACCEPTED and npcUtil.tradeHas( trade, {{"gil",10}} )) then
+        if (npcUtil.giveItem(player, 532)) then
+            player:confirmTrade();
         end
-    elseif (trade:hasItemQty(532,1) == true and count == 1) then
-        if (player:getQuestStatus(SANDORIA,FLYERS_FOR_REGINE) == QUEST_ACCEPTED) then
-            player:messageSpecial(FLYER_REFUSED);
-        end
-    elseif (trade:hasItemQty(593,1) == true and count == 1) then
-        if (player:getQuestStatus(SANDORIA,THE_BRUGAIRE_CONSORTIUM) == QUEST_ACCEPTED) then
-            player:tradeComplete();
-            player:startEvent(535);
-            player:setVar("TheBrugaireConsortium-Parcels", 11);
-        end
+    elseif (flyersForRegine == QUEST_ACCEPTED and npcUtil.tradeHas(trade, 532)) then
+        player:messageSpecial(FLYER_REFUSED);
+
+    -- THE BRUGAIRE CONSORTIUM
+    elseif (theBrugaireConsortium == QUEST_ACCEPTED and npcUtil.tradeHas(trade, 593)) then
+        player:startEvent(535);
     end
-
 end;
 
 function onTrigger(player,npc)
-    if (player:getVar("FFR") == 1) then
+    local ffr = player:getVar("FFR");
+
+    -- FLYERS FOR REGINE
+    if (player:getQuestStatus(SANDORIA,FLYERS_FOR_REGINE) == QUEST_AVAILABLE and ffr == 0) then
+        player:startEvent(601);
+    elseif (ffr == 1) then
         player:startEvent(510,2);
     elseif (player:getVar("FFR") == 2) then
         player:startEvent(603);
-    elseif (player:getVar("FFR") > 2 and (not(player:hasItem(532)))) then
+    elseif (player:getVar("FFR") > 2 and not player:hasItem(532)) then
         player:startEvent(510,3);
-    elseif (player:getQuestStatus(SANDORIA,FLYERS_FOR_REGINE) == QUEST_AVAILABLE and player:getVar("FFR") == 0) then
-        player:startEvent(601);
+        
+    -- DEFAULT MENU
     else
         player:startEvent(510);
     end
 end;
 
 function onEventUpdate(player,csid,option)
-    -- printf("CSID: %u",csid);
-    -- printf("RESULT: %u",option);
 end;
 
 function onEventFinish(player,csid,option)
-    -- printf("CSID: %u",csid);
-    -- printf("RESULT: %u",option);
-    if (csid == 510 and option == 2) then
-        if (npcUtil.giveItem(player, {{532, 12}, {532, 3}})) then
+    -- FLYERS FOR REGINE
+    if (csid == 601) then
+        player:setVar("FFR",1);
+    elseif (csid == 510 and option == 2) then
+        if (npcUtil.giveItem(player, {{532,12}, {532,3}} )) then
             player:addQuest(SANDORIA,FLYERS_FOR_REGINE);
             player:setVar("FFR",17);
         end
-    elseif (csid == 601) then
-        player:setVar("FFR",1);
     elseif (csid == 603) then
-        player:completeQuest(SANDORIA,FLYERS_FOR_REGINE);
-        player:addGil(GIL_RATE*440)
-        player:messageSpecial(GIL_OBTAINED,GIL_RATE*440);
-        player:addTitle(ADVERTISING_EXECUTIVE);
-        player:addFame(SANDORIA,30);
-        player:setVar("tradeAnswald",0);
-        player:setVar("tradePrietta",0);
-        player:setVar("tradeMiene",0);
-        player:setVar("tradePortaure",0);
-        player:setVar("tradeAuvare",0);
-        player:setVar("tradeGuilberdrier",0);
-        player:setVar("tradeVilion",0);
-        player:setVar("tradeCapiria",0);
-        player:setVar("tradeBoncort",0);
-        player:setVar("tradeCoullene",0);
-        player:setVar("tradeLeuveret",0);
-        player:setVar("tradeBlendare",0);
-        player:setVar("tradeMaugie",0);
-        player:setVar("tradeAdaunel",0);
-        player:setVar("tradeRosel",0);
-        player:setVar("FFR",0);
-    elseif (csid == 510) then
-        if (option == 0) then
-            local stockA =
-            {
-                0x1221,1165,1, -- Scroll of Diaga
-                0x1238,837,1,  -- Scroll of Slow
-                0x1236,7025,1, -- Scroll of Stoneskin
-
-                0x121c,140,2,  -- Scroll of Banish
-                0x1226,1165,2, -- Scroll of Banishga
-                0x1235,2097,2, -- Scroll of Blink
-                0x1202,585,2,  -- Scroll of Cure II
-
-                0x1237,360,3,  -- Scroll of Aquaveil
-                0x1210,990,3,  -- Scroll of Blindna
-                0x1207,1363,3, -- Scroll of Curaga
-                0x1201,61,3,   -- Scroll of Cure
-                0x1217,82,3,   -- Scroll of Dia
-                0x120f,324,3,  -- Scroll of Paralyna
-                0x120e,180,3,  -- Scroll of Poisona
-                0x122b,219,3,  -- Scroll of Protect
-                0x1230,1584,3  -- Scroll of Shell
-            }
-            showNationShop(player, NATION_SANDORIA, stockA);
-        elseif (option == 1) then
-            local stockB =
-            {
-                0x12fe,111,1,  -- Scroll of Blind
-                0x12e6,360,2,  -- Scroll of Bio
-                0x12dc,82,2,   -- Scroll of Poison
-                0x12fd,2250,2, -- Scroll of Sleep
-
-                0x129a,324,3,  -- Scroll of Aero
-                0x1295,1584,3, -- Scroll of Blizzard
-                0x12eb,4644,3, -- Scroll of Burn
-                0x12ed,2250,3, -- Scroll of Choke
-                0x12f0,6366,3, -- Scroll of Drown
-                0x1290,837,3,  -- Scroll of Fire
-                0x12ec,3688,3, -- Scroll of Frost
-                0x12ee,1827,3, -- Scroll of Rasp
-                0x12ef,1363,3, -- Scroll of Shock
-                0x129f,61,3,   -- Scroll of Stone
-                0x12a4,3261,3, -- Scroll of Thunder
-                0x12a9,140,3   -- Scroll of Water
-            }
-            showNationShop(player, NATION_SANDORIA, stockB);
+        if (npcUtil.completeQuest(player, SANDORIA, FLYERS_FOR_REGINE, {gil=440, title=ADVERTISING_EXECUTIVE})) then
+            player:setVar("tradeAnswald",0);
+            player:setVar("tradePrietta",0);
+            player:setVar("tradeMiene",0);
+            player:setVar("tradePortaure",0);
+            player:setVar("tradeAuvare",0);
+            player:setVar("tradeGuilberdrier",0);
+            player:setVar("tradeVilion",0);
+            player:setVar("tradeCapiria",0);
+            player:setVar("tradeBoncort",0);
+            player:setVar("tradeCoullene",0);
+            player:setVar("tradeLeuveret",0);
+            player:setVar("tradeBlendare",0);
+            player:setVar("tradeMaugie",0);
+            player:setVar("tradeAdaunel",0);
+            player:setVar("tradeRosel",0);
+            player:setVar("FFR",0);
         end
+
+    -- THE BRUGAIRE CONSORTIUM
+    elseif (csid == 535) then
+        player:confirmTrade();
+        player:setVar("TheBrugaireConsortium-Parcels", 11);
+        
+    -- WHITE MAGIC SHOP
+    elseif (csid == 510 and option == 0) then
+        local stockA =
+        {
+            4641,1165,1, -- Scroll of Diaga
+            4664,837,1,  -- Scroll of Slow
+            4662,7025,1, -- Scroll of Stoneskin
+
+            4636,140,2,  -- Scroll of Banish
+            4646,1165,2, -- Scroll of Banishga
+            4661,2097,2, -- Scroll of Blink
+            4610,585,2,  -- Scroll of Cure II
+
+            4663,360,3,  -- Scroll of Aquaveil
+            4624,990,3,  -- Scroll of Blindna
+            4615,1363,3, -- Scroll of Curaga
+            4609,61,3,   -- Scroll of Cure
+            4631,82,3,   -- Scroll of Dia
+            4623,324,3,  -- Scroll of Paralyna
+            4622,180,3,  -- Scroll of Poisona
+            4651,219,3,  -- Scroll of Protect
+            4656,1584,3  -- Scroll of Shell
+        }
+        showNationShop(player, NATION_SANDORIA, stockA);
+
+    -- BLACK MAGIC SHOP
+    elseif (csid == 510 and option == 1) then
+        local stockB =
+        {
+            4862,111,1,  -- Scroll of Blind
+            4838,360,2,  -- Scroll of Bio
+            4828,82,2,   -- Scroll of Poison
+            4861,2250,2, -- Scroll of Sleep
+
+            4762,324,3,  -- Scroll of Aero
+            4757,1584,3, -- Scroll of Blizzard
+            4843,4644,3, -- Scroll of Burn
+            4845,2250,3, -- Scroll of Choke
+            4848,6366,3, -- Scroll of Drown
+            4752,837,3,  -- Scroll of Fire
+            4844,3688,3, -- Scroll of Frost
+            4846,1827,3, -- Scroll of Rasp
+            4847,1363,3, -- Scroll of Shock
+            4767,61,3,   -- Scroll of Stone
+            4772,3261,3, -- Scroll of Thunder
+            4777,140,3   -- Scroll of Water
+        }
+        showNationShop(player, NATION_SANDORIA, stockB);
     end
 end;

--- a/scripts/zones/Western_Adoulin/npcs/Chanteillie.lua
+++ b/scripts/zones/Western_Adoulin/npcs/Chanteillie.lua
@@ -1,54 +1,50 @@
 -----------------------------------
--- Area: Western Adoulin
+--  Area: Western Adoulin
 --  NPC: Chanteillie
--- Type: Standard NPC and Quest NPC
+--  Type: Standard NPC and Quest NPC
 --  Involved with Quests: 'Do Not Go Into the Light'
 --                        'Vegetable Vegetable Crisis'
---  @zone 256
 --  !pos 89 0 -75 256
 -----------------------------------
 package.loaded["scripts/zones/Western_Adoulin/TextIDs"] = nil;
 -----------------------------------
+require("scripts/zones/Western_Adoulin/TextIDs");
+require("scripts/globals/keyitems");
+require("scripts/globals/missions");
 require("scripts/globals/npc_util");
 require("scripts/globals/quests");
-require("scripts/globals/keyitems");
-require("scripts/zones/Western_Adoulin/TextIDs");
------------------------------------
 
 function onTrade(player,npc,trade)
     local DNGITL = player:getQuestStatus(ADOULIN, DO_NOT_GO_INTO_THE_LIGHT);
     local VVC = player:getQuestStatus(ADOULIN, VEGETABLE_VEGETABLE_CRISIS);
 
-    if ((DNGITL == QUEST_ACCEPTED) and (player:getVar("DNGITL_Status") == 3) and npcUtil.tradeHas(trade, {3927, 658, 4096})) then
-        -- Trading Urunday Lumber x1, Damascus Ingot x1, and Fire Crystal x1
-        -- Progresses Quest: 'Do Not Go Into the Light'
+    -- DO NOT GO INTO THE LIGHT (Urunday Lumber, Damascus Ingot, Fire Crystal)
+    if (DNGITL == QUEST_ACCEPTED and player:getVar("DNGITL_Status") == 3 and npcUtil.tradeHas(trade, {3927, 658, 4096})) then
         player:startEvent(5076);
-    elseif  ((VVC == QUEST_ACCEPTED) and (player:getVar("VVC_Status") == 1) and npcUtil.tradeHas(trade, {3927, 3919, 8708})) then
-        -- Trading Urunday Lumber x1, Midrium Ingot x1, and Raaz Leather x1
-        -- Progresses Quest: 'Vegetable Vegetable Crisis'
+
+    -- VEGETABLE VEGETABLE CRISIS (Urunday Lumber, Midrium Ingot, Raaz Leather)
+    elseif (VVC == QUEST_ACCEPTED and player:getVar("VVC_Status") == 1 and npcUtil.tradeHas(trade, {3927, 3919, 8708})) then
         player:startEvent(5089);
     end
 end;
 
 function onTrigger(player,npc)
-    local SOA_Mission = player:getCurrentMission(SOA);
     local DNGITL = player:getQuestStatus(ADOULIN, DO_NOT_GO_INTO_THE_LIGHT);
     local VVC = player:getQuestStatus(ADOULIN, VEGETABLE_VEGETABLE_CRISIS);
 
-    if ((VVC == QUEST_ACCEPTED) and (player:getVar("VVC_Status") == 1)) then
-        -- Reminder during Quest: 'Vegetable Vegetable Crisis'
-        player:startEvent(5088);
-    elseif ((DNGITL == QUEST_ACCEPTED) and player:hasKeyItem(INVENTORS_COALITION_PICKAXE)) then
-        -- Reminder during Quest: 'Do Not Go Into The Light'
+    -- DO NOT GO INTO THE LIGHT
+    if (DNGITL == QUEST_ACCEPTED and player:hasKeyItem(INVENTORS_COALITION_PICKAXE)) then
         player:startEvent(5077);
+
+    -- VEGETABLE VEGETABLE CRISIS
+    elseif (VVC == QUEST_ACCEPTED and player:getVar("VVC_Status") == 1) then
+        player:startEvent(5088);
+
+    -- STANDARD DIALOGS
+    elseif (player:getCurrentMission(SOA) >= LIFE_ON_THE_FRONTIER) then
+        player:startEvent(588); -- Standard dialogue
     else
-        if (SOA_Mission >= LIFE_ON_THE_FRONTIER) then
-            -- Standard dialogue
-            player:startEvent(588);
-        else
-            -- Dialogue prior to joining colonization effort
-            player:startEvent(531);
-        end
+        player:startEvent(531); -- Dialogue prior to joining colonization effort
     end
 end;
 
@@ -56,15 +52,15 @@ function onEventUpdate(player,csid,option)
 end;
 
 function onEventFinish(player,csid,option)
+    -- DO NOT GO INTO THE LIGHT
     if (csid == 5076) then
-        -- Progresses Quest: 'Do Not Go Into the Light'
-        player:tradeComplete();
-        player:addKeyItem(INVENTORS_COALITION_PICKAXE);
-        player:messageSpecial(KEYITEM_OBTAINED, INVENTORS_COALITION_PICKAXE);
+        player:confirmTrade();
+        npcUtil.giveKeyItem(player, INVENTORS_COALITION_PICKAXE);
         player:setVar("DNGITL_Status", 0);
+
+    -- VEGETABLE VEGETABLE CRISIS   
     elseif (csid == 5089) then
-        -- Progresses Quest: 'Vegetable Vegetable Crisis'
-        player:tradeComplete();
+        player:confirmTrade();
         player:setVar("VVC_Status", 2);
         player:setVar("VVC_Gameday_Wait", vanaDay());
     end

--- a/scripts/zones/Western_Adoulin/npcs/Defliaa.lua
+++ b/scripts/zones/Western_Adoulin/npcs/Defliaa.lua
@@ -1,42 +1,38 @@
 -----------------------------------
--- Area: Western Adoulin
+--  Area: Western Adoulin
 --  NPC: Defliaa
--- Type: Quest NPC and Shop NPC
+--  Type: Quest NPC and Shop NPC
 --  Involved with Quest: 'All the Way to the Bank'
---  @zone 256
 --  !pos 43 2 -113 256
 -----------------------------------
 package.loaded["scripts/zones/Western_Adoulin/TextIDs"] = nil;
 -----------------------------------
-require("scripts/globals/shop");
-require("scripts/globals/npc_util");
-require("scripts/globals/quests");
-require("scripts/globals/keyitems");
 require("scripts/zones/Western_Adoulin/TextIDs");
------------------------------------
+require("scripts/globals/keyitems");
+require("scripts/globals/npc_util");
+require("scripts/globals/shop");
 
 function onTrade(player,npc,trade)
+    -- ALL THE WAY TO THE BANK
     if (player:hasKeyItem(TARUTARU_SAUCE_INVOICE)) then
         local ATWTTB_Paid_Defliaa = player:getMaskBit(player:getVar("ATWTTB_Payments"), 0);
-        if ((not ATWTTB_Paid_Defliaa) and npcUtil.tradeHas(trade, nil, 19440)) then
-            -- Progresses Quest: 'All the Way to the Bank'
+        if (not ATWTTB_Paid_Defliaa and npcUtil.tradeHas( trade, {{"gil",19440}} )) then
             player:startEvent(5069);
         end
     end
 end;
 
 function onTrigger(player,npc)
-    -- Standard shop
     player:showText(npc, DEFLIAA_SHOP_TEXT);
     local stock =
     {
-        0x142E, 3400,   -- Coeurl Sub
-        0x1145, 1560,   -- Melon Pie
-        0x1701, 19440,  -- Stuffed Pitaru
-        0x16FD, 18900,  -- Saltena
-        0x112C, 280,    -- Sausage Roll
-        0x1104, 200,    -- White Bread
-        0x1636, 800,    -- Cheese Sandwich
+        5166, 3400,   -- Coeurl Sub
+        4421, 1560,   -- Melon Pie
+        5889, 19440,  -- Stuffed Pitaru
+        5885, 18900,  -- Saltena
+        4396, 280,    -- Sausage Roll
+        4356, 200,    -- White Bread
+        5686, 800,    -- Cheese Sandwich
     }
     showShop(player, STATIC, stock);
 end;
@@ -45,13 +41,12 @@ function onEventUpdate(player,csid,option)
 end;
 
 function onEventFinish(player,csid,option)
+    -- ALL THE WAY TO THE BANK
     if (csid == 5069) then
-        -- Progresses Quest: 'All the Way to the Bank'
-        player:tradeComplete();
+        player:confirmTrade();
         player:setMaskBit("ATWTTB_Payments", 0, true);
         if (player:isMaskFull(player:getVar("ATWTTB_Payments"), 5)) then
-            player:addKeyItem(TARUTARU_SAUCE_RECEIPT);
-            player:messageSpecial(KEYITEM_OBTAINED, TARUTARU_SAUCE_RECEIPT);
+            npcUtil.giveKeyItem(player, TARUTARU_SAUCE_RECEIPT);
         end
     end
 end;

--- a/scripts/zones/Western_Adoulin/npcs/Flapano.lua
+++ b/scripts/zones/Western_Adoulin/npcs/Flapano.lua
@@ -1,78 +1,75 @@
 -----------------------------------
--- Area: Western Adoulin
+--  Area: Western Adoulin
 --  NPC: Flapno
--- Type: Standard NPC, Quest NPC, and Shop NPC
+--  Type: Standard NPC, Quest NPC, and Shop NPC
 --  Starts, Involved with, and Finishes Quest: 'Exotic Delicacies'
 --  Involved with Quest: 'All the Way to the Bank'
---  @zone 256
 --  !pos 70 0 -13 256
 -----------------------------------
 package.loaded["scripts/zones/Western_Adoulin/TextIDs"] = nil;
 -----------------------------------
-require("scripts/globals/shop");
+require("scripts/zones/Western_Adoulin/TextIDs");
+require("scripts/globals/keyitems");
 require("scripts/globals/npc_util");
 require("scripts/globals/quests");
-require("scripts/globals/keyitems");
-require("scripts/zones/Western_Adoulin/TextIDs");
------------------------------------
+require("scripts/globals/shop");
 
 function onTrade(player,npc,trade)
-    local Exotic_Delicacies = player:getQuestStatus(ADOULIN, EXOTIC_DELICACIES);
+    local exoticDelacacies = player:getQuestStatus(ADOULIN, EXOTIC_DELICACIES);
 
-    if (player:hasKeyItem(TARUTARU_SAUCE_INVOICE) and npcUtil.tradeHas(trade, nil, 5600)) then
+    -- ALL THE WAY TO THE BANK
+    if (player:hasKeyItem(TARUTARU_SAUCE_INVOICE) and npcUtil.tradeHas( trade, {{"gil",5600}} )) then
         local ATWTTB_Paid_Flapano = player:getMaskBit(player:getVar("ATWTTB_Payments"), 2);
-        -- Progresses Quest: 'All the Way to the Bank'
         if (not ATWTTB_Paid_Flapano) then
             player:startEvent(5071);
         end
-    elseif (Exotic_Delicacies == QUEST_ACCEPTED) then
-        if (npcUtil.tradeHas(trade, {3916, 5954, 5954, 5949})) then
-            -- Trading Saffron x1, Barnacle x2, and Mussel x1
-            -- Finishes Quest: 'Exotic Delicacies'
+
+    -- EXOTIC DELICACIES
+    elseif (exoticDelacacies == QUEST_ACCEPTED) then
+        if (npcUtil.tradeHas( trade, {3916, 5949, {5954,2}} )) then
             player:startEvent(2861);
         elseif (npcUtil.tradeHas(trade, 5974) or npcUtil.tradeHas(trade, 5975)) then
-            -- Trading Barnacle Paella or Flapano's Paella
             player:startEvent(2862);
         end
     end
 end;
 
 function onTrigger(player,npc)
-    local Exotic_Delicacies = player:getQuestStatus(ADOULIN, EXOTIC_DELICACIES);
-    local TWW = player:getQuestStatus(ADOULIN, THE_WEATHERSPOON_WAR);
+    local theWeatherspoonWar = player:getQuestStatus(ADOULIN, THE_WEATHERSPOON_WAR);
+    local exoticDelacacies = player:getQuestStatus(ADOULIN, EXOTIC_DELICACIES);
 
-    if ((TWW == QUEST_ACCEPTED) and (player:getVar("Weatherspoon_War_Status") == 6)) then
-        -- Dialogue near the end of Quest: 'The Weatherspoon War'
+    -- THE WEATHERSPOON WAR
+    if (theWeatherspoonWar == QUEST_ACCEPTED and player:getVar("Weatherspoon_War_Status") == 6) then
         player:startEvent(191);
-    else
-        -- Flapano offers his quest every other time the player talks to him
-        if (player:getVar("Flapano_Odd_Even") > 0) then
-            if (Exotic_Delicacies == QUEST_ACCEPTED) then
-                -- Reminds player of items for Quest: 'Exotic Delicacies'
-                player:startEvent(2863);
-            elseif (Exotic_Delicacies == QUEST_AVAILABLE) then
-                --- Starts Quest: 'Exotic Delicacies'
-                player:startEvent(2860);
-            end
-            player:setVar("Flapano_Odd_Even", 0);
-        else
-            -- Standard shop
-            player:showText(npc, FLAPANO_SHOP_TEXT);
-            local stock =
-            {
-                0x1737, 125,   -- Smoked Mackerel
-                0x113F, 124,   -- Roasted Corn
-                0x1152, 5000,  -- Mushroom Risotto
-                0x1419, 5600,  -- Fish and Chips
-                0x1147, 300,   -- Apple Juice
-                0x1135, 160,   -- Rice Ball
-                0x162C, 76475, -- Mushroom Sautee
-            }
-            showShop(player, STATIC, stock);
+    
+    -- EXOTIC DELICACIES
+    -- Flapano offers his quest every other time the player talks to him
+    elseif (exoticDelacacies ~= QUEST_COMPLETED and player:getVar("Flapano_Odd_Even") == 0) then
+        if (exoticDelicacies == QUEST_AVAILABLE) then
+            player:startEvent(2860);
+        elseif (exoticDelicacies == QUEST_ACCEPTED) then
+            player:startEvent(2863);
+        end
 
-            if (Exotic_Delicacies ~= QUEST_COMPLETED) then
-                player:setVar("Flapano_Odd_Even", 1);
-            end
+        player:setVar("Flapano_Odd_Even", 1);
+    
+    -- SHOP
+    else
+        player:showText(npc, FLAPANO_SHOP_TEXT);
+        local stock =
+        {
+            5943, 125,   -- Smoked Mackerel
+            4415, 124,   -- Roasted Corn
+            4434, 5000,  -- Mushroom Risotto
+            5145, 5600,  -- Fish and Chips
+            4423, 300,   -- Apple Juice
+            4405, 160,   -- Rice Ball
+            5676, 76475, -- Mushroom Sautee
+        }
+        showShop(player, STATIC, stock);
+
+        if (exoticDelicacies ~= QUEST_COMPLETED) then
+            player:setVar("Flapano_Odd_Even", 0);
         end
     end
 end;
@@ -81,29 +78,21 @@ function onEventUpdate(player,csid,option)
 end;
 
 function onEventFinish(player,csid,option)
-    if (csid == 2860) then
-        if (option == 1) then
-            --- Starts Quest: 'Exotic Delicacies'
-            player:addQuest(ADOULIN, EXOTIC_DELICACIES);
-        end
-    elseif (csid == 2861) then
-        -- Finishes Quest: 'Exotic Delicacies'
-        if (npcUtil.giveItem(player, 5975)) then
-            player:tradeComplete();
-            player:setVar("Flapano_Odd_Even", 0);
-            player:completeQuest(ADOULIN, EXOTIC_DELICACIES);
-            player:addExp(1000 * EXP_RATE);
-            player:addCurrency('bayld', 500 * BAYLD_RATE);
-            player:messageSpecial(BAYLD_OBTAINED, 500 * BAYLD_RATE);
-            player:addFame(ADOULIN);
-        end
-    elseif (csid == 5071) then
-        -- Progresses Quest: 'All the Way to the Bank'
-        player:tradeComplete();
+    -- ALL THE WAY TO THE BANK
+    if (csid == 5071) then
+        player:confirmTrade();
         player:setMaskBit("ATWTTB_Payments", 2, true);
         if (player:isMaskFull(player:getVar("ATWTTB_Payments"), 5)) then
-            player:addKeyItem(TARUTARU_SAUCE_RECEIPT);
-            player:messageSpecial(KEYITEM_OBTAINED, TARUTARU_SAUCE_RECEIPT);
+            npcUtil.giveKeyItem(TARUTARU_SAUCE_RECEIPT);
+        end
+
+    -- EXOTIC DELICACIES
+    elseif (csid == 2860 and option == 1) then
+        player:addQuest(ADOULIN, EXOTIC_DELICACIES);
+    elseif (csid == 2861) then
+        if (npcUtil.completeQuest(player, ADOULIN, EXOTIC_DELICACIES, {bayld=500, item=5975, xp=1000})) then
+            player:confirmTrade();
+            player:setVar("Flapano_Odd_Even", 0);
         end
     end
 end;

--- a/scripts/zones/Western_Adoulin/npcs/Hujette.lua
+++ b/scripts/zones/Western_Adoulin/npcs/Hujette.lua
@@ -1,40 +1,37 @@
 -----------------------------------
--- Area: Western Adoulin
+--  Area: Western Adoulin
 --  NPC: Hujette
--- Type: Quest NPC and Shop NPC
+--  Type: Quest NPC and Shop NPC
 --  Involved with Quest: 'All the Way to the Bank'
---  @zone 256
 --  !pos 35 0 -56 256
 -----------------------------------
 package.loaded["scripts/zones/Western_Adoulin/TextIDs"] = nil;
 -----------------------------------
-require("scripts/globals/shop");
+require("scripts/zones/Western_Adoulin/TextIDs");
+require("scripts/globals/keyitems");
 require("scripts/globals/npc_util");
 require("scripts/globals/quests");
-require("scripts/globals/keyitems");
-require("scripts/zones/Western_Adoulin/TextIDs");
------------------------------------
+require("scripts/globals/shop");
 
 function onTrade(player,npc,trade)
+    -- ALL THE WAY TO THE BANK
     if (player:hasKeyItem(TARUTARU_SAUCE_INVOICE)) then
         local ATWTTB_Paid_Hujette = player:getMaskBit(player:getVar("ATWTTB_Payments"), 1);
-        if ((not ATWTTB_Paid_Hujette) and npcUtil.tradeHas(trade, nil, 3000)) then
-            -- Progresses Quest: 'All the Way to the Bank'
+        if ((not ATWTTB_Paid_Hujette) and npcUtil.tradeHas( trade, {{"gil",3000}} )) then
             player:startEvent(5070);
         end
     end
 end;
 
 function onTrigger(player,npc)
-    -- Standard shop
     player:showText(npc, HUJETTE_SHOP_TEXT);
     local stock =
     {
-        0x1735, 20,     -- Campfire Choco
-        0x1734, 8,      -- Trail Cookie
-        0x1736, 20,     -- Cascade Candy
-        0x168F, 544,    -- Chocolate Crepe
-        0x141B, 3000,   -- Snoll Gelato
+        5941, 20,     -- Campfire Choco
+        5940, 8,      -- Trail Cookie
+        5942, 20,     -- Cascade Candy
+        5775, 544,    -- Chocolate Crepe
+        5147, 3000,   -- Snoll Gelato
     }
     showShop(player, STATIC, stock);
 end;
@@ -43,13 +40,12 @@ function onEventUpdate(player,csid,option)
 end;
 
 function onEventFinish(player,csid,option)
+    -- ALL THE WAY TO THE BANK
     if (csid == 5070) then
-        -- Progresses Quest: 'All the Way to the Bank'
-        player:tradeComplete();
+        player:confirmTrade();
         player:setMaskBit("ATWTTB_Payments", 1, true);
         if (player:isMaskFull(player:getVar("ATWTTB_Payments"), 5)) then
-            player:addKeyItem(TARUTARU_SAUCE_RECEIPT);
-            player:messageSpecial(KEYITEM_OBTAINED, TARUTARU_SAUCE_RECEIPT);
+            npcUtil.giveKeyItem(player, TARUTARU_SAUCE_RECEIPT);
         end
     end
 end;

--- a/src/map/lua/lua_baseentity.cpp
+++ b/src/map/lua/lua_baseentity.cpp
@@ -3435,8 +3435,7 @@ inline int32 CLuaBaseEntity::confirmTrade(lua_State *L)
         if (PChar->TradeContainer->getInvSlotID(slotID) != 0xFF && PChar->TradeContainer->getConfirmedStatus(slotID))
         {
             uint8 invSlotID = PChar->TradeContainer->getInvSlotID(slotID);
-            auto quantity = (int32)std::max<uint32>(PChar->TradeContainer->getQuantity(slotID), PChar->TradeContainer->getConfirmedStatus(slotID));
-
+            auto quantity = (int32)std::min<uint32>(PChar->TradeContainer->getQuantity(slotID), PChar->TradeContainer->getConfirmedStatus(slotID));
             charutils::UpdateItem(PChar, LOC_INVENTORY, invSlotID, -quantity);
         }
     }

--- a/src/map/lua/lua_trade_container.cpp
+++ b/src/map/lua/lua_trade_container.cpp
@@ -229,24 +229,24 @@ inline int32 CLuaTradeContainer::confirmItem(lua_State *L)
     {
         if (!lua_isnil(L, 1) && lua_isnumber(L, 1))
         {
-            uint8 itemID = (uint8)lua_tonumber(L, 1);
-            uint8 amount = 1;
+            uint16 itemID = (uint16)lua_tonumber(L, 1);
+            uint32 amount = 1;
             if (lua_isnumber(L, 2))
             {
-                amount = (uint8)lua_tonumber(L, 2);
+                amount = (uint32)lua_tonumber(L, 2);
             }
-            for (uint8 slotid = 1; slotid < 8; ++slotid)
+            for (uint8 slotID = 0; slotID < TRADE_CONTAINER_SIZE; ++slotID)
             {
-                if (m_pMyTradeContainer->getItemID(slotid) == itemID)
+                if (m_pMyTradeContainer->getItemID(slotID) == itemID)
                 {
-                    if (m_pMyTradeContainer->getQuantity(slotid) < amount)
+                    if (m_pMyTradeContainer->getQuantity(slotID) < amount)
                     {
-                        m_pMyTradeContainer->setConfirmedStatus(slotid, m_pMyTradeContainer->getQuantity(slotid));
-                        amount -= m_pMyTradeContainer->getQuantity(slotid);
+                        m_pMyTradeContainer->setConfirmedStatus(slotID, m_pMyTradeContainer->getQuantity(slotID));
+                        amount -= m_pMyTradeContainer->getQuantity(slotID);
                     }
                     else
                     {
-                        m_pMyTradeContainer->setConfirmedStatus(slotid, amount);
+                        m_pMyTradeContainer->setConfirmedStatus(slotID, amount);
                         lua_pushboolean(L, true);
                         return 1;
                     }
@@ -267,10 +267,10 @@ inline int32 CLuaTradeContainer::confirmSlot(lua_State *L)
         if (!lua_isnil(L, 1) && lua_isnumber(L, 1))
         {
             uint8 slotID = (uint8)lua_tonumber(L, 1);
-            uint8 amount = 1;
+            uint32 amount = 1;
             if (lua_isnumber(L, 2))
             {
-                amount = (uint8)lua_tonumber(L, 2);
+                amount = (uint32)lua_tonumber(L, 2);
             }
             lua_pushboolean(L, m_pMyTradeContainer->setConfirmedStatus(slotID, amount));
             return 1;


### PR DESCRIPTION
Fixed an issue where npcUtil.completeQuest() would crash server when given an area without a corresponding fame area.

Converted several bastok markets quest NPCS to use npc_util.lua