### PR TITLE
DRK Traits

### DIFF
--- a/scripts/globals/abilities/last_resort.lua
+++ b/scripts/globals/abilities/last_resort.lua
@@ -14,5 +14,5 @@ function onAbilityCheck(player,target,ability)
 end;
 
 function onUseAbility(player,target,ability)
-    player:addStatusEffect(dsp.effect.LAST_RESORT,player:getMerit(dsp.merit.DESPERATE_BLOWS),0,180);
+    player:addStatusEffect(dsp.effect.LAST_RESORT, 0, 0, 180);
 end;

--- a/scripts/globals/effects/last_resort.lua
+++ b/scripts/globals/effects/last_resort.lua
@@ -11,12 +11,11 @@ require("scripts/globals/status");
 -----------------------------------
 
 function onEffectGain(target,effect)
-    target:addMod(dsp.mod.ATTP, 15 + target:getMerit(dsp.merit.LAST_RESORT_EFFECT));
-    
-    effect:setPower(-15 - target:getMerit(dsp.merit.LAST_RESORT_EFFECT) + target:getMod(dsp.mod.LAST_RESORT_DEF_PENALTY));
-    target:addMod(dsp.mod.DEFP, effect:getPower());
-    
+    target:addMod(dsp.mod.ATTP, 25 + target:getMerit(dsp.merit.LAST_RESORT_EFFECT));
     target:addMod(dsp.mod.HASTE_ABILITY, target:getMod(dsp.mod.DESPERATE_BLOWS) + target:getMerit(dsp.merit.DESPERATE_BLOWS));
+    
+    -- Gear that affects this mod is handled by a Latent Effect because the gear must remain equipped
+    target:addMod(dsp.mod.DEFP, -25 - target:getMerit(dsp.merit.LAST_RESORT_EFFECT));
 end;
 
 -----------------------------------
@@ -31,7 +30,9 @@ end;
 -----------------------------------
 
 function onEffectLose(target,effect)
-    target:delMod(dsp.mod.ATTP, 15 + target:getMerit(dsp.merit.LAST_RESORT_EFFECT));
-    target:delMod(dsp.mod.DEFP, effect:getPower());
+    target:delMod(dsp.mod.ATTP, 25 + target:getMerit(dsp.merit.LAST_RESORT_EFFECT));
     target:delMod(dsp.mod.HASTE_ABILITY, target:getMod(dsp.mod.DESPERATE_BLOWS) + target:getMerit(dsp.merit.DESPERATE_BLOWS));
+    
+     -- Gear that affects this mod is handled by a Latent Effect because the gear must remain equipped
+    target:delMod(dsp.mod.DEFP, -25 - target:getMerit(dsp.merit.LAST_RESORT_EFFECT));
 end;

--- a/scripts/globals/effects/last_resort.lua
+++ b/scripts/globals/effects/last_resort.lua
@@ -11,9 +11,12 @@ require("scripts/globals/status");
 -----------------------------------
 
 function onEffectGain(target,effect)
