### PR TITLE
updates for beaucedine zone.lua

### DIFF
--- a/scripts/zones/Beaucedine_Glacier/Zone.lua
+++ b/scripts/zones/Beaucedine_Glacier/Zone.lua
@@ -3,74 +3,74 @@
 -- Zone: Beaucedine_Glacier (111)
 --
 -----------------------------------
-package.loaded[ "scripts/zones/Beaucedine_Glacier/TextIDs"] = nil;
+package.loaded[ "scripts/zones/Beaucedine_Glacier/TextIDs"] = nil
 -----------------------------------
-require("scripts/zones/Beaucedine_Glacier/TextIDs");
-require("scripts/globals/missions");
-require("scripts/globals/icanheararainbow");
-require("scripts/globals/zone");
-require("scripts/globals/conquest");
+require("scripts/zones/Beaucedine_Glacier/TextIDs")
+require("scripts/globals/icanheararainbow")
+require("scripts/globals/missions")
+require("scripts/globals/conquest")
+require("scripts/globals/zone")
 -----------------------------------
 
 function onInitialize(zone)
     SetRegionalConquestOverseers(zone:getRegionID())
-end;
+end
 
 function onZoneIn( player, prevZone)
-    local cs = -1;
+    local cs = -1
 
-    if (prevZone == 134) then -- warp player to a correct position after dynamis
-        player:setPos(-284.751,-39.923,-422.948,235);
+    if prevZone == 134 then -- warp player to a correct position after dynamis
+        player:setPos(-284.751,-39.923,-422.948,235)
     end
 
-    if (player:getXPos() == 0 and player:getYPos() == 0 and player:getZPos() == 0) then
-        player:setPos( -247.911, -82.165, 260.207, 248);
+    if player:getXPos() == 0 and player:getYPos() == 0 and player:getZPos() == 0 then
+        player:setPos( -247.911, -82.165, 260.207, 248)
     end
 
-    if (player:getCurrentMission( COP) == DESIRES_OF_EMPTINESS and player:getVar( "PromathiaStatus") == 9) then
-        cs = 206;
-    elseif (triggerLightCutscene(player)) then -- Quest: I Can Hear A Rainbow
-        cs = 114;
-    elseif (player:getCurrentMission(WINDURST) == VAIN and player:getVar("MissionStatus") ==1) then
-        cs = 116;
+    if player:getCurrentMission( COP) == DESIRES_OF_EMPTINESS and player:getVar( "PromathiaStatus") == 9 then
+        cs = 206
+    elseif triggerLightCutscene(player) then -- Quest: I Can Hear A Rainbow
+        cs = 114
+    elseif player:getCurrentMission(WINDURST) == VAIN and player:getVar("MissionStatus") ==1 then
+        cs = 116
     end
 
-    return cs;
-end;
+    return cs
+end
 
 function onConquestUpdate(zone, updatetype)
-    local players = zone:getPlayers();
+    local players = zone:getPlayers()
 
     for name, player in pairs(players) do
-        conquestUpdate(zone, player, updatetype, CONQUEST_BASE);
+        conquestUpdate(zone, player, updatetype, CONQUEST_BASE)
     end
-end;
+end
 
 function onRegionEnter( player, region)
-end;
+end
 
 function onEventUpdate( player, csid, option)
-    if (csid == 114) then
-        lightCutsceneUpdate(player); -- Quest: I Can Hear A Rainbow
-    elseif (csid == 116) then
-        player:updateEvent(0,0,0,0,0,4);
+    if csid == 114 then
+        lightCutsceneUpdate(player) -- Quest: I Can Hear A Rainbow
+    elseif csid == 116 then
+        player:updateEvent(0,0,0,0,0,4)
     end
-end;
+end
 
 function onEventFinish( player, csid, option)
-    if (csid == 206) then
-        player:setVar("PromathiaStatus",10);
-    elseif (csid == 114) then
+    if csid == 206 then
+        player:setVar("PromathiaStatus",10)
+    elseif csid == 114 then
         lightCutsceneFinish(player); -- Quest: I Can Hear A Rainbow
     end
-end;
+end
 
 function onZoneWeatherChange(weather)
-    local mirrorPond = GetNPCByID(17232196); -- Quest: Love And Ice
+    local mirrorPond = GetNPCByID(MIRROR_POND_J8) -- Quest: Love And Ice
 
-    if (weather == dsp.weather.GLOOM or weather == dsp.weather.DARKNESS) then
-        mirrorPond:setStatus(dsp.status.NORMAL);
+    if weather ~= dsp.weather.SNOW and weather ~= dsp.weather.BLIZZARDS then
+        mirrorPond:setStatus(dsp.status.NORMAL)
     else
-        mirrorPond:setStatus(dsp.status.DISAPPEAR);
+        mirrorPond:setStatus(dsp.status.DISAPPEAR)
     end
-end;
+end


### PR DESCRIPTION
1- rearranged requires
2- removed unnecessary semicolons and parenthesis
3- replaced npcID number for Mirror Pond with var from MobIDs
4- Mirror Pond npc shows up with any weather offered in the zone except Snow or Blizzards (including fog which happens on retail but not on dsp as far as I can tell)