### PR TITLE
Resolve issue with item in inventory becoming unusable

### DIFF
--- a/src/map/ai/states/item_state.cpp
+++ b/src/map/ai/states/item_state.cpp
@@ -169,7 +169,7 @@ void CItemState::Cleanup(time_point tick)
 {
     m_PEntity->UContainer->Clean();
 
-    if (m_interrupted && !m_PItem->isType(ITEM_ARMOR))
+    if ((m_interrupted || !IsCompleted()) && !m_PItem->isType(ITEM_ARMOR))
         m_PItem->setSubType(ITEM_UNLOCKED);
 
     auto PItem = m_PEntity->getStorage(m_location)->GetItem(m_slot);


### PR DESCRIPTION
If a player rests while using an item it will clear the AI state leaving the item in a locked state since it was not technically `m_interrupted`. The fix here is to treat the item as being interrupted if we are cleaning up the state before it finished using the item.