### PR TITLE
Quick Draw Additions and Cleanup

### DIFF
--- a/scripts/globals/abilities/dark_shot.lua
+++ b/scripts/globals/abilities/dark_shot.lua
@@ -3,30 +3,29 @@
 -- Consumes a Dark Card to enhance dark-based debuffs. Additional effect: Dark-based Dispel
 -- Bio Effect: Attack Down Effect +5% and DoT + 3
 -----------------------------------
-require("scripts/globals/settings")
-require("scripts/globals/status")
 require("scripts/globals/magic")
+require("scripts/globals/status")
 -----------------------------------
 
-function onAbilityCheck(player,target,ability)
+function onAbilityCheck(player, target, ability)
     --ranged weapon/ammo: You do not have an appropriate ranged weapon equipped.
     --no card: <name> cannot perform that action.
-    if (player:getWeaponSkillType(dsp.slot.RANGED) ~= dsp.skill.MARKSMANSHIP or player:getWeaponSkillType(dsp.slot.AMMO) ~= dsp.skill.MARKSMANSHIP) then
-        return 216,0
+    if player:getWeaponSkillType(dsp.slot.RANGED) ~= dsp.skill.MARKSMANSHIP or player:getWeaponSkillType(dsp.slot.AMMO) ~= dsp.skill.MARKSMANSHIP then
+        return 216, 0
     end
-    if (player:hasItem(2183, 0) or player:hasItem(2974, 0)) then
-        return 0,0
+    if player:hasItem(2183, 0) or player:hasItem(2974, 0) then
+        return 0, 0
     else
         return 71, 0
     end
 end
 
-function onUseAbility(player,target,ability)
-
+function onUseAbility(player, target, ability)
     local duration = 60
-    local resist = applyResistanceAbility(player,target,dsp.magic.ele.DARK,dsp.skill.MARKSMANSHIP, (player:getStat(dsp.mod.AGI)/2) + player:getMerit(dsp.merit.QUICK_DRAW_ACCURACY))
+    local bonusAcc = player:getStat(dsp.mod.AGI) / 2 + player:getMerit(dsp.merit.QUICK_DRAW_ACCURACY) + player:getMod(dsp.mod.QUICK_DRAW_MACC)
+    local resist = applyResistanceAbility(player, target, dsp.magic.ele.DARK, dsp.skill.NONE, bonusAcc)
 
-    if (resist < 0.25) then
+    if resist < 0.25 then
         ability:setMsg(dsp.msg.basic.JA_MISS_2) -- resist message
         return 0
     end
@@ -34,25 +33,21 @@ function onUseAbility(player,target,ability)
     duration = duration * resist
 
     local effects = {}
-    local counter = 1
     local bio = target:getStatusEffect(dsp.effect.BIO)
-    if (bio ~= nil) then
-        effects[counter] = bio
-        counter = counter + 1
+    if bio ~= nil then
+        table.insert(effects, bio)
     end
     local blind = target:getStatusEffect(dsp.effect.BLINDNESS)
-    if (blind ~= nil) then
-        effects[counter] = blind
-        counter = counter + 1
+    if blind ~= nil then
+        table.insert(effects, blind)
     end
     local threnody = target:getStatusEffect(dsp.effect.THRENODY)
-    if (threnody ~= nil and threnody:getSubPower() == dsp.mod.LIGHTRES) then
-        effects[counter] = threnody
-        counter = counter + 1
+    if threnody ~= nil and threnody:getSubPower() == dsp.mod.LIGHTRES then
+        table.insert(effects, threnody)
     end
 
