### PR TITLE
quest(food for thought): Enable quest completion through all paths

### DIFF
--- a/scripts/zones/Windurst_Waters/npcs/Kenapa-Keppa.lua
+++ b/scripts/zones/Windurst_Waters/npcs/Kenapa-Keppa.lua
@@ -22,15 +22,16 @@ function onTrade(player,npc,trade)
         gil = trade:getGil();
         if (trade:hasItemQty(4409,1) == false) then -- Traded in wrong item. Not accepted.
             player:startEvent(329);
-        elseif (count == 1 and trade:hasItemQty(4409,1) == true and gil == 0 and KenapaFood == 0) then -- Traded item without receiving order
-            rand = math.random(1,2);
-            if (rand == 1) then
-                player:startEvent(331);
-            else
-                player:startEvent(330,120);
+        elseif (count == 1 and trade:hasItemQty(4409,1) == true and gil == 0) then
+            if (KenapaFood < 3) then -- Traded item without receiving order
+                if (math.random(1,2) == 1) then
+                    player:startEvent(331);
+                else
+                    player:startEvent(330,120);
+                end
+            elseif (KenapaFood == 3) then  -- Traded item after receiving order
+                player:startEvent(327,120);
             end
-        elseif (count == 1 and trade:hasItemQty(4409,1) == true and gil == 0 and KenapaFood == 3) then  -- Traded item after receiving order
-            player:startEvent(327,120);
         end
     end
 end;
@@ -144,10 +145,10 @@ end;
 function onEventFinish(player,csid,option)
     -- printf("CSID: %u",csid);
     -- printf("RESULT: %u",option);
-    if (csid == 327 or csid == 330) then
-        if (player:getVar("Kerutoto_Food_var") == 3 and player:getVar("Kenapa_Food_var") == 3 and player:getVar("Ohbiru_Food_var") == 3) then -- If this is the last NPC to be fed
-            player:addGil(GIL_RATE*120);
-            player:tradeComplete();
+    if (csid == 327 or csid == 330 or csid == 331) then
+        player:tradeComplete();
+        player:addGil(GIL_RATE*120);
+        if (player:getVar("Kerutoto_Food_var") == 2 and player:getVar("Ohbiru_Food_var") == 3) then -- If this is the last NPC to be fed
             player:completeQuest(WINDURST,FOOD_FOR_THOUGHT);
             player:addTitle(dsp.title.FAST_FOOD_DELIVERER);
             player:addFame(WINDURST,100);
@@ -155,28 +156,8 @@ function onEventFinish(player,csid,option)
             player:setVar("Kerutoto_Food_var",0);          -- ------------------------------------------
             player:setVar("Kenapa_Food_var",0);            -- Erase all the variables used in this quest
             player:setVar("Ohbiru_Food_var",0);            -- ------------------------------------------
-        else
-            player:tradeComplete();
-            player:addGil(GIL_RATE*120);
-            player:setVar("Kenapa_Food_var",4); -- If this is NOT the last NPC given food, flag this NPC as completed.
-        end
-    elseif (csid == 331) then
-        if (player:getVar("Kerutoto_Food_var") == 3 and player:getVar("Kenapa_Food_var") == 3 and player:getVar("Ohbiru_Food_var") == 3) then -- If this is the last NPC to be fed
-            player:addGil(GIL_RATE*120);
-            player:messageSpecial(GIL_OBTAINED,GIL_RATE*120);
-            player:tradeComplete();
-            player:completeQuest(WINDURST,FOOD_FOR_THOUGHT);
-            player:addTitle(dsp.title.FAST_FOOD_DELIVERER);
-            player:addFame(WINDURST,100);
-            player:needToZone(true);
-            player:setVar("Kerutoto_Food_var",0);          -- ------------------------------------------
-            player:setVar("Kenapa_Food_var",0);            -- Erase all the variables used in this quest
-            player:setVar("Ohbiru_Food_var",0);            -- ------------------------------------------
-        else
-            player:tradeComplete();
-            player:addGil(GIL_RATE*120);
-            player:messageSpecial(GIL_OBTAINED,GIL_RATE*120);
-            player:setVar("Kenapa_Food_var",4); -- If this is NOT the last NPC given food, flag this NPC as completed.
+        else -- If this is NOT the last NPC given food, flag this NPC as completed.
+            player:setVar("Kenapa_Food_var",4);
         end
     elseif  (csid == 56) then  -- Show Off Hat
         player:setVar("QuestHatInHand_var",player:getVar("QuestHatInHand_var")+4);

--- a/scripts/zones/Windurst_Waters/npcs/Kerutoto.lua
+++ b/scripts/zones/Windurst_Waters/npcs/Kerutoto.lua
@@ -28,14 +28,14 @@ function onTrade(player,npc,trade)
                 player:startEvent(358,3600);
             end
         end
