### PR TITLE
Jnun's sleep during the day

### DIFF
--- a/scripts/zones/Caedarva_Mire/mobs/Jnun.lua
+++ b/scripts/zones/Caedarva_Mire/mobs/Jnun.lua
@@ -1,0 +1,31 @@
+-----------------------------------
+-- Area: Caedarva Mire
+--  MOB: Jnun
+-----------------------------------
+require("scripts/globals/status")
+
+function onMobInitialize(mob)
+end
+
+function onMobSpawn(mob)
+end
+
+function onMobFight(mob, target)
+end
+
+function onMobRoam(mob)
+    if VanadielHour() >= 6 and VanadielHour() < 18 then -- Jnun's sleep during the day
+        mob:AnimationSub(0)
+        mob:AnimationSub(1)
+        mob:setMobMod(MOBMOD_NO_MOVE, 1)
+        mob:setAggressive(0)
+    elseif VanadielHour() >= 18 or VanadielHour() < 6 then -- Jnun's awake at night
+        mob:AnimationSub(1)
+        mob:AnimationSub(0)
+        mob:setMobMod(MOBMOD_NO_MOVE, 0)
+        mob:setAggressive(1)
+    end
+end
+
+function onMobDeath(mob, player, isKiller)
+end


### PR DESCRIPTION
The AnimationSub reset is in there purposefully in order to make sure you see the animation after moving more then 50 yalms from the Mob. Otherwise you don't get the sleep animation unless the mob falls asleep while within range of the player.