### PR TITLE
various fixes for dynamis

### DIFF
--- a/scripts/globals/dynamis.lua
+++ b/scripts/globals/dynamis.lua
@@ -706,33 +706,43 @@ end;
 
 --------------------------------------------------
 -- checkFirstDyna
--- true if the first dyna
+--[[ CS Option params
+        1 = First CS - if first time visiting ANY dyna zone
+        2 = Second CS - if first time visiting THIS dyna zone
+        3 = Completed CS - if second time or more visiting THIS dyna zone
+        Add 65536 if obtained KI that removes dyna wait time restriction (Rhapsody in Azure) --]]
 --------------------------------------------------
 
 function checkFirstDyna(player,number)
 
-    local dynaVar = 0;
-    local bit = {};
+    local dynaVar = 0
+    local bit = {}
+    local timeKI = 0
+    if player:hasKeyItem(dsp.ki.RHAPSODY_IN_AZURE) then timeKI = 65536 end
 
-    dynaVar = player:getVar("Dynamis_Status");
+    dynaVar = player:getVar("Dynamis_Status")
 
-    for i = 7,0,-1 do
-        twop = 2^i;
-        if (dynaVar >= twop) then
-            bit[i+1] = 1;
-            dynaVar = dynaVar - twop;
-        else
-            bit[i+1] = 0;
-        end;
-        --printf("bit %u: %u\n",i,bit[i+1]);
-    end;
-    --printf("received %u",bit[number+1]);
-    if (bit[number+1] == 0) then
-        return true;
+    if dynaVar == 0 then
+        return 1+timeKI
     else
-        return false;
+        for i = 7,0,-1 do
+            twop = 2^i
+            if dynaVar >= twop then
+                bit[i+1] = 1
+                dynaVar = dynaVar - twop
+            else
+                bit[i+1] = 0
+            end
+            -- printf("bit %u: %u\n",i,bit[i+1])
+        end
+        -- printf("received %u",bit[number+1])
+        if bit[number+1] == 0 then
+            return 2+timeKI
+        else
+            return 3+timeKI
+        end
     end
-end;
+end
 
 --------------------------------------------------
 -- alreadyReceived
@@ -988,7 +998,7 @@ function dynamis.addExtension(player, keyitem, duration)
         local effect = player:getStatusEffect(dsp.effect.DYNAMIS)
         local old_duration = effect:getDuration()
         effect:setDuration((old_duration + (duration * 60)) * 1000)
-        player:setLocalVar("dynamis_lasttimeupdate", (old_duration / 60) + duration)
+        player:setLocalVar("dynamis_lasttimeupdate", effect:getTimeRemaining() / 1000)
         player:messageSpecial(DYNAMIS_TIME_EXTEND, duration)
     end
 end

--- a/scripts/zones/Dynamis-Valkurm/Zone.lua
+++ b/scripts/zones/Dynamis-Valkurm/Zone.lua
@@ -7,6 +7,7 @@ package.loaded["scripts/zones/Dynamis-Valkurm/TextIDs"] = nil
 -----------------------------------
 require("scripts/zones/Dynamis-Valkurm/TextIDs")
 require("scripts/zones/Dynamis-Valkurm/MobIDs")
+require("scripts/globals/keyitems")
 require("scripts/globals/settings")
 -----------------------------------
 
@@ -49,11 +50,11 @@ function onZoneIn(player,prevZone)
 
     if player:getVar("Dynamis_Entry") == 1 then
         if player:getVar("Dynamis_subjob") == 1 then
-            player:messageBasic(107)
+            player:timer(5000, function(player) player:messageBasic(107) end)
             player:addStatusEffect(dsp.effect.SJ_RESTRICTION, 0, 0, 0, 7200)
         end
         player:addStatusEffectEx(dsp.effect.DYNAMIS, 0, 0, 3, 3600)
