### PR TITLE
Player death message fix

### DIFF
--- a/scripts/globals/spells/death.lua
+++ b/scripts/globals/spells/death.lua
@@ -17,8 +17,6 @@ function onSpellCast(caster,target,spell)
         return 0
     end
 
-    -- falls to the ground
-    spell:setMsg(dsp.msg.basic.FALL_TO_GROUND)
     target:setHP(0)
 
     return 0

--- a/src/map/entities/battleentity.cpp
+++ b/src/map/entities/battleentity.cpp
@@ -73,6 +73,7 @@ CBattleEntity::CBattleEntity()
     PPet = nullptr;
     PParty = nullptr;
     PMaster = nullptr;
+    PLastAttacker = nullptr;
 
     StatusEffectContainer = std::make_unique<CStatusEffectContainer>(this);
     PRecastContainer = std::make_unique<CRecastContainer>(this);
@@ -515,6 +516,7 @@ int32 CBattleEntity::addMP(int32 mp)
 
 int32 CBattleEntity::takeDamage(int32 amount, CBattleEntity* attacker /* = nullptr*/)
 {
+    PLastAttacker = attacker;
     return addHP(-amount);
 }
 
@@ -1269,8 +1271,8 @@ void CBattleEntity::OnCastFinished(CMagicState& state, action_t& action)
             actionTarget.param = luautils::OnSpellCast(this, PTarget, PSpell);
 
             // Manually set the attacker here since the spell scripts call CLuaBaseEntity::delHP and do not provide the attacker
-            if (PTarget->objtype == TYPE_PC && PSpell->dealsDamage())
-                static_cast<CCharEntity*>(PTarget)->PLastAttacker = this;
+            if (PSpell->dealsDamage())
+                PTarget->PLastAttacker = this;
 
             // remove effects from damage
             if (PSpell->canTargetEnemy() && actionTarget.param > 0 && PSpell->dealsDamage())

--- a/src/map/entities/battleentity.cpp
+++ b/src/map/entities/battleentity.cpp
@@ -73,7 +73,6 @@ CBattleEntity::CBattleEntity()
     PPet = nullptr;
     PParty = nullptr;
     PMaster = nullptr;
-    PLastAttacker = nullptr;
 
     StatusEffectContainer = std::make_unique<CStatusEffectContainer>(this);
     PRecastContainer = std::make_unique<CRecastContainer>(this);
@@ -516,7 +515,6 @@ int32 CBattleEntity::addMP(int32 mp)
 
 int32 CBattleEntity::takeDamage(int32 amount, CBattleEntity* attacker /* = nullptr*/)
 {
-    PLastAttacker = attacker;
     return addHP(-amount);
 }
 
@@ -1271,8 +1269,8 @@ void CBattleEntity::OnCastFinished(CMagicState& state, action_t& action)
             actionTarget.param = luautils::OnSpellCast(this, PTarget, PSpell);
 
             // Manually set the attacker here since the spell scripts call CLuaBaseEntity::delHP and do not provide the attacker
-            if (PSpell->dealsDamage())
-                PTarget->PLastAttacker = this;
+            if (PTarget->objtype == TYPE_PC && PSpell->dealsDamage())
+                static_cast<CCharEntity*>(PTarget)->PLastAttacker = this;
 
             // remove effects from damage
             if (PSpell->canTargetEnemy() && actionTarget.param > 0 && PSpell->dealsDamage())

--- a/src/map/entities/battleentity.h
+++ b/src/map/entities/battleentity.h
@@ -518,8 +518,6 @@ public:
     virtual int16	addTP(int16 tp);			// увеличиваем/уменьшаем количество tp
     virtual int32	addHP(int32 hp);			// увеличиваем/уменьшаем количество hp
     virtual int32 	addMP(int32 mp);			// увеличиваем/уменьшаем количество mp
-
-    //Deals damage and updates the last attacker which is used when sending a player death message
     virtual int32   takeDamage(int32 amount, CBattleEntity* attacker = nullptr);
 
     int16		    getMod(Mod modID);		// величина модификатора
@@ -644,7 +642,6 @@ public:
     CParty*			PParty;					    // описание группы, в которой состоит сущность
     CBattleEntity*	PPet;					    // питомец сущности
     CBattleEntity*	PMaster;				    // владелец/хозяин сущности (распространяется на все боевые сущности)
