### PR TITLE
Resolved issue with Mog Safe 2 not being factored into Storage amount properly

### DIFF
--- a/src/map/utils/charutils.cpp
+++ b/src/map/utils/charutils.cpp
@@ -912,7 +912,7 @@ namespace charutils
                         PItem->setSignature(EncodedString);
                     }
 
-                    if (PItem->isType(ITEM_FURNISHING) && PItem->getLocationID() == LOC_MOGSAFE)
+                    if (PItem->isType(ITEM_FURNISHING) && (PItem->getLocationID() == LOC_MOGSAFE || PItem->getLocationID() == LOC_MOGSAFE2))
                     {
                         if (((CItemFurnishing*)PItem)->isInstalled()) // способ узнать, что предмет действительно установлен
                         {


### PR DESCRIPTION
This would result in two issues:
1. The player's storage would show less storage space than they really had and would prevent them from using it.
2. The player could not remove items that were providing storage because their bonus was not originally added so removing them would result in having less space than what was available.