### PR TITLE
quest: A Boy's Dream fixes where having the fish and bug at the same …

### DIFF
--- a/scripts/zones/Northern_San_dOria/npcs/Ailbeche.lua
+++ b/scripts/zones/Northern_San_dOria/npcs/Ailbeche.lua
@@ -11,26 +11,39 @@ require("scripts/globals/settings");
 require("scripts/globals/keyitems");
 require("scripts/globals/titles");
 require("scripts/globals/quests");
+
 require("scripts/globals/shop");
 -----------------------------------
 
-function onTrade(player,npc,trade)
-    -- "Flyers for Regine" conditional script
-    local FlyerForRegine = player:getQuestStatus(SANDORIA,FLYERS_FOR_REGINE);
+-- Helper constants in order to keep it straight about what part
+-- of the quest we are working on
+BOYS_DREAM_WILL_BEGIN_ACCEPTING_BUG = 3
+BOYS_DREAM_HAS_TRADED_BUG = 4
+BOYS_DREAM_VISIT_ZALDON_FOR_BOOTS_TRADED_FISH = 5
 
+function onTrade(player,npc,trade)
     if (player:getQuestStatus(SANDORIA, FATHER_AND_SON) == QUEST_COMPLETED and player:getVar("returnedAilbecheRod") ~= 1) then
         if (trade:hasItemQty(17391,1) == true and trade:getItemCount() == 1) then
             player:startEvent(61); -- Finish Quest "Father and Son" (part2) (trading fishing rod)
+            return
         end
     end
 
-    if (player:getVar("aBoysDreamCS") >= 3) then
-        if (trade:hasItemQty(17001,1) == true and trade:getItemCount() == 1 and player:hasItem(4562) == false) then
+    aBoysDreamCS = player:getVar("aBoysDreamCS");
+    
+    if (aBoysDreamCS >= BOYS_DREAM_WILL_BEGIN_ACCEPTING_BUG) then
+        -- If you have been told to visit Zaldon already (traded in the fish), your chance to get the CS is over with now
+        if (aBoysDreamCS == BOYS_DREAM_WILL_BEGIN_ACCEPTING_BUG and trade:hasItemQty(17001,1) == true and trade:getItemCount() == 1) then
             player:startEvent(15); -- During Quest "A Boy's Dream" (trading bug) madame ?
-        elseif (trade:hasItemQty(4562,1) == true and trade:getItemCount() == 1) then
+            return
+        elseif (aBoysDreamCS == BOYS_DREAM_HAS_TRADED_BUG and trade:hasItemQty(4562,1) == true and trade:getItemCount() == 1) then
             player:startEvent(47); -- During Quest "A Boy's Dream" (trading odontotyrannus)
+            return
         end
     end
+    
+    -- "Flyers for Regine" conditional script
+    local FlyerForRegine = player:getQuestStatus(SANDORIA,FLYERS_FOR_REGINE);
 
     if (FlyerForRegine == 1) then
         local count = trade:getItemCount();
@@ -87,7 +100,7 @@ function onTrigger(player,npc)
         player:startEvent(60); -- During Quest "A Boy's Dream" (after trading bug) madame ?
     elseif (aBoysDreamCS == 5) then
         player:startEvent(47); -- During Quest "A Boy's Dream" (after trading odontotyrannus)
-    elseif (aBoysDreamCS >= 6) then
+    elseif (aBoysDreamCS == 6) then
         player:startEvent(25); -- During Quest "A Boy's Dream" (after Zaldon CS)
     elseif (player:hasKeyItem(dsp.ki.KNIGHTS_CONFESSION) and player:getVar("UnderOathCS") == 6) then
         player:startEvent(59); -- During Quest "Under Oath" (he's going fishing in Jugner)
@@ -145,11 +158,11 @@ function onEventFinish(player,csid,option)
         player:setVar("aBoysDreamCS",2);
     elseif (csid == 41 and option == 0) then
         player:setVar("aBoysDreamCS",1);
-    elseif (csid == 15 and player:getVar("aBoysDreamCS") == 3) then
-        player:setVar("aBoysDreamCS",4);
-    elseif (csid == 47 and player:getVar("aBoysDreamCS") == 4) then
-        player:setVar("aBoysDreamCS",5);
-    elseif (csid == 25 and player:getVar("aBoysDreamCS") == 6) then
+    elseif (csid == 15) then
+        player:setVar("aBoysDreamCS",BOYS_DREAM_HAS_TRADED_BUG);
+    elseif (csid == 47) then
+        player:setVar("aBoysDreamCS",BOYS_DREAM_VISIT_ZALDON_FOR_BOOTS_TRADED_FISH);
+    elseif (csid == 25) then
         player:setVar("aBoysDreamCS",7);
     elseif (csid == 59) then
         player:setVar("UnderOathCS", 7);

--- a/scripts/zones/Southern_San_dOria/npcs/Exoroche.lua
+++ b/scripts/zones/Southern_San_dOria/npcs/Exoroche.lua
@@ -36,7 +36,7 @@ function onTrigger(player,npc)
         player:startEvent(542);
     elseif (player:getVar("aBoysDreamCS") == 2) then
         player:startEvent(50);
-    elseif (player:getVar("aBoysDreamCS") >= 7) then
+    elseif (player:getVar("aBoysDreamCS") == 7) then
         player:startEvent(32);
     elseif (player:getVar("UnderOathCS") == 4 and player:hasKeyItem(dsp.ki.STRANGE_SHEET_OF_PAPER)) then
         player:startEvent(77);
@@ -60,7 +60,7 @@ function onEventFinish(player,csid,option)
         player:setVar("QuestfatherAndSonVar",1);
     elseif (csid == 50) then
         player:setVar("aBoysDreamCS",3);
-    elseif (csid == 32 and player:getVar("aBoysDreamCS") == 7) then
+    elseif (csid == 32) then
         player:setVar("aBoysDreamCS",8);
     elseif (csid == 77) then
         player:setVar("UnderOathCS",5)


### PR DESCRIPTION
There are a few issues with the quest. See below, this is just  a WIP PR so that I can get some feedback before I go ahead and do some cleanup while I setup DSP. 

**I still need to setup DSP locally to test, so doing that right after this. The problems I found are...**

1. If you have the fish and the bug in your inventory at the same time, they will not accept the bug. But the bug CS is needed in order for the fish CS to count for state credit. Otherwise, you can trade the fish but you end up in this weird state where you are told to go to Zaldon and you are unable to actually trade the fish. (https://github.com/DarkstarProject/darkstar/issues/5069)

2. There were some greater than checks which made no sense, since getting into that state would indicate some  kind of optional step but none of those steps were optional.

I cleaned up a few of these things and serialized the bug and the fish portion so you must do both. If one is truly optional or the ordering is not important, we can rejig it. I do not have a retail subscription so I cannot say one way or the other if this is right. I asked in Discord to see if anyone is able to confirm or deny. 
