### PR TITLE
Modify barspell/status to use new power and duration

### DIFF
--- a/scripts/globals/magic.lua
+++ b/scripts/globals/magic.lua
@@ -1274,18 +1274,19 @@ function calculateDurationForLvl(duration, spellLvl, targetLvl)
     return duration;
 end
 
-function calculateBarspellPower(caster,enhanceSkill)
-    local meritBonus = caster:getMerit(dsp.merit.BAR_SPELL_EFFECT);
-    local equipBonus = caster:getMod(dsp.mod.BARSPELL_AMOUNT);
-    --printf("Barspell: Merit Bonus +%d", meritBonus);
-
-    if (enhanceSkill == nil or enhanceSkill < 0) then
-        enhanceSkill = 0;
+function calculateDuration(duration,magicSkill,spellGroup,caster,target)
+    if (magicSkill ~= dsp.skill.ENHANCING_MAGIC) then 
+        return duration 
     end
-
-    local power = 40 + 0.2 * enhanceSkill + meritBonus + equipBonus;
-
-    return power;
+        
+    if (caster:hasStatusEffect(dsp.effect.COMPOSURE) == true and caster:getID() == target:getID()) then
+        duration = duration * 3
+    end
+        
+    if (caster:hasStatusEffect(dsp.effect.PERPETUANCE) and spellGroup == dsp.magic.spellGroup.WHITE) then
+        duration  = duration * 2
+    end
+    return duration
 end
 
 -- Output magic hit rate for all levels

--- a/scripts/globals/spells/baraera.lua
+++ b/scripts/globals/spells/baraera.lua
@@ -3,6 +3,7 @@
 -----------------------------------------
 
 require("scripts/globals/status");
+require("scripts/globals/spells/barspell");
 
 -----------------------------------------
 -- OnSpellCast
@@ -13,21 +14,5 @@ function onMagicCastingCheck(caster,target,spell)
 end;
 
 function onSpellCast(caster,target,spell)
-
-    local enhanceSkill = caster:getSkillLevel(dsp.skill.ENHANCING_MAGIC);
-    local power = calculateBarspellPower(caster,enhanceSkill);
-    local mdefBonus = caster:getMerit(dsp.merit.BAR_SPELL_EFFECT) + caster:getMod(dsp.mod.BARSPELL_MDEF_BONUS);
-    local duration = 150;
-
-    if (enhanceSkill > 180) then
-        duration = 150 + 0.8 * (enhanceSkill - 180);
-    end
-
-    if (caster:hasStatusEffect(dsp.effect.COMPOSURE) == true and caster:getID() == target:getID()) then
-        duration = duration * 3;
-    end
-
-    target:addStatusEffect(dsp.effect.BARAERO,power,0,duration,0,mdefBonus);
-
-    return dsp.effect.BARAERO;
+    return applyBarspell(dsp.effect.BARAERO,caster,target,spell)
 end;

--- a/scripts/globals/spells/baraero.lua
+++ b/scripts/globals/spells/baraero.lua
@@ -3,6 +3,7 @@
 -----------------------------------------
 
 require("scripts/globals/status");
+require("scripts/globals/spells/barspell");
 
 -----------------------------------------
 -- OnSpellCast
@@ -13,21 +14,5 @@ function onMagicCastingCheck(caster,target,spell)
 end;
 
 function onSpellCast(caster,target,spell)
-
-    local enhanceSkill = caster:getSkillLevel(dsp.skill.ENHANCING_MAGIC);
-    local power = calculateBarspellPower(caster,enhanceSkill);
-    local mdefBonus = caster:getMerit(dsp.merit.BAR_SPELL_EFFECT) + caster:getMod(dsp.mod.BARSPELL_MDEF_BONUS);
-    local duration = 150;
-
-    if (enhanceSkill > 180) then
-        duration = 150 + 0.8 * (enhanceSkill - 180);
-    end
-
-    if (caster:hasStatusEffect(dsp.effect.COMPOSURE) == true and caster:getID() == target:getID()) then
-        duration = duration * 3;
-    end
-
-    target:addStatusEffect(dsp.effect.BARAERO,power,0,duration,0,mdefBonus);
-
-    return dsp.effect.BARAERO;
+    return applyBarspell(dsp.effect.BARAERO,caster,target,spell)
 end;

--- a/scripts/globals/spells/baramnesia.lua
+++ b/scripts/globals/spells/baramnesia.lua
@@ -3,6 +3,7 @@
 -----------------------------------------
 
 require("scripts/globals/status");
+require("scripts/globals/spells/barstatus");
 
 -----------------------------------------
 -- OnSpellCast
@@ -13,24 +14,5 @@ function onMagicCastingCheck(caster,target,spell)
 end;
 
 function onSpellCast(caster,target,spell)
-    local meritBonus = caster:getMerit(dsp.merit.BAR_SPELL_EFFECT);
-    --printf("Barspell: Merit Bonus +%d", meritBonus);
-    
-    local enhanceSkill = caster:getSkillLevel(34);
-
-    local power = 1 + 0.02 * enhanceSkill + meritBonus;
-
-    local duration = 150;
-
-    if (enhanceSkill > 180) then
-        duration = 150 + 0.8 * (enhanceSkill - 180);
-    end
-
-    if (caster:hasStatusEffect(dsp.effect.COMPOSURE) == true and caster:getID() == target:getID()) then
-        duration = duration * 3;
-    end
-
-    target:addStatusEffect(dsp.effect.BARAMNESIA,power,0,duration);
-
-    return dsp.effect.BARAMNESIA;
+    return applyBarstatus(dsp.effect.BARAMNESIA,caster,target,spell)
 end;

