### PR TITLE
Maint mode

### DIFF
--- a/conf/maint.conf
+++ b/conf/maint.conf
@@ -1,3 +1,3 @@
 #0 - disabled (normal operation)
 #1 - enabled (only GM characters allowed online, no new character creation)
-MAINT_MODE: 1
+MAINT_MODE: 0

--- a/conf/maint.conf
+++ b/conf/maint.conf
@@ -1,0 +1,3 @@
+#0 - disabled (normal operation)
+#1 - enabled (only GM characters allowed online, no new character creation)
+MAINT_MODE: 1

--- a/src/login/lobby.cpp
+++ b/src/login/lobby.cpp
@@ -146,7 +146,8 @@ int32 lobbydata_parse(int32 fd)
                 pfmtQuery = "SELECT charid, charname, pos_zone, pos_prevzone, mjob,\
                             race, face, head, body, hands, legs, feet, main, sub,\
                             war, mnk, whm, blm, rdm, thf, pld, drk, bst, brd, rng,\
-                            sam, nin, drg, smn, blu, cor, pup, dnc, sch, geo, run \
+                            sam, nin, drg, smn, blu, cor, pup, dnc, sch, geo, run, \
+                            gmlevel \
                         FROM chars \
                             INNER JOIN char_stats USING(charid)\
                             INNER JOIN char_look  USING(charid) \
@@ -185,41 +186,70 @@ int32 lobbydata_parse(int32 fd)
 
                     Sql_GetData(SqlHandle, 1, &strCharName, nullptr);
 
