### PR TITLE
Added various Dynamis Divergence NPCs.

### DIFF
--- a/scripts/zones/Bastok_Mines/TextIDs.lua
+++ b/scripts/zones/Bastok_Mines/TextIDs.lua
@@ -25,13 +25,14 @@
 
 -- Mission Dialogs
         YOU_ACCEPT_THE_MISSION =  6506; -- You have accepted the mission.
-       ORIGINAL_MISSION_OFFSET =  6511; -- You can consult the ission section of the main menu to review your objectives. Speed and efficiency are your priorities. Dismissed. 
+       ORIGINAL_MISSION_OFFSET =  6511; -- You can consult the ission section of the main menu to review your objectives. Speed and efficiency are your priorities. Dismissed.
        EXTENDED_MISSION_OFFSET = 11612; -- Go to Ore Street and talk to Medicine Eagle. He says he was there when the commotion started.
 
 -- Dynamis dialogs
       YOU_CANNOT_ENTER_DYNAMIS = 11723; -- You cannot enter Dynamis
 PLAYERS_HAVE_NOT_REACHED_LEVEL = 11725; -- Players who have not reached levelare prohibited from entering Dynamis.
    UNUSUAL_ARRANGEMENT_PEBBLES = 11736; -- There is an unusual arrangement of pebbles here.
+       TEAR_IN_FABRIC_OF_SPACE = 16546; -- There appears to be a tear in the fabric of space...
 
 -- Dialog Texts
                HEMEWMEW_DIALOG =  7058; -- I have been appointed by the Guildworkers' Union to manage the trading of manufactured crafts and the exchange of guild points.

--- a/scripts/zones/Bastok_Mines/npcs/Enigmatic_Footprints.lua
+++ b/scripts/zones/Bastok_Mines/npcs/Enigmatic_Footprints.lua
@@ -1,0 +1,20 @@
+-----------------------------------
+-- Area: Bastok Mines
+--  NPC: Enigmatic Footprints
+-- Entry NPC for Dynamis Divergence
+-----------------------------------
+package.loaded["scripts/zones/Bastok_Mines/TextIDs"] = nil
+require("scripts/zones/Bastok_Mines/TextIDs")
+
+function onTrade(player,npc,trade)
+end
+
+function onTrigger(player,npc)
+    player:messageSpecial(TEAR_IN_FABRIC_OF_SPACE)
+end
+
+function onEventUpdate(player,csid,option)
+end
+
+function onEventFinish(player,csid,option)
+end

--- a/scripts/zones/RuLude_Gardens/TextIDs.lua
+++ b/scripts/zones/RuLude_Gardens/TextIDs.lua
@@ -26,6 +26,7 @@ SOVEREIGN_WITHOUT_AN_APPOINTMENT = 10165; -- Nobody sees the sovereign without a
         YOU_CANNOT_ENTER_DYNAMIS = 11220; -- You cannot enter Dynamis
   PLAYERS_HAVE_NOT_REACHED_LEVEL = 11222; -- Players who have not reached level   are prohibited from entering Dynamis.
       UNUSUAL_ARRANGEMENT_LEAVES = 11235; -- There is an unusual arrangement of leaves on the ground.
+         TEAR_IN_FABRIC_OF_SPACE = 15863; -- There appears to be a tear in the fabric of space...
 
 -- Quest Dialog
       YOUR_LEVEL_LIMIT_IS_NOW_55 = 10373; -- Your level limit is now 55.

--- a/scripts/zones/RuLude_Gardens/npcs/Enigmatic_Footprints.lua
+++ b/scripts/zones/RuLude_Gardens/npcs/Enigmatic_Footprints.lua
@@ -1,0 +1,20 @@
+-----------------------------------
+-- Area: Ru'Lude Gardens
+--  NPC: Enigmatic Footprints
+-- Entry NPC for Dynamis Divergence
+-----------------------------------
+package.loaded["scripts/zones/RuLude_Gardens/TextIDs"] = nil
+require("scripts/zones/RuLude_Gardens/TextIDs")
+
+function onTrade(player,npc,trade)
+end
+
+function onTrigger(player,npc)
+    player:messageSpecial(TEAR_IN_FABRIC_OF_SPACE)
+end
+
+function onEventUpdate(player,csid,option)
+end
+
+function onEventFinish(player,csid,option)
+end

