### PR TITLE
Measure BETWEEN_2DYNA_WAIT_TIME in hours instead of days

### DIFF
--- a/scripts/globals/settings.lua
+++ b/scripts/globals/settings.lua
@@ -93,7 +93,7 @@ LandKingSystem_NQ = 0;
 LandKingSystem_HQ = 0;
 
 -- DYNAMIS SETTINGS
-    BETWEEN_2DYNA_WAIT_TIME = 1;        -- wait time between 2 Dynamis (in real day) min: 1 day
+    BETWEEN_2DYNA_WAIT_TIME = 24;       -- Hours before player can renter Dynamis. Default is 1 Earthday (24 hours).
         DYNA_MIDNIGHT_RESET = true;     -- if true, makes the wait time count by number of server midnights instead of full 24 hour intervals
              DYNA_LEVEL_MIN = 65;       -- level min for entering in Dynamis
     TIMELESS_HOURGLASS_COST = 500000;   -- refund for the timeless hourglass for Dynamis.

--- a/scripts/zones/Bastok_Mines/npcs/Trail_Markings.lua
+++ b/scripts/zones/Bastok_Mines/npcs/Trail_Markings.lua
@@ -33,10 +33,10 @@ function onTrigger(player,npc)
 
         if (player:getMainLvl() < DYNA_LEVEL_MIN) then
             player:messageSpecial(PLAYERS_HAVE_NOT_REACHED_LEVEL,DYNA_LEVEL_MIN);
-        elseif ((dynaWaitxDay + (BETWEEN_2DYNA_WAIT_TIME * 24 * 60 * 60)) < realDay or (player:getVar("DynamisID") == dynaUniqueID and dynaUniqueID > 0)) then
+        elseif ((dynaWaitxDay + (BETWEEN_2DYNA_WAIT_TIME * 60 * 60)) < realDay or (player:getVar("DynamisID") == dynaUniqueID and dynaUniqueID > 0)) then
             player:startEvent(201,2,firstDyna,0,BETWEEN_2DYNA_WAIT_TIME,64,VIAL_OF_SHROUDED_SAND,4236,4237);
         else
-            dayRemaining = math.floor(((dynaWaitxDay + (BETWEEN_2DYNA_WAIT_TIME * 24 * 60 * 60)) - realDay)/3456);
+            dayRemaining = math.floor(((dynaWaitxDay + (BETWEEN_2DYNA_WAIT_TIME * 60 * 60)) - realDay)/3456);
             player:messageSpecial(YOU_CANNOT_ENTER_DYNAMIS,dayRemaining,2);
         end
     else

--- a/scripts/zones/Beaucedine_Glacier/npcs/Trail_Markings.lua
+++ b/scripts/zones/Beaucedine_Glacier/npcs/Trail_Markings.lua
@@ -31,10 +31,10 @@ function onTrigger(player,npc)
 
         if (player:getMainLvl() < DYNA_LEVEL_MIN) then
             player:messageSpecial(PLAYERS_HAVE_NOT_REACHED_LEVEL,DYNA_LEVEL_MIN);
-        elseif ((dynaWaitxDay + (BETWEEN_2DYNA_WAIT_TIME * 24 * 60 * 60)) < realDay or (player:getVar("DynamisID") == dynaUniqueID and dynaUniqueID > 0)) then
+        elseif ((dynaWaitxDay + (BETWEEN_2DYNA_WAIT_TIME * 60 * 60)) < realDay or (player:getVar("DynamisID") == dynaUniqueID and dynaUniqueID > 0)) then
             player:startEvent(119,5,firstDyna,0,BETWEEN_2DYNA_WAIT_TIME,64,VIAL_OF_SHROUDED_SAND,4236,4237);
         else
-            dayRemaining = math.floor(((dynaWaitxDay + (BETWEEN_2DYNA_WAIT_TIME * 24 * 60 * 60)) - realDay)/3456);
+            dayRemaining = math.floor(((dynaWaitxDay + (BETWEEN_2DYNA_WAIT_TIME * 60 * 60)) - realDay)/3456);
             player:messageSpecial(YOU_CANNOT_ENTER_DYNAMIS,dayRemaining,5);
         end
     else

--- a/scripts/zones/Buburimu_Peninsula/npcs/Hieroglyphics.lua
+++ b/scripts/zones/Buburimu_Peninsula/npcs/Hieroglyphics.lua
@@ -27,10 +27,10 @@ function onTrigger(player,npc)
              player:startEvent(40);
         elseif (player:getMainLvl() < DYNA_LEVEL_MIN) then
             player:messageSpecial(PLAYERS_HAVE_NOT_REACHED_LEVEL,DYNA_LEVEL_MIN);