--- a/scripts/globals/spells/baramnesra.lua
+++ b/scripts/globals/spells/baramnesra.lua
@@ -3,6 +3,7 @@
 -----------------------------------------
 
 require("scripts/globals/status");
+require("scripts/globals/spells/barstatus");
 
 -----------------------------------------
 -- OnSpellCast
@@ -13,24 +14,5 @@ function onMagicCastingCheck(caster,target,spell)
 end;
 
 function onSpellCast(caster,target,spell)
-    local meritBonus = caster:getMerit(dsp.merit.BAR_SPELL_EFFECT);
-    --printf("Barspell: Merit Bonus +%d", meritBonus);
-    
-    local enhanceSkill = caster:getSkillLevel(34);
-
-    local power = 1 + 0.02 * enhanceSkill + meritBonus;
-
-    local duration = 150;
-
-    if (enhanceSkill > 180) then
-        duration = 150 + 0.8 * (enhanceSkill - 180);
-    end
-
-    if (caster:hasStatusEffect(dsp.effect.COMPOSURE) == true and caster:getID() == target:getID()) then
-        duration = duration * 3;
-    end
-
-    target:addStatusEffect(dsp.effect.BARAMNESIA,power,0,duration);
-
-    return dsp.effect.BARAMNESIA;
+    return applyBarstatus(dsp.effect.BARAMNESIA,caster,target,spell)
 end;

--- a/scripts/globals/spells/barblind.lua
+++ b/scripts/globals/spells/barblind.lua
@@ -3,6 +3,7 @@
 -----------------------------------------
 
 require("scripts/globals/status");
+require("scripts/globals/spells/barstatus");
 
 -----------------------------------------
 -- OnSpellCast
@@ -13,24 +14,5 @@ function onMagicCastingCheck(caster,target,spell)
 end;
 
 function onSpellCast(caster,target,spell)
-    local meritBonus = caster:getMerit(dsp.merit.BAR_SPELL_EFFECT);
-    --printf("Barspell: Merit Bonus +%d", meritBonus);
-    
-    local enhanceSkill = caster:getSkillLevel(34);
-
-    local duration = 150;
-
-    local power = 1 + 0.02 * enhanceSkill + meritBonus;
-
-    if (enhanceSkill > 180) then
-        duration = 150 + 0.8 * (enhanceSkill - 180);
-    end
-
-    if (caster:hasStatusEffect(dsp.effect.COMPOSURE) == true and caster:getID() == target:getID()) then
-        duration = duration * 3;
-    end
-
-    target:addStatusEffect(dsp.effect.BARBLIND,power,0,duration);
-
-    return dsp.effect.BARBLIND;
+    return applyBarstatus(dsp.effect.BARBLIND,caster,target,spell)
 end;

--- a/scripts/globals/spells/barblindra.lua
+++ b/scripts/globals/spells/barblindra.lua
@@ -3,6 +3,7 @@
 -----------------------------------------
 
 require("scripts/globals/status");
+require("scripts/globals/spells/barstatus");
 
 -----------------------------------------
 -- OnSpellCast
@@ -13,24 +14,5 @@ function onMagicCastingCheck(caster,target,spell)
 end;
 
 function onSpellCast(caster,target,spell)
-    local meritBonus = caster:getMerit(dsp.merit.BAR_SPELL_EFFECT);
-    --printf("Barspell: Merit Bonus +%d", meritBonus);
-    
-    local enhanceSkill = caster:getSkillLevel(34);
-    
-    local power = 1 + 0.02 * enhanceSkill + meritBonus;
-
-    local duration = 150;
-
-    if (enhanceSkill > 180) then
-        duration = 150 + 0.8 * (enhanceSkill - 180);
-    end
-
-    if (caster:hasStatusEffect(dsp.effect.COMPOSURE) == true and caster:getID() == target:getID()) then
-        duration = duration * 3;
-    end
-
-    target:addStatusEffect(dsp.effect.BARBLIND,power,0,duration);
-
-    return dsp.effect.BARBLIND;
+    return applyBarstatus(dsp.effect.BARBLIND,caster,target,spell)
 end;

--- a/scripts/globals/spells/barblizzara.lua
+++ b/scripts/globals/spells/barblizzara.lua
@@ -3,6 +3,7 @@
 -----------------------------------------
 
 require("scripts/globals/status");
+require("scripts/globals/spells/barspell");
 
 -----------------------------------------
 -- OnSpellCast
@@ -13,21 +14,5 @@ function onMagicCastingCheck(caster,target,spell)
 end;
 
 function onSpellCast(caster,target,spell)
-
-    local enhanceSkill = caster:getSkillLevel(dsp.skill.ENHANCING_MAGIC);
-    local power = calculateBarspellPower(caster,enhanceSkill);
-    local mdefBonus = caster:getMerit(dsp.merit.BAR_SPELL_EFFECT) + caster:getMod(dsp.mod.BARSPELL_MDEF_BONUS);
-    local duration = 150;
-
-    if (enhanceSkill > 180) then
-        duration = 150 + 0.8 * (enhanceSkill - 180);
-    end
-
-    if (caster:hasStatusEffect(dsp.effect.COMPOSURE) == true and caster:getID() == target:getID()) then
-        duration = duration * 3;
-    end
-
-    target:addStatusEffect(dsp.effect.BARBLIZZARD,power,0,duration,0,mdefBonus);
-
-    return dsp.effect.BARBLIZZARD;
+    return applyBarspell(dsp.effect.BARBLIZZARD,caster,target,spell)
 end;

