### PR TITLE
prevent NIN/SMN mobs with 2hr from insta-booming

### DIFF
--- a/scripts/mixins/job_special.lua
+++ b/scripts/mixins/job_special.lua
@@ -21,8 +21,9 @@ g_mixins.job_special = function(mob)
         mob:setLocalVar("useSpecAtHpMin", 40)
         mob:setLocalVar("useSpecAtHpMax", 60)
         mob:setLocalVar("useMainSpecAtHPP", math.random(40,60))
+        mob:setLocalVar("waitJobSpec", 2)
     end)
-    
+
     mob:addListener("COMBAT_TICK", "JOB_SPECIAL_CTICK", function(mob)
         local defaultAbility = {
             [dsp.job.WAR] = dsp.jsa.MIGHTY_STRIKES,
@@ -78,13 +79,13 @@ g_mixins.job_special = function(mob)
 
         local hpMin =  mob:getLocalVar("useSpecAtHpMin")
         local hpMax =  mob:getLocalVar("useSpecAtHpMax")
-  
+
         mob:setLocalVar("useMainSpecAtHPP", math.random(hpMin,hpMax))
         if mob:getLocalVar("useSubSpecAtHPP") > 0 then
             mob:setLocalVar("useSubSpecAtHPP", math.random(hpMin,hpMax))
         end
     end)
-    
+
 end
 
 return g_mixins.job_special


### PR DESCRIPTION
This prevents mobs with the job_special mixin from using their 2hr within the first 2 seconds of combat.

In Dynamis, when you aggro a statue and it spawns a bunch of minions, there's a split second where some of those minions have health that triggers the 2hr, and it causes occasional insta-flows or insta-mijins that can wipe the alliance.  This may be a side effect of the hacked-together way we despawn the mobs at the end of Dynamis.