-                    uint32 CharID = Sql_GetIntData(SqlHandle, 0);
+                    auto gmlevel = Sql_GetIntData(SqlHandle, 36);
+                    if (maint_config.maint_mode == 0 || gmlevel > 0)
+                    {
+                        uint32 CharID = Sql_GetIntData(SqlHandle, 0);
 
-                    uint16 zone = (uint16)Sql_GetIntData(SqlHandle, 2);
+                        uint16 zone = (uint16)Sql_GetIntData(SqlHandle, 2);
 
-                    uint8 MainJob = (uint8)Sql_GetIntData(SqlHandle, 4);
-                    uint8 lvlMainJob = (uint8)Sql_GetIntData(SqlHandle, 13 + MainJob);
+                        uint8 MainJob = (uint8)Sql_GetIntData(SqlHandle, 4);
+                        uint8 lvlMainJob = (uint8)Sql_GetIntData(SqlHandle, 13 + MainJob);
 
-                    // Update the character and user list content ids..
-                    ref<uint32>(uList, 16 * (i + 1)) = CharID;
-                    ref<uint32>(CharList, 32 + 140 * i) = CharID;
+                        // Update the character and user list content ids..
+                        ref<uint32>(uList, 16 * (i + 1)) = CharID;
+                        ref<uint32>(CharList, 32 + 140 * i) = CharID;
 
-                    ref<uint32>(uList, 20 * (i + 1)) = CharID;
+                        ref<uint32>(uList, 20 * (i + 1)) = CharID;
 
-                    ////////////////////////////////////////////////////
-                    ref<uint32>(CharList, 4 + 32 + i * 140) = CharID;
+                        ////////////////////////////////////////////////////
+                        ref<uint32>(CharList, 4 + 32 + i * 140) = CharID;
 
-                    memcpy(CharList + 12 + 32 + i * 140, strCharName, 15);
+                        memcpy(CharList + 12 + 32 + i * 140, strCharName, 15);
 
-                    ref<uint8>(CharList, 46 + 32 + i * 140) = MainJob;
-                    ref<uint8>(CharList, 73 + 32 + i * 140) = lvlMainJob;
+                        ref<uint8>(CharList, 46 + 32 + i * 140) = MainJob;
+                        ref<uint8>(CharList, 73 + 32 + i * 140) = lvlMainJob;
 
-                    ref<uint8>(CharList, 44 + 32 + i * 140) = (uint8)Sql_GetIntData(SqlHandle, 5); // race;
-                    ref<uint8>(CharList, 56 + 32 + i * 140) = (uint8)Sql_GetIntData(SqlHandle, 6); // face;
-                    ref<uint16>(CharList, 58 + 32 + i * 140) = (uint16)Sql_GetIntData(SqlHandle, 7); // head;
-                    ref<uint16>(CharList, 60 + 32 + i * 140) = (uint16)Sql_GetIntData(SqlHandle, 8); // body;
-                    ref<uint16>(CharList, 62 + 32 + i * 140) = (uint16)Sql_GetIntData(SqlHandle, 9); // hands;
-                    ref<uint16>(CharList, 64 + 32 + i * 140) = (uint16)Sql_GetIntData(SqlHandle, 10); // legs;
-                    ref<uint16>(CharList, 66 + 32 + i * 140) = (uint16)Sql_GetIntData(SqlHandle, 11); // feet;
-                    ref<uint16>(CharList, 68 + 32 + i * 140) = (uint16)Sql_GetIntData(SqlHandle, 12); // main;
-                    ref<uint16>(CharList, 70 + 32 + i * 140) = (uint16)Sql_GetIntData(SqlHandle, 13); // sub;
+                        ref<uint8>(CharList, 44 + 32 + i * 140) = (uint8)Sql_GetIntData(SqlHandle, 5); // race;
+                        ref<uint8>(CharList, 56 + 32 + i * 140) = (uint8)Sql_GetIntData(SqlHandle, 6); // face;
+                        ref<uint16>(CharList, 58 + 32 + i * 140) = (uint16)Sql_GetIntData(SqlHandle, 7); // head;
+                        ref<uint16>(CharList, 60 + 32 + i * 140) = (uint16)Sql_GetIntData(SqlHandle, 8); // body;
+                        ref<uint16>(CharList, 62 + 32 + i * 140) = (uint16)Sql_GetIntData(SqlHandle, 9); // hands;
+                        ref<uint16>(CharList, 64 + 32 + i * 140) = (uint16)Sql_GetIntData(SqlHandle, 10); // legs;
+                        ref<uint16>(CharList, 66 + 32 + i * 140) = (uint16)Sql_GetIntData(SqlHandle, 11); // feet;
+                        ref<uint16>(CharList, 68 + 32 + i * 140) = (uint16)Sql_GetIntData(SqlHandle, 12); // main;
+                        ref<uint16>(CharList, 70 + 32 + i * 140) = (uint16)Sql_GetIntData(SqlHandle, 13); // sub;
 
-                    ref<uint8>(CharList, 72 + 32 + i * 140) = (uint8)zone;
-                    ref<uint16>(CharList, 78 + 32 + i * 140) = zone;
-                    ///////////////////////////////////////////////////
-                    ++i;
+                        ref<uint8>(CharList, 72 + 32 + i * 140) = (uint8)zone;
+                        ref<uint16>(CharList, 78 + 32 + i * 140) = zone;
+                        ///////////////////////////////////////////////////
+                        ++i;
+                    }
+                }
+
+                // the filtering above removes any non-GM characters so
+                // at this point we need to make sure stop players with empty lists
+                // from logging in or creating new characters
+                if (maint_config.maint_mode > 0 && i == 0)
+                {
+                    LOBBBY_ERROR_MESSAGE(ReservePacket);
+                    ref<uint16>(ReservePacket, 32) = 321;
+                    //memcpy(MainReservePacket, ReservePacket, ref<uint8>(ReservePacket, 0));
+
+                    unsigned char Hash[16];
+                    uint8 SendBuffSize = ref<uint8>(ReservePacket, 0);
+
+                    memset(ReservePacket + 12, 0, sizeof(Hash));
+                    md5(ReservePacket, Hash, SendBuffSize);
+
+                    memcpy(ReservePacket + 12, Hash, sizeof(Hash));
+                    session[sd->login_lobbyview_fd]->wdata.assign((const char*)ReservePacket, SendBuffSize);
+
+                    RFIFOSKIP(sd->login_lobbyview_fd, session[sd->login_lobbyview_fd]->rdata.size());
+                    RFIFOFLUSH(sd->login_lobbyview_fd);
+                    ShowWarning("lobbydata_parse: char:(%i) login during maintenance mode (0xA2). Sending error to client.\n", sd->accid);
+                    // TODO: consider logging failed attempts during maintenance
+                    return -1;
                 }
 
                 if (session[sd->login_lobbyview_fd] != nullptr)
@@ -271,13 +301,14 @@ int32 lobbydata_parse(int32 fd)
 
                 uint32 charid = ref<uint32>(session[sd->login_lobbyview_fd]->rdata.data(), 28);
 
-                const char *fmtQuery = "SELECT zoneip, zoneport, zoneid, pos_prevzone \
+                const char* fmtQuery = "SELECT zoneip, zoneport, zoneid, pos_prevzone, gmlevel \
                                         FROM zone_settings, chars \
                                         WHERE IF(pos_zone = 0, zoneid = pos_prevzone, zoneid = pos_zone) AND charid = %u;";
                 uint32 ZoneIP = sd->servip;
                 uint16 ZonePort = 54230;
                 uint16 ZoneID = 0;
                 uint16 PrevZone = 0;
+                uint16 gmlevel = 0;
 
                 if (Sql_Query(SqlHandle, fmtQuery, charid) != SQL_ERROR &&
                     Sql_NumRows(SqlHandle) != 0)
@@ -286,6 +317,7 @@ int32 lobbydata_parse(int32 fd)
 
                     ZoneID = (uint16)Sql_GetUIntData(SqlHandle, 2);
                     PrevZone = (uint16)Sql_GetUIntData(SqlHandle, 3);
+                    gmlevel = (uint16)Sql_GetUIntData(SqlHandle, 4);
 
                     //new char only (first login from char create)
                     if (PrevZone == 0)  key3[16] += 6;
