### PR TITLE
Pvs high nov

### DIFF
--- a/src/login/login.cpp
+++ b/src/login/login.cpp
@@ -150,7 +150,8 @@ int32 do_init(int32 argc, char** argv)
                         if (inputs[0] == "verlock")
                         {
                             // handle wrap around from 2->3 as 0
-                            version_info.ver_lock = (++version_info.ver_lock % 3);
+                            auto temp = (++version_info.ver_lock) % 3;
+                            version_info.ver_lock = temp;
 
                             auto value = "";
                             switch (version_info.ver_lock)

--- a/src/map/ai/states/magic_state.cpp
+++ b/src/map/ai/states/magic_state.cpp
@@ -292,31 +292,38 @@ void CMagicState::ApplyEnmity(CBattleEntity* PTarget, int ce, int ve)
         m_PEntity->addModifier(Mod::ENMITY, -(m_PEntity->getMod(Mod::DIVINE_BENISON) >> 1)); // Half of divine benison mod amount = -enmity
     }
 
-    if (PTarget->objtype == TYPE_MOB && PTarget->allegiance != m_PEntity->allegiance)
+    if (PTarget != nullptr)
     {
-        if (PTarget->isDead())
+        if (PTarget->objtype == TYPE_MOB && PTarget->allegiance != m_PEntity->allegiance)
         {
-            ((CMobEntity*)PTarget)->m_DropItemTime = m_PSpell->getAnimationTime();
-        }
-
-        if (!(m_PSpell->isHeal()) || m_PSpell->tookEffect())  //can't claim mob with cure unless it does damage
-        {
-            if (m_PEntity->objtype == TYPE_PC)
+            auto mob = dynamic_cast<CMobEntity*>(PTarget);
+            if (mob != nullptr)
             {
-                ((CMobEntity*)PTarget)->m_OwnerID.id = m_PEntity->id;
-                ((CMobEntity*)PTarget)->m_OwnerID.targid = m_PEntity->targid;
-                ((CMobEntity*)PTarget)->updatemask |= UPDATE_STATUS;
+                if (PTarget->isDead())
+                {
+                    mob->m_DropItemTime = m_PSpell->getAnimationTime();
+                }
+
+                if (!(m_PSpell->isHeal()) || m_PSpell->tookEffect())  //can't claim mob with cure unless it does damage
+                {
+                    if (m_PEntity->objtype == TYPE_PC)
+                    {
+                        mob->m_OwnerID.id = m_PEntity->id;
+                        mob->m_OwnerID.targid = m_PEntity->targid;
+                        mob->updatemask |= UPDATE_STATUS;
+                    }
+                    mob->PEnmityContainer->UpdateEnmity(m_PEntity, ce, ve);
+                    if (mob->m_HiPCLvl < m_PEntity->GetMLevel())
+                        mob->m_HiPCLvl = m_PEntity->GetMLevel();
+                    enmityApplied = true;
+                }
             }
-            ((CMobEntity*)PTarget)->PEnmityContainer->UpdateEnmity(m_PEntity, ce, ve);
-            if (PTarget && ((CMobEntity*)PTarget)->m_HiPCLvl < m_PEntity->GetMLevel())
-                ((CMobEntity*)PTarget)->m_HiPCLvl = m_PEntity->GetMLevel();
+        }
+        else if (PTarget->allegiance == m_PEntity->allegiance)
+        {
+            battleutils::GenerateInRangeEnmity(m_PEntity, ce, ve);
             enmityApplied = true;
         }
-    }
-    else if (PTarget->allegiance == m_PEntity->allegiance)
-    {
-        battleutils::GenerateInRangeEnmity(m_PEntity, ce, ve);
-        enmityApplied = true;
     }
 
     if (m_PEntity->StatusEffectContainer->HasStatusEffect(EFFECT_TRANQUILITY) && m_PSpell->getSpellGroup() == SPELLGROUP_WHITE)

--- a/src/map/ai/states/state.h
+++ b/src/map/ai/states/state.h
@@ -31,7 +31,7 @@
 
 class CBattleEntity;
 