-        elseif ((dynaWaitxDay + (BETWEEN_2DYNA_WAIT_TIME * 24 * 60 * 60)) < realDay or (player:getVar("DynamisID") == dynaUniqueID and dynaUniqueID > 0)) then
+        elseif ((dynaWaitxDay + (BETWEEN_2DYNA_WAIT_TIME * 60 * 60)) < realDay or (player:getVar("DynamisID") == dynaUniqueID and dynaUniqueID > 0)) then
             player:startEvent(22,8,0,0,BETWEEN_2DYNA_WAIT_TIME,32,VIAL_OF_SHROUDED_SAND,4236,4237);
         else
-            dayRemaining = math.floor(((dynaWaitxDay + (BETWEEN_2DYNA_WAIT_TIME * 24 * 60 * 60)) - realDay)/3456);
+            dayRemaining = math.floor(((dynaWaitxDay + (BETWEEN_2DYNA_WAIT_TIME * 60 * 60)) - realDay)/3456);
             player:messageSpecial(YOU_CANNOT_ENTER_DYNAMIS,dayRemaining,8);
         end
     else

--- a/scripts/zones/Dynamis-Bastok/bcnms/dynamis_bastok.lua
+++ b/scripts/zones/Dynamis-Bastok/bcnms/dynamis_bastok.lua
@@ -5,16 +5,16 @@
 
 -- After registering the BCNM via bcnmRegister(bcnmid)
 function onBcnmRegister(player,instance)
-    
+
     SetServerVariable("[DynaBastok]UniqueID",os.time());
     SetServerVariable("[DynaBastok]Boss_Trigger",0);
     SetServerVariable("[DynaBastok]Already_Received",0);
-    
+
 end;
 
 -- Physically entering the BCNM via bcnmEnter(bcnmid)
 function onBcnmEnter(player,instance)
-    
+
     player:setVar("DynamisID",GetServerVariable("[DynaBastok]UniqueID"));
     local realDay = os.time();
     if (DYNA_MIDNIGHT_RESET == true) then
@@ -22,10 +22,10 @@ function onBcnmEnter(player,instance)
     end
     local dynaWaitxDay = player:getVar("dynaWaitxDay");
 
-    if ((dynaWaitxDay + (BETWEEN_2DYNA_WAIT_TIME * 24 * 60 * 60)) < realDay) then
+    if ((dynaWaitxDay + (BETWEEN_2DYNA_WAIT_TIME * 60 * 60)) < realDay) then
         player:setVar("dynaWaitxDay",realDay);
     end
-    
+
 end;
 
 -- Leaving the Dynamis by every mean possible, given by the LeaveCode
@@ -34,10 +34,10 @@ end;
 
 function onBcnmLeave(player,instance,leavecode)
 --print("leave code "..leavecode);
-    
+
     if (leavecode == 4) then
         GetNPCByID(17539323):setStatus(2);
         SetServerVariable("[DynaBastok]UniqueID",0);
     end
-    
+
 end;

--- a/scripts/zones/Dynamis-Beaucedine/bcnms/dynamis_beaucedine.lua
+++ b/scripts/zones/Dynamis-Beaucedine/bcnms/dynamis_beaucedine.lua
@@ -5,15 +5,15 @@
 
 -- After registering the BCNM via bcnmRegister(bcnmid)
 function onBcnmRegister(player,instance)
-    
+
     SetServerVariable("[DynaBeaucedine]UniqueID",os.time());
     SetServerVariable("[DynaBeaucedine]Already_Received",0);
-    
+
 end;
 
 -- Physically entering the BCNM via bcnmEnter(bcnmid)
 function onBcnmEnter(player,instance)
-    
+
     player:setVar("DynamisID",GetServerVariable("[DynaBeaucedine]UniqueID"));
     local realDay = os.time();
     if (DYNA_MIDNIGHT_RESET == true) then
@@ -21,10 +21,10 @@ function onBcnmEnter(player,instance)
     end
     local dynaWaitxDay = player:getVar("dynaWaitxDay");
 
-    if ((dynaWaitxDay + (BETWEEN_2DYNA_WAIT_TIME * 24 * 60 * 60)) < realDay) then
+    if ((dynaWaitxDay + (BETWEEN_2DYNA_WAIT_TIME * 60 * 60)) < realDay) then
         player:setVar("dynaWaitxDay",realDay);
     end
-    
+
 end;
 
 -- Leaving the Dynamis by every mean possible, given by the LeaveCode
@@ -33,9 +33,9 @@ end;
 
 function onBcnmLeave(player,instance,leavecode)
 --print("leave code "..leavecode);
