### PR TITLE
Fix issue with a cancelled raise preventing future raises and tractors

### DIFF
--- a/src/map/packet_system.cpp
+++ b/src/map/packet_system.cpp
@@ -714,9 +714,9 @@ void SmallPacket0x01A(map_session_data_t* session, CCharEntity* PChar, CBasicPac
         if (!PChar->m_hasRaise)
             return;
         if (data.ref<uint8>(0x0C) == 0) //ACCEPTED RAISE
-        {
             PChar->Raise();
-        }
+        else
+            PChar->m_hasRaise = 0;
     }
     break;
     case 0x0E: // Fishing


### PR DESCRIPTION
The raise flag was only being cleared when raised which meant that if the player declined a raise they would not receive anymore raise or tractor menus until they homepointed. Now we clear it when the player cancels the menu.

Tested with cancelling a raise and casting another raise then cancelling that and casting tractor on the character then cancelling that and then casting raise and accepting finally.