### PR TITLE
Add capability to log GM command use to database.

### DIFF
--- a/conf/map_darkstar.conf
+++ b/conf/map_darkstar.conf
@@ -171,7 +171,13 @@ max_merit_points: 30
 #Minimum time between uses of yell command (in seconds).
 yell_cooldown: 30
 
-#Audit[logging] settings
+#Command Audit[logging] commands with lower permission than this will not be logged.
+# Zero for no logging at all. Commands given to non GMs are not logged. Autotranslate is not parsed.
+audit_gm_cmd: 0
+
+#Todo: other logging including anti-cheat messages
+
+#Chat Audit[logging] settings
 audit_chat: 0
 audit_say: 0
 audit_shout: 0

--- a/sql/audit_gm.sql
+++ b/sql/audit_gm.sql
@@ -1,0 +1,20 @@
+-- MySQL dump 10.13  Distrib 5.7.12, for Win64 (x86_64)
+--
+-- Host: localhost    Database: dspdb
+-- ------------------------------------------------------
+-- Server version	5.5.5-10.0.20-MariaDB
+
+--
+-- Table structure for table `audit_gm`
+--
+
+DROP TABLE IF EXISTS `audit_gm`;
+CREATE TABLE `audit_gm` (
+  `date_time` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  `gm_name` varchar(16) NOT NULL,
+  `command` varchar(40) NOT NULL,
+  `full_string` varchar(200) NOT NULL,
+  PRIMARY KEY (`date_time`,`gm_name`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+
+-- Dump completed on 2016-10-04  4:18:42

--- a/src/map/map.cpp
+++ b/src/map/map.cpp
@@ -993,6 +993,7 @@ int32 map_config_default()
     map_config.CoP_Battle_cap = 1;
     map_config.max_merit_points = 30;
     map_config.yell_cooldown = 30;
+    map_config.audit_gm_cmd = 0;
     map_config.audit_chat = 0;
     map_config.audit_say = 0;
     map_config.audit_shout = 0;
@@ -1279,6 +1280,10 @@ int32 map_config_read(const int8* cfgName)
         else if (strcmp(w1, "yell_cooldown") == 0)
         {
             map_config.yell_cooldown = atoi(w2);
+        }
+        else if (strcmp(w1, "audit_gm_cmd") == 0)
+        {
+            map_config.audit_gm_cmd = atoi(w2);
         }
         else if (strcmp(w1, "audit_chat") == 0)
         {

--- a/src/map/map.h
+++ b/src/map/map.h
@@ -123,6 +123,7 @@ struct map_config_t
     uint8  max_merit_points;          // global variable, amount of merit points players are allowed
     uint16 yell_cooldown;             // Minimum time between uses of yell command (in seconds).
     float  fame_multiplier;           // Fame multiplier
+    uint8  audit_gm_cmd;              // Minimum permission level of GM command to bother logging.
     bool   audit_chat;
     bool   audit_say;
     bool   audit_shout;

--- a/src/map/packets/chat_message.h
+++ b/src/map/packets/chat_message.h
@@ -76,7 +76,7 @@ class CChatMessagePacket : public CBasicPacket
 {
 public:
     static const uint16 id {0x17};
-	CChatMessagePacket(CCharEntity* PChar, CHAT_MESSAGE_TYPE MessageType, const std::string& message, const std::string& sender = std::string());
+    CChatMessagePacket(CCharEntity* PChar, CHAT_MESSAGE_TYPE MessageType, const std::string& message, const std::string& sender = std::string());
 };
 
 #endif


### PR DESCRIPTION
Note: if this is merged then from here out we require a minimum of **mysql 5.6,5** or **MariaDB 10.0.1** as anything older doesn't allow a default value of CURRENT_TIME on datestamp columns.