### PR TITLE
Weaponskill bugfix - Fencer

### DIFF
--- a/scripts/globals/weaponskills.lua
+++ b/scripts/globals/weaponskills.lua
@@ -103,7 +103,7 @@ function doPhysicalWeaponskill(attacker, target, wsID, tp, primary, action, taCh
         -- Handle Fencer
         local mainEquip = attacker:getStorageItem(0, 0, dsp.slot.MAIN)
         
-        if not mainEquip:isTwoHanded() and not mainEquip:isHandToHand() then
+        if mainEquip and not mainEquip:isTwoHanded() and not mainEquip:isHandToHand() then
             local subEquip = attacker:getStorageItem(0, 0, dsp.slot.SUB)
             if subEquip == nil or subEquip:getSkillType() == dsp.skill.NONE or subEquip:isShield() then
                 nativecrit = nativecrit + attacker:getMod(dsp.mod.FENCER_CRITHITRATE) / 100

--- a/scripts/globals/weaponskills.lua
+++ b/scripts/globals/weaponskills.lua
@@ -102,9 +102,10 @@ function doPhysicalWeaponskill(attacker, target, wsID, tp, primary, action, taCh
 
         -- Handle Fencer
         local mainEquip = attacker:getStorageItem(0, 0, dsp.slot.MAIN)
-        local subEquip = attacker:getStorageItem(0, 0, dsp.slot.SUB)
-        if (mainEquip:isTwoHanded() == false and mainEquip:isHandToHand() == false) then
-            if (subEquip == nil or subEquip:getSkillType() == dsp.skill.NONE or subEquip:isShield()) then
+        
+        if not mainEquip:isTwoHanded() and not mainEquip:isHandToHand() then
+            local subEquip = attacker:getStorageItem(0, 0, dsp.slot.SUB)
+            if subEquip == nil or subEquip:getSkillType() == dsp.skill.NONE or subEquip:isShield() then
                 nativecrit = nativecrit + attacker:getMod(dsp.mod.FENCER_CRITHITRATE) / 100
             end
         end
@@ -772,9 +773,9 @@ end
 
         -- Handle Fencer
         local mainEquip = attacker:getStorageItem(0, 0, dsp.slot.MAIN)
-        local subEquip = attacker:getStorageItem(0, 0, dsp.slot.SUB)
-        if (mainEquip:isTwoHanded() == false and mainEquip:isHandToHand() == false) then
-            if (subEquip == nil or subEquip:getSkillType() == dsp.skill.NONE or subEquip:isShield()) then
+        if mainEquip and not mainEquip:isTwoHanded() and not mainEquip:isHandToHand() then
+            local subEquip = attacker:getStorageItem(0, 0, dsp.slot.SUB)
+            if subEquip == nil or subEquip:getSkillType() == dsp.skill.NONE or subEquip:isShield() then
                 nativecrit = nativecrit + attacker:getMod(dsp.mod.FENCER_CRITHITRATE) / 100
             end
         end


### PR DESCRIPTION
Ranged weaponskills and Eagle Eye shot were failing without a main slot equip because of my dumb Fencer check. Added the check to melee weaponskill code for naked h2h weaponskill. Cleaned up the styling while I was in the area and moved the sub slot check inside of the main slot check for the barely noticeable and edge-case performance gain.