### PR TITLE
Goblin Wolfman not Spawning at Scrawled Writing

### DIFF
--- a/scripts/zones/Oldton_Movalpolos/mobs/Goblin_Wolfman.lua
+++ b/scripts/zones/Oldton_Movalpolos/mobs/Goblin_Wolfman.lua
@@ -1,0 +1,20 @@
+-----------------------------------
+-- Area: Oldton Movalpolos
+--  MOB: Goblin Wolfman
+-----------------------------------
+require("scripts/zones/Oldton_Movalpolos/MobIDs");
+require("scripts/globals/settings");
+require("scripts/globals/status");
+-----------------------------------
+
+function onMobInitialize(mob)
+mob:setMobMod(dsp.mobMod.IDLE_DESPAWN, 55);
+
+function onMobSpawn(mob)
+end;
+
+function onMobDeath(mob, player, isKiller)
+end;
+
+function onMobDespawn(mob)
+end;

--- a/scripts/zones/Oldton_Movalpolos/mobs/Goblin_Wolfman.lua
+++ b/scripts/zones/Oldton_Movalpolos/mobs/Goblin_Wolfman.lua
@@ -8,7 +8,7 @@ require("scripts/globals/status");
 -----------------------------------
 
 function onMobInitialize(mob)
-    mob:setMobMod(dsp.mobMod.IDLE_DESPAWN, 55);
+    mob:setMobMod(dsp.mobMod.IDLE_DESPAWN, 180);
 end;
 
 function onMobSpawn(mob)

--- a/scripts/zones/Oldton_Movalpolos/mobs/Goblin_Wolfman.lua
+++ b/scripts/zones/Oldton_Movalpolos/mobs/Goblin_Wolfman.lua
@@ -8,7 +8,8 @@ require("scripts/globals/status");
 -----------------------------------
 
 function onMobInitialize(mob)
-mob:setMobMod(dsp.mobMod.IDLE_DESPAWN, 55);
+    mob:setMobMod(dsp.mobMod.IDLE_DESPAWN, 55);
+end;
 
 function onMobSpawn(mob)
 end;

--- a/scripts/zones/Oldton_Movalpolos/npcs/Scrawled_Writing.lua
+++ b/scripts/zones/Oldton_Movalpolos/npcs/Scrawled_Writing.lua
@@ -14,7 +14,7 @@ function onTrade(player,npc,trade)
         local x = npc:getXPos();
         local y = npc:getYPos();
         local z = npc:getZPos();
-        mob:setPos(x-1,y,z);
+        mob:setSpawn(x-1,y,z)
         SpawnMob(GOBLIN_WOLFMAN):updateClaim(player);
     end
 end;


### PR DESCRIPTION
Goblin Wolfman will spawn in his default spawn pos, then move to the Scrawled Writing resulting in sitting in the default spawn location because the setPos is used before the mob is spawned.

Ideally it's best to use setSpawn to spawn at the onTrade location instead of spawning it else where and using setPos to relocate it.