### PR TITLE
Fixes maat stuck in 2 hour casting loop

### DIFF
--- a/scripts/mixins/families/maat.lua
+++ b/scripts/mixins/families/maat.lua
@@ -69,7 +69,7 @@ g_mixins.maat = function(mob)
             local ID = zones[mob:getZoneID()]
             mob:messageText(mob, ID.text.NOW_THAT_IM_WARMED_UP)
             mob:useMobAbility(defaultAbility[mob:getMainJob()])
-            mob:setLocalVar("specialThreshold", -1)
+            mob:setLocalVar("specialThreshold", 0)
         end
 
         if mob:getHPP() < 20 or (mob:getMainJob() == dsp.job.WHM and mob:getBattleTime() > 300) then


### PR DESCRIPTION
For some reason if specialThreshold is set to -1, Maat ends up stuck recasting 2 hour ability once his HPP gets below the original specialThreshold value . This only gets fixed if the server is restarted as Maat will be found still casting 2 hour ability indefinitely.