### PR TITLE
Implement sitchair functionality

### DIFF
--- a/scripts/globals/items/astral_cube.lua
+++ b/scripts/globals/items/astral_cube.lua
@@ -10,7 +10,7 @@ require("scripts/globals/msg");
 local keyItemId = dsp.ki.ASTRAL_CUBE;
 
 function onItemCheck(target)
-    if (target:hasKeyItem(keyItemId)) then
+    if target:hasKeyItem(keyItemId) then
         return dsp.msg.basic.ALREADY_HAVE_KEY_ITEM,0,keyItemId
     end
     return 0

--- a/scripts/globals/items/astral_cube.lua
+++ b/scripts/globals/items/astral_cube.lua
@@ -1,0 +1,22 @@
+-----------------------------------------
+-- ID: 6413
+-- Item: Astral Cube
+-- Item Effect: Grant Astral cube key item
+-----------------------------------------
+require("scripts/globals/settings");
+require("scripts/globals/keyitems");
+require("scripts/globals/msg");
+
+local keyItemId = dsp.ki.ASTRAL_CUBE;
+
+function onItemCheck(target)
+    if (target:hasKeyItem(keyItemId)) then
+        return dsp.msg.basic.ALREADY_HAVE_KEY_ITEM,0,keyItemId
+    end
+    return 0
+end
+
+function onItemUse(target)
+    target:addKeyItem(keyItemId)
+    target:messageBasic(dsp.basic.OBTAINED_KEY_ITEM,6413,keyItemId);
+end

--- a/scripts/globals/items/chocobo_chair.lua
+++ b/scripts/globals/items/chocobo_chair.lua
@@ -10,7 +10,7 @@ require("scripts/globals/msg");
 local keyItemId = dsp.ki.CHOCOBO_CHAIR;
 
 function onItemCheck(target)
-    if (target:hasKeyItem(keyItemId)) then
+    if target:hasKeyItem(keyItemId) then
         return dsp.msg.basic.ALREADY_HAVE_KEY_ITEM,0,keyItemId
     end
     return 0

--- a/scripts/globals/items/chocobo_chair.lua
+++ b/scripts/globals/items/chocobo_chair.lua
@@ -1,0 +1,22 @@
+-----------------------------------------
+-- ID: 6411
+-- Item: Chocobo Chair
+-- Item Effect: Grant Chocobo chair key item
+-----------------------------------------
+require("scripts/globals/settings");
+require("scripts/globals/keyitems");
+require("scripts/globals/msg");
+
+local keyItemId = dsp.ki.CHOCOBO_CHAIR;
+
+function onItemCheck(target)
+    if (target:hasKeyItem(keyItemId)) then
+        return dsp.msg.basic.ALREADY_HAVE_KEY_ITEM,0,keyItemId
+    end
+    return 0
+end
+
+function onItemUse(target)
+    target:addKeyItem(keyItemId)
+    target:messageBasic(dsp.basic.OBTAINED_KEY_ITEM,6411,keyItemId);
+end

--- a/scripts/globals/items/decorative_chair_set.lua
+++ b/scripts/globals/items/decorative_chair_set.lua
@@ -10,7 +10,7 @@ require("scripts/globals/msg");
 local keyItemId = dsp.ki.DECORATIVE_CHAIR;
 
 function onItemCheck(target)
-    if (target:hasKeyItem(keyItemId)) then
+    if target:hasKeyItem(keyItemId) then
         return dsp.msg.basic.ALREADY_HAVE_KEY_ITEM,0,keyItemId
     end
     return 0

--- a/scripts/globals/items/decorative_chair_set.lua
+++ b/scripts/globals/items/decorative_chair_set.lua
@@ -1,0 +1,22 @@
+-----------------------------------------
+-- ID: 6378
+-- Item: Decorative Chair
+-- Item Effect: Grant Decorative chair key item
+-----------------------------------------
+require("scripts/globals/settings");
+require("scripts/globals/keyitems");
+require("scripts/globals/msg");
+
+local keyItemId = dsp.ki.DECORATIVE_CHAIR;
+
+function onItemCheck(target)
+    if (target:hasKeyItem(keyItemId)) then
+        return dsp.msg.basic.ALREADY_HAVE_KEY_ITEM,0,keyItemId
+    end
+    return 0
+end
+
+function onItemUse(target)
+    target:addKeyItem(keyItemId)
+    target:messageBasic(dsp.basic.OBTAINED_KEY_ITEM,6378,keyItemId);
+end

