### PR TITLE
Stoneskin tiers

### DIFF
--- a/scripts/globals/abilities/pets/earthen_ward.lua
+++ b/scripts/globals/abilities/pets/earthen_ward.lua
@@ -14,7 +14,7 @@ end
 function onPetAbility(target, pet, skill)
     target:delStatusEffect(dsp.effect.STONESKIN)
     local amount = pet:getMainLvl()*2 + 50
-    target:addStatusEffect(dsp.effect.STONESKIN,amount,0,900)
+    target:addStatusEffect(dsp.effect.STONESKIN,amount,0,900,0,0,3)
     skill:setMsg(dsp.msg.basic.SKILL_GAIN_EFFECT)
     return dsp.effect.STONESKIN
 end

--- a/scripts/globals/abilities/pets/shock_absorber.lua
+++ b/scripts/globals/abilities/pets/shock_absorber.lua
@@ -46,7 +46,7 @@ function onPetAbility(target, automaton, skill, master, action)
     end
     amount = amount + math.floor(bonus)
 
-    if target:addStatusEffect(dsp.effect.STONESKIN, amount, 0, duration) then
+    if target:addStatusEffect(dsp.effect.STONESKIN, amount, 0, duration, 0, 0, 4) then
         skill:setMsg(dsp.msg.basic.SKILL_GAIN_EFFECT)
     else
         skill:setMsg(dsp.msg.basic.SKILL_NO_EFFECT)

--- a/scripts/globals/items/stoneskin_torque.lua
+++ b/scripts/globals/items/stoneskin_torque.lua
@@ -11,7 +11,7 @@ function onItemCheck(target)
 end
 
 function onItemUse(target)
-    if (target:addStatusEffect(dsp.effect.STONESKIN, 104, 0, 300)) then
+    if target:addStatusEffect(dsp.effect.STONESKIN, 104, 0, 300, 0, 0, 4) then
         target:messageBasic(dsp.msg.basic.GAINS_EFFECT_OF_STATUS, dsp.effect.STONESKIN)
     else
         target:messageBasic(dsp.msg.basic.NO_EFFECT)

--- a/scripts/globals/spells/bluemagic/diamondhide.lua
+++ b/scripts/globals/spells/bluemagic/diamondhide.lua
@@ -29,7 +29,7 @@ function onSpellCast(caster,target,spell)
     local power = ((blueskill)/3) *2
     local duration = 300
 
-    if (target:addStatusEffect(typeEffect,power,0,duration) == false) then
+    if not target:addStatusEffect(typeEffect,power,0,duration,0,0,2) then
         spell:setMsg(dsp.msg.basic.MAGIC_NO_EFFECT)
     end
 

--- a/scripts/globals/spells/bluemagic/metallic_body.lua
+++ b/scripts/globals/spells/bluemagic/metallic_body.lua
@@ -43,7 +43,7 @@ function onSpellCast(caster,target,spell)
         caster:delStatusEffect(dsp.effect.DIFFUSION)
     end
 
-    if (target:addStatusEffect(typeEffect,power,0,duration) == false) then
+    if not target:addStatusEffect(typeEffect,power,0,duration,0,0,2) then
         spell:setMsg(dsp.msg.basic.MAGIC_NO_EFFECT)
     end
 

--- a/scripts/globals/spells/cure.lua
+++ b/scripts/globals/spells/cure.lua
@@ -79,7 +79,7 @@ function onSpellCast(caster,target,spell)
             else
                 solaceStoneskin = math.floor(final * 0.25)
             end
-            target:addStatusEffect(dsp.effect.STONESKIN,solaceStoneskin,0,25)
+            target:addStatusEffect(dsp.effect.STONESKIN,solaceStoneskin,0,25,0,0,1)
         end
         final = final + (final * (target:getMod(dsp.mod.CURE_POTENCY_RCVD)/100))
 

--- a/scripts/globals/spells/cure_ii.lua
+++ b/scripts/globals/spells/cure_ii.lua
@@ -79,7 +79,7 @@ function onSpellCast(caster,target,spell)
             else
                 solaceStoneskin = math.floor(final * 0.25)
             end
