### PR TITLE
latents not applied for entire listing

### DIFF
--- a/src/map/latent_effect_container.cpp
+++ b/src/map/latent_effect_container.cpp
@@ -624,15 +624,22 @@ void CLatentEffectContainer::CheckLatentsWeather(uint16 weather)
 
 // Process the latent effects container and apply a logic function responsible for
 // filtering the appropriate latents to be activated/deactivated and finally update
-// health post looping
+// mask with UPDATE_HP post looping if at least one logic function returned true
 void CLatentEffectContainer::ProcessLatentEffects(std::function <bool(CLatentEffect&)> logic)
 {
+    auto count = 0;
+
     for (auto& latent : m_LatentEffectList)
     {
         if (logic(latent))
         {
-            m_POwner->UpdateHealth();
+            count++;
         }
+    }
+
+    if (count > 0)
+    {
+        m_POwner->updatemask |= UPDATE_HP;
     }
 }
 

--- a/src/map/latent_effect_container.cpp
+++ b/src/map/latent_effect_container.cpp
@@ -627,9 +627,12 @@ void CLatentEffectContainer::CheckLatentsWeather(uint16 weather)
 // health post looping
 void CLatentEffectContainer::ProcessLatentEffects(std::function <bool(CLatentEffect&)> logic)
 {
-    if (std::any_of(m_LatentEffectList.begin(), m_LatentEffectList.end(), logic))
+    for (auto& latent : m_LatentEffectList)
     {
-        m_POwner->UpdateHealth();
+        if (logic(latent))
+        {
+            m_POwner->UpdateHealth();
+        }
     }
 }
 


### PR DESCRIPTION
- std::any_of will exit after satisfying true and will prevent further
latents from applying
- need to have a decision made if we want to apply UpdateHealth() once
after all latent processing or each time a latent activates/deactivates.
- Fixes #4438 