### PR TITLE
level cap/sync should be taken into account when charming mobs

### DIFF
--- a/src/map/utils/battleutils.cpp
+++ b/src/map/utils/battleutils.cpp
@@ -4098,9 +4098,9 @@ namespace battleutils
             {
                 charmerBSTlevel = charmerBRDlevel;
             }
-            if (charmerBSTlevel > PCharmer->GetMLevel()) // takes level cap/sync into account
+            if (charmerBSTlevel > charmerLvl) // takes level cap/sync into account
             {
-                charmerBSTlevel = PCharmer->GetMLevel();
+                charmerBSTlevel = charmerLvl;
             }
         }
         else if (PCharmer->objtype == TYPE_MOB)

--- a/src/map/utils/battleutils.cpp
+++ b/src/map/utils/battleutils.cpp
@@ -4098,6 +4098,10 @@ namespace battleutils
             {
                 charmerBSTlevel = charmerBRDlevel;
             }
+            if (charmerBSTlevel > PCharmer->GetMLevel()) // takes level cap/sync into account
+            {
+                charmerBSTlevel = PCharmer->GetMLevel();
+            }
         }
         else if (PCharmer->objtype == TYPE_MOB)
         {
@@ -5525,4 +5529,3 @@ namespace battleutils
         }
     }
 };
-

--- a/src/map/utils/battleutils.cpp
+++ b/src/map/utils/battleutils.cpp
@@ -1,4 +1,4 @@
-﻿/*
+/*
 ===========================================================================
 
   Copyright (c) 2010-2015 Darkstar Dev Teams
@@ -4098,7 +4098,7 @@ namespace battleutils
             {
                 charmerBSTlevel = charmerBRDlevel;
             }
-            if (charmerBSTlevel > charmerLvl) // takes level cap/sync into account
+            if (charmerBSTlevel > charmerLvl)
             {
                 charmerBSTlevel = charmerLvl;
             }


### PR DESCRIPTION
When doing things like a lvl cap 20 bcnm we shouldn't be comparing charm lvl as if we are 75 to calculate charm chance.