### PR TITLE
Fix Lua Stack Leak

### DIFF
--- a/src/map/lua/luautils.cpp
+++ b/src/map/lua/luautils.cpp
@@ -2301,7 +2301,7 @@ namespace luautils
         lua_getglobal(LuaHandle, "mixins");
         if (lua_isnil(LuaHandle, -1))
         {
-            lua_pop(LuaHandle, 1);
+            lua_pop(LuaHandle, 3);
             return -1;
         }
         //get the parameter "mixinOptions" (optional)


### PR DESCRIPTION
luautils::ApplyMixins was not properly cleaning up after itself if a mob script did not contain any mixins.