### PR TITLE
Fix Eagle Eye Shot message

### DIFF
--- a/scripts/globals/abilities/eagle_eye_shot.lua
+++ b/scripts/globals/abilities/eagle_eye_shot.lua
@@ -43,11 +43,14 @@ function onUseAbility(player,target,ability,action)
     params.enmityMult = 0.5
 
     local damage, criticalHit, tpHits, extraHits = doRangedWeaponskill(player, target, 0, params, 0, true, action)
-    action:messageID(target:getID(), msgBasic.JA_DAMAGE);
-
-    if not (tpHits + extraHits > 0) then
-        ability:setMsg(msgBasic.JA_MISS_2)
-        action:speceffect(target:getID(), 0)
+    
+    -- Set the message id ourselves
+    if (tpHits + extraHits > 0) then
+        action:messageID(target:getID(), msgBasic.JA_DAMAGE);
+        action:speceffect(target:getID(), 32);
+    else
+        action:messageID(target:getID(), msgBasic.JA_MISS_2);
+        action:speceffect(target:getID(), 0);
     end
 
     return damage;

--- a/scripts/globals/abilities/eagle_eye_shot.lua
+++ b/scripts/globals/abilities/eagle_eye_shot.lua
@@ -43,6 +43,7 @@ function onUseAbility(player,target,ability,action)
     params.enmityMult = 0.5
 
     local damage, criticalHit, tpHits, extraHits = doRangedWeaponskill(player, target, 0, params, 0, true, action)
+    action:messageID(target:getID(), msgBasic.JA_DAMAGE);
 
     if not (tpHits + extraHits > 0) then
         ability:setMsg(msgBasic.JA_MISS_2)


### PR DESCRIPTION
Eagle Eye Shot used to say "Player used Mercy Stroke..."
Eagle Eye Shot uses weaponskill functions to determine its damage. Those functions change the message id to a weaponskill specific one so we need to set it back to JA_DAMAGE (110) when it's done calculating damage.