### PR TITLE
Correct Anims -Seether Mob Abilities + Wanion Script

### DIFF
--- a/scripts/globals/mobskills/wanion.lua
+++ b/scripts/globals/mobskills/wanion.lua
@@ -1,43 +1,31 @@
 ---------------------------------------------
 -- Wanion
--- AoE of all status ailments it has.
+-- Transfers all ailments the Seether itself has to players in AoE range.
 ---------------------------------------------
-require("scripts/globals/monstertpmoves");
-require("scripts/globals/settings");
-require("scripts/globals/status");
-require("scripts/globals/msg");
+require("scripts/globals/monstertpmoves")
+require("scripts/globals/status")
+require("scripts/globals/msg")
 ---------------------------------------------
 
 function onMobSkillCheck(target,mob,skill)
-    return 0;
-end;
+    return 0
+end
 
 function onMobWeaponSkill(target, mob, skill)
     -- list of effects to give in AoE
-    local effects = {dsp.effect.SLOW, dsp.effect.DIA, dsp.effect.BIO, dsp.effect.WEIGHT, dsp.effect.DEFENSE_DOWN, dsp.effect.PARALYSIS, dsp.effect.BLINDNESS, dsp.effect.SILENCE, dsp.effect.POISON}
-    local lastEffect = 0;
-    local effectCount = false;
+    local effects = {dsp.effect.POISON,dsp.effect.PARALYSIS,dsp.effect.BLINDNESS,dsp.effect.SILENCE,
+        dsp.effect.WEIGHT,dsp.effect.SLOW,dsp.effect.ADDLE,dsp.effect.DIA,dsp.effect.BIO,dsp.effect.BURN,
+        dsp.effect.FROST,dsp.effect.CHOKE,dsp.effect.RASP,dsp.effect.SHOCK,dsp.effect.DROWN,dsp.effect.STR_DOWN,
+        dsp.effect.DEX_DOWN,dsp.effect.VIT_DOWN,dsp.effect.AGI_DOWN,dsp.effect.INT_DOWN,dsp.effect.MND_DOWN,
+        dsp.effect.CHR_DOWN,dsp.effect.ACCURACY_DOWN,dsp.effect.ATTACK_DOWN,dsp.effect.EVASION_DOWN,
+        dsp.effect.DEFENSE_DOWN,dsp.effect.MAGIC_DEF_DOWN,dsp.effect.MAGIC_ACC_DOWN,dsp.effect.MAGIC_ATK_DOWN}
 
     for i, effect in ipairs(effects) do
-        if (mob:hasStatusEffect(effect) == true) then
-            effectCount = true;
-            local currentEffect = mob:getStatusEffect(effect);
-            local msg = MobStatusEffectMove(mob, target, effect, currentEffect:getPower(), currentEffect:getTick(), 120);
-            if (msg == dsp.msg.basic.SKILL_ENFEEB_IS) then
-                lastEffect = effect;
-            end
+        if mob:hasStatusEffect(effect) then
+            local currentEffect = mob:getStatusEffect(effect)
+            MobStatusEffectMove(mob, target, effect, currentEffect:getPower(), currentEffect:getTick(), currentEffect:getTimeRemaining() / 1000)
+            mob:delStatusEffect(effect)
         end
     end
-
-    -- all resisted
-    if (lastEffect == 0) then
-        skill:setMsg(dsp.msg.basic.RESIST);
-    end
-
-    -- no effects present
-    if (effectCount == false) then
-        skill:setMsg(dsp.msg.basic.SKILL_NO_EFFECT);
-    end
-
-    return lastEffect;
-end;
+    skill:setMsg(dsp.msg.basic.NONE)
+end

--- a/sql/mob_skills.sql
+++ b/sql/mob_skills.sql
@@ -1072,12 +1072,12 @@ INSERT INTO `mob_skills` VALUES (1249,940,'spirit_tap',0,7.0,2000,1500,4,0,0,0,0
 INSERT INTO `mob_skills` VALUES (1250,941,'binary_tap',0,7.0,2000,1500,4,0,0,0,0,0,0);
 INSERT INTO `mob_skills` VALUES (1251,941,'trinary_tap',0,7.0,2000,1500,4,0,0,0,0,0,0);
 INSERT INTO `mob_skills` VALUES (1252,943,'shadow_spread',1,15.0,2000,1500,4,0,0,0,0,0,0);
-INSERT INTO `mob_skills` VALUES (1253,872,'vanity_strike',0,7.0,2000,1500,4,0,0,0,0,0,0);
-INSERT INTO `mob_skills` VALUES (1254,872,'wanion',1,10.0,2000,1500,4,0,0,0,0,0,0);
-INSERT INTO `mob_skills` VALUES (1255,873,'occultation',0,7.0,2000,1500,1,0,0,0,0,0,0);
-INSERT INTO `mob_skills` VALUES (1256,874,'empty_crush',0,7.0,2000,1500,4,0,0,0,0,0,0);
+INSERT INTO `mob_skills` VALUES (1253,956,'vanity_strike',0,7.0,2000,1500,4,0,0,0,0,0,0);
+INSERT INTO `mob_skills` VALUES (1254,957,'wanion',1,10.0,2000,1500,4,0,0,0,0,0,0);
+INSERT INTO `mob_skills` VALUES (1255,958,'occultation',0,7.0,2000,1500,1,0,0,0,0,0,0);
+INSERT INTO `mob_skills` VALUES (1256,959,'empty_crush',0,7.0,2000,1500,4,0,0,2,0,0,0);
 -- INSERT INTO `mob_skills` VALUES (1257,1001,'special_attack',0,7.0,2000,1500,4,0,0,0,0,0,0);
-INSERT INTO `mob_skills` VALUES (1258,876,'lamentation',1,10.0,2000,1500,4,0,0,0,0,0,0);
+INSERT INTO `mob_skills` VALUES (1258,961,'lamentation',1,10.0,2000,1500,4,0,0,0,0,0,0);
 INSERT INTO `mob_skills` VALUES (1259,944,'wire_cutter',0,10.0,2000,1500,4,0,0,0,0,0,0);
 INSERT INTO `mob_skills` VALUES (1260,945,'antimatter',0,10.0,2000,1500,4,0,0,0,0,0,0);
 INSERT INTO `mob_skills` VALUES (1261,946,'equalizer',2,10.0,2000,1500,4,0,0,0,0,0,0);


### PR DESCRIPTION
Pulled some animation ids from retail while sitting at a seether for a couple hours. Also, noted empty crush to have a slight knockback effect (I guessed at 2 seems close to me - someone else can correct me if they watch the vid after it uploads)

Wanion- lots of things changed
1. The GIANT list of effects in the effects table... it would probably be nice if there were an ailments effect flag but for lack of that, I didn't know how else to do it but to continue the table that was already in place.
2. I'm sure there are more ailments that wanion transfers (i.e. songs) but I haven't confirmed that so I left them off. I can surely add anything anyone wants to tell me they know that should be on the list.
3. When effects are transferred the duration is also transferred.
4. There are no messages for wanion (either success or miss) other than the message(s) of what effect(s) the mob has LOST. Which is handled nicely with the delStatusEffect()

This PR fixes the issue which caused crashes with clients and also debug breaks with dsp, which I cannot currently find in the issue tracker for some reason... ???