-    target:addMod(dsp.mod.ATTP,15 + target:getMerit(dsp.merit.LAST_RESORT_EFFECT));
-    target:addMod(dsp.mod.DEFP,-15 - target:getMerit(dsp.merit.LAST_RESORT_EFFECT));
-    target:addMod(dsp.mod.HASTE_ABILITY, 156+effect:getPower())
+    target:addMod(dsp.mod.ATTP, 15 + target:getMerit(dsp.merit.LAST_RESORT_EFFECT));
+    
+    effect:setPower(-15 - target:getMerit(dsp.merit.LAST_RESORT_EFFECT) + target:getMod(dsp.mod.LAST_RESORT_DEF_PENALTY);
+    target:addMod(dsp.mod.DEFP, effect:getPower());
+    
+    target:addMod(dsp.mod.HASTE_ABILITY, target:getMod(dsp.mod.DESPERATE_BLOWS) + target:getMerit(dsp.merit.DESPERATE_BLOWS));
 end;
 
 -----------------------------------
@@ -28,7 +31,7 @@ end;
 -----------------------------------
 
 function onEffectLose(target,effect)
-    target:delMod(dsp.mod.ATTP,15 + target:getMerit(dsp.merit.LAST_RESORT_EFFECT));
-    target:delMod(dsp.mod.DEFP,-15 - target:getMerit(dsp.merit.LAST_RESORT_EFFECT));
-    target:delMod(dsp.mod.HASTE_ABILITY, 156+effect:getPower())
+    target:delMod(dsp.mod.ATTP, 15 + target:getMerit(dsp.merit.LAST_RESORT_EFFECT));
+    target:delMod(dsp.mod.DEFP, effect:getPower());
+    target:delMod(dsp.mod.HASTE_ABILITY, target:getMod(dsp.mod.DESPERATE_BLOWS) + target:getMerit(dsp.merit.DESPERATE_BLOWS));
 end;

--- a/scripts/globals/effects/last_resort.lua
+++ b/scripts/globals/effects/last_resort.lua
@@ -13,7 +13,7 @@ require("scripts/globals/status");
 function onEffectGain(target,effect)
     target:addMod(dsp.mod.ATTP, 15 + target:getMerit(dsp.merit.LAST_RESORT_EFFECT));
     
-    effect:setPower(-15 - target:getMerit(dsp.merit.LAST_RESORT_EFFECT) + target:getMod(dsp.mod.LAST_RESORT_DEF_PENALTY);
+    effect:setPower(-15 - target:getMerit(dsp.merit.LAST_RESORT_EFFECT) + target:getMod(dsp.mod.LAST_RESORT_DEF_PENALTY));
     target:addMod(dsp.mod.DEFP, effect:getPower());
     
     target:addMod(dsp.mod.HASTE_ABILITY, target:getMod(dsp.mod.DESPERATE_BLOWS) + target:getMerit(dsp.merit.DESPERATE_BLOWS));

--- a/scripts/globals/status.lua
+++ b/scripts/globals/status.lua
@@ -964,6 +964,9 @@ dsp.mod =
     MEDITATE_DURATION               = 94,  -- Meditate duration in seconds
     WARDING_CIRCLE_DURATION         = 95,  -- Warding Circle duration in seconds
     SOULEATER_EFFECT                = 96,  -- Souleater power in percents
+    DESPERATE_BLOWS                 = 906, -- Adds ability haste to Last Resort
+    LAST_RESORT_DEF_PENALTY         = 907, -- Reduces the defense penalty of last resort
+    STALWART_SOUL                   = 908, -- Reduces damage taken from Souleater
     BOOST_EFFECT                    = 97,  -- Boost power in tenths
     CAMOUFLAGE_DURATION             = 98,  -- Camouflage duration in percents
     AUTO_MELEE_SKILL                = 101,
@@ -1470,9 +1473,9 @@ dsp.mod =
 
     -- The spares take care of finding the next ID to use so long as we don't forget to list IDs that have been freed up by refactoring.
     -- 570 - 825 used by WS DMG mods these are not spares.
-    -- SPARE = 906, -- stuff
-    -- SPARE = 907, -- stuff
-    -- SPARE = 908, -- stuff
+    -- SPARE = 909, -- stuff
+    -- SPARE = 910, -- stuff
+    -- SPARE = 911, -- stuff
 };
 
 ------------------------------------

--- a/scripts/globals/status.lua
+++ b/scripts/globals/status.lua
@@ -965,8 +965,7 @@ dsp.mod =
     WARDING_CIRCLE_DURATION         = 95,  -- Warding Circle duration in seconds
     SOULEATER_EFFECT                = 96,  -- Souleater power in percents
     DESPERATE_BLOWS                 = 906, -- Adds ability haste to Last Resort
-    LAST_RESORT_DEF_PENALTY         = 907, -- Reduces the defense penalty of last resort
-    STALWART_SOUL                   = 908, -- Reduces damage taken from Souleater
+    STALWART_SOUL                   = 907, -- Reduces damage taken from Souleater
     BOOST_EFFECT                    = 97,  -- Boost power in tenths
     CAMOUFLAGE_DURATION             = 98,  -- Camouflage duration in percents
     AUTO_MELEE_SKILL                = 101,
@@ -1473,9 +1472,9 @@ dsp.mod =
 
     -- The spares take care of finding the next ID to use so long as we don't forget to list IDs that have been freed up by refactoring.
     -- 570 - 825 used by WS DMG mods these are not spares.
+    -- SPARE = 908, -- stuff
     -- SPARE = 909, -- stuff
     -- SPARE = 910, -- stuff
-    -- SPARE = 911, -- stuff
 };
 
 ------------------------------------

