### PR TITLE
set costume flag to match packet

### DIFF
--- a/src/map/lua/lua_baseentity.cpp
+++ b/src/map/lua/lua_baseentity.cpp
@@ -4136,7 +4136,7 @@ inline int32 CLuaBaseEntity::costume(lua_State *L)
             PChar->status != STATUS_DISAPPEAR)
         {
             PChar->m_Costum = costum;
-            PChar->updatemask |= UPDATE_HP;
+            PChar->updatemask |= UPDATE_POS;
         }
         return 0;
     }


### PR DESCRIPTION
although, costumes were now staying on while moving, they were not updating until after the PC wearing the costume made their first pos move. This sets the lua binding flag to match with what the packet was changed to and allows costumes to be seen by other players immediately upon donning regardless of whether or not they receive an update pos move packet.