### PR TITLE
Resolved death auto hp issue (and friends)

### DIFF
--- a/src/map/entities/charentity.cpp
+++ b/src/map/entities/charentity.cpp
@@ -1629,6 +1629,15 @@ int32 CCharEntity::GetSecondsElapsedSinceDeath()
     return m_DeathTimestamp > 0 ? (uint32)time(nullptr) - m_DeathTimestamp : 0;
 }
 
+int32 CCharEntity::GetTimeRemainingUntilDeathHomepoint()
+{
+    //0x0003A020 is 60 * 3960 and 3960 is 66 minutes in seconds
+    //The client uses this time as the maximum amount of time for death
+    //We convert the elapsed death time to this total time and subtract it which gives us the remaining time to a forced homepoint
+    //Once the returned value here reaches below 360 then the client with force homepoint the character
+    return 0x0003A020 - (60 * GetSecondsElapsedSinceDeath());
+}
+
 void CCharEntity::TrackArrowUsageForScavenge(CItemWeapon* PAmmo)
 {
     // Check if local has been set yet

--- a/src/map/entities/charentity.cpp
+++ b/src/map/entities/charentity.cpp
@@ -464,6 +464,17 @@ bool CCharEntity::ReloadParty()
     return m_reloadParty;
 }
 
+void CCharEntity::Tick(time_point tick)
+{
+    CBattleEntity::Tick(tick);
+    if (m_DeathTimestamp > 0 && tick >= m_deathSyncTime)
+    {
+        //Send an update packet at a regular interval to keep the player's death variables synced
+        updatemask |= UPDATE_STATUS;
+        m_deathSyncTime = tick + death_update_frequency;
+    }
+}
+
 void CCharEntity::PostTick()
 {
     CBattleEntity::PostTick();
@@ -1597,6 +1608,7 @@ void CCharEntity::Die()
 
 void CCharEntity::Die(duration _duration)
 {
+    m_deathSyncTime = server_clock::now() + death_update_frequency;
     PAI->ClearStateStack();
     PAI->Internal_Die(_duration);
     pushPacket(new CRaiseTractorMenuPacket(this, TYPE_HOMEPOINT));

--- a/src/map/entities/charentity.cpp
+++ b/src/map/entities/charentity.cpp
@@ -519,7 +519,9 @@ void CCharEntity::PostTick()
                 static_cast<CCharEntity*>(PEntity)->pushPacket(new CCharHealthPacket(this));
             });
         }
-        pushPacket(new CCharUpdatePacket(this));
+        //Do not send an update packet when only the position has change
+        if (updatemask ^ UPDATE_POS)
+            pushPacket(new CCharUpdatePacket(this));
         updatemask = 0;
     }
 }

--- a/src/map/entities/charentity.cpp
+++ b/src/map/entities/charentity.cpp
@@ -1613,7 +1613,6 @@ void CCharEntity::Die(duration _duration)
     m_deathSyncTime = server_clock::now() + death_update_frequency;
     PAI->ClearStateStack();
     PAI->Internal_Die(_duration);
-    pushPacket(new CRaiseTractorMenuPacket(this, TYPE_HOMEPOINT));
 
     // reraise modifiers
     if (this->getMod(Mod::RERAISE_I) > 0)

--- a/src/map/entities/charentity.cpp
+++ b/src/map/entities/charentity.cpp
@@ -469,7 +469,7 @@ void CCharEntity::Tick(time_point tick)
     CBattleEntity::Tick(tick);
     if (m_DeathTimestamp > 0 && tick >= m_deathSyncTime)
     {
-        //Send an update packet at a regular interval to keep the player's death variables synced
+        // Send an update packet at a regular interval to keep the player's death variables synced
         updatemask |= UPDATE_STATUS;
         m_deathSyncTime = tick + death_update_frequency;
     }
@@ -519,7 +519,7 @@ void CCharEntity::PostTick()
                 static_cast<CCharEntity*>(PEntity)->pushPacket(new CCharHealthPacket(this));
             });
         }
-        //Do not send an update packet when only the position has change
+        // Do not send an update packet when only the position has change
         if (updatemask ^ UPDATE_POS)
             pushPacket(new CCharUpdatePacket(this));
         updatemask = 0;
@@ -1644,10 +1644,10 @@ int32 CCharEntity::GetSecondsElapsedSinceDeath()
 
 int32 CCharEntity::GetTimeRemainingUntilDeathHomepoint()
 {
-    //0x0003A020 is 60 * 3960 and 3960 is 66 minutes in seconds
-    //The client uses this time as the maximum amount of time for death
-    //We convert the elapsed death time to this total time and subtract it which gives us the remaining time to a forced homepoint
-    //Once the returned value here reaches below 360 then the client with force homepoint the character
+    // 0x0003A020 is 60 * 3960 and 3960 is 66 minutes in seconds
+    // The client uses this time as the maximum amount of time for death
+    // We convert the elapsed death time to this total time and subtract it which gives us the remaining time to a forced homepoint
+    // Once the returned value here reaches below 360 then the client with force homepoint the character
     return 0x0003A020 - (60 * GetSecondsElapsedSinceDeath());
 }
 

