### PR TITLE
Riverne A01 portal IDs

### DIFF
--- a/scripts/zones/Riverne-Site_A01/npcs/Spatial_Displacement.lua
+++ b/scripts/zones/Riverne-Site_A01/npcs/Spatial_Displacement.lua
@@ -25,67 +25,9 @@ function onTrigger(player,npc)
         player:startEvent(3);
     elseif (id == base+2) then 
         player:startEvent(4);
-    elseif (id == base+7) then 
-        player:startEvent(7);
-    elseif (id == base+8) then 
-        player:startEvent(8);
-    elseif (id == base+9) then 
-        player:startEvent(9);
-    elseif (id == base+10) then 
-        player:startEvent(10);
-    elseif (id == base+11) then 
-        player:startEvent(11);
-    elseif (id == base+12) then 
-        player:startEvent(12);
-    elseif (id == base+13) then 
-        player:startEvent(13);
-    elseif (id == base+14) then 
-        player:startEvent(14);
-    elseif (id == base+15) then 
-        player:startEvent(15);
-    elseif (id == base+16) then 
-        player:startEvent(16);
-    elseif (id == base+18) then 
-        player:startEvent(18);
-    elseif (id == base+20) then 
-        player:startEvent(20);
-    elseif (id == base+21) then 
-        player:startEvent(21);
-    elseif (id == base+22) then 
-        player:startEvent(22);
-    elseif (id == base+23) then 
-        player:startEvent(23);
-    elseif (id == base+24) then 
-        player:startEvent(24);
-    elseif (id == base+25) then 
-        player:startEvent(25);
-    elseif (id == base+26) then 
-        player:startEvent(26);
-    elseif (id == base+27) then 
-        player:startEvent(27);
-    elseif (id == base+28) then 
-        player:startEvent(28);
-    elseif (id == base+29) then 
-        player:startEvent(29);
-    elseif (id == base+30) then 
-        player:startEvent(30);
-    elseif (id == base+31) then 
-        player:startEvent(31);
-    elseif (id == base+33) then 
-        player:startEvent(21);
-    elseif (id == base+34) then 
-        player:startEvent(22);
-    elseif (id == base+35) then 
-        player:startEvent(23);
-    elseif (id == base+36) then 
-        player:startEvent(24);
-    elseif (id == base+37) then 
-        player:startEvent(25);
-    elseif (id == base+38) then 
-        player:startEvent(26);
-    elseif (id == base+39) then 
-        player:startEvent(27);
-    end
+    elseif (id - base <= 39) then
+        player:startEvent(id - base);
+    end;
     
 end;
 
@@ -106,7 +48,7 @@ function onEventFinish(player,csid,option)
     -- printf("CSID: %u",csid);
     -- printf("RESULT: %u",option);
     
-    if (csid == 23 and option == 1) then
+    if (csid == 35 and option == 1) then
         player:setPos(12.527,0.345,-539.602,127,31); -- to Monarch Linn (Retail confirmed)
     elseif (csid == 10 and option == 1) then
         player:setPos(-538.526,-29.5,359.219,255,25); -- back to Misareaux Coast (Retail confirmed)


### PR DESCRIPTION
Some spatial displacements in Riverne A01 send you to the wrong destination, after a certain client update, making it difficult to reach monarch linn for CoP mission. Mapped new IDs, changed npc script and tested all paths both ways. (Edit: A particular unstable displacement appears to not be coded, but seems like a useless dead end anyway)