-    
+
     if (leavecode == 4) then
         SetServerVariable("[DynaBeaucedine]UniqueID",0);
     end
-    
+
 end;

--- a/scripts/zones/Dynamis-Buburimu/bcnms/dynamis_buburimu.lua
+++ b/scripts/zones/Dynamis-Buburimu/bcnms/dynamis_buburimu.lua
@@ -7,17 +7,17 @@
 
 -- After registering the BCNM via bcnmRegister(bcnmid)
 function onBcnmRegister(player,instance)
-    
+
     SetServerVariable("[DynaBuburimu]UniqueID",os.time());
     SetServerVariable("[DynaBuburimu]Boss_Trigger",0);
     SetServerVariable("[DynaBuburimu]Already_Received",0);
-    
-    
+
+
 end;
 
 -- Physically entering the BCNM via bcnmEnter(bcnmid)
 function onBcnmEnter(player,instance)
-    
+
     player:setVar("DynamisID",GetServerVariable("[DynaBuburimu]UniqueID"));
     local realDay = os.time();
     if (DYNA_MIDNIGHT_RESET == true) then
@@ -25,10 +25,10 @@ function onBcnmEnter(player,instance)
     end
     local dynaWaitxDay = player:getVar("dynaWaitxDay");
 
-    if ((dynaWaitxDay + (BETWEEN_2DYNA_WAIT_TIME * 24 * 60 * 60)) < realDay) then
+    if ((dynaWaitxDay + (BETWEEN_2DYNA_WAIT_TIME * 60 * 60)) < realDay) then
         player:setVar("dynaWaitxDay",realDay);
     end
-    
+
 end;
 
 -- Leaving the Dynamis by every mean possible, given by the LeaveCode
@@ -37,9 +37,9 @@ end;
 
 function onBcnmLeave(player,instance,leavecode)
 --print("leave code "..leavecode);
-    
+
     if (leavecode == 4) then
         SetServerVariable("[DynaBuburimu]UniqueID",0);
     end
-    
+
 end;

--- a/scripts/zones/Dynamis-Jeuno/bcnms/dynamis_jeuno.lua
+++ b/scripts/zones/Dynamis-Jeuno/bcnms/dynamis_jeuno.lua
@@ -5,16 +5,16 @@
 
 -- After registering the BCNM via bcnmRegister(bcnmid)
 function onBcnmRegister(player,instance)
-    
+
     SetServerVariable("[DynaJeuno]UniqueID",os.time());
     SetServerVariable("[DynaJeuno]Boss_Trigger",0);
     SetServerVariable("[DynaJeuno]Already_Received",0);
-    
+
 end;
 
 -- Physically entering the BCNM via bcnmEnter(bcnmid)
 function onBcnmEnter(player,instance)
-    
+
     player:setVar("DynamisID",GetServerVariable("[DynaJeuno]UniqueID"));
     local realDay = os.time();
     if (DYNA_MIDNIGHT_RESET == true) then
@@ -22,10 +22,10 @@ function onBcnmEnter(player,instance)
     end
     local dynaWaitxDay = player:getVar("dynaWaitxDay");
 
-    if ((dynaWaitxDay + (BETWEEN_2DYNA_WAIT_TIME * 24 * 60 * 60)) < realDay) then
+    if ((dynaWaitxDay + (BETWEEN_2DYNA_WAIT_TIME * 60 * 60)) < realDay) then
         player:setVar("dynaWaitxDay",realDay);
     end
-    
+
 end;
 
 -- Leaving the Dynamis by every mean possible, given by the LeaveCode
@@ -34,10 +34,10 @@ end;
 
 function onBcnmLeave(player,instance,leavecode)
 --print("leave code "..leavecode);
-    
+
     if (leavecode == 4) then
         GetNPCByID(17547510):setStatus(2);
         SetServerVariable("[DynaJeuno]UniqueID",0);
     end
-    
+
 end;

--- a/scripts/zones/Dynamis-Qufim/bcnms/dynamis_qufim.lua
+++ b/scripts/zones/Dynamis-Qufim/bcnms/dynamis_qufim.lua
@@ -7,17 +7,17 @@
 
 -- After registering the BCNM via bcnmRegister(bcnmid)
 function onBcnmRegister(player,instance)
-    
+
     SetServerVariable("[DynaQufim]UniqueID",os.time());
     SetServerVariable("[DynaQufim]Boss_Trigger",0);
     SetServerVariable("[DynaQufim]Already_Received",0);
-    
-    
+
+
 end;
 
 -- Physically entering the BCNM via bcnmEnter(bcnmid)
 function onBcnmEnter(player,instance)
