### PR TITLE
Fixed getting cutscenes while mounted.

### DIFF
--- a/scripts/globals/icanheararainbow.lua
+++ b/scripts/globals/icanheararainbow.lua
@@ -102,10 +102,6 @@ function triggerLightCutscene( player)
                     player:setVar( "I_CAN_HEAR_A_RAINBOW_Weather", weather);
                 end
             end
-
-            if (cutsceneTriggered) then
-                fixChocoboBug(player);
-            end
         end
     end
 
@@ -135,20 +131,5 @@ end;
 -----------------------------------
 
 function lightCutsceneFinish( player)
-    fixChocoboBug(player);
     player:setVar("I_CAN_HEAR_A_RAINBOW_Weather", 0);
-end;
-
------------------------------------
--- fixChocoboBug
------------------------------------
-
-function fixChocoboBug( player)
-    if (player:hasStatusEffect(dsp.effect.MOUNTED)) then
-        if (player:getAnimation() == 5) then
-            player:setAnimation( 0);
-        elseif (player:getAnimation() == 0) then
-            player:setAnimation( 5);
-        end
-    end
 end;

--- a/src/map/entities/baseentity.h
+++ b/src/map/entities/baseentity.h
@@ -58,6 +58,7 @@ enum ANIMATIONTYPE
     ANIMATION_ATTACK             = 1,
     // Death                        = 2,
     ANIMATION_DEATH              = 3,
+    ANIMATION_EVENT              = 4,
     ANIMATION_CHOCOBO            = 5,
     ANIMATION_FISHING            = 6,
     // Healing                      = 7,

--- a/src/map/packet_system.cpp
+++ b/src/map/packet_system.cpp
@@ -1,4 +1,4 @@
-﻿/*
+/*
 ===========================================================================
 
 Copyright (c) 2010-2015 Darkstar Dev Teams
@@ -2676,7 +2676,7 @@ void SmallPacket0x05B(map_session_data_t* session, CCharEntity* PChar, CBasicPac
     }
 
     PChar->pushPacket(new CReleasePacket(PChar, RELEASE_EVENT));
-    return;
+    PChar->updatemask |= UPDATE_HP;
 }
 
 /************************************************************************

--- a/src/map/packets/char_update.cpp
+++ b/src/map/packets/char_update.cpp
@@ -1,4 +1,4 @@
-﻿/*
+/*
 ===========================================================================
 
   Copyright (c) 2010-2015 Darkstar Dev Teams
@@ -65,7 +65,7 @@ CCharUpdatePacket::CCharUpdatePacket(CCharEntity* PChar)
     ref<uint8>(0x29) = PChar->GetGender() + (PChar->look.size > 0 ? PChar->look.size * 8 : 2); // +  управляем ростом: 0x02 - 0; 0x08 - 1; 0x10 - 2;
     ref<uint8>(0x2C) = PChar->GetSpeed();
     ref<uint16>(0x2E) |= PChar->speedsub << 1;
-    ref<uint8>(0x30) = PChar->animation;
+    ref<uint8>(0x30) = PChar->m_event.EventID != -1 ? ANIMATION_EVENT : PChar->animation;
 
     CItemLinkshell* linkshell = (CItemLinkshell*)PChar->getEquip(SLOT_LINK1);
 


### PR DESCRIPTION
Cutscenes seem to expect the client ANIMATION 0 or 4 to play, on retail the couple instances where you can encounter a cutscene while mounted seems to switch the player to 4.

Tested SMN quest, and the final cutscene for Chains of Promathia in Lufaise Meadows.