### PR TITLE
Add some Coeurl skills

### DIFF
--- a/scripts/globals/mobskills/charged_whisker.lua
+++ b/scripts/globals/mobskills/charged_whisker.lua
@@ -2,21 +2,19 @@
 -- Charged Whisker
 -- Deals Lightning damage to enemies within area of effect.
 ---------------------------------------------------
-
-require("scripts/globals/settings");
-require("scripts/globals/status");
-require("scripts/globals/monstertpmoves");
-
+require("scripts/globals/monstertpmoves")
+require("scripts/globals/settings")
+require("scripts/globals/status")
 ---------------------------------------------------
 
 function onMobSkillCheck(target,mob,skill)
-    return 0;
-end;
+    return 0
+end
 
 function onMobWeaponSkill(target, mob, skill)
-    local dmgmod = 1;
-    local info = MobMagicalMove(mob,target,skill,mob:getWeaponDmg()*2.8,dsp.magic.ele.THUNDER,dmgmod,TP_MAB_BONUS,1);
-    local dmg = MobFinalAdjustments(info.dmg,mob,skill,target,MOBSKILL_MAGICAL,MOBPARAM_THUNDER,MOBPARAM_WIPE_SHADOWS);
-    target:delHP(dmg);
-    return dmg;
-end;
+    local dmgmod = 2.5
+    local info = MobMagicalMove(mob,target,skill,mob:getWeaponDmg()*2.8,dsp.magic.ele.THUNDER,dmgmod,TP_MAB_BONUS,1)
+    local dmg = MobFinalAdjustments(info.dmg,mob,skill,target,MOBSKILL_MAGICAL,MOBPARAM_THUNDER,MOBPARAM_WIPE_SHADOWS)
+    target:delHP(dmg)
+    return dmg
+end

--- a/scripts/globals/mobskills/frenzied_rage.lua
+++ b/scripts/globals/mobskills/frenzied_rage.lua
@@ -1,0 +1,27 @@
+---------------------------------------------
+-- Frenzied Rage
+--
+-- Description: Attack Boost
+-- Type: Enhancing
+-- Utsusemi/Blink absorb: N/A
+-- Range: Self
+-- Notes: 20% Attack Boost.
+---------------------------------------------
+require("scripts/globals/monstertpmoves")
+require("scripts/globals/settings")
+require("scripts/globals/status")
+---------------------------------------------
+
+function onMobSkillCheck(target,mob,skill)
+    return 0
+end
+
+function onMobWeaponSkill(target, mob, skill)
+    local power = 20
+    local duration = 120
+
+    local typeEffect = dsp.effect.ATTACK_BOOST
+
+    skill:setMsg(MobBuffMove(mob, typeEffect, power, 0, duration))
+    return typeEffect
+end

--- a/scripts/globals/mobskills/petrifactive_breath.lua
+++ b/scripts/globals/mobskills/petrifactive_breath.lua
@@ -1,0 +1,25 @@
+---------------------------------------------
+-- Petrifactive Breath
+--
+-- Description: Petrifies a single target.
+-- Type: Breath
+-- Utsusemi/Blink absorb: Ignores shadows
+-- Range: Unknown
+-- Notes:
+---------------------------------------------
+require("scripts/globals/monstertpmoves")
+require("scripts/globals/settings")
+require("scripts/globals/status")
+---------------------------------------------
+
+function onMobSkillCheck(target,mob,skill)
+    return 0
+end
+
+function onMobWeaponSkill(target, mob, skill)
+    local typeEffect = dsp.effect.PETRIFICATION
+
+    skill:setMsg(MobStatusEffectMove(mob, target, typeEffect, 1, 0, math.random(15,45)))
+
+    return typeEffect
+end

--- a/scripts/globals/mobskills/pounce.lua
+++ b/scripts/globals/mobskills/pounce.lua
@@ -1,0 +1,21 @@
+---------------------------------------------------
+-- Pounce: Deals damage to a single target.
+---------------------------------------------
+require("scripts/globals/monstertpmoves")
+require("scripts/globals/settings")
+require("scripts/globals/status")
+---------------------------------------------
+
+function onMobSkillCheck(target,mob,skill)
+    return 0
+end
+
+function onMobWeaponSkill(target, mob, skill)
+    local numhits = 1
+    local accmod = 1
+    local dmgmod = 2.4
+    local info = MobPhysicalMove(mob,target,skill,numhits,accmod,dmgmod,TP_DMG_VARIES,1,2,3)
+    local dmg = MobFinalAdjustments(info.dmg,mob,skill,target,MOBSKILL_PHYSICAL,MOBPARAM_SLASH,info.hitslanded)
+    target:delHP(dmg)
+    return dmg
+end