-        player:messageSpecial(DYNAMIS_TIME_BEGIN, 60, dsp.ki.PRISMATIC_HOURGLASS)
+        player:timer(5500, function(player) player:messageSpecial(DYNAMIS_TIME_BEGIN, 60, dsp.ki.PRISMATIC_HOURGLASS) end)
         player:setVar("Dynamis_Entry", 0)
         player:setVar("Dynamis_subjob", 0)
     else

--- a/scripts/zones/Valkurm_Dunes/npcs/Hieroglyphics.lua
+++ b/scripts/zones/Valkurm_Dunes/npcs/Hieroglyphics.lua
@@ -48,7 +48,7 @@ function onEventFinish(player,csid,option)
     if csid == 39 then
         player:setVar("DynaValkurm_Win", 0)
     elseif csid == 58 then
-        if checkFirstDyna(player,7) then
+        if checkFirstDyna(player,7) ~= 3 and checkFirstDyna(player,7) ~= 65539 then
             player:setVar("Dynamis_Status",bit.bor(player:getVar("Dynamis_Status"),128))
         end
         if option == 0 or option == 1 then

--- a/scripts/zones/Valkurm_Dunes/npcs/Hieroglyphics.lua
+++ b/scripts/zones/Valkurm_Dunes/npcs/Hieroglyphics.lua
@@ -4,68 +4,67 @@
 -- Dynamis Valkurm_Dunes Enter
 -- !pos 117 -10 133 103
 -----------------------------------
-package.loaded["scripts/zones/Valkurm_Dunes/TextIDs"] = nil;
+package.loaded["scripts/zones/Valkurm_Dunes/TextIDs"] = nil
 -----------------------------------
-require("scripts/globals/settings");
-require("scripts/globals/keyitems");
-require("scripts/globals/dynamis");
-require("scripts/globals/missions");
-require("scripts/zones/Valkurm_Dunes/TextIDs");
+require("scripts/zones/Valkurm_Dunes/TextIDs")
+require("scripts/globals/keyitems")
+require("scripts/globals/missions")
+require("scripts/globals/settings")
+require("scripts/globals/dynamis")
 -----------------------------------
 
 function onTrade(player,npc,trade)
-end;
+end
 
 function onTrigger(player,npc)
-    if ((player:hasCompletedMission(COP,DARKNESS_NAMED) or FREE_COP_DYNAMIS == 1) and player:hasKeyItem(dsp.ki.VIAL_OF_SHROUDED_SAND)) then
-        local realDay = os.time();
-        local dynaWaitxDay = player:getVar("dynaWaitxDay");
-        local dynaUniqueID = GetServerVariable("[DynaValkurm]UniqueID");
+    if player:getVar("DynaValkurm_Win") == 1 then
+        player:startEvent(39)
+    elseif (player:hasCompletedMission(COP,DARKNESS_NAMED) or FREE_COP_DYNAMIS == 0) and player:hasKeyItem(dsp.ki.VIAL_OF_SHROUDED_SAND) then
+        local realDay = os.time()
+        local dynaWaitxDay = player:getVar("dynaWaitxDay")
 
-        if (checkFirstDyna(player,7)) then
-            player:startEvent(58,7,0x010002,0x060E,1,0x195,dsp.ki.VIAL_OF_SHROUDED_SAND,4236,4237);
-        elseif (player:getMainLvl() < DYNA_LEVEL_MIN) then
-            player:messageSpecial(PLAYERS_HAVE_NOT_REACHED_LEVEL,DYNA_LEVEL_MIN);
-        elseif ((dynaWaitxDay + (BETWEEN_2DYNA_WAIT_TIME * 60 * 60)) < realDay or (player:getVar("DynamisID") == dynaUniqueID and dynaUniqueID > 0)) then
-            player:startEvent(58,7,0x010003,0x060E,1,0xFFFF5DC2,dsp.ki.VIAL_OF_SHROUDED_SAND,4236,4237);
+        if player:getMainLvl() < DYNA_LEVEL_MIN then
+            player:messageSpecial(PLAYERS_HAVE_NOT_REACHED_LEVEL,DYNA_LEVEL_MIN)
+        elseif (dynaWaitxDay + (BETWEEN_2DYNA_WAIT_TIME * 60 * 60)) < realDay then
+--          Params: DynamisCity, CS option, KI, Support Job Option, junk, KI, Timeless Hrgls, Perpetual Hrgls
+            player:startEvent(58,7,checkFirstDyna(player,7),dsp.ki.PRISMATIC_HOURGLASS,1,0,dsp.ki.VIAL_OF_SHROUDED_SAND,4236,4237)
         else
