### PR TITLE
Implemented CSpecialReleasePacket

### DIFF
--- a/src/map/packet_system.cpp
+++ b/src/map/packet_system.cpp
@@ -131,6 +131,7 @@ This file is part of DarkStar-server source code.
 #include "packets/party_search.h"
 #include "packets/position.h"
 #include "packets/release.h"
+#include "packets/release_special.h"
 #include "packets/server_ip.h"
 #include "packets/server_message.h"
 #include "packets/shop_appraise.h"
@@ -4908,6 +4909,21 @@ void SmallPacket0x0EA(map_session_data_t* session, CCharEntity* PChar, CBasicPac
 
 /************************************************************************
 *                                                                       *
+*  Special Release Request                                              *
+*                                                                       *
+************************************************************************/
+
+void SmallPacket0x0EB(map_session_data_t* session, CCharEntity* PChar, CBasicPacket data)
+{
+    if (PChar->m_event.EventID == -1)
+        return;
+
+    PChar->pushPacket(new CSpecialReleasePacket(PChar));
+    return;
+}
+
+/************************************************************************
+*                                                                       *
 *  Cancel Status Effect                                                 *
 *                                                                       *
 ************************************************************************/
@@ -5951,6 +5967,7 @@ void PacketParserInitialize()
     PacketSize[0x0E7] = 0x04; PacketParser[0x0E7] = &SmallPacket0x0E7;
     PacketSize[0x0E8] = 0x04; PacketParser[0x0E8] = &SmallPacket0x0E8;
     PacketSize[0x0EA] = 0x00; PacketParser[0x0EA] = &SmallPacket0x0EA;
+    PacketSize[0x0EB] = 0x00; PacketParser[0x0EB] = &SmallPacket0x0EB;
     PacketSize[0x0F1] = 0x00; PacketParser[0x0F1] = &SmallPacket0x0F1;
     PacketSize[0x0F2] = 0x00; PacketParser[0x0F2] = &SmallPacket0x0F2;
     PacketSize[0x0F4] = 0x04; PacketParser[0x0F4] = &SmallPacket0x0F4;

--- a/src/map/packets/release_special.cpp
+++ b/src/map/packets/release_special.cpp
@@ -1,0 +1,33 @@
+/*
+===========================================================================
+
+Copyright (c) 2010-2018 Darkstar Dev Teams
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see http://www.gnu.org/licenses/
+
+This file is part of DarkStar-server source code.
+
+===========================================================================
+*/
+
+#include "release_special.h"
+#include "../entities/charentity.h"
+
+CSpecialReleasePacket::CSpecialReleasePacket(CCharEntity* PChar)
+{
+    this->id(0x10E);
+    this->length(0x08);
+
+    ref<uint8>(0x04) = 0;    // unknown1
+}

--- a/src/map/packets/release_special.h
+++ b/src/map/packets/release_special.h
@@ -1,0 +1,38 @@
+/*
+===========================================================================
+
+Copyright (c) 2010-2018 Darkstar Dev Teams
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see http://www.gnu.org/licenses/
+
+This file is part of DarkStar-server source code.
+
+===========================================================================
+*/
+
+#ifndef _CRELEASE_SPECIALPACKET_H
+#define _CRELEASE_SPECIALPACKET_H
+
+#include "basic.h"
+
+class CCharEntity;
+
+class CSpecialReleasePacket : public CBasicPacket
+{
+public:
+
+    CSpecialReleasePacket(CCharEntity* PChar);
+};
+
+#endif

--- a/win32/vcxproj/DSGame-server.vcxproj
+++ b/win32/vcxproj/DSGame-server.vcxproj
@@ -387,6 +387,7 @@
     <ClInclude Include="..\..\src\map\packets\message_system.h" />
     <ClInclude Include="..\..\src\map\packets\message_text.h" />
     <ClInclude Include="..\..\src\map\packets\party_effects.h" />
+    <ClInclude Include="..\..\src\map\packets\release_special.h" />
     <ClInclude Include="..\..\src\map\packets\status_effects.h" />
     <ClInclude Include="..\..\src\map\packets\synth_result.h" />
     <ClInclude Include="..\..\src\map\packets\synth_suggestion.h" />
@@ -629,6 +630,7 @@
     <ClCompile Include="..\..\src\map\packets\message_system.cpp" />
     <ClCompile Include="..\..\src\map\packets\message_text.cpp" />
     <ClCompile Include="..\..\src\map\packets\party_effects.cpp" />
+    <ClCompile Include="..\..\src\map\packets\release_special.cpp" />
     <ClCompile Include="..\..\src\map\packets\status_effects.cpp" />
     <ClCompile Include="..\..\src\map\packets\synth_result.cpp" />
     <ClCompile Include="..\..\src\map\packets\synth_suggestion.cpp" />

--- a/win32/vcxproj/DSGame-server.vcxproj.filters
+++ b/win32/vcxproj/DSGame-server.vcxproj.filters
@@ -863,6 +863,9 @@
     <ClInclude Include="..\..\src\map\packets\event_update_string.h">
       <Filter>Header Files\packets</Filter>
     </ClInclude>
+    <ClInclude Include="..\..\src\map\packets\release_special.h">
+      <Filter>Header Files\packets</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="..\..\src\map\ability.cpp">
@@ -1580,6 +1583,9 @@
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="..\..\src\map\packets\event_update_string.cpp">
+      <Filter>Source Files\packets</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\map\packets\release_special.cpp">
       <Filter>Source Files\packets</Filter>
     </ClCompile>
   </ItemGroup>


### PR DESCRIPTION
Implements 0x10E.

Required for Windurst 9-2 (and currently, the only thing captured using it).