-    
+
     player:setVar("DynamisID",GetServerVariable("[DynaQufim]UniqueID"));
     local realDay = os.time();
     if (DYNA_MIDNIGHT_RESET == true) then
@@ -25,10 +25,10 @@ function onBcnmEnter(player,instance)
     end
     local dynaWaitxDay = player:getVar("dynaWaitxDay");
 
-    if ((dynaWaitxDay + (BETWEEN_2DYNA_WAIT_TIME * 24 * 60 * 60)) < realDay) then
+    if ((dynaWaitxDay + (BETWEEN_2DYNA_WAIT_TIME * 60 * 60)) < realDay) then
         player:setVar("dynaWaitxDay",realDay);
     end
-    
+
 end;
 
 -- Leaving the Dynamis by every mean possible, given by the LeaveCode
@@ -37,9 +37,9 @@ end;
 
 function onBcnmLeave(player,instance,leavecode)
 --print("leave code "..leavecode);
-    
+
     if (leavecode == 4) then
         SetServerVariable("[DynaQufim]UniqueID",0);
     end
-    
+
 end;

--- a/scripts/zones/Dynamis-San_dOria/bcnms/dynamis_sandoria.lua
+++ b/scripts/zones/Dynamis-San_dOria/bcnms/dynamis_sandoria.lua
@@ -5,16 +5,16 @@
 
 -- After registering the BCNM via bcnmRegister(bcnmid)
 function onBcnmRegister(player,instance)
-    
+
     SetServerVariable("[DynaSandoria]UniqueID",os.time());
     SetServerVariable("[DynaSandoria]Boss_Trigger",0);
     SetServerVariable("[DynaSandoria]Already_Received",0);
-    
+
 end;
 
 -- Physically entering the BCNM via bcnmEnter(bcnmid)
 function onBcnmEnter(player,instance)
-    
+
     player:setVar("DynamisID",GetServerVariable("[DynaSandoria]UniqueID"));
     local realDay = os.time();
     if (DYNA_MIDNIGHT_RESET == true) then
@@ -22,10 +22,10 @@ function onBcnmEnter(player,instance)
     end
     local dynaWaitxDay = player:getVar("dynaWaitxDay");
 
-    if ((dynaWaitxDay + (BETWEEN_2DYNA_WAIT_TIME * 24 * 60 * 60)) < realDay) then
+    if ((dynaWaitxDay + (BETWEEN_2DYNA_WAIT_TIME * 60 * 60)) < realDay) then
         player:setVar("dynaWaitxDay",realDay);
     end
-    
+
 end;
 
 -- Leaving the Dynamis by every mean possible, given by the LeaveCode
@@ -34,10 +34,10 @@ end;
 
 function onBcnmLeave(player,instance,leavecode)
 --print("leave code "..leavecode);
-    
+
     if (leavecode == 4) then
         GetNPCByID(17535224):setStatus(2);
         SetServerVariable("[DynaSandoria]UniqueID",0);
     end
-    
+
 end;

--- a/scripts/zones/Dynamis-Tavnazia/bcnms/dynamis_tavnazia.lua
+++ b/scripts/zones/Dynamis-Tavnazia/bcnms/dynamis_tavnazia.lua
@@ -11,12 +11,12 @@ function onBcnmRegister(player,instance)
     SetServerVariable("[DynaTavnazia]UniqueID",os.time());
     SetServerVariable("[DynaTavnazia]Boss_Trigger",0);
     SetServerVariable("[DynaTavnazia]Already_Received",0);
-    
+
 end;
 
 -- Physically entering the BCNM via bcnmEnter(bcnmid)
 function onBcnmEnter(player,instance)
-    
+
     player:setVar("DynamisID",GetServerVariable("[DynaTavnazia]UniqueID"));
     local realDay = os.time();
     if (DYNA_MIDNIGHT_RESET == true) then
@@ -24,10 +24,10 @@ function onBcnmEnter(player,instance)
     end
     local dynaWaitxDay = player:getVar("dynaWaitxDay");
 
-    if ((dynaWaitxDay + (BETWEEN_2DYNA_WAIT_TIME * 24 * 60 * 60)) < realDay) then
+    if ((dynaWaitxDay + (BETWEEN_2DYNA_WAIT_TIME * 60 * 60)) < realDay) then
         player:setVar("dynaWaitxDay",realDay);
     end
-    
+
 end;
 
 -- Leaving the Dynamis by every mean possible, given by the LeaveCode
