### PR TITLE
Correct char packet order on status effect change

### DIFF
--- a/src/map/entities/charentity.cpp
+++ b/src/map/entities/charentity.cpp
@@ -30,6 +30,7 @@
 #include "../packets/action.h"
 #include "../packets/basic.h"
 #include "../packets/char.h"
+#include "../packets/char_sync.h"
 #include "../packets/char_update.h"
 #include "../packets/char_recast.h"
 #include "../packets/lock_on.h"
@@ -481,6 +482,7 @@ void CCharEntity::PostTick()
     if (m_EffectsChanged)
     {
         pushPacket(new CCharUpdatePacket(this));
+        pushPacket(new CCharSyncPacket(this));
         pushPacket(new CCharJobExtraPacket(this, true));
         pushPacket(new CCharJobExtraPacket(this, false));
         pushPacket(new CStatusEffectPacket(this));

--- a/src/map/status_effect_container.cpp
+++ b/src/map/status_effect_container.cpp
@@ -44,7 +44,6 @@ When a status effect is gained twice on a player. It can do one or more of the f
 
 #include "packets/char_health.h"
 #include "packets/char_job_extra.h"
-#include "packets/char_sync.h"
 #include "packets/char_update.h"
 #include "packets/message_basic.h"
 #include "packets/party_effects.h"
@@ -405,7 +404,6 @@ bool CStatusEffectContainer::AddStatusEffect(CStatusEffect* PStatusEffect, bool 
                 PChar->PLatentEffectContainer->CheckLatentsRollSong();
                 PChar->UpdateHealth();
             }
-            PChar->pushPacket(new CCharSyncPacket(PChar));
         }
         m_POwner->updatemask |= UPDATE_HP;
 
@@ -464,7 +462,6 @@ void CStatusEffectContainer::DeleteStatusEffects()
             PChar->PLatentEffectContainer->CheckLatentsFoodEffect();
             PChar->PLatentEffectContainer->CheckLatentsStatusEffect();
             PChar->PLatentEffectContainer->CheckLatentsRollSong();
-            PChar->pushPacket(new CCharSyncPacket(PChar));
         }
         m_POwner->UpdateHealth();
     }


### PR DESCRIPTION
This seems to be the only instance char_sync precedes char_update packet on dsp, this order is necessary for changing chocobo color.