-    CBattleEntity*	PLastAttacker;
 
     std::unique_ptr<CStatusEffectContainer> StatusEffectContainer;
     std::unique_ptr<CRecastContainer> PRecastContainer;         //

--- a/src/map/entities/battleentity.h
+++ b/src/map/entities/battleentity.h
@@ -518,6 +518,8 @@ public:
     virtual int16	addTP(int16 tp);			// увеличиваем/уменьшаем количество tp
     virtual int32	addHP(int32 hp);			// увеличиваем/уменьшаем количество hp
     virtual int32 	addMP(int32 mp);			// увеличиваем/уменьшаем количество mp
+
+    //Deals damage and updates the last attacker which is used when sending a player death message
     virtual int32   takeDamage(int32 amount, CBattleEntity* attacker = nullptr);
 
     int16		    getMod(Mod modID);		// величина модификатора
@@ -642,6 +644,7 @@ public:
     CParty*			PParty;					    // описание группы, в которой состоит сущность
     CBattleEntity*	PPet;					    // питомец сущности
     CBattleEntity*	PMaster;				    // владелец/хозяин сущности (распространяется на все боевые сущности)
+    CBattleEntity*	PLastAttacker;
 
     std::unique_ptr<CStatusEffectContainer> StatusEffectContainer;
     std::unique_ptr<CRecastContainer> PRecastContainer;         //

--- a/src/map/entities/battleentity.h
+++ b/src/map/entities/battleentity.h
@@ -519,6 +519,9 @@ public:
     virtual int32	addHP(int32 hp);			// увеличиваем/уменьшаем количество hp
     virtual int32 	addMP(int32 mp);			// увеличиваем/уменьшаем количество mp
 
+    //Deals damage and updates the last attacker which is used when sending a player death message
+    virtual int32   takeDamage(int32 amount, CBattleEntity* attacker = nullptr);
+
     int16		    getMod(Mod modID);		// величина модификатора
 
     bool            CanRest(); // checks if able to heal
@@ -641,6 +644,7 @@ public:
     CParty*			PParty;					    // описание группы, в которой состоит сущность
     CBattleEntity*	PPet;					    // питомец сущности
     CBattleEntity*	PMaster;				    // владелец/хозяин сущности (распространяется на все боевые сущности)
+    CBattleEntity*	PLastAttacker;
 
     std::unique_ptr<CStatusEffectContainer> StatusEffectContainer;
     std::unique_ptr<CRecastContainer> PRecastContainer;         //

