### PR TITLE
remove unused server vars and setting related to Bastok 8-1

### DIFF
--- a/scripts/globals/settings.lua
+++ b/scripts/globals/settings.lua
@@ -111,7 +111,6 @@ AF3_QUEST_LEVEL = 50; -- Minimum level to start AF3 quest
 AF1_FAME = 20; -- base fame for completing an AF1 quest
 AF2_FAME = 40; -- base fame for completing an AF2 quest
 AF3_FAME = 60; -- base fame for completing an AF3 quest
-QM_RESET_TIME = 300; -- Default time (in seconds) you have from killing ???-pop mission NMs to click again and get key item, until ??? resets.
 OldSchoolG1 = false; -- Set to true to require farming Exoray Mold, Bombd Coal, and Ancient Papyrus drops instead of allowing key item method.
 OldSchoolG2 = false; -- Set true to require the NMs for "Atop the Highest Mountains" be dead to get KI like before SE changed it.
 FrigiciteDuration = 30; -- When OldSChoolG2 is enabled, this is the time (in seconds) you have from killing Boreal NMs to click the "???" target.

--- a/scripts/zones/Quicksand_Caves/Zone.lua
+++ b/scripts/zones/Quicksand_Caves/Zone.lua
@@ -35,9 +35,6 @@ function onInitialize(zone)
     zone:registerRegion(33,-297,6,415,-295,8,417);   -- E-7 (Map 6)
     zone:registerRegion(34,-137,6,-177,-135,8,-175); -- G-7 (Map 8)
 
-    SetServerVariable("BastokFight8_1" ,0);
-    SetServerVariable("Bastok8-1LastClear", os.time() - QM_RESET_TIME); -- Set a delay on ??? mission NM pop.
-
     dsp.treasure.initZone(zone)
 
     npcUtil.UpdateNPCSpawnPoint(ID.npc.ANTICAN_TAG_QM, 60, 120, ID.npc.ANTICAN_TAG_POSITIONS, "[POP]Antican_Tag");


### PR DESCRIPTION
remove no-longer-needed server vars for Bastok 8-1
remove no-longer-used setting QM_RESET_TIME