### PR TITLE
Fixed synth breaks not unreserving the right amount of items

### DIFF
--- a/src/map/utils/synthutils.cpp
+++ b/src/map/utils/synthutils.cpp
@@ -712,6 +712,7 @@ int32 doSynthFail(CCharEntity* PChar)
             {
                 PItem->setSubType(ITEM_UNLOCKED);
                 PItem->setReserve(PItem->getReserve() - totalCount);
+                totalCount = 0;
 
                 if(lostCount > 0)
                 {


### PR DESCRIPTION
Fixes #4647