### PR TITLE
Update pet wyvern and DRG parameter increases

### DIFF
--- a/scripts/globals/pets/wyvern.lua
+++ b/scripts/globals/pets/wyvern.lua
@@ -143,7 +143,7 @@ function onMobSpawn(mob)
                 master:addMod(dsp.mod.HASTE_ABILITY,20*diff)
             end
             pet:setLocalVar("wyvern_exp", prev_exp + exp)
-            mob:setLocalVar("level_Ups", diff)
+            mob:setLocalVar("level_Ups", mob:getLocalVar("level_Ups") + diff)
         end
     end);
 end;

--- a/scripts/globals/pets/wyvern.lua
+++ b/scripts/globals/pets/wyvern.lua
@@ -133,13 +133,17 @@ function onMobSpawn(mob)
             local diff = math.floor((prev_exp + currentExp)/200) - math.floor(prev_exp/200)
             if diff ~= 0 then
                 -- wyvern levelled up (diff is the number of level ups)
-                pet:addMod(dsp.mod.ACC,2*diff)
-                pet:addMod(dsp.mod.HPP,5*diff)
+                pet:addMod(dsp.mod.ACC,6*diff)
+                pet:addMod(dsp.mod.HPP,6*diff)
                 pet:addMod(dsp.mod.ATTP,5*diff)
                 pet:setHP(pet:getMaxHP())
                 player:messageBasic(dsp.msg.basic.STATUS_INCREASED, 0, 0, pet);
+                master:addMod(dsp.mod.ATTP,4*diff)
+                master:addMod(dsp.mod.DEFP,4*diff)
+                master:addMod(dsp.mod.HASTE_ABILITY,20*diff)
             end
             pet:setLocalVar("wyvern_exp", prev_exp + exp)
+            mob:setLocalVar("level_Ups", diff)
         end
     end);
 end;
@@ -150,6 +154,12 @@ end;
 
 function onMobDeath(mob)
     local master = mob:getMaster();
+    local numLvls = mob:getLocalVar("level_Ups");
+    if (numLvls ~= nil) then
+        master:delMod(dsp.mod.ATTP,4*numLvls);
+        master:delMod(dsp.mod.DEFP,4*numLvls);
+        master:delMod(dsp.mod.HASTE_ABILITY,20*numLvls);
+    end
     master:removeListener("PET_WYVERN_WS");
     master:removeListener("PET_WYVERN_MAGIC");
     master:removeListener("PET_WYVERN_ENGAGE");

--- a/scripts/globals/pets/wyvern.lua
+++ b/scripts/globals/pets/wyvern.lua
@@ -143,7 +143,7 @@ function onMobSpawn(mob)
                 master:addMod(dsp.mod.HASTE_ABILITY,20*diff)
             end
             pet:setLocalVar("wyvern_exp", prev_exp + exp)
-            mob:setLocalVar("level_Ups", mob:getLocalVar("level_Ups") + diff)
+            pet:setLocalVar("level_Ups", pet:getLocalVar("level_Ups") + diff)
         end
     end);
 end;
@@ -152,9 +152,10 @@ end;
 -- onMobDespawn Action
 -----------------------------------
 
-function onMobDeath(mob)
+function onMobDeath(mob, player)
     local master = mob:getMaster();
-    local numLvls = mob:getLocalVar("level_Ups");
+    local pet = player:getPet();
+    local numLvls = pet:getLocalVar("level_Ups");
     if (numLvls ~= nil) then
         master:delMod(dsp.mod.ATTP,4*numLvls);
         master:delMod(dsp.mod.DEFP,4*numLvls);

--- a/scripts/globals/pets/wyvern.lua
+++ b/scripts/globals/pets/wyvern.lua
@@ -138,9 +138,9 @@ function onMobSpawn(mob)
                 pet:addMod(dsp.mod.ATTP,5*diff)
                 pet:setHP(pet:getMaxHP())
                 player:messageBasic(dsp.msg.basic.STATUS_INCREASED, 0, 0, pet);
-                master:addMod(dsp.mod.ATTP,4*diff)
-                master:addMod(dsp.mod.DEFP,4*diff)
-                master:addMod(dsp.mod.HASTE_ABILITY,20*diff)
+                master:addMod(dsp.mod.ATTP, 4 * diff)
+                master:addMod(dsp.mod.DEFP, 4 * diff)
+                master:addMod(dsp.mod.HASTE_ABILITY, 20 * diff)
             end
             pet:setLocalVar("wyvern_exp", prev_exp + exp)
             pet:setLocalVar("level_Ups", pet:getLocalVar("level_Ups") + diff)
@@ -154,12 +154,12 @@ end;
 
 function onMobDeath(mob, player)
     local master = mob:getMaster();
-    local pet = player:getPet();
-    local numLvls = pet:getLocalVar("level_Ups");
-    if (numLvls ~= nil) then
-        master:delMod(dsp.mod.ATTP,4*numLvls);
-        master:delMod(dsp.mod.DEFP,4*numLvls);
-        master:delMod(dsp.mod.HASTE_ABILITY,20*numLvls);
+    local pet = player:getPet()
+    local numLvls = pet:getLocalVar("level_Ups")
+    if numLvls ~= 0 then
+        master:delMod(dsp.mod.ATTP, 4 * numLvls)
+        master:delMod(dsp.mod.DEFP, 4 * numLvls)
+        master:delMod(dsp.mod.HASTE_ABILITY, 20 * numLvls)
     end
     master:removeListener("PET_WYVERN_WS");
     master:removeListener("PET_WYVERN_MAGIC");


### PR DESCRIPTION
Got DRG update information from here: 
http://forum.square-enix.com/ffxi/threads/43912-dev1229-Job-Adjustments

Square Enix added DRG bonus effects of attack, defense, haste percentage increase based on wyvern leveling up 5 times. 4% increase per level up, maximum 20% attack/defense boost. 2% increase per level up for haste, maximum 10% job ability haste.

As for changing wyvern HP percentage increase to 6% per level instead of 5% and accuracy from 2 to 6 per level:
https://www.bg-wiki.com/bg/Wyvern_(Dragoon_Pet)

"For the Wyvern per parameter increase:
HP +6% (Cap: +30%)
Attack +4.6875% [12/256] (Cap: +23.4375% [60/256])
Accuracy +6 (Cap: +30)"