### PR TITLE
Add Destrier beret (Costume Function)

### DIFF
--- a/scripts/globals/effects/costume.lua
+++ b/scripts/globals/effects/costume.lua
@@ -4,25 +4,19 @@
 --
 -----------------------------------
 
------------------------------------
--- onEffectGain Action
------------------------------------
-
 function onEffectGain(target,effect)
-    target:costume(effect:getPower());
-end;
-
------------------------------------
--- onEffectTick Action
------------------------------------
+    target:costume(effect:getPower())
+    if effect:getPower() == 1999 then
+        target:speed(target:speed()+10) 
+    end
+end
 
 function onEffectTick(target,effect)
-end;
-
------------------------------------
--- onEffectLose Action
------------------------------------
+end
 
 function onEffectLose(target,effect)
-    target:costume(0);
-end;
+    target:costume(0)
+    if effect:getPower() == 1999 then
+        target:speed(target:speed()-10)
+    end
+end

--- a/scripts/globals/effects/costume.lua
+++ b/scripts/globals/effects/costume.lua
@@ -7,7 +7,13 @@
 function onEffectGain(target,effect)
     target:costume(effect:getPower())
     if effect:getPower() == 1999 then
-        target:speed(target:speed()+10) 
+        if effect:getTimeRemaining() / 1000 >= 7170 then
+            target:speed(target:speed()+5)
+            effect:setPower(19991)
+        else
+            target:speed(target:speed()+10)
+            effect:setPower(19992)
+        end
     end
 end
 
@@ -16,7 +22,9 @@ end
 
 function onEffectLose(target,effect)
     target:costume(0)
-    if effect:getPower() == 1999 then
+    if effect:getPower() == 19991 then
+        target:speed(target:speed()-5)
+    elseif effect:getPower() == 19992 then
         target:speed(target:speed()-10)
     end
 end

--- a/scripts/globals/effects/egg.lua
+++ b/scripts/globals/effects/egg.lua
@@ -1,26 +1,21 @@
 -----------------------------------
 --
---
+--    dsp.effect.EGG
 --
 -----------------------------------
-
------------------------------------
--- onEffectGain Action
+require("scripts/globals/status")
 -----------------------------------
 
 function onEffectGain(target,effect)
-end;
-
------------------------------------
--- onEffectTick Action
------------------------------------
+    target:costume(2416)
+    effect:setPower(target:speed())
+    target:speed(0)
+end
 
 function onEffectTick(target,effect)
-end;
-
------------------------------------
--- onEffectLose Action
------------------------------------
+end
 
 function onEffectLose(target,effect)
-end;
+    target:speed(effect:getPower())
+    target:addStatusEffect(dsp.effect.COSTUME,1999,0,effect:getTimeRemaining() / 1000)
+end

--- a/scripts/globals/items/destrier_beret.lua
+++ b/scripts/globals/items/destrier_beret.lua
@@ -1,0 +1,16 @@
+-----------------------------------------
+-- ID: 11811
+-- Destrier Beret
+-- Enchantment: 120Min - Retail Timed
+-- Costume: Egg that hatches into Adolescent Chocobo when removed
+-----------------------------------------
+require("scripts/globals/status")
+-----------------------------------------
+
+function onItemCheck(target)
+    return target:canUseCostume()
+end
+
+function onItemUse(target)
+    target:addStatusEffect(dsp.effect.EGG,1,0,7200)
+end


### PR DESCRIPTION
Adds the costume feature to the destrier beret item which when used turns you into an egg initially.
Then, based on how long you wait as an egg you get a speed bonus while the costume remains in effect.
I wasn't able to get more than 20% even after waiting an hour as an egg. Only thing this doesn't do is keep the costume on after zoning. That's probably something that needs to be defined in core? Some costumes come off with zoning, some don't. I even was able to wear the chocobo costume into my mog house. But, there it is. @wrenffxi if you wanna streamline it or tell me how to make it prettier?