### PR TITLE
Resolved issue with Rose Garden Spawning

### DIFF
--- a/scripts/zones/Yuhtunga_Jungle/mobs/Overgrown_Rose.lua
+++ b/scripts/zones/Yuhtunga_Jungle/mobs/Overgrown_Rose.lua
@@ -4,22 +4,16 @@
 -----------------------------------
 local ID = require("scripts/zones/Yuhtunga_Jungle/IDs")
 
-function disturbMob(mob)
+function onMobSpawn(mob)
     if mob:getID() == ID.mob.ROSE_GARDEN_PH then
         mob:setLocalVar("timeToGrow", os.time() + math.random(36000,37800)) -- 10:00:00 to 10:30:00
     end
 end
 
-function onMobSpawn(mob)
-    disturbMob(mob)
-end
-
-function onMobEngaged(mob, target)
-    disturbMob(mob)
-end
-
-function onMobFight(mob, target)
-    disturbMob(mob)
+function onMobDisengage(mob)
+    if mob:getID() == ID.mob.ROSE_GARDEN_PH then
+        mob:setLocalVar("timeToGrow", os.time() + math.random(36000,37800)) -- 10:00:00 to 10:30:00
+    end
 end
 
 function onMobRoam(mob)

--- a/scripts/zones/Yuhtunga_Jungle/mobs/Overgrown_Rose.lua
+++ b/scripts/zones/Yuhtunga_Jungle/mobs/Overgrown_Rose.lua
@@ -2,38 +2,39 @@
 -- Area: Yuhtunga Jungle
 --  MOB: Overgrown Rose
 -----------------------------------
-local ID = require("scripts/zones/Yuhtunga_Jungle/IDs");
+local ID = require("scripts/zones/Yuhtunga_Jungle/IDs")
 
 function disturbMob(mob)
     if (mob:getID() == ID.mob.ROSE_GARDEN_PH) then
-        mob:setLocalVar("timeToGrow", os.time() + math.random(36000,37800)); -- 10:00:00 to 10:30:00
+        mob:setLocalVar("timeToGrow", os.time() + math.random(36000,37800)) -- 10:00:00 to 10:30:00
     end
 end
 
 function onMobSpawn(mob)
-    disturbMob(mob);
-end;
+    disturbMob(mob)
+end
 
 function onMobEngaged(mob, target)
-    disturbMob(mob);
-end;
+    disturbMob(mob)
+end
 
 function onMobFight(mob, target)
-    disturbMob(mob);
-end;
+    disturbMob(mob)
+end
 
 function onMobRoam(mob)
     -- Rose Garden PH has been left alone for 10.25 hours
