### PR TITLE
Fix haste samba applying effect twice

### DIFF
--- a/scripts/globals/effects/haste_samba_haste_effect.lua
+++ b/scripts/globals/effects/haste_samba_haste_effect.lua
@@ -3,9 +3,10 @@
 -- JA Haste 5-10%
 -----------------------------------
 require("scripts/globals/status")
+-----------------------------------
+
 function onEffectGain(target, effect)
     target:addMod(dsp.mod.HASTE_ABILITY, effect:getPower())
-    target:addMod(dsp.mod.HASTE_ABILITY,effect:getPower())
 end
 
 function onEffectTick(target, effect)


### PR DESCRIPTION
Fix haste samba applying haste mod twice, which was causing player to attack very fast, then overflow and attack very slow.