--- a/scripts/zones/RuLude_Gardens/npcs/qm1.lua
+++ b/scripts/zones/RuLude_Gardens/npcs/qm1.lua
@@ -1,0 +1,20 @@
+-----------------------------------
+-- Area: Ru'Lude Gardens
+--  NPC: ???
+-- NPC for Dynamis Divergence Quest
+-----------------------------------
+package.loaded["scripts/zones/RuLude_Gardens/TextIDs"] = nil
+require("scripts/zones/RuLude_Gardens/TextIDs")
+
+function onTrade(player,npc,trade)
+end
+
+function onTrigger(player,npc)
+    player:messageSpecial(NOTHING_OUT_OF_ORDINARY)
+end
+
+function onEventUpdate(player,csid,option)
+end
+
+function onEventFinish(player,csid,option)
+end

--- a/scripts/zones/Southern_San_dOria/TextIDs.lua
+++ b/scripts/zones/Southern_San_dOria/TextIDs.lua
@@ -32,6 +32,7 @@
       YOU_CANNOT_ENTER_DYNAMIS =  7412; -- You cannot enter Dynamis
 PLAYERS_HAVE_NOT_REACHED_LEVEL =  7414; -- Players who have not reached level <<<Numeric Parameter 0>>> are prohibited from entering Dynamis.
   UNUSUAL_ARRANGEMENT_BRANCHES =  7424; -- There is an unusual arrangement of branches here.
+       TEAR_IN_FABRIC_OF_SPACE = 16751; -- There appears to be a tear in the fabric of space...
 
 -- Quest Dialogs
                 UNLOCK_PALADIN =  8007; -- You can now become a paladin!

--- a/scripts/zones/Southern_San_dOria/npcs/Enigmatic_Footprints.lua
+++ b/scripts/zones/Southern_San_dOria/npcs/Enigmatic_Footprints.lua
@@ -1,0 +1,20 @@
+-----------------------------------
+-- Area: Southern San d'Oria
+--  NPC: Enigmatic Footprints
+-- Entry NPC for Dynamis Divergence
+-----------------------------------
+package.loaded["scripts/zones/Southern_San_dOria/TextIDs"] = nil
+require("scripts/zones/Southern_San_dOria/TextIDs")
+
+function onTrade(player,npc,trade)
+end
+
+function onTrigger(player,npc)
+    player:messageSpecial(TEAR_IN_FABRIC_OF_SPACE)
+end
+
+function onEventUpdate(player,csid,option)
+end
+
+function onEventFinish(player,csid,option)
+end

--- a/scripts/zones/Windurst_Walls/TextIDs.lua
+++ b/scripts/zones/Windurst_Walls/TextIDs.lua
@@ -22,6 +22,7 @@
       YOU_CANNOT_ENTER_DYNAMIS = 9081; -- You cannot enter Dynamis
 PLAYERS_HAVE_NOT_REACHED_LEVEL = 9083; -- Players who have not reached levelare prohibited from entering Dynamis.
          STRANDS_OF_GRASS_HERE = 9095; -- The strands of grass here have been tied together.
+      TEAR_IN_FABRIC_OF_SPACE = 10780; -- There appears to be a tear in the fabric of space...
 
 -- Shop Texts
            SCAVNIX_SHOP_DIALOG = 8670; -- I'm goood Goblin from underwooorld.I find lotshhh of gooodieshhh.You want try shhhome chipshhh? Cheap for yooou.

--- a/scripts/zones/Windurst_Walls/npcs/Enigmatic_Footprints.lua
+++ b/scripts/zones/Windurst_Walls/npcs/Enigmatic_Footprints.lua
@@ -1,0 +1,20 @@
+-----------------------------------
+-- Area: Windurst Walls
+--  NPC: Enigmatic Footprints
+-- Entry NPC for Dynamis Divergence
+-----------------------------------
+package.loaded["scripts/zones/Windurst_Walls/TextIDs"] = nil
+require("scripts/zones/Windurst_Walls/TextIDs")
+
+function onTrade(player,npc,trade)
+end
+
+function onTrigger(player,npc)
+    player:messageSpecial(TEAR_IN_FABRIC_OF_SPACE)
+end
+
+function onEventUpdate(player,csid,option)
+end
+
+function onEventFinish(player,csid,option)
+end


### PR DESCRIPTION
- Added Enigmatic Footprints to Bastok Mines, Windurst Walls, Southern San d'Oria, and Ru'Lude Gardens.
- Added ??? to Ru'Lude Gardens.

All position/flags/textid's accurate to retail as of April 2018 version update.

Left content_tag as null for now, do we want Divergence to have it's own tag?
