### PR TITLE
scripts: Fixed an issue where the WHM AF1 weapon NM spawning even during the day

### DIFF
--- a/scripts/zones/Valkurm_Dunes/npcs/qm1.lua
+++ b/scripts/zones/Valkurm_Dunes/npcs/qm1.lua
@@ -13,14 +13,14 @@ function onTrade(player,npc,trade)
 end;
 
 function onTrigger(player,npc)
+    local TOTD = VanadielTOTD();
 
-    if (player:getFreeSlotsCount() > 0 and player:hasItem(503) == false) then
+    if (player:getFreeSlotsCount() > 0 and player:hasItem(503) == false and TOTD == dsp.time.NIGHT) then
         player:addItem(503);
         player:messageSpecial(ITEM_OBTAINED,503);
     else
         player:messageSpecial(ITEM_CANNOT_BE_OBTAINED,503);
     end
-
 end;
 
 function onEventUpdate(player,csid,option)


### PR DESCRIPTION
I think the ??? is supposed to respawn in most cases technically but it does not, at least not  while I was testing. It does not do this on the Nasomi server either (which may have diverged) 

This adds a check at least so that we can prevent it from spawning even if the ??? is there.

First time contributor, so open to guidance. 