@@ -303,34 +335,43 @@ int32 lobbydata_parse(int32 fd)
                   //ref<uint16>(ReservePacket,(0x3C)) = port;         // map-server port
                 }
 
-                if (PrevZone == 0)
-                    Sql_Query(SqlHandle, "UPDATE chars SET pos_prevzone = %d WHERE charid = %u;", ZoneID, charid);
-
-                ref<uint32>(ReservePacket, (0x40)) = sd->servip;                                  // search-server ip
-                ref<uint16>(ReservePacket, (0x44)) = login_config.search_server_port;             // search-server port
-
-                memcpy(MainReservePacket, ReservePacket, ref<uint8>(ReservePacket, 0));
-
-                // необходиму одалять сессию, необработанную игровым сервером
-                Sql_Query(SqlHandle, "DELETE FROM accounts_sessions WHERE accid = %u and client_port = 0", sd->accid);
-
-                char session_key[sizeof(key3) * 2 + 1];
-                bin2hex(session_key, key3, sizeof(key3));
-
-                fmtQuery = "INSERT INTO accounts_sessions(accid,charid,session_key,server_addr,server_port,client_addr, version_mismatch) VALUES(%u,%u,x'%s',%u,%u,%u,%u)";
-
-                if (Sql_Query(SqlHandle, fmtQuery, sd->accid, charid, session_key, ZoneIP, ZonePort, sd->client_addr, (uint8)session[sd->login_lobbyview_fd]->ver_mismatch) == SQL_ERROR)
+                if (maint_config.maint_mode == 0 || gmlevel > 0)
                 {
-                    //отправляем клиенту сообщение об ошибке
+                    if (PrevZone == 0)
+                        Sql_Query(SqlHandle, "UPDATE chars SET pos_prevzone = %d WHERE charid = %u;", ZoneID, charid);
+
+                    ref<uint32>(ReservePacket, (0x40)) = sd->servip;                                  // search-server ip
+                    ref<uint16>(ReservePacket, (0x44)) = login_config.search_server_port;             // search-server port
+
+                    memcpy(MainReservePacket, ReservePacket, ref<uint8>(ReservePacket, 0));
+
+                    // необходиму одалять сессию, необработанную игровым сервером
+                    Sql_Query(SqlHandle, "DELETE FROM accounts_sessions WHERE accid = %u and client_port = 0", sd->accid);
+
+                    char session_key[sizeof(key3) * 2 + 1];
+                    bin2hex(session_key, key3, sizeof(key3));
+
+                    fmtQuery = "INSERT INTO accounts_sessions(accid,charid,session_key,server_addr,server_port,client_addr, version_mismatch) VALUES(%u,%u,x'%s',%u,%u,%u,%u)";
+
+                    if (Sql_Query(SqlHandle, fmtQuery, sd->accid, charid, session_key, ZoneIP, ZonePort, sd->client_addr, (uint8)session[sd->login_lobbyview_fd]->ver_mismatch) == SQL_ERROR)
+                    {
+                        //отправляем клиенту сообщение об ошибке
+                        LOBBBY_ERROR_MESSAGE(ReservePacket);
+                        // устанавливаем код ошибки
+                        // Unable to connect to world server. Specified operation failed
+                        ref<uint16>(ReservePacket, 32) = 305;
+                        memcpy(MainReservePacket, ReservePacket, ref<uint8>(ReservePacket, 0));
+                    }
+
+                    fmtQuery = "UPDATE char_stats SET zoning = 2 WHERE charid = %u";
+                    Sql_Query(SqlHandle, fmtQuery, charid);
+                }
+                else
+                {
                     LOBBBY_ERROR_MESSAGE(ReservePacket);
-                    // устанавливаем код ошибки
-                    // Unable to connect to world server. Specified operation failed
-                    ref<uint16>(ReservePacket, 32) = 305;
+                    ref<uint16>(ReservePacket, 32) = 321;
                     memcpy(MainReservePacket, ReservePacket, ref<uint8>(ReservePacket, 0));
                 }
-
-                fmtQuery = "UPDATE char_stats SET zoning = 2 WHERE charid = %u";
-                Sql_Query(SqlHandle, fmtQuery, charid);
 
                 unsigned char Hash[16];
                 uint8 SendBuffSize = ref<uint8>(MainReservePacket, 0);
@@ -657,66 +698,76 @@ int32 lobbyview_parse(int32 fd)
                 session[fd]->wdata.assign((const char*)ReservePacket, sendsize);
                 RFIFOSKIP(fd, session[fd]->rdata.size());
                 RFIFOFLUSH(fd);