--- a/src/map/entities/charentity.h
+++ b/src/map/entities/charentity.h
@@ -266,6 +266,7 @@ public:
     uint16			  m_Monstrosity;				// Monstrosity model ID
     uint32			  m_AHHistoryTimestamp;			// Timestamp when last asked to view history
     uint32            m_DeathTimestamp;             // Timestamp when death counter has been saved to database
+    time_point        m_deathSyncTime;              // Timer used for sending an update packet at a regular interval while the character is dead
 
     uint8			  m_hasTractor;					// checks if player has tractor already
     uint8			  m_hasRaise;					// checks if player has raise already
@@ -297,8 +298,6 @@ public:
     bool              m_EffectsChanged;
     time_point        m_LastSynthTime;
 
-    static constexpr duration death_duration = 60min;
-
     int16 addTP(int16 tp) override;
     int32 addHP(int32 hp) override;
     int32 addMP(int32 mp) override;
@@ -315,6 +314,7 @@ public:
     void        ReloadPartyDec();
     bool        ReloadParty();
 
+    virtual void Tick(time_point) override;
     void        PostTick() override;
 
     virtual void addTrait(CTrait*) override;
@@ -326,6 +326,9 @@ public:
     virtual void Die() override;
     void Die(duration _duration);
     void Raise();
+
+    static constexpr duration death_duration = 60min;
+    static constexpr duration death_update_frequency = 16s;
 
     void SetDeathTimestamp(uint32 timestamp);
     int32 GetSecondsElapsedSinceDeath();

--- a/src/map/entities/charentity.h
+++ b/src/map/entities/charentity.h
@@ -329,6 +329,7 @@ public:
 
     void SetDeathTimestamp(uint32 timestamp);
     int32 GetSecondsElapsedSinceDeath();
+    int32 GetTimeRemainingUntilDeathHomepoint();  //Amount of time remaining before the player should be forced back to homepoint while dead
 
     /* State callbacks */
     virtual bool CanAttack(CBattleEntity* PTarget, std::unique_ptr<CBasicPacket>& errMsg) override;

--- a/src/map/entities/charentity.h
+++ b/src/map/entities/charentity.h
@@ -332,7 +332,7 @@ public:
 
     void SetDeathTimestamp(uint32 timestamp);
     int32 GetSecondsElapsedSinceDeath();
-    int32 GetTimeRemainingUntilDeathHomepoint();  //Amount of time remaining before the player should be forced back to homepoint while dead
+    int32 GetTimeRemainingUntilDeathHomepoint();  // Amount of time remaining before the player should be forced back to homepoint while dead
 
     /* State callbacks */
     virtual bool CanAttack(CBattleEntity* PTarget, std::unique_ptr<CBasicPacket>& errMsg) override;

