### PR TITLE
SCH Helix Magic Atk./Acc supplementary fix

### DIFF
--- a/scripts/globals/spells/anemohelix.lua
+++ b/scripts/globals/spells/anemohelix.lua
@@ -35,6 +35,7 @@ function onSpellCast(caster,target,spell)
     params.diff = caster:getStat(MOD_INT)-target:getStat(MOD_INT);
     params.attribute = MOD_INT;
     params.skillType = ELEMENTAL_MAGIC_SKILL;
+    -- bonus accuracy from merit
     params.bonus = merit*3;
     local resist = applyResistance(caster, target, spell, params);
     -- get the resisted damage
@@ -43,6 +44,8 @@ function onSpellCast(caster,target,spell)
     dmg = addBonuses(caster,spell,target,dmg,params);
     -- add in target adjustment
     dmg = adjustForTarget(target,dmg,spell:getElement());
+    -- helix MAB merits are actually a percentage increase
+    dmg = dmg * ((100 + merit*2)/100);
     local dot = dmg;
     -- add in final adjustments
     dmg = finalMagicAdjustments(caster,target,spell,dmg);

--- a/scripts/globals/spells/cryohelix.lua
+++ b/scripts/globals/spells/cryohelix.lua
@@ -35,6 +35,7 @@ function onSpellCast(caster,target,spell)
     params.diff = caster:getStat(MOD_INT)-target:getStat(MOD_INT);
     params.attribute = MOD_INT;
     params.skillType = ELEMENTAL_MAGIC_SKILL;
+    -- bonus accuracy from merit
     params.bonus = merit*3;
     local resist = applyResistance(caster, target, spell, params);
     -- get the resisted damage
@@ -43,6 +44,8 @@ function onSpellCast(caster,target,spell)
     dmg = addBonuses(caster,spell,target,dmg,params);
     -- add in target adjustment
     dmg = adjustForTarget(target,dmg,spell:getElement());
+    -- helix MAB merits are actually a percentage increase
+    dmg = dmg * ((100 + merit*2)/100);
     local dot = dmg;
     -- add in final adjustments
     dmg = finalMagicAdjustments(caster,target,spell,dmg);

--- a/scripts/globals/spells/geohelix.lua
+++ b/scripts/globals/spells/geohelix.lua
@@ -35,6 +35,7 @@ function onSpellCast(caster,target,spell)
     params.diff = caster:getStat(MOD_INT)-target:getStat(MOD_INT);
     params.attribute = MOD_INT;
     params.skillType = ELEMENTAL_MAGIC_SKILL;
+    -- bonus accuracy from merit
     params.bonus = merit*3;
     local resist = applyResistance(caster, target, spell, params);
     -- get the resisted damage
@@ -43,6 +44,8 @@ function onSpellCast(caster,target,spell)
     dmg = addBonuses(caster,spell,target,dmg,params);
     -- add in target adjustment
     dmg = adjustForTarget(target,dmg,spell:getElement());
+    -- helix MAB merits are actually a percentage increase
+    dmg = dmg * ((100 + merit*2)/100);
     local dot = dmg;
     -- add in final adjustments
     dmg = finalMagicAdjustments(caster,target,spell,dmg);

--- a/scripts/globals/spells/hydrohelix.lua
+++ b/scripts/globals/spells/hydrohelix.lua
@@ -35,6 +35,7 @@ function onSpellCast(caster,target,spell)
     params.diff = caster:getStat(MOD_INT)-target:getStat(MOD_INT);
     params.attribute = MOD_INT;
     params.skillType = ELEMENTAL_MAGIC_SKILL;
+    -- bonus accuracy from merit
     params.bonus = merit*3;
     local resist = applyResistance(caster, target, spell, params);
     -- get the resisted damage
@@ -43,6 +44,8 @@ function onSpellCast(caster,target,spell)
     dmg = addBonuses(caster,spell,target,dmg,params);
     -- add in target adjustment
     dmg = adjustForTarget(target,dmg,spell:getElement());
+    -- helix MAB merits are actually a percentage increase
+    dmg = dmg * ((100 + merit*2)/100);
     local dot = dmg;
     -- add in final adjustments
     dmg = finalMagicAdjustments(caster,target,spell,dmg);

