### PR TITLE
fix for messageSpecial packet

### DIFF
--- a/src/map/packets/message_special.cpp
+++ b/src/map/packets/message_special.cpp
@@ -31,17 +31,19 @@
 
 
 CMessageSpecialPacket::CMessageSpecialPacket(
-	CBaseEntity* PEntity, 
-	uint16 messageID,  
-	uint32 param0, 
-	uint32 param1, 
-	uint32 param2, 
-	uint32 param3, 
+	CBaseEntity* PEntity,
+	uint16 messageID,
+	uint32 param0,
+	uint32 param1,
+	uint32 param2,
+	uint32 param3,
 	bool ShowName,
 	CBaseEntity* messageEntity)
 {
     this->type = 0x2A;
     this->size = 0x10;
+
+    //DSP_DEBUG_BREAK_IF(PEntity == nullptr);
 
     ref<uint32>(0x04) = PEntity->id;
 
@@ -54,7 +56,7 @@ CMessageSpecialPacket::CMessageSpecialPacket(
 
     if (ShowName)
     {
-		this->size = 0x18;
+        this->size = 0x18;
 
         if (messageEntity != nullptr)
         {
@@ -63,12 +65,12 @@ CMessageSpecialPacket::CMessageSpecialPacket(
         else
         {
             memcpy(data + (0x1E), PEntity->GetName(), (PEntity->name.size() > 15 ? 15 : PEntity->name.size()));
-        }	
+        }
     }
-	else if (PEntity->objtype == TYPE_PC)
-	{
-		messageID += 0x8000;
-	}
+    else if (PEntity->objtype == TYPE_PC)
+    {
+        messageID += 0x8000;
+    }
 
     ref<uint16>(0x1A) = messageID;
 }

--- a/src/map/packets/message_special.cpp
+++ b/src/map/packets/message_special.cpp
@@ -37,32 +37,38 @@ CMessageSpecialPacket::CMessageSpecialPacket(
 	uint32 param1, 
 	uint32 param2, 
 	uint32 param3, 
-	bool ShowName)
+	bool ShowName,
+	CBaseEntity* messageEntity)
 {
-	this->type = 0x2A;
-	this->size = 0x10;
+    this->type = 0x2A;
+    this->size = 0x10;
 
-	//DSP_DEBUG_BREAK_IF(PEntity == nullptr);
+    ref<uint32>(0x04) = PEntity->id;
 
-	ref<uint32>(0x04) = PEntity->id;
+    ref<uint32>(0x08) = param0;
+    ref<uint32>(0x0C) = param1;
+    ref<uint32>(0x10) = param2;
+    ref<uint32>(0x14) = param3;
 
-	ref<uint32>(0x08) = param0;
-	ref<uint32>(0x0C) = param1;
-	ref<uint32>(0x10) = param2;
-	ref<uint32>(0x14) = param3;
+    ref<uint16>(0x18) = PEntity->targid;
 
-	ref<uint16>(0x18) = PEntity->targid;
-
-	if (ShowName)
-	{
+    if (ShowName)
+    {
 		this->size = 0x18;
 
-		memcpy(data+(0x1E), PEntity->GetName(), (PEntity->name.size() > 15 ? 15 : PEntity->name.size())); 
-	}
+        if (messageEntity != nullptr)
+        {
+            memcpy(data + (0x1E), messageEntity->GetName(), (messageEntity->name.size() > 15 ? 15 : messageEntity->name.size()));
+        }
+        else
+        {
+            memcpy(data + (0x1E), PEntity->GetName(), (PEntity->name.size() > 15 ? 15 : PEntity->name.size()));
+        }	
+    }
 	else if (PEntity->objtype == TYPE_PC)
 	{
 		messageID += 0x8000;
 	}
 
-	ref<uint16>(0x1A) = messageID;
+    ref<uint16>(0x1A) = messageID;
 }

--- a/src/map/packets/message_special.h
+++ b/src/map/packets/message_special.h
@@ -47,7 +47,8 @@ public:
 		uint32 param1 = 0, 
 		uint32 param2 = 0, 
 		uint32 param3 = 0, 
-		bool ShowName = false);
+		bool ShowName = false,
+		CBaseEntity* messageEntity = nullptr);
 };
 
 #endif


### PR DESCRIPTION
this is to fix the messageSpecial packet being able to take an additional entity used in the message if not the base entity sending the message,

from my testing this does not seem to intefere with exsisting uses of messageSpecial or showText, but it meets the needs of special cases when the entity needs to be set.