@@ -40,5 +40,5 @@ function onBcnmLeave(player,instance,leavecode)
     if (leavecode == 4) then
         SetServerVariable("[DynaTavnazia]UniqueID",0);
     end
-    
+
 end;

--- a/scripts/zones/Dynamis-Valkurm/bcnms/dynamis_valkurm.lua
+++ b/scripts/zones/Dynamis-Valkurm/bcnms/dynamis_valkurm.lua
@@ -7,11 +7,11 @@
 
 -- After registering the BCNM via bcnmRegister(bcnmid)
 function onBcnmRegister(player,instance)
-    
+
     SetServerVariable("[DynaValkurm]UniqueID",os.time());
     SetServerVariable("[DynaValkurm]Boss_Trigger",0);
     SetServerVariable("[DynaValkurm]Already_Received",0);
-    
+
         local RNDpositionTable=TimerStatueRandomPos;
         local X=0;
         local Y=0;
@@ -20,23 +20,23 @@ function onBcnmRegister(player,instance)
     --spawn random timer statue
         local statueRND = math.random(1,4);
         local SpawnStatueID= statueID[statueRND];
-        --printf("timer_statue_ID = %u",SpawnStatueID); 
-        local F={2,4,6,8};         
-        --printf("position_type = %u",statueRND);     
+        --printf("timer_statue_ID = %u",SpawnStatueID);
+        local F={2,4,6,8};
+        --printf("position_type = %u",statueRND);
         X=RNDpositionTable[F[statueRND]][1];
-        --printf("X = %u",X); 
+        --printf("X = %u",X);
         Y=RNDpositionTable[F[statueRND]][2];
-        --printf("Y = %u",Y); 
+        --printf("Y = %u",Y);
         Z=RNDpositionTable[F[statueRND]][3];
-        --printf("Z = %u",Z); 
+        --printf("Z = %u",Z);
                     SpawnMob(SpawnStatueID);
                      GetMobByID(SpawnStatueID):setPos(X,Y,Z);
-                    GetMobByID(SpawnStatueID):setSpawn(X,Y,Z);    
+                    GetMobByID(SpawnStatueID):setSpawn(X,Y,Z);
 end;
 
 -- Physically entering the BCNM via bcnmEnter(bcnmid)
 function onBcnmEnter(player,instance)
-    
+
     player:setVar("DynamisID",GetServerVariable("[DynaValkurm]UniqueID"));
     local realDay = os.time();
     if (DYNA_MIDNIGHT_RESET == true) then
@@ -44,10 +44,10 @@ function onBcnmEnter(player,instance)
     end
     local dynaWaitxDay = player:getVar("dynaWaitxDay");
 
-    if ((dynaWaitxDay + (BETWEEN_2DYNA_WAIT_TIME * 24 * 60 * 60)) < realDay) then
+    if ((dynaWaitxDay + (BETWEEN_2DYNA_WAIT_TIME * 60 * 60)) < realDay) then
         player:setVar("dynaWaitxDay",realDay);
     end
-    
+
 end;
 
 -- Leaving the Dynamis by every mean possible, given by the LeaveCode
@@ -56,9 +56,9 @@ end;
 
 function onBcnmLeave(player,instance,leavecode)
 --print("leave code "..leavecode);
-    
+
     if (leavecode == 4) then
         SetServerVariable("[DynaValkurm]UniqueID",0);
     end
-    
+
 end;

--- a/scripts/zones/Dynamis-Windurst/bcnms/dynamis_windurst.lua
+++ b/scripts/zones/Dynamis-Windurst/bcnms/dynamis_windurst.lua
@@ -5,16 +5,16 @@
 
 -- After registering the BCNM via bcnmRegister(bcnmid)
 function onBcnmRegister(player,instance)
-    
+
     SetServerVariable("[DynaWindurst]UniqueID",os.time());
     SetServerVariable("[DynaWindurst]Boss_Trigger",0);
     SetServerVariable("[DynaWindurst]Already_Received",0);
-    
+
 end;
 
 -- Physically entering the BCNM via bcnmEnter(bcnmid)
 function onBcnmEnter(player,instance)
-    
+
     player:setVar("DynamisID",GetServerVariable("[DynaWindurst]UniqueID"));
     local realDay = os.time();
     if (DYNA_MIDNIGHT_RESET == true) then
@@ -22,10 +22,10 @@ function onBcnmEnter(player,instance)
     end
     local dynaWaitxDay = player:getVar("dynaWaitxDay");
 
-    if ((dynaWaitxDay + (BETWEEN_2DYNA_WAIT_TIME * 24 * 60 * 60)) < realDay) then
+    if ((dynaWaitxDay + (BETWEEN_2DYNA_WAIT_TIME * 60 * 60)) < realDay) then
         player:setVar("dynaWaitxDay",realDay);
     end
