### PR TITLE
Last item in inventory container not being iterated on in a few scenarios

### DIFF
--- a/src/map/entities/charentity.cpp
+++ b/src/map/entities/charentity.cpp
@@ -1670,7 +1670,7 @@ void CCharEntity::UpdateMoghancement()
     for (auto containerID : {LOC_MOGSAFE, LOC_MOGSAFE2})
     {
         CItemContainer* PContainer = getStorage(containerID);
-        for (int slotID = 0; slotID < PContainer->GetSize(); ++slotID)
+        for (int slotID = 1; slotID <= PContainer->GetSize(); ++slotID)
         {
             CItem* PItem = PContainer->GetItem(slotID);
             if (PItem != nullptr && PItem->isType(ITEM_FURNISHING))
@@ -1712,7 +1712,7 @@ void CCharEntity::UpdateMoghancement()
         for (auto containerID : { LOC_MOGSAFE, LOC_MOGSAFE2 })
         {
             CItemContainer* PContainer = getStorage(containerID);
-            for (int slotID = 0; slotID < PContainer->GetSize(); ++slotID)
+            for (int slotID = 1; slotID <= PContainer->GetSize(); ++slotID)
             {
                 CItem* PItem = PContainer->GetItem(slotID);
                 if (PItem != nullptr && PItem->isType(ITEM_FURNISHING))

--- a/src/map/packet_system.cpp
+++ b/src/map/packet_system.cpp
@@ -5209,7 +5209,7 @@ void SmallPacket0x0FA(map_session_data_t* session, CCharEntity* PChar, CBasicPac
         for (auto safeContainerId : {LOC_MOGSAFE, LOC_MOGSAFE2})
         {
             CItemContainer* PContainer = PChar->getStorage(safeContainerId);
-            for (int slotIndex = 0; slotIndex < PContainer->GetSize(); ++slotIndex)
+            for (int slotIndex = 1; slotIndex <= PContainer->GetSize(); ++slotIndex)
             {
                 if (slotID == slotIndex && containerID == safeContainerId)
                     continue;


### PR DESCRIPTION
There is a `CItemContainer::ForEachItem` which could be used here instead but is only used in one place. Using it might complicate the code more than it is worth; however, if desired I can refactor the code to use that.