--- a/src/map/entities/charentity.cpp
+++ b/src/map/entities/charentity.cpp
@@ -1579,15 +1579,14 @@ CBattleEntity* CCharEntity::IsValidTarget(uint16 targid, uint16 validTargetFlags
 
 void CCharEntity::Die()
 {
-    if (GetBattleTargetID() == 0)
+    if (PLastAttacker)
     {
-        //falls to the ground
-        loc.zone->PushPacket(this, CHAR_INRANGE_SELF, new CMessageBasicPacket(this, this, 0, 0, 20));
+        loc.zone->PushPacket(this, CHAR_INRANGE_SELF, new CMessageBasicPacket(PLastAttacker, this, 0, 0, 97));
     }
     else
     {
-        auto PTarget = GetEntity(GetBattleTargetID());
-        loc.zone->PushPacket(this, CHAR_INRANGE_SELF, new CMessageBasicPacket(PTarget, this, 0, 0, 97));
+        //falls to the ground
+        loc.zone->PushPacket(this, CHAR_INRANGE_SELF, new CMessageBasicPacket(this, this, 0, 0, 20));
     }
     Die(60min);
     m_DeathCounter = 0;

--- a/src/map/entities/charentity.cpp
+++ b/src/map/entities/charentity.cpp
@@ -177,6 +177,7 @@ CCharEntity::CCharEntity()
     PLinkshell2 = nullptr;
     PTreasurePool = nullptr;
     PWideScanTarget = nullptr;
+    PLastAttacker = nullptr;
 
     PAutomaton = nullptr;
     PRecastContainer = std::make_unique<CCharRecastContainer>(this);
@@ -386,6 +387,12 @@ int32 CCharEntity::addMP(int32 mp)
     PLatentEffectContainer->CheckLatentsMP();
 
     return abs(mp);
+}
+
+int32 CCharEntity::takeDamage(int32 amount, CBattleEntity* attacker)
+{
+    PLastAttacker = attacker;
+    return CBattleEntity::takeDamage(amount, attacker);
 }
 
 bool CCharEntity::getWeaponSkillKill()

--- a/src/map/entities/charentity.cpp
+++ b/src/map/entities/charentity.cpp
@@ -1580,14 +1580,10 @@ CBattleEntity* CCharEntity::IsValidTarget(uint16 targid, uint16 validTargetFlags
 void CCharEntity::Die()
 {
     if (PLastAttacker)
-    {
-        loc.zone->PushPacket(this, CHAR_INRANGE_SELF, new CMessageBasicPacket(PLastAttacker, this, 0, 0, 97));
-    }
+        loc.zone->PushPacket(this, CHAR_INRANGE_SELF, new CMessageBasicPacket(PLastAttacker, this, 0, 0, MSGBASIC_PLAYER_DEFEATED_BY));
     else
-    {
-        //falls to the ground
-        loc.zone->PushPacket(this, CHAR_INRANGE_SELF, new CMessageBasicPacket(this, this, 0, 0, 20));
-    }
+        loc.zone->PushPacket(this, CHAR_INRANGE_SELF, new CMessageBasicPacket(this, this, 0, 0, MSGBASIC_FALLS_TO_GROUND));
+
     Die(60min);
     m_DeathCounter = 0;
     m_DeathTimestamp = (uint32)time(nullptr);

--- a/src/map/entities/charentity.cpp
+++ b/src/map/entities/charentity.cpp
@@ -177,7 +177,6 @@ CCharEntity::CCharEntity()
     PLinkshell2 = nullptr;
     PTreasurePool = nullptr;
     PWideScanTarget = nullptr;
-    PLastAttacker = nullptr;
 
     PAutomaton = nullptr;
     PRecastContainer = std::make_unique<CCharRecastContainer>(this);
@@ -387,12 +386,6 @@ int32 CCharEntity::addMP(int32 mp)
     PLatentEffectContainer->CheckLatentsMP();
 
     return abs(mp);
-}
-
-int32 CCharEntity::takeDamage(int32 amount, CBattleEntity* attacker)
-{
-    PLastAttacker = attacker;
-    return CBattleEntity::takeDamage(amount, attacker);
 }
 
 bool CCharEntity::getWeaponSkillKill()

--- a/src/map/entities/charentity.h
+++ b/src/map/entities/charentity.h
@@ -247,6 +247,7 @@ public:
     CTradeContainer*  CraftContainer;               // Container used for crafting actions.
 
     CBaseEntity*	  PWideScanTarget;				// wide scane цель
+    CBattleEntity*    PLastAttacker;
 
     SpawnIDList_t	  SpawnPCList;					// список видимых персонажей
     SpawnIDList_t	  SpawnMOBList;					// список видимых монстров
@@ -301,6 +302,8 @@ public:
     int16 addTP(int16 tp) override;
     int32 addHP(int32 hp) override;
     int32 addMP(int32 mp) override;
+    //Deal damage to the player and updates the last attacker which is used when sending a death message
+    int32 takeDamage(int32 amount, CBattleEntity* attacker) override;
 
     std::vector<GearSetMod_t> m_GearSetMods;		// The list of gear set mods currently applied to the character.
     std::vector<AuctionHistory_t> m_ah_history;		// AH history list (в будущем нужно использовать UContainer)

--- a/src/map/entities/charentity.h
+++ b/src/map/entities/charentity.h
@@ -247,7 +247,6 @@ public:
     CTradeContainer*  CraftContainer;               // Container used for crafting actions.
 
     CBaseEntity*	  PWideScanTarget;				// wide scane цель
-    CBattleEntity*    PLastAttacker;
 
     SpawnIDList_t	  SpawnPCList;					// список видимых персонажей
     SpawnIDList_t	  SpawnMOBList;					// список видимых монстров
@@ -302,8 +301,6 @@ public:
     int16 addTP(int16 tp) override;
     int32 addHP(int32 hp) override;
     int32 addMP(int32 mp) override;
-    //Deal damage to the player and updates the last attacker which is used when sending a death message
-    int32 takeDamage(int32 amount, CBattleEntity* attacker) override;
 
     std::vector<GearSetMod_t> m_GearSetMods;		// The list of gear set mods currently applied to the character.
     std::vector<AuctionHistory_t> m_ah_history;		// AH history list (в будущем нужно использовать UContainer)

--- a/src/map/entities/mobentity.cpp
+++ b/src/map/entities/mobentity.cpp
@@ -791,7 +791,6 @@ void CMobEntity::DropItems()
     if (PChar != nullptr && PChar->id == m_OwnerID.id)
     {
 
-        loc.zone->PushPacket(this, CHAR_INRANGE, new CMessageBasicPacket(PChar, this, 0, 0, MSGBASIC_DEFEATS_TARG));
 
         if (!CalledForHelp())
         {
@@ -1021,6 +1020,11 @@ void CMobEntity::Die()
     PAI->QueueAction(queueAction_t(std::chrono::milliseconds(m_DropItemTime), false, [this](CBaseEntity* PEntity) {
         if (static_cast<CMobEntity*>(PEntity)->isDead())
         {
+            if (PLastAttacker)
+                loc.zone->PushPacket(this, CHAR_INRANGE, new CMessageBasicPacket(PLastAttacker, this, 0, 0, MSGBASIC_DEFEATS_TARG));
+            else
+                loc.zone->PushPacket(this, CHAR_INRANGE, new CMessageBasicPacket(this, this, 0, 0, MSGBASIC_FALLS_TO_GROUND));
+
             DropItems();
         }
     }));

--- a/src/map/lua/lua_baseentity.cpp
+++ b/src/map/lua/lua_baseentity.cpp
@@ -7198,6 +7198,10 @@ inline int32 CLuaBaseEntity::setHP(lua_State *L)
     ((CBattleEntity*)m_PBaseEntity)->addHP(value);
     m_PBaseEntity->updatemask |= UPDATE_HP;
 
+    //When setting the HP to 0 the entity "falls to the ground" so the last attacker needs to be cleared
+    if (value == 0)
+        ((CBattleEntity*)m_PBaseEntity)->PLastAttacker = nullptr;
+
     return 0;
 }
 

--- a/src/map/lua/lua_baseentity.cpp
+++ b/src/map/lua/lua_baseentity.cpp
@@ -7240,7 +7240,7 @@ inline int32 CLuaBaseEntity::delHP(lua_State *L)
 
     DSP_DEBUG_BREAK_IF(lua_isnil(L, 1) || !lua_isnumber(L, 1));
 
-    ((CBattleEntity*)m_PBaseEntity)->addHP((int32)(-lua_tointeger(L, 1)));
+    ((CBattleEntity*)m_PBaseEntity)->takeDamage((int32)(lua_tointeger(L, 1)));
 
     return 0;
 }

--- a/src/map/packets/message_basic.h
+++ b/src/map/packets/message_basic.h
@@ -39,6 +39,7 @@ enum MSGBASIC_ID : uint16
 	MSGBASIC_ALREADY_CLAIMED		= 12, /* Cannot attack. Your target is already claimed. */
 	MSGBASIC_IS_INTERRUPTED			= 16, /* The <player>'s casting is interrupted. */
 	MSGBASIC_UNABLE_TO_CAST			= 18, /* Unable to cast spells at this time. */
+    MSGBASIC_FALLS_TO_GROUND        = 20, /* The <target> falls to the ground. */
 	MSGBASIC_UNABLE_TO_USE_JA		= 87, /* Unable to use job ability. */
 	MSGBASIC_UNABLE_TO_USE_JA2		= 88, /* Unable to use job ability. */
 	MSGBASIC_IS_PARALYZED			= 29, /* The <player> is paralyzed. */
@@ -49,6 +50,7 @@ enum MSGBASIC_ID : uint16
     MSGBASIC_CANNOT_USE_IN_AREA      = 40, /* cannot use in this area */
 	MSGBASIC_UNABLE_TO_CAST_SPELLS  = 49, /* The <player> is unable to cast spells. */
 	MSGBASIC_WAIT_LONGER			= 94, /* You must wait longer to perform that action. */
+    MSGBASIC_PLAYER_DEFEATED_BY     = 97, /* <player> was defeated by the <target>. */
 	MSGBASIC_USES_JA				= 100, /* The <player> uses .. */
 	MSGBASIC_USES_JA2				= 101, /* The <player> uses .. */
 	MSGBASIC_USES_RECOVERS_HP		= 102, /* The <player> uses .. <target> recovers .. HP. */

--- a/src/map/status_effect_container.cpp
+++ b/src/map/status_effect_container.cpp
@@ -1462,7 +1462,7 @@ void CStatusEffectContainer::TickRegen(time_point tick)
             if (damage > 0)
             {
                 DelStatusEffectSilent(EFFECT_HEALING);
-                m_POwner->addHP(-damage);
+                m_POwner->takeDamage(damage);
                 WakeUp();
             }
         }

--- a/src/map/utils/battleutils.cpp
+++ b/src/map/utils/battleutils.cpp
@@ -753,7 +753,7 @@ namespace battleutils
                 case SPIKE_BLAZE:
                 case SPIKE_ICE:
                 case SPIKE_SHOCK:
-                    PAttacker->addHP(-Action->spikesParam);
+                    PAttacker->takeDamage(Action->spikesParam, PDefender);
                     break;
 
                 case SPIKE_DREAD:
@@ -785,14 +785,14 @@ namespace battleutils
                             }
                             PDefender->addHP(Action->spikesParam);
                         }
