### PR TITLE
Resolved issue with players death timer being set incorrectly while zoning

### DIFF
--- a/src/map/entities/charentity.cpp
+++ b/src/map/entities/charentity.cpp
@@ -1589,7 +1589,7 @@ void CCharEntity::Die()
         auto PTarget = GetEntity(GetBattleTargetID());
         loc.zone->PushPacket(this, CHAR_INRANGE_SELF, new CMessageBasicPacket(PTarget, this, 0, 0, 97));
     }
-    Die(60min);
+    Die(PLAYER_DEATH_COUNTER_TIME);
     m_DeathCounter = 0;
     m_DeathTimestamp = (uint32)time(nullptr);
 

--- a/src/map/entities/charentity.cpp
+++ b/src/map/entities/charentity.cpp
@@ -155,7 +155,6 @@ CCharEntity::CCharEntity()
     m_LevelRestriction = 0;
     m_lastBcnmTimePrompt = 0;
     m_AHHistoryTimestamp = 0;
-    m_DeathCounter = 0;
     m_DeathTimestamp = 0;
 
     m_EquipFlag = 0;
@@ -1589,9 +1588,8 @@ void CCharEntity::Die()
         auto PTarget = GetEntity(GetBattleTargetID());
         loc.zone->PushPacket(this, CHAR_INRANGE_SELF, new CMessageBasicPacket(PTarget, this, 0, 0, 97));
     }
-    Die(PLAYER_DEATH_COUNTER_TIME);
-    m_DeathCounter = 0;
-    m_DeathTimestamp = (uint32)time(nullptr);
+    Die(death_duration);
+    SetDeathTimestamp((uint32)time(nullptr));
 
     setBlockingAid(false);
 
@@ -1623,6 +1621,17 @@ void CCharEntity::Die(duration _duration)
 void CCharEntity::Raise()
 {
     PAI->Internal_Raise();
+    SetDeathTimestamp(0);
+}
+
+void CCharEntity::SetDeathTimestamp(uint32 timestamp)
+{
+    m_DeathTimestamp = timestamp;
+}
+
+int32 CCharEntity::GetSecondsElapsedSinceDeath()
+{
+    return m_DeathTimestamp > 0 ? (uint32)time(nullptr) - m_DeathTimestamp : 0;
 }
 
 void CCharEntity::TrackArrowUsageForScavenge(CItemWeapon* PAmmo)

--- a/src/map/entities/charentity.h
+++ b/src/map/entities/charentity.h
@@ -39,6 +39,7 @@ This file is part of DarkStar-server source code.
 #define MAX_QUESTID     256
 #define MAX_MISSIONAREA	 15
 #define MAX_MISSIONID    226
