### PR TITLE
fall back on new magic dmg calcs if spell is missing params for oldschool calcs

### DIFF
--- a/scripts/globals/magic.lua
+++ b/scripts/globals/magic.lua
@@ -1124,7 +1124,7 @@ function doElementalNuke(caster, spell, target, spellParams)
     local V = 0;
     local M = 0;
 
-    if (USE_OLD_MAGIC_DAMAGE) then
+    if (USE_OLD_MAGIC_DAMAGE and spellParams.V ~= nil and spellParams.M ~= nil) then
         V = spellParams.V;
         M = spellParams.M;
         local I = spellParams.I; -- inflection point


### PR DESCRIPTION
if USE_OLD_MAGIC_DAMAGE, some spells (such as tier-V nukes) are missing required spellParam properties.  In this case, fall back on new magic damage calculations.