### PR TITLE
More mount fixes.

### DIFF
--- a/src/map/packet_system.cpp
+++ b/src/map/packet_system.cpp
@@ -834,8 +834,8 @@ void SmallPacket0x01A(map_session_data_t* session, CCharEntity* PChar, CBasicPac
     {
         uint8 MountID = data.ref<uint8>(0x0C);
 
-        // TODO: Check if player is in combat.
-        if (charutils::hasKeyItem(PChar, 3072 + MountID))
+        // TODO: Check if player is in combat and get proper list of zones you can use mounts.
+        if (charutils::hasKeyItem(PChar, 3072 + MountID) && PChar->loc.zone->GetType() == ZONETYPE_OUTDOORS)
         {
             if (PChar->GetMLevel() >= 20)
             {

--- a/src/map/zone.cpp
+++ b/src/map/zone.cpp
@@ -847,7 +847,7 @@ void CZone::CharZoneIn(CCharEntity* PChar)
     //remove temp items
     charutils::ClearTempItems(PChar);
 
-    if (PChar->animation == ANIMATION_MOUNT && m_zoneType != ZONETYPE_DUNGEON) // TODO: Confirm zones mounts are usable in, new MISC flag?
+    if (PChar->animation == ANIMATION_MOUNT && m_zoneType != ZONETYPE_OUTDOORS) // TODO: Confirm zones mounts are usable in, new MISC flag?
     {
         PChar->animation = ANIMATION_NONE;
         PChar->StatusEffectContainer->DelStatusEffectSilent(EFFECT_MOUNTED);


### PR DESCRIPTION
- Limit summoning mounts to outdoor areas.
- Fixed dismount conditions for mounts.

ZONETYPE_OUTDOORS is the best way to define where mounts are usable at the moment, it'll need more research on retail and probably a new flag.