### PR TITLE
Re-Insert players to a BCNM in case of D'C

### DIFF
--- a/scripts/zones/Ghelsba_Outpost/Zone.lua
+++ b/scripts/zones/Ghelsba_Outpost/Zone.lua
@@ -3,35 +3,44 @@
 -- Zone: Ghelsba_Outpost (140)
 --
 -----------------------------------
-package.loaded["scripts/zones/Ghelsba_Outpost/TextIDs"] = nil;
+package.loaded["scripts/zones/Ghelsba_Outpost/TextIDs"] = nil
 -----------------------------------
-require("scripts/zones/Ghelsba_Outpost/TextIDs");
-require("scripts/globals/conquest");
+require("scripts/zones/Ghelsba_Outpost/TextIDs")
+require("scripts/globals/conquest")
+require("scripts/globals/status")
 -----------------------------------
 
 function onInitialize(zone)
-end;
+end
 
 function onZoneIn(player,prevZone)
-    local cs = -1;
+    local cs = -1
     if (player:getXPos() == 0 and player:getYPos() == 0 and player:getZPos() == 0) then
-        player:setPos(125.852,-22.097,180.403,128);
+        player:setPos(125.852,-22.097,180.403,128)
     end
-    return cs;
-end;
+    return cs
+end
+
+function afterZoneIn (player)
+    if player:hasStatusEffect(dsp.effect.LEVEL_RESTRICTION) then
+        local effect = player:getStatusEffect(dsp.effect.LEVEL_RESTRICTION)
+        player:delStatusEffect(dsp.effect.LEVEL_RESTRICTION)
+        player:addStatusEffect(dsp.effect.LEVEL_RESTRICTION,effect:getPower(),0,0)
+    end
+end
 
 function onConquestUpdate(zone, updatetype)
-    local players = zone:getPlayers();
+    local players = zone:getPlayers()
     for name, player in pairs(players) do
-        conquestUpdate(zone, player, updatetype, CONQUEST_BASE);
+        conquestUpdate(zone, player, updatetype, CONQUEST_BASE)
     end
-end;
+end
 
 function onRegionEnter(player,region)
-end;
+end
 
 function onEventUpdate(player,csid,option)
-end;
+end
 
 function onEventFinish(player,csid,option)
-end;
+end

--- a/src/map/zone.cpp
+++ b/src/map/zone.cpp
@@ -625,6 +625,12 @@ void CZone::IncreaseZoneCounter(CCharEntity* PChar)
     }
 
     CharZoneIn(PChar);
+
+    if (m_BattlefieldHandler)
+    {
+        if (auto PBattlefield = m_BattlefieldHandler->GetBattlefield(PChar, true))
+            PBattlefield->InsertEntity(PChar, true);
+    }
 }
 
 /************************************************************************


### PR DESCRIPTION
This was the best method that I was able to find for re-applying the Level Cap Sync after a Disconnect from a BCNM. Every BCNM capable zone.lua would have to have this 'afterZoneIn' code and If this is accepted, I will do the rest of them. 