### PR TITLE
Fixed NPC Text for Gallijaux and Joulet

### DIFF
--- a/scripts/zones/Port_San_dOria/npcs/Gallijaux.lua
+++ b/scripts/zones/Port_San_dOria/npcs/Gallijaux.lua
@@ -50,9 +50,9 @@ function onTrigger(player,npc)
     if (player:getQuestStatus(SANDORIA,THE_COMPETITION) == QUEST_AVAILABLE and player:getQuestStatus(SANDORIA,THE_RIVALRY) == QUEST_AVAILABLE) then -- If you haven't started either quest yet
         player:startEvent(300, 4401, 4289); -- 4401 = Moat Carp, 4289 = Forest Carp
     elseif (player:getQuestStatus(SANDORIA,THE_RIVALRY) == QUEST_ACCEPTED) then
-        player:messageSpecial(GALLIJAUX_CARP_STATUS, 0, player:getVar("theCompetitionFishCountVar"), 0, 0, true);
+        player:showText(npc, GALLIJAUX_CARP_STATUS, 0, player:getVar("theCompetitionFishCountVar"));
     elseif ((player:getQuestStatus(SANDORIA,THE_COMPETITION)) == QUEST_ACCEPTED) then
-        player:messageSpecial(GALLIJAUX_HELP_OTHER_BROTHER, 0, 0, 0, 0, true);
+        player:showText(npc, GALLIJAUX_HELP_OTHER_BROTHER);
     end
 end;
 

--- a/scripts/zones/Port_San_dOria/npcs/Joulet.lua
+++ b/scripts/zones/Port_San_dOria/npcs/Joulet.lua
@@ -52,9 +52,9 @@ function onTrigger(player,npc)
     if (player:getQuestStatus(SANDORIA,THE_COMPETITION) == QUEST_AVAILABLE and player:getQuestStatus(SANDORIA,THE_RIVALRY) == QUEST_AVAILABLE) then -- If you haven't started either quest yet
         player:startEvent(304, 4401, 4289); -- Moat Carp = 4401, 4289 = Forest Carp
     elseif (player:getQuestStatus(SANDORIA,THE_RIVALRY) == QUEST_ACCEPTED) then
-        player:messageSpecial(JOULET_HELP_OTHER_BROTHER, 0, 0, 0, 0, true);
+        player:showText(npc, JOULET_HELP_OTHER_BROTHER);
     elseif ((player:getQuestStatus(SANDORIA,THE_COMPETITION)) == QUEST_ACCEPTED) then
-        player:messageSpecial(JOULET_CARP_STATUS, 0, player:getVar("theCompetitionFishCountVar"), 0, 0, true);
+        player:showText(npc, JOULET_CARP_STATUS, 0, player:getVar("theCompetitionFishCountVar"));
     end
 end;
 


### PR DESCRIPTION
Old code resulted in player name being used in place of NPC name.