-
             }
             break;
             case 0x22:
             {
-                //creating new char
-                char CharName[15];
-                memset(CharName, 0, sizeof(CharName));
-                memcpy(CharName, session[fd]->rdata.data() + 32, sizeof(CharName));
-
-                //find assigns
-                const char *fmtQuery = "SELECT charname FROM chars WHERE charname LIKE '%s'";
-
                 int32 sendsize = 0x24;
                 unsigned char MainReservePacket[0x24];
 
-                std::string myNameIs(&CharName[0]);
-                bool invalidName = false;
-                for (auto letters : myNameIs)
+                // block creation of character if in maintenance mode
+                if (maint_config.maint_mode > 0)
                 {
-                    if (!std::isalpha(letters))
-                    {
-                        invalidName = true;
-                        break;
-                    }
-                }
-
-                char escapedCharName[16*2 +1];
-                Sql_EscapeString(SqlHandle, escapedCharName, CharName);
-                if (Sql_Query(SqlHandle, fmtQuery, escapedCharName) == SQL_ERROR)
-                {
-                    do_close_lobbyview(sd, fd);
-                    return -1;
-                }
-
-                if (Sql_NumRows(SqlHandle) != 0 || invalidName == true)
-                {
-                    if (invalidName == true)
-                    {
-                        ShowWarning(CL_WHITE"lobbyview_parse:" CL_RESET" character name " CL_WHITE"<%s>" CL_RESET" invalid\n", CharName);
-                    }
-                    else
-                    {
-                        ShowWarning(CL_WHITE"lobbyview_parse:" CL_RESET" character name " CL_WHITE"<%s>" CL_RESET" already taken\n", CharName);
-                    }
-                    // Send error code
                     LOBBBY_ERROR_MESSAGE(ReservePacket);
-                    // The character name you entered is unavailable. Please choose another name.
-                    // A message is displayed in Japanese
-                    ref<uint16>(ReservePacket, 32) = 313;
+                    ref<uint16>(ReservePacket, 32) = 314;
                     memcpy(MainReservePacket, ReservePacket, sendsize);
                 }
                 else
                 {
-                    //copy charname
-                    memcpy(sd->charname, CharName, 15);
-                    sendsize = 0x20;
-                    LOBBY_ACTION_DONE(ReservePacket);
-                    memcpy(MainReservePacket, ReservePacket, sendsize);
+                    //creating new char
+                    char CharName[15];
+                    memset(CharName, 0, sizeof(CharName));
+                    memcpy(CharName, session[fd]->rdata.data() + 32, sizeof(CharName));
+
+                    //find assigns
+                    const char *fmtQuery = "SELECT charname FROM chars WHERE charname LIKE '%s'";
+
+                    std::string myNameIs(&CharName[0]);
+                    bool invalidName = false;
+                    for (auto letters : myNameIs)
+                    {
+                        if (!std::isalpha(letters))
+                        {
+                            invalidName = true;
+                            break;
+                        }
+                    }
+
+                    char escapedCharName[16 * 2 + 1];
+                    Sql_EscapeString(SqlHandle, escapedCharName, CharName);
+                    if (Sql_Query(SqlHandle, fmtQuery, escapedCharName) == SQL_ERROR)
+                    {
+                        do_close_lobbyview(sd, fd);
+                        return -1;
+                    }
+
+                    if (Sql_NumRows(SqlHandle) != 0 || invalidName == true)
+                    {
+                        if (invalidName == true)
+                        {
+                            ShowWarning(CL_WHITE"lobbyview_parse:" CL_RESET" character name " CL_WHITE"<%s>" CL_RESET" invalid\n", CharName);
+                        }
+                        else
+                        {
+                            ShowWarning(CL_WHITE"lobbyview_parse:" CL_RESET" character name " CL_WHITE"<%s>" CL_RESET" already taken\n", CharName);
+                        }
+                        // Send error code
+                        LOBBBY_ERROR_MESSAGE(ReservePacket);
+                        // The character name you entered is unavailable. Please choose another name.
+                        // A message is displayed in Japanese
+                        ref<uint16>(ReservePacket, 32) = 313;
+                        memcpy(MainReservePacket, ReservePacket, sendsize);
+                    }
+                    else
+                    {
+                        //copy charname
+                        memcpy(sd->charname, CharName, 15);
+                        sendsize = 0x20;
+                        LOBBY_ACTION_DONE(ReservePacket);
+                        memcpy(MainReservePacket, ReservePacket, sendsize);
+                    }
                 }
+
                 unsigned char hash[16];
 
                 md5(MainReservePacket, hash, sendsize);

--- a/src/login/login.cpp
+++ b/src/login/login.cpp
@@ -28,9 +28,13 @@
 
 #include <stdio.h>
 #include <stdlib.h>
-#include <string.h>
+#include <string>
+#include <sstream>
+#include <vector>
+#include <limits>
 #include <thread>
 #include <iostream>
+#include <functional>
 
 #ifdef WIN32
 #include <io.h>
@@ -46,10 +50,12 @@
 
 const char* LOGIN_CONF_FILENAME = nullptr;
 const char* VERSION_INFO_FILENAME = nullptr;
+const char* MAINT_CONF_FILENAME = nullptr;
 
 //lan_config_t   lan_config;        // lan settings
 login_config_t login_config;    //main settings
 version_info_t version_info;
+maint_config_t maint_config;
 
 Sql_t *SqlHandle = nullptr;
 std::thread messageThread;
@@ -60,6 +66,7 @@ int32 do_init(int32 argc, char** argv)
     int32 i;
     LOGIN_CONF_FILENAME = "conf/login_darkstar.conf";
     VERSION_INFO_FILENAME = "version.info";
+    MAINT_CONF_FILENAME = "conf/maint.conf";
 
     //srand(gettick());
 
@@ -75,11 +82,13 @@ int32 do_init(int32 argc, char** argv)
     }
 
     login_config_default();
