### PR TITLE
Add insta death to crit hits in non NM chigoe scripts. Fixes #4878

### DIFF
--- a/scripts/zones/Abyssea-Attohwa/mobs/Murrain_Chigoe.lua
+++ b/scripts/zones/Abyssea-Attohwa/mobs/Murrain_Chigoe.lua
@@ -2,19 +2,32 @@
 -- Area:
 --  MOB: Chigoe
 -----------------------------------
-
---require("scripts/globals/titles");
 mixins = { require("scripts/mixins/families/chigoe") }
+require("scripts/globals/status")
 -----------------------------------
 
 function onMobSpawn(mob)
-end;
+end
 
 function onMobEngaged(mob, target)
-end;
+end
 
 function onMobDisengage(mob)
-end;
+end
+
+function onCriticalHit(mob)
+    if mob:getHP() > 0 then
+        mob:setMobMod(dsp.mobMod.EXP_BONUS, -100)
+        mob:setHP(0)
+    end
+end
+
+function onWeaponskillHit(mob, attacker, weaponskill)
+    if mob:getHP() > 0 then
+        mob:setMobMod(dsp.mobMod.EXP_BONUS, -100)
+        mob:setHP(0)
+    end
+end
 
 function onMobDeath(mob, player, isKiller)
-end;
+end

--- a/scripts/zones/Aydeewa_Subterrane/mobs/Fossorial_Flea.lua
+++ b/scripts/zones/Aydeewa_Subterrane/mobs/Fossorial_Flea.lua
@@ -2,19 +2,32 @@
 -- Area:
 --  MOB: Chigoe
 -----------------------------------
-
---require("scripts/globals/titles");
 mixins = { require("scripts/mixins/families/chigoe") }
+require("scripts/globals/status")
 -----------------------------------
 
 function onMobSpawn(mob)
-end;
+end
 
 function onMobEngaged(mob, target)
-end;
+end
 
 function onMobDisengage(mob)
-end;
+end
+
+function onCriticalHit(mob)
+    if mob:getHP() > 0 then
+        mob:setMobMod(dsp.mobMod.EXP_BONUS, -100)
+        mob:setHP(0)
+    end
+end
+
+function onWeaponskillHit(mob, attacker, weaponskill)
+    if mob:getHP() > 0 then
+        mob:setMobMod(dsp.mobMod.EXP_BONUS, -100)
+        mob:setHP(0)
+    end
+end
 
 function onMobDeath(mob, player, isKiller)
-end;
+end

--- a/scripts/zones/Bhaflau_Thickets/mobs/Chigoe.lua
+++ b/scripts/zones/Bhaflau_Thickets/mobs/Chigoe.lua
@@ -2,19 +2,32 @@
 -- Area:
 --  MOB: Chigoe
 -----------------------------------
-
---require("scripts/globals/titles");
 mixins = { require("scripts/mixins/families/chigoe") }
+require("scripts/globals/status")
 -----------------------------------
 
 function onMobSpawn(mob)
-end;
+end
 
 function onMobEngaged(mob, target)
-end;
+end
 
 function onMobDisengage(mob)
-end;
+end
+
+function onCriticalHit(mob)
+    if mob:getHP() > 0 then
+        mob:setMobMod(dsp.mobMod.EXP_BONUS, -100)
+        mob:setHP(0)
+    end
+end
+
+function onWeaponskillHit(mob, attacker, weaponskill)
+    if mob:getHP() > 0 then
+        mob:setMobMod(dsp.mobMod.EXP_BONUS, -100)
+        mob:setHP(0)
+    end
+end
 
 function onMobDeath(mob, player, isKiller)
-end;
+end

--- a/scripts/zones/Caedarva_Mire/mobs/Chigoe.lua
+++ b/scripts/zones/Caedarva_Mire/mobs/Chigoe.lua
@@ -2,19 +2,32 @@
 -- Area:
 --  MOB: Chigoe
 -----------------------------------
-
---require("scripts/globals/titles");
 mixins = { require("scripts/mixins/families/chigoe") }
+require("scripts/globals/status")
 -----------------------------------
 
 function onMobSpawn(mob)
-end;
+end
 
 function onMobEngaged(mob, target)
