### PR TITLE
Resolve #4804 by creating inviter party on successful response

### DIFF
--- a/src/map/message.cpp
+++ b/src/map/message.cpp
@@ -279,7 +279,7 @@ namespace message
                     {
                         if (PInviter->PParty == nullptr)
                         {
-                            // PInviter->PParty = new CParty(PInviter);
+                            PInviter->PParty = new CParty(PInviter);
                         }
                         if (PInviter->PParty && PInviter->PParty->GetLeader() == PInviter)
                         {


### PR DESCRIPTION
This should resolve #4804 by creating the inviter's party if they were solo when the invite was sent. 

- [x] Solo player invite solo player (same process)
- [x] Solo player invite solo player (different process)
- [x] Party leader invite solo player (same process)
- [x] Party leader invite solo player (different process)