-    
+
 end;
 
 -- Leaving the Dynamis by every mean possible, given by the LeaveCode
@@ -39,5 +39,5 @@ function onBcnmLeave(player,instance,leavecode)
         GetNPCByID(17543480):setStatus(2);
         SetServerVariable("[DynaWindurst]UniqueID",0);
     end
-    
+
 end;

--- a/scripts/zones/Dynamis-Xarcabard/bcnms/dynamis_xarcabard.lua
+++ b/scripts/zones/Dynamis-Xarcabard/bcnms/dynamis_xarcabard.lua
@@ -5,18 +5,18 @@
 
 -- After registering the BCNM via bcnmRegister(bcnmid)
 function onBcnmRegister(player,instance)
-    
+
     SetServerVariable("[DynaXarcabard]UniqueID",os.time());
     SetServerVariable("[DynaXarcabard]TE43_Trigger",0);
     SetServerVariable("[DynaXarcabard]TE60_Trigger",0);
     SetServerVariable("[DynaXarcabard]TE150_Trigger",0);
     SetServerVariable("[DynaXarcabard]Boss_Trigger",0);
-    
+
 end;
 
 -- Physically entering the BCNM via bcnmEnter(bcnmid)
 function onBcnmEnter(player,instance)
-    
+
     player:setVar("DynamisID",GetServerVariable("[DynaXarcabard]UniqueID"));
     local realDay = os.time();
     if (DYNA_MIDNIGHT_RESET == true) then
@@ -24,10 +24,10 @@ function onBcnmEnter(player,instance)
     end
     local dynaWaitxDay = player:getVar("dynaWaitxDay");
 
-    if ((dynaWaitxDay + (BETWEEN_2DYNA_WAIT_TIME * 24 * 60 * 60)) < realDay) then
+    if ((dynaWaitxDay + (BETWEEN_2DYNA_WAIT_TIME * 60 * 60)) < realDay) then
         player:setVar("dynaWaitxDay",realDay);
     end
-    
+
 end;
 
 -- Leaving the Dynamis by every mean possible, given by the LeaveCode
@@ -36,10 +36,10 @@ end;
 
 function onBcnmLeave(player,instance,leavecode)
 --print("leave code "..leavecode);
-    
+
     if (leavecode == 4) then
         GetNPCByID(17330778):setStatus(2);
         SetServerVariable("[DynaXarcabard]UniqueID",0);
     end
-    
+
 end;

--- a/scripts/zones/Qufim_Island/npcs/Hieroglyphics.lua
+++ b/scripts/zones/Qufim_Island/npcs/Hieroglyphics.lua
@@ -27,10 +27,10 @@ function onTrigger(player,npc)
              player:startEvent(22);
         elseif (player:getMainLvl() < DYNA_LEVEL_MIN) then
             player:messageSpecial(PLAYERS_HAVE_NOT_REACHED_LEVEL,DYNA_LEVEL_MIN);
-        elseif ((dynaWaitxDay + (BETWEEN_2DYNA_WAIT_TIME * 24 * 60 * 60)) < realDay or (player:getVar("DynamisID") == dynaUniqueID and dynaUniqueID > 0)) then
+        elseif ((dynaWaitxDay + (BETWEEN_2DYNA_WAIT_TIME * 60 * 60)) < realDay or (player:getVar("DynamisID") == dynaUniqueID and dynaUniqueID > 0)) then
             player:startEvent(3,9,0,0,BETWEEN_2DYNA_WAIT_TIME,32,VIAL_OF_SHROUDED_SAND,4236,4237);
         else
-            dayRemaining = math.floor(((dynaWaitxDay + (BETWEEN_2DYNA_WAIT_TIME * 24 * 60 * 60)) - realDay)/3456);
+            dayRemaining = math.floor(((dynaWaitxDay + (BETWEEN_2DYNA_WAIT_TIME * 60 * 60)) - realDay)/3456);
             player:messageSpecial(YOU_CANNOT_ENTER_DYNAMIS,dayRemaining,8);
         end
     else

--- a/scripts/zones/RuLude_Gardens/npcs/Trail_Markings.lua
+++ b/scripts/zones/RuLude_Gardens/npcs/Trail_Markings.lua
@@ -33,10 +33,10 @@ function onTrigger(player,npc)
 
         if (player:getMainLvl() < DYNA_LEVEL_MIN) then
             player:messageSpecial(PLAYERS_HAVE_NOT_REACHED_LEVEL,DYNA_LEVEL_MIN);