-            target:addStatusEffect(dsp.effect.STONESKIN,solaceStoneskin,0,25)
+            target:addStatusEffect(dsp.effect.STONESKIN,solaceStoneskin,0,25,0,0,1)
         end
         final = final + (final * (target:getMod(dsp.mod.CURE_POTENCY_RCVD)/100))
 

--- a/scripts/globals/spells/cure_iii.lua
+++ b/scripts/globals/spells/cure_iii.lua
@@ -75,7 +75,7 @@ function onSpellCast(caster,target,spell)
             else
                 solaceStoneskin = math.floor(final * 0.25)
             end
-            target:addStatusEffect(dsp.effect.STONESKIN,solaceStoneskin,0,25)
+            target:addStatusEffect(dsp.effect.STONESKIN,solaceStoneskin,0,25,0,0,1)
         end
         final = final + (final * (target:getMod(dsp.mod.CURE_POTENCY_RCVD)/100))
 

--- a/scripts/globals/spells/cure_iv.lua
+++ b/scripts/globals/spells/cure_iv.lua
@@ -73,7 +73,7 @@ function onSpellCast(caster,target,spell)
             else
                 solaceStoneskin = math.floor(final * 0.25)
             end
-            target:addStatusEffect(dsp.effect.STONESKIN,solaceStoneskin,0,25)
+            target:addStatusEffect(dsp.effect.STONESKIN,solaceStoneskin,0,25,0,0,1)
         end
         final = final + (final * (target:getMod(dsp.mod.CURE_POTENCY_RCVD)/100))
 

--- a/scripts/globals/spells/cure_v.lua
+++ b/scripts/globals/spells/cure_v.lua
@@ -83,7 +83,7 @@ function onSpellCast(caster,target,spell)
             else
                 solaceStoneskin = math.floor(final * 0.25)
             end
-            target:addStatusEffect(dsp.effect.STONESKIN,solaceStoneskin,0,25)
+            target:addStatusEffect(dsp.effect.STONESKIN,solaceStoneskin,0,25,0,0,1)
         end
         final = final + (final * (target:getMod(dsp.mod.CURE_POTENCY_RCVD)/100))
 

--- a/scripts/globals/spells/cure_vi.lua
+++ b/scripts/globals/spells/cure_vi.lua
@@ -62,7 +62,7 @@ function onSpellCast(caster,target,spell)
             else
                 solaceStoneskin = math.floor(final * 0.25)
             end
-            target:addStatusEffect(dsp.effect.STONESKIN,solaceStoneskin,0,25)
+            target:addStatusEffect(dsp.effect.STONESKIN,solaceStoneskin,0,25,0,0,1)
         end
         final = final + (final * (target:getMod(dsp.mod.CURE_POTENCY_RCVD)/100))
 

--- a/scripts/globals/spells/stoneskin.lua
+++ b/scripts/globals/spells/stoneskin.lua
@@ -35,7 +35,7 @@ function onSpellCast(caster, target, spell)
     duration = calculateDurationForLvl(duration, 28, target:getMainLvl())
 
     local final = pAbs + pEquipMods
-    if target:addStatusEffect(dsp.effect.STONESKIN, final, 0, duration) then
+    if target:addStatusEffect(dsp.effect.STONESKIN, final, 0, duration, 0, 0, 4) then
         spell:setMsg(dsp.msg.basic.MAGIC_GAIN_EFFECT)
     else
         spell:setMsg(dsp.msg.basic.MAGIC_NO_EFFECT)

--- a/sql/status_effects.sql
+++ b/sql/status_effects.sql
@@ -76,7 +76,7 @@ INSERT INTO `status_effects` VALUES (33,'haste',33,0,13,0,0,0,4,0);
 INSERT INTO `status_effects` VALUES (34,'blaze_spikes',33,34,0,0,0,0,1,0);
 INSERT INTO `status_effects` VALUES (35,'ice_spikes',33,34,0,0,0,0,5,0);
 INSERT INTO `status_effects` VALUES (36,'blink',33,36,0,0,66,0,4,0);
-INSERT INTO `status_effects` VALUES (37,'stoneskin',33,0,0,2,0,0,2,0);
+INSERT INTO `status_effects` VALUES (37,'stoneskin',33,0,0,5,0,0,2,0);
 INSERT INTO `status_effects` VALUES (38,'shock_spikes',33,34,0,0,0,0,6,0);
 INSERT INTO `status_effects` VALUES (39,'aquaveil',33,0,0,0,0,0,3,0);
 INSERT INTO `status_effects` VALUES (40,'protect',33,0,0,0,0,0,7,0);