-                        PAttacker->addHP(-Action->spikesParam);
+                        PAttacker->takeDamage(Action->spikesParam, PDefender);
                     }
                     break;
 
                 case SPIKE_REPRISAL:
                     if (Action->reaction == REACTION_BLOCK)
                     {
-                        PAttacker->addHP(-Action->spikesParam);
+                        PAttacker->takeDamage(Action->spikesParam, PDefender);
                         auto PEffect = PDefender->StatusEffectContainer->GetStatusEffect(EFFECT_REPRISAL);
                         if (PEffect)
                         {
@@ -888,7 +888,7 @@ namespace battleutils
             {
                 auto ratio = std::clamp<uint8>(damage / 4, 1, 255);
                 Action->spikesParam = HandleStoneskin(PAttacker, damage - dsprand::GetRandomNumber<uint16>(ratio) + dsprand::GetRandomNumber<uint16>(ratio));
-                PAttacker->addHP(-Action->spikesParam);
+                PAttacker->takeDamage(Action->spikesParam);
             }
 
             // Temp till moved to script.
@@ -1020,7 +1020,7 @@ namespace battleutils
                     Action->addEffectMessage = 384;
                 }
 
-                PDefender->addHP(-Action->addEffectParam);
+                PDefender->takeDamage(Action->addEffectParam, PAttacker);
             }
             else if (enspell > 8 && enspell <= 14 && isFirstSwing)
             {
@@ -1034,7 +1034,7 @@ namespace battleutils
                     Action->addEffectMessage = 384;
                 }
 
