### PR TITLE
quest(a minstrel in despair): Allow obtaining additional poetic parchments

### DIFF
--- a/scripts/zones/Buburimu_Peninsula/npcs/Song_Runes.lua
+++ b/scripts/zones/Buburimu_Peninsula/npcs/Song_Runes.lua
@@ -2,52 +2,54 @@
 -- Area: Buburimu Peninsula
 --  NPC: Song Runes
 --  Finishes Quest: The Old Monument
--- !pos -244 16 -280 40
+-- !pos -244 16 -280 118
 -----------------------------------
-package.loaded["scripts/zones/Buburimu_Peninsula/TextIDs"] = nil;
+package.loaded["scripts/zones/Buburimu_Peninsula/TextIDs"] = nil
 -----------------------------------
-require("scripts/globals/settings");
-require("scripts/globals/titles");
-require("scripts/globals/quests");
-require("scripts/zones/Buburimu_Peninsula/TextIDs");
+require("scripts/globals/settings")
+require("scripts/globals/titles")
+require("scripts/globals/quests")
+require("scripts/zones/Buburimu_Peninsula/TextIDs")
 -----------------------------------
+
+local PARCHMENT = 917
+local POETIC_PARCHMENT = 634
 
 function onTrade(player,npc,trade)
     -- THE OLD MONUMENT (parchment)
-    if (player:getVar("TheOldMonument_Event") == 3 and trade:hasItemQty(917,1) and trade:getItemCount() == 1) then
-        player:startEvent(2);
-    end;
-end;
+    if player:getVar("TheOldMonument_Event") == 3 and trade:hasItemQty(PARCHMENT,1) and trade:getItemCount() == 1 then
+        player:startEvent(2)
+    end
+end
 
 function onTrigger(player,npc)
     -- THE OLD MONUMENT
-    if (player:getVar("TheOldMonument_Event") == 2) then
-        player:startEvent(0);
-    elseif (player:getVar("TheOldMonument_Event") == 3) then
-        player:messageSpecial(SONG_RUNES_REQUIRE,917);
+    if player:getVar("TheOldMonument_Event") == 2 then
+        player:startEvent(0)
+    elseif player:getVar("TheOldMonument_Event") == 3 then
+        player:messageSpecial(SONG_RUNES_REQUIRE,917)
 
     -- DEFAULT DIALOG
     else
-        player:messageSpecial(SONG_RUNES_DEFAULT);
-    end;
-end;
+        player:messageSpecial(SONG_RUNES_DEFAULT)
+    end
+end
 
 function onEventUpdate(player,csid,option)
-end;
+end
 
 function onEventFinish(player,csid,option)
-    if (csid == 0) then
-        player:setVar("TheOldMonument_Event",3);
-    elseif (csid == 2) then
-        player:tradeComplete();
-        player:messageSpecial(SONG_RUNES_WRITING,917);
-        player:addItem(634,1);
-        player:messageSpecial(ITEM_OBTAINED, 634);
-        player:completeQuest(JEUNO,THE_OLD_MONUMENT);
-        player:addTitle(dsp.title.RESEARCHER_OF_CLASSICS);
-        player:addFame(BASTOK,10);
-        player:addFame(SANDORIA,10);
-        player:addFame(WINDURST,10);
-        player:setVar("TheOldMonument_Event",0);
-    end;
-end;
+    if csid == 0 then
+        player:setVar("TheOldMonument_Event",3)
+    elseif csid == 2 then
+        player:tradeComplete()
+        player:messageSpecial(SONG_RUNES_WRITING,917)
+        player:addItem(POETIC_PARCHMENT,1)
+        player:messageSpecial(ITEM_OBTAINED, POETIC_PARCHMENT)
+        player:completeQuest(JEUNO,THE_OLD_MONUMENT)
+        player:addTitle(dsp.title.RESEARCHER_OF_CLASSICS)
+        player:addFame(BASTOK,10)
+        player:addFame(SANDORIA,10)
+        player:addFame(WINDURST,10)
+    end
+end

--- a/scripts/zones/Lower_Jeuno/npcs/Mertaire.lua
+++ b/scripts/zones/Lower_Jeuno/npcs/Mertaire.lua
@@ -1,93 +1,99 @@
 -----------------------------------
