### PR TITLE
Remove error output if getStorageItem will return nil

### DIFF
--- a/src/map/lua/lua_baseentity.cpp
+++ b/src/map/lua/lua_baseentity.cpp
@@ -3790,7 +3790,6 @@ inline int32 CLuaBaseEntity::getStorageItem(lua_State *L)
         lua_pcall(L, 2, 1, 0);
         return 1;
     }
-    ShowError(CL_RED"Lua::getItem: unable to find item! Slot: %i Container: %i\n" CL_RESET, equipID > 0 ? equipID : slotID, container);
     lua_pushnil(L);
     return 1;
 }


### PR DESCRIPTION
The implementation and fix (#4940) for Fencer use getStorageItem assuming that it will return nil. The previous version of the function printed an error to the console when returning nil. All seven of the existing uses check for nil and handle it in their scripts. 