-        elseif ((dynaWaitxDay + (BETWEEN_2DYNA_WAIT_TIME * 24 * 60 * 60)) < realDay or (player:getVar("DynamisID") == dynaUniqueID and dynaUniqueID > 0)) then
+        elseif ((dynaWaitxDay + (BETWEEN_2DYNA_WAIT_TIME * 60 * 60)) < realDay or (player:getVar("DynamisID") == dynaUniqueID and dynaUniqueID > 0)) then
             player:startEvent(10012,4,firstDyna,0,BETWEEN_2DYNA_WAIT_TIME,64,VIAL_OF_SHROUDED_SAND,4236,4237);
         else
-            dayRemaining = math.floor(((dynaWaitxDay + (BETWEEN_2DYNA_WAIT_TIME * 24 * 60 * 60)) - realDay)/3456);
+            dayRemaining = math.floor(((dynaWaitxDay + (BETWEEN_2DYNA_WAIT_TIME * 60 * 60)) - realDay)/3456);
             player:messageSpecial(YOU_CANNOT_ENTER_DYNAMIS,dayRemaining,4);
         end
     else

--- a/scripts/zones/Southern_San_dOria/npcs/Trail_Markings.lua
+++ b/scripts/zones/Southern_San_dOria/npcs/Trail_Markings.lua
@@ -33,10 +33,10 @@ function onTrigger(player,npc)
 
         if (player:getMainLvl() < DYNA_LEVEL_MIN) then
             player:messageSpecial(PLAYERS_HAVE_NOT_REACHED_LEVEL,DYNA_LEVEL_MIN);
-        elseif ((dynaWaitxDay + (BETWEEN_2DYNA_WAIT_TIME * 24 * 60 * 60)) < realDay or (player:getVar("DynamisID") == dynaUniqueID and dynaUniqueID > 0)) then
+        elseif ((dynaWaitxDay + (BETWEEN_2DYNA_WAIT_TIME * 60 * 60)) < realDay or (player:getVar("DynamisID") == dynaUniqueID and dynaUniqueID > 0)) then
             player:startEvent(685,1,firstDyna,0,BETWEEN_2DYNA_WAIT_TIME,64,VIAL_OF_SHROUDED_SAND,4236,4237);
         else
-            dayRemaining = math.floor(((dynaWaitxDay + (BETWEEN_2DYNA_WAIT_TIME * 24 * 60 * 60)) - realDay)/3456);
+            dayRemaining = math.floor(((dynaWaitxDay + (BETWEEN_2DYNA_WAIT_TIME * 60 * 60)) - realDay)/3456);
             player:messageSpecial(YOU_CANNOT_ENTER_DYNAMIS,dayRemaining,1);
         end
     else

--- a/scripts/zones/Tavnazian_Safehold/npcs/Hieroglyphics.lua
+++ b/scripts/zones/Tavnazian_Safehold/npcs/Hieroglyphics.lua
@@ -28,10 +28,10 @@ function onTrigger(player,npc)
              player:startEvent(614);
         elseif (player:getMainLvl() < DYNA_LEVEL_MIN) then
             player:messageSpecial(PLAYERS_HAVE_NOT_REACHED_LEVEL,DYNA_LEVEL_MIN);
-        elseif ((dynaWaitxDay + (BETWEEN_2DYNA_WAIT_TIME * 24 * 60 * 60)) < realDay or (player:getVar("DynamisID") == dynaUniqueID and dynaUniqueID > 0)) then
+        elseif ((dynaWaitxDay + (BETWEEN_2DYNA_WAIT_TIME * 60 * 60)) < realDay or (player:getVar("DynamisID") == dynaUniqueID and dynaUniqueID > 0)) then
             player:startEvent(588,10,0,0,BETWEEN_2DYNA_WAIT_TIME,32,VIAL_OF_SHROUDED_SAND,4236,4237);
         else
-            dayRemaining = math.floor(((dynaWaitxDay + (BETWEEN_2DYNA_WAIT_TIME * 24 * 60 * 60)) - realDay)/3456);
+            dayRemaining = math.floor(((dynaWaitxDay + (BETWEEN_2DYNA_WAIT_TIME * 60 * 60)) - realDay)/3456);
             player:messageSpecial(YOU_CANNOT_ENTER_DYNAMIS,dayRemaining,10);
         end
     else

--- a/scripts/zones/Valkurm_Dunes/npcs/Hieroglyphics.lua
+++ b/scripts/zones/Valkurm_Dunes/npcs/Hieroglyphics.lua
@@ -26,10 +26,10 @@ function onTrigger(player,npc)
              player:startEvent(33);
         elseif (player:getMainLvl() < DYNA_LEVEL_MIN) then
             player:messageSpecial(PLAYERS_HAVE_NOT_REACHED_LEVEL,DYNA_LEVEL_MIN);
