### PR TITLE
clang fixes nov

### DIFF
--- a/src/map/entities/mobentity.h
+++ b/src/map/entities/mobentity.h
@@ -168,9 +168,9 @@ public:
     virtual void OnMobSkillFinished(CMobSkillState&, action_t&);
     virtual void OnEngage(CAttackState&) override;
 
-    virtual bool OnAttack(CAttackState&, action_t&);
+    virtual bool OnAttack(CAttackState&, action_t&) override;
     virtual bool CanAttack(CBattleEntity* PTarget, std::unique_ptr<CBasicPacket>& errMsg) override;
-    virtual void OnCastFinished(CMagicState&, action_t&);
+    virtual void OnCastFinished(CMagicState&, action_t&) override;
 
     virtual void OnDisengage(CAttackState&) override;
     virtual void OnDeathTimer() override;public:

--- a/src/map/packets/menu_merit.h
+++ b/src/map/packets/menu_merit.h
@@ -22,7 +22,7 @@
 */
 
 #ifndef _CMENUMERITPACKET_H
-#define _CMENUMERTIPACKET_H
+#define _CMENUMERITPACKET_H
 
 #include "../../common/cbasetypes.h"
 

--- a/src/map/trait.cpp
+++ b/src/map/trait.cpp
@@ -120,7 +120,7 @@ namespace traits
 
     TraitList_t* GetTraits(uint8 JobID)
     {
-        DSP_DEBUG_BREAK_IF(JobID >= sizeof(PTraitsList));
+        DSP_DEBUG_BREAK_IF(JobID >= MAX_JOBTYPE);
 
 	    return &PTraitsList[JobID];
     }

--- a/src/map/utils/itemutils.cpp
+++ b/src/map/utils/itemutils.cpp
@@ -110,7 +110,7 @@ namespace itemutils
 
     CItem* GetItem(uint16 ItemID)
     {
-        if( (ItemID == 0xFFFF) )
+        if (ItemID == 0xFFFF)
         {
             return new CItemCurrency(ItemID);
         }

--- a/src/search/search.cpp
+++ b/src/search/search.cpp
@@ -121,7 +121,7 @@ void PrintPacket(char* data, int size)
     {
         char msgtmp[50];
         memset(&msgtmp, 0, 50);
-        sprintf(msgtmp, "%s %02hx", message, (uint8)data[y]);
+        sprintf(msgtmp, "%s %02ux", message, (uint8)data[y]);
         strncpy(message, msgtmp, 50);
         if (((y + 1) % 16) == 0)
         {


### PR DESCRIPTION
- CTrait - GetTraits incorrectly checks against the size of PTraitsList instead of MAX_JOBTYPE
- CItem - extra parentheses
- Search - print packet converting uint8 to short in format string
- MobEntity - missing override specifier from onAttack, onCastFinished
- menu_merit.h - incorrect define for header guard