+#define PLAYER_DEATH_COUNTER_TIME 60min
 
 struct jobs_t
 {

--- a/src/map/entities/charentity.h
+++ b/src/map/entities/charentity.h
@@ -39,7 +39,6 @@ This file is part of DarkStar-server source code.
 #define MAX_QUESTID     256
 #define MAX_MISSIONAREA	 15
 #define MAX_MISSIONID    226
-#define PLAYER_DEATH_COUNTER_TIME 60min
 
 struct jobs_t
 {
@@ -266,7 +265,6 @@ public:
     uint16            m_Costum;                     // карнавальный костюм персонажа (модель)
     uint16			  m_Monstrosity;				// Monstrosity model ID
     uint32			  m_AHHistoryTimestamp;			// Timestamp when last asked to view history
-    uint32            m_DeathCounter;               // Counter when you last died. This is set when you first login
     uint32            m_DeathTimestamp;             // Timestamp when death counter has been saved to database
 
     uint8			  m_hasTractor;					// checks if player has tractor already
@@ -299,6 +297,8 @@ public:
     bool              m_EffectsChanged;
     time_point        m_LastSynthTime;
 
+    static constexpr duration death_duration = 60min;
+
     int16 addTP(int16 tp) override;
     int32 addHP(int32 hp) override;
     int32 addMP(int32 mp) override;
@@ -324,8 +324,11 @@ public:
     virtual bool CanUseSpell(CSpell*) override;
 
     virtual void Die() override;
-    void Die(duration);
+    void Die(duration _duration);
     void Raise();
+
+    void SetDeathTimestamp(uint32 timestamp);
+    int32 GetSecondsElapsedSinceDeath();
 
     /* State callbacks */
     virtual bool CanAttack(CBattleEntity* PTarget, std::unique_ptr<CBasicPacket>& errMsg) override;

--- a/src/map/packet_system.cpp
+++ b/src/map/packet_system.cpp
@@ -272,10 +272,11 @@ void SmallPacket0x00A(map_session_data_t* session, CCharEntity* PChar, CBasicPac
         int32 ret = Sql_Query(SqlHandle, fmtQuery, PChar->id);
         if (Sql_NextRow(SqlHandle) == SQL_SUCCESS)
         {
-            PChar->m_DeathCounter = (uint32)Sql_GetUIntData(SqlHandle, 0);
-            PChar->m_DeathTimestamp = (uint32)time(nullptr);
+            //Update the character's death timestamp based off of how long they were previously dead
+            uint32 secondsSinceDeath = (uint32)Sql_GetUIntData(SqlHandle, 0);
+            PChar->SetDeathTimestamp((uint32)time(nullptr) - secondsSinceDeath);
             if (PChar->health.hp == 0)
-                PChar->Die(PLAYER_DEATH_COUNTER_TIME - std::chrono::seconds(PChar->m_DeathCounter));
+                PChar->Die(CCharEntity::death_duration - std::chrono::seconds(secondsSinceDeath));
         }
 
         fmtQuery = "SELECT pos_prevzone FROM chars WHERE charid = %u";

--- a/src/map/packet_system.cpp
+++ b/src/map/packet_system.cpp
@@ -275,7 +275,7 @@ void SmallPacket0x00A(map_session_data_t* session, CCharEntity* PChar, CBasicPac
             PChar->m_DeathCounter = (uint32)Sql_GetUIntData(SqlHandle, 0);
             PChar->m_DeathTimestamp = (uint32)time(nullptr);
             if (PChar->health.hp == 0)
-                PChar->Die(std::chrono::seconds(PChar->m_DeathCounter));
+                PChar->Die(PLAYER_DEATH_COUNTER_TIME - std::chrono::seconds(PChar->m_DeathCounter));
         }
 
         fmtQuery = "SELECT pos_prevzone FROM chars WHERE charid = %u";

--- a/src/map/packets/char_update.cpp
+++ b/src/map/packets/char_update.cpp
@@ -93,19 +93,7 @@ CCharUpdatePacket::CCharUpdatePacket(CCharEntity* PChar)
     ref<uint8>(0x36) = flag;
 
     //This contains the amount of time remaining before the player is forced back to homepoint while dead
-    if (PChar->PAI->IsCurrentState<CDeathState>())
-    {
-        //Update the player death counter and timestamp and send the amount of time remaining
-        uint32 currentTime = (uint32)time(nullptr);
-        PChar->m_DeathCounter += (currentTime - PChar->m_DeathTimestamp);
-        PChar->m_DeathTimestamp = currentTime;
-        ref<uint32>(0x3C) = 0x0003A020 - (60 * PChar->m_DeathCounter);
-    }
-    else
-    {
-        //While the player is alive we always send a max time (60 minutes)
-        ref<uint32>(0x3C) = 0x0003A020;
-    }
+    ref<uint32>(0x3C) = 0x0003A020 - (60 * PChar->GetSecondsElapsedSinceDeath());
 
     ref<uint32>(0x40) = CVanaTime::getInstance()->getVanaTime();
     ref<uint16>(0x44) = PChar->m_Costum;

--- a/src/map/packets/zone_in.cpp
+++ b/src/map/packets/zone_in.cpp
@@ -189,8 +189,9 @@ CZoneInPacket::CZoneInPacket(CCharEntity * PChar, int16 csid)
     ref<uint32>(0x3C) = pktTime;
 
     // 60min starts at 0x03A020 (66 min) and ventures down to 0x5460 (6 min)
-    if (PChar->m_DeathCounter < 3600 && PChar->isDead())
-        ref<uint32>(0xA4) = 0x03A020 - (60 * PChar->m_DeathCounter);
+    uint32 deathDuration = PChar->GetSecondsElapsedSinceDeath();
+    if (deathDuration < 3600 && PChar->isDead())
+        ref<uint32>(0xA4) = 0x03A020 - (60 * deathDuration);
 
     ref<uint8>(0xB4) = PChar->GetMJob();
     ref<uint8>(0xB7) = PChar->GetSJob();

--- a/src/map/utils/charutils.cpp
+++ b/src/map/utils/charutils.cpp
@@ -4445,12 +4445,8 @@ namespace charutils
 
     void SaveDeathTime(CCharEntity* PChar)
     {
-        uint32 currentTime = (uint32)time(nullptr);
-        PChar->m_DeathCounter += (currentTime - PChar->m_DeathTimestamp);
-        PChar->m_DeathTimestamp = currentTime;
-
         const char* fmtQuery = "UPDATE char_stats SET death = %u WHERE charid = %u LIMIT 1;";
-        Sql_Query(SqlHandle, fmtQuery, PChar->m_DeathCounter, PChar->id);
+        Sql_Query(SqlHandle, fmtQuery, PChar->GetSecondsElapsedSinceDeath(), PChar->id);
     }
 
     void SavePlayTime(CCharEntity* PChar)
@@ -4881,6 +4877,8 @@ namespace charutils
         // remove weakness on homepoint
         PChar->StatusEffectContainer->DelStatusEffectSilent(EFFECT_WEAKNESS);
         PChar->StatusEffectContainer->DelStatusEffectSilent(EFFECT_LEVEL_SYNC);
+
+        PChar->SetDeathTimestamp(0);
 
         PChar->health.hp = PChar->GetMaxHP();
         PChar->health.mp = PChar->GetMaxMP();


### PR DESCRIPTION
Whenever the player would zone we would set their death time to how long they were dead for not how much more time they have. So the quicker you zoned after death the faster you would be automatically sent back to your homepoint.

This also fixes an issue where we were not sending the death timer correctly in the char_update packet. While digging through the auto HP issue for hours I noticed that retail always sends max death time while alive and sends the time remaining while dead. It is worth noting that retail also sends the char_update with an updated death time every 15~ seconds. My guess is that this is to help keep the client time synced.

This was tested with countless deaths and tractoring. After tractoring your timer correctly persists.

@Wiggo32 helped significantly through the process of coming up with these changes.