### PR TITLE
Promyvion global and portal randomizing

### DIFF
--- a/scripts/globals/promyvion.lua
+++ b/scripts/globals/promyvion.lua
@@ -1,0 +1,153 @@
+require("scripts/zones/Promyvion-Dem/IDs")
+require("scripts/zones/Promyvion-Holla/IDs")
+require("scripts/zones/Promyvion-Mea/IDs")
+require("scripts/zones/Promyvion-Vahzl/IDs")
+require("scripts/globals/status")
+------------------------------------
+
+dsp = dsp or {}
+dsp.promyvion = dsp.promyvion or {}
+
+------------------------------------
+-- LOCAL FUNCTIONS
+------------------------------------
+
+local function maxFloor(ID)
+    local m = 0
+
+    for _, v in pairs(ID.mob.MEMORY_RECEPTACLES) do
+        m = math.max(m, v[1])
+    end
+
+    return m
+end
+
+local function randomizeFloorExit(ID, floor)
+    local streams = {}
+
+    for _, v in pairs(ID.mob.MEMORY_RECEPTACLES) do
+        if v[1] == floor then
+            GetNPCByID(v[3]):setLocalVar("[promy]floorExit", 0)
+            table.insert(streams, v[3])
+        end
+    end
+
+    local exitStreamId = streams[math.random(#streams)]
+    GetNPCByID(exitStreamId):setLocalVar("[promy]floorExit", 1)
+end
+
+local function findMother(mob)
+    local ID = zones[mob:getZoneID()]
+    local mobId = mob:getID()
+    local mother = 0
+    for k, v in pairs(ID.mob.MEMORY_RECEPTACLES) do
+        if k < mobId and k > mother then
+            mother = k
+        end
+    end
+    return mother
+end
+
+local function checkStray(mob)
+    local ID = zones[mob:getZoneID()]
+    local mobId = mob:getID()
+    local numStrays = ID.mob.MEMORY_RECEPTACLES[mobId][2]
+
+    if os.time() > mob:getLocalVar("[promy]nextStray") then
+        for i = mobId + 1, mobId + numStrays do
+            local stray = GetMobByID(i)
+            if not stray:isSpawned() then
+                mob:setLocalVar("[promy]nextStray", os.time() + 20)
+                SpawnMob(stray:getID())
+                break
+            end
+        end
+    else
+        mob:AnimationSub(2)
+    end
+end
+
+------------------------------------
+-- PUBLIC FUNCTIONS
+------------------------------------
+
+dsp.promyvion.initZone = function(zone)
+    local ID = zones[zone:getID()]
+
+    -- register teleporter regions
+    for k, v in pairs(ID.npc.MEMORY_STREAMS) do
+        zone:registerRegion(k,v[1],v[2],v[3],v[4],v[5],v[6])
+    end
+
+    -- randomize floor exits
+    for i = 1, maxFloor(ID) do
+        randomizeFloorExit(ID, i)
+    end
+end
+
+dsp.promyvion.strayOnSpawn = function(mob)
+    local mother = GetMobByID(findMother(mob))
+
+    if mother ~= nil and mother:isSpawned() then
+        mob:setPos(mother:getXPos(), mother:getYPos() - 5, mother:getZPos())
+        mother:AnimationSub(1)
+    end
+end
+
+dsp.promyvion.receptacleOnFight = function(mob, target)
+    local ID = zones[mob:getZoneID()]
+    local mobId = mob:getID()
+    local numStrays = ID.mob.MEMORY_RECEPTACLES[mobId][2]
+
+    -- keep pets linked
+    for i = mobId + 1, mobId + numStrays do
+        local stray = GetMobByID(i)
+        if stray:isSpawned() then
+            stray:updateEnmity(target)
+        end
+    end
+
+    checkStray(mob)
+end
+
+dsp.promyvion.receptacleOnDeath = function(mob, isKiller)
+    if isKiller then
+        local ID = zones[mob:getZoneID()]
+        local mobId = mob:getID()
+        local floor = ID.mob.MEMORY_RECEPTACLES[mobId][1]
+        local streamId = ID.mob.MEMORY_RECEPTACLES[mobId][3]
+        local stream = GetNPCByID(streamId)
+
+        mob:AnimationSub(0)
+
+        -- open floor exit portal
+        if stream:getLocalVar("[promy]floorExit") == 1 then
+            randomizeFloorExit(ID, floor)
+            local events = ID.npc.MEMORY_STREAMS[streamId][7]
+            local event = events[math.random(#events)]
+            stream:setLocalVar("[promy]destination",event)
+            stream:openDoor(180)
+        end
+    end
+end
+
+dsp.promyvion.onRegionEnter = function(player, region)
+    if player:getAnimation() == 0 then
+        local ID = zones[player:getZoneID()]
+        local regionId = region:GetRegionID()
+        local event = nil
+
+        if regionId < 100 then
+            event = ID.npc.MEMORY_STREAMS[regionId][7][1]
+        else
+            local stream = GetNPCByID(regionId)
+            if stream ~= nil and stream:getAnimation() == dsp.anim.OPEN_DOOR then
+                event = stream:getLocalVar("[promy]destination")
+            end
+        end
+
+        if event ~= nil then
+            player:startEvent(event)
+        end
+    end
+end

--- a/scripts/globals/promyvion.lua
+++ b/scripts/globals/promyvion.lua
@@ -48,25 +48,6 @@ local function findMother(mob)
     return mother
 end
 
-local function checkStray(mob)
-    local ID = zones[mob:getZoneID()]
-    local mobId = mob:getID()
-    local numStrays = ID.mob.MEMORY_RECEPTACLES[mobId][2]
-
-    if os.time() > mob:getLocalVar("[promy]nextStray") then
-        for i = mobId + 1, mobId + numStrays do
-            local stray = GetMobByID(i)
-            if not stray:isSpawned() then
-                mob:setLocalVar("[promy]nextStray", os.time() + 20)
-                SpawnMob(stray:getID())
-                break
-            end
-        end
-    else
-        mob:AnimationSub(2)
-    end
-end
-
 ------------------------------------
 -- PUBLIC FUNCTIONS
 ------------------------------------
@@ -95,19 +76,23 @@ dsp.promyvion.strayOnSpawn = function(mob)
 end
 
 dsp.promyvion.receptacleOnFight = function(mob, target)
-    local ID = zones[mob:getZoneID()]
-    local mobId = mob:getID()
-    local numStrays = ID.mob.MEMORY_RECEPTACLES[mobId][2]
+    if os.time() > mob:getLocalVar("[promy]nextStray") then
+        local ID = zones[mob:getZoneID()]
+        local mobId = mob:getID()
+        local numStrays = ID.mob.MEMORY_RECEPTACLES[mobId][2]
 
-    -- keep pets linked
-    for i = mobId + 1, mobId + numStrays do
-        local stray = GetMobByID(i)
-        if stray:isSpawned() then
-            stray:updateEnmity(target)
+        for i = mobId + 1, mobId + numStrays do
+            local stray = GetMobByID(i)
+            if not stray:isSpawned() then
+                mob:setLocalVar("[promy]nextStray", os.time() + 20)
+                stray:spawn()
+                stray:updateEnmity(target)
+                break
+            end
         end
+    else
+        mob:AnimationSub(2)
     end
-
-    checkStray(mob)
 end
 
 dsp.promyvion.receptacleOnDeath = function(mob, isKiller)

--- a/scripts/zones/Promyvion-Dem/Zone.lua
+++ b/scripts/zones/Promyvion-Dem/Zone.lua
@@ -3,12 +3,12 @@
 -- Zone: Promyvion-Dem (18)
 --
 -----------------------------------
-local ID = require("scripts/zones/Promyvion-Dem/IDs");
+local ID = require("scripts/zones/Promyvion-Dem/IDs")
 require("scripts/globals/promyvion")
-require("scripts/globals/keyitems");
-require("scripts/globals/missions");
-require("scripts/globals/settings");
-require("scripts/globals/status");
+require("scripts/globals/keyitems")
+require("scripts/globals/missions")
+require("scripts/globals/settings")
+require("scripts/globals/status")
 -----------------------------------
 
 function onInitialize(zone)
@@ -16,57 +16,57 @@ function onInitialize(zone)
 end
 
 function onZoneIn(player,prevZone)
-    local cs = -1;
+    local cs = -1
 
-    if (player:getXPos() == 0 and player:getYPos() == 0 and player:getZPos() == 0) then
-        player:setPos(185.891, 0, -52.331, 128);
+    if player:getXPos() == 0 and player:getYPos() == 0 and player:getZPos() == 0 then
+        player:setPos(185.891, 0, -52.331, 128)
     end
 
-    if (player:getCurrentMission(COP) == BELOW_THE_ARKS and player:getVar("PromathiaStatus") == 2) then
-        player:completeMission(COP,BELOW_THE_ARKS);
-        player:addMission(COP,THE_MOTHERCRYSTALS); -- start mission 1.3
-        player:setVar("PromathiaStatus",0);
-    elseif (player:getCurrentMission(COP) == THE_MOTHERCRYSTALS) then
-        if (player:hasKeyItem(dsp.ki.LIGHT_OF_HOLLA) and player:hasKeyItem(dsp.ki.LIGHT_OF_MEA)) then
-            if (player:getVar("cslastpromy") == 1) then
-                player:setVar("cslastpromy",0)
-                cs = 52;
+    if player:getCurrentMission(COP) == BELOW_THE_ARKS and player:getVar("PromathiaStatus") == 2 then
+        player:completeMission(COP, BELOW_THE_ARKS)
+        player:addMission(COP, THE_MOTHERCRYSTALS)
+        player:setVar("PromathiaStatus", 0)
+    elseif player:getCurrentMission(COP) == THE_MOTHERCRYSTALS then
+        if player:hasKeyItem(dsp.ki.LIGHT_OF_HOLLA) and player:hasKeyItem(dsp.ki.LIGHT_OF_MEA) then
+            if player:getVar("cslastpromy") == 1 then
+                player:setVar("cslastpromy", 0)
+                cs = 52
             end
-        elseif (player:hasKeyItem(dsp.ki.LIGHT_OF_HOLLA) or player:hasKeyItem(dsp.ki.LIGHT_OF_MEA)) then
-            if (player:getVar("cs2ndpromy") == 1) then
-                player:setVar("cs2ndpromy",0)
-                cs = 51;
+        elseif player:hasKeyItem(dsp.ki.LIGHT_OF_HOLLA) or player:hasKeyItem(dsp.ki.LIGHT_OF_MEA) then
+            if player:getVar("cs2ndpromy") == 1 then
+                player:setVar("cs2ndpromy", 0)
+                cs = 51
             end
         end
     end
 
-    if (player:getVar("FirstPromyvionDem") == 1) then
-        cs = 50;
+    if player:getVar("FirstPromyvionDem") == 1 then
+        cs = 50
     end
 
-    return cs;
-end;
+    return cs
+end
 
 function afterZoneIn(player)
-    if (ENABLE_COP_ZONE_CAP == 1) then -- ZONE WIDE LEVEL RESTRICTION
-        player:addStatusEffect(dsp.effect.LEVEL_RESTRICTION,30,0,0); -- LV30 cap
+    if ENABLE_COP_ZONE_CAP == 1 then
+        player:addStatusEffect(dsp.effect.LEVEL_RESTRICTION, 30, 0, 0)
     end
-end;
+end
 
 function onRegionEnter(player,region)
     dsp.promyvion.onRegionEnter(player, region)
 end
 
 function onRegionLeave(player,region)
-end;
+end
 
 function onEventUpdate(player,csid,option)
-end;
+end
 
 function onEventFinish(player,csid,option)
-    if (csid == 46 and option == 1) then
-        player:setPos(-226.193, -46.459, -280.046, 127, 14); -- To Hall of Transference {R}
-    elseif (csid == 50) then
-        player:setVar("FirstPromyvionDem",0);
+    if csid == 46 and option == 1 then
+        player:setPos(-226.193, -46.459, -280.046, 127, 14) -- To Hall of Transference {R}
+    elseif csid == 50 then
+        player:setVar("FirstPromyvionDem", 0)
     end
-end;
+end

--- a/scripts/zones/Promyvion-Dem/Zone.lua
+++ b/scripts/zones/Promyvion-Dem/Zone.lua
@@ -4,16 +4,16 @@
 --
 -----------------------------------
 local ID = require("scripts/zones/Promyvion-Dem/IDs");
+require("scripts/globals/promyvion")
 require("scripts/globals/keyitems");
 require("scripts/globals/missions");
 require("scripts/globals/settings");
 require("scripts/globals/status");
+-----------------------------------
 
 function onInitialize(zone)
-    for k, v in pairs(ID.npc.MEMORY_STREAMS) do
-        zone:registerRegion(k,v[1],v[2],v[3],v[4],v[5],v[6]);
-    end
-end;
+    dsp.promyvion.initZone(zone)
+end
 
 function onZoneIn(player,prevZone)
     local cs = -1;
@@ -54,25 +54,8 @@ function afterZoneIn(player)
 end;
 
 function onRegionEnter(player,region)
-    if (player:getAnimation() == 0) then
-        local regionId = region:GetRegionID();
-        local event = nil;
-        if (regionId < 100) then
-            event = ID.npc.MEMORY_STREAMS[regionId][7][1];
-        else
-            local stream = GetNPCByID(regionId);
-            if (stream ~= nil and stream:getAnimation() == dsp.anim.OPEN_DOOR) then
-                event = stream:getLocalVar("destination");
-                if (event == nil or event == 0) then -- this should never happen, but sanity check
-                    event = ID.npc.MEMORY_STREAMS[regionId][7][1];
-                end
-            end
-        end
-        if (event ~= nil) then
-            player:startEvent(event);
-        end
-    end
-end;
+    dsp.promyvion.onRegionEnter(player, region)
+end
 
 function onRegionLeave(player,region)
 end;

--- a/scripts/zones/Promyvion-Dem/mobs/Memory_Receptacle.lua
+++ b/scripts/zones/Promyvion-Dem/mobs/Memory_Receptacle.lua
@@ -2,67 +2,17 @@
 -- Area: Promyvion-Dem
 --  MOB: Memory Receptacle
 -----------------------------------
-local ID = require("scripts/zones/Promyvion-Dem/IDs");
-require("scripts/globals/status");
+require("scripts/globals/promyvion")
+-----------------------------------
 
 function onMobInitialize(mob)
-    mob:addMod(dsp.mod.REGAIN, 100); -- 10% Regain for now
-    mob:SetAutoAttackEnabled(false); -- Recepticles only use TP moves.
-end;
-
-function checkStray(mob)
-    local mobId = mob:getID();
-    local numStrays = ID.mob.MEMORY_RECEPTACLES[mobId][2];
-
-    if (os.time() > mob:getLocalVar("nextStray")) then
-        for i = mobId + 1, mobId + numStrays do
-            local stray = GetMobByID(i);
-            if (not stray:isSpawned()) then
-                mob:setLocalVar("nextStray", os.time() + 20);
-                SpawnMob(stray:getID());
-                break;
-            end
-        end
-    else
-        mob:AnimationSub(2);
-    end
-end;
+    mob:SetAutoAttackEnabled(false) -- Recepticles only use TP moves.
+end
 
 function onMobFight(mob, target)
-    local mobId = mob:getID();
-    local numStrays = ID.mob.MEMORY_RECEPTACLES[mobId][2];
-
-    -- keep pets linked
-    for i = mobId + 1, mobId + numStrays do
-        local stray = GetMobByID(i);
-        if (stray:isSpawned()) then
-            stray:updateEnmity(target);
-        end
-    end
-
-    checkStray(mob);
-end;
+    dsp.promyvion.receptacleOnFight(mob, target)
+end
 
 function onMobDeath(mob, player, isKiller)
-    if (isKiller) then
-        mob:AnimationSub(0);
-
-        -- chance to open portal
-        local mobId = mob:getID();
-        local floor = ID.mob.MEMORY_RECEPTACLES[mobId][1];
-        local numAlive = 1;
-        for k, v in pairs(ID.mob.MEMORY_RECEPTACLES) do
-            if (k ~= mobId and v[1] == floor and GetMobByID(k):isAlive()) then
-                numAlive = numAlive + 1;
-            end
-        end
-        if (math.random(numAlive) == 1) then
-            local streamId = ID.mob.MEMORY_RECEPTACLES[mobId][3];
-            local stream = GetNPCByID(streamId);
-            local events = ID.npc.MEMORY_STREAMS[streamId][7];
-            local event = events[math.random(#events)];
-            stream:setLocalVar("destination",event);
-            stream:openDoor(180);
-        end
-    end
-end;
+    dsp.promyvion.receptacleOnDeath(mob, isKiller)
+end

--- a/scripts/zones/Promyvion-Dem/mobs/Stray.lua
+++ b/scripts/zones/Promyvion-Dem/mobs/Stray.lua
@@ -2,31 +2,12 @@
 -- Area: Promyvion-Dem
 --  MOB: Stray
 -----------------------------------
-local ID = require("scripts/zones/Promyvion-Dem/IDs");
-require("scripts/globals/status");
+require("scripts/globals/promyvion")
+-----------------------------------
 
-function findMother(mob)
-    local mobId = mob:getID();
-    local mother = 0;
-    for k,v in pairs(ID.mob.MEMORY_RECEPTACLES) do
-        if (k < mobId and k > mother) then
-            mother = k;
-        end
-    end
-    return mother;
-end;
-
-function onMobInitialize(mob)
-    mob:setMobMod(dsp.mobMod.GIL_MAX, -1);
-end;
-
-function onMobSpawn(mob, target)
-    local mother = GetMobByID(findMother(mob));
-    if (mother ~= nil and mother:isSpawned()) then
-        mob:setPos(mother:getXPos(), mother:getYPos()-5, mother:getZPos());
-        mother:AnimationSub(1);
-    end
-end;
+function onMobSpawn(mob)
+    dsp.promyvion.strayOnSpawn(mob)
+end
 
 function onMobDeath(mob, player, isKiller)
-end;
+end

--- a/scripts/zones/Promyvion-Holla/Zone.lua
+++ b/scripts/zones/Promyvion-Holla/Zone.lua
@@ -3,12 +3,12 @@
 -- Zone: Promyvion-Holla (16)
 --
 -----------------------------------
-local ID = require("scripts/zones/Promyvion-Holla/IDs");
+local ID = require("scripts/zones/Promyvion-Holla/IDs")
 require("scripts/globals/promyvion")
-require("scripts/globals/keyitems");
-require("scripts/globals/missions");
-require("scripts/globals/settings");
-require("scripts/globals/status");
+require("scripts/globals/keyitems")
+require("scripts/globals/missions")
+require("scripts/globals/settings")
+require("scripts/globals/status")
 -----------------------------------
 
 function onInitialize(zone)
@@ -16,57 +16,57 @@ function onInitialize(zone)
 end
 
 function onZoneIn(player,prevZone)
-    local cs = -1;
+    local cs = -1
 
-    if (player:getXPos() == 0 and player:getYPos() == 0 and player:getZPos() == 0) then
-        player:setPos(92.033, 0, 80.380, 255); -- To Floor 1 {R}
+    if player:getXPos() == 0 and player:getYPos() == 0 and player:getZPos() == 0 then
+        player:setPos(92.033, 0, 80.380, 255) -- To Floor 1 {R}
     end
 
-    if (player:getCurrentMission(COP) == BELOW_THE_ARKS and player:getVar("PromathiaStatus") == 2) then
-        player:completeMission(COP,BELOW_THE_ARKS);
-        player:addMission(COP,THE_MOTHERCRYSTALS); -- start mission 1.3
-        player:setVar("PromathiaStatus",0);
-    elseif (player:getCurrentMission(COP) == THE_MOTHERCRYSTALS) then
-        if (player:hasKeyItem(dsp.ki.LIGHT_OF_DEM) and player:hasKeyItem(dsp.ki.LIGHT_OF_MEA)) then
-            if (player:getVar("cslastpromy") == 1) then
-                player:setVar("cslastpromy",0)
-                cs = 52;
+    if player:getCurrentMission(COP) == BELOW_THE_ARKS and player:getVar("PromathiaStatus") == 2 then
+        player:completeMission(COP, BELOW_THE_ARKS)
+        player:addMission(COP, THE_MOTHERCRYSTALS) -- start mission 1.3
+        player:setVar("PromathiaStatus", 0)
+    elseif player:getCurrentMission(COP) == THE_MOTHERCRYSTALS then
+        if player:hasKeyItem(dsp.ki.LIGHT_OF_DEM) and player:hasKeyItem(dsp.ki.LIGHT_OF_MEA) then
+            if player:getVar("cslastpromy") == 1 then
+                player:setVar("cslastpromy", 0)
+                cs = 52
             end
-        elseif (player:hasKeyItem(dsp.ki.LIGHT_OF_DEM) or player:hasKeyItem(dsp.ki.LIGHT_OF_MEA)) then
-            if (player:getVar("cs2ndpromy") == 1) then
-                player:setVar("cs2ndpromy",0)
-                cs = 51;
+        elseif player:hasKeyItem(dsp.ki.LIGHT_OF_DEM) or player:hasKeyItem(dsp.ki.LIGHT_OF_MEA) then
+            if player:getVar("cs2ndpromy") == 1 then
+                player:setVar("cs2ndpromy", 0)
+                cs = 51
             end
         end
     end
 
-    if (player:getVar("FirstPromyvionHolla") == 1) then
-        cs = 50;
+    if player:getVar("FirstPromyvionHolla") == 1 then
+        cs = 50
     end
 
-    return cs;
-end;
+    return cs
+end
 
 function afterZoneIn(player)
-    if (ENABLE_COP_ZONE_CAP == 1) then -- ZONE WIDE LEVEL RESTRICTION
-        player:addStatusEffect(dsp.effect.LEVEL_RESTRICTION,30,0,0); -- LV30 cap
+    if ENABLE_COP_ZONE_CAP == 1 then
+        player:addStatusEffect(dsp.effect.LEVEL_RESTRICTION, 30, 0, 0)
     end
-end;
+end
 
 function onRegionEnter(player,region)
     dsp.promyvion.onRegionEnter(player, region)
 end
 
 function onRegionLeave(player,region)
-end;
+end
 
 function onEventUpdate(player,csid,option)
-end;
+end
 
 function onEventFinish(player,csid,option)
-    if (csid == 46 and option == 1) then
-        player:setPos(-225.682, -6.459, 280.002, 128, 14); -- To Hall of Transference {R}
-    elseif (csid == 50) then
-        player:setVar("FirstPromyvionHolla",0);
+    if csid == 46 and option == 1 then
+        player:setPos(-225.682, -6.459, 280.002, 128, 14) -- To Hall of Transference {R}
+    elseif csid == 50 then
+        player:setVar("FirstPromyvionHolla", 0)
     end
-end;
+end

--- a/scripts/zones/Promyvion-Holla/Zone.lua
+++ b/scripts/zones/Promyvion-Holla/Zone.lua
@@ -4,16 +4,16 @@
 --
 -----------------------------------
 local ID = require("scripts/zones/Promyvion-Holla/IDs");
+require("scripts/globals/promyvion")
 require("scripts/globals/keyitems");
 require("scripts/globals/missions");
 require("scripts/globals/settings");
 require("scripts/globals/status");
+-----------------------------------
 
 function onInitialize(zone)
-    for k, v in pairs(ID.npc.MEMORY_STREAMS) do
-        zone:registerRegion(k,v[1],v[2],v[3],v[4],v[5],v[6]);
-    end
-end;
+    dsp.promyvion.initZone(zone)
+end
 
 function onZoneIn(player,prevZone)
     local cs = -1;
@@ -54,25 +54,8 @@ function afterZoneIn(player)
 end;
 
 function onRegionEnter(player,region)
-    if (player:getAnimation() == 0) then
-        local regionId = region:GetRegionID();
-        local event = nil;
-        if (regionId < 100) then
-            event = ID.npc.MEMORY_STREAMS[regionId][7][1];
-        else
-            local stream = GetNPCByID(regionId);
-            if (stream ~= nil and stream:getAnimation() == dsp.anim.OPEN_DOOR) then
-                event = stream:getLocalVar("destination");
-                if (event == nil or event == 0) then -- this should never happen, but sanity check
-                    event = ID.npc.MEMORY_STREAMS[regionId][7][1];
-                end
-            end
-        end
-        if (event ~= nil) then
-            player:startEvent(event);
-        end
-    end
-end;
+    dsp.promyvion.onRegionEnter(player, region)
+end
 
 function onRegionLeave(player,region)
 end;

--- a/scripts/zones/Promyvion-Holla/mobs/Memory_Receptacle.lua
+++ b/scripts/zones/Promyvion-Holla/mobs/Memory_Receptacle.lua
@@ -2,67 +2,17 @@
 -- Area: Promyvion-Holla
 --  MOB: Memory Receptacle
 -----------------------------------
-local ID = require("scripts/zones/Promyvion-Holla/IDs");
-require("scripts/globals/status");
+require("scripts/globals/promyvion")
+-----------------------------------
 
 function onMobInitialize(mob)
-    mob:addMod(dsp.mod.REGAIN, 100); -- 10% Regain for now
-    mob:SetAutoAttackEnabled(false); -- Recepticles only use TP moves.
-end;
-
-function checkStray(mob)
-    local mobId = mob:getID();
-    local numStrays = ID.mob.MEMORY_RECEPTACLES[mobId][2];
-
-    if (os.time() > mob:getLocalVar("nextStray")) then
-        for i = mobId + 1, mobId + numStrays do
-            local stray = GetMobByID(i);
-            if (not stray:isSpawned()) then
-                mob:setLocalVar("nextStray", os.time() + 20);
-                SpawnMob(stray:getID());
-                break;
-            end
-        end
-    else
-        mob:AnimationSub(2);
-    end
-end;
+    mob:SetAutoAttackEnabled(false) -- Recepticles only use TP moves.
+end
 
 function onMobFight(mob, target)
-    local mobId = mob:getID();
-    local numStrays = ID.mob.MEMORY_RECEPTACLES[mobId][2];
-
-    -- keep pets linked
-    for i = mobId + 1, mobId + numStrays do
-        local stray = GetMobByID(i);
-        if (stray:isSpawned()) then
-            stray:updateEnmity(target);
-        end
-    end
-
-    checkStray(mob);
-end;
+    dsp.promyvion.receptacleOnFight(mob, target)
+end
 
 function onMobDeath(mob, player, isKiller)
-    if (isKiller) then
-        mob:AnimationSub(0);
-
-        -- chance to open portal
-        local mobId = mob:getID();
-        local floor = ID.mob.MEMORY_RECEPTACLES[mobId][1];
-        local numAlive = 1;
-        for k, v in pairs(ID.mob.MEMORY_RECEPTACLES) do
-            if (k ~= mobId and v[1] == floor and GetMobByID(k):isAlive()) then
-                numAlive = numAlive + 1;
-            end
-        end
-        if (math.random(numAlive) == 1) then
-            local streamId = ID.mob.MEMORY_RECEPTACLES[mobId][3];
-            local stream = GetNPCByID(streamId);
-            local events = ID.npc.MEMORY_STREAMS[streamId][7];
-            local event = events[math.random(#events)];
-            stream:setLocalVar("destination",event);
-            stream:openDoor(180);
-        end
-    end
-end;
+    dsp.promyvion.receptacleOnDeath(mob, isKiller)
+end

--- a/scripts/zones/Promyvion-Holla/mobs/Stray.lua
+++ b/scripts/zones/Promyvion-Holla/mobs/Stray.lua
@@ -2,31 +2,12 @@
 -- Area: Promyvion-Holla
 --  MOB: Stray
 -----------------------------------
-local ID = require("scripts/zones/Promyvion-Holla/IDs");
-require("scripts/globals/status");
+require("scripts/globals/promyvion")
+-----------------------------------
 
-function findMother(mob)
-    local mobId = mob:getID();
-    local mother = 0;
-    for k,v in pairs(ID.mob.MEMORY_RECEPTACLES) do
-        if (k < mobId and k > mother) then
-            mother = k;
-        end
-    end
-    return mother;
-end;
-
-function onMobInitialize(mob)
-    mob:setMobMod(dsp.mobMod.GIL_MAX, -1);
-end;
-
-function onMobSpawn(mob, target)
-    local mother = GetMobByID(findMother(mob));
-    if (mother ~= nil and mother:isSpawned()) then
-        mob:setPos(mother:getXPos(), mother:getYPos()-5, mother:getZPos());
-        mother:AnimationSub(1);
-    end
-end;
+function onMobSpawn(mob)
+    dsp.promyvion.strayOnSpawn(mob)
+end
 
 function onMobDeath(mob, player, isKiller)
-end;
+end

--- a/scripts/zones/Promyvion-Mea/Zone.lua
+++ b/scripts/zones/Promyvion-Mea/Zone.lua
@@ -4,16 +4,16 @@
 --
 -----------------------------------
 local ID = require("scripts/zones/Promyvion-Mea/IDs");
+require("scripts/globals/promyvion")
 require("scripts/globals/keyitems");
 require("scripts/globals/missions");
 require("scripts/globals/settings");
 require("scripts/globals/status");
+-----------------------------------
 
 function onInitialize(zone)
-    for k, v in pairs(ID.npc.MEMORY_STREAMS) do
-        zone:registerRegion(k,v[1],v[2],v[3],v[4],v[5],v[6]);
-    end
-end;
+    dsp.promyvion.initZone(zone)
+end
 
 function onZoneIn(player,prevZone)
     local cs = -1;
@@ -54,25 +54,8 @@ function afterZoneIn(player)
 end;
 
 function onRegionEnter(player,region)
-    if (player:getAnimation() == 0) then
-        local regionId = region:GetRegionID();
-        local event = nil;
-        if (regionId < 100) then
-            event = ID.npc.MEMORY_STREAMS[regionId][7][1];
-        else
-            local stream = GetNPCByID(regionId);
-            if (stream ~= nil and stream:getAnimation() == dsp.anim.OPEN_DOOR) then
-                event = stream:getLocalVar("destination");
-                if (event == nil or event == 0) then -- this should never happen, but sanity check
-                    event = ID.npc.MEMORY_STREAMS[regionId][7][1];
-                end
-            end
-        end
-        if (event ~= nil) then
-            player:startEvent(event);
-        end
-    end
-end;
+    dsp.promyvion.onRegionEnter(player, region)
+end
 
 function onRegionLeave(player,region)
 end;

--- a/scripts/zones/Promyvion-Mea/Zone.lua
+++ b/scripts/zones/Promyvion-Mea/Zone.lua
@@ -3,12 +3,12 @@
 -- Zone: Promyvion-Mea (20)
 --
 -----------------------------------
-local ID = require("scripts/zones/Promyvion-Mea/IDs");
+local ID = require("scripts/zones/Promyvion-Mea/IDs")
 require("scripts/globals/promyvion")
-require("scripts/globals/keyitems");
-require("scripts/globals/missions");
-require("scripts/globals/settings");
-require("scripts/globals/status");
+require("scripts/globals/keyitems")
+require("scripts/globals/missions")
+require("scripts/globals/settings")
+require("scripts/globals/status")
 -----------------------------------
 
 function onInitialize(zone)
@@ -16,57 +16,57 @@ function onInitialize(zone)
 end
 
 function onZoneIn(player,prevZone)
-    local cs = -1;
+    local cs = -1
 
-    if (player:getXPos() == 0 and player:getYPos() == 0 and player:getZPos() == 0) then
-        player:setPos(-93.268, 0, 170.749, 162); -- Floor 1 {R}
+    if player:getXPos() == 0 and player:getYPos() == 0 and player:getZPos() == 0 then
+        player:setPos(-93.268, 0, 170.749, 162) -- Floor 1 {R}
     end
 
-    if (player:getCurrentMission(COP) == BELOW_THE_ARKS and player:getVar("PromathiaStatus") == 2) then
-        player:completeMission(COP,BELOW_THE_ARKS);
-        player:addMission(COP,THE_MOTHERCRYSTALS); -- start mission 1.3
-        player:setVar("PromathiaStatus",0);
-    elseif (player:getCurrentMission(COP) == THE_MOTHERCRYSTALS) then
-        if (player:hasKeyItem(dsp.ki.LIGHT_OF_HOLLA) and player:hasKeyItem(dsp.ki.LIGHT_OF_DEM)) then
-            if (player:getVar("cslastpromy") == 1) then
-                player:setVar("cslastpromy",0)
-                cs = 52;
+    if player:getCurrentMission(COP) == BELOW_THE_ARKS and player:getVar("PromathiaStatus") == 2 then
+        player:completeMission(COP, BELOW_THE_ARKS)
+        player:addMission(COP, THE_MOTHERCRYSTALS)
+        player:setVar("PromathiaStatus", 0)
+    elseif player:getCurrentMission(COP) == THE_MOTHERCRYSTALS then
+        if player:hasKeyItem(dsp.ki.LIGHT_OF_HOLLA) and player:hasKeyItem(dsp.ki.LIGHT_OF_DEM) then
+            if player:getVar("cslastpromy") == 1 then
+                player:setVar("cslastpromy", 0)
+                cs = 52
             end
-        elseif (player:hasKeyItem(dsp.ki.LIGHT_OF_HOLLA) or player:hasKeyItem(dsp.ki.LIGHT_OF_DEM)) then
-            if (player:getVar("cs2ndpromy") == 1) then
-                player:setVar("cs2ndpromy",0)
-                cs = 51;
+        elseif player:hasKeyItem(dsp.ki.LIGHT_OF_HOLLA) or player:hasKeyItem(dsp.ki.LIGHT_OF_DEM) then
+            if player:getVar("cs2ndpromy") == 1 then
+                player:setVar("cs2ndpromy", 0)
+                cs = 51
             end
         end
     end
 
-    if (player:getVar("FirstPromyvionMea") == 1) then
-        cs = 50;
+    if player:getVar("FirstPromyvionMea") == 1 then
+        cs = 50
     end
 
-    return cs;
-end;
+    return cs
+end
 
 function afterZoneIn(player)
-    if (ENABLE_COP_ZONE_CAP == 1) then -- ZONE WIDE LEVEL RESTRICTION
-        player:addStatusEffect(dsp.effect.LEVEL_RESTRICTION,30,0,0); -- LV30 cap
+    if ENABLE_COP_ZONE_CAP == 1 then
+        player:addStatusEffect(dsp.effect.LEVEL_RESTRICTION, 30, 0, 0)
     end
-end;
+end
 
 function onRegionEnter(player,region)
     dsp.promyvion.onRegionEnter(player, region)
 end
 
 function onRegionLeave(player,region)
-end;
+end
 
 function onEventUpdate(player,region)
-end;
+end
 
 function onEventFinish(player,csid,option)
-    if (csid == 46 and option == 1) then
-        player:setPos(279.988, -86.459, -25.994, 63, 14); -- To Hall of Transferance {R}
-    elseif (csid == 50) then
-        player:setVar("FirstPromyvionMea",0);
+    if csid == 46 and option == 1 then
+        player:setPos(279.988, -86.459, -25.994, 63, 14) -- To Hall of Transferance {R}
+    elseif csid == 50 then
+        player:setVar("FirstPromyvionMea", 0)
     end
-end;
+end

--- a/scripts/zones/Promyvion-Mea/mobs/Memory_Receptacle.lua
+++ b/scripts/zones/Promyvion-Mea/mobs/Memory_Receptacle.lua
@@ -2,67 +2,17 @@
 -- Area: Promyvion-Mea
 --  MOB: Memory Receptacle
 -----------------------------------
-local ID = require("scripts/zones/Promyvion-Mea/IDs");
-require("scripts/globals/status");
+require("scripts/globals/promyvion")
+-----------------------------------
 
 function onMobInitialize(mob)
-    mob:addMod(dsp.mod.REGAIN, 100); -- 10% Regain for now
-    mob:SetAutoAttackEnabled(false); -- Recepticles only use TP moves.
-end;
-
-function checkStray(mob)
-    local mobId = mob:getID();
-    local numStrays = ID.mob.MEMORY_RECEPTACLES[mobId][2];
-
-    if (os.time() > mob:getLocalVar("nextStray")) then
-        for i = mobId + 1, mobId + numStrays do
-            local stray = GetMobByID(i);
-            if (not stray:isSpawned()) then
-                mob:setLocalVar("nextStray", os.time() + 20);
-                SpawnMob(stray:getID());
-                break;
-            end
-        end
-    else
-        mob:AnimationSub(2);
-    end
-end;
+    mob:SetAutoAttackEnabled(false) -- Recepticles only use TP moves.
+end
 
 function onMobFight(mob, target)
-    local mobId = mob:getID();
-    local numStrays = ID.mob.MEMORY_RECEPTACLES[mobId][2];
-
-    -- keep pets linked
-    for i = mobId + 1, mobId + numStrays do
-        local stray = GetMobByID(i);
-        if (stray:isSpawned()) then
-            stray:updateEnmity(target);
-        end
-    end
-
-    checkStray(mob);
-end;
+    dsp.promyvion.receptacleOnFight(mob, target)
+end
 
 function onMobDeath(mob, player, isKiller)
-    if (isKiller) then
-        mob:AnimationSub(0);
-
-        -- chance to open portal
-        local mobId = mob:getID();
-        local floor = ID.mob.MEMORY_RECEPTACLES[mobId][1];
-        local numAlive = 1;
-        for k, v in pairs(ID.mob.MEMORY_RECEPTACLES) do
-            if (k ~= mobId and v[1] == floor and GetMobByID(k):isAlive()) then
-                numAlive = numAlive + 1;
-            end
-        end
-        if (math.random(numAlive) == 1) then
-            local streamId = ID.mob.MEMORY_RECEPTACLES[mobId][3];
-            local stream = GetNPCByID(streamId);
-            local events = ID.npc.MEMORY_STREAMS[streamId][7];
-            local event = events[math.random(#events)];
-            stream:setLocalVar("destination",event);
-            stream:openDoor(180);
-        end
-    end
-end;
+    dsp.promyvion.receptacleOnDeath(mob, isKiller)
+end

--- a/scripts/zones/Promyvion-Mea/mobs/Stray.lua
+++ b/scripts/zones/Promyvion-Mea/mobs/Stray.lua
@@ -2,31 +2,12 @@
 -- Area: Promyvion-Mea
 --  MOB: Stray
 -----------------------------------
-local ID = require("scripts/zones/Promyvion-Mea/IDs");
-require("scripts/globals/status");
+require("scripts/globals/promyvion")
+-----------------------------------
 
-function findMother(mob)
-    local mobId = mob:getID();
-    local mother = 0;
-    for k,v in pairs(ID.mob.MEMORY_RECEPTACLES) do
-        if (k < mobId and k > mother) then
-            mother = k;
-        end
-    end
-    return mother;
-end;
-
-function onMobInitialize(mob)
-    mob:setMobMod(dsp.mobMod.GIL_MAX, -1);
-end;
-
-function onMobSpawn(mob, target)
-    local mother = GetMobByID(findMother(mob));
-    if (mother ~= nil and mother:isSpawned()) then
-        mob:setPos(mother:getXPos(), mother:getYPos()-5, mother:getZPos());
-        mother:AnimationSub(1);
-    end
-end;
+function onMobSpawn(mob)
+    dsp.promyvion.strayOnSpawn(mob)
+end
 
 function onMobDeath(mob, player, isKiller)
-end;
+end

--- a/scripts/zones/Promyvion-Vahzl/Zone.lua
+++ b/scripts/zones/Promyvion-Vahzl/Zone.lua
@@ -4,16 +4,16 @@
 --
 -----------------------------------
 local ID = require("scripts/zones/Promyvion-Vahzl/IDs");
+require("scripts/globals/promyvion")
 require("scripts/globals/keyitems");
 require("scripts/globals/missions");
 require("scripts/globals/settings");
 require("scripts/globals/status");
+-----------------------------------
 
 function onInitialize(zone)
-    for k, v in pairs(ID.npc.MEMORY_STREAMS) do
-        zone:registerRegion(k,v[1],v[2],v[3],v[4],v[5],v[6]);
-    end
-end;
+    dsp.promyvion.initZone(zone)
+end
 
 function onZoneIn(player,prevZone)
     local cs = -1;
@@ -34,15 +34,8 @@ function afterZoneIn(player)
 end;
 
 function onRegionEnter(player,region)
-    if (player:getAnimation() == 0) then
-        local regionId = region:GetRegionID();
-        local events = ID.npc.MEMORY_STREAMS[regionId][7];
-        local event = events[math.random(#events)];
-        if (regionId < 100 or GetNPCByID(regionId):getAnimation() == dsp.anim.OPEN_DOOR) then
-            player:startEvent(event);
-        end
-    end
-end;
+    dsp.promyvion.onRegionEnter(player, region)
+end
 
 function onRegionLeave(player,region)
 end;

--- a/scripts/zones/Promyvion-Vahzl/Zone.lua
+++ b/scripts/zones/Promyvion-Vahzl/Zone.lua
@@ -3,12 +3,11 @@
 -- Zone: Promyvion-Vahzl (22)
 --
 -----------------------------------
-local ID = require("scripts/zones/Promyvion-Vahzl/IDs");
+local ID = require("scripts/zones/Promyvion-Vahzl/IDs")
 require("scripts/globals/promyvion")
-require("scripts/globals/keyitems");
-require("scripts/globals/missions");
-require("scripts/globals/settings");
-require("scripts/globals/status");
+require("scripts/globals/missions")
+require("scripts/globals/settings")
+require("scripts/globals/status")
 -----------------------------------
 
 function onInitialize(zone)
@@ -16,37 +15,37 @@ function onInitialize(zone)
 end
 
 function onZoneIn(player,prevZone)
-    local cs = -1;
-    if (player:getXPos() == 0 and player:getYPos() == 0 and player:getZPos() == 0) then
-        player:setPos(-14.744,0.036,-119.736,1); -- To Floor 1 {R}
+    local cs = -1
+    if player:getXPos() == 0 and player:getYPos() == 0 and player:getZPos() == 0 then
+        player:setPos(-14.744, 0.036, -119.736, 1) -- To Floor 1 {R}
     end
 
-    if (player:getCurrentMission(COP) == DESIRES_OF_EMPTINESS and player:getVar("PromathiaStatus") == 0) then
-        cs = 50;
+    if player:getCurrentMission(COP) == DESIRES_OF_EMPTINESS and player:getVar("PromathiaStatus") == 0 then
+        cs = 50
     end
-    return cs;
-end;
+    return cs
+end
 
 function afterZoneIn(player)
-    if (ENABLE_COP_ZONE_CAP == 1) then -- ZONE WIDE LEVEL RESTRICTION
-        player:addStatusEffect(dsp.effect.LEVEL_RESTRICTION,50,0,0); -- LV50 cap
+    if ENABLE_COP_ZONE_CAP == 1 then
+        player:addStatusEffect(dsp.effect.LEVEL_RESTRICTION, 50, 0, 0)
     end
-end;
+end
 
 function onRegionEnter(player,region)
     dsp.promyvion.onRegionEnter(player, region)
 end
 
 function onRegionLeave(player,region)
-end;
+end
 
 function onEventUpdate(player,csid,option)
-end;
+end
 
 function onEventFinish(player,csid,option)
-    if (csid == 50) then
-        player:setVar("PromathiaStatus",1);
-    elseif (csid == 45 and option == 1) then
-        player:setPos(-379.947, 48.045, 334.059, 192, 9); -- To Pso'Xja {R}
+    if csid == 50 then
+        player:setVar("PromathiaStatus", 1)
+    elseif csid == 45 and option == 1 then
+        player:setPos(-379.947, 48.045, 334.059, 192, 9) -- To Pso'Xja {R}
     end
-end;
+end

--- a/scripts/zones/Promyvion-Vahzl/mobs/Memory_Receptacle.lua
+++ b/scripts/zones/Promyvion-Vahzl/mobs/Memory_Receptacle.lua
@@ -2,63 +2,17 @@
 -- Area: Promyvion-Vahzl
 --  MOB: Memory Receptacle
 -----------------------------------
-local ID = require("scripts/zones/Promyvion-Vahzl/IDs");
-require("scripts/globals/status");
+require("scripts/globals/promyvion")
+-----------------------------------
 
 function onMobInitialize(mob)
-    mob:addMod(dsp.mod.REGAIN, 100); -- 10% Regain for now
-    mob:SetAutoAttackEnabled(false); -- Recepticles only use TP moves.
-end;
-
-function checkStray(mob)
-    local mobId = mob:getID();
-    local numStrays = ID.mob.MEMORY_RECEPTACLES[mobId][2];
-
-    if (os.time() > mob:getLocalVar("nextStray")) then
-        for i = mobId + 1, mobId + numStrays do
-            local stray = GetMobByID(i);
-            if (not stray:isSpawned()) then
-                mob:setLocalVar("nextStray", os.time() + 20);
-                SpawnMob(stray:getID());
-                break;
-            end
-        end
-    else
-        mob:AnimationSub(2);
-    end
-end;
+    mob:SetAutoAttackEnabled(false) -- Recepticles only use TP moves.
+end
 
 function onMobFight(mob, target)
-    local mobId = mob:getID();
-    local numStrays = ID.mob.MEMORY_RECEPTACLES[mobId][2];
-
-    -- keep pets linked
-    for i = mobId + 1, mobId + numStrays do
-        local stray = GetMobByID(i);
-        if (stray:isSpawned()) then
-            stray:updateEnmity(target);
-        end
-    end
-
-    checkStray(mob);
-end;
+    dsp.promyvion.receptacleOnFight(mob, target)
+end
 
 function onMobDeath(mob, player, isKiller)
-    if (isKiller) then
-        mob:AnimationSub(0);
-
-        -- chance to open portal
-        local mobId = mob:getID();
-        local floor = ID.mob.MEMORY_RECEPTACLES[mobId][1];
-        local numAlive = 1;
-        for k, v in pairs(ID.mob.MEMORY_RECEPTACLES) do
-            if (k ~= mobId and v[1] == floor and GetMobByID(k):isAlive()) then
-                numAlive = numAlive + 1;
-            end
-        end
-        if (math.random(numAlive) == 1) then
-            local stream = GetNPCByID(ID.mob.MEMORY_RECEPTACLES[mobId][3]);
-            stream:openDoor(180);
-        end
-    end
-end;
+    dsp.promyvion.receptacleOnDeath(mob, isKiller)
+end

--- a/scripts/zones/Promyvion-Vahzl/mobs/Stray.lua
+++ b/scripts/zones/Promyvion-Vahzl/mobs/Stray.lua
@@ -2,31 +2,12 @@
 -- Area: Promyvion-Vahzl
 --  MOB: Stray
 -----------------------------------
-local ID = require("scripts/zones/Promyvion-Vahzl/IDs");
-require("scripts/globals/status");
+require("scripts/globals/promyvion")
+-----------------------------------
 
-function findMother(mob)
-    local mobId = mob:getID();
-    local mother = 0;
-    for k,v in pairs(ID.mob.MEMORY_RECEPTACLES) do
-        if (k < mobId and k > mother) then
-            mother = k;
-        end
-    end
-    return mother;
-end;
-
-function onMobInitialize(mob)
-    mob:setMobMod(dsp.mobMod.GIL_MAX, -1);
-end;
-
-function onMobSpawn(mob, target)
-    local mother = GetMobByID(findMother(mob));
-    if (mother ~= nil and mother:isSpawned()) then
-        mob:setPos(mother:getXPos(), mother:getYPos()-5, mother:getZPos());
-        mother:AnimationSub(1);
-    end
-end;
+function onMobSpawn(mob)
+    dsp.promyvion.strayOnSpawn(mob)
+end
 
 function onMobDeath(mob, player, isKiller)
-end;
+end

--- a/sql/mob_pool_mods.sql
+++ b/sql/mob_pool_mods.sql
@@ -292,6 +292,9 @@ INSERT INTO `mob_pool_mods` VALUES (4836,62,1,1); -- Maat (BLM) NO_STANDBACK
 INSERT INTO `mob_pool_mods` VALUES (4837,62,1,1); -- Maat (RNG) NO_STANDBACK
 INSERT INTO `mob_pool_mods` VALUES (5403,62,1,1); -- Maat (NIN) NO_STANDBACK
 
+INSERT INTO `mob_pool_mods` VALUES (3784,2,-1,1); -- Stray GIL_MAX: don't drop gil
+INSERT INTO `mob_pool_mods` VALUES (2614,368,100,0); -- Memory Receptacle regain 10%
+
 /*!40000 ALTER TABLE `mob_pool_mods` ENABLE KEYS */;
 UNLOCK TABLES;
 /*!40103 SET TIME_ZONE=@OLD_TIME_ZONE */;


### PR DESCRIPTION
moved all the promyvion MR/Stray/Stream logic into a global

the correct exit to next floor is now picked randomly at server spawn, and randomized again after the portal opens, rather than having it be a chance based on number of remaining MRs.

moved spawn mods into sql

style in separate commit