--- a/scripts/globals/spells/barblizzard.lua
+++ b/scripts/globals/spells/barblizzard.lua
@@ -3,6 +3,7 @@
 -----------------------------------------
 
 require("scripts/globals/status");
+require("scripts/globals/spells/barspell");
 
 -----------------------------------------
 -- OnSpellCast
@@ -13,21 +14,5 @@ function onMagicCastingCheck(caster,target,spell)
 end;
 
 function onSpellCast(caster,target,spell)
-
-    local enhanceSkill = caster:getSkillLevel(dsp.skill.ENHANCING_MAGIC);
-    local power = calculateBarspellPower(caster,enhanceSkill);
-    local mdefBonus = caster:getMerit(dsp.merit.BAR_SPELL_EFFECT) + caster:getMod(dsp.mod.BARSPELL_MDEF_BONUS);
-    local duration = 150;
-
-    if (enhanceSkill > 180) then
-        duration = 150 + 0.8 * (enhanceSkill - 180);
-    end
-
-    if (caster:hasStatusEffect(dsp.effect.COMPOSURE) == true and caster:getID() == target:getID()) then
-        duration = duration * 3;
-    end
-
-    target:addStatusEffect(dsp.effect.BARBLIZZARD,power,0,duration,0,mdefBonus);
-
-    return dsp.effect.BARBLIZZARD;
+    return applyBarspell(dsp.effect.BARBLIZZARD,caster,target,spell)
 end;

--- a/scripts/globals/spells/barfira.lua
+++ b/scripts/globals/spells/barfira.lua
@@ -3,6 +3,7 @@
 -----------------------------------------
 
 require("scripts/globals/status");
+require("scripts/globals/spells/barspell");
 
 -----------------------------------------
 -- OnSpellCast
@@ -13,21 +14,5 @@ function onMagicCastingCheck(caster,target,spell)
 end;
 
 function onSpellCast(caster,target,spell)
-
-    local enhanceSkill = caster:getSkillLevel(dsp.skill.ENHANCING_MAGIC);
-    local power = calculateBarspellPower(caster,enhanceSkill);
-    local mdefBonus = caster:getMerit(dsp.merit.BAR_SPELL_EFFECT) + caster:getMod(dsp.mod.BARSPELL_MDEF_BONUS);
-    local duration = 150;
-
-    if (enhanceSkill > 180) then
-        duration = 150 + 0.8 * (enhanceSkill - 180);
-    end
-
-    if (caster:hasStatusEffect(dsp.effect.COMPOSURE) == true and caster:getID() == target:getID()) then
-        duration = duration * 3;
-    end
-
-    target:addStatusEffect(dsp.effect.BARFIRE,power,0,duration,0,mdefBonus);
-
-    return dsp.effect.BARFIRE;
+    return applyBarspell(dsp.effect.BARFIRE,caster,target,spell)
 end;

--- a/scripts/globals/spells/barfire.lua
+++ b/scripts/globals/spells/barfire.lua
@@ -3,6 +3,7 @@
 -----------------------------------------
 
 require("scripts/globals/status");
+require("scripts/globals/spells/barspell");
 
 -----------------------------------------
 -- OnSpellCast
@@ -13,21 +14,5 @@ function onMagicCastingCheck(caster,target,spell)
 end;
 
 function onSpellCast(caster,target,spell)
-
-    local enhanceSkill = caster:getSkillLevel(dsp.skill.ENHANCING_MAGIC);
-    local power = calculateBarspellPower(caster,enhanceSkill);
-    local mdefBonus = caster:getMerit(dsp.merit.BAR_SPELL_EFFECT) + caster:getMod(dsp.mod.BARSPELL_MDEF_BONUS);
-    local duration = 150;
-
-    if (enhanceSkill > 180) then
-        duration = 150 + 0.8 * (enhanceSkill - 180);
-    end
-
-    if (caster:hasStatusEffect(dsp.effect.COMPOSURE) == true and caster:getID() == target:getID()) then
-        duration = duration * 3;
-    end
-
-    target:addStatusEffect(dsp.effect.BARFIRE,power,0,duration,0,mdefBonus);
-
-    return dsp.effect.BARFIRE;
+    return applyBarspell(dsp.effect.BARFIRE,caster,target,spell)
 end;

--- a/scripts/globals/spells/barparalyze.lua
+++ b/scripts/globals/spells/barparalyze.lua
@@ -3,6 +3,7 @@
 -----------------------------------------
 
 require("scripts/globals/status");
+require("scripts/globals/spells/barstatus");
 
 -----------------------------------------
 -- OnSpellCast
@@ -13,24 +14,5 @@ function onMagicCastingCheck(caster,target,spell)
 end;
 
 function onSpellCast(caster,target,spell)
-    local meritBonus = caster:getMerit(dsp.merit.BAR_SPELL_EFFECT);
-    --printf("Barspell: Merit Bonus +%d", meritBonus);
-    
-    local enhanceSkill = caster:getSkillLevel(34);
-
-    local power = 1 + 0.02 * enhanceSkill + meritBonus;
-
-    local duration = 150;
-
-    if (enhanceSkill > 180) then
-        duration = 150 + 0.8 * (enhanceSkill - 180);
-    end
-
-    if (caster:hasStatusEffect(dsp.effect.COMPOSURE) == true and caster:getID() == target:getID()) then
-        duration = duration * 3;
-    end
-
-    target:addStatusEffect(dsp.effect.BARPARALYZE,power,0,duration);
-
-    return dsp.effect.BARPARALYZE;
+    return applyBarstatus(dsp.effect.BARPARALYZE,caster,target,spell)
 end;