--- a/src/map/packet_system.cpp
+++ b/src/map/packet_system.cpp
@@ -272,7 +272,7 @@ void SmallPacket0x00A(map_session_data_t* session, CCharEntity* PChar, CBasicPac
         int32 ret = Sql_Query(SqlHandle, fmtQuery, PChar->id);
         if (Sql_NextRow(SqlHandle) == SQL_SUCCESS)
         {
-            //Update the character's death timestamp based off of how long they were previously dead
+            // Update the character's death timestamp based off of how long they were previously dead
             uint32 secondsSinceDeath = (uint32)Sql_GetUIntData(SqlHandle, 0);
             if (PChar->health.hp == 0)
             {

--- a/src/map/packet_system.cpp
+++ b/src/map/packet_system.cpp
@@ -274,9 +274,11 @@ void SmallPacket0x00A(map_session_data_t* session, CCharEntity* PChar, CBasicPac
         {
             //Update the character's death timestamp based off of how long they were previously dead
             uint32 secondsSinceDeath = (uint32)Sql_GetUIntData(SqlHandle, 0);
-            PChar->SetDeathTimestamp((uint32)time(nullptr) - secondsSinceDeath);
             if (PChar->health.hp == 0)
+            {
+                PChar->SetDeathTimestamp((uint32)time(nullptr) - secondsSinceDeath);
                 PChar->Die(CCharEntity::death_duration - std::chrono::seconds(secondsSinceDeath));
+            }
         }
 
         fmtQuery = "SELECT pos_prevzone FROM chars WHERE charid = %u";

--- a/src/map/packets/char_update.cpp
+++ b/src/map/packets/char_update.cpp
@@ -92,10 +92,11 @@ CCharUpdatePacket::CCharUpdatePacket(CCharEntity* PChar)
     
     ref<uint8>(0x36) = flag;
 
-    //This contains the amount of time remaining before the player is forced back to homepoint while dead
-    ref<uint32>(0x3C) = 0x0003A020 - (60 * PChar->GetSecondsElapsedSinceDeath());
+    uint32 timeRemainingToForcedHomepoint = PChar->GetTimeRemainingUntilDeathHomepoint();
+    ref<uint32>(0x3C) = timeRemainingToForcedHomepoint;
 
-    ref<uint32>(0x40) = CVanaTime::getInstance()->getVanaTime();
+    //Vanatime at which the player should be forced back to homepoint while dead. Vanatime is in seconds so we must convert the time remaining to seconds.
+    ref<uint32>(0x40) = CVanaTime::getInstance()->getVanaTime() + timeRemainingToForcedHomepoint / 60;
     ref<uint16>(0x44) = PChar->m_Costum;
 
     if (PChar->animation == ANIMATION_FISHING_START)

--- a/src/map/packets/char_update.cpp
+++ b/src/map/packets/char_update.cpp
@@ -95,7 +95,7 @@ CCharUpdatePacket::CCharUpdatePacket(CCharEntity* PChar)
     uint32 timeRemainingToForcedHomepoint = PChar->GetTimeRemainingUntilDeathHomepoint();
     ref<uint32>(0x3C) = timeRemainingToForcedHomepoint;
 
-    //Vanatime at which the player should be forced back to homepoint while dead. Vanatime is in seconds so we must convert the time remaining to seconds.
+    // Vanatime at which the player should be forced back to homepoint while dead. Vanatime is in seconds so we must convert the time remaining to seconds.
     ref<uint32>(0x40) = CVanaTime::getInstance()->getVanaTime() + timeRemainingToForcedHomepoint / 60;
     ref<uint16>(0x44) = PChar->m_Costum;
 

--- a/src/map/packets/zone_in.cpp
+++ b/src/map/packets/zone_in.cpp
@@ -188,10 +188,7 @@ CZoneInPacket::CZoneInPacket(CCharEntity * PChar, int16 csid)
     ref<uint32>(0x38) = pktTime + VTIME_BASEDATE;
     ref<uint32>(0x3C) = pktTime;
 
-    // 60min starts at 0x03A020 (66 min) and ventures down to 0x5460 (6 min)
-    uint32 deathDuration = PChar->GetSecondsElapsedSinceDeath();
-    if (deathDuration < 3600 && PChar->isDead())
-        ref<uint32>(0xA4) = 0x03A020 - (60 * deathDuration);
+    ref<uint32>(0xA4) = PChar->GetTimeRemainingUntilDeathHomepoint();
 
     ref<uint8>(0xB4) = PChar->GetMJob();
     ref<uint8>(0xB7) = PChar->GetSJob();


### PR DESCRIPTION
The death auto HP issue is now finally understood and fixed. This is after a long night of digging through decompiled code, using cheat engine to debug breakpoints on the client, and carefully reviewing the incoming packets on retail with great help from @atom0s.

The underlying issue is that char_update (`0x37`) should be sending in `0x40` the VanaTime of when the player will be forced to homepoint while dead. While alive this value is about 3960 (66 minutes) above the client's VanaTime and keeps increasing. Once the player dies this value stops moving and decreases at the same rate the value at `0x3C` in char_update packet increases. The problem is that dsp would always send the current VanaTime regardless if the character is alive or dead and it would not be offset by any amount.

Digging deeper we found the client compares `0x40` to its locally calculated VanaTime and if it is less than it would set that time as the "send to homepoint" time. Since this time had already passed it would fail the initial check and immediately send the character back to their homepoint. This appeared randomly because sometimes the conditional would fail and it would instead use the value in `0x3C` to calculate the send to homepoint time which would be a correct time.

Along the way several other discrepancies were noticed which I addressed here as well:
* The char_update packet is being sent whenever the character moves but this is not necessary and not the case on retail
* The char_update packet should be sent while the character is dead at some interval. This interval is about 16 seconds and seems to be used to keep the client's death times in sync.
* We were sending an unnecessary homepoint menu packet on death (retail does not do this)
* There was an issue with the death timestamp being set incorrectly while zoning in

While working on this I also looked over the zone_in packet to see if that also needs the "send to homepoint" VanaTime but it does not.

More data can be provided such as the decompiled code or retail packets.

This fix was tested with countless sacrificial deaths.