### PR TITLE
Outofrange actions

### DIFF
--- a/src/map/spell.cpp
+++ b/src/map/spell.cpp
@@ -556,6 +556,8 @@ namespace spell
     //Get Spell By ID
     CSpell* GetSpell(SpellID SpellID)
     {
+        DSP_DEBUG_BREAK_IF(SpellID >= MAX_SPELL_ID);
+
         auto id = static_cast<uint16>(SpellID);
         if (id >= MAX_SPELL_ID)
         {

--- a/src/map/spell.cpp
+++ b/src/map/spell.cpp
@@ -556,7 +556,12 @@ namespace spell
     //Get Spell By ID
     CSpell* GetSpell(SpellID SpellID)
     {
-        return PSpellList[static_cast<size_t>(SpellID)];
+        auto id = static_cast<uint16>(SpellID);
+        if (id >= MAX_SPELL_ID)
+        {
+            return nullptr;
+        }
+        return PSpellList[id];
     }
 
     bool CanUseSpell(CBattleEntity* PCaster, SpellID SpellID)

--- a/src/map/spell.h
+++ b/src/map/spell.h
@@ -747,6 +747,8 @@ enum class SpellID : uint16
     Flurry_II               = 846
 };
 
+#define MAX_SPELL_ID 1024U
+
 class CSpell
 {
 public:

--- a/src/map/utils/battleutils.cpp
+++ b/src/map/utils/battleutils.cpp
@@ -364,6 +364,10 @@ namespace battleutils
     CWeaponSkill* GetWeaponSkill(uint16 WSkillID)
     {
         DSP_DEBUG_BREAK_IF(WSkillID >= MAX_WEAPONSKILL_ID);
+        if (WSkillID >= MAX_WEAPONSKILL_ID)
+        {
+            return nullptr;
+        }
 
         return g_PWeaponSkillList[WSkillID];
     }


### PR DESCRIPTION
Fix issue with GetSpell/GetWeaponSkill where a forged packet could push an out of range access.  Debug break should catch for the brave souls running in debug mode.