--- Area: Lower Jeuno
+-- Area: Lower Jeuno (245)
 --  NPC: Mertaire
 -- Starts and Finishes Quest: The Old Monument (start only), A Minstrel in Despair, Painful Memory (BARD AF1)
 -- !pos -17 0 -61 245
 -----------------------------------
-package.loaded["scripts/zones/Lower_Jeuno/TextIDs"] = nil;
+package.loaded["scripts/zones/Lower_Jeuno/TextIDs"] = nil
 -----------------------------------
-require("scripts/globals/settings");
-require("scripts/globals/status");
-require("scripts/globals/keyitems");
-require("scripts/globals/quests");
-require("scripts/zones/Lower_Jeuno/TextIDs");
+require("scripts/globals/settings")
+require("scripts/globals/status")
+require("scripts/globals/keyitems")
+require("scripts/globals/quests")
+require("scripts/zones/Lower_Jeuno/TextIDs")
 -----------------------------------
+
+local POETIC_PARCHMENT = 634
 
 function onTrade(player,npc,trade)
-    local theOldMonument = player:getQuestStatus(JEUNO,THE_OLD_MONUMENT);
-    local aMinstrelInDespair = player:getQuestStatus(JEUNO,A_MINSTREL_IN_DESPAIR);
+    local theOldMonument = player:getQuestStatus(JEUNO,THE_OLD_MONUMENT)
+    local aMinstrelInDespair = player:getQuestStatus(JEUNO,A_MINSTREL_IN_DESPAIR)
 
     -- A MINSTREL IN DESPAIR (poetic parchment)
-    if (trade:hasItemQty(634,1) and trade:getItemCount() == 1 and theOldMonument == QUEST_COMPLETED and aMinstrelInDespair == QUEST_AVAILABLE) then
-        player:startEvent(101);
-    end;
-end;
+    if trade:hasItemQty(POETIC_PARCHMENT,1) and trade:getItemCount() == 1 and theOldMonument == QUEST_COMPLETED and aMinstrelInDespair == QUEST_AVAILABLE then
+        player:startEvent(101)
+    end
+end
 
 function onTrigger(player,npc)
-    local theOldMonument = player:getQuestStatus(JEUNO,THE_OLD_MONUMENT);
-    local painfulMemory = player:getQuestStatus(JEUNO,PAINFUL_MEMORY);
-    local theRequiem = player:getQuestStatus(JEUNO,THE_REQUIEM);
-    local circleOfTime = player:getQuestStatus(JEUNO,THE_CIRCLE_OF_TIME);
-    local job = player:getMainJob();
-    local level = player:getMainLvl();
+    local theOldMonument = player:getQuestStatus(JEUNO,THE_OLD_MONUMENT)
+    local painfulMemory = player:getQuestStatus(JEUNO,PAINFUL_MEMORY)
+    local theRequiem = player:getQuestStatus(JEUNO,THE_REQUIEM)
+    local circleOfTime = player:getQuestStatus(JEUNO,THE_CIRCLE_OF_TIME)
+    local job = player:getMainJob()
+    local level = player:getMainLvl()
 
     -- THE OLD MONUMENT
-    if (theOldMonument == QUEST_AVAILABLE and level >= ADVANCED_JOB_LEVEL) then
-        player:startEvent(102);
+    if theOldMonument == QUEST_AVAILABLE and level >= ADVANCED_JOB_LEVEL then
+        player:startEvent(102)
 
     -- PAINFUL MEMORY (Bard AF1)
-    elseif (painfulMemory == QUEST_AVAILABLE and job == dsp.job.BRD and level >= AF1_QUEST_LEVEL) then
-        if (player:getVar("PainfulMemoryCS") == 0) then
-            player:startEvent(138); -- Long dialog for "Painful Memory"
+    elseif painfulMemory == QUEST_AVAILABLE and job == dsp.job.BRD and level >= AF1_QUEST_LEVEL then
+        if player:getVar("PainfulMemoryCS") == 0 then
+            player:startEvent(138) -- Long dialog for "Painful Memory"
         else
-            player:startEvent(137); -- Short dialog for "Painful Memory"
-        end;
-    elseif (painfulMemory == QUEST_ACCEPTED) then
-        player:startEvent(136); -- During Quest "Painful Memory"
+            player:startEvent(137) -- Short dialog for "Painful Memory"
+        end
+    elseif painfulMemory == QUEST_ACCEPTED then
+        player:startEvent(136) -- During Quest "Painful Memory"
 
     -- CIRCLE OF TIME (Bard AF3)
