### PR TITLE
fix onEffectLose values for ic pilav +1, royal omelette

### DIFF
--- a/scripts/globals/items/plate_of_ic_pilav_+1.lua
+++ b/scripts/globals/items/plate_of_ic_pilav_+1.lua
@@ -44,13 +44,13 @@ end;
 
 function onEffectLose(target, effect)
     target:delMod(dsp.mod.FOOD_HPP, 14);
-    target:delMod(dsp.mod.FOOD_HP_CAP, 65);
-    target:delMod(dsp.mod.STR, 4);
-    target:delMod(dsp.mod.VIT, -1);
-    target:delMod(dsp.mod.INT, -1);
+    target:delMod(dsp.mod.FOOD_HP_CAP, 70);
+    target:delMod(dsp.mod.STR, 5);
+    target:delMod(dsp.mod.VIT, -2);
+    target:delMod(dsp.mod.INT, -2);
     target:delMod(dsp.mod.HPHEAL, 1);
     target:delMod(dsp.mod.FOOD_ATTP, 22);
-    target:delMod(dsp.mod.FOOD_ATT_CAP, 65);
+    target:delMod(dsp.mod.FOOD_ATT_CAP, 70);
     target:delMod(dsp.mod.FOOD_RATTP, 22);
-    target:delMod(dsp.mod.FOOD_RATT_CAP, 65);
+    target:delMod(dsp.mod.FOOD_RATT_CAP, 70);
 end;

--- a/scripts/globals/items/royal_omelette.lua
+++ b/scripts/globals/items/royal_omelette.lua
@@ -81,9 +81,9 @@ function onEffectLose(target, effect)
         target:delMod(dsp.mod.DEX, 2);
         target:delMod(dsp.mod.INT, -3);
         target:delMod(dsp.mod.MND, 4);
-        target:delMod(dsp.mod.FOOD_ATTP, 22);
+        target:delMod(dsp.mod.FOOD_ATTP, 20);
         target:delMod(dsp.mod.FOOD_ATT_CAP, 65);
-        target:delMod(dsp.mod.FOOD_RATTP, 22);
+        target:delMod(dsp.mod.FOOD_RATTP, 20);
         target:delMod(dsp.mod.FOOD_RATT_CAP, 65);
     end
 end;


### PR DESCRIPTION
Ran a search to check for foods that gained and lost different mods.  These were the only two foods with mismatched values.