### PR TITLE
Fix Feather Tickle TP reduction and message

### DIFF
--- a/scripts/globals/spells/bluemagic/feather_tickle.lua
+++ b/scripts/globals/spells/bluemagic/feather_tickle.lua
@@ -27,13 +27,13 @@ function onSpellCast(caster,target,spell)
     params.attribute = MOD_INT;
     params.skillType = BLUE_SKILL;
     local resist = applyResistance(caster, target, spell, params);
-    local power = 300 * resist;
+    local power = 3000 * resist;
 
     if (target:getTP() == 0) then
         spell:setMsg(msgBasic.MAGIC_NO_EFFECT);
     else
         target:delTP(power);
-        spell:setMsg(msgBasic.MAGIC_ERASE);
+        spell:setMsg(msgBasic.MAGIC_TP_REDUCE);
     end
 
     return tp;


### PR DESCRIPTION
Feather Tickle had the wrong message when used by BLU. Used to say "Removed KO Status". As far as I could find for details on the ability, it's supposed to remove ALL TP and the math in the script was still based on the old TP scale [0-300]. Left the resist multiplier in since I could not find much info about the mechanics of the spell.