### PR TITLE
Jailers of Faith and Fortitude use npcUtil.popFromQM

### DIFF
--- a/scripts/zones/The_Garden_of_RuHmet/mobs/Jailer_of_Faith.lua
+++ b/scripts/zones/The_Garden_of_RuHmet/mobs/Jailer_of_Faith.lua
@@ -31,8 +31,7 @@ function onMobDeath(mob)
 end
 
 function onMobDespawn(mob)
-    local qm3 = GetNPCByID(ID.npc.JAILER_OF_FAITH_QM)
-    qm3:updateNPCHideTime(FORCE_SPAWN_QM_RESET_TIME)
-    local qm3position = math.random(1,5)
-    qm3:setPos(ID.npc.JAILER_OF_FAITH_QM_POS[qm3position][1], ID.npc.JAILER_OF_FAITH_QM_POS[qm3position][2], ID.npc.JAILER_OF_FAITH_QM_POS[qm3position][3])
+    -- Move QM to random location
+    local pos = math.random(1, 5)
+    GetNPCByID(ID.npc.JAILER_OF_FAITH_QM):setPos(ID.npc.JAILER_OF_FAITH_QM_POS[pos][1], ID.npc.JAILER_OF_FAITH_QM_POS[pos][2], ID.npc.JAILER_OF_FAITH_QM_POS[pos][3])
 end

--- a/scripts/zones/The_Garden_of_RuHmet/mobs/Jailer_of_Fortitude.lua
+++ b/scripts/zones/The_Garden_of_RuHmet/mobs/Jailer_of_Fortitude.lua
@@ -1,6 +1,6 @@
 -----------------------------------
 -- Area: The Garden of Ru'Hmet
---  NM:  Jailer of Fortitude
+--   NM: Jailer of Fortitude
 -----------------------------------
 local ID = require("scripts/zones/The_Garden_of_RuHmet/IDs");
 require("scripts/globals/settings");
@@ -59,10 +59,7 @@ function onMobDeath(mob, player, isKiller)
 end;
 
 function onMobDespawn(mob)
-    local qm1 = GetNPCByID(ID.npc.JAILER_OF_FORTITUDE_QM);
-    qm1:updateNPCHideTime(FORCE_SPAWN_QM_RESET_TIME);
-
-    -- Move it to a random location
-    local qm1position = math.random(1,5);
-    qm1:setPos(ID.npc.JAILER_OF_FORTITUDE_QM_POS[qm1position][1], ID.npc.JAILER_OF_FORTITUDE_QM_POS[qm1position][2], ID.npc.JAILER_OF_FORTITUDE_QM_POS[qm1position][3]);
+    -- Move QM to random location
+    local pos = math.random(1, 5)
+    GetNPCByID(ID.npc.JAILER_OF_FORTITUDE_QM):setPos(ID.npc.JAILER_OF_FORTITUDE_QM_POS[pos][1], ID.npc.JAILER_OF_FORTITUDE_QM_POS[pos][2], ID.npc.JAILER_OF_FORTITUDE_QM_POS[pos][3])
 end;

--- a/scripts/zones/The_Garden_of_RuHmet/npcs/qm1.lua
+++ b/scripts/zones/The_Garden_of_RuHmet/npcs/qm1.lua
@@ -2,46 +2,26 @@
 -- Area: The_Garden_of_RuHmet
 --  NPC: ??? (Jailer of Fortitude Spawn)
 -- Allows players to spawn the Jailer of Fortitude by trading 12 Ghrah M Chips to a ???.
--- Random positions:
--- !pos -420 0 755
--- !pos -43 0 460
--- !pos -260 0 44.821
--- !pos -580 0 43
--- !pos -796 0 460
+-- !zone 35
 -----------------------------------
-local ID = require("scripts/zones/The_Garden_of_RuHmet/IDs");
+local ID = require("scripts/zones/The_Garden_of_RuHmet/IDs")
+require("scripts/globals/npc_util")
 -----------------------------------
 
 function onTrade(player,npc,trade)