--- a/sql/mob_skills.sql
+++ b/sql/mob_skills.sql
@@ -299,10 +299,10 @@ INSERT INTO `mob_skills` VALUES (476,220,'curse',1,15.0,2000,1500,4,0,0,0,0,0,0)
 INSERT INTO `mob_skills` VALUES (477,221,'dark_sphere',0,7.0,2000,1500,4,0,0,0,0,0,0);
 INSERT INTO `mob_skills` VALUES (478,222,'hell_slash',0,7.0,2000,1500,4,0,0,0,0,0,0);
 INSERT INTO `mob_skills` VALUES (479,223,'horror_cloud',0,7.0,2000,1500,4,0,0,0,0,0,0);
--- INSERT INTO `mob_skills` VALUES (480,224,'petrifactive_breath',0,7.0,2000,1500,4,0,0,0,0,0,0);
+INSERT INTO `mob_skills` VALUES (480,288,'petrifactive_breath',0,7.0,2000,1500,4,0,0,0,0,0,0);
 -- INSERT INTO `mob_skills` VALUES (481,225,'frenzied_rage',0,7.0,2000,1500,4,0,0,0,0,0,0);
--- INSERT INTO `mob_skills` VALUES (482,226,'pounce',0,7.0,2000,1500,4,0,0,0,0,0,0);
--- INSERT INTO `mob_skills` VALUES (483,227,'charged_whisker',0,7.0,2000,1500,4,0,0,0,0,0,0);
+INSERT INTO `mob_skills` VALUES (482,290,'pounce',0,7.0,2000,1500,4,0,0,0,0,0,0);
+INSERT INTO `mob_skills` VALUES (483,291,'charged_whisker',1,12.5,2000,2000,4,0,0,0,0,0,0);
 INSERT INTO `mob_skills` VALUES (484,228,'black_cloud',1,15.0,2000,1500,4,0,0,0,0,0,0);
 INSERT INTO `mob_skills` VALUES (485,229,'blood_saber',1,15.0,2000,1500,4,0,0,0,0,0,0);
 INSERT INTO `mob_skills` VALUES (486,230,'whip_tongue',0,7.0,2000,1500,4,0,0,1,0,0,0);
@@ -1155,7 +1155,7 @@ INSERT INTO `mob_skills` VALUES (1330,1074,'hoof_volley',0,7.0,2000,1500,4,0,0,2
 -- INSERT INTO `mob_skills` VALUES (1333,1077,'contagion_transfer',0,7.0,2000,1500,4,0,0,0,0,0,0);
 -- INSERT INTO `mob_skills` VALUES (1334,1078,'contamination',0,7.0,2000,1500,4,0,0,0,0,0,0);
 -- INSERT INTO `mob_skills` VALUES (1335,1079,'toxic_pick',0,7.0,2000,1500,4,0,0,0,0,0,0);
--- INSERT INTO `mob_skills` VALUES (1336,1080,'frenzied_rage',0,7.0,2000,1500,4,0,0,0,0,0,0);
+INSERT INTO `mob_skills` VALUES (1336,289,'frenzied_rage',0,7.0,2000,1500,1,0,0,0,0,0,0);
 -- INSERT INTO `mob_skills` VALUES (1337,1081,'charm',0,7.0,2000,1500,4,0,0,0,0,0,0);
 -- INSERT INTO `mob_skills` VALUES (1338,1082,'infernal_pestilence',0,7.0,2000,1500,4,0,0,0,0,0,0);
 -- INSERT INTO `mob_skills` VALUES (1339,1083,'bane',0,7.0,2000,1500,4,0,0,0,0,0,0);


### PR DESCRIPTION
I added:
-Petrifactive Breath
-Frenzied Rage
-Pounce
by taking similar .lua's for mobskills already existing and changing them a bit to reflect the new mobskills
my models were: (Petribreath, Sharp Strike, and Big Scissors)

I changed:
-Charged Whisker (dmgmod)
From researching websites as well as retail testing, this is what *I felt* was the best number to put in there for more retail realistic play. It's nothing more than a best guess because I did not spend enough time to really get a most accurate number. If we don't like this I can just put it back.

I've put these in place ahead of working on some of the BCNM's I've been capturing for when they're ready to be implemented. The main inspiration for these was "Wild Wild Whiskers" BCNM which you can watch the videos in the BCNM channel on discord.