### PR TITLE
adjusted auto-repair kit and mana tank values

### DIFF
--- a/scripts/globals/abilities/pets/attachments/auto-repair_kit.lua
+++ b/scripts/globals/abilities/pets/attachments/auto-repair_kit.lua
@@ -4,35 +4,31 @@
 require("scripts/globals/status");
 
 function onEquip(pet)
-    pet:addMod(dsp.mod.HPP, 6)
+    pet:addMod(dsp.mod.HPP, 5)
 end
 
 function onUnequip(pet)
-    pet:delMod(dsp.mod.HPP, 6)
+    pet:delMod(dsp.mod.HPP, 5)
 end
 
+-- regen values from http://wiki.ffo.jp/html/8619.html
+local prefix = "autoRepairKit1_"
+local regenValues =
+{
+    [1] = {base=1, pct=0.125},
+    [2] = {base=1, pct=0.125},
+    [3] = {base=1, pct=0.125},
+}
+
 function onManeuverGain(pet,maneuvers)
-    local bonus = 0
-    local frame = pet:getAutomatonFrame()
-    if frame == 32 or frame == 33 then bonus = 1 end
-    if (maneuvers == 1) then
-        pet:addMod(dsp.mod.REGEN, 3 + bonus);
-    elseif (maneuvers == 2) then
-        pet:addMod(dsp.mod.REGEN, 4);
-    elseif (maneuvers == 3) then
-        pet:addMod(dsp.mod.REGEN, 4 + bonus);
-    end
+    local rVals = regenValues[maneuvers]
+    local power = math.floor(rVals.base + (pet:getMaxHP() * rVals.pct / 100))
+
+    pet:setLocalVar(prefix .. maneuvers, power)
+    pet:addMod(dsp.mod.REGEN, power)
 end
 
 function onManeuverLose(pet,maneuvers)
-    local bonus = 0
-    local frame = pet:getAutomatonFrame()
-    if frame == 32 or frame == 33 then bonus = 1 end
-    if (maneuvers == 1) then
-        pet:delMod(dsp.mod.REGEN, 3 + bonus);
-    elseif (maneuvers == 2) then
-        pet:delMod(dsp.mod.REGEN, 4);
-    elseif (maneuvers == 3) then
-        pet:delMod(dsp.mod.REGEN, 4 + bonus);
-    end
+    pet:delMod(dsp.mod.REGEN, pet:getLocalVar(prefix .. maneuvers))
+    pet:setLocalVar(prefix .. maneuvers, 0)
 end

--- a/scripts/globals/abilities/pets/attachments/auto-repair_kit_ii.lua
+++ b/scripts/globals/abilities/pets/attachments/auto-repair_kit_ii.lua
@@ -4,37 +4,31 @@
 require("scripts/globals/status");
 
 function onEquip(pet)
-    pet:addMod(dsp.mod.HPP, 13)
+    pet:addMod(dsp.mod.HPP, 10)
 end
 
 function onUnequip(pet)
-    pet:delMod(dsp.mod.HPP, 13)
+    pet:delMod(dsp.mod.HPP, 10)
 end
 
+-- regen values from http://wiki.ffo.jp/html/8619.html
+local prefix = "autoRepairKit2_"
+local regenValues =
+{
+    [1] = {base=3, pct=0.6},
+    [2] = {base=3, pct=0.6},
+    [3] = {base=3, pct=0.6},
+}
+
 function onManeuverGain(pet,maneuvers)
-    local bonus = 0
-    local frame = pet:getAutomatonFrame()
-    if frame == 32 or frame == 33 then bonus = 2 end
-    if (maneuvers == 1) then
-        pet:addMod(dsp.mod.REGEN, 11 + bonus);
-    elseif (maneuvers == 2) then
-        if frame == 34 then bonus = 1 end
-        pet:addMod(dsp.mod.REGEN, 11 + bonus);
-    elseif (maneuvers == 3) then
-        pet:addMod(dsp.mod.REGEN, 11 + bonus);
-    end
+    local rVals = regenValues[maneuvers]
+    local power = math.floor(rVals.base + (pet:getMaxHP() * rVals.pct / 100))
+
+    pet:setLocalVar(prefix .. maneuvers, power)
+    pet:addMod(dsp.mod.REGEN, power)
 end
 
 function onManeuverLose(pet,maneuvers)