--- a/scripts/globals/items/ephramadian_throne.lua
+++ b/scripts/globals/items/ephramadian_throne.lua
@@ -10,7 +10,7 @@ require("scripts/globals/msg");
 local keyItemId = dsp.ki.EPHRAMADIAN_THRONE;
 
 function onItemCheck(target)
-    if (target:hasKeyItem(keyItemId)) then
+    if target:hasKeyItem(keyItemId) then
         return dsp.msg.basic.ALREADY_HAVE_KEY_ITEM,0,keyItemId
     end
     return 0

--- a/scripts/globals/items/ephramadian_throne.lua
+++ b/scripts/globals/items/ephramadian_throne.lua
@@ -1,0 +1,22 @@
+-----------------------------------------
+-- ID: 6409
+-- Item: Ephramadian Throne
+-- Item Effect: Grant Ephramadian throne key item
+-----------------------------------------
+require("scripts/globals/settings");
+require("scripts/globals/keyitems");
+require("scripts/globals/msg");
+
+local keyItemId = dsp.ki.EPHRAMADIAN_THRONE;
+
+function onItemCheck(target)
+    if (target:hasKeyItem(keyItemId)) then
+        return dsp.msg.basic.ALREADY_HAVE_KEY_ITEM,0,keyItemId
+    end
+    return 0
+end
+
+function onItemUse(target)
+    target:addKeyItem(keyItemId)
+    target:messageBasic(dsp.basic.OBTAINED_KEY_ITEM,6409,keyItemId);
+end

--- a/scripts/globals/items/imperial_chair_set.lua
+++ b/scripts/globals/items/imperial_chair_set.lua
@@ -1,0 +1,22 @@
+-----------------------------------------
+-- ID: 6377
+-- Item: Imperial Chair
+-- Item Effect: Grant Imperial chair key item
+-----------------------------------------
+require("scripts/globals/settings");
+require("scripts/globals/keyitems");
+require("scripts/globals/msg");
+
+local keyItemId = dsp.ki.IMPERIAL_CHAIR;
+
+function onItemCheck(target)
+    if (target:hasKeyItem(keyItemId)) then
+        return dsp.msg.basic.ALREADY_HAVE_KEY_ITEM,0,keyItemId
+    end
+    return 0
+end
+
+function onItemUse(target)
+    target:addKeyItem(keyItemId)
+    target:messageBasic(dsp.basic.OBTAINED_KEY_ITEM,6377,keyItemId);
+end

--- a/scripts/globals/items/imperial_chair_set.lua
+++ b/scripts/globals/items/imperial_chair_set.lua
@@ -10,7 +10,7 @@ require("scripts/globals/msg");
 local keyItemId = dsp.ki.IMPERIAL_CHAIR;
 
 function onItemCheck(target)
-    if (target:hasKeyItem(keyItemId)) then
+    if target:hasKeyItem(keyItemId) then
         return dsp.msg.basic.ALREADY_HAVE_KEY_ITEM,0,keyItemId
     end
     return 0

--- a/scripts/globals/items/leaf_bench.lua
+++ b/scripts/globals/items/leaf_bench.lua
@@ -1,0 +1,22 @@
+-----------------------------------------
+-- ID: 6412
+-- Item: Leaf Bench
+-- Item Effect: Grant Leaf bench key item
+-----------------------------------------
+require("scripts/globals/settings");
+require("scripts/globals/keyitems");
+require("scripts/globals/msg");
+
+local keyItemId = dsp.ki.LEAF_BENCH;
+
+function onItemCheck(target)
+    if (target:hasKeyItem(keyItemId)) then
+        return dsp.msg.basic.ALREADY_HAVE_KEY_ITEM,0,keyItemId
+    end
+    return 0
+end
+
+function onItemUse(target)
+    target:addKeyItem(keyItemId)
+    target:messageBasic(dsp.basic.OBTAINED_KEY_ITEM,6412,keyItemId);
+end

--- a/scripts/globals/items/leaf_bench.lua
+++ b/scripts/globals/items/leaf_bench.lua
@@ -10,7 +10,7 @@ require("scripts/globals/msg");
 local keyItemId = dsp.ki.LEAF_BENCH;
 
 function onItemCheck(target)