-    -- Trade 12 Ghrah M Chips
-    if (GetMobAction(ID.mob.JAILER_OF_FORTITUDE) == 0 and trade:hasItemQty(1872,12) and trade:getItemCount() == 12) then
-        local qm1 = GetNPCByID(ID.npc.JAILER_OF_FORTITUDE_QM);
-        -- Complete the trade
-        player:tradeComplete();
-        -- Hide the NPC, will become unhidden after Jailer of Fortitude despawns
-        qm1:setStatus(dsp.status.DISAPPEAR);
-        -- Change MobSpawn to ???'s pos.
-        GetMobByID(ID.mob.JAILER_OF_FORTITUDE):setSpawn(qm1:getXPos(),qm1:getYPos(),qm1:getZPos());
-        -- Change spawn point of pets to be at the ???'s pos as well
-        GetMobByID(ID.mob.KFGHRAH_WHM):setSpawn(qm1:getXPos(),qm1:getYPos(),qm1:getZPos());
-        GetMobByID(ID.mob.KFGHRAH_BLM):setSpawn(qm1:getXPos(),qm1:getYPos(),qm1:getZPos());
-        -- Spawn Jailer of Fortitude
-        SpawnMob(ID.mob.JAILER_OF_FORTITUDE):updateClaim(player);
-        SpawnMob(ID.mob.KFGHRAH_WHM):updateClaim(player);
-        SpawnMob(ID.mob.KFGHRAH_BLM):updateClaim(player);
+    if
+        npcUtil.tradeHas(trade, {{1872, 12}}) and -- 12x Ghrah M Chips
+        npcUtil.popFromQM(player, npc, {ID.mob.JAILER_OF_FORTITUDE, ID.mob.KFGHRAH_WHM, ID.mob.KFGHRAH_BLM}, {radius = 1})
+    then
+        player:confirmTrade()
     end
-end;
+end
 
 function onTrigger(player,npc)
-
-end;
+end
 
 function onEventUpdate(player,csid,option)
-    -- printf("onUpdate CSID: %u",csid);
-    -- printf("onUpdate RESULT: %u",option);
-end;
+end
 
 function onEventFinish(player,csid,option)
-    -- printf("onFinish CSID: %u",csid);
-    -- printf("onFinish RESULT: %u",option);
-end;
+end

--- a/scripts/zones/The_Garden_of_RuHmet/npcs/qm3.lua
+++ b/scripts/zones/The_Garden_of_RuHmet/npcs/qm3.lua
@@ -2,35 +2,23 @@
 -- Area: The_Garden_of_RuHmet
 --  NPC: ??? (Jailer of Faith Spawn)
 -- Allows players to spawn the Jailer of Faith by trading 1 High-Quality Euvhi Organ to a ???.
--- !pos -260 0 -645
+-- !zone 35
 -----------------------------------
-local ID = require("scripts/zones/The_Garden_of_RuHmet/IDs");
+local ID = require("scripts/zones/The_Garden_of_RuHmet/IDs")
+require("scripts/globals/npc_util")
 -----------------------------------
 
 function onTrade(player,npc,trade)
-    --Trade 1 High-Quality Euvhi Organ
-    if (GetMobAction(ID.mob.JAILER_OF_FAITH) == 0 and trade:hasItemQty(1899,1) and trade:getItemCount() == 1) then
-        local qm3 = GetNPCByID(ID.npc.JAILER_OF_FAITH_QM);
-        player:tradeComplete();
-        -- Hide the ???
-        qm3:setStatus(dsp.status.DISAPPEAR);
-        -- Change MobSpawn to ???'s pos.
-        GetMobByID(ID.mob.JAILER_OF_FAITH):setSpawn(qm3:getXPos(),qm3:getYPos(),qm3:getZPos());
-        -- Spawn Jailer of Faith
-        SpawnMob(ID.mob.JAILER_OF_FAITH):updateClaim(player);
+    if npcUtil.tradeHas(trade, 1899) and npcUtil.popFromQM(player, npc, ID.mob.JAILER_OF_FAITH, {radius = 1}) then -- High-Quality Euvhi Organ
+        player:confirmTrade()
     end
-end;
+end
 
 function onTrigger(player,npc)
-
-end;
+end
 
 function onEventUpdate(player,csid,option)
-    -- printf("onUpdate CSID: %u",csid);
-    -- printf("onUpdate RESULT: %u",option);
-end;
+end
 
 function onEventFinish(player,csid,option)
-    -- printf("onFinish CSID: %u",csid);
-    -- printf("onFinish RESULT: %u",option);
-end;
+end


### PR DESCRIPTION
this PR kills the last few GetMobAction() calls, except for those in Dynamis and Limbus zones.