### PR TITLE
Implement PrintToArea, an extension of the custom end of PrintToPlayer

### DIFF
--- a/scripts/globals/msg.lua
+++ b/scripts/globals/msg.lua
@@ -46,11 +46,11 @@ dsp.msg.channel =
 -- used by PrintToArea
 dsp.msg.area =
 {
-    SYSTEM      = 0, // Server wide like the purple stuff :)
-    SAY         = 1, // Will display in small area around player
-    SHOUT       = 2, // Will display in wide area around player
-    PARTY       = 3, // Will display to players entire party/alliance
-    YELL        = 4  // If yell is enabled in zone, will display.
+    SYSTEM      = 0, -- Server wide like the purple stuff :)
+    SAY         = 1, -- Will display in small area around player
+    SHOUT       = 2, -- Will display in wide area around player
+    PARTY       = 3, -- Will display to players entire party/alliance
+    YELL        = 4  -- If yell is enabled in zone, will display.
 }
 
 ------------------------------------

--- a/scripts/globals/msg.lua
+++ b/scripts/globals/msg.lua
@@ -43,6 +43,16 @@ dsp.msg.channel =
     UNITY          = 33
 }
 
+-- used by PrintToArea
+dsp.msg.area =
+{
+    SYSTEM      = 0  // Server wide like the purple stuff :)
+    SAY         = 1, // Will display in small area around player
+    SHOUT       = 2, // Will display in wide area around player
+    PARTY       = 3, // Will display to players entire party/alliance
+    YELL        = 4, // If yell is enabled in zone, will display.
+}
+
 ------------------------------------
 -- Message Basic
 ------------------------------------

--- a/scripts/globals/msg.lua
+++ b/scripts/globals/msg.lua
@@ -46,11 +46,11 @@ dsp.msg.channel =
 -- used by PrintToArea
 dsp.msg.area =
 {
-    SYSTEM      = 0  // Server wide like the purple stuff :)
+    SYSTEM      = 0, // Server wide like the purple stuff :)
     SAY         = 1, // Will display in small area around player
     SHOUT       = 2, // Will display in wide area around player
     PARTY       = 3, // Will display to players entire party/alliance
-    YELL        = 4, // If yell is enabled in zone, will display.
+    YELL        = 4  // If yell is enabled in zone, will display.
 }
 
 ------------------------------------

--- a/src/map/lua/lua_baseentity.h
+++ b/src/map/lua/lua_baseentity.h
@@ -50,6 +50,7 @@ public:
     int32 showText(lua_State*);             // Displays Dialog for npc
     int32 messageText(lua_State* L);
     int32 PrintToPlayer(lua_State* L);      // for sending debugging messages/command confirmations to the player's client
+    int32 PrintToArea(lua_State* L);        // for sending area messages to multiple players at once
     int32 messageBasic(lua_State*);         // Sends Basic Message
     int32 messagePublic(lua_State*);        // Sends a public Basic Message
     int32 messageSpecial(lua_State*);       // Sends Special Message


### PR DESCRIPTION
Unlike PrintToPlayer, this targets *groups* of players via same methods normal chat uses but does *not* have to match the chat type.

You can now have mobs that make server wide claim announcements, as one example.
```lua
function onMobEngaged(mob, target)
    if target:isPC() then
        local TEXT = string.format("%s has engaged in battle with the notorious monster, %s!", target:getName(), mob:getName())
        target:PrintToArea(TEXT, dsp.msg.channel.SYSTEM_3, dsp.msg.area.SYSTEM)
    elseif target:isPet() then
        local TEXT = string.format("%s has engaged in battle with the notorious monster, %s!", target:getMaster():getName(), mob:getName())
        target:getMaster():PrintToArea(TEXT, dsp.msg.channel.SYSTEM_3, dsp.msg.area.SYSTEM)
    end
end
```
This would print a **yellow** system text message to all zones.

Yes this is custom. So is PrintToPlayer. If we don't want to put this in master I understand, but I feel its worth it. We previously said the same thing about PrintToPlayers message types. By having this commonly desired addition in our main trunk we can have fewer people turning their fork into a train-wreck and saying our updates broke their server.