### PR TITLE
Update Kreutzet Weather Spawn Logic

### DIFF
--- a/scripts/zones/Cape_Teriggan/Zone.lua
+++ b/scripts/zones/Cape_Teriggan/Zone.lua
@@ -4,56 +4,59 @@
 --
 -----------------------------------
 local ID = require("scripts/zones/Cape_Teriggan/IDs")
-require("scripts/globals/icanheararainbow");
-require("scripts/globals/conquest");
-require("scripts/globals/weather");
-require("scripts/globals/zone");
+-----------------------------------
+require("scripts/globals/icanheararainbow")
+require("scripts/globals/conquest")
+require("scripts/globals/weather")
+require("scripts/globals/zone")
 -----------------------------------
 
 function onInitialize(zone)
-    UpdateNMSpawnPoint(ID.mob.KREUTZET);
-    GetMobByID(ID.mob.KREUTZET):setRespawnTime(math.random(900, 10800));
+    UpdateNMSpawnPoint(KREUTZET)
+    GetMobByID(KREUTZET):setRespawnTime(math.random(32400,43200)) -- 9 to 12 hours
+    GetMobByID(KREUTZET):setLocalVar("cooldown",os.time() + mob:getRespawnTime()/1000)
+    DisallowRespawn(GetMobByID(KREUTZET):getID(), true) -- prevents accidental 'pop' during no wind weather and immediate despawn
 
     dsp.conq.setRegionalConquestOverseers(zone:getRegionID())
-end;
+end
 
 function onConquestUpdate(zone, updatetype)
     dsp.conq.onConquestUpdate(zone, updatetype)
-end;
+end
 
 function onZoneIn( player, prevZone)
-    local cs = -1;
+    local cs = -1
 
-    if (player:getXPos() == 0 and player:getYPos() == 0 and player:getZPos() == 0) then
-        player:setPos( 315.644, -1.517, -60.633, 108);
+    if player:getXPos() == 0 and player:getYPos() == 0 and player:getZPos() == 0 then
+        player:setPos( 315.644, -1.517, -60.633, 108)
     end
 
-    if (triggerLightCutscene(player)) then -- Quest: I Can Hear A Rainbow
-        cs = 2;
+    if triggerLightCutscene(player) then -- Quest: I Can Hear A Rainbow
+        cs = 2
     end
 
-    return cs;
-end;
+    return cs
+end
 
 function onRegionEnter( player, region)
-end;
+end
 
 function onEventUpdate( player, csid, option)
-    if (csid == 2) then
-        lightCutsceneUpdate(player); -- Quest: I Can Hear A Rainbow
+    if csid == 2 then
+        lightCutsceneUpdate(player) -- Quest: I Can Hear A Rainbow
     end
-end;
+end
 
 function onEventFinish( player, csid, option)
-    if (csid == 2) then
-        lightCutsceneFinish(player); -- Quest: I Can Hear A Rainbow
+    if csid == 2 then
+        lightCutsceneFinish(player) -- Quest: I Can Hear A Rainbow
     end
-end;
+end
 
 function onZoneWeatherChange(weather)
-    if (GetMobAction(ID.mob.KREUTZET) == 24 and (weather == dsp.weather.WIND or weather == dsp.weather.GALES)) then
-        SpawnMob(ID.mob.KREUTZET); -- Kreutzet
-    elseif (GetMobAction(ID.mob.KREUTZET) == 16 and (weather ~= dsp.weather.WIND and weather ~= dsp.weather.GALES)) then
-        DespawnMob(ID.mob.KREUTZET);
+    if GetMobAction(KREUTZET) == 0 and os.time() > GetMobByID(KREUTZET):getLocalVar("cooldown") and
+        (weather == dsp.weather.WIND or weather == dsp.weather.GALES) then
+            DisallowRespawn(GetMobByID(KREUTZET):getID(), false)
+            GetMobByID(KREUTZET):setRespawnTime(math.random(30,150)) -- pop 30-150 sec after wind weather starts
     end
-end;
+end

--- a/scripts/zones/Cape_Teriggan/mobs/Kreutzet.lua
+++ b/scripts/zones/Cape_Teriggan/mobs/Kreutzet.lua
@@ -2,36 +2,44 @@
 -- Area: Cape Teriggan
 --  NM:  Kreutzet
 -----------------------------------
+require("scripts/globals/weather")
+-----------------------------------
 
-require("scripts/globals/weather");
+function onMobRoam(mob)
+    if not (mob:getWeather() == dsp.weather.WIND or mob:getWeather() == dsp.weather.GALES) then
+        DespawnMob(mob:getID())
+    end
+end
 
 function onMobWeaponSkill(target, mob, skill)
-    if (skill:getID() == 926) then
-        local stormwindCounter = mob:getLocalVar("stormwindCounter");
+    if skill:getID() == 926 then
+        local stormwindCounter = mob:getLocalVar("stormwindCounter")
 
-        stormwindCounter = stormwindCounter +1;
-        mob:setLocalVar("stormwindCounter", stormwindCounter);
-        mob:setLocalVar("stormwindDamage", stormwindCounter); -- extra var for dmg calculation (in stormwind.lua)
+        stormwindCounter = stormwindCounter +1
+        mob:setLocalVar("stormwindCounter", stormwindCounter)
+        mob:setLocalVar("stormwindDamage", stormwindCounter) -- extra var for dmg calculation (in stormwind.lua)
 
-        if (stormwindCounter > 2) then
-            mob:setLocalVar("stormwindCounter", 0);
+        if stormwindCounter > 2 then
+            mob:setLocalVar("stormwindCounter", 0)
         else
-            mob:useMobAbility(926);
+            mob:useMobAbility(926)
         end
-    end;
-end;
+    end
+end
+
+function onMobDisengage(mob, weather)
+    if not (mob:getWeather() == dsp.weather.WIND or mob:getWeather() == dsp.weather.GALES) then
+        DespawnMob(mob:getID())
+    end
+end
 
 function onMobDeath(mob, player, isKiller)
-end;
+end
 
 function onMobDespawn(mob)
     -- Set Kruetzet's spawnpoint and respawn time (9-12 hours)
-    UpdateNMSpawnPoint(mob:getID());
-    mob:setRespawnTime(math.random(32400,43200));
-end;
-
-function onMobDisengage(mob, weather)
-    if (weather ~= dsp.weather.WIND and weather ~= WEATHER_GALE) then
-        DespawnMob(mob:getID());
-    end
-end;
+    UpdateNMSpawnPoint(mob:getID())
+    mob:setRespawnTime(math.random(32400,43200))
+    mob:setLocalVar("cooldown",os.time() + mob:getRespawnTime()/1000)
+    DisallowRespawn(mob:getID(), true) -- prevents accidental 'pop' during no wind weather and immediate despawn
+end


### PR DESCRIPTION
- Cleaned up the files with new style changes
- Updated tabled vars so they now work
- Updated weather spawn logic so the NM only spawns while wind weather is active and it's window is open. Achieved by adding a "cooldown" LocalVar which checks to make sure enough time has passed and a DisallowRespawn flag to make sure the mob doesn't accidently pop with no weather and then immediately despawn resetting its cooldown to 9-12 hrs.

ref: http://ffxiclopedia.wikia.com/wiki/Kreutzet