--- a/src/map/status_effect.h
+++ b/src/map/status_effect.h
@@ -33,11 +33,12 @@
 
 enum EFFECTOVERWRITE
 {
-    EFFECTOVERWRITE_EQUAL_HIGHER = 0, // only overwrite if equal or higher
-    EFFECTOVERWRITE_HIGHER = 1, // only overwrite if higher
+    EFFECTOVERWRITE_EQUAL_HIGHER = 0, // only overwrite if equal or higher (tier, power)
+    EFFECTOVERWRITE_HIGHER = 1, // only overwrite if higher (tier, power)
     EFFECTOVERWRITE_NEVER = 2, // never overwrite
     EFFECTOVERWRITE_ALWAYS = 3, // always overwrite no matter
-    EFFECTOVERWRITE_IGNORE = 4 // ignore dupes
+    EFFECTOVERWRITE_IGNORE = 4, // ignore dupes
+    EFFECTOVERWRITE_TIER_HIGHER = 5 // only overwrite if tier is higher (regardless of power)
 };
 
 enum EFFECTFLAG

--- a/src/map/status_effect_container.cpp
+++ b/src/map/status_effect_container.cpp
@@ -275,28 +275,26 @@ bool CStatusEffectContainer::CanGainStatusEffect(CStatusEffect* PStatusEffect)
     if (existingEffect != nullptr) {
         EFFECTOVERWRITE overwrite = effects::EffectsParams[statusEffect].Overwrite;
 
-        if (overwrite == EFFECTOVERWRITE_ALWAYS || overwrite == EFFECTOVERWRITE_IGNORE) {
+        if (overwrite == EFFECTOVERWRITE_ALWAYS || overwrite == EFFECTOVERWRITE_IGNORE)
             return true;
-        }
-
-        if (overwrite == EFFECTOVERWRITE_NEVER) {
+        else if (overwrite == EFFECTOVERWRITE_NEVER)
             return false;
-        }
-
-        if (overwrite == EFFECTOVERWRITE_EQUAL_HIGHER) {
+        else if (overwrite == EFFECTOVERWRITE_EQUAL_HIGHER)
+        {
             if (PStatusEffect->GetTier() != 0 && existingEffect->GetTier() != 0)
-            {
                 return PStatusEffect->GetTier() >= existingEffect->GetTier();
-            }
             return PStatusEffect->GetPower() >= existingEffect->GetPower();
         }
-        else if (overwrite == EFFECTOVERWRITE_HIGHER) {
-            // overwrite only if higher
+        else if (overwrite == EFFECTOVERWRITE_HIGHER)
+        {
             if (PStatusEffect->GetTier() != 0 && existingEffect->GetTier() != 0)
-            {
                 return PStatusEffect->GetTier() > existingEffect->GetTier();
-            }
             return PStatusEffect->GetPower() > existingEffect->GetPower();
+        }
+        else if (overwrite == EFFECTOVERWRITE_TIER_HIGHER)
+        {
+            if (PStatusEffect->GetTier() != 0 && existingEffect->GetTier() != 0)
+                return PStatusEffect->GetTier() > existingEffect->GetTier();
         }
 
         return false;
@@ -328,10 +326,10 @@ void CStatusEffectContainer::OverwriteStatusEffect(CStatusEffect* StatusEffect)
 }
 
 /************************************************************************
-*																		*
-*  Добавляем статус-эффект в контейнер									*
-*  Если не ошибаюсь, то максимально-возможное количество эффектов 32 	*
-*																		*
+*                                                                       *
+*  Добавляем статус-эффект в контейнер                                  *
+*  Если не ошибаюсь, то максимально-возможное количество эффектов 32    *
+*                                                                       *
 ************************************************************************/
 
 bool CStatusEffectContainer::AddStatusEffect(CStatusEffect* PStatusEffect, bool silent)
@@ -418,10 +416,10 @@ bool CStatusEffectContainer::AddStatusEffect(CStatusEffect* PStatusEffect, bool 
 }
 
 /************************************************************************
-*																		*
-*  Эффекты во всех методах удаляются одинаково, вынес этот код в		*
-*  отдельную функцию. Удаляем иконки только у CharEntity.				*
-*																		*
+*                                                                       *
+*  Эффекты во всех методах удаляются одинаково, вынес этот код в        *
+*  отдельную функцию. Удаляем иконки только у CharEntity.               *
+*                                                                       *
 ************************************************************************/
 
 void CStatusEffectContainer::DeleteStatusEffects()
@@ -506,10 +504,10 @@ void CStatusEffectContainer::RemoveStatusEffect(uint32 id, bool silent)
 }
 
 /************************************************************************
-*																		*
-*  Удаляем статус-эффект по его основному и дополнительному типам.		*
-*  Возвращаем результат выполнения операции.							*
-*																		*
+*                                                                       *
+*  Удаляем статус-эффект по его основному и дополнительному типам.      *
+*  Возвращаем результат выполнения операции.                            *
+*                                                                       *
 ************************************************************************/
 
 bool CStatusEffectContainer::DelStatusEffect(EFFECT StatusID)
@@ -569,9 +567,9 @@ bool CStatusEffectContainer::DelStatusEffectByTier(EFFECT StatusID, uint16 tier)
 }
 
 /************************************************************************
-*																		*
-*  Deletes all status effects without sending messages              	*
-*																		*
+*                                                                       *
+*  Deletes all status effects without sending messages                  *
+*                                                                       *
 ************************************************************************/
 void CStatusEffectContainer::KillAllStatusEffect()
 {
@@ -595,9 +593,9 @@ void CStatusEffectContainer::KillAllStatusEffect()
 }
 
 /************************************************************************
-*																		*
-*  Удаляем все эффекты с указанными иконками    						*
-*																		*
+*                                                                       *
+*  Удаляем все эффекты с указанными иконками                            *
+*                                                                       *
 ************************************************************************/
 
 void CStatusEffectContainer::DelStatusEffectsByIcon(uint16 IconID)
