### PR TITLE
Fixes Automatons only being able to use an ability once per activation

### DIFF
--- a/src/map/ai/controllers/automaton_controller.cpp
+++ b/src/map/ai/controllers/automaton_controller.cpp
@@ -1374,7 +1374,7 @@ bool CAutomatonController::CanCastSpells()
 
 bool CAutomatonController::Cast(uint16 targid, SpellID spellid)
 {
-    if (!autoSpell::CanUseSpell(PAutomaton, spellid) || PAutomaton->PRecastContainer->Has(RECAST_MAGIC, static_cast<uint16>(spellid)))
+    if (!autoSpell::CanUseSpell(PAutomaton, spellid) || PAutomaton->PRecastContainer->HasRecast(RECAST_MAGIC, static_cast<uint16>(spellid), 0))
         return false;
 
     return CPetController::Cast(targid, spellid);
@@ -1382,7 +1382,7 @@ bool CAutomatonController::Cast(uint16 targid, SpellID spellid)
 
 bool CAutomatonController::MobSkill(uint16 targid, uint16 wsid)
 {
-    if(PAutomaton->PRecastContainer->HasRecast(RECAST_ABILITY, wsid))
+    if(PAutomaton->PRecastContainer->HasRecast(RECAST_ABILITY, wsid, 0))
         return false;
     return CPetController::MobSkill(targid, wsid);
 }

--- a/src/map/ai/controllers/automaton_controller.cpp
+++ b/src/map/ai/controllers/automaton_controller.cpp
@@ -1382,7 +1382,7 @@ bool CAutomatonController::Cast(uint16 targid, SpellID spellid)
 
 bool CAutomatonController::MobSkill(uint16 targid, uint16 wsid)
 {
-    if(PAutomaton->PRecastContainer->Has(RECAST_ABILITY, wsid))
+    if(PAutomaton->PRecastContainer->HasRecast(RECAST_ABILITY, wsid))
         return false;
     return CPetController::MobSkill(targid, wsid);
 }


### PR DESCRIPTION
Whenever an ability cooldown finishes it does not get completely removed from the container and instead it is just set to 0. `RecastContainer::Has()` checks if the ability has been added at all. `RecastContainer::HasRecast()` checks if it is currently on cooldown.

Fixes #5102