### PR TITLE
Limit number of items a mob can drop to the treasure pool size

### DIFF
--- a/src/map/entities/mobentity.cpp
+++ b/src/map/entities/mobentity.cpp
@@ -784,7 +784,7 @@ void CMobEntity::OnMobSkillFinished(CMobSkillState& state, action_t& action)
     }
 }
 
-void CMobEntity::DropItems()
+void CMobEntity::HandleDeath()
 {
     CCharEntity* PChar = (CCharEntity*)GetEntity(m_OwnerID.targid, TYPE_PC);
 
@@ -803,137 +803,13 @@ void CMobEntity::DropItems()
                 charutils::DistributeExperiencePoints(PChar, this);
             }
 
-            DropList_t* DropList = itemutils::GetDropList(m_DropID);
-            //ShowDebug(CL_CYAN"DropID: %u dropping with TH Level: %u\n" CL_RESET, PMob->m_DropID, PMob->m_THLvl);
-
-            if (DropList != nullptr && !getMobMod(MOBMOD_NO_DROPS) && DropList->Items.size() || DropList->Groups.size())
-            {
-                //THLvl is the number of 'extra chances' at an item. If the item is obtained, then break out.
-                uint8 maxRolls = 1 + (m_THLvl > 2 ? 2 : m_THLvl);
-                uint8 bonus = (m_THLvl > 2 ? (m_THLvl - 2) * 10 : 0);
-
-                for (const DropGroup_t&  group : DropList->Groups)
-                {
-                    for (uint8 roll = 0; roll < maxRolls; ++roll)
-                    {
-                        //Determine if this group should drop an item
-                        if (group.GroupRate > 0 && dsprand::GetRandomNumber(1000) < group.GroupRate * map_config.drop_rate_multiplier + bonus)
-                        {
-                            //Each item in the group is given its own weight range which is the previous value to the previous value + item.DropRate
-                            //Such as 2 items with drop rates of 200 and 800 would be 0-199 and 200-999 respectively
-                            uint16 previousRateValue = 0;
-                            uint16 itemRoll = dsprand::GetRandomNumber(1000);
-                            for (const DropItem_t& item : group.Items)
-                            {
-                                if (previousRateValue + item.DropRate > itemRoll)
-                                {
-                                    PChar->PTreasurePool->AddItem(item.ItemID, this);
-                                    break;
-                                }
-                                previousRateValue += item.DropRate;
-                            }
-                            break;
-                        }
-                    }
-                }
-
-                for (const DropItem_t& item : DropList->Items)
-                {
-                    for (uint8 roll = 0; roll < maxRolls; ++roll)
-                    {
-                        if (item.DropRate > 0 && dsprand::GetRandomNumber(1000) < item.DropRate * map_config.drop_rate_multiplier + bonus)
-                        {
-                            PChar->PTreasurePool->AddItem(item.ItemID, this);
-                            break;
-                        }
-                    }
-                }
-            }
-
             // check for gil (beastmen drop gil, some NMs drop gil)
             if (CanDropGil() || (map_config.all_mobs_gil_bonus > 0 && getMobMod(MOBMOD_GIL_MAX) >= 0)) // Negative value of MOBMOD_GIL_MAX is used to prevent gil drops in Dynamis/Limbus.
             {
                 charutils::DistributeGil(PChar, this); // TODO: REALISATION MUST BE IN TREASUREPOOL
             }
-            //check for seal drops
-            /* MobLvl >= 1 = Beastmen Seals ID=1126
-                      >= 50 = Kindred Seals ID=1127
-                      >= 75 = Kindred Crests ID=2955
-                      >= 90 = High Kindred Crests ID=2956
-            */
 