-end;
+end
 
 function onMobDisengage(mob)
-end;
+end
+
+function onCriticalHit(mob)
+    if mob:getHP() > 0 then
+        mob:setMobMod(dsp.mobMod.EXP_BONUS, -100)
+        mob:setHP(0)
+    end
+end
+
+function onWeaponskillHit(mob, attacker, weaponskill)
+    if mob:getHP() > 0 then
+        mob:setMobMod(dsp.mobMod.EXP_BONUS, -100)
+        mob:setHP(0)
+    end
+end
 
 function onMobDeath(mob, player, isKiller)
-end;
+end

--- a/scripts/zones/Grauberg_[S]/mobs/Chigoe.lua
+++ b/scripts/zones/Grauberg_[S]/mobs/Chigoe.lua
@@ -2,17 +2,32 @@
 -- Area: Grauberg [S]
 --  MOB: Chigoe
 -----------------------------------
-mixins = {require("scripts/mixins/families/chigoe")};
+mixins = { require("scripts/mixins/families/chigoe") }
+require("scripts/globals/status")
 -----------------------------------
 
 function onMobSpawn(mob)
-end;
+end
 
 function onMobEngaged(mob, target)
-end;
+end
 
 function onMobDisengage(mob)
-end;
+end
+
+function onCriticalHit(mob)
+    if mob:getHP() > 0 then
+        mob:setMobMod(dsp.mobMod.EXP_BONUS, -100)
+        mob:setHP(0)
+    end
+end
+
+function onWeaponskillHit(mob, attacker, weaponskill)
+    if mob:getHP() > 0 then
+        mob:setMobMod(dsp.mobMod.EXP_BONUS, -100)
+        mob:setHP(0)
+    end
+end
 
 function onMobDeath(mob, player, isKiller)
-end;
+end

--- a/scripts/zones/Mamool_Ja_Training_Grounds/mobs/Chigoe.lua
+++ b/scripts/zones/Mamool_Ja_Training_Grounds/mobs/Chigoe.lua
@@ -2,19 +2,32 @@
 -- Area:
 --  MOB: Chigoe
 -----------------------------------
-
---require("scripts/globals/titles");
 mixins = { require("scripts/mixins/families/chigoe") }
+require("scripts/globals/status")
 -----------------------------------
 
 function onMobSpawn(mob)
-end;
+end
 
 function onMobEngaged(mob, target)
-end;
+end
 
 function onMobDisengage(mob)
-end;
+end
+
+function onCriticalHit(mob)
+    if mob:getHP() > 0 then
+        mob:setMobMod(dsp.mobMod.EXP_BONUS, -100)
+        mob:setHP(0)
+    end
+end
+
+function onWeaponskillHit(mob, attacker, weaponskill)
+    if mob:getHP() > 0 then
+        mob:setMobMod(dsp.mobMod.EXP_BONUS, -100)
+        mob:setHP(0)
+    end
+end
 
 function onMobDeath(mob, player, isKiller)
-end;
+end

--- a/scripts/zones/Rolanberry_Fields_[S]/mobs/Chigoe.lua
+++ b/scripts/zones/Rolanberry_Fields_[S]/mobs/Chigoe.lua
@@ -2,19 +2,32 @@
 -- Area:
 --  MOB: Chigoe
 -----------------------------------
-
---require("scripts/globals/titles");
 mixins = { require("scripts/mixins/families/chigoe") }
+require("scripts/globals/status")
 -----------------------------------
 
 function onMobSpawn(mob)
-end;
+end
 
 function onMobEngaged(mob, target)
-end;
+end
 
 function onMobDisengage(mob)
-end;
+end
+
+function onCriticalHit(mob)
+    if mob:getHP() > 0 then
+        mob:setMobMod(dsp.mobMod.EXP_BONUS, -100)
+        mob:setHP(0)
+    end
+end
+
+function onWeaponskillHit(mob, attacker, weaponskill)
+    if mob:getHP() > 0 then
+        mob:setMobMod(dsp.mobMod.EXP_BONUS, -100)
+        mob:setHP(0)
+    end
+end
 
 function onMobDeath(mob, player, isKiller)
-end;
+end

