### PR TITLE
October 2018 Update

### DIFF
--- a/version.info
+++ b/version.info
@@ -1,7 +1,7 @@
 #DarkStar Version Info
 
 #Expected Client version (wrong version cannot log in)
-CLIENT_VER: 30180904_0
+CLIENT_VER: 30181003_1
 
 #0 - disabled (every version allowed)
 #1 - enabled - strict (only exact CLIENT_VER allowed, default)


### PR DESCRIPTION
Mostly Ambuscade/Vagary stuff.
Text IDs shifted in SoA zones outside of the range of ids we currently have.