### PR TITLE
Prevent exploiting mobs with navmesh over impassible terrain

### DIFF
--- a/src/map/ai/helpers/pathfind.cpp
+++ b/src/map/ai/helpers/pathfind.cpp
@@ -381,6 +381,7 @@ bool CPathFind::FindClosestPath(const position_t& start, const position_t& end)
 {
     m_points = m_PTarget->loc.zone->m_navMesh->findPath(start, end);
     m_currentPoint = 0;
+    m_points.push_back(end);  // this prevents exploits with navmesh / impassible terrain
 
     if (m_points.empty())
     {

--- a/src/map/ai/helpers/pathfind.cpp
+++ b/src/map/ai/helpers/pathfind.cpp
@@ -383,11 +383,13 @@ bool CPathFind::FindClosestPath(const position_t& start, const position_t& end)
     m_currentPoint = 0;
     m_points.push_back(end);  // this prevents exploits with navmesh / impassible terrain
 
+/* this check requirement is never met as intended since m_points are never empty when mob has a path
     if (m_points.empty())
     {
         // this is a trick to make mobs go up / down impassible terrain
         m_points.push_back(end);
     }
+*/
 
     return true;
 }


### PR DESCRIPTION
I've been running this for about a month and I'm very happy with the results, you guys can try it out and see if you like it.

What this does:
This forces a mob to kind of 'wallhack' through ALL areas of terrain that were previously impassible for them.
Before this, the only thing people could do to avoid this exploiting was to disable navmesh and that caused mobs to be able to aggro through walls and just walk straight at players with no regard to obstacles. With this, the mob will follow the path 'around' terrain as it normally would with navmesh enabled but, when it finds itself becoming 'stuck' it just simply walks through the area that was an issue and then continues to track players around terrain as normal.

No more nuking lizards in crawler's nest from the top ledge while they just stare up at you. No more standing in "safe spots" next to walls to get away from the mobs attacks. No more exploiting...