-                PDefender->addHP(-Action->addEffectParam);
+                PDefender->takeDamage(Action->addEffectParam, PAttacker);
             }
             else if (enspell > 6 && enspell <= 8)
             {
@@ -1048,7 +1048,7 @@ namespace battleutils
                     Action->addEffectMessage = 384;
                 }
 
-                PDefender->addHP(-Action->addEffectParam);
+                PDefender->takeDamage(Action->addEffectParam, PAttacker);
             }
             else if (enspell == ENSPELL_BLOOD_WEAPON)
             {
@@ -1072,7 +1072,7 @@ namespace battleutils
                     Action->addEffectMessage = 384;
                 }
 
-                PDefender->addHP(-Action->addEffectParam);
+                PDefender->takeDamage(Action->addEffectParam, PAttacker);
             }
         }
         //check weapon for additional effects
@@ -1329,7 +1329,7 @@ namespace battleutils
                     damage = HandleStoneskin(PDefender, damage);
                     //set damage TODO: handle resi st/staff/day
                     Action->addEffectParam = damage;
-                    PDefender->addHP(-damage);
+                    PDefender->takeDamage(damage, PAttacker);
                 }
                 break;
             case 18699:{ //Earth Arrow
@@ -1351,7 +1351,7 @@ namespace battleutils
                     damage += (float)damage * ((float)PDefender->getMod(Mod::EARTHRES)/-100);
                     damage = HandleStoneskin(PDefender, damage);
                     Action->addEffectParam  = damage;
-                    PDefender->addHP(-damage);
+                    PDefender->takeDamage(damage, PAttacker);
                 }
                 break;
             case 18698:{ //Water Arrow
@@ -1372,7 +1372,7 @@ namespace battleutils
                     damage += (float)damage * ((float)PDefender->getMod(Mod::WATERRES)/-100);
                     damage = HandleStoneskin(PDefender, damage);
                     Action->addEffectParam  = damage;
-                    PDefender->addHP(-damage);
+                    PDefender->takeDamage(damage, PAttacker);
                 }
                 break;
             case 18153:{ //Holy Bolt
@@ -1393,7 +1393,7 @@ namespace battleutils
                     damage += (float)damage * ((float)PDefender->getMod(Mod::LIGHTRES)/-100);
                     damage = HandleStoneskin(PDefender, damage);
                     Action->addEffectParam  = damage;
-                    PDefender->addHP(-damage);
+                    PDefender->takeDamage(damage, PAttacker);
                 }
                 break;
             case 17324:{ //Lightning Arrow
@@ -1414,7 +1414,7 @@ namespace battleutils
                     damage += (float)damage * ((float)PDefender->getMod(Mod::THUNDERRES)/-100);
                     damage = HandleStoneskin(PDefender, damage);
                     Action->addEffectParam  = damage;
-                    PDefender->addHP(-damage);
+                    PDefender->takeDamage(damage, PAttacker);
                 }
                 break;
             case 17323:{ //Ice Arrow
@@ -1435,7 +1435,7 @@ namespace battleutils
                     damage += (float)damage * ((float)PDefender->getMod(Mod::ICERES)/-100);
                     damage = HandleStoneskin(PDefender, damage);
                     Action->addEffectParam  = damage;
-                    PDefender->addHP(-damage);
+                    PDefender->takeDamage(damage, PAttacker);
                 }
                 break;
             case 17327: // Grand knights Arrow