-        elseif ((dynaWaitxDay + (BETWEEN_2DYNA_WAIT_TIME * 24 * 60 * 60)) < realDay or (player:getVar("DynamisID") == dynaUniqueID and dynaUniqueID > 0)) then
+        elseif ((dynaWaitxDay + (BETWEEN_2DYNA_WAIT_TIME * 60 * 60)) < realDay or (player:getVar("DynamisID") == dynaUniqueID and dynaUniqueID > 0)) then
             player:startEvent(16,7,0,0,BETWEEN_2DYNA_WAIT_TIME,32,VIAL_OF_SHROUDED_SAND,4236,4237);
         else
-            dayRemaining = math.floor(((dynaWaitxDay + (BETWEEN_2DYNA_WAIT_TIME * 24 * 60 * 60)) - realDay)/3456);
+            dayRemaining = math.floor(((dynaWaitxDay + (BETWEEN_2DYNA_WAIT_TIME * 60 * 60)) - realDay)/3456);
             player:messageSpecial(YOU_CANNOT_ENTER_DYNAMIS,dayRemaining,7);
         end
     else

--- a/scripts/zones/Windurst_Walls/npcs/Trail_Markings.lua
+++ b/scripts/zones/Windurst_Walls/npcs/Trail_Markings.lua
@@ -33,10 +33,10 @@ function onTrigger(player,npc)
 
         if (player:getMainLvl() < DYNA_LEVEL_MIN) then
             player:messageSpecial(PLAYERS_HAVE_NOT_REACHED_LEVEL,DYNA_LEVEL_MIN);
-        elseif ((dynaWaitxDay + (BETWEEN_2DYNA_WAIT_TIME * 24 * 60 * 60)) < realDay or (player:getVar("DynamisID") == dynaUniqueID and dynaUniqueID > 0)) then
+        elseif ((dynaWaitxDay + (BETWEEN_2DYNA_WAIT_TIME * 60 * 60)) < realDay or (player:getVar("DynamisID") == dynaUniqueID and dynaUniqueID > 0)) then
             player:startEvent(452,3,firstDyna,0,BETWEEN_2DYNA_WAIT_TIME,64,VIAL_OF_SHROUDED_SAND,4236,4237);
         else
-            dayRemaining = math.floor(((dynaWaitxDay + (BETWEEN_2DYNA_WAIT_TIME * 24 * 60 * 60)) - realDay)/3456);
+            dayRemaining = math.floor(((dynaWaitxDay + (BETWEEN_2DYNA_WAIT_TIME * 60 * 60)) - realDay)/3456);
             player:messageSpecial(YOU_CANNOT_ENTER_DYNAMIS,dayRemaining,3);
         end
     else

--- a/scripts/zones/Xarcabard/npcs/Trail_Markings.lua
+++ b/scripts/zones/Xarcabard/npcs/Trail_Markings.lua
@@ -31,10 +31,10 @@ function onTrigger(player,npc)
 
         if (player:getMainLvl() < DYNA_LEVEL_MIN) then
             player:messageSpecial(PLAYERS_HAVE_NOT_REACHED_LEVEL,DYNA_LEVEL_MIN);
-        elseif ((dynaWaitxDay + (BETWEEN_2DYNA_WAIT_TIME * 24 * 60 * 60)) < realDay or (player:getVar("DynamisID") == dynaUniqueID and dynaUniqueID > 0)) then
+        elseif ((dynaWaitxDay + (BETWEEN_2DYNA_WAIT_TIME * 60 * 60)) < realDay or (player:getVar("DynamisID") == dynaUniqueID and dynaUniqueID > 0)) then
             player:startEvent(16,6,firstDyna,0,BETWEEN_2DYNA_WAIT_TIME,32,VIAL_OF_SHROUDED_SAND,4236,4237);
         else
-            dayRemaining = math.floor(((dynaWaitxDay + (BETWEEN_2DYNA_WAIT_TIME * 24 * 60 * 60)) - realDay)/3456);
+            dayRemaining = math.floor(((dynaWaitxDay + (BETWEEN_2DYNA_WAIT_TIME * 60 * 60)) - realDay)/3456);
             player:messageSpecial(YOU_CANNOT_ENTER_DYNAMIS,dayRemaining,6);
         end
     else


### PR DESCRIPTION
modern retail has KeyItems that reduce this drastically less than the 1 Earth day.

I left the default the same as it was: 24 hours (1 day).