### PR TITLE
Fix movement speed reduction for Gravity

### DIFF
--- a/scripts/globals/effects/weight.lua
+++ b/scripts/globals/effects/weight.lua
@@ -7,10 +7,6 @@ require("scripts/globals/status")
 -----------------------------------
 
 function onEffectGain(target, effect)
-    if effect:getPower() > 100 then
-        effect:setPower(50)
-    end
-
     target:addMod(dsp.mod.MOVE, -effect:getPower())
 end
 

--- a/scripts/globals/spells/gravity.lua
+++ b/scripts/globals/spells/gravity.lua
@@ -14,7 +14,8 @@ function onSpellCast(caster, target, spell)
     -- Pull base stats.
     local dINT = caster:getStat(dsp.mod.INT) - target:getStat(dsp.mod.INT)
 
-    local power = calculatePotency(50, dINT, spell:getSkillType(), caster, target) -- 50% reduction
+    -- Movement speed reduction caps at -50%
+    local power = math.min(calculatePotency(50, dINT, spell:getSkillType(), caster, target), 50)
 
     -- Duration, including resistance.  Unconfirmed.
     local duration = calculateDuration(120, spell:getSkillType(), spell:getSpellGroup(), caster, target)


### PR DESCRIPTION
Previous check in Weight was... dumb.

Moved power check to the spell itself, as other sources of weight can give < -50% reduction.