@@ -1463,7 +1463,7 @@ namespace battleutils
                     damage = HandleStoneskin(PDefender, damage);
 
                     Action->addEffectParam  = damage;
-                    PDefender->addHP(-damage);
+                    PDefender->takeDamage(damage, PAttacker);
                 }
                 break;
             }*/
@@ -1997,7 +1997,7 @@ namespace battleutils
         }
         damage = std::clamp(damage, -99999, 99999);
 
-        int32 corrected = PDefender->addHP(-damage);
+        int32 corrected = PDefender->takeDamage(damage, PAttacker);
         if (damage < 0)
             damage = -corrected;
 
@@ -2135,7 +2135,7 @@ namespace battleutils
     *																		*
     ************************************************************************/
 
-    int32 TakeWeaponskillDamage(CCharEntity* PChar, CBattleEntity* PDefender, int32 damage, uint8 slot, bool primary, float tpMultiplier, uint16 bonusTP, float targetTPMultiplier)
+    int32 TakeWeaponskillDamage(CCharEntity* PAttacker, CBattleEntity* PDefender, int32 damage, uint8 slot, bool primary, float tpMultiplier, uint16 bonusTP, float targetTPMultiplier)
     {
         bool isRanged = (slot == SLOT_AMMO || slot == SLOT_RANGED);
 
@@ -2147,28 +2147,28 @@ namespace battleutils
 
         if (!isRanged)
         {
-            damage = getOverWhelmDamageBonus(PChar, PDefender, (uint16)damage);
+            damage = getOverWhelmDamageBonus(PAttacker, PDefender, (uint16)damage);
         }
 
         HandleAfflatusMiseryDamage(PDefender, damage);
         damage = std::clamp(damage, -99999, 99999);
 
-        int32 corrected = PDefender->addHP(-damage);
+        int32 corrected = PDefender->takeDamage(damage, PAttacker);
         if (damage < 0)
             damage = -corrected;
 
         if (PDefender->objtype == TYPE_MOB)
         {
-            if (PChar->PMaster != nullptr)
+            if (PAttacker->PMaster != nullptr)
             {
-                PDefender->m_OwnerID.id = PChar->PMaster->id;
-                PDefender->m_OwnerID.targid = PChar->PMaster->targid;
+                PDefender->m_OwnerID.id = PAttacker->PMaster->id;
+                PDefender->m_OwnerID.targid = PAttacker->PMaster->targid;
                 PDefender->updatemask |= UPDATE_STATUS;
             }
             else
             {
-                PDefender->m_OwnerID.id = PChar->id;
-                PDefender->m_OwnerID.targid = PChar->targid;
+                PDefender->m_OwnerID.id = PAttacker->id;
+                PDefender->m_OwnerID.targid = PAttacker->targid;
                 PDefender->updatemask |= UPDATE_STATUS;
             }
         }
@@ -2180,7 +2180,7 @@ namespace battleutils
             PDefender->StatusEffectContainer->DelStatusEffectsByFlag(EFFECTFLAG_DAMAGE);
 
             // Check for bind breaking
-            BindBreakCheck(PChar, PDefender);
+            BindBreakCheck(PAttacker, PDefender);
 
             switch (PDefender->objtype)
             {
@@ -2189,9 +2189,9 @@ namespace battleutils
                     if (PDefender->PMaster != nullptr && PDefender->PMaster->objtype == TYPE_PC)
                         ((CPetEntity*)PDefender)->loc.zone->PushPacket(PDefender, CHAR_INRANGE, new CEntityUpdatePacket(PDefender, ENTITY_UPDATE, UPDATE_COMBAT));
 
-                    if (((CMobEntity*)PDefender)->m_HiPCLvl < PChar->GetMLevel())
+                    if (((CMobEntity*)PDefender)->m_HiPCLvl < PAttacker->GetMLevel())
                     {
-                        ((CMobEntity*)PDefender)->m_HiPCLvl = PChar->GetMLevel();
+                        ((CMobEntity*)PDefender)->m_HiPCLvl = PAttacker->GetMLevel();
                     }
 
                     break;
@@ -2205,29 +2205,29 @@ namespace battleutils
             }
 
             // try to interrupt spell
-            PDefender->TryHitInterrupt(PChar);
+            PDefender->TryHitInterrupt(PAttacker);
 
             int16 baseTp = 0;
 
             if (isRanged)
             {
-                int16 delay = PChar->GetRangedWeaponDelay(true);
+                int16 delay = PAttacker->GetRangedWeaponDelay(true);
                 baseTp = CalculateBaseTP((delay * 120) / 1000);
             }
             else
             {
-                int16 delay = PChar->GetWeaponDelay(true);
+                int16 delay = PAttacker->GetWeaponDelay(true);
 
-                if (PChar->m_Weapons[SLOT_SUB]->getDmgType() > 0 &&
-                    PChar->m_Weapons[SLOT_SUB]->getDmgType() < 4 &&
-                    PChar->m_Weapons[slot]->getSkillType() != SKILL_HAND_TO_HAND)
+                if (PAttacker->m_Weapons[SLOT_SUB]->getDmgType() > 0 &&
+                    PAttacker->m_Weapons[SLOT_SUB]->getDmgType() < 4 &&
+                    PAttacker->m_Weapons[slot]->getSkillType() != SKILL_HAND_TO_HAND)
                 {
                     delay /= 2;
                 }
 
                 float ratio = 1.0f;
 
-                if (PChar->m_Weapons[slot]->getSkillType() == SKILL_HAND_TO_HAND)
+                if (PAttacker->m_Weapons[slot]->getSkillType() == SKILL_HAND_TO_HAND)
                     ratio = 2.0f;
 
                 baseTp = (int16)(CalculateBaseTP((delay * 60) / 1000) / ratio);
@@ -2238,31 +2238,31 @@ namespace battleutils
             if (primary)
             // Calculate TP Return from WS
             {
-                standbyTp = ((int16)(((tpMultiplier * baseTp) + bonusTP) * (1.0f + 0.01f * (float)((PChar->getMod(Mod::STORETP) + getStoreTPbonusFromMerit(PChar))))));
+                standbyTp = ((int16)(((tpMultiplier * baseTp) + bonusTP) * (1.0f + 0.01f * (float)((PAttacker->getMod(Mod::STORETP) + getStoreTPbonusFromMerit(PAttacker))))));
             }
 
             //account for attacker's subtle blow which reduces the baseTP gain for the defender
-            float sBlowMult = ((100.0f - std::clamp((float)PChar->getMod(Mod::SUBTLE_BLOW), 0.0f, 50.0f)) / 100.0f);
+            float sBlowMult = ((100.0f - std::clamp((float)PAttacker->getMod(Mod::SUBTLE_BLOW), 0.0f, 50.0f)) / 100.0f);
 
             //mobs hit get basetp+30 whereas pcs hit get basetp/3
             if (PDefender->objtype == TYPE_PC)
-                PDefender->addTP((int16)(tpMultiplier * targetTPMultiplier * ((baseTp / 3) * sBlowMult * (1.0f + 0.01f * (float)((PDefender->getMod(Mod::STORETP) + getStoreTPbonusFromMerit(PChar))))))); //yup store tp counts on hits taken too!
+                PDefender->addTP((int16)(tpMultiplier * targetTPMultiplier * ((baseTp / 3) * sBlowMult * (1.0f + 0.01f * (float)((PDefender->getMod(Mod::STORETP) + getStoreTPbonusFromMerit(PAttacker))))))); //yup store tp counts on hits taken too!
             else
                 PDefender->addTP((int16)(tpMultiplier * targetTPMultiplier * ((baseTp + 30) * sBlowMult * (1.0f + 0.01f * (float)PDefender->getMod(Mod::STORETP))))); //subtle blow also reduces the "+30" on mob tp gain
         }
         else if (PDefender->objtype == TYPE_MOB)
-            ((CMobEntity*)PDefender)->PEnmityContainer->UpdateEnmityFromDamage(PChar, 0);
+            ((CMobEntity*)PDefender)->PEnmityContainer->UpdateEnmityFromDamage(PAttacker, 0);
 
         if (!isRanged)
-            PChar->StatusEffectContainer->DelStatusEffectsByFlag(EFFECTFLAG_ATTACK);
+            PAttacker->StatusEffectContainer->DelStatusEffectsByFlag(EFFECTFLAG_ATTACK);
 
         // Apply TP
-        PChar->addTP(std::max((PChar->getMod(Mod::SAVETP)), standbyTp));
+        PAttacker->addTP(std::max((PAttacker->getMod(Mod::SAVETP)), standbyTp));
 
         // Remove Hagakure Effect if present
-        if (PChar->StatusEffectContainer->HasStatusEffect(EFFECT_HAGAKURE))
+        if (PAttacker->StatusEffectContainer->HasStatusEffect(EFFECT_HAGAKURE))
         {
-            PChar->StatusEffectContainer->DelStatusEffect(EFFECT_HAGAKURE);
+            PAttacker->StatusEffectContainer->DelStatusEffect(EFFECT_HAGAKURE);
         }
 
         return damage;
@@ -3186,7 +3186,7 @@ namespace battleutils
         }
         damage = std::clamp(damage, -99999, 99999);
 