-    login_config_read(LOGIN_CONF_FILENAME);
+    config_read(LOGIN_CONF_FILENAME, "login", login_config_read);
 
     version_info_default();
-    version_info_read(VERSION_INFO_FILENAME);
+    config_read(VERSION_INFO_FILENAME, "version info", version_info_read);
 
+    maint_config_default();
+    config_read(MAINT_CONF_FILENAME, "maint", maint_config_read);
 
     login_fd = makeListenBind_tcp(login_config.login_auth_ip.c_str(), login_config.login_auth_port, connect_client_login);
     ShowStatus("The login-server-auth is " CL_GREEN"ready" CL_RESET" (Server is listening on the port %u).\n\n", login_config.login_auth_port);
@@ -126,33 +135,76 @@ int32 do_init(int32 argc, char** argv)
             {
                 if ((server_clock::now() - lastInputTime) > 1s)
                 {
+                    std::string line;
+                    std::getline(std::cin, line);
+                    std::istringstream stream(line);
                     std::string input;
-                    std::cin >> input;
-
-                    if (strcmp(input.c_str(), "verlock") == 0)
+                    std::vector<std::string> inputs;
+                    while (stream >> input)
                     {
-                        // handle wrap around from 2->3 as 0
-                        version_info.ver_lock = (++version_info.ver_lock % 3);
+                        inputs.push_back(input);
+                    }
 
-                        auto value = "";
-                        switch (version_info.ver_lock)
+                    if (inputs.size() > 0)
+                    {
+                        if (inputs[0] == "verlock")
                         {
-                            case 0:
-                                value = "disabled";
-                                break;
-                            case 1:
-                                value = "enabled - strict";
-                                break;
-                            case 2:
-                                value = "enabled - greater than or equal";
-                                break;
+                            // handle wrap around from 2->3 as 0
+                            version_info.ver_lock = (++version_info.ver_lock % 3);
+
+                            auto value = "";
+                            switch (version_info.ver_lock)
+                            {
+                                case 0:
+                                    value = "disabled";
+                                    break;
+                                case 1:
+                                    value = "enabled - strict";
+                                    break;
+                                case 2:
+                                    value = "enabled - greater than or equal";
+                                    break;
+                            }
+                            ShowStatus("Version lock %i - %s\r\n", version_info.ver_lock, value);
                         }
-                        ShowStatus("Version lock %i - %s\r\n", version_info.ver_lock, value);
+                        else if (inputs[0] == "maint_mode")
+                        {
+                            if (inputs.size() >= 2)
+                            {
+                                uint8 mode = 0;
+                                try
+                                {
+                                    mode = std::stoi(inputs[1]);
+                                }
+                                catch (...)
+                                {
+                                    // set to invalid if string -> uint8 fails
+                                    mode = -1;
+                                }
+
+                                if (mode < 0 || mode > 2)
+                                {
+                                    ShowStatus("Maintenance mode %i not supported\r\n", maint_config.maint_mode);
+                                }
+                                else
+                                {
+                                    maint_config.maint_mode = mode;
+                                    config_write(MAINT_CONF_FILENAME, "maint", maint_config_write);
+
+                                    ShowStatus("Maintenance mode changed to %i\r\n", maint_config.maint_mode);
+                                }
+                            }
+                            else
+                            {
+                                ShowStatus("Maintenance mode requires 1 argument (mode - 0-1)\r\n");
+                            }
+                        }
+                        else
+                        {
+                            ShowStatus("Unknown console input command\r\n");
+                        }
                     }
-                    else
-                    {
-                        ShowStatus("Unknown console input command\r\n");
-                    }
+
                     lastInputTime = server_clock::now();
                 }
             };
@@ -305,171 +357,118 @@ int parse_console(char *buf)
     return 0;
 }
 
