### PR TITLE
adjust relic wait times to match new retail standards from 2016.

### DIFF
--- a/scripts/globals/settings.lua
+++ b/scripts/globals/settings.lua
@@ -99,8 +99,8 @@ LandKingSystem_HQ = 0;
     TIMELESS_HOURGLASS_COST = 500000;   -- refund for the timeless hourglass for Dynamis.
    PRISMATIC_HOURGLASS_COST = 50000;    -- cost of the prismatic hourglass for Dynamis.
      CURRENCY_EXCHANGE_RATE = 100;      -- X Tier 1 ancient currency -> 1 Tier 2, and so on.  Certain values may conflict with shop items.  Not designed to exceed 198.
-RELIC_2ND_UPGRADE_WAIT_TIME = 604800;      -- wait time for 2nd relic upgrade (stage 2 -> stage 3) in seconds. 604800s = 1 RL week.
-RELIC_3RD_UPGRADE_WAIT_TIME = 295200;      -- wait time for 3rd relic upgrade (stage 3 -> stage 4) in seconds. 295200s = 82 hours.
+RELIC_2ND_UPGRADE_WAIT_TIME = 7200;     -- wait time for 2nd relic upgrade (stage 2 -> stage 3) in seconds. 7200s = 2 hours.
+RELIC_3RD_UPGRADE_WAIT_TIME = 3600;     -- wait time for 3rd relic upgrade (stage 3 -> stage 4) in seconds. 3600s = 1 hour.
 FREE_COP_DYNAMIS = 1 ; -- Authorize player to entering inside COP Dynamis without completing COP mission ( 1 = enable 0= disable)
 
 -- QUEST/MISSION SPECIFIC SETTINGS

--- a/scripts/zones/Castle_Zvahl_Baileys/npcs/Switchstix.lua
+++ b/scripts/zones/Castle_Zvahl_Baileys/npcs/Switchstix.lua
@@ -193,11 +193,11 @@ function onTrade(player,npc,trade)
          if (eventParams[7] == 1) then
             player:setVar("RELIC_DUE_AT",getMidnight());
 
-         -- Stage 2->3, wait RELIC_2ND_UPGRADE_WAIT_TIME (604800s / 1 week default)
+         -- Stage 2->3, wait RELIC_2ND_UPGRADE_WAIT_TIME (7200s / 2 hours default)
          elseif (eventParams[7] == 2) then
             player:setVar("RELIC_DUE_AT",os.time() + RELIC_2ND_UPGRADE_WAIT_TIME);
 
-         -- Stage 3->4, wait RELIC_3RD_UPGRADE_WAIT_TIME (295200s / 3 days 10 hours default)
+         -- Stage 3->4, wait RELIC_3RD_UPGRADE_WAIT_TIME (3600s / 1 hour default)
          elseif (eventParams[7] == 3) then
             player:setVar("RELIC_DUE_AT",os.time() + RELIC_3RD_UPGRADE_WAIT_TIME);
          end


### PR DESCRIPTION
*Stage 1 > 2
Wait Time: 2 Earth hours

*Stage 2 > 3
Wait Time: 1 Earth hour

*Stage 3 > 4
Wait Time: None

if this is wrong or i missed something let me know.