### PR TITLE
Revert "Fire Fragment being given to players who havn't killed Tiphia/Carthi"

### DIFF
--- a/scripts/zones/Yuhtunga_Jungle/npcs/Cermet_Headstone.lua
+++ b/scripts/zones/Yuhtunga_Jungle/npcs/Cermet_Headstone.lua
@@ -32,7 +32,7 @@ function onTrigger(player,npc)
     if player:getCurrentMission(ZILART) == HEADSTONE_PILGRIMAGE then
         if player:hasKeyItem(dsp.ki.FIRE_FRAGMENT) then
             player:messageSpecial(ALREADY_OBTAINED_FRAG, dsp.ki.FIRE_FRAGMENT)
-        elseif os.time() >= npc:getLocalVar("cooldown") then
+        elseif os.time() <= npc:getLocalVar("cooldown") then
             if not GetMobByID(TIPHA):isSpawned() and not GetMobByID(CARTHI):isSpawned() then
                 player:startEvent(200, dsp.ki.FIRE_FRAGMENT)
             else


### PR DESCRIPTION
Reverts DarkstarProject/darkstar#5033 

This doesn't fix the Mission, it just takes away the free Fire Fragment, and replaces it with endless NM's

This used to work properly before someone got rid of the server variable telling the headstone not to pop the NM's if they have recently been defeated.