-    local bonus = 0
-    local frame = pet:getAutomatonFrame()
-    if frame == 32 or frame == 33 then bonus = 2 end
-    if (maneuvers == 1) then
-        pet:delMod(dsp.mod.REGEN, 11 + bonus);
-    elseif (maneuvers == 2) then
-        if frame == 34 then bonus = 1 end
-        pet:delMod(dsp.mod.REGEN, 11 + bonus);
-    elseif (maneuvers == 3) then
-        pet:delMod(dsp.mod.REGEN, 11 + bonus);
-    end
+    pet:delMod(dsp.mod.REGEN, pet:getLocalVar(prefix .. maneuvers))
+    pet:setLocalVar(prefix .. maneuvers, 0)
 end

--- a/scripts/globals/abilities/pets/attachments/auto-repair_kit_iii.lua
+++ b/scripts/globals/abilities/pets/attachments/auto-repair_kit_iii.lua
@@ -4,49 +4,31 @@
 require("scripts/globals/status");
 
 function onEquip(pet)
-    pet:addMod(dsp.mod.HPP, 19)
+    pet:addMod(dsp.mod.HPP, 15)
 end
 
 function onUnequip(pet)
-    pet:delMod(dsp.mod.HPP, 19)
+    pet:delMod(dsp.mod.HPP, 15)
 end
 
+-- regen values from http://wiki.ffo.jp/html/8619.html
+local prefix = "autoRepairKit3_"
+local regenValues =
+{
+    [1] = {base=9, pct=1.8},
+    [2] = {base=3, pct=0.6},
+    [3] = {base=3, pct=0.6},
+}
+
 function onManeuverGain(pet,maneuvers)
-    local bonus = 0
-    local frame = pet:getAutomatonFrame()
-    if (maneuvers == 1) then
-        if frame == 32 then bonus = 4 end
-        if frame == 33 then bonus = 6 end
-        if frame == 34 then bonus = 2 end
-        pet:addMod(dsp.mod.REGEN, 37 + bonus);
-    elseif (maneuvers == 2) then
-        if frame == 32 then bonus = 3 end
-        if frame == 33 then bonus = 4 end
-        if frame == 34 then bonus = 1 end
-        pet:addMod(dsp.mod.REGEN, 10 + bonus);
-    elseif (maneuvers == 3) then
-        if frame == 32 then bonus = 3 end
-        if frame == 33 then bonus = 4 end
-        pet:addMod(dsp.mod.REGEN, 10 + bonus);
-    end
+    local rVals = regenValues[maneuvers]
+    local power = math.floor(rVals.base + (pet:getMaxHP() * rVals.pct / 100))
+
+    pet:setLocalVar(prefix .. maneuvers, power)
+    pet:addMod(dsp.mod.REGEN, power)
 end
 
 function onManeuverLose(pet,maneuvers)
-    local bonus = 0
-    local frame = pet:getAutomatonFrame()
-    if (maneuvers == 1) then
-        if frame == 32 then bonus = 4 end
-        if frame == 33 then bonus = 6 end
-        if frame == 34 then bonus = 2 end
-        pet:delMod(dsp.mod.REGEN, 37 + bonus);
-    elseif (maneuvers == 2) then
-        if frame == 32 then bonus = 3 end
-        if frame == 33 then bonus = 4 end
-        if frame == 34 then bonus = 1 end
-        pet:delMod(dsp.mod.REGEN, 10 + bonus);
-    elseif (maneuvers == 3) then
-        if frame == 32 then bonus = 3 end
-        if frame == 33 then bonus = 4 end
-        pet:delMod(dsp.mod.REGEN, 10 + bonus);
-    end
+    pet:delMod(dsp.mod.REGEN, pet:getLocalVar(prefix .. maneuvers))
+    pet:setLocalVar(prefix .. maneuvers, 0)
 end

--- a/scripts/globals/abilities/pets/attachments/mana_tank.lua
+++ b/scripts/globals/abilities/pets/attachments/mana_tank.lua
@@ -4,35 +4,31 @@
 require("scripts/globals/status");
 
 function onEquip(pet)
-    pet:addMod(dsp.mod.MPP, 4);
+    pet:addMod(dsp.mod.MPP, 5);
 end
 
 function onUnequip(pet)
