### PR TITLE
SetMobLevel (for abyssea)

### DIFF
--- a/scripts/commands/setmoblevel.lua
+++ b/scripts/commands/setmoblevel.lua
@@ -1,0 +1,36 @@
+---------------------------------------------------------------------------------------------------
+-- func: setmoblevel
+-- desc: Sets the target monsters level.
+---------------------------------------------------------------------------------------------------
+require("scripts/globals/msg");
+
+cmdprops =
+{
+    permission = 1,
+    parameters = "i"
+};
+
+
+function error(player, msg)
+    player:PrintToPlayer(msg);
+    player:PrintToPlayer("!setmoblevel <level>");
+end;
+
+function onTrigger(player, lv)
+    local target = player:getCursorTarget()
+
+    -- set level
+    if target and target:isMob() then
+        player:PrintToPlayer(string.format("Old MainJob(jID: %s) LV: %i / SubJob(jID: %s) LV: %i ",
+            target:getMainJob(), target:getMainLvl(), target:getSubJob(), target:getSubLvl()), dsp.msg.channel.SYSTEM_3
+        )
+
+        target:setMobLevel(lv);
+
+        player:PrintToPlayer(string.format("New MainJob(jID: %s) LV: %i / SubJob(jID: %s) LV: %i ",
+            target:getMainJob(), target:getMainLvl(), target:getSubJob(), target:getSubLvl()), dsp.msg.channel.SYSTEM_3
+        )
+    else
+        error("must target a monster first!")
+    end
+end

--- a/src/map/entities/mobentity.cpp
+++ b/src/map/entities/mobentity.cpp
@@ -790,7 +790,11 @@ void CMobEntity::DistributeRewards()
 
     if (PChar != nullptr && PChar->id == m_OwnerID.id)
     {
+        PChar->setWeaponSkillKill(false);
+        StatusEffectContainer->KillAllStatusEffect();
 
+        // NOTE: this is called for all alliance / party members!
+        luautils::OnMobDeath(this, PChar);
 
         if (!CalledForHelp())
         {
@@ -811,12 +815,6 @@ void CMobEntity::DistributeRewards()
             DropItems(PChar);
         }
 
-        PChar->setWeaponSkillKill(false);
-        StatusEffectContainer->KillAllStatusEffect();
-
-        // NOTE: this is called for all alliance / party members!
-        luautils::OnMobDeath(this, PChar);
-
     }
     else
     {
@@ -824,9 +822,11 @@ void CMobEntity::DistributeRewards()
     }
 }
 
-void CMobEntity::DropItems(CCharEntity* PChar) {
+void CMobEntity::DropItems(CCharEntity* PChar)
+{
     //Adds an item to the treasure pool and returns true if the pool has been filled
-    auto AddItemToPool = [this, PChar](uint16 ItemID, uint8 dropCount) {
+    auto AddItemToPool = [this, PChar](uint16 ItemID, uint8 dropCount)
+    {
         PChar->PTreasurePool->AddItem(ItemID, this);
         return dropCount >= TREASUREPOOL_SIZE;
     };

--- a/src/map/lua/lua_baseentity.cpp
+++ b/src/map/lua/lua_baseentity.cpp
@@ -12425,9 +12425,9 @@ inline int32 CLuaBaseEntity::removeAllManeuvers(lua_State* L)
 }
 /************************************************************************
 *  Function: setMobLevel()
-*  Purpose : Updates the level of the monsters level
+*  Purpose : Updates the monsters level and recalculates stats
 *  Example : mob:setMobLevel(125)
-*  Notes   : does not refill mobs hp/mp
+*  Notes   : CalculateStats will refill mobs hp/mp as well
 ************************************************************************/
 
 inline int32 CLuaBaseEntity::setMobLevel(lua_State *L)

--- a/src/map/lua/lua_baseentity.cpp
+++ b/src/map/lua/lua_baseentity.cpp
@@ -12423,6 +12423,27 @@ inline int32 CLuaBaseEntity::removeAllManeuvers(lua_State* L)
 
     return 0;
 }
+/************************************************************************
+*  Function: setMobLevel()
+*  Purpose : Updates the level of the monsters level
+*  Example : mob:setMobLevel(125)
+*  Notes   : does not refill mobs hp/mp
+************************************************************************/
+
+inline int32 CLuaBaseEntity::setMobLevel(lua_State *L)
+{
+    DSP_DEBUG_BREAK_IF(m_PBaseEntity == nullptr);
+    DSP_DEBUG_BREAK_IF(m_PBaseEntity->objtype != TYPE_MOB);
+
+    DSP_DEBUG_BREAK_IF(lua_isnil(L, 1) || !lua_isnumber(L, 1));
+
+    CMobEntity * PMob = (CMobEntity*)m_PBaseEntity;
+    PMob->SetMLevel((uint8)lua_tointeger(L, 1));
+    mobutils::CalculateStats(PMob);
+    mobutils::GetAvailableSpells(PMob);
+
+    return 0;
+}
 
 /************************************************************************
 *  Function: getSystem()
@@ -14404,6 +14425,7 @@ Lunar<CLuaBaseEntity>::Register_t CLuaBaseEntity::methods[] =
     LUNAR_DECLARE_METHOD(CLuaBaseEntity,removeAllManeuvers),
 
     // Mob Entity-Specific
+    LUNAR_DECLARE_METHOD(CLuaBaseEntity,setMobLevel),
     LUNAR_DECLARE_METHOD(CLuaBaseEntity,getSystem),
     LUNAR_DECLARE_METHOD(CLuaBaseEntity,getFamily),
     LUNAR_DECLARE_METHOD(CLuaBaseEntity,isMobType),

--- a/src/map/lua/lua_baseentity.h
+++ b/src/map/lua/lua_baseentity.h
@@ -614,6 +614,7 @@ public:
     int32 removeAllManeuvers(lua_State*);
 
     // Mob Entity-Specific
+    int32 setMobLevel(lua_State*);
     int32 getSystem(lua_State*);
     int32 getFamily(lua_State*);
     int32 isMobType(lua_State*);            // True if mob is of type passed to function


### PR DESCRIPTION
 ability to set monster levels in script - for use in abyssea mixin

I thought it better to go ahead and make a new function rather than a conditional on the existing player specific function. Can change that on request but the sub level version is 100% player only at this time so I figured may as well be specific.

Todo: move cruor stuff out of charutils and into a mixin. The reason it was in the core was I didn't want to individually script mobs (this was before mixins existed) and now we know each mobs is going to have a script+mixin ***anyways*** for lights level changes size changes etc. so we may as well do cruor there too.