-            uint16 Pzone = PChar->getZone();
-
-            bool validZone = ((Pzone > 0 && Pzone < 39) || (Pzone > 42 && Pzone < 134) || (Pzone > 135 && Pzone < 185) || (Pzone > 188 && Pzone < 255));
-
-            if (validZone && charutils::GetRealExp(PChar->GetMLevel(), GetMLevel()) > 0)
-            {
-                if (((PChar->StatusEffectContainer->HasStatusEffect(EFFECT_SIGNET) && conquest::GetInfluenceGraphics(PChar->loc.zone->GetRegionID()) < 64) ||
-                    (PChar->StatusEffectContainer->HasStatusEffect(EFFECT_SANCTION) && PChar->loc.zone->GetRegionID() >= 28 && PChar->loc.zone->GetRegionID() <= 32) ||
-                    (PChar->StatusEffectContainer->HasStatusEffect(EFFECT_SIGIL) && PChar->loc.zone->GetRegionID() >= 33 && PChar->loc.zone->GetRegionID() <= 40)) &&
-                    m_Element > 0 && dsprand::GetRandomNumber(100) < 20) // Need to move to CRYSTAL_CHANCE constant
-                {
-                    PChar->PTreasurePool->AddItem(4095 + m_Element, this);
-                }
-
-                // Todo: Avatarite and Geode drops during day/weather. Much higher chance during weather than day.
-                // Item element matches day/weather element, not mob crystal. Lv80+ xp mobs can drop Avatarite.
-                // Wiki's have conflicting info on mob lv required for Geodes. One says 50 the other 75. I think 50 is correct.
-
-                if (dsprand::GetRandomNumber(100) < 20 && PChar->PTreasurePool->CanAddSeal() && !getMobMod(MOBMOD_NO_DROPS))
-                {
-                    //RULES: Only 1 kind may drop per mob
-                    if (GetMLevel() >= 75 && luautils::IsContentEnabled("ABYSSEA")) //all 4 types
-                    {
-                        switch (dsprand::GetRandomNumber(4))
-                        {
-                            case 0:
-                                PChar->PTreasurePool->AddItem(1126, this);
-                                break;
-                            case 1:
-                                PChar->PTreasurePool->AddItem(1127, this);
-                                break;
-                            case 2:
-                                PChar->PTreasurePool->AddItem(2955, this);
-                                break;
-                            case 3:
-                                PChar->PTreasurePool->AddItem(2956, this);
-                                break;
-                        }
-                    }
-                    else if (GetMLevel() >= 70 && luautils::IsContentEnabled("ABYSSEA")) //b.seal & k.seal & k.crest
-                    {
-                        switch (dsprand::GetRandomNumber(3))
-                        {
-                            case 0:
-                                PChar->PTreasurePool->AddItem(1126, this);
-                                break;
-                            case 1:
-                                PChar->PTreasurePool->AddItem(1127, this);
-                                break;
-                            case 2:
-                                PChar->PTreasurePool->AddItem(2955, this);
-                                break;
-                        }
-                    }
-                    else if (GetMLevel() >= 50) //b.seal & k.seal only
-                    {
-                        if (dsprand::GetRandomNumber(2) == 0)
-                        {
-                            PChar->PTreasurePool->AddItem(1126, this);
-                        }
-                        else
-                        {
-                            PChar->PTreasurePool->AddItem(1127, this);
-                        }
-                    }
-                    else
-                    {
-                        //b.seal only
-                        PChar->PTreasurePool->AddItem(1126, this);
-                    }
-                }
-            }
+            DropItems(PChar);
         }
 
         PChar->setWeaponSkillKill(false);
@@ -947,6 +823,140 @@ void CMobEntity::DropItems()
     {
         luautils::OnMobDeath(this, nullptr);
     }