--- a/scripts/globals/spells/ionohelix.lua
+++ b/scripts/globals/spells/ionohelix.lua
@@ -35,6 +35,7 @@ function onSpellCast(caster,target,spell)
     params.diff = caster:getStat(MOD_INT)-target:getStat(MOD_INT);
     params.attribute = MOD_INT;
     params.skillType = ELEMENTAL_MAGIC_SKILL;
+    -- bonus accuracy from merit
     params.bonus = merit*3;
     local resist = applyResistance(caster, target, spell, params);
     -- get the resisted damage
@@ -43,6 +44,8 @@ function onSpellCast(caster,target,spell)
     dmg = addBonuses(caster,spell,target,dmg,params);
     -- add in target adjustment
     dmg = adjustForTarget(target,dmg,spell:getElement());
+    -- helix MAB merits are actually a percentage increase
+    dmg = dmg * ((100 + merit*2)/100);
     local dot = dmg;
     -- add in final adjustments
     dmg = finalMagicAdjustments(caster,target,spell,dmg);

--- a/scripts/globals/spells/luminohelix.lua
+++ b/scripts/globals/spells/luminohelix.lua
@@ -35,6 +35,7 @@ function onSpellCast(caster,target,spell)
     params.diff = caster:getStat(MOD_INT)-target:getStat(MOD_INT);
     params.attribute = MOD_INT;
     params.skillType = ELEMENTAL_MAGIC_SKILL;
+    -- bonus accuracy from merit
     params.bonus = merit*3;
     local resist = applyResistance(caster, target, spell, params);
     -- get the resisted damage
@@ -43,6 +44,8 @@ function onSpellCast(caster,target,spell)
     dmg = addBonuses(caster,spell,target,dmg,params);
     -- add in target adjustment
     dmg = adjustForTarget(target,dmg,spell:getElement());
+    -- helix MAB merits are actually a percentage increase
+    dmg = dmg * ((100 + merit*2)/100);
     local dot = dmg;
     -- add in final adjustments
     dmg = finalMagicAdjustments(caster,target,spell,dmg);

--- a/scripts/globals/spells/noctohelix.lua
+++ b/scripts/globals/spells/noctohelix.lua
@@ -35,6 +35,7 @@ function onSpellCast(caster,target,spell)
     params.diff = caster:getStat(MOD_INT)-target:getStat(MOD_INT);
     params.attribute = MOD_INT;
     params.skillType = ELEMENTAL_MAGIC_SKILL;
+    -- bonus accuracy from merit
     params.bonus = merit*3;
     local resist = applyResistance(caster, target, spell, params);
     -- get the resisted damage
@@ -43,6 +44,8 @@ function onSpellCast(caster,target,spell)
     dmg = addBonuses(caster,spell,target,dmg,params);
     -- add in target adjustment
     dmg = adjustForTarget(target,dmg,spell:getElement());
+    -- helix MAB merits are actually a percentage increase
+    dmg = dmg * ((100 + merit*2)/100);
     local dot = dmg;
     -- add in final adjustments
     dmg = finalMagicAdjustments(caster,target,spell,dmg);

--- a/scripts/globals/spells/pyrohelix.lua
+++ b/scripts/globals/spells/pyrohelix.lua
@@ -35,6 +35,7 @@ function onSpellCast(caster,target,spell)
     params.diff = caster:getStat(MOD_INT)-target:getStat(MOD_INT);
     params.attribute = MOD_INT;
     params.skillType = ELEMENTAL_MAGIC_SKILL;
+    -- bonus accuracy from merit
     params.bonus = merit*3;
     local resist = applyResistance(caster, target, spell, params);
     -- get the resisted damage.
@@ -43,6 +44,8 @@ function onSpellCast(caster,target,spell)
     dmg = addBonuses(caster,spell,target,dmg,params);
     -- add in target adjustment
     dmg = adjustForTarget(target,dmg,spell:getElement());
+    -- helix MAB merits are actually a percentage increase
+    dmg = dmg * ((100 + merit*2)/100);
     local dot = dmg;
     -- add in final adjustments
     dmg = finalMagicAdjustments(caster,target,spell,dmg);


### PR DESCRIPTION
Poked around after seeing the issue (too late), and found that the MAB bonus is actually a percent increase in damage.

The Magic Atk. part of the merits wasn't implemented before. Magic Acc is implemented as params.bonus, so I added a comment reflecting that.

Source: https://www.bg-wiki.com/bg/Category:Helix