-    pet:delMod(dsp.mod.MPP, 4);
+    pet:delMod(dsp.mod.MPP, 5);
 end
 
+-- refresh values from http://wiki.ffo.jp/html/5330.html
+local prefix = "manaTank1_"
+local refreshValues =
+{
+    [1] = {base=1, pct=0.2},
+    [2] = {base=1, pct=0.2},
+    [3] = {base=1, pct=0.2},
+}
+
 function onManeuverGain(pet,maneuvers)
-    local bonus = 0
-    local frame = pet:getAutomatonFrame()
-    if frame == 35 then bonus = 1 end
-    if (maneuvers == 1) then
-        pet:addMod(dsp.mod.REFRESH, 1 + bonus);
-    elseif (maneuvers == 2) then
-        pet:addMod(dsp.mod.REFRESH, 1 + bonus);
-    elseif (maneuvers == 3) then
-        pet:addMod(dsp.mod.REFRESH, 2 + bonus);
-    end
+    local rVals = refreshValues[maneuvers]
+    local power = math.floor(rVals.base + (pet:getMaxMP() * rVals.pct / 100))
+
+    pet:setLocalVar(prefix .. maneuvers, power)
+    pet:addMod(dsp.mod.REFRESH, power)
 end
 
 function onManeuverLose(pet,maneuvers)
-    local bonus = 0
-    local frame = pet:getAutomatonFrame()
-    if frame == 35 then bonus = 1 end
-    if (maneuvers == 1) then
-        pet:delMod(dsp.mod.REFRESH, 1 + bonus);
-    elseif (maneuvers == 2) then
-        pet:delMod(dsp.mod.REFRESH, 1 + bonus);
-    elseif (maneuvers == 3) then
-        pet:delMod(dsp.mod.REFRESH, 2 + bonus);
-    end
+    pet:delMod(dsp.mod.REFRESH, pet:getLocalVar(prefix .. maneuvers))
+    pet:setLocalVar(prefix .. maneuvers, 0)
 end

--- a/scripts/globals/abilities/pets/attachments/mana_tank_ii.lua
+++ b/scripts/globals/abilities/pets/attachments/mana_tank_ii.lua
@@ -4,39 +4,31 @@
 require("scripts/globals/status");
 
 function onEquip(pet)
-    pet:addMod(dsp.mod.MPP, 8);
+    pet:addMod(dsp.mod.MPP, 10);
 end
 
 function onUnequip(pet)
-    pet:delMod(dsp.mod.MPP, 8);
+    pet:delMod(dsp.mod.MPP, 10);
 end
 
+-- refresh values from http://wiki.ffo.jp/html/5330.html
+local prefix = "manaTank2_"
+local refreshValues =
+{
+    [1] = {base=2, pct=0.4},
+    [2] = {base=1, pct=0.2},
+    [3] = {base=1, pct=0.2},
+}
+
 function onManeuverGain(pet,maneuvers)
-    local bonus = 0
-    local frame = pet:getAutomatonFrame()
-    if (maneuvers == 1) then
-        if frame == 35 then bonus = 2 end
-        pet:addMod(dsp.mod.REFRESH, 2 + bonus);
-    elseif (maneuvers == 2) then
-        if frame == 35 then bonus = 1 end
-        pet:addMod(dsp.mod.REFRESH, 2 + bonus);
-    elseif (maneuvers == 3) then
-        if frame == 35 then bonus = 1 end
-        pet:addMod(dsp.mod.REFRESH, 1 + bonus);
-    end
+    local rVals = refreshValues[maneuvers]
+    local power = math.floor(rVals.base + (pet:getMaxMP() * rVals.pct / 100))
+
+    pet:setLocalVar(prefix .. maneuvers, power)
+    pet:addMod(dsp.mod.REFRESH, power)
 end
 
 function onManeuverLose(pet,maneuvers)
