### PR TITLE
Fix quest SAY_IT_WITH_FLOWERS

### DIFF
--- a/scripts/zones/Windurst_Waters/npcs/Moari-Kaaori.lua
+++ b/scripts/zones/Windurst_Waters/npcs/Moari-Kaaori.lua
@@ -1,92 +1,87 @@
 -----------------------------------
 -- Area: Windurst Waters
 --  NPC: Moari-Kaaori
--- Working 100%
 -----------------------------------
-package.loaded["scripts/zones/Windurst_Waters/TextIDs"] = nil;
+package.loaded["scripts/zones/Windurst_Waters/TextIDs"] = nil
 -----------------------------------
-require("scripts/zones/Windurst_Waters/TextIDs");
-require("scripts/globals/quests");
-require("scripts/globals/titles");
-require("scripts/globals/settings");
+require("scripts/zones/Windurst_Waters/TextIDs")
+require("scripts/globals/settings")
+require("scripts/globals/quests")
+require("scripts/globals/titles")
 -----------------------------------
 
-function onTrade(player,npc,trade)
-    local SayFlowers = player:getQuestStatus(WINDURST,SAY_IT_WITH_FLOWERS);
-    local FlowerProgress = player:getVar("FLOWER_PROGRESS");
-    local offer = trade:getItemId();
+function onTrade(player, npc, trade)
+    local SayFlowers = player:getQuestStatus(WINDURST, SAY_IT_WITH_FLOWERS)
+    local FlowerProgress = player:getVar("FLOWER_PROGRESS")
+    local offer = trade:getItemId()
 
-    if (FlowerProgress == 3) then
-        if (trade:hasItemQty(950, 1) and trade:getItemCount() == 1) then
-            if (SayFlowers == QUEST_COMPLETED) then
-                player:startEvent(525,GIL_RATE*400);
+    if FlowerProgress == 3 then
+        if trade:hasItemQty(950, 1) and trade:getItemCount() == 1 then
+            if SayFlowers == QUEST_COMPLETED then
+                player:startEvent(525, GIL_RATE*400)
             else
-                player:startEvent(520);
+                player:startEvent(520)
             end
-        elseif (offer == 941 or offer == 948 or offer == 949 or offer == 956 or offer == 957 or offer == 958) then
-            player:startEvent(522); -- Brought wrong flowers.
+        elseif offer == 941 or offer == 948 or offer == 949 or offer == 956 or offer == 957 or offer == 958 then
+            player:startEvent(522) -- Brought wrong flowers.
         end
     end
-end;
+end
 
-function onTrigger(player,npc)
-    local SayFlowers = player:getQuestStatus(WINDURST,SAY_IT_WITH_FLOWERS);
-    local FlowerProgress = player:getVar("FLOWER_PROGRESS");
-    local NeedToZone = player:needToZone();
+function onTrigger(player, npc)
+    local SayFlowers = player:getQuestStatus(WINDURST, SAY_IT_WITH_FLOWERS)
+    local FlowerProgress = player:getVar("FLOWER_PROGRESS")
+    local NeedToZone = player:needToZone()
 
-    if (FlowerProgress == 3 or FlowerProgress == 1) then
-        player:startEvent(515); -- Waiting for trade.
-    elseif (SayFlowers == QUEST_COMPLETED and NeedToZone == true and FlowerProgress == 0) then -- Must zone to retry quest.
-        player:startEvent(521);
-    elseif (SayFlowers == QUEST_COMPLETED and NeedToZone == false and FlowerProgress == 0) then
-        player:startEvent(523); -- Repeat Say It with Flowers.
-    elseif (SayFlowers == QUEST_AVAILABLE and player:getFameLevel(WINDURST) >= 2) then
-        player:startEvent(514); -- Begin Say It with Flowers.
+    if SayFlowers == QUEST_AVAILABLE and player:getFameLevel(WINDURST) >= 2 then
+        player:startEvent(514) -- Begin Say It with Flowers.
+    elseif FlowerProgress == 3 or FlowerProgress == 1 then
+        player:startEvent(515) -- Waiting for trade.
+    elseif SayFlowers == QUEST_COMPLETED and NeedToZone and FlowerProgress == 0 then -- Must zone to retry quest.
+        player:startEvent(521)
+    elseif SayFlowers == QUEST_COMPLETED and FlowerProgress == 0 then
+        player:startEvent(523) -- Repeat Say It with Flowers.
     else
-        player:startEvent(512);
+        player:startEvent(512)
     end
-end;
+end
 
-function onEventUpdate(player,csid,option)
-end;
+function onEventUpdate(player, csid, option)
+end
 
