### PR TITLE
AH adjustments with regard to "charged items" *by malrd

### DIFF
--- a/src/map/packet_system.cpp
+++ b/src/map/packet_system.cpp
@@ -2218,6 +2218,11 @@ void SmallPacket0x04E(map_session_data_t* session, CCharEntity* PChar, CBasicPac
             !(PItem->isSubType(ITEM_LOCKED)) &&
             !(PItem->getFlag() & ITEM_FLAG_NOAUCTION))
         {
+            if (PItem->isSubType(ITEM_CHARGED) && ((CItemUsable*)PItem)->getCurrentCharges() < ((CItemUsable*)PItem)->getMaxCharges())
+            {
+                PChar->pushPacket(new CAuctionHousePacket(action, 197, 0, 0));
+                return;
+            }
             PItem->setCharPrice(price); // not sure setCharPrice is right
             PChar->pushPacket(new CAuctionHousePacket(action, PItem, quantity, price));
         }
@@ -2276,6 +2281,11 @@ void SmallPacket0x04E(map_session_data_t* session, CCharEntity* PChar, CBasicPac
             !(PItem->isSubType(ITEM_LOCKED)) &&
             !(PItem->getFlag() & ITEM_FLAG_NOAUCTION))
         {
+            if (PItem->isSubType(ITEM_CHARGED) && ((CItemUsable*)PItem)->getCurrentCharges() < ((CItemUsable*)PItem)->getMaxCharges())
+            {
+                PChar->pushPacket(new CAuctionHousePacket(action, 197, 0, 0));
+                return;
+            }
             uint32 auctionFee = 0;
             if (quantity == 0)
             {

--- a/src/map/packets/inventory_item.cpp
+++ b/src/map/packets/inventory_item.cpp
@@ -34,40 +34,51 @@
 
 CInventoryItemPacket::CInventoryItemPacket(CItem* PItem, uint8 LocationID, uint8 SlotID) 
 {
-	this->type = 0x20;
-	this->size = 0x16;
+    this->type = 0x20;
+    this->size = 0x16;
 
-	ref<uint8>(0x0E) = LocationID;
-	ref<uint8>(0x0F) = SlotID;	
+    ref<uint8>(0x0E) = LocationID;
+    ref<uint8>(0x0F) = SlotID;    
 
-	if (PItem != nullptr)
-	{
-		ref<uint32>(0x04) = PItem->getQuantity();
-		ref<uint32>(0x08) = PItem->getCharPrice();
-		ref<uint16>(0x0C) = PItem->getID();
+    if (PItem != nullptr)
+    {
+        ref<uint32>(0x04) = PItem->getQuantity();
+        ref<uint32>(0x08) = PItem->getCharPrice();
+        ref<uint16>(0x0C) = PItem->getID();
         memcpy(data + 0x11 , PItem->m_extra, sizeof(PItem->m_extra));
 
-		if (PItem->isSubType(ITEM_CHARGED))
-		{
-			ref<uint8>(0x11) = 0x01;
+        if (PItem->isSubType(ITEM_CHARGED))
+        {
+            ref<uint8>(0x11) = 0x01;
+
+            uint8 flags = 0x80; // Tests showed high bit always set.
+            if (((CItemUsable*)PItem)->getCurrentCharges() < ((CItemUsable*)PItem)->getMaxCharges())
+            {
+                flags |= 0x10; // Partial charges mask
+            }
 
             if (((CItemUsable*)PItem)->getCurrentCharges() > 0)
             {
                 if (((CItemUsable*)PItem)->getReuseTime() == 0)
                 {
-                    ref<uint8>(0x14) = 0xD0;
+                    flags |= 0x40; // Ready to use
                 }
                 else
                 {
-                    ref<uint8>(0x14) = 0x90;
-
                     uint32 CurrentTime = CVanaTime::getInstance()->getVanaTime();
-
                     ref<uint32>(0x15) = ((CItemUsable*)PItem)->getNextUseTime();
+
+                    // Not sent if the item is unequipped.
+
                     ref<uint32>(0x19) = ((CItemUsable*)PItem)->getUseDelay() + CurrentTime;
                 }
             }
-		}
+            else
+            {
+                flags |= 0x20; // Empty charges
+            }
+            ref<uint8>(0x14) = flags;
+        }
 
         if (PItem->isType(ITEM_WEAPON) && ((CItemWeapon*)PItem)->isUnlockable())
         {
@@ -98,5 +109,5 @@ CInventoryItemPacket::CInventoryItemPacket(CItem* PItem, uint8 LocationID, uint8
         {
             ref<uint8>(0x19) = ((CItemLinkshell*)PItem)->GetLSType();
         }
-	}
+    }
 }


### PR DESCRIPTION
another one malrd worked out... this one fixes: https://github.com/DarkstarProject/darkstar/issues/534
plus a whole plethora of issues that have been started but then closed due to this one taking precedence.

This will allow you to list items that are "fully charged" on the auction house as long as they are listable. This also gives the proper message when an item is attempted to be listed but is not fully charged. and finally, this prevents players from listing items with 0 charges left and essentially buying it back for a complete recharge!

Again, something I've been running since we've implemented it. No noticeable issues with this and it pretty much worked well from the start, wasn't anything to debug initially. (that malrd does some good work!)