-    end
-    if (player:getQuestStatus(WINDURST,FOOD_FOR_THOUGHT) == QUEST_ACCEPTED and trade:hasItemQty(4371,1) and count == 1) then
-        player:startEvent(332,440);
-        player:setVar("Kerutoto_Food_var",2);
-    end
 
-    if (player:getQuestStatus(JEUNO,RIDING_ON_THE_CLOUDS) == QUEST_ACCEPTED and player:getVar("ridingOnTheClouds_4") == 3) then
-        if (trade:hasItemQty(1127,1) and count == 1) then -- Trade Kindred seal
+    elseif (player:getQuestStatus(WINDURST,FOOD_FOR_THOUGHT) == QUEST_ACCEPTED) then
+        local KerutotoFood = player:getVar("Kerutoto_Food_var");
+        if (trade:hasItemQty(4371,1) and count == 1 and KerutotoFood == 1) then
+            player:startEvent(332,440);
+        end
+    elseif (player:getQuestStatus(JEUNO,RIDING_ON_THE_CLOUDS) == QUEST_ACCEPTED) then
+        if (player:getVar("ridingOnTheClouds_4") == 3 and trade:hasItemQty(1127,1) and count == 1) then -- Trade Kindred seal
             player:setVar("ridingOnTheClouds_4",0);
             player:tradeComplete();
             player:addKeyItem(dsp.ki.SPIRITED_STONE);
@@ -129,7 +129,7 @@ function onTrigger(player,npc)
     elseif (FoodForThought == QUEST_ACCEPTED) then
         if (KerutotoFood == 1)  then
             player:startEvent(315,0,4371); -- Repeats Order
-        elseif (KerutotoFood == 3) then
+        elseif (KerutotoFood == 2) then
             player:startEvent(333); -- Reminder to check with the others if this NPC has already been fed
         end
     elseif (FoodForThought == QUEST_COMPLETED and needZone) then
@@ -157,20 +157,18 @@ function onEventFinish(player,csid,option)
     elseif (csid == 313 and option == 1) then
         player:setVar("Kerutoto_Food_var",256);
     elseif (csid == 332) then
-        if (player:getVar("Kerutoto_Food_var") == 2 and player:getVar("Kenapa_Food_var") == 4 and player:getVar("Ohbiru_Food_var") == 3) then -- If this is the last NPC to be fed
-            player:addGil(GIL_RATE*440);
-            player:tradeComplete();
-            player:addTitle(dsp.title.FAST_FOOD_DELIVERER);
-            player:addFame(WINDURST,100);
-            player:needToZone(true);
+        player:tradeComplete();
+        player:addGil(GIL_RATE*440);
+        if (player:getVar("Kenapa_Food_var") == 4 and player:getVar("Ohbiru_Food_var") == 3) then -- If this is the last NPC to be fed
             player:completeQuest(WINDURST,FOOD_FOR_THOUGHT);
+            player:addFame(WINDURST,100);
+            player:addTitle(dsp.title.FAST_FOOD_DELIVERER);
+            player:needToZone(true);
             player:setVar("Kerutoto_Food_var",0);        -- ------------------------------------------
             player:setVar("Kenapa_Food_var",0);            -- Erase all the variables used in this quest
             player:setVar("Ohbiru_Food_var",0);            -- ------------------------------------------
-        else
-            player:tradeComplete();
-            player:addGil(GIL_RATE*440);
-            player:setVar("Kerutoto_Food_var",3); -- If this is NOT the last NPC given food, flag this NPC as completed.
+        else -- If this is NOT the last NPC given food, flag this NPC as completed.
+            player:setVar("Kerutoto_Food_var",2);
         end
     elseif (csid == 357) then
         player:addQuest(WINDURST,BLUE_RIBBON_BLUES);

--- a/scripts/zones/Windurst_Waters/npcs/Ohbiru-Dohbiru.lua
+++ b/scripts/zones/Windurst_Waters/npcs/Ohbiru-Dohbiru.lua
@@ -25,15 +25,16 @@ function onTrade(player,npc,trade)
     elseif (player:getQuestStatus(WINDURST,FOOD_FOR_THOUGHT) == QUEST_ACCEPTED) then
         local OhbiruFood = player:getVar("Ohbiru_Food_var");
 
-        if (trade:hasItemQty(4493,1) == true and trade:hasItemQty(4408,1) == true and trade:hasItemQty(624,1) == true and count == 3 and OhbiruFood ~= 2) then -- Traded all 3 items & Didn't ask for order
-            rand = math.random(1,2);
-            if (rand == 1) then
-                player:startEvent(325,440);
-            else
-                player:startEvent(326);
+        if (trade:hasItemQty(4493,1) == true and trade:hasItemQty(4408,1) == true and trade:hasItemQty(624,1) == true and count == 3) then
+            if (OhbiruFood < 2) then -- Traded all 3 items & Didn't ask for order
+                if (math.random(1,2) == 1) then
+                    player:startEvent(325,440);
+                else
+                    player:startEvent(326);
+                end
+            elseif (OhbiruFood == 2) then -- Traded all 3 items after receiving order
+                player:startEvent(322,440);
             end