--- a/sql/abilities.sql
+++ b/sql/abilities.sql
@@ -264,8 +264,8 @@ INSERT INTO `abilities` VALUES (225,'focalization',20,75,1,1,231,0,0,212,2000,0,
 INSERT INTO `abilities` VALUES (226,'tranquility',20,75,1,1,231,0,0,211,2000,0,6,20.0,0,1,80,3268,17,'WOTG');
 INSERT INTO `abilities` VALUES (227,'equanimity',20,75,1,1,231,0,0,213,2000,0,6,20.0,0,1,80,3270,33,'WOTG');
 INSERT INTO `abilities` VALUES (228,'enlightenment',20,75,1,300,235,0,0,214,2000,0,6,20.0,0,1,80,3272,1,'WOTG');
-INSERT INTO `abilities` VALUES (229,'afflatus_solace',3,40,1,60,29,0,0,216,2000,0,6,20.0,0,1,80,0,0,'WOTG');
-INSERT INTO `abilities` VALUES (230,'afflatus_misery',3,40,1,60,30,0,0,217,2000,0,6,20.0,0,1,80,0,0,'WOTG');
+INSERT INTO `abilities` VALUES (229,'afflatus_solace',3,40,1,60,29,0,0,216,2000,0,6,20.0,0,1,80,0,4,'WOTG');
+INSERT INTO `abilities` VALUES (230,'afflatus_misery',3,40,1,60,30,0,0,217,2000,0,6,20.0,0,1,80,0,4,'WOTG');
 INSERT INTO `abilities` VALUES (231,'composure',5,50,1,300,50,0,0,215,2000,0,6,20.0,0,1,80,0,0,'WOTG');
 INSERT INTO `abilities` VALUES (232,'yonin',13,40,1,180,146,0,0,218,2000,0,6,20.0,0,1,600,0,4,'WOTG');
 INSERT INTO `abilities` VALUES (233,'innin',13,40,1,180,147,0,0,219,2000,0,6,20.0,0,1,60,0,4,'WOTG');

--- a/sql/item_latents.sql
+++ b/sql/item_latents.sql
@@ -23,6 +23,8 @@ CREATE TABLE IF NOT EXISTS `item_latents` (
 
 -- INSERT INTO `item_latents` VALUES(itemID, modId, modValue, latentId, latentParam);
 
+INSERT INTO `item_latents` VALUES(10737, 63, 10, 513, 64); -- Abyss Sollerets +2, Enhances "Last Resort" effect
+
 -- -------------------------------------------------------
 -- Oneiros Ring
 -- -------------------------------------------------------
@@ -48,6 +50,10 @@ INSERT INTO `item_latents` VALUES(13870, 14, 14, 49, 4596); -- CHR +14
 
 INSERT INTO `item_latents` VALUES(14725, 68, 5, 25, 0); -- Melody Earring, EVA+5 song/roll active
 INSERT INTO `item_latents` VALUES(14726, 68, 6, 25, 0); -- Melody Earring +1, EVA+6 song/roll active
+
+INSERT INTO `item_latents` VALUES(15139, 63, 10, 13, 64); -- Abyss Sollerets, Enhances "Last Resort" effect
+INSERT INTO `item_latents` VALUES(15672, 63, 10, 13, 64); -- Abyss Sollerets +1, Enhances "Last Resort" effect
+
 INSERT INTO `item_latents` VALUES(16017, 28, 1, 22, 4); -- Ardent Earring, MATT+1 if BLM is in party
 INSERT INTO `item_latents` VALUES(16018, 30, 1, 22, 5); -- Ataraxy Earring, MACC+1 if RDM is in party
 INSERT INTO `item_latents` VALUES(16029, 2, 10, 22, 16); -- Booster Earring, HP+10 if BLU is in party
@@ -89,6 +95,9 @@ INSERT INTO `item_latents` VALUES(18256, 25, 1, 25, 0); -- Orphic Egg, ACC+1 son
 INSERT INTO `item_latents` VALUES(18256, 23, 1, 25, 0); -- Orphic Egg, ATT+1 song/roll active
 INSERT INTO `item_latents` VALUES(18256, 68, 1, 25, 0); -- Orphic Egg, EVA+1 song/roll active
 INSERT INTO `item_latents` VALUES(18486, 171, -30, 25, 0); -- Wardancer, Delay: 474 (504 - 30) song/roll active
+
+INSERT INTO `item_latents` VALUES(27342, 63, 10, 13, 64); -- Fallen's Sollerets, "Last Resort"+1
+INSERT INTO `item_latents` VALUES(27343, 63, 10, 13, 64); -- Fallen's Sollerets +1, "Last Resort"+1
 
 INSERT INTO `item_latents` VALUES(28235,169,25,26,2);      -- Hachiya Kyahan: Dusk to dawn: Movement speed +25%
 INSERT INTO `item_latents` VALUES(28256,169,25,26,2);      -- Hachiya Kyahan +1: Dusk to dawn: Movement speed +25%

--- a/sql/item_mods.sql
+++ b/sql/item_mods.sql
@@ -2176,7 +2176,6 @@ INSERT INTO `item_mods` VALUES (10736,837,10);
 INSERT INTO `item_mods` VALUES (10737,1,22);
 INSERT INTO `item_mods` VALUES (10737,8,6);
 INSERT INTO `item_mods` VALUES (10737,23,6);
-INSERT INTO `item_mods` VALUES (10737,907,10); -- Enhances "Last Resort" effect
 INSERT INTO `item_mods` VALUES (10738,1,18);
 INSERT INTO `item_mods` VALUES (10738,2,18);
 INSERT INTO `item_mods` VALUES (10738,8,7);
@@ -16285,7 +16284,6 @@ INSERT INTO `item_mods` VALUES (15138,837,10);
 INSERT INTO `item_mods` VALUES (15139,1,17);
 INSERT INTO `item_mods` VALUES (15139,5,12);
 INSERT INTO `item_mods` VALUES (15139,114,5);
-INSERT INTO `item_mods` VALUES (15139,907,10); -- Enhances "Last Resort" effect
 INSERT INTO `item_mods` VALUES (15140,1,14);
 INSERT INTO `item_mods` VALUES (15140,2,13);
 INSERT INTO `item_mods` VALUES (15140,10,4);
@@ -18071,7 +18069,6 @@ INSERT INTO `item_mods` VALUES (15672,1,18);
 INSERT INTO `item_mods` VALUES (15672,5,12);
 INSERT INTO `item_mods` VALUES (15672,25,2);
 INSERT INTO `item_mods` VALUES (15672,114,5);
-INSERT INTO `item_mods` VALUES (15672,907,10); -- Enhances "Last Resort" effect
 INSERT INTO `item_mods` VALUES (15673,1,15);
 INSERT INTO `item_mods` VALUES (15673,2,13);
 INSERT INTO `item_mods` VALUES (15673,10,5);
@@ -37916,7 +37913,6 @@ INSERT INTO `item_mods` VALUES (27342,29,1);
 INSERT INTO `item_mods` VALUES (27342,31,43);
 INSERT INTO `item_mods` VALUES (27342,68,23);
 INSERT INTO `item_mods` VALUES (27342,384,30);
-INSERT INTO `item_mods` VALUES (27342,907,10); -- "Last Resort"+1
 INSERT INTO `item_mods` VALUES (27343,1,88);
 INSERT INTO `item_mods` VALUES (27343,2,18);
 INSERT INTO `item_mods` VALUES (27343,8,21);
@@ -37930,7 +37926,6 @@ INSERT INTO `item_mods` VALUES (27343,29,2);
 INSERT INTO `item_mods` VALUES (27343,31,64);
 INSERT INTO `item_mods` VALUES (27343,68,49);
 INSERT INTO `item_mods` VALUES (27343,384,30);
-INSERT INTO `item_mods` VALUES (27343,907,10); -- "Last Resort"+1
 INSERT INTO `item_mods` VALUES (27344,1,51);
 INSERT INTO `item_mods` VALUES (27344,2,8);
 INSERT INTO `item_mods` VALUES (27344,8,8);

--- a/sql/item_mods.sql
+++ b/sql/item_mods.sql
@@ -2176,6 +2176,7 @@ INSERT INTO `item_mods` VALUES (10736,837,10);
 INSERT INTO `item_mods` VALUES (10737,1,22);
 INSERT INTO `item_mods` VALUES (10737,8,6);
 INSERT INTO `item_mods` VALUES (10737,23,6);
+INSERT INTO `item_mods` VALUES (10737,907,10); -- Enhances "Last Resort" effect
 INSERT INTO `item_mods` VALUES (10738,1,18);
 INSERT INTO `item_mods` VALUES (10738,2,18);
 INSERT INTO `item_mods` VALUES (10738,8,7);
@@ -16284,6 +16285,7 @@ INSERT INTO `item_mods` VALUES (15138,837,10);
 INSERT INTO `item_mods` VALUES (15139,1,17);
 INSERT INTO `item_mods` VALUES (15139,5,12);
 INSERT INTO `item_mods` VALUES (15139,114,5);
+INSERT INTO `item_mods` VALUES (15139,907,10); -- Enhances "Last Resort" effect
 INSERT INTO `item_mods` VALUES (15140,1,14);
 INSERT INTO `item_mods` VALUES (15140,2,13);
 INSERT INTO `item_mods` VALUES (15140,10,4);
@@ -18069,6 +18071,7 @@ INSERT INTO `item_mods` VALUES (15672,1,18);
 INSERT INTO `item_mods` VALUES (15672,5,12);
 INSERT INTO `item_mods` VALUES (15672,25,2);
 INSERT INTO `item_mods` VALUES (15672,114,5);
+INSERT INTO `item_mods` VALUES (15672,907,10); -- Enhances "Last Resort" effect
 INSERT INTO `item_mods` VALUES (15673,1,15);
 INSERT INTO `item_mods` VALUES (15673,2,13);
 INSERT INTO `item_mods` VALUES (15673,10,5);
@@ -37913,6 +37916,7 @@ INSERT INTO `item_mods` VALUES (27342,29,1);
 INSERT INTO `item_mods` VALUES (27342,31,43);
 INSERT INTO `item_mods` VALUES (27342,68,23);
 INSERT INTO `item_mods` VALUES (27342,384,30);
+INSERT INTO `item_mods` VALUES (27342,907,10); -- "Last Resort"+1
 INSERT INTO `item_mods` VALUES (27343,1,88);
 INSERT INTO `item_mods` VALUES (27343,2,18);
 INSERT INTO `item_mods` VALUES (27343,8,21);
@@ -37926,6 +37930,7 @@ INSERT INTO `item_mods` VALUES (27343,29,2);
 INSERT INTO `item_mods` VALUES (27343,31,64);
 INSERT INTO `item_mods` VALUES (27343,68,49);
 INSERT INTO `item_mods` VALUES (27343,384,30);
+INSERT INTO `item_mods` VALUES (27343,907,10); -- "Last Resort"+1
 INSERT INTO `item_mods` VALUES (27344,1,51);
 INSERT INTO `item_mods` VALUES (27344,2,8);
 INSERT INTO `item_mods` VALUES (27344,8,8);

--- a/sql/merits.sql
+++ b/sql/merits.sql
@@ -226,7 +226,7 @@ INSERT INTO `merits` VALUES (2438,'guardian',5,19,64,7,37);
 INSERT INTO `merits` VALUES (2496,'dark_seal',5,1,128,7,38);
 INSERT INTO `merits` VALUES (2498,'diabolic_eye',5,5,128,7,38);
 INSERT INTO `merits` VALUES (2500,'muted_soul',5,10,128,7,38);
-INSERT INTO `merits` VALUES (2502,'desperate_blows_effect',5,20,128,7,38);
+INSERT INTO `merits` VALUES (2502,'desperate_blows_effect',5,21,128,7,38);
 INSERT INTO `merits` VALUES (2560,'feral_howl',5,5,256,7,39);
 INSERT INTO `merits` VALUES (2562,'killer_instinct',5,10,256,7,39);
 INSERT INTO `merits` VALUES (2564,'beast_affinity',5,2,256,7,39);

--- a/sql/traits.sql
+++ b/sql/traits.sql
@@ -476,10 +476,10 @@ INSERT INTO `traits` VALUES ('112','elemental celerity','4','90','5','901','30',
 INSERT INTO `traits` VALUES ('114','tranquil heart','3','21','1','0','0','ABYSSEA','0');
 INSERT INTO `traits` VALUES ('114','tranquil heart','5','26','1','0','0','ABYSSEA','0');
 INSERT INTO `traits` VALUES ('114','tranquil heart','20','30','1','0','0','ABYSSEA','0');
-INSERT INTO `traits` VALUES ('115','stalwart soul','8','45','1','908','15','TOAU','0');
-INSERT INTO `traits` VALUES ('115','stalwart soul','8','60','2','908','30','TOAU','0');
-INSERT INTO `traits` VALUES ('115','stalwart soul','8','75','3','908','40','TOAU','0');
-INSERT INTO `traits` VALUES ('115','stalwart soul','8','90','4','908','50','ABYSSEA','0');
+INSERT INTO `traits` VALUES ('115','stalwart soul','8','45','1','907','15','TOAU','0');
+INSERT INTO `traits` VALUES ('115','stalwart soul','8','60','2','907','30','TOAU','0');
+INSERT INTO `traits` VALUES ('115','stalwart soul','8','75','3','907','40','TOAU','0');
+INSERT INTO `traits` VALUES ('115','stalwart soul','8','90','4','907','50','ABYSSEA','0');
 INSERT INTO `traits` VALUES ('127','smite','1','35','1','898','25','SOA','0'); -- 25/256 ~ 9.7%
 INSERT INTO `traits` VALUES ('127','smite','1','65','2','898','38','SOA','0'); -- 38/256 ~ 15%
 INSERT INTO `traits` VALUES ('127','smite','1','95','3','898','51','SOA','0'); -- 51/256 ~ 19.9%

--- a/sql/traits.sql
+++ b/sql/traits.sql
@@ -79,8 +79,12 @@ INSERT INTO `traits` VALUES ('3','attack bonus','8','70','4','23','48',null,'0')
 INSERT INTO `traits` VALUES ('3','attack bonus','8','70','4','24','48',null,'0');
 INSERT INTO `traits` VALUES ('3','attack bonus','8','76','5','23','60','ABYSSEA','0');
 INSERT INTO `traits` VALUES ('3','attack bonus','8','76','5','24','60','ABYSSEA','0');
-INSERT INTO `traits` VALUES ('3','attack bonus','8','91','6','23','72','ABYSSEA','0');
-INSERT INTO `traits` VALUES ('3','attack bonus','8','91','6','24','72','ABYSSEA','0');
+INSERT INTO `traits` VALUES ('3','attack bonus','8','83','6','23','72','ABYSSEA','0');
+INSERT INTO `traits` VALUES ('3','attack bonus','8','83','6','24','72','ABYSSEA','0');
+INSERT INTO `traits` VALUES ('3','attack bonus','8','91','7','23','84','ABYSSEA','0');
+INSERT INTO `traits` VALUES ('3','attack bonus','8','91','7','24','84','ABYSSEA','0');
+INSERT INTO `traits` VALUES ('3','attack bonus','8','99','8','23','96','ABYSSEA','0');
+INSERT INTO `traits` VALUES ('3','attack bonus','8','99','8','24','96','ABYSSEA','0');
 INSERT INTO `traits` VALUES ('3','attack bonus','14','10','1','23','10',null,'0'); -- ROTZ
 INSERT INTO `traits` VALUES ('3','attack bonus','14','10','1','24','10',null,'0'); -- ROTZ
 INSERT INTO `traits` VALUES ('3','attack bonus','14','91','2','23','22','ABYSSEA','0');
@@ -260,6 +264,7 @@ INSERT INTO `traits` VALUES ('37','amorph killer','9','30','1','226','8',null,'0
 INSERT INTO `traits` VALUES ('38','aquan killer','9','50','1','228','8',null,'0');
 INSERT INTO `traits` VALUES ('39','undead killer','7','5','1','231','8',null,'0');
 INSERT INTO `traits` VALUES ('41','arcana killer','8','25','1','232','8',null,'0');
+INSERT INTO `traits` VALUES ('41','arcana killer','8','86','2','232','10','ABYSSEA','0');
 INSERT INTO `traits` VALUES ('42','demon killer','12','40','1','234','8',null,'0'); -- ROTZ
 INSERT INTO `traits` VALUES ('43','dragon killer','14','25','1','233','8',null,'0'); -- ROTZ
 INSERT INTO `traits` VALUES ('48','resist sleep','7','20','1','240','2',null,'0');
@@ -268,10 +273,11 @@ INSERT INTO `traits` VALUES ('48','resist sleep','7','60','3','240','5',null,'0'
 INSERT INTO `traits` VALUES ('49','resist poison','11','20','1','241','2',null,'0');
 INSERT INTO `traits` VALUES ('49','resist poison','11','40','2','241','3',null,'0');
 INSERT INTO `traits` VALUES ('49','resist poison','11','60','3','241','5',null,'0');
-INSERT INTO `traits` VALUES ('50','resist paralyze','8','20','1','242','2',null,'0');
-INSERT INTO `traits` VALUES ('50','resist paralyze','8','40','2','242','3',null,'0');
-INSERT INTO `traits` VALUES ('50','resist paralyze','8','60','3','242','5',null,'0');
-INSERT INTO `traits` VALUES ('50','resist paralyze','8','75','4','242','6',null,'0');
+INSERT INTO `traits` VALUES ('50','resist paralyze','8','20','1','242','10',null,'0');
+INSERT INTO `traits` VALUES ('50','resist paralyze','8','40','2','242','15',null,'0');
+INSERT INTO `traits` VALUES ('50','resist paralyze','8','50','3','242','20',null,'0');
+INSERT INTO `traits` VALUES ('50','resist paralyze','8','75','4','242','25',null,'0');
+INSERT INTO `traits` VALUES ('50','resist paralyze','8','81','5','242','30','ABYSSEA','0');
 INSERT INTO `traits` VALUES ('50','resist paralyze','17','5','1','242','2','TOAU','0');
 INSERT INTO `traits` VALUES ('50','resist paralyze','17','25','2','242','3','TOAU','0');
 INSERT INTO `traits` VALUES ('50','resist paralyze','17','45','3','242','5','TOAU','0');
@@ -373,8 +379,10 @@ INSERT INTO `traits` VALUES ('75','aura steal','6','75','1','0','0','TOAU','2372
 INSERT INTO `traits` VALUES ('76','ambush','6','75','1','0','0','TOAU','2374');
 INSERT INTO `traits` VALUES ('77','iron will','7','75','1','0','0','TOAU','0');
 INSERT INTO `traits` VALUES ('78','guardian','7','75','1','0','0','TOAU','0');
-INSERT INTO `traits` VALUES ('79','muted soul','8','75','1','0','0','TOAU','0');
-INSERT INTO `traits` VALUES ('80','desperate blows','8','75','1','0','0','TOAU','0');
+INSERT INTO `traits` VALUES ('79','muted soul','8','75','1','0','0','TOAU','2500');
+INSERT INTO `traits` VALUES ('80','desperate blows','8','15','1','906','52','TOAU','0'); -- 1024 base ~5%
+INSERT INTO `traits` VALUES ('80','desperate blows','8','30','2','906','104','TOAU','0'); -- 1024 base ~10%
+INSERT INTO `traits` VALUES ('80','desperate blows','8','45','3','906','156','TOAU','0'); -- 1024 base ~15%
 INSERT INTO `traits` VALUES ('81','beast affinity ','9','75','1','0','0','TOAU','0');
 INSERT INTO `traits` VALUES ('82','beast healer','9','75','1','0','0','TOAU','0');
 INSERT INTO `traits` VALUES ('83','snapshot','11','75','1','0','0','TOAU','0');
@@ -399,18 +407,20 @@ INSERT INTO `traits` VALUES ('98','crit. atk. bonus','6','78','1','421','5','ABY
 INSERT INTO `traits` VALUES ('98','crit. atk. bonus','6','84','2','421','8','ABYSSEA','0');
 INSERT INTO `traits` VALUES ('98','crit. atk. bonus','6','91','3','421','11','ABYSSEA','0');
 INSERT INTO `traits` VALUES ('98','crit. atk. bonus','6','97','4','421','14','ABYSSEA','0');
-INSERT INTO `traits` VALUES ('100','tactical parry','8','88','10','486','2','ABYSSEA','0');
-INSERT INTO `traits` VALUES ('100','tactical parry','8','98','20','486','3','ABYSSEA','0');
-INSERT INTO `traits` VALUES ('100','tactical parry','13','77','10','486','2','ABYSSEA','0');
-INSERT INTO `traits` VALUES ('100','tactical parry','13','87','20','486','3','ABYSSEA','0');
-INSERT INTO `traits` VALUES ('100','tactical parry','13','97','30','486','4','ABYSSEA','0');
-INSERT INTO `traits` VALUES ('100','tactical parry','19','77','10','486','2','ABYSSEA','0');
-INSERT INTO `traits` VALUES ('100','tactical parry','19','84','20','486','3','ABYSSEA','0');
-INSERT INTO `traits` VALUES ('100','tactical parry','19','91','30','486','4','ABYSSEA','0');
-INSERT INTO `traits` VALUES ('100','tactical parry','19','97','40','486','5','ABYSSEA','0');
-INSERT INTO `traits` VALUES ('100','tactical parry','22','40','10','486','2',null,'0');
-INSERT INTO `traits` VALUES ('100','tactical parry','22','60','20','486','3',null,'0');
-INSERT INTO `traits` VALUES ('100','tactical parry','22','97','30','486','4',null,'0');
+INSERT INTO `traits` VALUES ('98','crit. atk. bonus','8','85','1','421','5','ABYSSEA','0');
+INSERT INTO `traits` VALUES ('98','crit. atk. bonus','8','95','2','421','8','ABYSSEA','0');
+INSERT INTO `traits` VALUES ('100','tactical parry','8','88','1','486','20','ABYSSEA','0');
+INSERT INTO `traits` VALUES ('100','tactical parry','8','98','2','486','30','ABYSSEA','0');
+INSERT INTO `traits` VALUES ('100','tactical parry','13','77','1','486','20','ABYSSEA','0');
+INSERT INTO `traits` VALUES ('100','tactical parry','13','87','2','486','30','ABYSSEA','0');
+INSERT INTO `traits` VALUES ('100','tactical parry','13','97','3','486','40','ABYSSEA','0');
+INSERT INTO `traits` VALUES ('100','tactical parry','19','77','1','486','20','ABYSSEA','0');
+INSERT INTO `traits` VALUES ('100','tactical parry','19','84','2','486','30','ABYSSEA','0');
+INSERT INTO `traits` VALUES ('100','tactical parry','19','91','3','486','40','ABYSSEA','0');
+INSERT INTO `traits` VALUES ('100','tactical parry','19','97','4','486','50','ABYSSEA','0');
+INSERT INTO `traits` VALUES ('100','tactical parry','22','40','1','486','20',null,'0');
+INSERT INTO `traits` VALUES ('100','tactical parry','22','60','2','486','30',null,'0');
+INSERT INTO `traits` VALUES ('100','tactical parry','22','97','3','486','40',null,'0');
 INSERT INTO `traits` VALUES ('101','tactical guard','2','77','1','899','30','ABYSSEA','0');
 INSERT INTO `traits` VALUES ('101','tactical guard','2','87','2','899','45','ABYSSEA','0');
 INSERT INTO `traits` VALUES ('101','tactical guard','2','97','3','899','60','ABYSSEA','0');
@@ -441,6 +451,11 @@ INSERT INTO `traits` VALUES ('107','fencer','1','97','5','903','500','ABYSSEA','
 INSERT INTO `traits` VALUES ('107','fencer','1','97','5','904','10','ABYSSEA','0');
 INSERT INTO `traits` VALUES ('109','occult acumen','4','85','1','902','25','ABYSSEA','0');
 INSERT INTO `traits` VALUES ('109','occult acumen','4','95','2','902','50','ABYSSEA','0');
+INSERT INTO `traits` VALUES ('109','occult acumen','8','45','1','902','25',null,'0');
+INSERT INTO `traits` VALUES ('109','occult acumen','8','58','2','902','50',null,'0');
+INSERT INTO `traits` VALUES ('109','occult acumen','8','71','3','902','75',null,'0');
+INSERT INTO `traits` VALUES ('109','occult acumen','8','84','4','902','100','ABYSSEA','0');
+INSERT INTO `traits` VALUES ('109','occult acumen','8','97','5','902','125','ABYSSEA','0');
 INSERT INTO `traits` VALUES ('110','mag. burst bonus','4','45','1','487','5','ABYSSEA','0');
 INSERT INTO `traits` VALUES ('110','mag. burst bonus','4','58','2','487','7','ABYSSEA','0');
 INSERT INTO `traits` VALUES ('110','mag. burst bonus','4','71','3','487','9','ABYSSEA','0');
@@ -461,11 +476,20 @@ INSERT INTO `traits` VALUES ('112','elemental celerity','4','90','5','901','30',
 INSERT INTO `traits` VALUES ('114','tranquil heart','3','21','1','0','0','ABYSSEA','0');
 INSERT INTO `traits` VALUES ('114','tranquil heart','5','26','1','0','0','ABYSSEA','0');
 INSERT INTO `traits` VALUES ('114','tranquil heart','20','30','1','0','0','ABYSSEA','0');
+INSERT INTO `traits` VALUES ('115','stalwart soul','8','45','1','908','15','TOAU','0');
+INSERT INTO `traits` VALUES ('115','stalwart soul','8','60','2','908','30','TOAU','0');
+INSERT INTO `traits` VALUES ('115','stalwart soul','8','75','3','908','40','TOAU','0');
+INSERT INTO `traits` VALUES ('115','stalwart soul','8','90','4','908','50','ABYSSEA','0');
 INSERT INTO `traits` VALUES ('127','smite','1','35','1','898','25','SOA','0'); -- 25/256 ~ 9.7%
 INSERT INTO `traits` VALUES ('127','smite','1','65','2','898','38','SOA','0'); -- 38/256 ~ 15%
 INSERT INTO `traits` VALUES ('127','smite','1','95','3','898','51','SOA','0'); -- 51/256 ~ 19.9%
 INSERT INTO `traits` VALUES ('127','smite','2','40','1','898','25','SOA','0'); -- 25/256 ~ 9.7%
 INSERT INTO `traits` VALUES ('127','smite','2','80','2','898','38','SOA','0'); -- 38/256 ~ 15%
+INSERT INTO `traits` VALUES ('127','smite','8','15','1','898','25','SOA','0');
+INSERT INTO `traits` VALUES ('127','smite','8','35','2','898','38','SOA','0');
+INSERT INTO `traits` VALUES ('127','smite','8','55','3','898','51','SOA','0');
+INSERT INTO `traits` VALUES ('127','smite','8','75','4','898','64','SOA','0'); -- 64/256 = 25%
+INSERT INTO `traits` VALUES ('127','smite','8','95','5','898','76','SOA','0'); -- 76/256 ~ 29.6%
 
 -- --- RUNE FENCER --- -- (Tenacity needs verifying)
 -- Tenacity Tier I

--- a/src/map/entities/battleentity.cpp
+++ b/src/map/entities/battleentity.cpp
@@ -251,9 +251,9 @@ int16 CBattleEntity::GetWeaponDelay(bool tp)
     if (!tp)
     {
         // Cap haste at appropriate levels.
-        int16 hasteMagic = (getMod(Mod::HASTE_MAGIC) > 448) ? 448 : getMod(Mod::HASTE_MAGIC);
-        int16 hasteAbility = (getMod(Mod::HASTE_ABILITY) > 256) ? 256 : getMod(Mod::HASTE_ABILITY);
-        int16 hasteGear = (getMod(Mod::HASTE_GEAR) > 256) ? 256 : getMod(Mod::HASTE_GEAR);
+        int16 hasteMagic = std::clamp<int16>(getMod(Mod::HASTE_MAGIC), -448, 448);
+        int16 hasteAbility = std::clamp<int16>(getMod(Mod::HASTE_ABILITY), -256, 256);
+        int16 hasteGear = std::clamp<int16>(getMod(Mod::HASTE_GEAR), -256, 256);
         WeaponDelay = (uint16)(WeaponDelay * ((1024.0f - hasteMagic - hasteAbility - hasteGear) / 1024.0f));
     }
     WeaponDelay = (uint16)(WeaponDelay * ((100.0f + getMod(Mod::DELAYP)) / 100.0f));

--- a/src/map/modifier.h
+++ b/src/map/modifier.h
@@ -348,8 +348,7 @@ enum class Mod
     ARCANE_CIRCLE_DURATION    = 858, // Arcane Circle extended duration in seconds
     SOULEATER_EFFECT          = 96,  // Souleater power in percents
     DESPERATE_BLOWS           = 906, // Adds ability haste to Last Resort
-    LAST_RESORT_DEF_PENALTY   = 907, // Reduces the defense penalty of last resort
-    STALWART_SOUL             = 908, // Reduces damage taken from Souleater
+    STALWART_SOUL             = 907, // Reduces damage taken from Souleater
 
     // Beastmaster
     TAME                      = 304, // Additional percent chance to charm
@@ -724,9 +723,9 @@ enum class Mod
 
     // The spares take care of finding the next ID to use so long as we don't forget to list IDs that have been freed up by refactoring.
     // 570 through 825 used by WS DMG mods these are not spares.
+    // SPARE = 908, // stuff
     // SPARE = 909, // stuff
     // SPARE = 910, // stuff
-    // SPARE = 911, // stuff
 };
 
 //temporary workaround for using enum class as unordered_map key until compilers support it

--- a/src/map/modifier.h
+++ b/src/map/modifier.h
@@ -345,8 +345,11 @@ enum class Mod
     SHIELD_DEF_BONUS          = 905, // Shield Defense Bonus
 
     // Dark Knight
-    ARCANE_CIRCLE_DURATION    = 858,  // Arcane Circle extended duration in seconds
+    ARCANE_CIRCLE_DURATION    = 858, // Arcane Circle extended duration in seconds
     SOULEATER_EFFECT          = 96,  // Souleater power in percents
+    DESPERATE_BLOWS           = 906, // Adds ability haste to Last Resort
+    LAST_RESORT_DEF_PENALTY   = 907, // Reduces the defense penalty of last resort
+    STALWART_SOUL             = 908, // Reduces damage taken from Souleater
 
     // Beastmaster
     TAME                      = 304, // Additional percent chance to charm
@@ -721,9 +724,9 @@ enum class Mod
 
     // The spares take care of finding the next ID to use so long as we don't forget to list IDs that have been freed up by refactoring.
     // 570 through 825 used by WS DMG mods these are not spares.
-    // SPARE = 906, // stuff
-    // SPARE = 907, // stuff
-    // SPARE = 908, // stuff
+    // SPARE = 909, // stuff
+    // SPARE = 910, // stuff
+    // SPARE = 911, // stuff
 };
 
 //temporary workaround for using enum class as unordered_map key until compilers support it

--- a/src/map/packet_system.cpp
+++ b/src/map/packet_system.cpp
@@ -876,7 +876,6 @@ void SmallPacket0x01A(map_session_data_t* session, CCharEntity* PChar, CBasicPac
     break;
     }
     ShowDebug(CL_CYAN"CLIENT %s PERFORMING ACTION %02hX\n" CL_RESET, PChar->GetName(), action);
-    return;
 }
 
 /************************************************************************

--- a/src/map/utils/battleutils.cpp
+++ b/src/map/utils/battleutils.cpp
@@ -3571,12 +3571,12 @@ namespace battleutils
             drainPercent = drainPercent + std::min(0.02f, 0.01f * gearBonusPercent);
 
             damage += (uint32)(m_PChar->health.hp * drainPercent);
-            m_PChar->addHP((int32)(-(drainPercent - m_PChar->getMod(Mod::STALWART_SOUL) * 0.001f) * m_PChar->health.hp));
+            m_PChar->addHP((int32)(m_PChar->health.hp * -(drainPercent - m_PChar->getMod(Mod::STALWART_SOUL) * 0.001f)));
         }
         else if (m_PChar->GetSJob() == JOB_DRK &&m_PChar->health.hp >= 10 && m_PChar->StatusEffectContainer->HasStatusEffect(EFFECT_SOULEATER)) {
             //lose 10% Current HP, only HALF (5%) converted to damage
-            damage += (uint32)(m_PChar->health.hp * 0.05);
-            m_PChar->addHP((int32)(-0.1 * m_PChar->health.hp));
+            damage += (uint32)(m_PChar->health.hp * 0.05f);
+            m_PChar->addHP((int32)(m_PChar->health.hp * 0.1f));
         }
         return damage;
     }

--- a/src/map/utils/battleutils.cpp
+++ b/src/map/utils/battleutils.cpp
@@ -3576,7 +3576,7 @@ namespace battleutils
         else if (m_PChar->GetSJob() == JOB_DRK &&m_PChar->health.hp >= 10 && m_PChar->StatusEffectContainer->HasStatusEffect(EFFECT_SOULEATER)) {
             //lose 10% Current HP, only HALF (5%) converted to damage
             damage += (uint32)(m_PChar->health.hp * 0.05f);
-            m_PChar->addHP((int32)(m_PChar->health.hp * 0.1f));
+            m_PChar->addHP((int32)(m_PChar->health.hp * -0.1f));
         }
         return damage;
     }

--- a/src/map/utils/battleutils.cpp
+++ b/src/map/utils/battleutils.cpp
@@ -3571,7 +3571,7 @@ namespace battleutils
             drainPercent = drainPercent + std::min(0.02f, 0.01f * gearBonusPercent);
 
             damage += (uint32)(m_PChar->health.hp * drainPercent);
-            m_PChar->addHP((int32)(-drainPercent * m_PChar->health.hp));
+            m_PChar->addHP((int32)(-(drainPercent - m_PChar->getMod(Mod::STALWART_SOUL) * 0.001f) * m_PChar->health.hp));
         }
         else if (m_PChar->GetSJob() == JOB_DRK &&m_PChar->health.hp >= 10 && m_PChar->StatusEffectContainer->HasStatusEffect(EFFECT_SOULEATER)) {
             //lose 10% Current HP, only HALF (5%) converted to damage


### PR DESCRIPTION
Fixed Attack bonus levels/tiers
Fixed Resist Paralyze levels/values
Added Arcana Killer tier
Added Crit. Atk. Bonus
Added Smite
Added Occult Acumen

Fixed Some Last Resort Stuff
* Added item mods for it
* Def reduction penalty is now being stored in the effect power at time of ability use so that we can remove the appropriate amount from the mod when it wears

Fixed Desperate Blows
* I tied the trait to a mod and added it to the ability haste mod in the effect script

Implemented Stalwart Soul
* Decreases the base amount of HP drained by Souleater without affecting the damage percent calculation

Implemented Muted Soul
* Enmity reduction while Souleater is active

Fixed Afflatus Solace/Misery
* Small update. This job ability is only supposed to be usable as WHM main job. Updated the entry in the ability table to reflect this.