### PR TITLE
redesign Lunar Roar to behave as retail does

### DIFF
--- a/scripts/globals/mobskills/lunar_roar.lua
+++ b/scripts/globals/mobskills/lunar_roar.lua
@@ -1,6 +1,6 @@
 ---------------------------------------------
 -- Lunar Roar
--- Fenrir removes two beneficial status effects from enemies within Area of effect.
+-- Fenrir removes up to 10 beneficial status effects from enemies within Area of Effect.
 ---------------------------------------------
 require("scripts/globals/monstertpmoves");
 require("scripts/globals/settings");
@@ -13,16 +13,15 @@ function onMobSkillCheck(target,mob,skill)
 end;
 
 function onMobWeaponSkill(target, mob, skill)
-    local dis = target:dispelStatusEffect();
-    local dis2 = target:dispelStatusEffect();
+    local effects = target:getStatusEffects();
     local num = 0;
 
-    if (dis ~= dsp.effects.NONE) then
-        num = num + 1;
-    end
-
-    if (dis2 ~= dsp.effects.NONE) then
-        num = num + 1;
+    for i,effect in ipairs(effects) do
+        -- check mask bit for EFFECTFLAG_DISPELABLE
+        if (target:getMaskBit(effect:getFlag(),0) == true and effect:getType() ~= dsp.effects.RERAISE and num < 10) then
+            target:delStatusEffect(effect:getType());
+            num = num + 1;
+        end
     end
 
     skill:setMsg(msgBasic.DISAPPEAR_NUM);
@@ -32,4 +31,4 @@ function onMobWeaponSkill(target, mob, skill)
 
     return num;
 
-end
+end;

--- a/src/map/lua/lua_statuseffect.cpp
+++ b/src/map/lua/lua_statuseffect.cpp
@@ -286,6 +286,14 @@ inline int32 CLuaStatusEffect::addMod(lua_State* L)
 
 //======================================================//
 
+inline int32 CLuaStatusEffect::getFlag(lua_State* L)
+{
+    DSP_DEBUG_BREAK_IF(m_PLuaStatusEffect == nullptr);
+
+    lua_pushinteger(L, m_PLuaStatusEffect->GetFlag());
+    return 1;
+}
+
 inline int32 CLuaStatusEffect::setFlag(lua_State* L)
 {
     DSP_DEBUG_BREAK_IF(m_PLuaStatusEffect == nullptr);
@@ -332,6 +340,7 @@ Lunar<CLuaStatusEffect>::Register_t CLuaStatusEffect::methods[] =
     LUNAR_DECLARE_METHOD(CLuaStatusEffect,getTick),
     LUNAR_DECLARE_METHOD(CLuaStatusEffect,setTick),
     LUNAR_DECLARE_METHOD(CLuaStatusEffect,setStartTime),
+    LUNAR_DECLARE_METHOD(CLuaStatusEffect,getFlag),
     LUNAR_DECLARE_METHOD(CLuaStatusEffect,setFlag),
     LUNAR_DECLARE_METHOD(CLuaStatusEffect,unsetFlag),
     {nullptr,nullptr}

--- a/src/map/lua/lua_statuseffect.h
+++ b/src/map/lua/lua_statuseffect.h
@@ -68,6 +68,7 @@ public:
     int32 resetStartTime(lua_State*);
 
     int32 addMod(lua_State*);
+    int32 getFlag(lua_State*);
     int32 setFlag(lua_State*);
     int32 unsetFlag(lua_State*);
 };


### PR DESCRIPTION
This fixes: https://github.com/DarkstarProject/darkstar/issues/4650

No real efficient way to single out Reraise without adding a flag check for effects.
This script looks through the list of "dispelable" effects and moves forward as long as reraise isn't one of them.