### PR TITLE
Fix crash that occurs when a monster with no drops is killed

### DIFF
--- a/src/map/entities/mobentity.cpp
+++ b/src/map/entities/mobentity.cpp
@@ -837,7 +837,7 @@ void CMobEntity::DropItems(CCharEntity* PChar) {
     DropList_t* DropList = itemutils::GetDropList(m_DropID);
     //ShowDebug(CL_CYAN"DropID: %u dropping with TH Level: %u\n" CL_RESET, PMob->m_DropID, PMob->m_THLvl);
 
-    if (DropList != nullptr && !getMobMod(MOBMOD_NO_DROPS) && DropList->Items.size() || DropList->Groups.size())
+    if (DropList != nullptr && !getMobMod(MOBMOD_NO_DROPS) && (DropList->Items.size() || DropList->Groups.size()))
     {
         //THLvl is the number of 'extra chances' at an item. If the item is obtained, then break out.
         uint8 maxRolls = 1 + (m_THLvl > 2 ? 2 : m_THLvl);


### PR DESCRIPTION
Apparently some smart guy forgot to include parentheses in his conditional which resulted in DropList being used even when it is a nullptr.