### PR TITLE
Die price swap fix. Typo. Trailing comma.

### DIFF
--- a/scripts/zones/Nashmau/npcs/Jajaroon.lua
+++ b/scripts/zones/Nashmau/npcs/Jajaroon.lua
@@ -25,11 +25,11 @@ function onTrigger(player,npc)
         5870, 10000,    -- Trump Card Case
         5488, 35200,    -- Samurai Die
         5489,   600,    -- Ninja Die
-        5490, 82500,    -- Dragoon Die
+        5490,  9216,    -- Dragoon Die
         5491, 40000,    -- Summoner Die
         5492,  3525,    -- Blue Mage Die
-        5493,   316,    -- Corsar Die
-        5494,  9216,    -- Puppetmaster Die
+        5493,   316,    -- Corsair Die
+        5494, 82500     -- Puppetmaster Die
     }
 
     player:showText(npc, JAJAROON_SHOP_DIALOG)


### PR DESCRIPTION
Prices swapped for Dragoon Die (lv23) and Puppetmaster Die (lv52). Cleaned up typo and trailing comma while here.