-    if counter > 1 then
-        local effect = effects[math.random(1, counter-1)]
+    if #effects > 0 then
+        local effect = effects[math.random(#effects)]
         local duration = effect:getDuration()
         local startTime = effect:getStartTime()
         local tick = effect:getTick()
@@ -71,7 +66,7 @@ function onUseAbility(player,target,ability)
 
     ability:setMsg(dsp.msg.basic.JA_REMOVE_EFFECT_2)
     local dispelledEffect = target:dispelStatusEffect()
-    if (dispelledEffect == dsp.effect.NONE) then
+    if dispelledEffect == dsp.effect.NONE then
         -- no effect
         ability:setMsg(dsp.msg.basic.JA_NO_EFFECT_2)
     end

--- a/scripts/globals/abilities/earth_shot.lua
+++ b/scripts/globals/abilities/earth_shot.lua
@@ -3,64 +3,55 @@
 -- Consumes a Earth Card to enhance earth-based debuffs. Deals earth-based magic damage
 -- Rasp Effect: Enhanced DoT and DEX-, Slow Effect +10%
 -----------------------------------
-require("scripts/globals/settings")
-require("scripts/globals/status")
-require("scripts/globals/magic")
-require("scripts/globals/weaponskills")
 require("scripts/globals/ability")
+require("scripts/globals/magic")
+require("scripts/globals/status")
 -----------------------------------
 
-function onAbilityCheck(player,target,ability)
+function onAbilityCheck(player, target, ability)
     --ranged weapon/ammo: You do not have an appropriate ranged weapon equipped.
     --no card: <name> cannot perform that action.
-    if (player:getWeaponSkillType(dsp.slot.RANGED) ~= dsp.skill.MARKSMANSHIP or player:getWeaponSkillType(dsp.slot.AMMO) ~= dsp.skill.MARKSMANSHIP) then
-        return 216,0
+    if player:getWeaponSkillType(dsp.slot.RANGED) ~= dsp.skill.MARKSMANSHIP or player:getWeaponSkillType(dsp.slot.AMMO) ~= dsp.skill.MARKSMANSHIP then
+        return 216, 0
     end
-    if (player:hasItem(2179, 0) or player:hasItem(2974, 0)) then
-        return 0,0
+    if player:hasItem(2179, 0) or player:hasItem(2974, 0) then
+        return 0, 0
     else
         return 71, 0
     end
 end
 
-function onUseAbility(player,target,ability,action)
+function onUseAbility(player, target, ability, action)
     local params = {}
     params.includemab = true
-    local dmg = (2 * player:getRangedDmg() + player:getAmmoDmg() + player:getMod(dsp.mod.QUICK_DRAW_DMG)) * 1 + player:getMod(dsp.mod.QUICK_DRAW_DMG_PERCENT)/100
+    local dmg = (2 * (player:getRangedDmg() + player:getAmmoDmg()) + player:getMod(dsp.mod.QUICK_DRAW_DMG)) * (1 + player:getMod(dsp.mod.QUICK_DRAW_DMG_PERCENT) / 100)
     dmg  = addBonusesAbility(player, dsp.magic.ele.EARTH, target, dmg, params)
-    dmg = dmg * applyResistanceAbility(player,target,dsp.magic.ele.EARTH,dsp.skill.MARKSMANSHIP, (player:getStat(dsp.mod.AGI)/2) + player:getMerit(dsp.merit.QUICK_DRAW_ACCURACY))
-    dmg = adjustForTarget(target,dmg,dsp.magic.ele.EARTH)
+    local bonusAcc = player:getStat(dsp.mod.AGI) / 2 + player:getMerit(dsp.merit.QUICK_DRAW_ACCURACY) + player:getMod(dsp.mod.QUICK_DRAW_MACC)
+    dmg = dmg * applyResistanceAbility(player, target, dsp.magic.ele.EARTH, dsp.skill.NONE, bonusAcc)
+    dmg = adjustForTarget(target, dmg, dsp.magic.ele.EARTH)
 
-    local shadowsAbsorbed = 0
-    
-    if shadowAbsorb(target) then
-        shadowsAbsorbed = 1
-    end
-    
-    dmg = takeAbilityDamage(target, player, {}, true, dmg, dsp.slot.RANGED, 1, shadowsAbsorbed, 0, 0, action, nil)
+    params.targetTPMult = 0 -- Quick Draw does not feed TP
+    dmg = takeAbilityDamage(target, player, params, true, dmg, dsp.slot.RANGED, 1, 0, 0, 0, action, nil)
 
-    if shadowsAbsorbed == 0 then
-    
+    if dmg > 0 then
         local effects = {}
-        local counter = 1
         local rasp = target:getStatusEffect(dsp.effect.RASP)
-        if (rasp ~= nil) then
-            effects[counter] = rasp
-            counter = counter + 1
+        if rasp ~= nil then
+            table.insert(effects, rasp)
         end
+    
         local threnody = target:getStatusEffect(dsp.effect.THRENODY)
-        if (threnody ~= nil and threnody:getSubPower() == dsp.mod.THUNDERRES) then
-            effects[counter] = threnody
-            counter = counter + 1
+        if threnody ~= nil and threnody:getSubPower() == dsp.mod.THUNDERRES then
+            table.insert(effects, threnody)
         end
+
         local slow = target:getStatusEffect(dsp.effect.SLOW)
-        if (slow ~= nil) then
-            effects[counter] = slow
-            counter = counter + 1
+        if slow ~= nil then
+            table.insert(effects, slow)
         end
-        
-        if counter > 1 then
-            local effect = effects[math.random(1, counter-1)]
+
+        if #effects > 0 then
+            local effect = effects[math.random(#effects)]
             local duration = effect:getDuration()
             local startTime = effect:getStartTime()
             local tick = effect:getTick()

--- a/scripts/globals/abilities/fire_shot.lua
+++ b/scripts/globals/abilities/fire_shot.lua
@@ -3,57 +3,50 @@
 -- Consumes a Fire Card to enhance fire-based debuffs. Deals fire-based magic damage
 -- Burn effect: Enhanced DoT and INT-
 -----------------------------------
-require("scripts/globals/settings")
-require("scripts/globals/status")
-require("scripts/globals/magic")
-require("scripts/globals/weaponskills")
 require("scripts/globals/ability")
+require("scripts/globals/magic")
+require("scripts/globals/status")
 -----------------------------------
 
-function onAbilityCheck(player,target,ability)
+function onAbilityCheck(player, target, ability)
     --ranged weapon/ammo: You do not have an appropriate ranged weapon equipped.
     --no card: <name> cannot perform that action.
-    if (player:getWeaponSkillType(dsp.slot.RANGED) ~= dsp.skill.MARKSMANSHIP or player:getWeaponSkillType(dsp.slot.AMMO) ~= dsp.skill.MARKSMANSHIP) then
-        return 216,0
+    if player:getWeaponSkillType(dsp.slot.RANGED) ~= dsp.skill.MARKSMANSHIP or player:getWeaponSkillType(dsp.slot.AMMO) ~= dsp.skill.MARKSMANSHIP then
+        return 216, 0
     end
-    if (player:hasItem(2176, 0) or player:hasItem(2974, 0)) then
-        return 0,0
+    if player:hasItem(2176, 0) or player:hasItem(2974, 0) then
+        return 0, 0
     else
         return 71, 0
     end
 end
 
-function onUseAbility(player,target,ability,action)
+function onUseAbility(player, target, ability, action)
     local params = {}
     params.includemab = true
-    local dmg = (2 * player:getRangedDmg() + player:getAmmoDmg() + player:getMod(dsp.mod.QUICK_DRAW_DMG)) * 1 + player:getMod(dsp.mod.QUICK_DRAW_DMG_PERCENT)/100
+    local dmg = (2 * (player:getRangedDmg() + player:getAmmoDmg()) + player:getMod(dsp.mod.QUICK_DRAW_DMG)) * (1 + player:getMod(dsp.mod.QUICK_DRAW_DMG_PERCENT) / 100)
     dmg  = addBonusesAbility(player, dsp.magic.ele.FIRE, target, dmg, params)
-    dmg = dmg * applyResistanceAbility(player,target,dsp.magic.ele.FIRE,dsp.skill.MARKSMANSHIP, (player:getStat(dsp.mod.AGI)/2) + player:getMerit(dsp.merit.QUICK_DRAW_ACCURACY))
-    dmg = adjustForTarget(target,dmg,dsp.magic.ele.FIRE)
+    local bonusAcc = player:getStat(dsp.mod.AGI) / 2 + player:getMerit(dsp.merit.QUICK_DRAW_ACCURACY) + player:getMod(dsp.mod.QUICK_DRAW_MACC)
+    dmg = dmg * applyResistanceAbility(player,target, dsp.magic.ele.FIRE, dsp.skill.NONE, bonusAcc)
+    dmg = adjustForTarget(target, dmg, dsp.magic.ele.FIRE)
 
-    local shadowsAbsorbed = 0
-    if shadowAbsorb(target) then
-        shadowsAbsorbed = 1
-    end
+    params.targetTPMult = 0 -- Quick Draw does not feed TP
+    dmg = takeAbilityDamage(target, player, params, true, dmg, dsp.slot.RANGED, 1, 0, 0, 0, action, nil)
 
-    dmg = takeAbilityDamage(target, player, {}, true, dmg, dsp.slot.RANGED, 1, shadowsAbsorbed, 0, 0, action, nil)
-    
-    if shadowsAbsorbed == 0 then
+    if dmg > 0 then
         local effects = {}
-        local counter = 1
         local burn = target:getStatusEffect(dsp.effect.BURN)
-        if (burn ~= nil) then
-            effects[counter] = burn
-            counter = counter + 1
+        if burn ~= nil then
+            table.insert(effects, burn)
         end
+
         local threnody = target:getStatusEffect(dsp.effect.THRENODY)
-        if (threnody ~= nil and threnody:getSubPower() == dsp.mod.ICERES) then
-            effects[counter] = threnody
-            counter = counter + 1
+        if threnody ~= nil and threnody:getSubPower() == dsp.mod.ICERES then
+            table.insert(effects, threnody)
         end
-        
-        if counter > 1 then
-            local effect = effects[math.random(1, counter-1)]
+
+        if #effects > 0 then
+            local effect = effects[math.random(#effects)]
             local duration = effect:getDuration()
             local startTime = effect:getStartTime()
             local tick = effect:getTick()

--- a/scripts/globals/abilities/ice_shot.lua
+++ b/scripts/globals/abilities/ice_shot.lua
@@ -3,63 +3,55 @@
 -- Consumes a Ice Card to enhance ice-based debuffs. Deals ice-based magic damage
 -- Frost Effect: Enhanced DoT and AGI-
 -----------------------------------
-require("scripts/globals/settings")
-require("scripts/globals/status")
-require("scripts/globals/magic")
-require("scripts/globals/weaponskills")
 require("scripts/globals/ability")
+require("scripts/globals/magic")
+require("scripts/globals/status")
 -----------------------------------
 
-function onAbilityCheck(player,target,ability)
+function onAbilityCheck(player, target, ability)
     --ranged weapon/ammo: You do not have an appropriate ranged weapon equipped.
     --no card: <name> cannot perform that action.
-    if (player:getWeaponSkillType(dsp.slot.RANGED) ~= dsp.skill.MARKSMANSHIP or player:getWeaponSkillType(dsp.slot.AMMO) ~= dsp.skill.MARKSMANSHIP) then
-        return 216,0
+    if player:getWeaponSkillType(dsp.slot.RANGED) ~= dsp.skill.MARKSMANSHIP or player:getWeaponSkillType(dsp.slot.AMMO) ~= dsp.skill.MARKSMANSHIP then
+        return 216, 0
     end
-    if (player:hasItem(2177, 0) or player:hasItem(2974, 0)) then
-        return 0,0
+    if player:hasItem(2177, 0) or player:hasItem(2974, 0) then
+        return 0, 0
     else
         return 71, 0
     end
 end
 
-function onUseAbility(player,target,ability,action)
+function onUseAbility(player, target, ability, action)
     local params = {}
     params.includemab = true
-    local dmg = (2 * player:getRangedDmg() + player:getAmmoDmg() + player:getMod(dsp.mod.QUICK_DRAW_DMG)) * 1 + player:getMod(dsp.mod.QUICK_DRAW_DMG_PERCENT)/100
+    local dmg = (2 * (player:getRangedDmg() + player:getAmmoDmg()) + player:getMod(dsp.mod.QUICK_DRAW_DMG)) * (1 + player:getMod(dsp.mod.QUICK_DRAW_DMG_PERCENT) / 100)
     dmg  = addBonusesAbility(player, dsp.magic.ele.ICE, target, dmg, params)
-    dmg = dmg * applyResistanceAbility(player,target,dsp.magic.ele.ICE,dsp.skill.MARKSMANSHIP, (player:getStat(dsp.mod.AGI)/2) + player:getMerit(dsp.merit.QUICK_DRAW_ACCURACY))
-    dmg = adjustForTarget(target,dmg,dsp.magic.ele.ICE)
+    local bonusAcc = player:getStat(dsp.mod.AGI) / 2 + player:getMerit(dsp.merit.QUICK_DRAW_ACCURACY) + player:getMod(dsp.mod.QUICK_DRAW_MACC)
+    dmg = dmg * applyResistanceAbility(player, target, dsp.magic.ele.ICE, dsp.skill.NONE, bonusAcc)
+    dmg = adjustForTarget(target, dmg, dsp.magic.ele.ICE)
 
-    local shadowsAbsorbed = 0
-    if shadowAbsorb(target) then
-        shadowsAbsorbed = 1
-    end
+    params.targetTPMult = 0 -- Quick Draw does not feed TP
+    dmg = takeAbilityDamage(target, player, params, true, dmg, dsp.slot.RANGED, 1, 0, 0, 0, action, nil)
 
-    dmg = takeAbilityDamage(target, player, {}, true, dmg, dsp.slot.RANGED, 1, shadowsAbsorbed, 0, 0, action, nil)
-
-    if shadowsAbsorbed == 0 then
-    
+    if dmg > 0 then
         local effects = {}
-        local counter = 1
         local frost = target:getStatusEffect(dsp.effect.FROST)
-        if (frost ~= nil) then
-            effects[counter] = frost
-            counter = counter + 1
+        if frost ~= nil then
+            table.insert(effects, frost)
         end
+
         local threnody = target:getStatusEffect(dsp.effect.THRENODY)
-        if (threnody ~= nil and threnody:getSubPower() == dsp.mod.WINDRES) then
-            effects[counter] = threnody
-            counter = counter + 1
+        if threnody ~= nil and threnody:getSubPower() == dsp.mod.WINDRES then
+            table.insert(effects, threnody)
         end
+
         local paralyze = target:getStatusEffect(dsp.effect.PARALYSIS)
-        if (paralyze ~= nil) then
-            effects[counter] = paralyze
-            counter = counter + 1
+        if paralyze ~= nil then
+            table.insert(effects, paralyze)
         end
         
-        if counter > 1 then
-            local effect = effects[math.random(1, counter-1)]
+        if #effects > 0 then
+            local effect = effects[math.random(#effects)]
             local duration = effect:getDuration()
             local startTime = effect:getStartTime()
             local tick = effect:getTick()

--- a/scripts/globals/abilities/light_shot.lua
+++ b/scripts/globals/abilities/light_shot.lua
@@ -3,30 +3,29 @@
 -- Consumes a Light Card to enhance light-based debuffs. Additional effect: Light-based Sleep
 -- Dia Effect: Defense Down Effect +5% and DoT + 1
 -----------------------------------
-require("scripts/globals/settings")
-require("scripts/globals/status")
 require("scripts/globals/magic")
+require("scripts/globals/status")
 -----------------------------------
 
-function onAbilityCheck(player,target,ability)
+function onAbilityCheck(player, target, ability)
     --ranged weapon/ammo: You do not have an appropriate ranged weapon equipped.
     --no card: <name> cannot perform that action.
-    if (player:getWeaponSkillType(dsp.slot.RANGED) ~= dsp.skill.MARKSMANSHIP or player:getWeaponSkillType(dsp.slot.AMMO) ~= dsp.skill.MARKSMANSHIP) then
-        return 216,0
+    if player:getWeaponSkillType(dsp.slot.RANGED) ~= dsp.skill.MARKSMANSHIP or player:getWeaponSkillType(dsp.slot.AMMO) ~= dsp.skill.MARKSMANSHIP then
+        return 216, 0
     end
-    if (player:hasItem(2182, 0) or player:hasItem(2974, 0)) then
-        return 0,0
+    if player:hasItem(2182, 0) or player:hasItem(2974, 0) then
+        return 0, 0
     else
         return 71, 0
     end
 end
 
-function onUseAbility(player,target,ability)
-
+function onUseAbility(player, target, ability)
     local duration = 60
-    local resist = applyResistanceAbility(player,target,dsp.magic.ele.LIGHT,dsp.skill.MARKSMANSHIP, (player:getStat(dsp.mod.AGI)/2) + player:getMerit(dsp.merit.QUICK_DRAW_ACCURACY))
+    local bonusAcc = player:getStat(dsp.mod.AGI) / 2 + player:getMerit(dsp.merit.QUICK_DRAW_ACCURACY) + player:getMod(dsp.mod.QUICK_DRAW_MACC)
+    local resist = applyResistanceAbility(player, target, dsp.magic.ele.LIGHT, dsp.skill.NONE, bonusAcc)
 
-    if (resist < 0.5) then
+    if resist < 0.5 then
         ability:setMsg(dsp.msg.basic.JA_MISS_2) -- resist message
         return dsp.effect.SLEEP_I
     end
@@ -34,20 +33,17 @@ function onUseAbility(player,target,ability)
     duration = duration * resist
 
     local effects = {}
-    local counter = 1
     local dia = target:getStatusEffect(dsp.effect.DIA)
-    if (dia ~= nil) then
-        effects[counter] = dia
-        counter = counter + 1
+    if dia ~= nil then
+        table.insert(effects, dia)
     end
     local threnody = target:getStatusEffect(dsp.effect.THRENODY)
-    if (threnody ~= nil and threnody:getSubPower() == dsp.mod.DARKRES) then
-        effects[counter] = threnody
-        counter = counter + 1
+    if threnody ~= nil and threnody:getSubPower() == dsp.mod.DARKRES then
+        table.insert(effects, threnody)
     end
 
-    if counter > 1 then
-        local effect = effects[math.random(1, counter-1)]
+    if #effects > 0 then
+        local effect = effects[math.random(#effects)]
         local duration = effect:getDuration()
         local startTime = effect:getStartTime()
         local tick = effect:getTick()
@@ -64,7 +60,7 @@ function onUseAbility(player,target,ability)
         newEffect:setStartTime(startTime)
     end
 
-    if (target:addStatusEffect(dsp.effect.SLEEP_I,1,0,duration)) then
+    if target:addStatusEffect(dsp.effect.SLEEP_I, 1, 0, duration) then
         ability:setMsg(dsp.msg.basic.JA_ENFEEB_IS)
     else
         ability:setMsg(dsp.msg.basic.JA_NO_EFFECT_2)

--- a/scripts/globals/abilities/thunder_shot.lua
+++ b/scripts/globals/abilities/thunder_shot.lua
@@ -3,57 +3,50 @@
 -- Consumes a Thunder Card to enhance lightning-based debuffs. Deals lightning-based magic damage
 -- Shock Effect: Enhanced DoT and MND-
 -----------------------------------
-require("scripts/globals/settings")
-require("scripts/globals/status")
-require("scripts/globals/magic")
-require("scripts/globals/weaponskills")
 require("scripts/globals/ability")
+require("scripts/globals/magic")
+require("scripts/globals/status")
 -----------------------------------
 
-function onAbilityCheck(player,target,ability)
+function onAbilityCheck(player, target, ability)
     --ranged weapon/ammo: You do not have an appropriate ranged weapon equipped.
     --no card: <name> cannot perform that action.
-    if (player:getWeaponSkillType(dsp.slot.RANGED) ~= dsp.skill.MARKSMANSHIP or player:getWeaponSkillType(dsp.slot.AMMO) ~= dsp.skill.MARKSMANSHIP) then
-        return 216,0
+    if player:getWeaponSkillType(dsp.slot.RANGED) ~= dsp.skill.MARKSMANSHIP or player:getWeaponSkillType(dsp.slot.AMMO) ~= dsp.skill.MARKSMANSHIP then
+        return 216, 0
     end
-    if (player:hasItem(2180, 0) or player:hasItem(2974, 0)) then
-        return 0,0
+    if player:hasItem(2180, 0) or player:hasItem(2974, 0) then
+        return 0, 0
     else
         return 71, 0
     end
 end
 
-function onUseAbility(player,target,ability,action)
+function onUseAbility(player, target, ability, action)
     local params = {}
     params.includemab = true
-    local dmg = (2 * player:getRangedDmg() + player:getAmmoDmg() + player:getMod(dsp.mod.QUICK_DRAW_DMG)) * 1 + player:getMod(dsp.mod.QUICK_DRAW_DMG_PERCENT)/100
+    local dmg = (2 * (player:getRangedDmg() + player:getAmmoDmg()) + player:getMod(dsp.mod.QUICK_DRAW_DMG)) * (1 + player:getMod(dsp.mod.QUICK_DRAW_DMG_PERCENT) / 100)
     dmg  = addBonusesAbility(player, dsp.magic.ele.LIGHTNING, target, dmg, params)
-    dmg = dmg * applyResistanceAbility(player,target,dsp.magic.ele.LIGHTNING,dsp.skill.MARKSMANSHIP, (player:getStat(dsp.mod.AGI)/2) + player:getMerit(dsp.merit.QUICK_DRAW_ACCURACY))
-    dmg = adjustForTarget(target,dmg,dsp.magic.ele.LIGHTNING)
-    
-    local shadowsAbsorbed = 0
-    if shadowAbsorb(target) then
-        shadowsAbsorbed = 1
-    end
+    local bonusAcc = player:getStat(dsp.mod.AGI) / 2 + player:getMerit(dsp.merit.QUICK_DRAW_ACCURACY) + player:getMod(dsp.mod.QUICK_DRAW_MACC)
+    dmg = dmg * applyResistanceAbility(player, target, dsp.magic.ele.LIGHTNING, dsp.skill.NONE, bonusAcc)
+    dmg = adjustForTarget(target, dmg, dsp.magic.ele.LIGHTNING)
 
-    dmg = takeAbilityDamage(target, player, {}, true, dmg, dsp.slot.RANGED, 1, shadowsAbsorbed, 0, 0, action, nil)
-    
-    if shadowsAbsorbed == 0 then
+    params.targetTPMult = 0 -- Quick Draw does not feed TP
+    dmg = takeAbilityDamage(target, player, params, true, dmg, dsp.slot.RANGED, 1, 0, 0, 0, action, nil)
+
+    if dmg > 0 then
         local effects = {}
-        local counter = 1
         local shock = target:getStatusEffect(dsp.effect.SHOCK)
-        if (shock ~= nil) then
-            effects[counter] = shock
-            counter = counter + 1
+        if shock ~= nil then
+            table.insert(effects, shock)
         end
+
         local threnody = target:getStatusEffect(dsp.effect.THRENODY)
-        if (threnody ~= nil and threnody:getSubPower() == dsp.mod.WATERRES) then
-            effects[counter] = threnody
-            counter = counter + 1
+        if threnody ~= nil and threnody:getSubPower() == dsp.mod.WATERRES then
+            table.insert(effects, threnody)
         end
-        
-        if counter > 1 then
-            local effect = effects[math.random(1, counter-1)]
+
+        if #effects > 0 then
+            local effect = effects[math.random(#effects)]
             local duration = effect:getDuration()
             local startTime = effect:getStartTime()
             local tick = effect:getTick()

--- a/scripts/globals/abilities/water_shot.lua
+++ b/scripts/globals/abilities/water_shot.lua
@@ -3,62 +3,55 @@
 -- Consumes a Water Card to enhance water-based debuffs. Deals water-based magic damage
 -- Drown Effect: Enhanced DoT and STR-
 -----------------------------------
-require("scripts/globals/settings")
-require("scripts/globals/status")
-require("scripts/globals/magic")
-require("scripts/globals/weaponskills")
 require("scripts/globals/ability")
+require("scripts/globals/magic")
+require("scripts/globals/status")
 -----------------------------------
 
-function onAbilityCheck(player,target,ability)
+function onAbilityCheck(player, target, ability)
     --ranged weapon/ammo: You do not have an appropriate ranged weapon equipped.
     --no card: <name> cannot perform that action.
-    if (player:getWeaponSkillType(dsp.slot.RANGED) ~= dsp.skill.MARKSMANSHIP or player:getWeaponSkillType(dsp.slot.AMMO) ~= dsp.skill.MARKSMANSHIP) then
-        return 216,0
+    if player:getWeaponSkillType(dsp.slot.RANGED) ~= dsp.skill.MARKSMANSHIP or player:getWeaponSkillType(dsp.slot.AMMO) ~= dsp.skill.MARKSMANSHIP then
+        return 216, 0
     end
-    if (player:hasItem(2181, 0) or player:hasItem(2974, 0)) then
-        return 0,0
+    if player:hasItem(2181, 0) or player:hasItem(2974, 0) then
+        return 0, 0
     else
         return 71, 0
     end
 end
 
-function onUseAbility(player,target,ability,action)
+function onUseAbility(player, target, ability, action)
     local params = {}
     params.includemab = true
-    local dmg = (2 * player:getRangedDmg() + player:getAmmoDmg() + player:getMod(dsp.mod.QUICK_DRAW_DMG)) * 1 + player:getMod(dsp.mod.QUICK_DRAW_DMG_PERCENT)/100
+    local dmg = (2 * (player:getRangedDmg() + player:getAmmoDmg()) + player:getMod(dsp.mod.QUICK_DRAW_DMG)) * (1 + player:getMod(dsp.mod.QUICK_DRAW_DMG_PERCENT) / 100)
     dmg  = addBonusesAbility(player, dsp.magic.ele.WATER, target, dmg, params)
-    dmg = dmg * applyResistanceAbility(player,target,dsp.magic.ele.WATER,dsp.skill.MARKSMANSHIP, (player:getStat(dsp.mod.AGI)/2) + player:getMerit(dsp.merit.QUICK_DRAW_ACCURACY))
-    dmg = adjustForTarget(target,dmg,dsp.magic.ele.WATER)
-    
-    local shadowsAbsorbed = 0
-    if shadowAbsorb(target) then
-        shadowsAbsorbed = 1
-    end
+    local bonusAcc = player:getStat(dsp.mod.AGI) / 2 + player:getMerit(dsp.merit.QUICK_DRAW_ACCURACY) + player:getMod(dsp.mod.QUICK_DRAW_MACC)
+    dmg = dmg * applyResistanceAbility(player, target, dsp.magic.ele.WATER, dsp.skill.NONE, bonusAcc)
+    dmg = adjustForTarget(target, dmg, dsp.magic.ele.WATER)
 
-    dmg = takeAbilityDamage(target, player, {}, true, dmg, dsp.slot.RANGED, 1, shadowsAbsorbed, 0, 0, action, nil)
-    
-    if shadowsAbsorbed == 0 then
+    params.targetTPMult = 0 -- Quick Draw does not feed TP
+    dmg = takeAbilityDamage(target, player, params, true, dmg, dsp.slot.RANGED, 1, 0, 0, 0, action, nil)
+
+    if dmg > 0 then
         local effects = {}
-        local counter = 1
         local drown = target:getStatusEffect(dsp.effect.DROWN)
-        if (drown ~= nil) then
-            effects[counter] = drown
-            counter = counter + 1
+        if drown ~= nil then
+            table.insert(effects, drown)
         end
+
         local poison = target:getStatusEffect(dsp.effect.POISON)
-        if (poison ~= nil) then
-            effects[counter] = poison
-            counter = counter + 1
+        if poison ~= nil then
+            table.insert(effects, poison)
         end
+
         local threnody = target:getStatusEffect(dsp.effect.THRENODY)
-        if (threnody ~= nil and threnody:getSubPower() == dsp.mod.FIRERES) then
-            effects[counter] = threnody
-            counter = counter + 1
+        if threnody ~= nil and threnody:getSubPower() == dsp.mod.FIRERES then
+            table.insert(effects, threnody)
         end
         
-        if counter > 1 then
-            local effect = effects[math.random(1, counter-1)]
+        if #effects > 0 then
+            local effect = effects[math.random(#effects)]
             local duration = effect:getDuration()
             local startTime = effect:getStartTime()
             local tick = effect:getTick()

--- a/scripts/globals/abilities/wind_shot.lua
+++ b/scripts/globals/abilities/wind_shot.lua
@@ -3,53 +3,46 @@
 -- Consumes a Wind Card to enhance wind-based debuffs. Deals wind-based magic damage
 -- Choke Effect: Enhanced DoT and VIT-
 -----------------------------------
-require("scripts/globals/settings")
-require("scripts/globals/status")
-require("scripts/globals/magic")
-require("scripts/globals/weaponskills")
 require("scripts/globals/ability")
+require("scripts/globals/magic")
+require("scripts/globals/status")
 -----------------------------------
 
-function onAbilityCheck(player,target,ability)
+function onAbilityCheck(player, target, ability)
     --ranged weapon/ammo: You do not have an appropriate ranged weapon equipped.
     --no card: <name> cannot perform that action.
-    if (player:getWeaponSkillType(dsp.slot.RANGED) ~= dsp.skill.MARKSMANSHIP or player:getWeaponSkillType(dsp.slot.AMMO) ~= dsp.skill.MARKSMANSHIP) then
-        return 216,0
+    if player:getWeaponSkillType(dsp.slot.RANGED) ~= dsp.skill.MARKSMANSHIP or player:getWeaponSkillType(dsp.slot.AMMO) ~= dsp.skill.MARKSMANSHIP then
+        return 216, 0
     end
-    if (player:hasItem(2178, 0) or player:hasItem(2974, 0)) then
-        return 0,0
+    if player:hasItem(2178, 0) or player:hasItem(2974, 0) then
+        return 0, 0
     else
         return 71, 0
     end
 end
 
-function onUseAbility(player,target,ability,action)
+function onUseAbility(player, target, ability, action)
     local params = {}
     params.includemab = true
-    local dmg = (2 * player:getRangedDmg() + player:getAmmoDmg() + player:getMod(dsp.mod.QUICK_DRAW_DMG)) * 1 + player:getMod(dsp.mod.QUICK_DRAW_DMG_PERCENT)/100
+    local dmg = (2 * (player:getRangedDmg() + player:getAmmoDmg()) + player:getMod(dsp.mod.QUICK_DRAW_DMG)) * (1 + player:getMod(dsp.mod.QUICK_DRAW_DMG_PERCENT) / 100)
     dmg  = addBonusesAbility(player, dsp.magic.ele.WIND, target, dmg, params)
-    dmg = dmg * applyResistanceAbility(player,target,dsp.magic.ele.WIND,dsp.skill.MARKSMANSHIP, (player:getStat(dsp.mod.AGI)/2) + player:getMerit(dsp.merit.QUICK_DRAW_ACCURACY))
-    dmg = adjustForTarget(target,dmg,dsp.magic.ele.WIND)
-    
-    local shadowsAbsorbed = 0
-    if shadowAbsorb(target) then
-        shadowsAbsorbed = 1
-    end
+    local bonusAcc = player:getStat(dsp.mod.AGI) / 2 + player:getMerit(dsp.merit.QUICK_DRAW_ACCURACY) + player:getMod(dsp.mod.QUICK_DRAW_MACC)
+    dmg = dmg * applyResistanceAbility(player, target, dsp.magic.ele.WIND, dsp.skill.NONE, bonusAcc)
+    dmg = adjustForTarget(target, dmg, dsp.magic.ele.WIND)
 
-    dmg = takeAbilityDamage(target, player, {}, true, dmg, dsp.slot.RANGED, 1, shadowsAbsorbed, 0, 0, action, nil)
+    params.targetTPMult = 0 -- Quick Draw does not feed TP
+    dmg = takeAbilityDamage(target, player, params, true, dmg, dsp.slot.RANGED, 1, 0, 0, 0, action, nil)
     
-    if shadowsAbsorbed == 0 then
+    if dmg > 0 then
         local effects = {}
-        local counter = 1
         local choke = target:getStatusEffect(dsp.effect.CHOKE)
-        if (choke ~= nil) then
-            effects[counter] = choke
-            counter = counter + 1
+        if choke ~= nil then
+            table.insert(effects, choke)
         end
+
         local threnody = target:getStatusEffect(dsp.effect.THRENODY)
-        if (threnody ~= nil and threnody:getSubPower() == dsp.mod.EARTHRES) then
-            effects[counter] = threnody
-            counter = counter + 1
+        if threnody ~= nil and threnody:getSubPower() == dsp.mod.EARTHRES then
+            table.insert(effects, threnody)
         end
         --TODO: Frightful Roar
         --[[local frightfulRoar = target:getStatusEffect(dsp.effect.)
@@ -58,8 +51,8 @@ function onUseAbility(player,target,ability,action)
             counter = counter + 1
         end]]
         
-        if counter > 1 then
-            local effect = effects[math.random(1, counter-1)]
+        if #effects > 0 then
+            local effect = effects[math.random(#effects)]
             local duration = effect:getDuration()
             local startTime = effect:getStartTime()
             local tick = effect:getTick()

--- a/scripts/globals/status.lua
+++ b/scripts/globals/status.lua
@@ -1314,6 +1314,7 @@ dsp.mod =
     SONG_SPELLCASTING_TIME          = 455, --
 
     QUICK_DRAW_DMG                  = 411, --
+    QUICK_DRAW_MACC                 = 191, -- Quick draw magic accuracy
     QUAD_ATTACK                     = 430, -- Quadruple attack chance.
 
     ADDITIONAL_EFFECT               = 431, -- All additional effects

--- a/sql/item_mods.sql
+++ b/sql/item_mods.sql
@@ -23426,7 +23426,8 @@ INSERT INTO `item_mods` VALUES (19006,30,10);  -- Tizone 75 - Magic Accuracy+10
 INSERT INTO `item_mods` VALUES (19006,256,32); -- Aftermath
 INSERT INTO `item_mods` VALUES (19006,355,46); -- Expiacion
 INSERT INTO `item_mods` VALUES (19006,431,1);  -- Additional Effect - scripts\globals\items\tizona.lua
-INSERT INTO `item_mods` VALUES (19007,256,33);  -- Death Penalty 75 - Aftermath
+INSERT INTO `item_mods` VALUES (19007,191,20);  -- Death Pentalty 75 - Enhances "Quick Draw" effect (MACC+20)
+INSERT INTO `item_mods` VALUES (19007,256,33);  -- Aftermath
 INSERT INTO `item_mods` VALUES (19007,355,218); -- Leaden Salute
 INSERT INTO `item_mods` VALUES (19007,834,20);  -- Enhances "Quick Draw" effect (Damage +20%)
 INSERT INTO `item_mods` VALUES (19008,125,1);  -- Kenkonken 75 - Supresses "Overload"
@@ -23578,7 +23579,8 @@ INSERT INTO `item_mods` VALUES (19075,30,10);  -- Tizona 80 - Magic Accuracy+10
 INSERT INTO `item_mods` VALUES (19075,256,37); -- Aftermath
 INSERT INTO `item_mods` VALUES (19075,355,46); -- Expiacion
 INSERT INTO `item_mods` VALUES (19075,431,1);  -- Additional Effect - scripts\globals\items\tizona.lua
-INSERT INTO `item_mods` VALUES (19076,256,38);  -- Death Penalty 80 - Aftermath
+INSERT INTO `item_mods` VALUES (19076,191,20);  -- Death Penalty 80 - Enhances "Quick Draw" effect II (MACC+30)
+INSERT INTO `item_mods` VALUES (19076,256,38);  -- Aftermath
 INSERT INTO `item_mods` VALUES (19076,355,218); -- Leaden Salute
 INSERT INTO `item_mods` VALUES (19076,834,30);  -- Enhances "Quick Draw" effect II (Quick Draw damage +30%)
 INSERT INTO `item_mods` VALUES (19077,125,1);  -- Kenkonken 80 - Suppresses "Overload"
@@ -23655,7 +23657,8 @@ INSERT INTO `item_mods` VALUES (19095,30,15);  -- Tizona 85 - Magic Accuracy+15
 INSERT INTO `item_mods` VALUES (19095,256,37); -- Aftermath
 INSERT INTO `item_mods` VALUES (19095,355,46); -- Expiacion
 INSERT INTO `item_mods` VALUES (19095,431,1);  -- Additional Effect - scripts\globals\items\tizona.lua
-INSERT INTO `item_mods` VALUES (19096,256,38);  -- Death Penalty 85 - Aftermath
+INSERT INTO `item_mods` VALUES (19096,191,40);  -- Death Penalty 85 - Enhances "Quick Draw" effect II (MACC+40)
+INSERT INTO `item_mods` VALUES (19096,256,38);  -- Aftermath
 INSERT INTO `item_mods` VALUES (19096,355,218); -- Leaden Salute
 INSERT INTO `item_mods` VALUES (19096,834,40);  -- Enhances "Quick Draw" effect III (Damage+40%)
 INSERT INTO `item_mods` VALUES (19097,125,1);  -- Kenkonken 85 - Suppresses "Overload"
@@ -24118,7 +24121,8 @@ INSERT INTO `item_mods` VALUES (19627,256,37); -- Aftermath
 INSERT INTO `item_mods` VALUES (19627,355,46); -- Expiacion
 INSERT INTO `item_mods` VALUES (19627,431,1);  -- Additional Effect - scripts\globals\items\tizona.lua
 INSERT INTO `item_mods` VALUES (19627,616,15); -- Expiacion WS DMG +15%
-INSERT INTO `item_mods` VALUES (19628,256,38);  -- Death Penalty 90 - Aftermath
+INSERT INTO `item_mods` VALUES (19628,191,50);  -- Death Penalty 90 - Enhances "Quick Draw" effect IV (MACC+50)
+INSERT INTO `item_mods` VALUES (19628,256,38);  -- Aftermath
 INSERT INTO `item_mods` VALUES (19628,355,218); -- Leaden Salute
 INSERT INTO `item_mods` VALUES (19628,788,15);  -- Leadend Salute WS DMG +15%
 INSERT INTO `item_mods` VALUES (19628,834,50);  -- Enahnces "Quick Draw" effect IV (DMG+50%)
@@ -24260,7 +24264,8 @@ INSERT INTO `item_mods` VALUES (19725,256,42); -- Aftermath
 INSERT INTO `item_mods` VALUES (19725,355,46); -- Expiacion
 INSERT INTO `item_mods` VALUES (19725,431,1);  -- Additional Effect - scripts\globals\items\tizona.lua
 INSERT INTO `item_mods` VALUES (19725,616,15); -- Expiacion WS DMG +15%
-INSERT INTO `item_mods` VALUES (19726,256,43);  -- Death Penalty 95 - Aftermath
+INSERT INTO `item_mods` VALUES (19726,191,50);  -- Death Penalty 95 - Enhances "Quick Draw" effect IV (MACC+50)
+INSERT INTO `item_mods` VALUES (19726,256,43);  -- Aftermath
 INSERT INTO `item_mods` VALUES (19726,355,218); -- Leaden Salute
 INSERT INTO `item_mods` VALUES (19726,788,15);  -- Leaden Salute WS damage +15%
 INSERT INTO `item_mods` VALUES (19726,834,50);  -- Enhances "Quick Draw" effect IV (Damage+50%)
@@ -24576,7 +24581,8 @@ INSERT INTO `item_mods` VALUES (19834,256,42); -- Aftermath
 INSERT INTO `item_mods` VALUES (19834,355,46); -- Expiacion
 INSERT INTO `item_mods` VALUES (19834,431,1);  -- Additional Effect - scripts\globals\items\tizona.lua
 INSERT INTO `item_mods` VALUES (19834,616,30); -- Expiacion WS DMG +30%
-INSERT INTO `item_mods` VALUES (19835,256,43);  -- Death Penalty 99 - Aftermath
+INSERT INTO `item_mods` VALUES (19835,191,60);  -- Death Penalty 99 - Enhances "Quick Draw" effect V (MACC+60)
+INSERT INTO `item_mods` VALUES (19835,256,43);  -- Aftermath
 INSERT INTO `item_mods` VALUES (19835,355,218); -- Leaden Salute
 INSERT INTO `item_mods` VALUES (19835,788,30);  -- Leaden Salute WS damage +30%
 INSERT INTO `item_mods` VALUES (19835,834,60);  -- Enhances "Quick Draw" effect V (DMG+60%)
@@ -24817,7 +24823,8 @@ INSERT INTO `item_mods` VALUES (19963,256,42);  -- Aftermath
 INSERT INTO `item_mods` VALUES (19963,355,46);  -- Tizona 99 - Expiacion
 INSERT INTO `item_mods` VALUES (19963,431,1);   -- Additional Effect
 INSERT INTO `item_mods` VALUES (19963,616,30);  -- Expiacion WS DMG +30%
-INSERT INTO `item_mods` VALUES (19964,256,43);  -- Death Penalty 99 AG - Aftermath
+INSERT INTO `item_mods` VALUES (19964,191,60);  -- Death Penalty 99 AG - Enhances "Quick Draw" effect V (MACC+60)
+INSERT INTO `item_mods` VALUES (19964,256,43);  -- Aftermath
 INSERT INTO `item_mods` VALUES (19964,355,218); -- Leaden Salute
 INSERT INTO `item_mods` VALUES (19964,788,30);  -- Leaden Salute WS DMG +30%
 INSERT INTO `item_mods` VALUES (19964,834,60);  -- Enhances "Quick Draw" effect V (DMG+60%)
@@ -26103,11 +26110,13 @@ INSERT INTO `item_mods` VALUES (21261,355,216); -- Coronach
 INSERT INTO `item_mods` VALUES (21261,506,130); -- Extra DMG Chance 13%
 INSERT INTO `item_mods` VALUES (21261,507,300); -- Extra DMG X3
 INSERT INTO `item_mods` VALUES (21261,786,40); -- Coronach DMG +40%
-INSERT INTO `item_mods` VALUES (21262,256,43);  -- Death Penalty 119 - Aftermath
+INSERT INTO `item_mods` VALUES (21262,191,60);  -- Death Penalty 119 - Enhances "Quick Draw" effect V (MACC+60)
+INSERT INTO `item_mods` VALUES (21262,256,43);  -- Aftermath
 INSERT INTO `item_mods` VALUES (21262,355,218); -- Leaden Salute
 INSERT INTO `item_mods` VALUES (21262,788,30);  -- Leaden Salute WS damage +30%
 INSERT INTO `item_mods` VALUES (21262,834,60);  -- Enhances "Quick Draw" effect V (DMG+60%)
-INSERT INTO `item_mods` VALUES (21263,256,43);  -- Death Penalty 119 AG - Aftermath
+INSERT INTO `item_mods` VALUES (21263,191,60);  -- Death Penalty 119 AG - Enhances "Quick Draw" effect V (MACC+60)
+INSERT INTO `item_mods` VALUES (21263,256,43);  -- Aftermath
 INSERT INTO `item_mods` VALUES (21263,355,218); -- Leaden Salute
 INSERT INTO `item_mods` VALUES (21263,788,30);  -- Leaden Salute WS damage +30%
 INSERT INTO `item_mods` VALUES (21263,834,60);  -- Enhances "Quick Draw" effect V (DMG+60%)
@@ -26132,7 +26141,8 @@ INSERT INTO `item_mods` VALUES (21267,355,216); -- Coronach
 INSERT INTO `item_mods` VALUES (21267,506,130); -- Extra DMG Chance 13%
 INSERT INTO `item_mods` VALUES (21267,507,300); -- Extra DMG X3
 INSERT INTO `item_mods` VALUES (21267,786,40); -- Coronach DMG +40%
-INSERT INTO `item_mods` VALUES (21268,256,43);  -- Death Penalty 119 III - Aftermath
+INSERT INTO `item_mods` VALUES (21268,191,60);  -- Death Penalty 119 III - Enhances "Quick Draw" effect V (MACC+60)
+INSERT INTO `item_mods` VALUES (21268,256,43);  -- Aftermath
 INSERT INTO `item_mods` VALUES (21268,311,217); -- Magic Damage+217
 INSERT INTO `item_mods` VALUES (21268,355,218); -- Leaden Salute
 INSERT INTO `item_mods` VALUES (21268,788,30);  -- Leaden Salute WS DMG +30%

--- a/src/map/modifier.h
+++ b/src/map/modifier.h
@@ -475,6 +475,7 @@ enum class Mod
     BUST                      = 332, // # of busts
     QUICK_DRAW_DMG            = 411, // Flat damage increase to base QD damage
     QUICK_DRAW_DMG_PERCENT    = 834, // Percentage increase to QD damage
+    QUICK_DRAW_MACC           = 191, // Quick draw magic accuracy
     PHANTOM_ROLL              = 881, // Phantom Roll+ Effect from SOA Rings.
     PHANTOM_DURATION          = 882, // Phantom Roll Duration +.
 


### PR DESCRIPTION
* Fixed Quick Draw damage calculation (was multiplying ranged weapon dmg by 2 and then adding ammo dmg)
* Added Quick Draw Magic Accuracy mod (added mod to Death Penalty)
* Removed marksmanship skill from the accuracy check
* Quick Draw should ignore shadows, gutted that nonsense
* Cleaned up and formatted the *_shot.lua scripts
* Quick Draw doesn't give the target TP

Made sure all shots still work. Light shot still sleeps. Dark shot still dispels.