-    elseif (theRequiem == QUEST_COMPLETED and circleOfTime == QUEST_AVAILABLE and job == dsp.job.BRD and level >= AF3_QUEST_LEVEL) then
-        player:startEvent(139); -- Start "The Circle of Time"
-    elseif (circleOfTime == QUEST_ACCEPTED) then
-        player:messageSpecial(MERTAIRE_RING);
+    elseif theRequiem == QUEST_COMPLETED and circleOfTime == QUEST_AVAILABLE and job == dsp.job.BRD and level >= AF3_QUEST_LEVEL then
+        player:startEvent(139) -- Start "The Circle of Time"
+    elseif circleOfTime == QUEST_ACCEPTED then
+        player:messageSpecial(MERTAIRE_RING)
 
     -- DEFAULT DIALOG
-    elseif (painfulMemory == QUEST_COMPLETED) then
-        player:startEvent(135); -- Standard dialog after completed "Painful Memory"
+    elseif painfulMemory == QUEST_COMPLETED then
+        player:startEvent(135) -- Standard dialog after completed "Painful Memory"
     else
-        player:messageSpecial(MERTAIRE_DEFAULT);
+        player:messageSpecial(MERTAIRE_DEFAULT)
 
-    end;
-end;
+    end
+end
 
 function onEventUpdate(player,csid,option)
-end;
+end
 
 function onEventFinish(player,csid,option)
     -- THE OLD MONUMENT
-    if (csid == 102) then
-        player:setVar("TheOldMonument_Event",1);
+    if csid == 102 then
+        player:setVar("TheOldMonument_Event",1)
 
     -- A MINSTREL IN DESPAIR
-    elseif (csid == 101) then
-        player:addGil(GIL_RATE*2100);
-        player:messageSpecial(GIL_OBTAINED, GIL_RATE*2100);
-        player:tradeComplete();
-        player:completeQuest(JEUNO,A_MINSTREL_IN_DESPAIR);
-        player:addFame(JEUNO, 30);
+    elseif csid == 101 then
+        player:addGil(GIL_RATE*2100)
+        player:messageSpecial(GIL_OBTAINED, GIL_RATE*2100)
+        player:tradeComplete()
+        player:completeQuest(JEUNO,A_MINSTREL_IN_DESPAIR)
+        player:addFame(JEUNO, 30)
+
+        -- Placing this here allows the player to get additional poetic
+        -- parchments should they drop them until this quest is complete
+        player:setVar("TheOldMonument_Event",0)
 
     -- PAINFUL MEMORY (Bard AF1)
-    elseif (csid == 138 and option == 0) then
-        player:setVar("PainfulMemoryCS",1); -- player declined quest
-    elseif ((csid == 137 or csid == 138) and option == 1) then
-        player:addQuest(JEUNO,PAINFUL_MEMORY);
-        player:setVar("PainfulMemoryCS",0);
-        player:addKeyItem(dsp.ki.MERTAIRES_BRACELET);
-        player:messageSpecial(KEYITEM_OBTAINED,dsp.ki.MERTAIRES_BRACELET);
+    elseif csid == 138 and option == 0 then
+        player:setVar("PainfulMemoryCS",1) -- player declined quest
+    elseif (csid == 137 or csid == 138) and option == 1 then
+        player:addQuest(JEUNO,PAINFUL_MEMORY)
+        player:setVar("PainfulMemoryCS",0)
+        player:addKeyItem(dsp.ki.MERTAIRES_BRACELET)
+        player:messageSpecial(KEYITEM_OBTAINED,dsp.ki.MERTAIRES_BRACELET)
 
     -- CIRCLE OF TIME (Bard AF3)
-    elseif (csid == 139) then
-        player:addQuest(JEUNO,THE_CIRCLE_OF_TIME);
-        player:setVar("circleTime",1);
-    end;
-end;
+    elseif csid == 139 then
+        player:addQuest(JEUNO,THE_CIRCLE_OF_TIME)
+        player:setVar("circleTime",1)
+    end
+end


### PR DESCRIPTION
If you dropped your poetic parchment during "The Old Monument", the player var from the quest would prevent you from obtaining additional parchments which you need to complete the following quest. I've delayed the player var reset to the completion of "A Minstrel in Despair".

Regardless of the number of poetic parchments the player receives, he will only be able to complete "A Minstrel in Despair" once.

Closes https://github.com/KupoServer/Issues/issues/40