### PR TITLE
sky portals / pincerstone, typo npcId -> portalId

### DIFF
--- a/scripts/zones/RuAun_Gardens/npcs/Pincerstone.lua
+++ b/scripts/zones/RuAun_Gardens/npcs/Pincerstone.lua
@@ -18,7 +18,7 @@ function onTrigger(player,npc)
     if (portalId ~= nil) then
         local portal = GetNPCByID(portalId);
         if (portal:getAnimation() == ANIMATION_CLOSE_DOOR) then
-            GetNPCByID(npcId - 1):openDoor(120);
+            GetNPCByID(portalId - 1):openDoor(120);
             portal:openDoor(120);
         else
             player:messageSpecial(IT_IS_ALREADY_FUNCTIONING);


### PR DESCRIPTION
client /ver 30171205_0
GIT_VER 761961e4f484c6648da0d07f0edbc280ffce13ef (master)

Noticed that at least some of the pincerstones in sky (Ru'Aun Gardens) were not activating the teleport pads. Script was attempting to index a nil value on line 21 because tried to use (npcId - 1) instead of (RUAUN_PINCERSTONES[npcId] - 1). Simple one line fix. Tested going around the circle.