-            dayRemaining = math.floor(((dynaWaitxDay + (BETWEEN_2DYNA_WAIT_TIME * 60 * 60)) - realDay)/3456);
-            player:messageSpecial(YOU_CANNOT_ENTER_DYNAMIS,dayRemaining,7);
+            dayRemaining = math.floor(((dynaWaitxDay + (BETWEEN_2DYNA_WAIT_TIME * 60 * 60)) - realDay)/3456)
+            player:messageSpecial(YOU_CANNOT_ENTER_DYNAMIS,dayRemaining,7)
         end
     else
-        player:messageSpecial(MYSTERIOUS_VOICE);
+        player:messageSpecial(MYSTERIOUS_VOICE)
     end
-end;
+end
 
 function onEventUpdate(player,csid,option)
-    -- printf("updateRESULT: %u",option);
-end;
+    -- printf("updateRESULT: %u",option)
+end
 
 function onEventFinish(player,csid,option)
-    -- printf("finishRESULT: %u",option);
+    -- printf("finishRESULT: %u",option)
      print(option)
 
-    if csid == 58 then
-        if (checkFirstDyna(player,7)) then
-            player:setVar("Dynamis_Status",bit.bor(player:getVar("Dynamis_Status"),128));
+    if csid == 39 then
+        player:setVar("DynaValkurm_Win", 0)
+    elseif csid == 58 then
+        if checkFirstDyna(player,7) then
+            player:setVar("Dynamis_Status",bit.bor(player:getVar("Dynamis_Status"),128))
         end
         if option == 0 or option == 1 then
-            if option == 1 then
-                player:setVar("Dynamis_subjob", 1)
-            else
-                player:setVar("Dynamis_subjob", 0)
-            end
+            player:setVar("Dynamis_subjob", option)
             player:setVar("Dynamis_Entry", 1)
-            local realDay = os.time();
+            local realDay = os.time()
             if (DYNA_MIDNIGHT_RESET == true) then
-                realDay = getMidnight() - 86400;
+                realDay = getMidnight() - 86400
             end
-            local dynaWaitxDay = player:getVar("dynaWaitxDay");
+            local dynaWaitxDay = player:getVar("dynaWaitxDay")
 
-            if ((dynaWaitxDay + (BETWEEN_2DYNA_WAIT_TIME * 60 * 60)) < realDay) then
-                player:setVar("dynaWaitxDay",realDay);
+            if (dynaWaitxDay + (BETWEEN_2DYNA_WAIT_TIME * 60 * 60)) < realDay
+                and not player:hasKeyItem(dsp.ki.RHAPSODY_IN_AZURE) then
+                    player:setVar("dynaWaitxDay",realDay)
             end
-            player:setPos(100,-8,131,47,0x27);
+            player:setPos(100,-8,131,47,0x27)
         end
     end
-end;
+end


### PR DESCRIPTION
-added event cs for DynaValkurm win
-removed unused instance stuff
-add support for 3 different cs's depending on dyna status by modifying checkFirstDyna which also condensed the elseif tree allowing use of only one cs event based on what the 2nd param returns.
-cleaned up event params and defined what they are
-added support for the KI that removed the "once a day" restriction from dynamis [RHAPSODY_IN_AZURE]
-fixed time extension var to properly display time warnings upon getting an extension past the warning
-add a delay to messages so they'll show on zone in