+}
+
+void CMobEntity::DropItems(CCharEntity* PChar) {
+    //Limit number of items that can drop to the treasure pool size
+    uint8 dropCount = 0;
+    #define ADD_ITEM_TO_POOL(ItemID) { PChar->PTreasurePool->AddItem(ItemID, this); if( ++dropCount == TREASUREPOOL_SIZE ) { return; } }
+
+    DropList_t* DropList = itemutils::GetDropList(m_DropID);
+    //ShowDebug(CL_CYAN"DropID: %u dropping with TH Level: %u\n" CL_RESET, PMob->m_DropID, PMob->m_THLvl);
+
+    if (DropList != nullptr && !getMobMod(MOBMOD_NO_DROPS) && DropList->Items.size() || DropList->Groups.size())
+    {
+        //THLvl is the number of 'extra chances' at an item. If the item is obtained, then break out.
+        uint8 maxRolls = 1 + (m_THLvl > 2 ? 2 : m_THLvl);
+        uint8 bonus = (m_THLvl > 2 ? (m_THLvl - 2) * 10 : 0);
+
+        for (const DropGroup_t& group : DropList->Groups)
+        {
+            for (uint8 roll = 0; roll < maxRolls; ++roll)
+            {
+                //Determine if this group should drop an item
+                if (group.GroupRate > 0 && dsprand::GetRandomNumber(1000) < group.GroupRate * map_config.drop_rate_multiplier + bonus)
+                {
+                    //Each item in the group is given its own weight range which is the previous value to the previous value + item.DropRate
+                    //Such as 2 items with drop rates of 200 and 800 would be 0-199 and 200-999 respectively
+                    uint16 previousRateValue = 0;
+                    uint16 itemRoll = dsprand::GetRandomNumber(1000);
+                    for (const DropItem_t& item : group.Items)
+                    {
+                        if (previousRateValue + item.DropRate > itemRoll)
+                        {
+                            ADD_ITEM_TO_POOL(item.ItemID);
+                            break;
+                        }
+                        previousRateValue += item.DropRate;
+                    }
+                    break;
+                }
+            }
+        }
+
+        for (const DropItem_t& item : DropList->Items)
+        {
+            for (uint8 roll = 0; roll < maxRolls; ++roll)
+            {
+                if (item.DropRate > 0 && dsprand::GetRandomNumber(1000) < item.DropRate * map_config.drop_rate_multiplier + bonus)
+                {
+                    ADD_ITEM_TO_POOL(item.ItemID);
+                    break;
+                }
+            }
+        }
+    }
+
+    //check for seal drops
+    /* MobLvl >= 1 = Beastmen Seals ID=1126
+    >= 50 = Kindred Seals ID=1127
+    >= 75 = Kindred Crests ID=2955
+    >= 90 = High Kindred Crests ID=2956
+    */
+
+    uint16 Pzone = PChar->getZone();
+
+    bool validZone = ((Pzone > 0 && Pzone < 39) || (Pzone > 42 && Pzone < 134) || (Pzone > 135 && Pzone < 185) || (Pzone > 188 && Pzone < 255));
+
+    if (validZone && charutils::GetRealExp(PChar->GetMLevel(), GetMLevel()) > 0)
+    {
+        if (((PChar->StatusEffectContainer->HasStatusEffect(EFFECT_SIGNET) && conquest::GetInfluenceGraphics(PChar->loc.zone->GetRegionID()) < 64) ||
+            (PChar->StatusEffectContainer->HasStatusEffect(EFFECT_SANCTION) && PChar->loc.zone->GetRegionID() >= 28 && PChar->loc.zone->GetRegionID() <= 32) ||
+            (PChar->StatusEffectContainer->HasStatusEffect(EFFECT_SIGIL) && PChar->loc.zone->GetRegionID() >= 33 && PChar->loc.zone->GetRegionID() <= 40)) &&
+            m_Element > 0 && dsprand::GetRandomNumber(100) < 20) // Need to move to CRYSTAL_CHANCE constant
+        {
+            ADD_ITEM_TO_POOL(4095 + m_Element);
+        }
+
+        // Todo: Avatarite and Geode drops during day/weather. Much higher chance during weather than day.
+        // Item element matches day/weather element, not mob crystal. Lv80+ xp mobs can drop Avatarite.
+        // Wiki's have conflicting info on mob lv required for Geodes. One says 50 the other 75. I think 50 is correct.
+
+        if (dsprand::GetRandomNumber(100) < 20 && PChar->PTreasurePool->CanAddSeal() && !getMobMod(MOBMOD_NO_DROPS))
+        {
+            //RULES: Only 1 kind may drop per mob
+            if (GetMLevel() >= 75 && luautils::IsContentEnabled("ABYSSEA")) //all 4 types
+            {
+                switch (dsprand::GetRandomNumber(4))
+                {
+                case 0:
+                    ADD_ITEM_TO_POOL(1126);
+                    break;
+                case 1:
+                    ADD_ITEM_TO_POOL(1127);
+                    break;
+                case 2:
+                    ADD_ITEM_TO_POOL(2955);
+                    break;
+                case 3:
+                    ADD_ITEM_TO_POOL(2956);
+                    break;
+                }
+            }
+            else if (GetMLevel() >= 70 && luautils::IsContentEnabled("ABYSSEA")) //b.seal & k.seal & k.crest
+            {
+                switch (dsprand::GetRandomNumber(3))
+                {
+                case 0:
+                    ADD_ITEM_TO_POOL(1126);
+                    break;
+                case 1:
+                    ADD_ITEM_TO_POOL(1127);
+                    break;
+                case 2:
+                    ADD_ITEM_TO_POOL(2955);
+                    break;
+                }
+            }
+            else if (GetMLevel() >= 50) //b.seal & k.seal only
+            {
+                if (dsprand::GetRandomNumber(2) == 0)
+                {
+                    ADD_ITEM_TO_POOL(1126);
+                }
+                else
+                {
+                    ADD_ITEM_TO_POOL(1127);
+                }
+            }
+            else
+            {
+                //b.seal only
+                ADD_ITEM_TO_POOL(1126);
+            }
+        }
+    }
+    #undef ADD_ITEM_TO_POOL
 }
 
 