--- a/scripts/globals/spells/barparalyzra.lua
+++ b/scripts/globals/spells/barparalyzra.lua
@@ -3,6 +3,7 @@
 -----------------------------------------
 
 require("scripts/globals/status");
+require("scripts/globals/spells/barstatus");
 
 -----------------------------------------
 -- OnSpellCast
@@ -13,24 +14,5 @@ function onMagicCastingCheck(caster,target,spell)
 end;
 
 function onSpellCast(caster,target,spell)
-    local meritBonus = caster:getMerit(dsp.merit.BAR_SPELL_EFFECT);
-    --printf("Barspell: Merit Bonus +%d", meritBonus);
-    
-    local enhanceSkill = caster:getSkillLevel(34);
-
-    local power = 1 + 0.02 * enhanceSkill + meritBonus;
-
-    local duration = 150;
-
-    if (enhanceSkill > 180) then
-        duration = 150 + 0.8 * (enhanceSkill - 180);
-    end
-
-    if (caster:hasStatusEffect(dsp.effect.COMPOSURE) == true and caster:getID() == target:getID()) then
-        duration = duration * 3;
-    end
-
-    target:addStatusEffect(dsp.effect.BARPARALYZE,power,0,duration);
-
-    return dsp.effect.BARPARALYZE;
+    return applyBarstatus(dsp.effect.BARPARALYZE,caster,target,spell)
 end;

--- a/scripts/globals/spells/barpetra.lua
+++ b/scripts/globals/spells/barpetra.lua
@@ -3,6 +3,7 @@
 -----------------------------------------
 
 require("scripts/globals/status");
+require("scripts/globals/spells/barstatus");
 
 -----------------------------------------
 -- OnSpellCast
@@ -13,24 +14,5 @@ function onMagicCastingCheck(caster,target,spell)
 end;
 
 function onSpellCast(caster,target,spell)
-    local meritBonus = caster:getMerit(dsp.merit.BAR_SPELL_EFFECT);
-    --printf("Barspell: Merit Bonus +%d", meritBonus);
-    
-    local enhanceSkill = caster:getSkillLevel(34);
-
-    local power = 1 + 0.02 * enhanceSkill + meritBonus;
-
-    local duration = 150;
-
-    if (enhanceSkill > 180) then
-        duration = 150 + 0.8 * (enhanceSkill - 180);
-    end
-
-    if (caster:hasStatusEffect(dsp.effect.COMPOSURE) == true and caster:getID() == target:getID()) then
-        duration = duration * 3;
-    end
-
-    target:addStatusEffect(dsp.effect.BARPETRIFY,power,0,duration);
-
-    return dsp.effect.BARPETRIFY;
+    return applyBarstatus(dsp.effect.BARPETRIFY,caster,target,spell)
 end;

--- a/scripts/globals/spells/barpetrify.lua
+++ b/scripts/globals/spells/barpetrify.lua
@@ -3,6 +3,7 @@
 -----------------------------------------
 
 require("scripts/globals/status");
+require("scripts/globals/spells/barstatus");
 
 -----------------------------------------
 -- OnSpellCast
@@ -13,24 +14,5 @@ function onMagicCastingCheck(caster,target,spell)
 end;
 
 function onSpellCast(caster,target,spell)
-    local meritBonus = caster:getMerit(dsp.merit.BAR_SPELL_EFFECT);
-    --printf("Barspell: Merit Bonus +%d", meritBonus);
-    
-    local enhanceSkill = caster:getSkillLevel(34);
-
-    local power = 1 + 0.02 * enhanceSkill + meritBonus;
-
-    local duration = 150;
-
-    if (enhanceSkill > 180) then
-        duration = 150 + 0.8 * (enhanceSkill - 180);
-    end
-
-    if (caster:hasStatusEffect(dsp.effect.COMPOSURE) == true and caster:getID() == target:getID()) then
-        duration = duration * 3;
-    end
-
-    target:addStatusEffect(dsp.effect.BARPETRIFY,power,0,duration);
-
-    return dsp.effect.BARPETRIFY;
+    return applyBarstatus(dsp.effect.BARPETRIFY,caster,target,spell)
 end;

--- a/scripts/globals/spells/barpoison.lua
+++ b/scripts/globals/spells/barpoison.lua
@@ -3,6 +3,7 @@
 -----------------------------------------
 
 require("scripts/globals/status");
+require("scripts/globals/spells/barstatus");
 
 -----------------------------------------
 -- OnSpellCast
@@ -13,24 +14,5 @@ function onMagicCastingCheck(caster,target,spell)
 end;
 
 function onSpellCast(caster,target,spell)
-    local meritBonus = caster:getMerit(dsp.merit.BAR_SPELL_EFFECT);
-    --printf("Barspell: Merit Bonus +%d", meritBonus);
-    
-    local enhanceSkill = caster:getSkillLevel(34);
-
-    local power = 1 + 0.02 * enhanceSkill + meritBonus;
-
-    local duration = 150;
-
-    if (enhanceSkill > 180) then
-        duration = 150 + 0.8 * (enhanceSkill - 180);
-    end
-
-    if (caster:hasStatusEffect(dsp.effect.COMPOSURE) == true and caster:getID() == target:getID()) then
-        duration = duration * 3;
-    end
-
-    target:addStatusEffect(dsp.effect.BARPOISON,power,0,duration);
-
-    return dsp.effect.BARPOISON;
+    return applyBarstatus(dsp.effect.BARPOISON,caster,target,spell)
 end;

