### PR TITLE
Add new statecheck to Internal_Despawn

### DIFF
--- a/src/map/ai/ai_container.cpp
+++ b/src/map/ai/ai_container.cpp
@@ -442,7 +442,7 @@ bool CAIContainer::QueueEmpty()
 
 bool CAIContainer::Internal_Despawn()
 {
-    if (!IsCurrentState<CDespawnState>())
+    if (!IsCurrentState<CDespawnState>() && !IsCurrentState<CRespawnState>())
     {
         return ForceChangeState<CDespawnState>(PEntity);
     }


### PR DESCRIPTION
Fixes https://github.com/DarkstarProject/darkstar/issues/5244

Check prevents state stack from filling up infinitely. 