### PR TITLE
Fix crash in CTargetFind

### DIFF
--- a/src/map/ai/helpers/targetfind.cpp
+++ b/src/map/ai/helpers/targetfind.cpp
@@ -205,18 +205,17 @@ void CTargetFind::findWithinCone(CBattleEntity* PTarget, float distance, float a
 
 void CTargetFind::addAllInMobList(CBattleEntity* PTarget, bool withPet)
 {
-    CCharEntity* PChar = (CCharEntity*)findMaster(m_PBattleEntity);
-    CBattleEntity* PBattleTarget = nullptr;
-
-    for (SpawnIDList_t::const_iterator it = PChar->SpawnMOBList.begin(); it != PChar->SpawnMOBList.end(); ++it)
+    CCharEntity* PChar = dynamic_cast<CCharEntity*>(findMaster(m_PBattleEntity));
+    if (PChar)
     {
-
-        PBattleTarget = (CBattleEntity*)it->second;
-
-        if (PBattleTarget && isMobOwner(PBattleTarget)){
-            addEntity(PBattleTarget, withPet);
+        for (SpawnIDList_t::const_iterator it = PChar->SpawnMOBList.begin(); it != PChar->SpawnMOBList.end(); ++it)
+        {
+            CBattleEntity* PBattleTarget = dynamic_cast<CBattleEntity*>(it->second);
+            if (PBattleTarget && isMobOwner(PBattleTarget))
+            {
+                addEntity(PBattleTarget, withPet);
+            }
         }
-
     }
 }
 


### PR DESCRIPTION
Found an edge case crash wherein the player uses an aoe weaponskill and is charmed before the WEAPONSKILL_FINISH action happens.

Attempting to C-style cast the player's PMaster pointer and then trying to access memory that doesn't exist in CMobEntity (SpawnMOBList) causes the server to crash.

The PBattleTarget casting and declaring outside the scope of the for loop was also potentially crashy.

Switched to dynamic casts for better error checking. Had a mob spamming Maiden's Virelai (charm song) to test. Didn't get the crash again after fixing it.