--- a/scripts/globals/spells/barpoisonra.lua
+++ b/scripts/globals/spells/barpoisonra.lua
@@ -3,6 +3,7 @@
 -----------------------------------------
 
 require("scripts/globals/status");
+require("scripts/globals/spells/barstatus");
 
 -----------------------------------------
 -- OnSpellCast
@@ -13,24 +14,5 @@ function onMagicCastingCheck(caster,target,spell)
 end;
 
 function onSpellCast(caster,target,spell)
-    local meritBonus = caster:getMerit(dsp.merit.BAR_SPELL_EFFECT);
-    --printf("Barspell: Merit Bonus +%d", meritBonus);
-    
-    local enhanceSkill = caster:getSkillLevel(34);
-
-    local power = 1 + 0.02 * enhanceSkill + meritBonus;
-
-    local duration = 150;
-
-    if (enhanceSkill > 180) then
-        duration = 150 + 0.8 * (enhanceSkill - 180);
-    end
-
-    if (caster:hasStatusEffect(dsp.effect.COMPOSURE) == true and caster:getID() == target:getID()) then
-        duration = duration * 3;
-    end
-
-    target:addStatusEffect(dsp.effect.BARPOISON,power,0,duration);
-
-    return dsp.effect.BARPOISON;
+    return applyBarstatus(dsp.effect.BARPOISON,caster,target,spell)
 end;

--- a/scripts/globals/spells/barsilence.lua
+++ b/scripts/globals/spells/barsilence.lua
@@ -3,6 +3,7 @@
 -----------------------------------------
 
 require("scripts/globals/status");
+require("scripts/globals/spells/barstatus");
 
 -----------------------------------------
 -- OnSpellCast
@@ -13,24 +14,5 @@ function onMagicCastingCheck(caster,target,spell)
 end;
 
 function onSpellCast(caster,target,spell)
-    local meritBonus = caster:getMerit(dsp.merit.BAR_SPELL_EFFECT);
-    --printf("Barspell: Merit Bonus +%d", meritBonus);
-    
-    local enhanceSkill = caster:getSkillLevel(34);
-
-    local duration = 150;
-
-    local power = 1 + 0.02 * enhanceSkill + meritBonus;
-
-    if (enhanceSkill > 180) then
-        duration = 150 + 0.8 * (enhanceSkill - 180);
-    end
-
-    if (caster:hasStatusEffect(dsp.effect.COMPOSURE) == true and caster:getID() == target:getID()) then
-        duration = duration * 3;
-    end
-
-    target:addStatusEffect(dsp.effect.BARSILENCE,power,0,duration);
-
-    return dsp.effect.BARSILENCE;
+    return applyBarstatus(dsp.effect.BARSILENCE,caster,target,spell)
 end;

--- a/scripts/globals/spells/barsilencera.lua
+++ b/scripts/globals/spells/barsilencera.lua
@@ -3,6 +3,7 @@
 -----------------------------------------
 
 require("scripts/globals/status");
+require("scripts/globals/spells/barstatus");
 
 -----------------------------------------
 -- OnSpellCast
@@ -13,24 +14,5 @@ function onMagicCastingCheck(caster,target,spell)
 end;
 
 function onSpellCast(caster,target,spell)
-    local meritBonus = caster:getMerit(dsp.merit.BAR_SPELL_EFFECT);
-    --printf("Barspell: Merit Bonus +%d", meritBonus);
-    
-    local enhanceSkill = caster:getSkillLevel(34);
-
-    local power = 1 + 0.02 * enhanceSkill + meritBonus;
-
-    local duration = 150;
-
-    if (enhanceSkill > 180) then
-        duration = 150 + 0.8 * (enhanceSkill - 180);
-    end
-
-    if (caster:hasStatusEffect(dsp.effect.COMPOSURE) == true and caster:getID() == target:getID()) then
-        duration = duration * 3;
-    end
-
-    target:addStatusEffect(dsp.effect.BARSILENCE,power,0,duration);
-
-    return dsp.effect.BARSILENCE;
+    return applyBarstatus(dsp.effect.BARSILENCE,caster,target,spell)
 end;

--- a/scripts/globals/spells/barsleep.lua
+++ b/scripts/globals/spells/barsleep.lua
@@ -3,6 +3,7 @@
 -----------------------------------------
 
 require("scripts/globals/status");
+require("scripts/globals/spells/barstatus");
 
 -----------------------------------------
 -- OnSpellCast
@@ -13,24 +14,5 @@ function onMagicCastingCheck(caster,target,spell)
 end;
 
 function onSpellCast(caster,target,spell)
-    local meritBonus = caster:getMerit(dsp.merit.BAR_SPELL_EFFECT);
-    --printf("Barspell: Merit Bonus +%d", meritBonus);
-    
-    local enhanceSkill = caster:getSkillLevel(34);
-
-    local power = 1 + 0.02 * enhanceSkill + meritBonus;
-
-    local duration = 150;
-
-    if (enhanceSkill > 180) then
-        duration = 150 + 0.8 * (enhanceSkill - 180);
-    end
-
-    if (caster:hasStatusEffect(dsp.effect.COMPOSURE) == true and caster:getID() == target:getID()) then
-        duration = duration * 3;
-    end
-
-
-    target:addStatusEffect(dsp.effect.BARSLEEP,power,0,duration);
-    return dsp.effect.BARSLEEP;
+    return applyBarstatus(dsp.effect.BARSLEEP,caster,target,spell)
 end;

