### PR TITLE
update petsync packets to perform like retail

### DIFF
--- a/src/map/packets/pet_sync.cpp
+++ b/src/map/packets/pet_sync.cpp
@@ -1,7 +1,7 @@
 ﻿/*
 ===========================================================================
 
-Copyright (c) 2010-2015 Darkstar Dev Teams
+Copyright (c) 2010-2018 Darkstar Dev Teams
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by
@@ -22,34 +22,39 @@ This file is part of DarkStar-server source code.
 */
 
 #include "../../common/socket.h"
+#include "../../common/utils.h"
 
 #include "pet_sync.h"
 
 #include "../entities/charentity.h"
 
 /************************************************************************
-*																		*
-*  Синхронизация питомца с персонажем (владельцем)						*
-*																		*
+*                                                                       *
+*  Synchronization of the pet with the owner                            *
+*                                                                       *
 ************************************************************************/
 
 CPetSyncPacket::CPetSyncPacket(CCharEntity* PChar)
 {
-    this->type = 0x67;
-    this->size = 0x12;
+    this->type = 0x68;
+    this->size = 0x0E;
 
-    DSP_DEBUG_BREAK_IF(PChar->PPet == nullptr);
-
-    ref<uint8>(0x04) = 0x44; 	// назначение неизвестно
-    ref<uint8>(0x05) = 0x08; 	// назначение неизвестно
-
+    ref<uint8>(0x04) |= 0x04; // Message Type
+    packBitsBE(data+(0x04), (0x18), 0, 6, 10); // Message Size (0 for Despawn)
     ref<uint16>(0x06) = PChar->targid;
     ref<uint32>(0x08) = PChar->id;
 
-    ref<uint16>(0x0C) = PChar->PPet->targid;
-    ref<uint8>(0x0E) = PChar->PPet->GetHPP();
-    ref<uint8>(0x0F) = PChar->PPet->GetMPP();
-    ref<uint16>(0x10) = PChar->PPet->health.tp;
+    if (PChar->PPet != nullptr)
+    {
+        this->size = 0x16;
+        packBitsBE(data+(0x04), (0x18)+PChar->PPet->name.size(), 0, 6, 10); // Message Size
+        ref<uint16>(0x0C) = PChar->PPet->targid;
+        ref<uint8>(0x0E) = PChar->PPet->GetHPP();
+        ref<uint8>(0x0F) = PChar->PPet->GetMPP();
+        ref<uint16>(0x10) = PChar->PPet->health.tp;
+        if (PChar->PPet->animation == ANIMATION_ATTACK)
+            ref<uint32>(0x14) = PChar->PPet->GetBattleTarget()->id;
 
-    // 0x14 - начинается имя питомца, но мы его записывать не будем, "мы экономить будем" © Матроскин
+        memcpy(data + (0x18), PChar->PPet->GetName(), PChar->PPet->name.size());
+    }
 }

--- a/src/map/utils/petutils.cpp
+++ b/src/map/utils/petutils.cpp
@@ -51,6 +51,7 @@ This file is part of DarkStar-server source code.
 #include "../ai/controllers/automaton_controller.h"
 #include "../ai/states/ability_state.h"
 
+#include "../packets/char_abilities.h"
 #include "../packets/char_sync.h"
 #include "../packets/char_update.h"
 #include "../packets/entity_update.h"
@@ -949,8 +950,11 @@ namespace petutils
             charutils::BuildingCharPetAbilityTable(PChar, PPetEnt, 0);// blank the pet commands
         }
 
+        charutils::BuildingCharAbilityTable(PChar);
         PChar->PPet = nullptr;
         PChar->pushPacket(new CCharUpdatePacket(PChar));
+        PChar->pushPacket(new CCharAbilitiesPacket(PChar));
+        PChar->pushPacket(new CPetSyncPacket(PChar));
     }
 
     /************************************************************************


### PR DESCRIPTION
Retail uses 0x068 for petsync 

We also want to send the CCharAbilitiesPacket on despawn which will refresh the available abilities since there is no longer a pet and fix this issue: https://github.com/DarkstarProject/darkstar/issues/4549

Thanks to @ZeromusXYZ#0849 , @Ivaar#6857 , @MrSent#1991 , @demolish#5315 , @Zynjec#6204 , @shelby_z#8776 , @Devi Ltti#5459 , @Lotus#8459 , and everyone who helped contribute ideas/guidance for me to make this possible.