### PR TITLE
Wrong itemid in quest "Claws of the Griffon"

### DIFF
--- a/scripts/zones/Jugner_Forest_[S]/npcs/qm6.lua
+++ b/scripts/zones/Jugner_Forest_[S]/npcs/qm6.lua
@@ -38,6 +38,6 @@ function onEventFinish(player,csid,option)
     elseif (csid == 202) then
         SpawnMob(FINGERFILCHER_DRADZAD):updateClaim(player);
     elseif (csid == 203) then
-        npcUtil.completeQuest(player, CRYSTAL_WAR, CLAWS_OF_THE_GRIFFON, {item=8131, var="ClawsOfGriffonProg"});
+        npcUtil.completeQuest(player, CRYSTAL_WAR, CLAWS_OF_THE_GRIFFON, {item=813, var="ClawsOfGriffonProg"});
     end
 end;


### PR DESCRIPTION
Change the itemid for this quest reward, for valid id. Changed to 813 which is 'angelstone', according to [ffxiwiki](http://ffxiclopedia.wikia.com/wiki/Claws_of_the_Griffon) and [bg](https://www.bg-wiki.com/bg/Claws_of_the_Griffon) 