--- a/scripts/globals/spells/barsleepra.lua
+++ b/scripts/globals/spells/barsleepra.lua
@@ -3,6 +3,7 @@
 -----------------------------------------
 
 require("scripts/globals/status");
+require("scripts/globals/spells/barstatus");
 
 -----------------------------------------
 -- OnSpellCast
@@ -13,24 +14,5 @@ function onMagicCastingCheck(caster,target,spell)
 end;
 
 function onSpellCast(caster,target,spell)
-    local meritBonus = caster:getMerit(dsp.merit.BAR_SPELL_EFFECT);
-    --printf("Barspell: Merit Bonus +%d", meritBonus);
-    
-    local enhanceSkill = caster:getSkillLevel(34);
-
-    local power = 1 + 0.02 * enhanceSkill + meritBonus;
-
-    local duration = 150;
-
-    if (enhanceSkill > 180) then
-        duration = 150 + 0.8 * (enhanceSkill - 180);
-    end
-
-    if (caster:hasStatusEffect(dsp.effect.COMPOSURE) == true and caster:getID() == target:getID()) then
-        duration = duration * 3;
-    end
-
-    target:addStatusEffect(dsp.effect.BARSLEEP,power,0,duration);
-
-    return dsp.effect.BARSLEEP;
+    return applyBarstatus(dsp.effect.BARSLEEP,caster,target,spell)
 end;

--- a/scripts/globals/spells/barspell.lua
+++ b/scripts/globals/spells/barspell.lua
@@ -1,0 +1,41 @@
+-----------------------------------------
+-- Implementation of Bar-spells
+-----------------------------------------
+
+require("scripts/globals/status");
+
+function calculateBarspellPower(caster,enhanceSkill)
+    local meritBonus = caster:getMerit(dsp.merit.BAR_SPELL_EFFECT)
+    local equipBonus = caster:getMod(dsp.mod.BARSPELL_AMOUNT)
+
+    if (enhanceSkill == nil or enhanceSkill < 0) then
+        enhanceSkill = 0
+    end
+
+    local power = 0
+    if (enhanceSkill > 500) then
+        power = 150
+    elseif (enhanceSkill > 300) then
+        power = 25 + math.floor(enhanceSkill * 0.25)
+    else
+        power = 40 + math.floor(enhanceSkill * 0.2)
+    end
+    return power + meritBonus + equipBonus
+end
+
+function calculateBarspellDuration(caster,enhanceSkill)
+    -- Function call to allow configuration conditional for old duration formulas.
+    return 480
+end
+
+function applyBarspell(effectType,caster,target,spell)
+    local enhanceSkill = caster:getSkillLevel(dsp.skill.ENHANCING_MAGIC)
+    local mdefBonus = caster:getMerit(dsp.merit.BAR_SPELL_EFFECT) + caster:getMod(dsp.mod.BARSPELL_MDEF_BONUS)
+
+    local power = calculateBarspellPower(caster,enhanceSkill);
+    local duration = calculateBarspellDuration(caster, enhanceSkill)
+    duration = calculateDuration(duration, dsp.skill.ENHANCING_MAGIC, dsp.magic.spellGroup.WHITE, caster, target)
+    
+    target:addStatusEffect(effectType,power,0,duration,0,mdefBonus)
+    return effectType
+end

--- a/scripts/globals/spells/barstatus.lua
+++ b/scripts/globals/spells/barstatus.lua
@@ -1,0 +1,33 @@
+-----------------------------------------
+-- Implementation of Bar-status
+-----------------------------------------
+
+require("scripts/globals/status");
+
+function calculateBarstatusPower(caster,enhanceSkill)
+    local meritBonus = caster:getMerit(dsp.merit.BAR_SPELL_EFFECT)
+
+    if (enhanceSkill == nil or enhanceSkill < 0) then
+        enhanceSkill = 0
+    end
+    
+    -- No known way to determine actual potency.
+    return 1 + 0.02 * enhanceSkill + meritBonus
+end
+
+function calculateBarstatusDuration(caster,enhanceSkill)
+    -- Function call to allow configuration conditional for old duration formulas.
+    return 480
+end
+
+function applyBarstatus(effectType,caster,target,spell)
+    local enhanceSkill = caster:getSkillLevel(dsp.skill.ENHANCING_MAGIC)
+    local mdefBonus = caster:getMerit(dsp.merit.BAR_SPELL_EFFECT) + caster:getMod(dsp.mod.BARSPELL_MDEF_BONUS)
+
+    local power = calculateBarstatusPower(caster,enhanceSkill);
+    local duration = calculateBarstatusDuration(caster, enhanceSkill)
+    duration = calculateDuration(duration, dsp.skill.ENHANCING_MAGIC, dsp.magic.spellGroup.WHITE, caster, target)
+    
+    target:addStatusEffect(effectType,power,0,duration)
+    return effectType
+end

--- a/scripts/globals/spells/barstone.lua
+++ b/scripts/globals/spells/barstone.lua
@@ -3,6 +3,7 @@
 -----------------------------------------
 
 require("scripts/globals/status");
+require("scripts/globals/spells/barspell");
 
 -----------------------------------------
 -- OnSpellCast
@@ -13,21 +14,5 @@ function onMagicCastingCheck(caster,target,spell)
 end;
 
 function onSpellCast(caster,target,spell)