-    local bonus = 0
-    local frame = pet:getAutomatonFrame()
-    if (maneuvers == 1) then
-        if frame == 35 then bonus = 2 end
-        pet:delMod(dsp.mod.REFRESH, 2 + bonus);
-    elseif (maneuvers == 2) then
-        if frame == 35 then bonus = 1 end
-        pet:delMod(dsp.mod.REFRESH, 2 + bonus);
-    elseif (maneuvers == 3) then
-        if frame == 35 then bonus = 1 end
-        pet:delMod(dsp.mod.REFRESH, 1 + bonus);
-    end
+    pet:delMod(dsp.mod.REFRESH, pet:getLocalVar(prefix .. maneuvers))
+    pet:setLocalVar(prefix .. maneuvers, 0)
 end

--- a/scripts/globals/abilities/pets/attachments/mana_tank_iii.lua
+++ b/scripts/globals/abilities/pets/attachments/mana_tank_iii.lua
@@ -4,39 +4,31 @@
 require("scripts/globals/status");
 
 function onEquip(pet)
-    pet:addMod(dsp.mod.MPP, 13);
+    pet:addMod(dsp.mod.MPP, 15);
 end
 
 function onUnequip(pet)
-    pet:delMod(dsp.mod.MPP, 13);
+    pet:delMod(dsp.mod.MPP, 15);
 end
 
+-- refresh values from http://wiki.ffo.jp/html/5330.html
+local prefix = "manaTank3_"
+local refreshValues =
+{
+    [1] = {base=3, pct=0.6},
+    [2] = {base=1, pct=0.2},
+    [3] = {base=1, pct=0.2},
+}
+
 function onManeuverGain(pet,maneuvers)
-    local bonus = 0
-    local frame = pet:getAutomatonFrame()
-    if (maneuvers == 1) then
-        if frame == 35 then bonus = 3 end
-        pet:addMod(dsp.mod.REFRESH, 7 + bonus);
-    elseif (maneuvers == 2) then
-        if frame == 35 then bonus = 2 end
-        pet:addMod(dsp.mod.REFRESH, 1 + bonus);
-    elseif (maneuvers == 3) then
-        if frame == 35 then bonus = 2 end
-        pet:addMod(dsp.mod.REFRESH, 2 + bonus);
-    end
+    local rVals = refreshValues[maneuvers]
+    local power = math.floor(rVals.base + (pet:getMaxMP() * rVals.pct / 100))
+
+    pet:setLocalVar(prefix .. maneuvers, power)
+    pet:addMod(dsp.mod.REFRESH, power)
 end
 
 function onManeuverLose(pet,maneuvers)
-    local bonus = 0
-    local frame = pet:getAutomatonFrame()
-    if (maneuvers == 1) then
-        if frame == 35 then bonus = 3 end
-        pet:delMod(dsp.mod.REFRESH, 7 + bonus);
-    elseif (maneuvers == 2) then
-        if frame == 35 then bonus = 2 end
-        pet:delMod(dsp.mod.REFRESH, 1 + bonus);
-    elseif (maneuvers == 3) then
-        if frame == 35 then bonus = 2 end
-        pet:delMod(dsp.mod.REFRESH, 2 + bonus);
-    end
+    pet:delMod(dsp.mod.REFRESH, pet:getLocalVar(prefix .. maneuvers))
+    pet:setLocalVar(prefix .. maneuvers, 0)
 end


### PR DESCRIPTION
Sources:
* [Auto-Repair Kit](https://www.bg-wiki.com/bg/Auto-Repair_Kit) (bg-wiki.com)
* [Auto-Repair Kit II](https://www.bg-wiki.com/bg/Auto-Rep._Kit_II) (bg-wiki.com)
* [Auto-Repair Kit III](https://www.bg-wiki.com/bg/Auto-Rep._Kit_III) (bg-wiki.com)
* [Auto-Repair Kit](http://wiki.ffo.jp/html/8619.html) (wiki.ffo.jp)

* [Mana Tank](https://www.bg-wiki.com/bg/Mana_Tank) (bg-wiki.com)
* [Mana Tank II](https://www.bg-wiki.com/bg/Mana_Tank_II) (bg-wiki.com)
* [Mana Tank III](https://www.bg-wiki.com/bg/Mana_Tank_III) (bg-wiki.com)
* [Mana Tank](http://wiki.ffo.jp/html/5330.html) (wiki.ffo.jp)

I'm storing the regen/refresh power in local vars, rather than recalculating onManeuverLose, because it's possible that Max HP/MP change between onManeuverGain and onManeuverLose.

~*edit: work in progress. please hold review.*~ All set!