### PR TITLE
Fix (Dangruf Gambling) THF AF2 quest

### DIFF
--- a/scripts/zones/Dangruf_Wadi/TextIDs.lua
+++ b/scripts/zones/Dangruf_Wadi/TextIDs.lua
@@ -1,30 +1,44 @@
 -- Variable TextID   Description text
 
 -- General Texts
-ITEM_CANNOT_BE_OBTAINED = 6540; -- You cannot obtain the item <item>. Come back after sorting your inventory.
-          ITEM_OBTAINED = 6546; -- Obtained: <item>.
-           GIL_OBTAINED = 6547; -- Obtained <number> gil.
-       KEYITEM_OBTAINED = 6549; -- Obtained key item: <keyitem>.
- FISHING_MESSAGE_OFFSET = 7207; -- You can't fish here.
+ITEM_CANNOT_BE_OBTAINED = 6540 -- You cannot obtain the item <item>. Come back after sorting your inventory.
+          ITEM_OBTAINED = 6546 -- Obtained: <item>.
+           GIL_OBTAINED = 6547 -- Obtained <number> gil.
+       KEYITEM_OBTAINED = 6549 -- Obtained key item: <keyitem>.
+ FISHING_MESSAGE_OFFSET = 7207 -- You can't fish here.
 
 -- Treasure Coffer/Chest Dialog
-         CHEST_UNLOCKED = 7432; -- You unlock the chest!
-             CHEST_FAIL = 7433; -- fails to open the chest.
-             CHEST_TRAP = 7434; -- The chest was trapped!
-             CHEST_WEAK = 7435; -- You cannot open the chest when you are in a weakened state.
-            CHEST_MIMIC = 7436; -- The chest was a mimic!
-           CHEST_MOOGLE = 7437; -- You cannot open the chest while participating in the moogle event.
-         CHEST_ILLUSION = 7438; -- The chest was but an illusion...
-           CHEST_LOCKED = 7439; -- The chest appears to be locked.
+         CHEST_UNLOCKED = 7432 -- You unlock the chest!
+             CHEST_FAIL = 7433 -- fails to open the chest.
+             CHEST_TRAP = 7434 -- The chest was trapped!
+             CHEST_WEAK = 7435 -- You cannot open the chest when you are in a weakened state.
+            CHEST_MIMIC = 7436 -- The chest was a mimic!
+           CHEST_MOOGLE = 7437 -- You cannot open the chest while participating in the moogle event.
+         CHEST_ILLUSION = 7438 -- The chest was but an illusion...
+           CHEST_LOCKED = 7439 -- The chest appears to be locked.
 
 -- Other Text