--- a/scripts/zones/The_Eldieme_Necropolis_[S]/mobs/Chigoe.lua
+++ b/scripts/zones/The_Eldieme_Necropolis_[S]/mobs/Chigoe.lua
@@ -2,21 +2,38 @@
 -- Area: The Eldieme Necropolis (S) (175)
 --  MOB: Chigoe
 -----------------------------------
-
--- require("scripts/zones/The_Eldieme_Necropolis_[S]/MobIDs");
+mixins = { require("scripts/mixins/families/chigoe") }
+require("scripts/globals/status")
 -----------------------------------
 
 function onMobInitialize(mob)
-end;
+end
 
 function onMobSpawn(mob)
-end;
+end
 
-function onMobEngaged(mob,target)
-end;
+function onMobEngaged(mob, target)
+end
 
 function onMobFight(mob,target)
-end;
+end
+
+function onMobDisengage(mob)
+end
+
+function onCriticalHit(mob)
+    if mob:getHP() > 0 then
+        mob:setMobMod(dsp.mobMod.EXP_BONUS, -100)
+        mob:setHP(0)
+    end
+end
+
+function onWeaponskillHit(mob, attacker, weaponskill)
+    if mob:getHP() > 0 then
+        mob:setMobMod(dsp.mobMod.EXP_BONUS, -100)
+        mob:setHP(0)
+    end
+end
 
 function onMobDeath(mob, player, isKiller)
-end;
+end

--- a/scripts/zones/Vunkerl_Inlet_[S]/mobs/Chigoe.lua
+++ b/scripts/zones/Vunkerl_Inlet_[S]/mobs/Chigoe.lua
@@ -2,19 +2,32 @@
 -- Area:
 --  MOB: Chigoe
 -----------------------------------
-
---require("scripts/globals/titles");
 mixins = { require("scripts/mixins/families/chigoe") }
+require("scripts/globals/status")
 -----------------------------------
 
 function onMobSpawn(mob)
-end;
+end
 
 function onMobEngaged(mob, target)
-end;
+end
 
 function onMobDisengage(mob)
-end;
+end
+
+function onCriticalHit(mob)
+    if mob:getHP() > 0 then
+        mob:setMobMod(dsp.mobMod.EXP_BONUS, -100)
+        mob:setHP(0)
+    end
+end
+
+function onWeaponskillHit(mob, attacker, weaponskill)
+    if mob:getHP() > 0 then
+        mob:setMobMod(dsp.mobMod.EXP_BONUS, -100)
+        mob:setHP(0)
+    end
+end
 
 function onMobDeath(mob, player, isKiller)
-end;
+end

--- a/scripts/zones/Wajaom_Woodlands/mobs/Chigoe.lua
+++ b/scripts/zones/Wajaom_Woodlands/mobs/Chigoe.lua
@@ -2,19 +2,32 @@
 -- Area:
 --  MOB: Chigoe
 -----------------------------------
-
---require("scripts/globals/titles");
 mixins = { require("scripts/mixins/families/chigoe") }
+require("scripts/globals/status")
 -----------------------------------
 
 function onMobSpawn(mob)
-end;
+end
 
 function onMobEngaged(mob, target)
-end;
+end
 
 function onMobDisengage(mob)
-end;
+end
+
+function onCriticalHit(mob)
+    if mob:getHP() > 0 then
+        mob:setMobMod(dsp.mobMod.EXP_BONUS, -100)
+        mob:setHP(0)
+    end
+end
+
+function onWeaponskillHit(mob, attacker, weaponskill)
+    if mob:getHP() > 0 then
+        mob:setMobMod(dsp.mobMod.EXP_BONUS, -100)
+        mob:setHP(0)
+    end
+end
 
 function onMobDeath(mob, player, isKiller)
-end;
+end


### PR DESCRIPTION
Note: if you want a mixin for it, knock yourself out and convert the existing onCriticalHit calls unrelated to this at the same time. It didn't seem worth it to me to go do that instead of this 5 second fix.

Insta death only triggers if the attack would not empty its hp bar, according to what I have been told.

----

Todo's:
 - DNC step also insta kills chigoe.
 - message displayed on death is the "falls down" message instead of regular defeat message (this might already happen, unsure).