-int32 login_config_read(const char *cfgName)
+void login_config_read(const char *key, const char *value)
 {
-    char line[1024], w1[1024], w2[1024];
-    FILE *fp;
-
-    fp = fopen(cfgName, "r");
-    if (fp == nullptr)
+    if (strcmpi(key, "timestamp_format") == 0)
     {
-        ShowError("login configuration file not found at: %s\n", cfgName);
-        return 1;
+        strncpy(timestamp_format, value, 19);
     }
-
-    while (fgets(line, sizeof(line), fp))
+    else if (strcmpi(key, "stdout_with_ansisequence") == 0)
     {
-        char* ptr;
-
-        if (line[0] == '#')
-            continue;
-        if (sscanf(line, "%[^:]: %[^\t\r\n]", w1, w2) < 2)
-            continue;
-
-        //Strip trailing spaces
-        ptr = w2 + strlen(w2);
-        while (--ptr >= w2 && *ptr == ' ');
-        ptr++;
-        *ptr = '\0';
-
-        if (strcmpi(w1, "timestamp_format") == 0)
-        {
-            strncpy(timestamp_format, w2, 19);
-        }
-        else if (strcmpi(w1, "stdout_with_ansisequence") == 0)
-        {
-            stdout_with_ansisequence = config_switch(w2);
-        }
-        else if (strcmpi(w1, "console_silent") == 0)
-        {
-            ShowInfo("Console Silent Setting: %d\n", atoi(w2));
-            msg_silent = atoi(w2);
-        }
-        else if (strcmp(w1, "login_data_ip") == 0)
-        {
-            login_config.login_data_ip = std::string(w2);
-        }
-        else if (strcmp(w1, "login_data_port") == 0)
-        {
-            login_config.login_data_port = atoi(w2);
-        }
-        else if (strcmp(w1, "login_view_ip") == 0)
-        {
-            login_config.login_view_ip = std::string(w2);
-        }
-        else if (strcmp(w1, "login_view_port") == 0)
-        {
-            login_config.login_view_port = atoi(w2);
-        }
-        else if (strcmp(w1, "login_auth_ip") == 0)
-        {
-            login_config.login_auth_ip = std::string(w2);
-        }
-        else if (strcmp(w1, "login_auth_port") == 0)
-        {
-            login_config.login_auth_port = atoi(w2);
-        }
-        else if (strcmp(w1, "mysql_host") == 0)
-        {
-            login_config.mysql_host = std::string(w2);
-        }
-        else if (strcmp(w1, "mysql_login") == 0)
-        {
-            login_config.mysql_login = std::string(w2);
-        }
-        else if (strcmp(w1, "mysql_password") == 0)
-        {
-            login_config.mysql_password = std::string(w2);
-        }
-        else if (strcmp(w1, "mysql_port") == 0)
-        {
-            login_config.mysql_port = atoi(w2);
-        }
-        else if (strcmp(w1, "mysql_database") == 0)
-        {
-            login_config.mysql_database = std::string(w2);
-        }
-        else if (strcmp(w1, "search_server_port") == 0)
-        {
-            login_config.search_server_port = atoi(w2);
-        }
-        else if (strcmp(w1, "servername") == 0)
-        {
-            login_config.servername = std::string(w2);
-        }
-        else if (strcmpi(w1, "import") == 0)
-        {
-            login_config_read(w2);
-        }
-        else if (strcmp(w1, "msg_server_port") == 0)
-        {
-            login_config.msg_server_port = atoi(w2);
-        }
-        else if (strcmp(w1, "msg_server_ip") == 0)
-        {
-            login_config.msg_server_ip = std::string(w2);
-        }
-        else if (strcmp(w1, "log_user_ip") == 0)
-        {
-            login_config.log_user_ip = config_switch(w2);
-        }
-        else
-        {
-            ShowWarning("Unknown setting '%s' in file %s\n", w1, cfgName);
-        }
+        stdout_with_ansisequence = config_switch(value);
     }
-
-    fclose(fp);
-    return 0;
+    else if (strcmpi(key, "console_silent") == 0)
+    {
+        ShowInfo("Console Silent Setting: %d\n", atoi(value));
+        msg_silent = atoi(value);
+    }
+    else if (strcmp(key, "login_data_ip") == 0)
+    {
+        login_config.login_data_ip = std::string(value);
+    }
+    else if (strcmp(key, "login_data_port") == 0)
+    {
+        login_config.login_data_port = atoi(value);
+    }
+    else if (strcmp(key, "login_view_ip") == 0)
+    {
+        login_config.login_view_ip = std::string(value);
+    }
+    else if (strcmp(key, "login_view_port") == 0)
+    {
+        login_config.login_view_port = atoi(value);
+    }
+    else if (strcmp(key, "login_auth_ip") == 0)
+    {
+        login_config.login_auth_ip = std::string(value);
+    }
+    else if (strcmp(key, "login_auth_port") == 0)
+    {
+        login_config.login_auth_port = atoi(value);
+    }
+    else if (strcmp(key, "mysql_host") == 0)
+    {
+        login_config.mysql_host = std::string(value);
+    }
+    else if (strcmp(key, "mysql_login") == 0)
+    {
+        login_config.mysql_login = std::string(value);
+    }
+    else if (strcmp(key, "mysql_password") == 0)
+    {
+        login_config.mysql_password = std::string(value);
+    }
+    else if (strcmp(key, "mysql_port") == 0)
+    {
+        login_config.mysql_port = atoi(value);
+    }
+    else if (strcmp(key, "mysql_database") == 0)
+    {
+        login_config.mysql_database = std::string(value);
+    }
+    else if (strcmp(key, "search_server_port") == 0)
+    {
+        login_config.search_server_port = atoi(value);
+    }
+    else if (strcmp(key, "servername") == 0)
+    {
+        login_config.servername = std::string(value);
+    }
+    else if (strcmpi(key, "import") == 0)
+    {
+        config_read(value, "login", login_config_read);
+    }
+    else if (strcmp(key, "msg_server_port") == 0)
+    {
+        login_config.msg_server_port = atoi(value);
+    }
+    else if (strcmp(key, "msg_server_ip") == 0)
+    {
+        login_config.msg_server_ip = std::string(value);
+    }
+    else if (strcmp(key, "log_user_ip") == 0)
+    {
+        login_config.log_user_ip = config_switch(value);
+    }
+    else
+    {
+        ShowWarning("Unknown setting '%s' with value '%s' in  login file\n", key, value);
+    }
 }
 
