### PR TITLE
Long character names no longer overflow.

### DIFF
--- a/src/login/lobby.cpp
+++ b/src/login/lobby.cpp
@@ -201,7 +201,7 @@ int32 lobbydata_parse(int32 fd)
                     ////////////////////////////////////////////////////
                     ref<uint32>(CharList, 4 + 32 + i * 140) = CharID;
 
-                    memcpy(CharList + 12 + 32 + i * 140, strCharName, 15);
+                    memcpy(CharList + 12 + 32 + i * 140, strCharName, 16);
 
                     ref<uint8>(CharList, 46 + 32 + i * 140) = MainJob;
                     ref<uint8>(CharList, 73 + 32 + i * 140) = lvlMainJob;
@@ -688,7 +688,7 @@ int32 lobbyview_parse(int32 fd)
                 else
                 {
                     //copy charname
-                    memcpy(sd->charname, CharName, 15);
+                    memcpy(sd->charname, CharName, 16);
                     sendsize = 0x20;
                     LOBBY_ACTION_DONE(ReservePacket);
                     memcpy(MainReservePacket, ReservePacket, sendsize);

--- a/src/login/lobby.cpp
+++ b/src/login/lobby.cpp
@@ -639,7 +639,7 @@ int32 lobbyview_parse(int32 fd)
             case 0x22:
             {
                 //creating new char
-                char CharName[15];
+                char CharName[16];
                 memset(CharName, 0, sizeof(CharName));
                 memcpy(CharName, session[fd]->rdata.data() + 32, sizeof(CharName));
 


### PR DESCRIPTION
Client caps at 16 characters.