-
-    local enhanceSkill = caster:getSkillLevel(dsp.skill.ENHANCING_MAGIC);
-    local power = calculateBarspellPower(caster,enhanceSkill);
-    local mdefBonus = caster:getMerit(dsp.merit.BAR_SPELL_EFFECT) + caster:getMod(dsp.mod.BARSPELL_MDEF_BONUS);
-    local duration = 150;
-
-    if (enhanceSkill > 180) then
-        duration = 150 + 0.8 * (enhanceSkill - 180);
-    end
-
-    if (caster:hasStatusEffect(dsp.effect.COMPOSURE) == true and caster:getID() == target:getID()) then
-        duration = duration * 3;
-    end
-
-    target:addStatusEffect(dsp.effect.BARSTONE,power,0,duration,0,mdefBonus);
-
-    return dsp.effect.BARSTONE;
+    return applyBarspell(dsp.effect.BARSTONE,caster,target,spell)
 end;

--- a/scripts/globals/spells/barstonra.lua
+++ b/scripts/globals/spells/barstonra.lua
@@ -3,6 +3,7 @@
 -----------------------------------------
 
 require("scripts/globals/status");
+require("scripts/globals/spells/barspell");
 
 -----------------------------------------
 -- OnSpellCast
@@ -13,21 +14,5 @@ function onMagicCastingCheck(caster,target,spell)
 end;
 
 function onSpellCast(caster,target,spell)
-
-    local enhanceSkill = caster:getSkillLevel(dsp.skill.ENHANCING_MAGIC);
-    local power = calculateBarspellPower(caster,enhanceSkill);
-    local mdefBonus = caster:getMerit(dsp.merit.BAR_SPELL_EFFECT) + caster:getMod(dsp.mod.BARSPELL_MDEF_BONUS);
-    local duration = 150;
-
-    if (enhanceSkill > 180) then
-        duration = 150 + 0.8 * (enhanceSkill - 180);
-    end
-
-    if (caster:hasStatusEffect(dsp.effect.COMPOSURE) == true and caster:getID() == target:getID()) then
-        duration = duration * 3;
-    end
-
-    target:addStatusEffect(dsp.effect.BARSTONE,power,0,duration,0,mdefBonus);
-
-    return dsp.effect.BARSTONE;
+    return applyBarspell(dsp.effect.BARSTONE,caster,target,spell)
 end;

--- a/scripts/globals/spells/barthunder.lua
+++ b/scripts/globals/spells/barthunder.lua
@@ -3,6 +3,7 @@
 -----------------------------------------
 
 require("scripts/globals/status");
+require("scripts/globals/spells/barspell");
 
 -----------------------------------------
 -- OnSpellCast
@@ -13,21 +14,5 @@ function onMagicCastingCheck(caster,target,spell)
 end;
 
 function onSpellCast(caster,target,spell)
-
-    local enhanceSkill = caster:getSkillLevel(dsp.skill.ENHANCING_MAGIC);
-    local power = calculateBarspellPower(caster,enhanceSkill);
-    local mdefBonus = caster:getMerit(dsp.merit.BAR_SPELL_EFFECT) + caster:getMod(dsp.mod.BARSPELL_MDEF_BONUS);
-    local duration = 150;
-
-    if (enhanceSkill > 180) then
-        duration = 150 + 0.8 * (enhanceSkill - 180);
-    end
-
-    if (caster:hasStatusEffect(dsp.effect.COMPOSURE) == true and caster:getID() == target:getID()) then
-        duration = duration * 3;
-    end
-
-    target:addStatusEffect(dsp.effect.BARTHUNDER,power,0,duration,0,mdefBonus);
-
-    return dsp.effect.BARTHUNDER;
+    return applyBarspell(dsp.effect.BARTHUNDER,caster,target,spell)
 end;

--- a/scripts/globals/spells/barthundra.lua
+++ b/scripts/globals/spells/barthundra.lua
@@ -3,6 +3,7 @@
 -----------------------------------------
 
 require("scripts/globals/status");
+require("scripts/globals/spells/barspell");
 
 -----------------------------------------
 -- OnSpellCast
@@ -13,21 +14,5 @@ function onMagicCastingCheck(caster,target,spell)
 end;
 
 function onSpellCast(caster,target,spell)
-
-    local enhanceSkill = caster:getSkillLevel(dsp.skill.ENHANCING_MAGIC);
-    local power = calculateBarspellPower(caster,enhanceSkill);
-    local mdefBonus = caster:getMerit(dsp.merit.BAR_SPELL_EFFECT) + caster:getMod(dsp.mod.BARSPELL_MDEF_BONUS);
-    local duration = 150;
-
-    if (enhanceSkill > 180) then
-        duration = 150 + 0.8 * (enhanceSkill - 180);
-    end
-
-    if (caster:hasStatusEffect(dsp.effect.COMPOSURE) == true and caster:getID() == target:getID()) then
-        duration = duration * 3;
-    end
-
-    target:addStatusEffect(dsp.effect.BARTHUNDER,power,0,duration,0,mdefBonus);
-
-    return dsp.effect.BARTHUNDER;
+    return applyBarspell(dsp.effect.BARTHUNDER,caster,target,spell)
 end;

--- a/scripts/globals/spells/barvira.lua
+++ b/scripts/globals/spells/barvira.lua
@@ -3,6 +3,7 @@
 -----------------------------------------
 
 require("scripts/globals/status");
+require("scripts/globals/spells/barstatus");
 
 -----------------------------------------
 -- OnSpellCast
@@ -13,24 +14,5 @@ function onMagicCastingCheck(caster,target,spell)
 end;
 
 function onSpellCast(caster,target,spell)
