### PR TITLE
add optional target argument for release command.

### DIFF
--- a/scripts/commands/release.lua
+++ b/scripts/commands/release.lua
@@ -6,9 +6,25 @@
 cmdprops =
 {
     permission = 1,
-    parameters = ""
-};
+    parameters = "s"
+}
 
-function onTrigger(player)
-    player:release();
+function error(player, msg)
+    player:PrintToPlayer(msg)
+    player:PrintToPlayer("!release {name}")
+end
+
+function onTrigger(player, name)
+    local target
+    if name == nil then
+        target = player
+    else
+        target = GetPlayerByName(name)
+        if target == nil then
+            error(player, string.format("Player named '%s' not found!", name))
+            return
+        end
+    end
+
+    target:release()
 end


### PR DESCRIPTION
Normally we'd just force zone someone stuck in cs but there is one situation where we'd want to avoid that: stuck at BCNNM entrance. Zoning the player would cancel/fail the BCNNM.