### PR TITLE
Bandaid fix in addBonuses

### DIFF
--- a/scripts/globals/magic.lua
+++ b/scripts/globals/magic.lua
@@ -741,6 +741,8 @@ function calculateMagicBurst(caster, spell, target, params)
 end;
 
 function addBonuses(caster, spell, target, dmg, params)
+    params = params or {};
+
     local ele = spell:getElement();
 
     local affinityBonus = AffinityBonusDmg(caster, ele);


### PR DESCRIPTION
Caused by #4620 
fix suggested in #4659 
responds to #4641 

I'm not sure what those 14 changes takhlaq mentioned as being needed in magic.lua are. It looks like the bio/drain/aspir/dia/cure (against undead)/impact issues are mainly from #4620 requiring the params table being passed by all calls to addBonuses.

teschnei pointed out it was preferable to use this bandaid fix so as not to break custom spell scripts.

Do please comment if something else is missing.