-    if (mob:getID() == ID.mob.ROSE_GARDEN_PH and os.time() > mob:getLocalVar("timeToGrow")) then
-        DisallowRespawn(ID.mob.ROSE_GARDEN_PH, true);
-        DespawnMob(ID.mob.ROSE_GARDEN_PH);
-        DisallowRespawn(ID.mob.ROSE_GARDEN, false);
-        SpawnMob(ID.mob.ROSE_GARDEN);
+    if (mob:gtID() == ID.mob.ROSE_GARDEN_PH and os.time() > mob:getLocalVar("timeToGrow") then
+        DisallowRespawn(ID.mob.ROSE_GARDEN_PH, true)
+        DespawnMob(ID.mob.ROSE_GARDEN_PH)
+        DisallowRespawn(ID.mob.ROSE_GARDEN, false)
+        pos = mob:getPos()
+        SpawnMob(ID.mob.ROSE_GARDEN):setPos(pos.x, pos.y, pos.z, pos.rot)
     end
-end;
+end
 
 function onMobDeath(mob, player, isKiller)
-end;
+end
 
 function onMobDespawn(mob)
-end;
+end

--- a/scripts/zones/Yuhtunga_Jungle/mobs/Overgrown_Rose.lua
+++ b/scripts/zones/Yuhtunga_Jungle/mobs/Overgrown_Rose.lua
@@ -24,7 +24,7 @@ end
 
 function onMobRoam(mob)
     -- Rose Garden PH has been left alone for 10.25 hours
-    if mob:gtID() == ID.mob.ROSE_GARDEN_PH and os.time() > mob:getLocalVar("timeToGrow") then
+    if mob:getID() == ID.mob.ROSE_GARDEN_PH and os.time() > mob:getLocalVar("timeToGrow") then
         DisallowRespawn(ID.mob.ROSE_GARDEN_PH, true)
         DespawnMob(ID.mob.ROSE_GARDEN_PH)
         DisallowRespawn(ID.mob.ROSE_GARDEN, false)

--- a/scripts/zones/Yuhtunga_Jungle/mobs/Overgrown_Rose.lua
+++ b/scripts/zones/Yuhtunga_Jungle/mobs/Overgrown_Rose.lua
@@ -5,7 +5,7 @@
 local ID = require("scripts/zones/Yuhtunga_Jungle/IDs")
 
 function disturbMob(mob)
-    if (mob:getID() == ID.mob.ROSE_GARDEN_PH) then
+    if mob:getID() == ID.mob.ROSE_GARDEN_PH then
         mob:setLocalVar("timeToGrow", os.time() + math.random(36000,37800)) -- 10:00:00 to 10:30:00
     end
 end
@@ -24,7 +24,7 @@ end
 
 function onMobRoam(mob)
     -- Rose Garden PH has been left alone for 10.25 hours
-    if (mob:gtID() == ID.mob.ROSE_GARDEN_PH and os.time() > mob:getLocalVar("timeToGrow") then
+    if mob:gtID() == ID.mob.ROSE_GARDEN_PH and os.time() > mob:getLocalVar("timeToGrow") then
         DisallowRespawn(ID.mob.ROSE_GARDEN_PH, true)
         DespawnMob(ID.mob.ROSE_GARDEN_PH)
         DisallowRespawn(ID.mob.ROSE_GARDEN, false)

--- a/scripts/zones/Yuhtunga_Jungle/mobs/Rose_Garden.lua
+++ b/scripts/zones/Yuhtunga_Jungle/mobs/Rose_Garden.lua
@@ -2,39 +2,42 @@
 -- Area: Yuhtunga Jungle
 --  MOB: Rose Garden
 -----------------------------------
-local ID = require("scripts/zones/Yuhtunga_Jungle/IDs");
+local ID = require("scripts/zones/Yuhtunga_Jungle/IDs")
 
 function disturbMob(mob)
-    mob:setLocalVar("timeToGrow", os.time() + math.random(36000,37800)); -- 10:00:00 to 10:30:00
+    mob:setLocalVar("timeToGrow", os.time() + math.random(36000,37800)) -- 10:00:00 to 10:30:00
 end
 
 function onMobSpawn(mob)
-    disturbMob(mob);
+    disturbMob(mob)
 end;
 
 function onMobEngaged(mob, target)
-    disturbMob(mob);
+    disturbMob(mob)
 end;
 
 function onMobFight(mob, target)
-    disturbMob(mob);
+    disturbMob(mob)
 end;
 
 function onMobRoam(mob)
     -- Rose Garden has been left alone for 10.25 hours
-    if (os.time() > mob:getLocalVar("timeToGrow")) then
-        DisallowRespawn(ID.mob.ROSE_GARDEN, true);
-        DespawnMob(ID.mob.ROSE_GARDEN);
-        DisallowRespawn(ID.mob.VOLUPTUOUS_VILMA, false);
-        SpawnMob(ID.mob.VOLUPTUOUS_VILMA);
+    if os.time() >= mob:getLocalVar("timeToGrow") then
+        DisallowRespawn(ID.mob.ROSE_GARDEN, true)
+        DespawnMob(ID.mob.ROSE_GARDEN)
+        DisallowRespawn(ID.mob.VOLUPTUOUS_VILMA, false)
+        pos = mob:getPos()
+        SpawnMob(ID.mob.VOLUPTUOUS_VILMA):setPos(pos.x, pos.y, pos.z, pos.rot)
     end
-end;
+end
 
 function onMobDeath(mob, player, isKiller)
-end;
+end
 
 function onMobDespawn(mob)
-    DisallowRespawn(ID.mob.ROSE_GARDEN, true);
-    DisallowRespawn(ID.mob.ROSE_GARDEN_PH, false);
-    GetMobByID(ID.mob.ROSE_GARDEN_PH):setRespawnTime(GetMobRespawnTime(ID.mob.ROSE_GARDEN_PH));
-end;
+    if os.time() < mob:getLocalVar("timeToGrow") then
+        DisallowRespawn(ID.mob.ROSE_GARDEN, true)
+        DisallowRespawn(ID.mob.ROSE_GARDEN_PH, false)
+        GetMobByID(ID.mob.ROSE_GARDEN_PH):setRespawnTime(GetMobRespawnTime(ID.mob.ROSE_GARDEN_PH))
+    end
+end

--- a/scripts/zones/Yuhtunga_Jungle/mobs/Rose_Garden.lua
+++ b/scripts/zones/Yuhtunga_Jungle/mobs/Rose_Garden.lua
@@ -4,21 +4,13 @@
 -----------------------------------
 local ID = require("scripts/zones/Yuhtunga_Jungle/IDs")
 
-function disturbMob(mob)
+function onMobSpawn(mob)
     mob:setLocalVar("timeToGrow", os.time() + math.random(36000,37800)) -- 10:00:00 to 10:30:00
 end
 
-function onMobSpawn(mob)
-    disturbMob(mob)
-end;
-
-function onMobEngaged(mob, target)
-    disturbMob(mob)
-end;
-
-function onMobFight(mob, target)
-    disturbMob(mob)
-end;
+function onMobDisengage(mob)
+    mob:setLocalVar("timeToGrow", os.time() + math.random(36000,37800)) -- 10:00:00 to 10:30:00
+end
 
 function onMobRoam(mob)
     -- Rose Garden has been left alone for 10.25 hours

--- a/scripts/zones/Yuhtunga_Jungle/mobs/Voluptuous_Vilma.lua
+++ b/scripts/zones/Yuhtunga_Jungle/mobs/Voluptuous_Vilma.lua
@@ -2,14 +2,14 @@
 -- Area: Yuhtunga Jungle
 --  MOB: Voluptuous Vilma
 -----------------------------------
-local ID = require("scripts/zones/Yuhtunga_Jungle/IDs");
+local ID = require("scripts/zones/Yuhtunga_Jungle/IDs")
 -----------------------------------
 
 function onMobDeath(mob, player, isKiller)
-end;
+end
 
 function onMobDespawn(mob)
-    DisallowRespawn(ID.mob.VOLUPTUOUS_VILMA, true);
-    DisallowRespawn(ID.mob.ROSE_GARDEN_PH, false);
-    GetMobByID(ID.mob.ROSE_GARDEN_PH):setRespawnTime(GetMobRespawnTime(ID.mob.ROSE_GARDEN_PH));
-end;
+    DisallowRespawn(ID.mob.VOLUPTUOUS_VILMA, true)
+    DisallowRespawn(ID.mob.ROSE_GARDEN_PH, false)
+    GetMobByID(ID.mob.ROSE_GARDEN_PH):setRespawnTime(GetMobRespawnTime(ID.mob.ROSE_GARDEN_PH))
+end


### PR DESCRIPTION
When Voluptuous Vilma would be spawned it would enable the Rose Garden PH to spawn as well by calling the `Rose_Garden:onMobDespawn`. This is resolved by checking the `timeToGrow` variable and only setting Rose Garden PH to spawn if Vilma did not spawn.

Bonus: Cleaned up related scripts and made Rose Garden and Vilma spawn in the exact place the previous one was at so that it looks more like it is evolving.