-    local meritBonus = caster:getMerit(dsp.merit.BAR_SPELL_EFFECT);
-    --printf("Barspell: Merit Bonus +%d", meritBonus);
-    
-    local enhanceSkill = caster:getSkillLevel(34);
-
-    local power = 1 + 0.02 * enhanceSkill + meritBonus;
-
-    local duration = 150;
-
-    if (enhanceSkill > 180) then
-        duration = 150 + 0.8 * (enhanceSkill - 180);
-    end
-
-    if (caster:hasStatusEffect(dsp.effect.COMPOSURE) == true and caster:getID() == target:getID()) then
-        duration = duration * 3;
-    end
-
-    target:addStatusEffect(dsp.effect.BARVIRUS,power,0,duration);
-
-    return dsp.effect.BARVIRUS;
+    return applyBarstatus(dsp.effect.BARVIRUS,caster,target,spell)
 end;

--- a/scripts/globals/spells/barvirus.lua
+++ b/scripts/globals/spells/barvirus.lua
@@ -3,6 +3,7 @@
 -----------------------------------------
 
 require("scripts/globals/status");
+require("scripts/globals/spells/barstatus");
 
 -----------------------------------------
 -- OnSpellCast
@@ -13,24 +14,5 @@ function onMagicCastingCheck(caster,target,spell)
 end;
 
 function onSpellCast(caster,target,spell)
-    local meritBonus = caster:getMerit(dsp.merit.BAR_SPELL_EFFECT);
-    --printf("Barspell: Merit Bonus +%d", meritBonus);
-    
-    local enhanceSkill = caster:getSkillLevel(34);
-
-    local power = 1 + 0.02 * enhanceSkill + meritBonus;
-
-    local duration = 150;
-
-    if (enhanceSkill > 180) then
-        duration = 150 + 0.8 * (enhanceSkill - 180);
-    end
-
-    if (caster:hasStatusEffect(dsp.effect.COMPOSURE) == true and caster:getID() == target:getID()) then
-        duration = duration * 3;
-    end
-
-    target:addStatusEffect(dsp.effect.BARVIRUS,power,0,duration);
-
-        return dsp.effect.BARVIRUS;
+    return applyBarstatus(dsp.effect.BARVIRUS,caster,target,spell)
 end;

--- a/scripts/globals/spells/barwater.lua
+++ b/scripts/globals/spells/barwater.lua
@@ -3,6 +3,7 @@
 -----------------------------------------
 
 require("scripts/globals/status");
+require("scripts/globals/spells/barspell");
 
 -----------------------------------------
 -- OnSpellCast
@@ -13,21 +14,5 @@ function onMagicCastingCheck(caster,target,spell)
 end;
 
 function onSpellCast(caster,target,spell)
-
-    local enhanceSkill = caster:getSkillLevel(dsp.skill.ENHANCING_MAGIC);
-    local power = calculateBarspellPower(caster,enhanceSkill);
-    local mdefBonus = caster:getMerit(dsp.merit.BAR_SPELL_EFFECT) + caster:getMod(dsp.mod.BARSPELL_MDEF_BONUS);
-    local duration = 150;
-
-    if (enhanceSkill > 180) then
-        duration = 150 + 0.8 * (enhanceSkill - 180);
-    end
-
-    if (caster:hasStatusEffect(dsp.effect.COMPOSURE) == true and caster:getID() == target:getID()) then
-        duration = duration * 3;
-    end
-
-    target:addStatusEffect(dsp.effect.BARWATER,power,0,duration,0,mdefBonus);
-
-    return dsp.effect.BARWATER;
+    return applyBarspell(dsp.effect.BARWATER,caster,target,spell)
 end;

--- a/scripts/globals/spells/barwatera.lua
+++ b/scripts/globals/spells/barwatera.lua
@@ -3,6 +3,7 @@
 -----------------------------------------
 
 require("scripts/globals/status");
+require("scripts/globals/spells/barspell");
 
 -----------------------------------------
 -- OnSpellCast
@@ -13,21 +14,5 @@ function onMagicCastingCheck(caster,target,spell)
 end;
 
 function onSpellCast(caster,target,spell)
-
-    local enhanceSkill = caster:getSkillLevel(dsp.skill.ENHANCING_MAGIC);
-    local power = calculateBarspellPower(caster,enhanceSkill);
-    local mdefBonus = caster:getMerit(dsp.merit.BAR_SPELL_EFFECT) + caster:getMod(dsp.mod.BARSPELL_MDEF_BONUS);
-    local duration = 150;
-
-    if (enhanceSkill > 180) then
-        duration = 150 + 0.8 * (enhanceSkill - 180);
-    end
-
-    if (caster:hasStatusEffect(dsp.effect.COMPOSURE) == true and caster:getID() == target:getID()) then
-        duration = duration * 3;
-    end
-
-    target:addStatusEffect(dsp.effect.BARWATER,power,0,duration,0,mdefBonus);
-
-    return dsp.effect.BARWATER;
+    return applyBarspell(dsp.effect.BARWATER,caster,target,spell)
 end;


### PR DESCRIPTION
This PR handles #4492 based on the current retail logic. Duration was changed to be 480 seconds for both bar-spell and bar-status effects. The power of bar-spells was modified to cap at 150 resist based on the enhancing magic skill. 

- [x] Move bar-spell logic into barspell.lua
- [x] Move bar-status logic into barstatus.lua
- [x] Correct bar-spell scaling logic to use enhancing magic skill
- [x] Add utility function for modifying spell durations