### PR TITLE
Shields and Grips don't 'unequip' with gear scaling disabled (#4686)

### DIFF
--- a/src/map/utils/charutils.cpp
+++ b/src/map/utils/charutils.cpp
@@ -2074,6 +2074,16 @@ namespace charutils
         if (PItem && PItem == PChar->getEquip((SLOTTYPE)equipSlotID))
             return;
 
+        if (equipSlotID == SLOT_SUB && ((CItemWeapon*)PItem)->getSkillType() == SKILL_NONE)
+        {
+            CItemArmor* PMainItem = PChar->getEquip(SLOT_MAIN);
+            if (!PMainItem || !((CItemWeapon*)PMainItem)->isTwoHanded())
+            {
+                PChar->pushPacket(new CMessageBasicPacket(PChar, PChar, 0, 0, 0x200));
+                return;
+            }
+        }
+
         if (slotID == 0)
         {
             CItemArmor* PSubItem = PChar->getEquip(SLOT_SUB);
@@ -2168,32 +2178,37 @@ namespace charutils
         for (uint8 slotID = 0; slotID < 16; ++slotID)
         {
             PItem = PChar->getEquip((SLOTTYPE)slotID);
-
-            if ((PItem != nullptr) && PItem->isType(ITEM_ARMOR))
+            if (PItem == nullptr || !PItem->isType(ITEM_ARMOR))
             {
-                if (slotID == SLOT_SUB && !charutils::hasTrait(PChar, TRAIT_DUAL_WIELD))
-                {
-                    // don't unequip shields
-                    if (PItem->IsShield())
-                        continue;
-
-                    // if the item isn't a grip, unequip it
-                    if (!((CItemWeapon*)PItem)->getSkillType() == SKILL_NONE)
-                        RemoveSub(PChar);
-
-                    continue;
-                }
-
-                if ((PItem->getJobs() & (1 << (PChar->GetMJob() - 1))) &&
-                    (PItem->getReqLvl() <= (map_config.disable_gear_scaling ?
-                    PChar->GetMLevel() : PChar->jobs.job[PChar->GetMJob()])) &&
-                    (PItem->getEquipSlotId() & (1 << slotID)))
-                {
-                    continue;
-                }
-
-                UnequipItem(PChar, slotID);
+                continue;
             }
+
+            if (PItem->getReqLvl() > (map_config.disable_gear_scaling ?
+                PChar->GetMLevel() : PChar->jobs.job[PChar->GetMJob()]))
+            {
+                UnequipItem(PChar, slotID);
+                continue;
+            }
+
+            if (slotID == SLOT_SUB && !PItem->IsShield())
+            {
+                // Unequip if no main weapon or a non-grip subslot without DW
+                if (!PChar->getEquip(SLOT_MAIN) ||
+                    (!charutils::hasTrait(PChar, TRAIT_DUAL_WIELD) &&
+                     !((CItemWeapon*)PItem)->getSkillType() == SKILL_NONE))
+                {
+                    UnequipItem(PChar, SLOT_SUB);
+                    continue;
+                }
+            }
+
+            if ((PItem->getJobs() & (1 << (PChar->GetMJob() - 1))) &&
+                (PItem->getEquipSlotId() & (1 << slotID)))
+            {
+                continue;
+            }
+        
+            UnequipItem(PChar, slotID);
         }
         // Unarmed H2H weapon check
         if (!PChar->getEquip(SLOT_MAIN) || !PChar->getEquip(SLOT_MAIN)->isType(ITEM_ARMOR) || PChar->m_Weapons[SLOT_MAIN] == itemutils::GetUnarmedH2HItem())


### PR DESCRIPTION
This PR should resolve #4686 and fix the same issue when a level restriction or job change removes the dual wield trait. It also includes a change to push the correct error packet when attempting to equip a grip without a two-hand weapon in the main slot. 

- [x] Unequip shield / grip when level restriction is in place
- [x] Unequip offhand when under level restriction or no dual wield
- [x] Return correct error when attempting to equip a grip with non-2H