-    if (target:hasKeyItem(keyItemId)) then
+    if target:hasKeyItem(keyItemId) then
         return dsp.msg.basic.ALREADY_HAVE_KEY_ITEM,0,keyItemId
     end
     return 0

--- a/scripts/globals/items/ornate_stool_set.lua
+++ b/scripts/globals/items/ornate_stool_set.lua
@@ -10,7 +10,7 @@ require("scripts/globals/msg");
 local keyItemId = dsp.ki.ORNATE_STOOL;
 
 function onItemCheck(target)
-    if (target:hasKeyItem(keyItemId)) then
+    if target:hasKeyItem(keyItemId) then
         return dsp.msg.basic.ALREADY_HAVE_KEY_ITEM,0,keyItemId
     end
     return 0

--- a/scripts/globals/items/ornate_stool_set.lua
+++ b/scripts/globals/items/ornate_stool_set.lua
@@ -1,0 +1,22 @@
+-----------------------------------------
+-- ID: 6379
+-- Item: Ornate Stool
+-- Item Effect: Grant Ornate stool key item
+-----------------------------------------
+require("scripts/globals/settings");
+require("scripts/globals/keyitems");
+require("scripts/globals/msg");
+
+local keyItemId = dsp.ki.ORNATE_STOOL;
+
+function onItemCheck(target)
+    if (target:hasKeyItem(keyItemId)) then
+        return dsp.msg.basic.ALREADY_HAVE_KEY_ITEM,0,keyItemId
+    end
+    return 0
+end
+
+function onItemUse(target)
+    target:addKeyItem(keyItemId)
+    target:messageBasic(dsp.basic.OBTAINED_KEY_ITEM,6379,keyItemId);
+end

--- a/scripts/globals/items/portable_container.lua
+++ b/scripts/globals/items/portable_container.lua
@@ -1,0 +1,22 @@
+-----------------------------------------
+-- ID: 6408
+-- Item: Portable Container
+-- Item Effect: Grant Portable container key item
+-----------------------------------------
+require("scripts/globals/settings");
+require("scripts/globals/keyitems");
+require("scripts/globals/msg");
+
+local keyItemId = dsp.ki.PORTABLE_CONTAINER;
+
+function onItemCheck(target)
+    if (target:hasKeyItem(keyItemId)) then
+        return dsp.msg.basic.ALREADY_HAVE_KEY_ITEM,0,keyItemId
+    end
+    return 0
+end
+
+function onItemUse(target)
+    target:addKeyItem(keyItemId)
+    target:messageBasic(dsp.basic.OBTAINED_KEY_ITEM,6408,keyItemId);
+end

--- a/scripts/globals/items/portable_container.lua
+++ b/scripts/globals/items/portable_container.lua
@@ -10,7 +10,7 @@ require("scripts/globals/msg");
 local keyItemId = dsp.ki.PORTABLE_CONTAINER;
 
 function onItemCheck(target)
-    if (target:hasKeyItem(keyItemId)) then
+    if target:hasKeyItem(keyItemId) then
         return dsp.msg.basic.ALREADY_HAVE_KEY_ITEM,0,keyItemId
     end
     return 0

--- a/scripts/globals/items/refined_chair_set.lua
+++ b/scripts/globals/items/refined_chair_set.lua
@@ -10,7 +10,7 @@ require("scripts/globals/msg");
 local keyItemId = dsp.ki.REFINED_CHAIR;
 
 function onItemCheck(target)
-    if (target:hasKeyItem(keyItemId)) then
+    if target:hasKeyItem(keyItemId) then
         return dsp.msg.basic.ALREADY_HAVE_KEY_ITEM,0,keyItemId
     end
     return 0

--- a/scripts/globals/items/refined_chair_set.lua
+++ b/scripts/globals/items/refined_chair_set.lua
@@ -1,0 +1,22 @@
+-----------------------------------------
+-- ID: 6380
+-- Item: Refined Chair
+-- Item Effect: Grant Refined chair key item
+-----------------------------------------
+require("scripts/globals/settings");
+require("scripts/globals/keyitems");
+require("scripts/globals/msg");
+
+local keyItemId = dsp.ki.REFINED_CHAIR;
+
+function onItemCheck(target)
+    if (target:hasKeyItem(keyItemId)) then
+        return dsp.msg.basic.ALREADY_HAVE_KEY_ITEM,0,keyItemId
+    end
+    return 0
+end
+
+function onItemUse(target)
+    target:addKeyItem(keyItemId)
+    target:messageBasic(dsp.basic.OBTAINED_KEY_ITEM,6380,keyItemId);
+end