@@ -1021,7 +1031,7 @@ void CMobEntity::Die()
     PAI->QueueAction(queueAction_t(std::chrono::milliseconds(m_DropItemTime), false, [this](CBaseEntity* PEntity) {
         if (static_cast<CMobEntity*>(PEntity)->isDead())
         {
-            DropItems();
+            HandleDeath();
         }
     }));
     if (PMaster && PMaster->PPet == this && PMaster->objtype == TYPE_PC)

--- a/src/map/entities/mobentity.h
+++ b/src/map/entities/mobentity.h
@@ -261,7 +261,8 @@ public:
 
 protected:
 
-    void DropItems();
+    void HandleDeath();
+    void DropItems(CCharEntity* PChar);
 
 
 


### PR DESCRIPTION
Monsters were able to drop more than 10 items which could result in the treasure pool being filled instantly and some items being randomly dropped to players before they had a chance to lot. With the new drop groups this should not be as much of a problem once the groups are adjusted in mob_droplist.sql. This will ignore any drops after 10 which means that perhaps we want to have the better drops to be listed first so they have the highest priority. I do not know if we want to ever allow mobs to drop over 10 items or not but if we dont then...

I wrote two makeshift unit tests and one of them would be useful for tracking down the potential offenders by checking for the maximum number of possible items - [commit with unit tests](https://github.com/jmcmorris/darkstar/commit/b3ea3863bb27240d3e4c4bf9e3aae30a11051d6c). Spoiler! There are a lot of offenders right now - 752 to be precise.

The majority of this change is honestly refactoring the code to make it easier to stop dropping items. This was done by moving all of the other mob death related logic to `CMobEntity::HandleDeath()` and then have that call `CMobEntity::DropItems()`. I was not sure if the macro I use fits with the styling of the source and if it does not then I can change it.

**Tested lightly** to ensure drops were working but did not try it with a mob that drops 10+ items. 