### PR TITLE
Enfeebling Potency bug fix

### DIFF
--- a/scripts/globals/magic.lua
+++ b/scripts/globals/magic.lua
@@ -1325,7 +1325,7 @@ function calculateDuration(duration, magicSkill, spellGroup, caster, target, use
     return math.floor(duration)
 end
 
-function calculatePotency(basePotency, dStat, magicSkill, caster, target)
+function calculatePotency(basePotency, magicSkill, caster, target)
     if magicSkill ~= dsp.skill.ENFEEBLING_MAGIC then
         return basePotency
     end
@@ -1338,7 +1338,7 @@ function calculatePotency(basePotency, dStat, magicSkill, caster, target)
         end
     end
 
-    return math.floor((basePotency + dStat) * (1 + caster:getMod(dsp.mod.ENF_MAG_POTENCY) / 100))
+    return math.floor(basePotency * (1 + caster:getMod(dsp.mod.ENF_MAG_POTENCY) / 100))
 end
 
 -- Output magic hit rate for all levels

--- a/scripts/globals/spells/addle.lua
+++ b/scripts/globals/spells/addle.lua
@@ -4,11 +4,11 @@
 -- Exact formula is unknown.
 --
 -- Raw Value is said to be 30%
--- It is said to increase to 50% w/ Saboteur
 -----------------------------------------
 require("scripts/globals/magic")
 require("scripts/globals/msg")
 require("scripts/globals/status")
+require("scripts/globals/utils")
 -----------------------------------------
 
 function onMagicCastingCheck(caster, target, spell)
@@ -18,12 +18,11 @@ end
 function onSpellCast(caster, target, spell)
     local dMND = caster:getStat(dsp.mod.MND) - target:getStat(dsp.mod.MND)
 
-    local power = calculatePotency(30, dMND, spell:getSkillType(), caster, target)
+    -- Spell casting increase
+    local power = calculatePotency(30, spell:getSkillType(), caster, target)
 
-    -- Sub Power: Magic Accuracy Modifier
-    -- Magic Accuracy penalty = floor(dMND/5)+20
-    -- Caps at -40 magic accuracy
-    local subPower = math.min(math.floor(dMND / 5) + 20, 40)
+    -- Magic Accuracy reduction (not affected by enfeebling skill)
+    local subPower = 20 + utils.clamp(math.floor(dMND / 5), 0, 20)
 
     --Duration, including resistance.
     local duration = calculateDuration(180, spell:getSkillType(), spell:getSpellGroup(), caster, target)

--- a/scripts/globals/spells/blind.lua
+++ b/scripts/globals/spells/blind.lua
@@ -15,9 +15,11 @@ function onSpellCast(caster, target, spell)
     -- Pull base stats.
     local dINT = caster:getStat(dsp.mod.INT) - target:getStat(dsp.mod.MND) -- blind uses caster INT vs target MND
 
-    -- Base power.  May need more research.
-    local basePotency = utils.clamp(math.floor((dINT + 40) / 2), 5, 50)
-    local potency = calculatePotency(basePotency, dINT, spell:getSkillType(), caster, target)
+    -- Base power
+    -- Min cap: 5 at -80 dINT
+    -- Max cap: 30 at 120 dINT
+    local basePotency = utils.clamp(math.floor(dINT * 9 / 40 + 23), 5, 50)
+    local potency = calculatePotency(basePotency, spell:getSkillType(), caster, target)
 
     -- Duration, including resistance.  Unconfirmed.
     local duration = calculateDuration(180, spell:getSkillType(), spell:getSpellGroup(), caster, target)

--- a/scripts/globals/spells/blind.lua
+++ b/scripts/globals/spells/blind.lua
@@ -17,7 +17,7 @@ function onSpellCast(caster, target, spell)
 
     -- Base power
     -- Min cap: 5 at -80 dINT
-    -- Max cap: 30 at 120 dINT
+    -- Max cap: 50 at 120 dINT
     local basePotency = utils.clamp(math.floor(dINT * 9 / 40 + 23), 5, 50)
     local potency = calculatePotency(basePotency, spell:getSkillType(), caster, target)
 

--- a/scripts/globals/spells/blind_ii.lua
+++ b/scripts/globals/spells/blind_ii.lua
@@ -19,14 +19,16 @@ function onSpellCast(caster, target, spell)
     -- Pull base stats.
     local dINT = caster:getStat(dsp.mod.INT) - target:getStat(dsp.mod.MND) -- blind uses caster INT vs target MND
 
-    -- Base potency.  May need more research.
-    local basePotency = utils.clamp(math.floor(dINT * 3/8) + 45, 15, 90)
+    -- Base power
+    -- Min cap: 15 at -80 dINT
+    -- Max cap: 40 at 120 dINT
+    local basePotency = utils.clamp(math.floor(dINT / 3 * 8 + 45), 15, 90)
 
     if (merits > 1) then
         basePotency = basePotency + merits - 1
     end
     
-    local potency = calculatePotency(basePotency, dINT, spell:getSkillType(), caster, target)
+    local potency = calculatePotency(basePotency, spell:getSkillType(), caster, target)
 
     -- Duration, including resistance.  Unconfirmed.
     local duration = calculateDuration(180, spell:getSkillType(), spell:getSpellGroup(), caster, target)

--- a/scripts/globals/spells/blind_ii.lua
+++ b/scripts/globals/spells/blind_ii.lua
@@ -21,7 +21,7 @@ function onSpellCast(caster, target, spell)
 
     -- Base power
     -- Min cap: 15 at -80 dINT
-    -- Max cap: 40 at 120 dINT
+    -- Max cap: 90 at 120 dINT
     local basePotency = utils.clamp(math.floor(dINT / 3 * 8 + 45), 15, 90)
 
     if (merits > 1) then

--- a/scripts/globals/spells/distract.lua
+++ b/scripts/globals/spells/distract.lua
@@ -4,6 +4,7 @@
 require("scripts/globals/magic")
 require("scripts/globals/msg")
 require("scripts/globals/status")
+require("scripts/globals/utils")
 -----------------------------------------
 
 function onMagicCastingCheck(caster, target, spell)
@@ -14,8 +15,15 @@ function onSpellCast(caster, target, spell)
     -- Pull base stats.
     local dMND = caster:getStat(dsp.mod.MND) - target:getStat(dsp.mod.MND)
 
-    -- Base power.  May need more research.
-    local power = calculatePotency(35, dMND, spell:getSkillType(), caster, target)
+    -- Base evasion reduction is determend by enfeebling skill
+    -- Caps at -25 evasion at 125 skill
+    local basePotency = utils.clamp(math.floor(caster:getSkillLevel(dsp.skill.ENFEEBLING_MAGIC) / 5), 0, 25)
+
+    -- dMND is tacked on after
+    -- Min cap: 0 at 0 dMND
+    -- Max cap: 10 at 50 dMND
+    basePotency = basePotency + utils.clamp(math.floor(dMND / 5), 0, 10)
+    local power = calculatePotency(basePotency, spell:getSkillType(), caster, target)
 
     -- Duration, including resistance.  Unconfirmed.
     local duration = calculateDuration(120, spell:getSkillType(), spell:getSpellGroup(), caster, target)

--- a/scripts/globals/spells/distract_ii.lua
+++ b/scripts/globals/spells/distract_ii.lua
@@ -14,8 +14,15 @@ end
 function onSpellCast(caster, target, spell)
     local dMND = caster:getStat(dsp.mod.MND) - target:getStat(dsp.mod.MND)
 
-    local power = utils.clamp(40 + math.floor(dMND / 5), 40, 50)
-    power = calculatePotency(power, dMND, spell:getSkillType(), caster, target)
+    -- Base evasion reduction is determend by enfeebling skill
+    -- Caps at -40 evasion at 350 skill
+    local basePotency = utils.clamp(math.floor(caster:getSkillLevel(dsp.skill.ENFEEBLING_MAGIC) * 4 / 35), 0, 40)
+
+    -- dMND is tacked on after
+    -- Min cap: 0 at 0 dMND
+    -- Max cap: 10 at 50 dMND
+    basePotency = basePotency + utils.clamp(math.floor(dMND / 5), 0, 10)
+    local power = calculatePotency(basePotency, spell:getSkillType(), caster, target)
 
     local duration = calculateDuration(120, spell:getSkillType(), spell:getSpellGroup(), caster, target)
 

--- a/scripts/globals/spells/frazzle.lua
+++ b/scripts/globals/spells/frazzle.lua
@@ -4,6 +4,7 @@
 require("scripts/globals/magic")
 require("scripts/globals/msg")
 require("scripts/globals/status")
+require("scripts/globals/utils")
 -----------------------------------------
 
 function onMagicCastingCheck(caster, target, spell)
@@ -13,7 +14,15 @@ end
 function onSpellCast(caster, target, spell)
     local dMND = caster:getStat(dsp.mod.MND) - target:getStat(dsp.mod.MND)
 
-    local power = calculatePotency(35, dMND, spell:getSkillType(), caster, target)
+    -- Base magic evasion reduction is determend by enfeebling skill
+    -- Caps at -25 magic evasion at 125 skill
+    local basePotency = utils.clamp(math.floor(caster:getSkillLevel(dsp.skill.ENFEEBLING_MAGIC) / 5), 0, 25)
+
+    -- dMND is tacked on after
+    -- Min cap: 0 at 0 dMND
+    -- Max cap: 10 at 50 dMND
+    basePotency = basePotency + utils.clamp(math.floor(dMND / 5), 0, 10)
+    local power = calculatePotency(basePotency, spell:getSkillType(), caster, target)
 
     local duration = calculateDuration(120, spell:getSkillType(), spell:getSpellGroup(), caster, target)
 

--- a/scripts/globals/spells/frazzle_ii.lua
+++ b/scripts/globals/spells/frazzle_ii.lua
@@ -14,8 +14,15 @@ end
 function onSpellCast(caster, target, spell)
     local dMND = caster:getStat(dsp.mod.MND) - target:getStat(dsp.mod.MND)
 
-    local power = utils.clamp(40 + math.floor(dMND / 5), 40, 50)
-    power = calculatePotency(power, dMND, spell:getSkillType(), caster, target)
+    -- Base evasion reduction is determend by enfeebling skill
+    -- Caps at -40 evasion at 350 skill
+    local basePotency = utils.clamp(math.floor(caster:getSkillLevel(dsp.skill.ENFEEBLING_MAGIC) * 4 / 35), 0, 40)
+
+    -- dMND is tacked on after
+    -- Min cap: 0 at 0 dMND
+    -- Max cap: 10 at 50 dMND
+    basePotency = basePotency + utils.clamp(math.floor(dMND / 5), 0, 10)
+    local power = calculatePotency(basePotency, spell:getSkillType(), caster, target)
 
     local duration = calculateDuration(120, spell:getSkillType(), spell:getSpellGroup(), caster, target)
 

--- a/scripts/globals/spells/gravity.lua
+++ b/scripts/globals/spells/gravity.lua
@@ -14,8 +14,7 @@ function onSpellCast(caster, target, spell)
     -- Pull base stats.
     local dINT = caster:getStat(dsp.mod.INT) - target:getStat(dsp.mod.INT)
 
-    -- Movement speed reduction caps at -50%
-    local power = math.min(calculatePotency(50, dINT, spell:getSkillType(), caster, target), 50)
+    local power = calculatePotency(26, spell:getSkillType(), caster, target)
 
     -- Duration, including resistance.  Unconfirmed.
     local duration = calculateDuration(120, spell:getSkillType(), spell:getSpellGroup(), caster, target)

--- a/scripts/globals/spells/gravity_ii.lua
+++ b/scripts/globals/spells/gravity_ii.lua
@@ -14,7 +14,7 @@ function onSpellCast(caster, target, spell)
     -- Pull base stats.
     local dINT = caster:getStat(dsp.mod.INT) - target:getStat(dsp.mod.INT)
 
-    local power = calculatePotency(60, dINT, spell:getSkillType(), caster, target) -- 60% reduction
+    local power = calculatePotency(32, spell:getSkillType(), caster, target)
 
     -- Duration, including resistance.  Unconfirmed.
     local duration = calculateDuration(180, spell:getSkillType(), spell:getSpellGroup(), caster, target)

--- a/scripts/globals/spells/paralyze.lua
+++ b/scripts/globals/spells/paralyze.lua
@@ -17,7 +17,7 @@ function onSpellCast(caster, target, spell)
 
     -- Calculate potency.
     local potency = utils.clamp(math.floor(dMND / 4) + 15, 5, 25)
-    potency = calculatePotency(potency, dMND, spell:getSkillType(), caster, target)
+    potency = calculatePotency(potency, spell:getSkillType(), caster, target)
     
     -- Calculate duration.
     local duration = calculateDuration(120, spell:getSkillType(), spell:getSpellGroup(), caster, target)

--- a/scripts/globals/spells/paralyze_ii.lua
+++ b/scripts/globals/spells/paralyze_ii.lua
@@ -27,7 +27,7 @@ function onSpellCast(caster, target, spell)
         potency = potency + merits - 1
     end
     
-    potency = calculatePotency(potency, dMND, spell:getSkillType(), caster, target)
+    potency = calculatePotency(potency, spell:getSkillType(), caster, target)
 
     local duration = calculateDuration(120, spell:getSkillType(), spell:getSpellGroup(), caster, target)
     local params = {}

--- a/scripts/globals/spells/poison.lua
+++ b/scripts/globals/spells/poison.lua
@@ -13,8 +13,12 @@ end
 function onSpellCast(caster, target, spell)
     local dINT = caster:getStat(dsp.mod.INT) - target:getStat(dsp.mod.INT)
 
-    local power = math.min(caster:getSkillLevel(dsp.skill.ENFEEBLING_MAGIC) / 25 + 1, 4)
-    power = calculatePotency(power, dINT, spell:getSkillType(), caster, target)
+    local skill = caster:getSkillLevel(dsp.skill.ENFEEBLING_MAGIC)
+    local power = math.max(skill / 25, 1)
+    if skill > 400 then
+        power = math.min((skill - 225) / 5, 55) -- Cap is 55 hp/tick
+    end
+    power = calculatePotency(power, spell:getSkillType(), caster, target)
 
     local duration = calculateDuration(30, spell:getSkillType(), spell:getSpellGroup(), caster, target)
 

--- a/scripts/globals/spells/poison_ii.lua
+++ b/scripts/globals/spells/poison_ii.lua
@@ -13,8 +13,12 @@ end
 function onSpellCast(caster, target, spell)
     local dINT = caster:getStat(dsp.mod.INT) - target:getStat(dsp.mod.INT)
 
-    local power = math.min(caster:getSkillLevel(dsp.skill.ENFEEBLING_MAGIC) / 20 + 1, 10)
-    power = calculatePotency(power, dINT, spell:getSkillType(), caster, target)
+    local skill = caster:getSkillLevel(dsp.skill.ENFEEBLING_MAGIC)
+    local power = math.max(skill / 20, 4)
+    if skill > 400 then
+        power = math.floor(skill * 49 / 183 - 55) -- No cap can be reached yet
+    end
+    power = calculatePotency(power, spell:getSkillType(), caster, target)
 
     local duration = calculateDuration(120, spell:getSkillType(), spell:getSpellGroup(), caster, target)
 

--- a/scripts/globals/spells/poison_iii.lua
+++ b/scripts/globals/spells/poison_iii.lua
@@ -14,7 +14,7 @@ function onSpellCast(caster, target, spell)
     local dINT = caster:getStat(dsp.mod.INT) - target:getStat(dsp.mod.INT)
 
     local power = math.min(caster:getSkillLevel(dsp.skill.ENFEEBLING_MAGIC) / 15 + 1, 25)
-    power = calculatePotency(power, dINT, spell:getSkillType(), caster, target)
+    power = calculatePotency(power, spell:getSkillType(), caster, target)
 
     local duration = calculateDuration(180, spell:getSkillType(), spell:getSpellGroup(), caster, target)
 

--- a/scripts/globals/spells/poisonga.lua
+++ b/scripts/globals/spells/poisonga.lua
@@ -13,8 +13,12 @@ end
 function onSpellCast(caster, target, spell)
     local dINT = caster:getStat(dsp.mod.INT) - target:getStat(dsp.mod.INT)
 
-    local power = math.min(caster:getSkillLevel(dsp.skill.ENFEEBLING_MAGIC) / 20 + 1, 6)
-    power = calculatePotency(power, dINT, spell:getSkillType(), caster, target)
+    local skill = caster:getSkillLevel(dsp.skill.ENFEEBLING_MAGIC)
+    local power = math.max(skill / 25, 1)
+    if skill > 400 then
+        power = math.min((skill - 225) / 5, 55) -- Cap is 55 hp/tick
+    end
+    power = calculatePotency(power, spell:getSkillType(), caster, target)
 
     local duration = calculateDuration(60, spell:getSkillType(), spell:getSpellGroup(), caster, target)
 

--- a/scripts/globals/spells/poisonga_ii.lua
+++ b/scripts/globals/spells/poisonga_ii.lua
@@ -13,8 +13,12 @@ end
 function onSpellCast(caster, target, spell)
     local dINT = caster:getStat(dsp.mod.INT) - target:getStat(dsp.mod.INT)
 
-    local power = math.min(caster:getSkillLevel(dsp.skill.ENFEEBLING_MAGIC) / 15 + 1, 15)
-    power = calculatePotency(power, dINT, spell:getSkillType(), caster, target)
+    local skill = caster:getSkillLevel(dsp.skill.ENFEEBLING_MAGIC)
+    local power = math.max(skill / 20, 4)
+    if skill > 400 then
+        power = math.floor(skill * 49 / 183 - 55) -- No cap can be reached yet
+    end
+    power = calculatePotency(power, spell:getSkillType(), caster, target)
 
     local duration = calculateDuration(120, spell:getSkillType(), spell:getSpellGroup(), caster, target)
 

--- a/scripts/globals/spells/slow.lua
+++ b/scripts/globals/spells/slow.lua
@@ -1,8 +1,5 @@
 -----------------------------------------
 -- Spell: Slow
--- Spell accuracy is most highly affected by Enfeebling Magic Skill, Magic Accuracy, and MND.
--- Slow's potency is calculated with the formula (187.5 + dMND*1.5)/1024, and caps at 300/1024 (~29.3%).
--- And MND of 75 is neccessary to reach the hardcap of Slow.
 -----------------------------------------
 require("scripts/globals/magic")
 require("scripts/globals/msg")
@@ -18,19 +15,14 @@ function onSpellCast(caster, target, spell)
     local dMND = caster:getStat(dsp.mod.MND) - target:getStat(dsp.mod.MND)
 
     --Power
-    local power = 1500
-    if dMND > 0 then
-        power = power + dMND * 20
-    else
-        power = power + dMND * 10
-    end
-    power = utils.clamp(power, 730, 2929) -- Lowest 75/1024, Highest 300/1024 ~7.3%-29.2%
-    
-    power = calculatePotency(power, dMND, spell:getSkillType(), caster, target)
+    -- Lowest ~7.3%
+    -- Highest ~29.2%
+    local power = utils.clamp(math.floor(dMND * 73 / 5) + 1825, 730, 2920)
+    power = calculatePotency(power, spell:getSkillType(), caster, target)
 
     --Duration
-    local duration = calculateDuration(120, spell:getSkillType(), spell:getSpellGroup(), caster, target)
-    
+    local duration = calculateDuration(180, spell:getSkillType(), spell:getSpellGroup(), caster, target)
+
     local params = {}
     params.diff = dMND
     params.skillType = dsp.skill.ENFEEBLING_MAGIC

--- a/scripts/globals/spells/slow_ii.lua
+++ b/scripts/globals/spells/slow_ii.lua
@@ -1,8 +1,5 @@
 -----------------------------------------
 -- Spell: Slow II
--- Spell accuracy is most highly affected by Enfeebling Magic Skill, Magic Accuracy, and MND.
--- caster:getMerit() returns a value which is equal to the number of merit points TIMES the value of each point
--- Slow II value per point is '1' This is a constant set in the table 'merits'
 -----------------------------------------
 require("scripts/globals/magic")
 require("scripts/globals/msg")
@@ -18,9 +15,14 @@ function onSpellCast(caster, target, spell)
     local dMND = caster:getStat(dsp.mod.MND) - target:getStat(dsp.mod.MND)
     local merits = caster:getMerit(dsp.merit.SLOW_II)
 
-    local base = 2440 + merits * 100
-    local power = utils.clamp(base + dMND * 1160/75, 1250, 3906) -- Lowest 128/1024 ~12.5%, Highest 400/1024 ~39.06%
-    power = calculatePotency(power, dMND, spell:getSkillType(), caster, target)
+    -- Lowest ~12.5%
+    -- Highest ~35.1%
+    local power = utils.clamp(math.floor(dMND * 226 / 15) + 2380, 1250, 3510)
+    power = calculatePotency(power, spell:getSkillType(), caster, target)
+
+    if merits > 1 then
+        power = power + merits - 1
+    end
 
     --Duration, including resistance.
     local duration = calculateDuration(180, spell:getSkillType(), spell:getSpellGroup(), caster, target)

--- a/scripts/globals/spells/slowga.lua
+++ b/scripts/globals/spells/slowga.lua
@@ -1,8 +1,5 @@
 -----------------------------------------
--- Spell: Slow
--- Spell accuracy is most highly affected by Enfeebling Magic Skill, Magic Accuracy, and MND.
--- Slow's potency is calculated with the formula (187.5 + dMND*1.5)/1024, and caps at 300/1024 (~29.3%).
--- And MND of 75 is neccessary to reach the hardcap of Slow.
+-- Spell: Slowga
 -----------------------------------------
 require("scripts/globals/magic")
 require("scripts/globals/msg")
@@ -17,15 +14,10 @@ end
 function onSpellCast(caster,target,spell)
     local dMND = caster:getStat(dsp.mod.MND) - target:getStat(dsp.mod.MND)
 
-    -- FIXME: PRETTY SURE THIS IS ALL WRONG
     --Power
-    local power = 1500
-    if dMND > 0 then
-        power = power + dMND * 20
-    else
-        power = power + dMND * 10
-    end
-    power = utils.clamp(power, 730, 2929) -- Lowest 75/1024, Highest 300/1024 ~7.3%-29.2%
+    -- Lowest ~7.3%
+    -- Highest ~29.2%
+    local power = utils.clamp(math.floor(dMND * 73 / 5) + 1825, 730, 2920)
     power = calculatePotency(power, dMND, spell:getSkillType(), caster, target)
 
     --Duration, including resistance


### PR DESCRIPTION
Addresses https://github.com/DarkstarProject/darkstar/issues/5372

* Removed the extra dStat addition from calculatePotency (I seriously don't know what I was thinking)
* Adjusted math of some enfeebles' base potency

Enfeebling cap references:
* https://www.bluegartr.com/threads/112776-Dev-Tracker-Findings-Posts-(NO-DISCUSSION)?p=6503005&viewfull=1#post6503005
* https://www.bluegartr.com/threads/112776-Dev-Tracker-Findings-Posts-(NO-DISCUSSION)?p=6503005&viewfull=1#post6503007

I extrapolated the values for low and high caps into a graph, calculated slope and turned it into a linear equation (y-intercept) to get some nice pretty math instead of all the conditional chains, and Bob's your uncle.

EDIT: I did test the spells, as well. Checked Paralyze rate on a Groundskeeper with !getmod and it was properly capped.