@@ -644,10 +642,10 @@ void CStatusEffectContainer::DelStatusEffectsByFlag(uint32 flag, bool silent)
 }
 
 /************************************************************************
-*																		*
-*  Удаляем первый добавленный отрицательный эффект с флагом	erase.      *
-*  Возвращаем результат выполнения операции.							*
-*																		*
+*                                                                       *
+*  Удаляем первый добавленный отрицательный эффект с флагом erase.      *
+*  Возвращаем результат выполнения операции.                            *
+*                                                                       *
 ************************************************************************/
 
 EFFECT CStatusEffectContainer::EraseStatusEffect()
@@ -716,15 +714,15 @@ uint8 CStatusEffectContainer::EraseAllStatusEffect()
 }
 
 /************************************************************************
-*																		*
+*                                                                       *
 *  Удаляем первый добавленный положительный эффект с флагом dispel.     *
-*  Возвращаем результат выполнения операции.							*
-*																		*
+*  Возвращаем результат выполнения операции.                            *
+*                                                                       *
 ************************************************************************/
 
 EFFECT CStatusEffectContainer::DispelStatusEffect(EFFECTFLAG flag)
 {
-    std::vector<uint16>	dispelableList;
+    std::vector<uint16> dispelableList;
     for (uint16 i = 0; i < m_StatusEffectList.size(); ++i)
     {
         if (m_StatusEffectList.at(i)->GetFlag() & flag &&
@@ -765,9 +763,9 @@ uint8 CStatusEffectContainer::DispelAllStatusEffect(EFFECTFLAG flag)
 }
 
 /************************************************************************
-*																		*
-*  Проверяем наличие статус-эффекта	в контейнере						*
-*																		*
+*                                                                       *
+*  Проверяем наличие статус-эффекта в контейнере                        *
+*                                                                       *
 ************************************************************************/
 
 bool CStatusEffectContainer::HasStatusEffect(EFFECT StatusID)
@@ -869,7 +867,7 @@ bool CStatusEffectContainer::ApplyCorsairEffect(CStatusEffect* PStatusEffect, ui
     {
         if ((PEffect->GetStatusID() >= EFFECT_FIGHTERS_ROLL &&
             PEffect->GetStatusID() <= EFFECT_NATURALISTS_ROLL) ||
-            PEffect->GetStatusID() == EFFECT_RUNEISTS_ROLL || 
+            PEffect->GetStatusID() == EFFECT_RUNEISTS_ROLL ||
             PEffect->GetStatusID() == EFFECT_BUST)//is a cor effect
         {
             if (PEffect->GetStatusID() == PStatusEffect->GetStatusID() &&
@@ -1037,7 +1035,7 @@ void CStatusEffectContainer::RemoveAllManeuvers()
 
 /************************************************************************
 *                                                                       *
-*  Проверяем наличие статус-эффекта	в контейнере с уникальным subid     *
+*  Проверяем наличие статус-эффекта в контейнере с уникальным subid     *
 *                                                                       *
 ************************************************************************/
 
@@ -1204,7 +1202,7 @@ void CStatusEffectContainer::SetEffectParams(CStatusEffect* StatusEffect)
     //Determine if this is a BRD Song or COR Effect.
     if (StatusEffect->GetSubID() == 0 || StatusEffect->GetSubID() > 20000 ||
         (effect >= EFFECT_REQUIEM && effect <= EFFECT_NOCTURNE) ||
-        (effect >= EFFECT_DOUBLE_UP_CHANCE && effect <= EFFECT_NATURALISTS_ROLL) || 
+        (effect >= EFFECT_DOUBLE_UP_CHANCE && effect <= EFFECT_NATURALISTS_ROLL) ||
         effect == EFFECT_RUNEISTS_ROLL)
     {
         name.insert(0, "globals/effects/");
@@ -1255,9 +1253,9 @@ void CStatusEffectContainer::SetEffectParams(CStatusEffect* StatusEffect)
 }
 
 /************************************************************************
-*																		*
-*  Загружаем эффекты персонажа											*
-*																		*
+*                                                                       *
+*  Загружаем эффекты персонажа                                          *
+*                                                                       *
 ************************************************************************/
 
 void CStatusEffectContainer::LoadStatusEffects()
@@ -1316,9 +1314,9 @@ void CStatusEffectContainer::LoadStatusEffects()
 }
 
 /************************************************************************
-*																		*
-*  Сохраняем временные эффекты персонажа								*
-*																		*
+*                                                                       *
+*  Сохраняем временные эффекты персонажа                                *
+*                                                                       *
 ************************************************************************/
 
 void CStatusEffectContainer::SaveStatusEffects(bool logout)
@@ -1383,9 +1381,9 @@ void CStatusEffectContainer::SaveStatusEffects(bool logout)
 }
 
 /************************************************************************
-*																		*
+*                                                                       *
 *  Expires status effects                                               *
-*																		*
+*                                                                       *
 ************************************************************************/
 
 void CStatusEffectContainer::CheckEffectsExpiry(time_point tick)
@@ -1406,9 +1404,9 @@ void CStatusEffectContainer::CheckEffectsExpiry(time_point tick)
 }
 
 /************************************************************************
-*																		*
+*                                                                       *
 *  Runs OnEffectTick for all status effects                             *
-*																		*
+*                                                                       *
 ************************************************************************/
 
 void CStatusEffectContainer::TickEffects(time_point tick)
@@ -1432,9 +1430,9 @@ void CStatusEffectContainer::TickEffects(time_point tick)
 }
 
 /************************************************************************
-*																		*
-*  Tick regen/refresh/regain effects									*
-*																		*
+*                                                                       *
+*  Tick regen/refresh/regain effects                                    *
+*                                                                       *
 ************************************************************************/
 
 void CStatusEffectContainer::TickRegen(time_point tick)


### PR DESCRIPTION
[Stoneskin effect](http://ffxiclopedia.wikia.com/wiki/Stoneskin_(Status_Effect)) now overwrites based on tier (only higher tier will overwrite, regardless of power).

tier 1: cureskin from [afflatus solace](http://ffxiclopedia.wikia.com/wiki/Afflatus_Solace)
tier 2: [diamondhide](http://ffxiclopedia.wikia.com/wiki/Diamondhide), [metallic body](http://ffxiclopedia.wikia.com/wiki/Metallic_Body)
tier 3: [earthen ward](http://ffxiclopedia.wikia.com/wiki/Earthen_Ward)
tier 4: [stoneskin](http://ffxiclopedia.wikia.com/wiki/Stoneskin)

Fixes #1202.

