### PR TITLE
Resolved issue with monster's hiPCLvl not being set correctly from spike damage

### DIFF
--- a/src/map/utils/battleutils.cpp
+++ b/src/map/utils/battleutils.cpp
@@ -823,9 +823,9 @@ namespace battleutils
             // Check for status effect proc. Todo: move to scripts soon™ after item additionalEffect refactor Teo is working on
             HandleSpikesStatusEffect(PAttacker, PDefender, Action);
 
-            if (((CMobEntity*)PDefender)->m_HiPCLvl < PAttacker->GetMLevel())
+            if (PAttacker->objtype == TYPE_MOB && ((CMobEntity*)PAttacker)->m_HiPCLvl < PDefender->GetMLevel())
             {
-                ((CMobEntity*)PDefender)->m_HiPCLvl = PAttacker->GetMLevel();
+                ((CMobEntity*)PAttacker)->m_HiPCLvl = PDefender->GetMLevel();
             }
             return true;
         }


### PR DESCRIPTION
The `PDefender` and `PAttacker` where flipped around here. The monster is the attacker hitting the defending player.