--- a/scripts/globals/items/shadow_throne.lua
+++ b/scripts/globals/items/shadow_throne.lua
@@ -1,0 +1,22 @@
+-----------------------------------------
+-- ID: 6410
+-- Item: Shadow Throne
+-- Item Effect: Grant Leaf bench key item
+-----------------------------------------
+require("scripts/globals/settings");
+require("scripts/globals/keyitems");
+require("scripts/globals/msg");
+
+local keyItemId = dsp.ki.SHADOW_THRONE;
+
+function onItemCheck(target)
+    if (target:hasKeyItem(keyItemId)) then
+        return dsp.msg.basic.ALREADY_HAVE_KEY_ITEM,0,keyItemId
+    end
+    return 0
+end
+
+function onItemUse(target)
+    target:addKeyItem(keyItemId)
+    target:messageBasic(dsp.basic.OBTAINED_KEY_ITEM,6410,keyItemId);
+end

--- a/scripts/globals/items/shadow_throne.lua
+++ b/scripts/globals/items/shadow_throne.lua
@@ -10,7 +10,7 @@ require("scripts/globals/msg");
 local keyItemId = dsp.ki.SHADOW_THRONE;
 
 function onItemCheck(target)
-    if (target:hasKeyItem(keyItemId)) then
+    if target:hasKeyItem(keyItemId) then
         return dsp.msg.basic.ALREADY_HAVE_KEY_ITEM,0,keyItemId
     end
     return 0

--- a/scripts/globals/msg.lua
+++ b/scripts/globals/msg.lua
@@ -159,6 +159,8 @@ dsp.msg.basic =
     MUG_SUCCESS            = 129, -- <user> uses <ability>. <user> mugs <amount> gil from <target>.
     MUG_FAIL               = 244, -- <user> fails to mug <target>.
     FULL_INVENTORY         = 356, --  Cannot execute command. Your inventory is full.
+    OBTAINED_KEY_ITEM      = 758, -- Obtained key item: <key item>.
+    ALREADY_HAVE_KEY_ITEM  = 759, -- You already have key item: <key item>.
 
     -- Distance
     TARG_OUT_OF_RANGE      = 4,   -- <target> is out of range.

--- a/sql/item_usable.sql
+++ b/sql/item_usable.sql
@@ -1,7 +1,6 @@
 -- MySQL dump 10.13  Distrib 5.6.17, for Win64 (x86_64)
 --
--- Host: localhost    Database: dspdb
--- ------------------------------------------------------
+-- Host: localhost    Database: -- ------------------------------------------------------
 -- Server version   5.6.21-log
 
 /*!40101 SET @OLD_CHARACTER_SET_CLIENT=@@CHARACTER_SET_CLIENT */;
@@ -1791,12 +1790,22 @@ INSERT INTO `item_usable` VALUES (6343,'grape_daifuku',1,1,28,0,0,0,0,0);
 INSERT INTO `item_usable` VALUES (6344,'grape_daifuku_+1',1,1,28,0,0,0,0,0);
 INSERT INTO `item_usable` VALUES (6368,'geomancer_die',1,1,55,0,0,0,0,0);
 INSERT INTO `item_usable` VALUES (6369,'rune_fencer_die',1,1,55,0,0,0,0,0);
