### PR TITLE
Revert changes to howling_moon.lua

### DIFF
--- a/scripts/globals/mobskills/howling_moon.lua
+++ b/scripts/globals/mobskills/howling_moon.lua
@@ -17,8 +17,7 @@ function onMobWeaponSkill(target, mob, skill)
 
     local dmgmod = 3;
     local info = MobMagicalMove(mob,target,skill,mob:getWeaponDmg() * 9,ELE_DARK,dmgmod,TP_MAB_BONUS,1);
-    local dmg = mobAddBonuses(mob,nil,target,info.dmg,ELE_DARK);
-    dmg = MobFinalAdjustments(dmg,mob,skill,target,MOBSKILL_MAGICAL,MOBPARAM_DARK,MOBPARAM_WIPE_SHADOWS);
+    local dmg = MobFinalAdjustments(info.dmg,mob,skill,target,MOBSKILL_MAGICAL,MOBPARAM_DARK,MOBPARAM_WIPE_SHADOWS);
     target:delHP(dmg);
     return dmg;
 


### PR DESCRIPTION
This change caused Magic Defense to be applied twice during the calculation path which I noticed only after applying shell and seeing a discrepancy in the numbers. 

 I've started on cleaning up the day/weather bonus in the monstertpmoves.lua and magic.lua and have added the missing day/weather bonus in the actual function called by the mobskill ability script already. This will mean the only files that need to be changed will be those two globals mentioned above instead of a whole slew of mobskill files. Meaning, howling_moon.lua will be fine as it was. However, it's going to take me some significant time to test and make sure the globals are done correctly. When I am finished, I will submit that PR for critique/review.  Sorry for the trouble.