-function onEventFinish(player,csid,option)
-
-    if (csid == 514 and option == 1) then
-        player:setVar("FLOWER_PROGRESS",1);
-        player:addQuest(WINDURST,SAY_IT_WITH_FLOWERS);
-    elseif (csid == 520) then -- First completion, Iron Sword awarded.
-        if (player:getFreeSlotsCount() > 0) then
-            player:tradeComplete();
-            player:addItem(16536);
-            player:completeQuest(WINDURST,SAY_IT_WITH_FLOWERS);
-            player:addFame(WINDURST,30);
-            player:messageSpecial(ITEM_OBTAINED,16536);
-            player:setVar("FLOWER_PROGRESS",0);
-            player:needToZone(true);
-            player:setTitle(dsp.title.CUPIDS_FLORIST);
+function onEventFinish(player, csid, option)
+    if csid == 514 and option == 1 then
+        player:setVar("FLOWER_PROGRESS", 1)
+        player:addQuest(WINDURST, SAY_IT_WITH_FLOWERS)
+    elseif csid == 520 then -- First completion, Iron Sword awarded.
+        if player:getFreeSlotsCount() > 0 then
+            player:tradeComplete()
+            player:addItem(16536)
+            player:completeQuest(WINDURST, SAY_IT_WITH_FLOWERS)
+            player:addFame(WINDURST, 30)
+            player:messageSpecial(ITEM_OBTAINED, 16536)
+            player:setVar("FLOWER_PROGRESS", 0)
+            player:needToZone(true)
+            player:setTitle(dsp.title.CUPIDS_FLORIST)
         else
-            player:messageSpecial(ITEM_CANNOT_BE_OBTAINED,16536);
+            player:messageSpecial(ITEM_CANNOT_BE_OBTAINED, 16536)
         end
-    elseif (csid == 522) then -- Wrong flowers so complete quest, but smaller reward/fame and no title.
-        player:completeQuest(WINDURST,SAY_IT_WITH_FLOWERS);
-        player:tradeComplete();
-        player:addGil(GIL_RATE * 100);
-        player:messageSpecial(GIL_OBTAINED,100);
-        player:addFame(WINDURST,10);
-        player:needToZone(true);
-        player:setVar("FLOWER_PROGRESS",0);
-    elseif (csid == 525) then -- Repeatable quest rewards.
-        player:tradeComplete();
-        player:addFame(WINDURST,30);
-        player:addGil(GIL_RATE * 400);
-        player:setVar("FLOWER_PROGRESS",0);
-        player:needToZone(true);
-        player:setTitle(dsp.title.CUPIDS_FLORIST);
-    elseif (csid == 523) then
-        player:setVar("FLOWER_PROGRESS",1);
+    elseif csid == 522 then -- Wrong flowers so complete quest, but smaller reward/fame and no title.
+        player:completeQuest(WINDURST, SAY_IT_WITH_FLOWERS)
+        player:tradeComplete()
+        player:addGil(GIL_RATE * 100)
+        player:messageSpecial(GIL_OBTAINED, 100)
+        player:addFame(WINDURST, 10)
+        player:needToZone(true)
+        player:setVar("FLOWER_PROGRESS", 0)
+    elseif csid == 523 then
+        player:setVar("FLOWER_PROGRESS", 1)
+    elseif csid == 525 then -- Repeatable quest rewards.
+        player:tradeComplete()
+        player:addFame(WINDURST, 30)
+        player:addGil(GIL_RATE * 400)
+        player:setVar("FLOWER_PROGRESS", 0)
+        player:needToZone(true)
+        player:setTitle(dsp.title.CUPIDS_FLORIST)
     end
-end;
-
-
-
+end

--- a/scripts/zones/Windurst_Waters/npcs/Moari-Kaaori.lua
+++ b/scripts/zones/Windurst_Waters/npcs/Moari-Kaaori.lua
@@ -39,9 +39,9 @@ function onTrigger(player,npc)
     elseif (SayFlowers == QUEST_COMPLETED and NeedToZone == true and FlowerProgress == 0) then -- Must zone to retry quest.
         player:startEvent(521);
     elseif (SayFlowers == QUEST_COMPLETED and NeedToZone == false and FlowerProgress == 0) then
-        player:startEvent(514); -- Repeat Say It with Flowers.
+        player:startEvent(523); -- Repeat Say It with Flowers.
     elseif (SayFlowers == QUEST_AVAILABLE and player:getFameLevel(WINDURST) >= 2) then
-        player:startEvent(523); -- Begin Say It with Flowers.
+        player:startEvent(514); -- Begin Say It with Flowers.
     else
         player:startEvent(512);
     end
@@ -53,12 +53,8 @@ end;
 function onEventFinish(player,csid,option)
 
     if (csid == 514 and option == 1) then
-        if (player:getQuestStatus(WINDURST,SAY_IT_WITH_FLOWERS) == QUEST_COMPLETED) then
-            player:setVar("FLOWER_PROGRESS",1);
-        else
-            player:addQuest(WINDURST,SAY_IT_WITH_FLOWERS);
-            player:setVar("FLOWER_PROGRESS",1);
-        end
+        player:setVar("FLOWER_PROGRESS",1);
+        player:addQuest(WINDURST,SAY_IT_WITH_FLOWERS);
     elseif (csid == 520) then -- First completion, Iron Sword awarded.
         if (player:getFreeSlotsCount() > 0) then
             player:tradeComplete();


### PR DESCRIPTION
The cs's were flipped between the initial quest and repeats, so he'd set the variable but not add the quest for new players and would keep re-adding the quest for people who had it finished. Additionally the quest status was being checked twice - once before starting the cs, and once on the end of the cs. Since its a different cs for repeats, this is not needed.

1st commit is the actual logic fixes, 2nd commit formatting/styling