+INSERT INTO `item_usable` VALUES (6377,'imperial_chair_set',1,1,0,0,0,0,0,0);
+INSERT INTO `item_usable` VALUES (6378,'decorative_chair_set',1,1,0,0,0,0,0,0);
+INSERT INTO `item_usable` VALUES (6379,'ornate_stool_set',1,1,0,0,0,0,0,0);
+INSERT INTO `item_usable` VALUES (6380,'refined_chair_set',1,1,0,0,0,0,0,0);
 INSERT INTO `item_usable` VALUES (6394,'pork_cutlet',1,1,24,0,0,0,0,0);
 INSERT INTO `item_usable` VALUES (6395,'pork_cutlet_+1',1,1,24,0,0,0,0,0);
 INSERT INTO `item_usable` VALUES (6396,'cutlet_sandwich',1,1,24,0,0,0,0,0);
 INSERT INTO `item_usable` VALUES (6397,'cutlet_sandwich_+1',1,1,24,0,0,0,0,0);
 INSERT INTO `item_usable` VALUES (6406,'pork_cutlet_rice_bowl',1,1,28,0,0,0,0,0);
 INSERT INTO `item_usable` VALUES (6407,'pork_cutlet_rice_bowl_+1',1,1,28,0,0,0,0,0);
+INSERT INTO `item_usable` VALUES (6409,'ephramadian_throne',1,1,0,0,0,0,0,0);
+INSERT INTO `item_usable` VALUES (6408,'portable_container',1,1,0,0,0,0,0,0);
+INSERT INTO `item_usable` VALUES (6410,'shadow_throne',1,1,0,0,0,0,0,0);
+INSERT INTO `item_usable` VALUES (6411,'chocobo_chair',1,1,0,0,0,0,0,0);
+INSERT INTO `item_usable` VALUES (6412,'leaf_bench',1,1,0,0,0,0,0,0);
+INSERT INTO `item_usable` VALUES (6413,'astral_cube',1,1,0,0,0,0,0,0);
 INSERT INTO `item_usable` VALUES (6447,'sasuke_shuriken_pouch',1,1,55,0,0,0,0,0);
 INSERT INTO `item_usable` VALUES (6448,'sasuke_shuriken_pouch_+1',1,1,55,0,0,0,0,0);
 INSERT INTO `item_usable` VALUES (6458,'bowl_of_soy_ramen',1,1,28,0,0,0,0,0);

--- a/src/map/ai/states/item_state.cpp
+++ b/src/map/ai/states/item_state.cpp
@@ -85,19 +85,20 @@ CItemState::CItemState(CCharEntity* PEntity, uint16 targid, uint8 loc, uint8 slo
         throw CStateInitException(std::move(m_errorMsg));
     }
 
-    auto error = luautils::OnItemCheck(PTarget, m_PItem, ITEMCHECK::NONE, m_PEntity);
-
+    auto [error, param, value] = luautils::OnItemCheck(PTarget, m_PItem, ITEMCHECK::NONE, m_PEntity);
     if (error || m_PEntity->StatusEffectContainer->HasPreventActionEffect())
     {
-        auto param = m_PItem->getFlag() & ITEM_FLAG_SCROLL ? m_PItem->getSubID() : m_PItem->getID();
-
         if (error == -1)
         {
             throw CStateInitException(nullptr);
         }
         else
         {
-            throw CStateInitException(std::make_unique<CMessageBasicPacket>(m_PEntity, PTarget ? PTarget : m_PEntity, param, 0, error == -1 ? 0 : error));
+            if (value == 0)
+            {
+                param = m_PItem->getFlag() & ITEM_FLAG_SCROLL ? m_PItem->getSubID() : m_PItem->getID();
+            }
+            throw CStateInitException(std::make_unique<CMessageBasicPacket>(m_PEntity, PTarget ? PTarget : m_PEntity, param, value, error));
         }
     }
 

--- a/src/map/entities/baseentity.h
+++ b/src/map/entities/baseentity.h
@@ -80,7 +80,18 @@ enum ANIMATIONTYPE
     ANIMATION_FISHING_START_OLD  = 50,
     ANIMATION_FISHING_START      = 56,
     // 63 through 72 are used with /sitchair
-    // 73 through 83 sitting on air (guessing future use for more chairs..)
+    ANIMATION_SITCHAIR_0 = 63,
+    ANIMATION_SITCHAIR_1 = 64,
+    ANIMATION_SITCHAIR_2 = 65,
+    ANIMATION_SITCHAIR_3 = 66,
+    ANIMATION_SITCHAIR_4 = 67,
+    ANIMATION_SITCHAIR_5 = 68,
+    ANIMATION_SITCHAIR_6 = 69,
+    ANIMATION_SITCHAIR_7 = 70,
+    ANIMATION_SITCHAIR_8 = 71,
+    ANIMATION_SITCHAIR_9 = 72,
+    ANIMATION_SITCHAIR_10 = 73,
+    // 74 through 83 sitting on air (guessing future use for more chairs..)
     ANIMATION_MOUNT              = 85,
     // ANIMATION_TRUST              = 90 // This is the animation for a trust NPC spawning in.
 };

