### PR TITLE
Howling Moon and monstertpmoves tweaks

### DIFF
--- a/scripts/globals/mobskills/howling_moon.lua
+++ b/scripts/globals/mobskills/howling_moon.lua
@@ -17,7 +17,8 @@ function onMobWeaponSkill(target, mob, skill)
 
     local dmgmod = 3;
     local info = MobMagicalMove(mob,target,skill,mob:getWeaponDmg() * 9,ELE_DARK,dmgmod,TP_MAB_BONUS,1);
-    local dmg = MobFinalAdjustments(info.dmg,mob,skill,target,MOBSKILL_MAGICAL,MOBPARAM_DARK,MOBPARAM_WIPE_SHADOWS);
+    local dmg = mobAddBonuses(mob,nil,target,info.dmg,ELE_DARK);
+    dmg = MobFinalAdjustments(dmg,mob,skill,target,MOBSKILL_MAGICAL,MOBPARAM_DARK,MOBPARAM_WIPE_SHADOWS);
     target:delHP(dmg);
     return dmg;
 

--- a/scripts/globals/monstertpmoves.lua
+++ b/scripts/globals/monstertpmoves.lua
@@ -371,7 +371,7 @@ function mobAddBonuses(caster, spell, target, dmg, ele)
         end
     elseif VanadielDayElement() == dayWeak[ele] then
         if math.random() < 0.33 then
-            dayWeatherBonus = dayWeatherBonus + 0.10;
+            dayWeatherBonus = dayWeatherBonus - 0.10;
         end
     end
 


### PR DESCRIPTION
1. Added the Day/Weather bonus to Howling Moon when cast by Fenrir Prime.
-Tested on Darksday, Lightsday, and Firesday and noted proper damage adjustments based on day.

2. mobAddBonuses had an incorrect addition in the "dayWeak[ele]" section, changed to subtraction.