### PR TITLE
Add packet to display teleport icons on maps

### DIFF
--- a/src/map/packet_system.cpp
+++ b/src/map/packet_system.cpp
@@ -118,6 +118,7 @@ This file is part of DarkStar-server source code.
 #include "packets/linkshell_equip.h"
 #include "packets/linkshell_message.h"
 #include "packets/macroequipset.h"
+#include "packets/map_marker.h"
 #include "packets/menu_config.h"
 #include "packets/menu_merit.h"
 #include "packets/merit_points_categories.h"
@@ -5867,6 +5868,17 @@ void SmallPacket0x113(map_session_data_t* session, CCharEntity* PChar, CBasicPac
 }
 
 /************************************************************************
+*                                                                       *
+*  Map Marker Request Packet                                            *
+*                                                                       *
+************************************************************************/
+
+void SmallPacket0x114(map_session_data_t* session, CCharEntity* PChar, CBasicPacket data)
+{
+    PChar->pushPacket(new CMapMarkerPacket(PChar));
+}
+
+/************************************************************************
 *                                                                        *
 *  Request Currency2 tab                                                  *
 *                                                                        *
@@ -5992,7 +6004,7 @@ void PacketParserInitialize()
     PacketSize[0x111] = 0x00; PacketParser[0x111] = &SmallPacket0x111; // Lock Style Request
     PacketSize[0x112] = 0x00; PacketParser[0x112] = &SmallPacket0xFFF;
     PacketSize[0x113] = 0x06; PacketParser[0x113] = &SmallPacket0x113;
-    PacketSize[0x114] = 0x00; PacketParser[0x114] = &SmallPacket0xFFF;
+    PacketSize[0x114] = 0x00; PacketParser[0x114] = &SmallPacket0x114;
     PacketSize[0x115] = 0x02; PacketParser[0x115] = &SmallPacket0x115;
 }
 

--- a/src/map/packets/map_marker.cpp
+++ b/src/map/packets/map_marker.cpp
@@ -1,0 +1,47 @@
+/*
+===========================================================================
+
+Copyright (c) 2010-2018 Darkstar Dev Teams
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see http://www.gnu.org/licenses/
+
+This file is part of DarkStar-server source code.
+
+===========================================================================
+*/
+
+#include "map_marker.h"
+
+#include "../entities/charentity.h"
+#include "../utils/charutils.h"
+
+CMapMarkerPacket::CMapMarkerPacket(CCharEntity* PChar)
+{
+    this->id(0x063);
+    this->length(0x48);
+
+    ref<uint8>(0x04) = 0x06;
+
+    // Homepoint teleport masks
+    ref<uint16>(0x08) = charutils::GetVar(PChar, "HpTeleportMask1b");
+    ref<uint16>(0x0A) = charutils::GetVar(PChar, "HpTeleportMask1a");
+    ref<uint16>(0x0C) = charutils::GetVar(PChar, "HpTeleportMask2b");
+    ref<uint16>(0x0E) = charutils::GetVar(PChar, "HpTeleportMask2a");
+    ref<uint16>(0x10) = charutils::GetVar(PChar, "HpTeleportMask3b");
+    ref<uint16>(0x12) = charutils::GetVar(PChar, "HpTeleportMask3a");
+    ref<uint16>(0x14) = charutils::GetVar(PChar, "HpTeleportMask4b");
+    ref<uint16>(0x16) = charutils::GetVar(PChar, "HpTeleportMask4a");
+
+    // TODO: Cavernous Maws, Abyssea Maws, Survival Guides
+}

--- a/src/map/packets/map_marker.h
+++ b/src/map/packets/map_marker.h
@@ -1,0 +1,36 @@
+/*
+===========================================================================
+
+Copyright (c) 2010-2018 Darkstar Dev Teams
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see http://www.gnu.org/licenses/
+
+This file is part of DarkStar-server source code.
+
+===========================================================================
+*/
+#ifndef _CMAPMARKERPACKET_H_
+#define _CMAPMARKERPACKET_H_
+
+#include "basic.h"
+
+class CCharEntity;
+
+class CMapMarkerPacket : public CBasicPacket
+{
+public:
+    CMapMarkerPacket(CCharEntity* PChar);
+};
+
+#endif // _CMAPMARKERPACKET_H_

--- a/win32/vcxproj/DSGame-server.vcxproj
+++ b/win32/vcxproj/DSGame-server.vcxproj
@@ -374,6 +374,7 @@
     <ClInclude Include="..\..\src\map\packets\linkshell_equip.h" />
     <ClInclude Include="..\..\src\map\packets\lock_on.h" />
     <ClInclude Include="..\..\src\map\packets\macroequipset.h" />
+    <ClInclude Include="..\..\src\map\packets\map_marker.h" />
     <ClInclude Include="..\..\src\map\packets\menu_config.h" />
     <ClInclude Include="..\..\src\map\packets\menu_merit.h" />
     <ClInclude Include="..\..\src\map\packets\menu_mog.h" />
@@ -617,6 +618,7 @@
     <ClCompile Include="..\..\src\map\packets\linkshell_equip.cpp" />
     <ClCompile Include="..\..\src\map\packets\lock_on.cpp" />
     <ClCompile Include="..\..\src\map\packets\macroequipset.cpp" />
+    <ClCompile Include="..\..\src\map\packets\map_marker.cpp" />
     <ClCompile Include="..\..\src\map\packets\menu_config.cpp" />
     <ClCompile Include="..\..\src\map\packets\menu_merit.cpp" />
     <ClCompile Include="..\..\src\map\packets\menu_mog.cpp" />

--- a/win32/vcxproj/DSGame-server.vcxproj.filters
+++ b/win32/vcxproj/DSGame-server.vcxproj.filters
@@ -866,6 +866,9 @@
     <ClInclude Include="..\..\src\map\packets\message_name.h">
       <Filter>Header Files\packets</Filter>
     </ClInclude>
+    <ClInclude Include="..\..\src\map\packets\map_marker.h">
+      <Filter>Source Files\packets</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="..\..\src\map\ability.cpp">
@@ -1586,6 +1589,9 @@
       <Filter>Source Files\packets</Filter>
     </ClCompile>
     <ClCompile Include="..\..\src\map\packets\message_name.cpp">
+      <Filter>Source Files\packets</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\map\packets\map_marker.cpp">
       <Filter>Source Files\packets</Filter>
     </ClCompile>
   </ItemGroup>


### PR DESCRIPTION
Added support for Homepoint Teleports since we currently support that.

Maws and Survival guides can be added in future.