--- a/src/map/lua/luautils.cpp
+++ b/src/map/lua/luautils.cpp
@@ -1920,13 +1920,13 @@ namespace luautils
     *                                                                       *
     ************************************************************************/
 
-    int32 OnItemCheck(CBaseEntity* PTarget, CItem* PItem, ITEMCHECK param, CBaseEntity* PCaster)
+    std::tuple<int32, int32, int32> OnItemCheck(CBaseEntity* PTarget, CItem* PItem, ITEMCHECK param, CBaseEntity* PCaster)
     {
         lua_prepscript("scripts/globals/items/%s.lua", PItem->getName());
 
         if (prepFile(File, "onItemCheck"))
         {
-            return 56;
+            return std::tuple(56, 0, 0);
         }
 
         CLuaBaseEntity LuaBaseEntityTarget(PTarget);
@@ -1937,16 +1937,19 @@ namespace luautils
 
         Lunar<CLuaBaseEntity>::push(LuaHandle, &LuaBaseEntityCaster);
 
-        if (lua_pcall(LuaHandle, 3, 1, 0))
+        if (lua_pcall(LuaHandle, 3, 3, 0))
         {
             ShowError("luautils::onItemCheck: %s\n", lua_tostring(LuaHandle, -1));
             lua_pop(LuaHandle, 1);
-            return 56;
+            return std::tuple(56, 0, 0);
         }
 
-        uint32 retVal = (!lua_isnil(LuaHandle, -1) && lua_isnumber(LuaHandle, -1) ? (int32)lua_tonumber(LuaHandle, -1) : 0);
-        lua_pop(LuaHandle, 1);
-        return retVal;
+        uint32 messageId = (!lua_isnil(LuaHandle, -3) && lua_isnumber(LuaHandle, -3) ? (int32)lua_tonumber(LuaHandle, -3) : 0);
+        uint32 param1 = (!lua_isnil(LuaHandle, -2) && lua_isnumber(LuaHandle, -2) ? (int32)lua_tonumber(LuaHandle, -2) : 0);
+        uint32 param2 = (!lua_isnil(LuaHandle, -1) && lua_isnumber(LuaHandle, -1) ? (int32)lua_tonumber(LuaHandle, -1) : 0);
+        lua_pop(LuaHandle, 3);
+
+        return std::tuple(messageId, param1, param2);
     }
 
     /************************************************************************

--- a/src/map/lua/luautils.cpp
+++ b/src/map/lua/luautils.cpp
@@ -1926,7 +1926,7 @@ namespace luautils
 
         if (prepFile(File, "onItemCheck"))
         {
-            return std::tuple(56, 0, 0);
+            return { 56, 0, 0 };
         }
 
         CLuaBaseEntity LuaBaseEntityTarget(PTarget);
@@ -1941,7 +1941,7 @@ namespace luautils
         {
             ShowError("luautils::onItemCheck: %s\n", lua_tostring(LuaHandle, -1));
             lua_pop(LuaHandle, 1);
-            return std::tuple(56, 0, 0);
+            return { 56, 0, 0 };
         }
 
         uint32 messageId = (!lua_isnil(LuaHandle, -3) && lua_isnumber(LuaHandle, -3) ? (int32)lua_tonumber(LuaHandle, -3) : 0);
@@ -1949,7 +1949,7 @@ namespace luautils
         uint32 param2 = (!lua_isnil(LuaHandle, -1) && lua_isnumber(LuaHandle, -1) ? (int32)lua_tonumber(LuaHandle, -1) : 0);
         lua_pop(LuaHandle, 3);
 
-        return std::tuple(messageId, param1, param2);
+        return { messageId, param1, param2 };
     }
 
     /************************************************************************

--- a/src/map/lua/luautils.h
+++ b/src/map/lua/luautils.h
@@ -206,7 +206,7 @@ namespace luautils
     int32 OnManeuverLose(CBattleEntity* PEntity, CItemPuppet* attachment, uint8 maneuvers);
 
     int32 OnItemUse(CBaseEntity* PTarget, CItem* PItem);                        // triggers when item is used
-    int32 OnItemCheck(CBaseEntity* PTarget, CItem* PItem, ITEMCHECK param = ITEMCHECK::NONE, CBaseEntity* PCaster = nullptr);    // check to see if item can be used
+    std::tuple<int32, int32, int32> OnItemCheck(CBaseEntity* PTarget, CItem* PItem, ITEMCHECK param = ITEMCHECK::NONE, CBaseEntity* PCaster = nullptr);    // check to see if item can be used
     int32 CheckForGearSet(CBaseEntity* PTarget);                                // check for gear sets
 
     int32 OnMagicCastingCheck(CBaseEntity* PChar, CBaseEntity* PTarget, CSpell* PSpell);    // triggers when a player attempts to cast a spell

--- a/src/map/packet_system.cpp
+++ b/src/map/packet_system.cpp
@@ -5809,6 +5809,44 @@ void SmallPacket0x111(map_session_data_t* session, CCharEntity* PChar, CBasicPac
 }
 
 /************************************************************************
+*                                                                       *
+*  /sitchair                                                            *
+*                                                                       *
+************************************************************************/
+void SmallPacket0x113(map_session_data_t* session, CCharEntity* PChar, CBasicPacket data)
+{
+    PrintPacket(data);
+
+    if (PChar->status != STATUS_NORMAL)
+        return;
+
+    if (PChar->StatusEffectContainer->HasPreventActionEffect())
+        return;
+    
+    uint8 type = data.ref<uint8>(0x04);
+    if (type == 2)
+    {
+        PChar->animation = ANIMATION_NONE;
+        PChar->updatemask |= UPDATE_HP;
+        return;
+    }
+    
+    uint8 chairId = data.ref<uint8>(0x08) + ANIMATION_SITCHAIR_0;
+    if (chairId < 63 || chairId > 83)
+        return;
+
+    // Validate key item ownership for 64 through 83
+    if (chairId != 63 && !charutils::hasKeyItem(PChar, chairId + 0xACA))
+    {
+        chairId = ANIMATION_SITCHAIR_0;
+    }
+
+    PChar->animation = PChar->animation == chairId ? ANIMATION_NONE : chairId;
+    PChar->updatemask |= UPDATE_HP;
+    return;
+}
+
+/************************************************************************
 *                                                                        *
 *  Request Currency2 tab                                                  *
 *                                                                        *
@@ -5932,6 +5970,7 @@ void PacketParserInitialize()
     PacketSize[0x110] = 0x0A; PacketParser[0x110] = &SmallPacket0x110;
     PacketSize[0x111] = 0x00; PacketParser[0x111] = &SmallPacket0x111; // Lock Style Request
     PacketSize[0x112] = 0x00; PacketParser[0x112] = &SmallPacket0xFFF;
+    PacketSize[0x113] = 0x06; PacketParser[0x113] = &SmallPacket0x113;
     PacketSize[0x114] = 0x00; PacketParser[0x114] = &SmallPacket0xFFF;
     PacketSize[0x115] = 0x02; PacketParser[0x115] = &SmallPacket0x115;
 }


### PR DESCRIPTION
This PR adds support for /sitchair to fix #4182. One notable aspect of this PR is that it changes the LuaUtils::OnItemCheck function to return a tuple<msgID, param1, param2> instead of a single error value. This allows a parameterized message basic packet to be pushed to the client in an error scenario, which occurs when attempting to acquire the same key item twice. 

Since I couldn't test every existing item script, I tried to maintain existing functionality. If the third value of the tuple is not provided, CItemState will fall back to getting the subID / itemID from the item based on the ITEM_SCROLL_FLAG. Since all previous OnItemCheck calls only return a single item, the third value in the tuple should always be 0, This allows already learned scrolls to continue giving the same error message. 

- [x] Add 0x113 sitchair packet handler
- [x] Add sitchair animation IDs
- [x] Add sitchair item scripts
- [x] Add sitchair item_usable records
- [x] Add sitchair message IDs
- [x] Add sitchair key item IDs
- [x] Modify LuaUtils::OnItemCheck to return msgID, param1, param2
- [x] Modify CItemState to handle tuple and avoid breaking old scripts