-int32 version_info_read(const char *fileName)
+void version_info_read(const char *key, const char *value)
 {
-    char line[1024], w1[1024], w2[1024];
-    FILE *fp;
-
-    fp = fopen(fileName, "r");
-    if (fp == nullptr)
+    if (strcmp(key, "CLIENT_VER") == 0)
     {
-        ShowError("version info file not found at: %s\n", fileName);
-        return 1;
+        version_info.client_ver = std::string(value);
     }
-
-    while (fgets(line, sizeof(line), fp))
+    else if (strcmp(key, "VER_LOCK") == 0)
     {
-        char* ptr;
+        version_info.ver_lock = std::atoi(value);
 
-        if (line[0] == '#')
-            continue;
-        if (sscanf(line, "%[^:]: %[^\t\r\n]", w1, w2) < 2)
-            continue;
-
-        //Strip trailing spaces
-        ptr = w2 + strlen(w2);
-        while (--ptr >= w2 && *ptr == ' ');
-        ptr++;
-        *ptr = '\0';
-
-        if (strcmp(w1, "CLIENT_VER") == 0)
+        if (version_info.ver_lock > 2 || version_info.ver_lock < 0)
         {
-            version_info.client_ver = std::string(w2);
-        }
-        else if (strcmp(w1, "VER_LOCK") == 0)
-        {
-            version_info.ver_lock = std::atoi(w2);
-
-            if (version_info.ver_lock > 2 || version_info.ver_lock < 0)
-            {
-                ShowError("ver_lock not within bounds (0..2) was %i, defaulting to 1\r\n", version_info.ver_lock);
-                version_info.ver_lock = 1;
-            }
+            ShowError("ver_lock not within bounds (0..2) was %i, defaulting to 1\r\n", version_info.ver_lock);
+            version_info.ver_lock = 1;
         }
     }
-    fclose(fp);
-    return 0;
+    else
+    {
+        ShowWarning("Unknown setting '%s' with value '%s' in  version info file\n", key, value);
+    }
 }
 
-int32 login_config_default()
+void login_config_default()
 {
     login_config.login_data_ip = "127.0.0.1";
     login_config.login_data_port = 54230;
@@ -491,14 +490,128 @@ int32 login_config_default()
     login_config.msg_server_ip = "127.0.0.1";
 
     login_config.log_user_ip = "false";
-    return 0;
 }
 
