### PR TITLE
quest(toraimarai turmoil): Add Blue Ribbon Blues prerequisite

### DIFF
--- a/scripts/zones/Windurst_Waters/npcs/Ohbiru-Dohbiru.lua
+++ b/scripts/zones/Windurst_Waters/npcs/Ohbiru-Dohbiru.lua
@@ -63,6 +63,7 @@ function onTrigger(player,npc)
     local overnightDelivery = player:getQuestStatus(WINDURST,OVERNIGHT_DELIVERY);
     local SayFlowers = player:getQuestStatus(WINDURST,SAY_IT_WITH_FLOWERS);
     local FlowerProgress = player:getVar("FLOWER_PROGRESS");
+    local blueRibbonBlues = player:getQuestStatus(WINDURST,BLUE_RIBBON_BLUES)
 
     if (player:getCurrentMission(COP) == THE_ROAD_FORKS and player:getVar("MEMORIES_OF_A_MAIDEN_Status")==2) then
         player:startEvent(872);
@@ -111,7 +112,7 @@ function onTrigger(player,npc)
     --
     -- Begin Toraimarai Turmoil Section
     --
-    elseif (turmoil == QUEST_AVAILABLE and pfame >= 6 and needToZone == false) then
+    elseif blueRibbonBlues == QUEST_COMPLETED and turmoil == QUEST_AVAILABLE and pfame >= 6 and needToZone == false then
         player:startEvent(785,4500,267,906);
     elseif (turmoil == QUEST_ACCEPTED) then
         player:startEvent(786,4500,267,906); -- Reminder of needed items


### PR DESCRIPTION
Right now you are able to start Toraimarai Turmoil as soon as you complete food for thought. You're supposed to complete a number of other quests firsts, the last of which is Blue Ribbon Blues.