### PR TITLE
Resolved issue with items traded for guild points not being consumed

### DIFF
--- a/scripts/globals/crafting.lua
+++ b/scripts/globals/crafting.lua
@@ -292,22 +292,22 @@ function unionRepresentativeTriggerFinish(player, option, target, guildID, curre
 end
 
 function unionRepresentativeTrade(player, npc, trade, csid, guildID)
-    local gpItem, remainingPoints = player:getCurrentGPItem(guildID);
+    local gpItem, remainingPoints = player:getCurrentGPItem(guildID)
     if (player:getVar('[GUILD]currentGuild') - 1 == guildID) then
         if remainingPoints == 0 then
-            player:messageText(npc, NO_MORE_GP_ELIGIBLE);
+            player:messageText(npc, NO_MORE_GP_ELIGIBLE)
         else
-            local totalPoints = 0;
-            for i=0,8,1 do
-                local items, points = player:addGuildPoints(guildID,i)
+            local totalPoints = 0
+            for i = 0, 8 do
+                local items, points = player:addGuildPoints(guildID, i)
                 if items ~= 0 and points ~= 0 then
-                    totalPoints = totalPoints + points;
-                    trade:confirmItem(i, items);
+                    totalPoints = totalPoints + points
+                    trade:confirmSlot(i, items)
                 end
             end
             if (totalPoints > 0) then
-                player:confirmTrade();
-                player:startEvent(csid,totalPoints);
+                player:confirmTrade()
+                player:startEvent(csid,totalPoints)
             end
         end
     end

--- a/scripts/globals/crafting.lua
+++ b/scripts/globals/crafting.lua
@@ -297,15 +297,16 @@ function unionRepresentativeTrade(player, npc, trade, csid, guildID)
         if remainingPoints == 0 then
             player:messageText(npc, NO_MORE_GP_ELIGIBLE);
         else
+            local totalItems = 0;
             local totalPoints = 0;
             for i=0,8,1 do
                 local items, points = player:addGuildPoints(guildID,i)
-                if items ~= 0 and points ~= 0 then
-                    totalPoints = totalPoints + points;
-                    trade:confirmItem(i, items);
-                end
+                totalItems = totalItems + items;
+                totalPoints = totalPoints + points;
             end
-            if (totalPoints > 0) then
+
+            if (totalItems > 0 and totalPoints > 0) then
+                trade:confirmItem(gpItem, totalItems);
                 player:confirmTrade();
                 player:startEvent(csid,totalPoints);
             end

--- a/scripts/globals/crafting.lua
+++ b/scripts/globals/crafting.lua
@@ -297,16 +297,15 @@ function unionRepresentativeTrade(player, npc, trade, csid, guildID)
         if remainingPoints == 0 then
             player:messageText(npc, NO_MORE_GP_ELIGIBLE);
         else
-            local totalItems = 0;
             local totalPoints = 0;
             for i=0,8,1 do
                 local items, points = player:addGuildPoints(guildID,i)
-                totalItems = totalItems + items;
-                totalPoints = totalPoints + points;
+                if items ~= 0 and points ~= 0 then
+                    totalPoints = totalPoints + points;
+                    trade:confirmItem(i, items);
+                end
             end
-
-            if (totalItems > 0 and totalPoints > 0) then
-                trade:confirmItem(gpItem, totalItems);
+            if (totalPoints > 0) then
                 player:confirmTrade();
                 player:startEvent(csid,totalPoints);
             end


### PR DESCRIPTION
There were two issues here with the code.
1. The correct signature is `confirmItem(itemID, amount)` but it was being passed in `i` which I guess was intended as the `slotID`. This lead to `confirmItem` never confirming any items.
2. `confirmItem` iterates over the entire trade container looking for `amount` of the provided `itemID`. The problem is that it was iterating over the trade container outside of that looking for each item. So if 2+ guild items were traded at the same time it would reconfirm the first one over and over.

The fix is to just add up the total number of items we want to confirm and then call that with the correct parameters. This fixes #4559.

Tested this with various trades with the goldsmith guild point npc.