-int32 version_info_default()
+void version_info_default()
 {
     version_info.client_ver = "99999999_9"; // xxYYMMDD_m = xx:MajorRelease YY:year MM:month DD:day _m:MinorRelease
     version_info.ver_lock = 1;
-    // version_info.DSP_VER = 0;
+}
+
+void maint_config_read(const char* key, const char* value)
+{
+    if (strcmp(key, "MAINT_MODE") == 0)
+    {
+        maint_config.maint_mode = std::atoi(value);
+
+        if (maint_config.maint_mode > 2 || maint_config.maint_mode < 0)
+        {
+            ShowError("maint_mode not within bounds (0..1) was %i, defaulting to 0\r\n", maint_config.maint_mode);
+            maint_config.maint_mode = 0;
+        }
+    }
+    else
+    {
+        ShowWarning("Unknown setting '%s' with value '%s' in  maint info file\n", key, value);
+    }
+}
+
+void maint_config_default()
+{
+    maint_config.maint_mode = 0;
+}
+
+std::string maint_config_write(const char* key)
+{
+    if (strcmp(key, "MAINT_MODE") == 0)
+    {
+        return std::to_string(maint_config.maint_mode).c_str();
+    }
+
+    ShowWarning("Did not find value for setting '%s'\n", key);
+
+    return std::string();
+}
+
+int32 config_read(const char* fileName, const char *config, std::function<void(const char*, const char*)> method)
+{
+    char line[1024], key[1024], value[1024];
+    FILE *fp;
+
+    fp = fopen(fileName, "r");
+    if (fp == nullptr)
+    {
+        ShowError("%s configuration file not found at: %s\n", config, fileName);
+        return 1;
+    }
+
+    while (fgets(line, sizeof(line), fp))
+    {
+        char* ptr;
+
+        if (line[0] == '#')
+            continue;
+        if (sscanf(line, "%[^:]: %[^\t\r\n]", key, value) < 2)
+            continue;
+
+        //Strip trailing spaces
+        ptr = value + strlen(value);
+        while (--ptr >= value && *ptr == ' ');
+        ptr++;
+        *ptr = '\0';
+
+        method(key, value);
+    }
+
+    fclose(fp);
+    return 0;
+}
+
+int32 config_write(const char* fileName, const char *config, std::function<std::string(const char*)> method)
+{
+    char line[1024], key[1024], value[1024];
+    std::vector<std::string> lines;
+    FILE *fp;
+
+    fp = fopen(fileName, "r");
+    if (fp == nullptr)
+    {
+        ShowError("%s configuration file not found at: %s\n", config, fileName);
+        return 1;
+    }
+
+    while (fgets(line, sizeof(line), fp))
+    {
+        char* ptr;
+
+        if (line[0] == '#' ||
+            sscanf(line, "%[^:]: %[^\t\r\n]", key, value) < 2)
+        {
+            lines.push_back(line);
+            continue;
+        }
+
+        //Strip trailing spaces
+        ptr = value + strlen(value);
+        while (--ptr >= value && *ptr == ' ');
+        ptr++;
+        *ptr = '\0';
+
+        auto replace = method(key);
+        auto new_line = std::string(key);
+        new_line.append(": ");
+        new_line.append(replace);
+        lines.push_back(new_line);
+    }
+    fclose(fp);
+
+    fp = fopen(fileName, "w");
+
+    for (auto& item : lines)
+    {
+        fputs(item.c_str(), fp);
+    }
+    fclose(fp);
     return 0;
 }
 

--- a/src/login/login.h
+++ b/src/login/login.h
@@ -27,6 +27,7 @@
 #include "../common/cbasetypes.h"
 
 #include <list>
+#include <functional>
 
 #include "../common/kernel.h"
 #include "../common/socket.h"
@@ -66,11 +67,17 @@ struct login_config_t
 struct version_info_t
 {
     std::string client_ver;         // Expected Client version
-    uint8 ver_lock;                 // version lock type - (0 - disabled, 1 - enabled - strict , 2 - enabled - greater than or equal
+    uint8 ver_lock;                 // version lock type - (0 - disabled, 1 - enabled - strict, 2 - enabled - greater than or equal
+};
+
+struct maint_config_t
+{
+    uint8 maint_mode;               // maintenance mode - (0 - disabled, 1 - enabled)
 };
 
 extern login_config_t login_config;
 extern version_info_t version_info;
+extern maint_config_t maint_config;
 
 extern Sql_t *SqlHandle;
 //////////////////////////////////////////////////////////
@@ -87,10 +94,17 @@ void login_versionscreen(int32 flag);
  * Login-Server Config [venom]
  *------------------------------------------*/
 
-int32 login_config_read(const char *cfgName);
-int32 login_config_default();
+void login_config_read(const char *key, const char* value);
+void login_config_default();
 
-int32 version_info_read(const char *cfgName);
-int32 version_info_default();
+void version_info_read(const char *key, const char* value);
+void version_info_default();
+
+void maint_config_read(const char *key, const char* value);
+void maint_config_default();
+std::string maint_config_write(const char* key);
+
+int32 config_read(const char* fileName, const char *config, std::function<void(const char*, const char*)> method);
+int32 config_write(const char* fileName, const char *config, std::function<std::string(const char*)> method);
 
 #endif


### PR DESCRIPTION
- Adding conf/maint.conf to contain maintenance mode configuration
- Updating console input thread for lobby server to support multiple input params
- adding maint_mode option to control change maintenance mode value (0 - disabled/default, 1 - enabled)
- when value is changed via console input it is saved to the above configuration file
- while maintenance mode is active:
  - character list will be filter to only contain GM characters
  - if the character list is empty they will be kicked out with error 3321 - character parameters are incorrect
  - character creation is disabled - will result in error 3314 - failed to register with name server
  - if a player was idle on the character list with a non-GM character and attempts login they will be kicked out with error 3321 - character parameters are incorrect (note character list is not update because the client doesn't re-request the character list)

**Still TODO**:
- consider adding logging of who attempts login during maintenance and keep count
- add GM command to put the system into maint_mode 1, set a timer and during intervals send messages updating the countdown to maintenance, once interval has passed force logout all remaining characters