### PR TITLE
Fixed entities with subanimations on client spawn

### DIFF
--- a/src/map/ai/controllers/mob_controller.cpp
+++ b/src/map/ai/controllers/mob_controller.cpp
@@ -780,14 +780,6 @@ void CMobController::DoRoamTick(time_point tick)
                     if(spellID)
                         CastSpell(spellID.value());
                 }
-                else if ((PMob->m_roamFlags & ROAMFLAG_STEALTH))
-                {
-                    // hidden name
-                    PMob->HideName(true);
-                    PMob->Untargetable(true);
-
-                    PMob->updatemask |= UPDATE_HP;
-                }
                 else if (PMob->m_roamFlags & ROAMFLAG_EVENT)
                 {
                     // allow custom event action
@@ -806,6 +798,14 @@ void CMobController::DoRoamTick(time_point tick)
 
                         // don't move around until i'm fully in the ground
                         Wait(2s);
+                    }
+                    else if ((PMob->m_roamFlags & ROAMFLAG_STEALTH))
+                    {
+                        // hidden name
+                        PMob->HideName(true);
+                        PMob->Untargetable(true);
+
+                        PMob->updatemask |= UPDATE_HP;
                     }
                     else
                     {

--- a/src/map/packets/entity_update.cpp
+++ b/src/map/packets/entity_update.cpp
@@ -61,6 +61,8 @@ CEntityUpdatePacket::CEntityUpdatePacket(CBaseEntity* PEntity, ENTITYUPDATE type
             {
                 updatemask = 0x57;
             }
+            if (PEntity->animationsub != 0)
+                ref<uint8>(0x2A) = 4;
             ref<uint8>(0x0A) = updatemask;
         }
         break;
@@ -94,7 +96,7 @@ CEntityUpdatePacket::CEntityUpdatePacket(CBaseEntity* PEntity, ENTITYUPDATE type
             {
                 ref<uint8>(0x1E) = 0x64;
                 ref<uint8>(0x1F) = PEntity->animation;
-                ref<uint8>(0x2A) = PEntity->animationsub;
+                ref<uint8>(0x2A) |= PEntity->animationsub;
                 ref<uint32>(0x21) = ((CNpcEntity*)PEntity)->m_flags;
                 ref<uint8>(0x27) = ((CNpcEntity*)PEntity)->name_prefix;     // gender and something else
                 ref<uint8>(0x29) = PEntity->allegiance;
@@ -124,7 +126,7 @@ CEntityUpdatePacket::CEntityUpdatePacket(CBaseEntity* PEntity, ENTITYUPDATE type
                 {
                     ref<uint8>(0x1E) = PMob->GetHPP();
                     ref<uint8>(0x1F) = PEntity->animation;
-                    ref<uint8>(0x2A) = PEntity->animationsub;
+                    ref<uint8>(0x2A) |= PEntity->animationsub;
                     ref<uint32>(0x21) = PMob->m_flags;
                     ref<uint8>(0x25) = PMob->health.hp > 0 ? 0x08 : 0;
                     ref<uint8>(0x27) = PMob->m_name_prefix;


### PR DESCRIPTION
also fixed ROAMFLAG_STEALTH updating the hp updatemask every tick instead of only on roam start