-class CStateInitException : std::exception
+class CStateInitException : public std::exception
 {
 public:
     explicit CStateInitException(std::unique_ptr<CBasicPacket> _msg) : std::exception(),

--- a/src/map/entities/baseentity.cpp
+++ b/src/map/entities/baseentity.cpp
@@ -30,24 +30,24 @@
 
 CBaseEntity::CBaseEntity()
 {
+    id = 0;
+    targid = 0;
+    objtype = ENTITYTYPE::TYPE_NONE;
+    status = STATUS_DISAPPEAR;
 	m_TargID = 0;
+    memset(&look, 0, sizeof(look));
+    memset(&mainlook, 0, sizeof(mainlook));
+    memset(&loc, 0, sizeof(loc));
+    animation = ANIMATION_NONE;
+    animationsub = 0;
+    speed = 40 + map_config.speed_mod;
+    speedsub = 40 + map_config.speed_mod;
 	namevis = 1;
-
+    allegiance = 0;
+    updatemask = 0;
     PAI = nullptr;
 	PBCNM = nullptr;
 	PInstance = nullptr;
-
-	speed    = 40 + map_config.speed_mod;
-	speedsub = 40 + map_config.speed_mod;
-
-	animationsub = 0;
-	animation    = ANIMATION_NONE;
-
-	status = STATUS_DISAPPEAR;
-    updatemask = 0;
-
-	memset(&loc,  0, sizeof(loc));
-	memset(&look, 0, sizeof(look));
 }
 
 CBaseEntity::~CBaseEntity()

--- a/src/map/entities/baseentity.h
+++ b/src/map/entities/baseentity.h
@@ -32,6 +32,7 @@
 
 enum ENTITYTYPE
 {
+    TYPE_NONE   = 0x00,
     TYPE_PC     = 0x01,
     TYPE_NPC    = 0x02,
     TYPE_MOB    = 0x04,

--- a/src/map/items/item_shop.cpp
+++ b/src/map/items/item_shop.cpp
@@ -26,12 +26,11 @@
 
 CItemShop::CItemShop(uint16 id) : CItem(id)
 {
-	// SetType(ITEM_SHOP);
-
 	m_MinPrice = 0;
 	m_MaxPrice = 0;
 
-	m_DailyIncrease = false;
+	m_DailyIncrease = 0;
+    m_InitialQuantity = 0;
 }
 
 CItemShop::~CItemShop()
@@ -56,7 +55,7 @@ bool CItemShop::IsInMenu()
 
 bool CItemShop::IsDailyIncrease()
 {
-	return m_DailyIncrease;
+	return m_DailyIncrease != 0;
 }
 
 void CItemShop::setMinPrice(uint32 price)

--- a/src/map/linkshell.cpp
+++ b/src/map/linkshell.cpp
@@ -50,9 +50,8 @@
 *                                                                       *
 ************************************************************************/
 
-CLinkshell::CLinkshell(uint32 id)
+CLinkshell::CLinkshell(uint32 id) : m_id(id), m_color(0)
 {
-    m_id = id;
 }
 
 uint32 CLinkshell::getID()

--- a/src/map/packet_system.cpp
+++ b/src/map/packet_system.cpp
@@ -3972,7 +3972,7 @@ void SmallPacket0x0B5(map_session_data_t* session, CCharEntity* PChar, CBasicPac
                         std::string qStr = ("INSERT INTO audit_chat (speaker,type,lsName,message,datetime) VALUES('");
                         qStr += (const char*)PChar->GetName();
                         qStr += "','LINKSHELL','";
-                        qStr += name.c_str();
+                        qStr += name;
                         qStr += "','";
                         qStr += escape((const char*)data[6]);
                         qStr += "',current_timestamp());";
@@ -3998,7 +3998,7 @@ void SmallPacket0x0B5(map_session_data_t* session, CCharEntity* PChar, CBasicPac
                         std::string qStr = ("INSERT INTO audit_chat (speaker,type,lsName,message,datetime) VALUES('");
                         qStr += (const char*)PChar->GetName();
                         qStr += "','LINKSHELL','";
-                        qStr += name.c_str();
+                        qStr += name;
                         qStr += "','";
                         qStr += escape((const char*)data[6]);
                         qStr += "',current_timestamp());";
@@ -4096,7 +4096,7 @@ void SmallPacket0x0B6(map_session_data_t* session, CCharEntity* PChar, CBasicPac
         std::string qStr = ("INSERT into audit_chat (speaker,type,recipient,message,datetime) VALUES('");
         qStr += (const char*)PChar->GetName();
         qStr += "','TELL','";
-        qStr += RecipientName.c_str();
+        qStr += RecipientName;
         qStr += "','";
         qStr += escape((const char*)data[20]);
         qStr += "',current_timestamp());";
@@ -4221,7 +4221,6 @@ void SmallPacket0x0C4(map_session_data_t* session, CCharEntity* PChar, CBasicPac
         {
             uint32   LinkshellID = 0;
             uint16   LinkshellColor = data.ref<uint16>(0x04);
-            string_t LinkshellName = (const char*)data[12];
             int8     DecodedName[21];
             int8     EncodedName[16];
 
@@ -5465,7 +5464,7 @@ void SmallPacket0x102(map_session_data_t* session, CCharEntity* PChar, CBasicPac
                     CBlueSpell* spell = (CBlueSpell*)spell::GetSpell(static_cast<SpellID>(spellInQuestion + 0x200)); // the spells in this packet are offsetted by 0x200 from their spell IDs.
 
                     if (spell != nullptr) {
-                        blueutils::SetBlueSpell(PChar, spell, spellIndex, (spellToAdd > 0));
+                        blueutils::SetBlueSpell(PChar, spell, spellIndex, false);
                     }
                     else {
                         ShowDebug("Cannot resolve spell id \n");

--- a/src/map/party.cpp
+++ b/src/map/party.cpp
@@ -88,14 +88,17 @@ CParty::CParty(CBattleEntity* PEntity)
 
 CParty::CParty(uint32 id)
 {
+    m_PAlliance = nullptr;
+
     m_PartyID = id;
     m_PartyType = PARTY_PCS;
     m_PartyNumber = 0;
 
     m_PLeader = nullptr;
-    m_PAlliance = nullptr;
     m_PSyncTarget = nullptr;
     m_PQuaterMaster = nullptr;
+
+    m_EffectsChanged = false;
 }
 
 /************************************************************************

--- a/src/map/utils/battlefieldutils.cpp
+++ b/src/map/utils/battlefieldutils.cpp
@@ -179,7 +179,7 @@ namespace battlefieldutils {
                 }
                 else
                 {
-                    ShowDebug(CL_CYAN"spawnTreasureForBcnm: <%s> is already spawned\n" CL_RESET, PNpc->GetName());
+                    ShowDebug(CL_CYAN"spawnTreasureForBcnm: is already spawned\n" CL_RESET);
                 }
             }
             return true;

--- a/src/map/weapon_skill.cpp
+++ b/src/map/weapon_skill.cpp
@@ -27,18 +27,18 @@
 CWeaponSkill::CWeaponSkill(uint16 id)
 {
 	m_ID = id;
-
+    m_TypeID = 0;
+    memset(m_Job, 0, sizeof(m_Job));
+    m_Skilllevel = 0;
 	m_AnimationId = 0;
-	m_AOE         = 0;
-	m_Skilllevel  = 0;
-	m_TypeID      = 0;
-	m_Range       = 0;
-	m_PrimarySkillchain   = SC_NONE;
+    m_Element = 0;
+    m_PrimarySkillchain = SC_NONE;
     m_SecondarySkillchain = SC_NONE;
-    m_TertiarySkillchain  = SC_NONE;
+    m_TertiarySkillchain = SC_NONE;
+    m_Range = 0;
+    m_AOE = 0;
     m_mainOnly = 0;
-
-	memset(m_Job, 0, sizeof(m_Job));
+    m_unlockId = 0;
 }
 
 void CWeaponSkill::setID(uint16 id)

--- a/src/search/data_loader.cpp
+++ b/src/search/data_loader.cpp
@@ -475,7 +475,6 @@ void CDataLoader::ExpireAHItems()
     {
         while (Sql_NextRow(SqlHandle) == SQL_SUCCESS)
         {
-            std::string qStr2;
             // iterate through the expired auctions and return them to the seller
             uint32 saleID = (uint32)Sql_GetUIntData(SqlHandle, 0);
             uint32 itemID = (uint32)Sql_GetUIntData(SqlHandle, 1);

--- a/src/search/tcp_request.cpp
+++ b/src/search/tcp_request.cpp
@@ -56,11 +56,8 @@ typedef u_int SOCKET;
 *                                                                       *
 ************************************************************************/
 
-CTCPRequestPacket::CTCPRequestPacket(SOCKET* socket)
+CTCPRequestPacket::CTCPRequestPacket(SOCKET* socket) : m_data(nullptr), m_size(0), m_socket(socket), blowfish(blowfish_t())
 {
-    m_data = nullptr;
-    m_socket = socket;
-
     uint8 keys[24] =
     {
         0x30, 0x73, 0x3D, 0x6D,


### PR DESCRIPTION
- do_init - compiler "could" reorder expression calculation producing undefined behavior
- CStateInitException inheriting non public std::exception prevent implicit type conversion in a catch all
- CDataLoader::ExpireAHItems has unused qStr2 (you will not be missed)
- CTCPRequestPacket has missing members from constructor
- CMagicState - check objects for nullptr before use and cleanup some
casting use
- CAlliance - updating some iterator usage to newer
algorithms/range-for, fixing uninitialized constructor members
- CBaseEntity - fixing unitialized constructor members, adding TYPE_NONE
- CItemShop - fixing unitialized constructor members, false.....
- CLinkshell - fixing unitialized constructor members
- CWeaponskill - fixing unitialized constructor members
- Battlefield Utils - ShowDebug deferencing null CBaseEntity*
- Packet System - call to SetBlueSpell always had false expression for addingSpell, string -> char* -> string conversions, LinkshellName created and not used
- CParty - fixing unitialized constructor members