### PR TITLE
Added recipe for Marine Stewpot (117 Cooking)

### DIFF
--- a/sql/synth_recipes.sql
+++ b/sql/synth_recipes.sql
@@ -4651,6 +4651,7 @@ INSERT INTO `synth_recipes` VALUES (4536,0,0,0,0,19,0,0,0,0,0,4100,4242,12849,0,
 INSERT INTO `synth_recipes` VALUES (4537,0,0,0,0,0,0,0,0,100,0,4100,4242,17252,0,0,0,0,0,0,0,1231,717,654,655,1,1,1,1); -- Culverin (desynth)
 INSERT INTO `synth_recipes` VALUES (4538,0,0,0,67,0,0,0,0,0,0,4100,4242,12838,0,0,0,0,0,0,0,826,851,896,896,1,1,1,1); -- Scorpion Subligar (desynth)
 INSERT INTO `synth_recipes` VALUES (4539,1,0,0,0,0,0,99,0,0,0,4100,4242,15771,0,0,0,0,0,0,0,747,747,2275,2275,1,1,1,1); -- Shining Ring (desynth)
+INSERT INTO `synth_recipes` VALUES (4540,1,2045,0,0,0,117,0,0,0,0,4096,4238,2110,4509,5134,5233,5234,5236,5237,5680,5893,5894,5894,5894,1,1,1,1); -- Marine Stewpot (117 cooking) https://www.bg-wiki.com/bg/Marine_Stewpot
 
 -- INSERT INTO `synth_recipes` VALUES (ID,Type,KeyItem,AL,BO,CL,CK,GO,LE,SM,WD,Crystal,HQCrystal,I1,I2,I3,I4,I5,I6,I7,I8,R1,R2,R3,R4,Q1,Q2,Q3,Q4); -- template
 -- crystals = fire(4096,4238) ice(4097,4239) wind(4098,4240) earth(4099,4241) lightning(4100,4242) water(4101,4243) light(4102,4244) dark(4103,4245)


### PR DESCRIPTION
https://www.bg-wiki.com/bg/Marine_Stewpot has craft level 115~120 so I chose the middle number because neither 115 or 120 wanted to play nice.

Recipe requires KI Culinarian's argentum tome (Key Item ID 2045) which is currently not obtainable on DSP

This recipe will be ready and waiting for when it is!