### PR TITLE
Old school barspell duration

### DIFF
--- a/scripts/globals/settings.lua
+++ b/scripts/globals/settings.lua
@@ -28,6 +28,9 @@ ENABLE_ROV     = 0;
 
 ENABLE_VOIDWATCH = 0; -- Not an expansion, but has its own storyline.
 
+-- Era "Old School" related settings
+OLD_SCHOOL_ENABLED = false -- General wide range Old School setting. Default: false (current retail)
+
 -- FIELDS OF VALOR/Grounds of Valor settings
 ENABLE_FIELD_MANUALS  = 1; -- Enables Fields of Valor
 ENABLE_GROUNDS_TOMES  = 1; -- Enables Grounds of Valor

--- a/scripts/globals/spells/barspell.lua
+++ b/scripts/globals/spells/barspell.lua
@@ -1,8 +1,11 @@
 -----------------------------------------
 -- Implementation of Bar-spells
 -----------------------------------------
-require("scripts/globals/magic")
+require("scripts/globals/settings")
 require("scripts/globals/status")
+require("scripts/globals/magic")
+require("scripts/globals/utils")
+-----------------------------------------
 
 function calculateBarspellPower(caster,enhanceSkill)
     local meritBonus = caster:getMerit(dsp.merit.BAR_SPELL_EFFECT)
@@ -25,7 +28,12 @@ end
 
 function calculateBarspellDuration(caster,enhanceSkill)
     -- Function call to allow configuration conditional for old duration formulas.
-    return 480
+    if OLD_SCHOOL_ENABLED then
+        local duration = 150 + math.floor((enhanceSkill - 180) * 0.8) -- Pre update formula: https://www.bg-wiki.com/bg/Category:Barspell
+        return utils.clamp(duration,150,300)
+    else
+        return 480
+    end
 end
 
 function applyBarspell(effectType,caster,target,spell)

--- a/scripts/globals/spells/barstatus.lua
+++ b/scripts/globals/spells/barstatus.lua
@@ -1,8 +1,11 @@
 -----------------------------------------
 -- Implementation of Bar-status
 -----------------------------------------
-require("scripts/globals/magic")
+require("scripts/globals/settings")
 require("scripts/globals/status")
+require("scripts/globals/magic")
+require("scripts/globals/utils")
+-----------------------------------------
 
 function calculateBarstatusPower(caster,enhanceSkill)
     local meritBonus = caster:getMerit(dsp.merit.BAR_SPELL_EFFECT)
@@ -17,7 +20,12 @@ end
 
 function calculateBarstatusDuration(caster,enhanceSkill)
     -- Function call to allow configuration conditional for old duration formulas.
-    return 480
+    if OLD_SCHOOL_ENABLED then
+        local duration = 150 + math.floor((enhanceSkill - 180) * 0.8) -- Pre update formula: https://www.bg-wiki.com/bg/Category:Barspell
+        return utils.clamp(duration,150,300)
+    else
+        return 480
+    end
 end
 
 function applyBarstatus(effectType,caster,target,spell)


### PR DESCRIPTION
Adds the calculation for barspell duration before the update.
https://www.bg-wiki.com/bg/Category:Barspell

Also, adds the setting for a 'generalized' old school switch which I've been starting to covert things over to use.

Also, in an attempt to organize the settings a bit we could clump the 'old school' related stuff into its own area? maybe? and another thought... should these settings be tabled?