-        elseif (trade:hasItemQty(4493,1) == true and trade:hasItemQty(4408,1) == true and trade:hasItemQty(624,1) == true and count == 3 and OhbiruFood == 2) then -- Traded all 3 items after receiving order
-            player:startEvent(322,440);
         end
     elseif (turmoil == QUEST_ACCEPTED) then
         if (count == 3 and trade:getGil() == 0 and trade:hasItemQty(906,3) == true) then --Check that all 3 items have been traded
@@ -42,7 +43,7 @@ function onTrade(player,npc,trade)
             player:startEvent(786,4500,267,906); -- Reminder of needed items
         end
     elseif (turmoil == QUEST_COMPLETED) then
-        if (count == 3 and trade:getGil () == 0 and trade:hasItemQty(906,3) == true) then --Check that all 3 items have been traded
+        if (count == 3 and trade:getGil() == 0 and trade:hasItemQty(906,3) == true) then --Check that all 3 items have been traded
             player:startEvent(791);
         else
             player:startEvent(795,4500,0,906); -- Reminder of needed items for repeated quest
@@ -145,39 +146,19 @@ function onEventFinish(player,csid,option)
     local turmoil = player:getQuestStatus(WINDURST,TORAIMARAI_TURMOIL);
     if (csid == 143) then
         player:setVar("ohbiru_dohbiru_talk",2);
-    elseif (csid == 322 or csid == 325)  then
-        if (player:getVar("Kerutoto_Food_var") == 3 and player:getVar("Kenapa_Food_var") == 4 and player:getVar("Ohbiru_Food_var") == 2) then -- If this is the last NPC to be fed
-            player:tradeComplete();
+    elseif (csid == 322 or csid == 325 or csid == 326) then
+        player:tradeComplete();
+        player:addGil(GIL_RATE*440);
+        if (player:getVar("Kerutoto_Food_var") == 2 and player:getVar("Kenapa_Food_var") == 4) then -- If this is the last NPC to be fed
             player:completeQuest(WINDURST,FOOD_FOR_THOUGHT);
+            player:addFame(WINDURST,100);
             player:addTitle(dsp.title.FAST_FOOD_DELIVERER);
-            player:addGil(GIL_RATE*440);
-            player:setVar("Kerutoto_Food_var",0);        -- ------------------------------------------
+            player:needToZone(true);
+            player:setVar("Kerutoto_Food_var",0);          -- ------------------------------------------
             player:setVar("Kenapa_Food_var",0);            -- Erase all the variables used in this quest
             player:setVar("Ohbiru_Food_var",0);            -- ------------------------------------------
-            player:addFame(WINDURST,100);
-            player:needToZone(true);
-        else
-            player:tradeComplete();
-            player:addGil(GIL_RATE*440);
-            player:setVar("Ohbiru_Food_var",3); -- If this is NOT the last NPC given food, flag this NPC as completed.
-        end
-    elseif (csid == 326) then
-        if (player:getVar("Kerutoto_Food_var") == 3 and player:getVar("Kenapa_Food_var") == 4 and player:getVar("Ohbiru_Food_var") == 2) then -- If this is the last NPC to be fed
-            player:tradeComplete();
-            player:completeQuest(WINDURST,FOOD_FOR_THOUGHT);
-            player:addTitle(dsp.title.FAST_FOOD_DELIVERER);
-            player:addGil(GIL_RATE*440);
-            player:messageSpecial(GIL_OBTAINED,GIL_RATE*440);
-            player:setVar("Kerutoto_Food_var",0);        -- ------------------------------------------
-            player:setVar("Kenapa_Food_var",0);            -- Erase all the variables used in this quest
-            player:setVar("Ohbiru_Food_var",0);            -- ------------------------------------------
-            player:addFame(WINDURST,100);
-            player:needToZone(true);
-        else
-            player:tradeComplete();
-            player:addGil(GIL_RATE*440);
-            player:messageSpecial(GIL_OBTAINED,GIL_RATE*440);
-            player:setVar("Ohbiru_Food_var",3); -- If this is NOT the last NPC given food, flag this NPC as completed.
+        else -- If this is NOT the last NPC given food, flag this NPC as completed.
+            player:setVar("Ohbiru_Food_var",3);
         end
     elseif (csid == 785 and option == 1) then -- Adds Toraimarai turmoil
         player:addQuest(WINDURST,TORAIMARAI_TURMOIL);


### PR DESCRIPTION
Before, the quest variable checking was sloppy and didn't account for cases where items were traded early. In addition to fixing this, this commit includes a refactor that makes the quest logic much more straightforward.

closes #4837