-      GEOMAGNETIC_FOUNT = 7169; -- A faint energy wafts up from the ground.
-             SMALL_HOLE = 7486; -- There is a small hole here.
+      GEOMAGNETIC_FOUNT = 7169 -- A faint energy wafts up from the ground.
+             SMALL_HOLE = 7486 -- There is a small hole here.
+
+-- THF AF Quest
+       CRYSTALLINE_DUST = 7339 -- The area is littered with a white crystalline dust.
+          PLANT_EXTRACT = 7340 -- A plant extract is smeared around the area.
+            BROKEN_EGGS = 7341 -- A number of broken eggs lie scattered about.
+         YOU_PLACE_ITEM = 7342 -- You place <item> down.
+        YOU_BEAT_GOBLIN = 7344 -- You beat the Goblin!
+        GOBLIN_BEAT_YOU = 7345 -- The Goblin beat you...
+            YOU_GAVE_UP = 7346 -- You gave up...
+           BEAT_SALTVIX = 7351 -- (...Hmph! All happy 'cause he beat Saltvix...Won't stand chance 'gainst Grasswix...)
+        DONT_WASTE_TIME = 7361 -- You hear a voice... (Grasswix don't waste time with losers...)
+          BEAT_GRASSWIX = 7362 -- (...can't believe it! How could Grasswix lose! Eggblix of Cavern...he no lose!)
+           JUST_WONT_DO = 7372 -- You hear a voice... (...just won't do...nope...nope...)
+           BEAT_EGGBLIX = 7373 -- (..Lucky, ya are! Don't forget to say hi to our sister at Drachenfall!)
 
 -- conquest Base
-          CONQUEST_BASE =    0;
+          CONQUEST_BASE =    0
 
 -- Strange Apparatus
-     DEVICE_NOT_WORKING = 7321; -- The device is not working.
-           SYS_OVERLOAD = 7330; -- arning! Sys...verload! Enterin...fety mode. ID eras...d
-           YOU_LOST_THE = 7335; -- You lost the #.
+     DEVICE_NOT_WORKING = 7321 -- The device is not working.
+           SYS_OVERLOAD = 7330 -- arning! Sys...verload! Enterin...fety mode. ID eras...d
+           YOU_LOST_THE = 7335 -- You lost the #.

--- a/scripts/zones/Dangruf_Wadi/npcs/qm3.lua
+++ b/scripts/zones/Dangruf_Wadi/npcs/qm3.lua
@@ -1,49 +1,71 @@
 -----------------------------------
 --  NPC: ??? (QM3)
--- Type: Saltvix dice roll game part 2
--- !zone 191
--- Involved in quest "As Thick As Thieves"
+-- Type: Saltvix (dice roll game part 1)
+--  @zone 191
+--  Involved in quest "As Thick As Thieves"
 -----------------------------------
-package.loaded["scripts/zones/Dangruf_Wadi/TextIDs"] = nil;
+package.loaded["scripts/zones/Dangruf_Wadi/TextIDs"] = nil
 -----------------------------------
-require("scripts/globals/quests");
-require("scripts/zones/Dangruf_Wadi/TextIDs");
+require("scripts/zones/Dangruf_Wadi/TextIDs")
+require("scripts/globals/npc_util")
+require("scripts/globals/quests")
 -----------------------------------
 
 function onTrade(player,npc,trade)
 
-    local thickAsThievesGamblingCS = player:getVar("thickAsThievesGamblingCS");
+    local thickAsThievesGamblingCS = player:getVar("thickAsThievesGamblingCS")
 
-    if (thickAsThievesGamblingCS == 2) then
-        if (trade:hasItemQty(936,1) and trade:getItemCount() == 1) then -- Trade 1x rock slat
-            local rand1 = math.random(1,999);
-            local rand2 = math.random(1,999);
+    if npcUtil.tradeHas(trade, 936) then -- Trade 1x rock slat
+        if thickAsThievesGamblingCS == 2 then
+            local rand1 = math.random(1,999)
+            local rand2 = math.random(1,999)
 
             if (rand1 > rand2) then
-                player:startEvent(136,1092,0,rand1,rand2); -- complete 1/3 gamble mini quest
+                player:messageSpecial(YOU_PLACE_ITEM,0,936)
+                player:startEvent(136,1092,0,rand1,rand2) -- complete 1/3 gamble mini quest
             else
-                player:startEvent(139,0,0,rand1,rand2); -- player looses
+                player:messageSpecial(YOU_PLACE_ITEM,0,936)
+                player:startEvent(139,0,0,rand1,rand2) -- player looses
             end
+        elseif thickAsThievesGamblingCS == -1 then  -- player previously lost to this goblin
+            local rand1 = math.random(1,999)
+            local rand2 = math.random(1,999)
+
+            if (rand1 > rand2) then
+                player:messageSpecial(YOU_PLACE_ITEM,0,936)
+                player:startEvent(142,1092,0,rand1,rand2) -- complete 1/3 gamble mini quest
+            else
+                player:messageSpecial(YOU_PLACE_ITEM,0,936)
+                player:startEvent(145,0,0,rand1,rand2) -- player looses
+            end
+        elseif thickAsThievesGamblingCS > 2 then
+            player:messageSpecial(BEAT_SALTVIX)
         end
     end
 
-end;
+end
 
 function onTrigger(player,npc)
-end;
+    player:messageSpecial(CRYSTALLINE_DUST)
+end
 
 function onEventUpdate(player,csid,option)
-end;
+end
 
 function onEventFinish(player,csid,option)
 
-    if (csid == 139 and option == 1) then -- player looses dice game
-        player:tradeComplete();
-        player:setVar("thickAsThievesGamblingCS",2);
-    elseif (csid == 136 and option == 0) then -- player wins dice game
-        player:tradeComplete();
-        player:setVar("thickAsThievesGamblingCS",3);
+    if (csid == 139 or csid == 136 or csid == 142 or csid == 145) and option == 2 then -- player gives up
+        player:confirmTrade()
+        player:messageSpecial(YOU_GAVE_UP)
+        player:setVar("thickAsThievesGamblingCS",-1)
+    elseif (csid == 139 or csid == 145) and option == 1 then -- player looses dice game
+        player:confirmTrade()
+        player:messageSpecial(GOBLIN_BEAT_YOU)
+        player:setVar("thickAsThievesGamblingCS",-1)
+    elseif (csid == 136 or csid == 142) and option == 0 then -- player wins dice game
+        player:confirmTrade()
+        player:messageSpecial(YOU_BEAT_GOBLIN)
+        player:setVar("thickAsThievesGamblingCS",3)
     end
 
-end;
-
+end

--- a/scripts/zones/Dangruf_Wadi/npcs/qm4.lua
+++ b/scripts/zones/Dangruf_Wadi/npcs/qm4.lua
@@ -1,48 +1,64 @@
 -----------------------------------
 --  NPC: ??? (QM4)
--- Type: Grasswix dice roll game part 2
--- @zone 191
--- Involved in quest "As Thick As Thieves"
+-- Type: Grasswix (dice roll game part 2)
+--  @zone 191
+--  Involved in quest "As Thick As Thieves"
 -----------------------------------
-package.loaded["scripts/zones/Dangruf_Wadi/TextIDs"] = nil;
+package.loaded["scripts/zones/Dangruf_Wadi/TextIDs"] = nil
 -----------------------------------
-require("scripts/globals/quests");
-require("scripts/zones/Dangruf_Wadi/TextIDs");
+require("scripts/zones/Dangruf_Wadi/TextIDs")
+require("scripts/globals/npc_util")
+require("scripts/globals/settings")
+require("scripts/globals/quests")
 -----------------------------------
 
 function onTrade(player,npc,trade)
 
-    local thickAsThievesGamblingCS = player:getVar("thickAsThievesGamblingCS");
+    local thickAsThievesGamblingCS = player:getVar("thickAsThievesGamblingCS")
 
-    if (thickAsThievesGamblingCS == 3) then
-        if (trade:hasItemQty(534,1) and trade:getItemCount() == 1) then -- Trade 1x gaussbit wildgrass
-            local rand1 = math.random(1,999);
-            local rand2 = math.random(1,999);
+    if npcUtil.tradeHas(trade, 534) then -- Trade 1x gaussbit wildgrass
+        if thickAsThievesGamblingCS == 3 then
+            local rand1 = math.random(1,999)
+            local rand2 = math.random(1,999)
 
             if (rand1 > rand2) then
-                player:startEvent(137,1092,0,rand1,rand2); -- complete 2/3 gamble mini quest
+                player:messageSpecial(YOU_PLACE_ITEM,0,534)
+                player:startEvent(137,1092,0,rand1,rand2) -- complete 2/3 gamble mini quest
             else
-                player:startEvent(140,0,0,rand1,rand2); -- player looses
+                player:messageSpecial(YOU_PLACE_ITEM,0,534)
+                player:startEvent(140,0,0,rand1,rand2) -- player looses
             end
+        elseif thickAsThievesGamblingCS < 3 then -- trading out of order
+            player:messageSpecial(DONT_WASTE_TIME)
+        elseif thickAsThievesGamblingCS > 3 then
+            player:messageSpecial(BEAT_GRASSWIX)
         end
     end
 
-end;
+end
 
 function onTrigger(player,npc)
-end;
+    player:messageSpecial(PLANT_EXTRACT)
+end
 
 function onEventUpdate(player,csid,option)
-end;
+end
 
 function onEventFinish(player,csid,option)
-    if (csid == 140 and option == 1) then -- player looses dice game
-        player:tradeComplete();
-        player:setVar("thickAsThievesGamblingCS",2);
-    elseif (csid == 137 and option == 0) then -- player wins dice game
-        player:tradeComplete();
-        player:setVar("thickAsThievesGamblingCS",4);
+
+    if (csid == 137 or csid == 140) and option == 2 then -- player gives up
+        player:confirmTrade()
+        player:messageSpecial(YOU_GAVE_UP)
+    elseif csid == 140 and option == 1 then -- player looses dice game
+        player:confirmTrade()
+        player:messageSpecial(GOBLIN_BEAT_YOU)
+        if OLD_SCHOOL_ENABLED then
+            player:setVar("thickAsThievesGamblingCS",-1) -- start over
+        end
+    elseif csid == 137 and option == 0 then -- player wins dice game
+        player:confirmTrade()
+        player:messageSpecial(YOU_BEAT_GOBLIN)
+        player:setVar("thickAsThievesGamblingCS",4)
     end
 
-end;
-
+end

--- a/scripts/zones/Dangruf_Wadi/npcs/qm5.lua
+++ b/scripts/zones/Dangruf_Wadi/npcs/qm5.lua
@@ -1,48 +1,64 @@
 -----------------------------------
 --  NPC: ??? (QM5)
--- Type: Eggblix dice roll game part 3
--- !zone 191
--- Involved in quest "As Thick As Thieves"
+-- Type: Eggblix (dice roll game part 3)
+--  @zone 191
+--  Involved in quest "As Thick As Thieves"
 -----------------------------------
-package.loaded["scripts/zones/Dangruf_Wadi/TextIDs"] = nil;
+package.loaded["scripts/zones/Dangruf_Wadi/TextIDs"] = nil
 -----------------------------------
-require("scripts/globals/quests");
-require("scripts/zones/Dangruf_Wadi/TextIDs");
+require("scripts/zones/Dangruf_Wadi/TextIDs")
+require("scripts/globals/npc_util")
+require("scripts/globals/settings")
+require("scripts/globals/quests")
 -----------------------------------
 
 function onTrade(player,npc,trade)
 
-    local thickAsThievesGamblingCS = player:getVar("thickAsThievesGamblingCS");
+    local thickAsThievesGamblingCS = player:getVar("thickAsThievesGamblingCS")
 
-    if (thickAsThievesGamblingCS == 4) then
-        if (trade:hasItemQty(4362,1) and trade:getItemCount() == 1) then -- Trade 1x lizard egg
-            local rand1 = math.random(1,999);
-            local rand2 = math.random(1,999);
+    if npcUtil.tradeHas(trade, 4362) then -- Trade 1x lizard egg
+        if thickAsThievesGamblingCS == 4 then
+            local rand1 = math.random(1,999)
+            local rand2 = math.random(1,999)
 
             if (rand1 > rand2) then
-                player:startEvent(138,1092,0,rand1,rand2); -- complete 2/3 gamble mini quest
+                player:messageSpecial(YOU_PLACE_ITEM,0,4362)
+                player:startEvent(138,1092,0,rand1,rand2) -- complete 3/3 gamble mini quest
             else
-                player:startEvent(141,0,0,rand1,rand2); -- player looses
+                player:messageSpecial(YOU_PLACE_ITEM,0,4362)
+                player:startEvent(141,0,0,rand1,rand2) -- player looses
             end
+        elseif thickAsThievesGamblingCS < 4 then -- trading out of order
+            player:messageSpecial(JUST_WONT_DO)
+        elseif thickAsThievesGamblingCS > 4 then
+            player:messageSpecial(BEAT_EGGBLIX)
         end
     end
 
-end;
+end
 
 function onTrigger(player,npc)
-end;
+    player:messageSpecial(BROKEN_EGGS)
+end
 
 function onEventUpdate(player,csid,option)
-end;
+end
 
 function onEventFinish(player,csid,option)
-    if (csid == 141 and option == 1) then -- player looses dice game
-        player:tradeComplete();
-        player:setVar("thickAsThievesGamblingCS",2);
-    elseif (csid == 138 and option == 0) then -- player wins dice game
-        player:tradeComplete();
-        player:setVar("thickAsThievesGamblingCS",5);
+
+    if (csid == 138 or csid == 141) and option == 2 then -- player gives up
+        player:confirmTrade()
+        player:messageSpecial(YOU_GAVE_UP)
+    elseif csid == 141 and option == 1 then -- player looses dice game
+        player:confirmTrade()
+        player:messageSpecial(GOBLIN_BEAT_YOU)
+        if OLD_SCHOOL_ENABLED then
+            player:setVar("thickAsThievesGamblingCS",-1) -- start over
+        end
+    elseif csid == 138 and option == 0 then -- player wins dice game
+        player:confirmTrade()
+        player:messageSpecial(YOU_BEAT_GOBLIN)
+        player:setVar("thickAsThievesGamblingCS",5)
     end
 
-end;
-
+end


### PR DESCRIPTION
I added all of the Text for the Gambling part of the quest "As Thick as Thieves". 
Also, retail does NOT make you start over any longer if you fail to beat one of the goblins.
I implemented the option for "giving up"
as well as the various messages obtained depending on what part of the quest you are on.
reference: https://youtu.be/SyWPTm2OA9w?t=3417

Here's the iffy part:
Since retail no longer makes you start over I thought it might be ok to start adding a "master" Old School Enabled switch that will essentially control EVERYTHING old school by either turning it on or off... and just have 1 and only 1 option in the bloated settings.lua. I put an if statement in there that would handle that and essentially make the quest like it used to be.  Maybe it's a good idea, idk... I was also going to start doing everything in the future the same way using the just one setting. And also could start converting everything else that is old school related to just one setting... either way don't matter to me, I can delete it just as well.