### PR TITLE
Add missing Fenrir mobskills

### DIFF
--- a/scripts/globals/mobskills/crescent_fang.lua
+++ b/scripts/globals/mobskills/crescent_fang.lua
@@ -1,0 +1,31 @@
+---------------------------------------------------
+-- Crescent Fang
+-- Fenrir inflicts Paralysis along with a single attack to target.
+---------------------------------------------------
+require("scripts/globals/monstertpmoves");
+require("scripts/globals/settings");
+require("scripts/globals/status");
+---------------------------------------------------
+
+function onMobSkillCheck(target,mob,skill)
+    return 0;
+end;
+
+function onMobWeaponSkill(target, mob, skill)
+    local numhits = 1;
+    local accmod = 2;
+    local dmgmod = 5;
+
+    local totaldamage = 0;
+    local damage = MobPhysicalMove(mob,target,skill,numhits,accmod,dmgmod,0,TP_NO_EFFECT,1,2,3);
+    totaldamage = MobFinalAdjustments(damage.dmg,mob,skill,target,MOBSKILL_PHYSICAL,MOBPARAM_PIERCE,numhits);
+
+    if (damage.hitslanded > 0) then
+        target:addStatusEffect(dsp.effects.PARALYSIS, 50, 0, 90);
+    end;
+
+    target:delHP(totaldamage);
+
+    return totaldamage;
+
+end;

--- a/scripts/globals/mobskills/eclipse_bite.lua
+++ b/scripts/globals/mobskills/eclipse_bite.lua
@@ -2,21 +2,24 @@
 -- Eclipse Bite
 -- Delivers a threefold attack.
 ---------------------------------------------------
-
+require("scripts/globals/monstertpmoves");
 require("scripts/globals/settings");
 require("scripts/globals/status");
-require("scripts/globals/monstertpmoves");
-
 ---------------------------------------------------
 
+function onMobSkillCheck(target,mob,skill)
+    return 0;
+end;
+
 function onMobWeaponSkill(target, mob, skill)
-    
     local numhits = 3;
-    local accmod = 2;
-    local dmgmod = 2;
+    local accmod = 1;
+    local dmgmod = 1;
+
     local info = MobPhysicalMove(mob,target,skill,numhits,accmod,dmgmod,TP_NO_EFFECT,1,2,3);
     local dmg = MobFinalAdjustments(info.dmg,mob,skill,target,MOBSKILL_PHYSICAL,MOBPARAM_SLASH,info.hitslanded);
     target:delHP(dmg);
+
     return dmg;
-    
-end
+
+end;

--- a/scripts/globals/mobskills/moonlit_charge.lua
+++ b/scripts/globals/mobskills/moonlit_charge.lua
@@ -1,0 +1,27 @@
+---------------------------------------------------
+-- Moonlit Charge
+-- Fenrir inflicts Blindness along with a single attack (knockback) to target.
+---------------------------------------------------
+require("scripts/globals/monstertpmoves");
+require("scripts/globals/settings");
+require("scripts/globals/status");
+---------------------------------------------------
+
+function onMobSkillCheck(target,mob,skill)
+    return 0;
+end;
+
+function onMobWeaponSkill(target, mob, skill)
+    local numhits = 1;
+    local accmod = 2;
+    local dmgmod = 4;
+
+    local totaldamage = 0;
+    local damage = MobPhysicalMove(mob,target,skill,numhits,accmod,dmgmod,0,TP_NO_EFFECT,1,2,3);
+    totaldamage = MobFinalAdjustments(damage.dmg,mob,skill,target,MOBSKILL_PHYSICAL,MOBPARAM_BLUNT,numhits);
+    target:addStatusEffect(dsp.effects.BLINDNESS, 20, 0, 30);
+    target:delHP(totaldamage);
+
+    return totaldamage;
+
+end;

--- a/sql/mob_skills.sql
+++ b/sql/mob_skills.sql
@@ -650,7 +650,7 @@ INSERT INTO `mob_skills` VALUES (827,499,'lightning_blade',0,7,2000,0,1,0,0,0,0,
 INSERT INTO `mob_skills` VALUES (828,500,'water_blade',0,7,2000,0,1,0,0,0,0,0,0);
 INSERT INTO `mob_skills` VALUES (829,501,'great_wheel',1,7.0,2000,1500,4,0,0,0,0,0,0);
 INSERT INTO `mob_skills` VALUES (830,502,'light_blade',0,30.0,2000,1500,4,0,0,0,0,0,0);
-INSERT INTO `mob_skills` VALUES (831,513,'moonlit_charge',0,10.0,512,3000,4,0,0,0,0,0,0);
+INSERT INTO `mob_skills` VALUES (831,513,'moonlit_charge',0,10.0,512,3000,4,0,0,7,0,0,0);
 INSERT INTO `mob_skills` VALUES (832,514,'crescent_fang',0,10.0,513,3000,4,0,0,0,0,0,0);
 INSERT INTO `mob_skills` VALUES (833,515,'lunar_cry',0,10.0,514,3000,4,0,0,0,0,0,0);
 INSERT INTO `mob_skills` VALUES (834,516,'ecliptic_growl',1,10.0,516,3000,1,0,0,0,0,0,0);


### PR DESCRIPTION
These may or may not need further scrutiny. I added and tweaked these numbers using the limited data gleaned from:
https://www.youtube.com/watch?v=WcZCtReetpw
The mobskill scripts I added are basically copies of the already implemented avatar scripts with tweaks to damage params to satisfy my "best guess" as to what damage should be inflicted using various situations with characters of different level/gear setups.

Eclipse Bite was not working due to the missing onMobSkillCheck and was also doing way too much damage during testing. Adjusting the params made it closer to retail.

Finally, moonlit charge was missing it's knockback effect flag in the db.