-        PDefender->addHP(-damage);
+        PDefender->takeDamage(damage, PAttacker);
 
         if (PAttacker->PMaster != nullptr)
         {

--- a/src/map/utils/battleutils.h
+++ b/src/map/utils/battleutils.h
@@ -149,7 +149,7 @@ namespace battleutils
     float               GetDamageRatio(CBattleEntity* PAttacker, CBattleEntity* PDefender, bool isCritical, uint16 bonusAttPercent);
 
     int32               TakePhysicalDamage(CBattleEntity* PAttacker, CBattleEntity* PDefender, PHYSICAL_ATTACK_TYPE attackType, int32 damage, bool isBlocked, uint8 slot, uint16 tpMultiplier, CBattleEntity* taChar, bool giveTPtoVictim, bool giveTPtoAttacker, bool isCounter = false);
-    int32               TakeWeaponskillDamage(CCharEntity* PChar, CBattleEntity* PDefender, int32 damage, uint8 slot, bool primary, float tpMultiplier, uint16 bonusTP, float targetTPMultiplier);
+    int32               TakeWeaponskillDamage(CCharEntity* PAttacker, CBattleEntity* PDefender, int32 damage, uint8 slot, bool primary, float tpMultiplier, uint16 bonusTP, float targetTPMultiplier);
     int32               TakeSkillchainDamage(CBattleEntity* PAttacker, CBattleEntity* PDefender, int32 lastSkillDamage, CBattleEntity* taChar);
 
     bool                TryInterruptSpell(CBattleEntity* PAttacker, CBattleEntity* PDefender, CSpell* PSpell);


### PR DESCRIPTION
This fixes the issue where a player can be sent the wrong death message. It currently uses the target but if the player is not currently targeting the monster that kills them then it will either say that the wrong monster killed them or "falls to the ground".

The fix here is to track which entity was the last one to deal damage to the character and clear it whenever the player takes neutral damage such as from poison.

One thing I'm not crazy about is how the magic case is handled. Magic from monsters deal damage by calling `CLuaBaseEntity::delHP()` but that does not pass in the attacker and is called by hundreds of scripts. It would be somewhat trival to do it for monster scripts but would greatly bloat this PR and have a much higher chance for conflicts. I'm open to whatever.

Tested this by dying to melee attack, magic attack, spikes and poison. All but the last now show "defeated by" message and the last shows "falls to the ground".

Thanks to @Wiggo32 for helping get the correct death spikes message.