### PR TITLE
scripts: Fixed an issue where the WHM AF1 weapon NM  appeared at night

### DIFF
--- a/scripts/zones/Valkurm_Dunes/npcs/qm2.lua
+++ b/scripts/zones/Valkurm_Dunes/npcs/qm2.lua
@@ -14,9 +14,10 @@ function onTrade(player,npc,trade)
 end;
 
 function onTrigger(player,npc)
-    local TOTD = VanadielTOTD();
-
-    if (TOTD == dsp.time.NIGHT and not GetMobByID(MARCHELUTE):isSpawned() and player:getQuestStatus(SANDORIA,MESSENGER_FROM_BEYOND) == QUEST_ACCEPTED and not player:hasItem(1096)) then
+    if player:getQuestStatus(SANDORIA,MESSENGER_FROM_BEYOND) == QUEST_ACCEPTED
+    and VanadielTOTD() == dsp.time.NIGHT
+    and not player:hasItem(1096)
+    and not GetMobByID(MARCHELUTE):isSpawned() then
         SpawnMob(MARCHELUTE):updateClaim(player);
     else
         player:messageSpecial(NOTHING_OUT_OF_ORDINARY);

--- a/scripts/zones/Valkurm_Dunes/npcs/qm2.lua
+++ b/scripts/zones/Valkurm_Dunes/npcs/qm2.lua
@@ -14,7 +14,9 @@ function onTrade(player,npc,trade)
 end;
 
 function onTrigger(player,npc)
-    if (not GetMobByID(MARCHELUTE):isSpawned() and player:getQuestStatus(SANDORIA,MESSENGER_FROM_BEYOND) == QUEST_ACCEPTED and not player:hasItem(1096)) then
+    local TOTD = VanadielTOTD();
+
+    if (TOTD == dsp.time.NIGHT and not GetMobByID(MARCHELUTE):isSpawned() and player:getQuestStatus(SANDORIA,MESSENGER_FROM_BEYOND) == QUEST_ACCEPTED and not player:hasItem(1096)) then
         SpawnMob(MARCHELUTE):updateClaim(player);
     else
         player:messageSpecial(NOTHING_OUT_OF_ORDINARY);


### PR DESCRIPTION
I think the ??? is supposed to despawn at night in most cases technically but it does not, at least not while I was testing. It does not do this on the Nasomi server either (which may have diverged)

This adds a check at least so that we can prevent it from spawning the NM even if the ??? is there.

First time contributor, so open to guidance.