### PR TITLE
Fixed costume updates

### DIFF
--- a/src/map/entities/charentity.cpp
+++ b/src/map/entities/charentity.cpp
@@ -149,7 +149,7 @@ CCharEntity::CCharEntity()
     m_mkeCurrent = 0;
     m_asaCurrent = 0;
 
-    m_Costum = 0;
+    m_Costume = 0;
     m_Monstrosity = 0;
     m_hasTractor = 0;
     m_hasRaise = 0;

--- a/src/map/entities/charentity.h
+++ b/src/map/entities/charentity.h
@@ -262,7 +262,7 @@ public:
 
     uint32			  m_InsideRegionID;				// номер региона, в котором сейчас находится персонаж (??? может засунуть в m_event ???)
     uint8			  m_LevelRestriction;			// ограничение уровня персонажа
-    uint16            m_Costum;                     // карнавальный костюм персонажа (модель)
+    uint16            m_Costume;                     // карнавальный костюм персонажа (модель)
     uint16			  m_Monstrosity;				// Monstrosity model ID
     uint32			  m_AHHistoryTimestamp;			// Timestamp when last asked to view history
     uint32            m_DeathTimestamp;             // Timestamp when death counter has been saved to database

--- a/src/map/lua/lua_baseentity.cpp
+++ b/src/map/lua/lua_baseentity.cpp
@@ -4304,21 +4304,23 @@ inline int32 CLuaBaseEntity::costume(lua_State *L)
     DSP_DEBUG_BREAK_IF(m_PBaseEntity == nullptr);
     DSP_DEBUG_BREAK_IF(m_PBaseEntity->objtype != TYPE_PC);
 
-    CCharEntity* PChar = (CCharEntity*)m_PBaseEntity;
+    auto PChar = dynamic_cast<CCharEntity*>(m_PBaseEntity);
 
-    if (!lua_isnil(L, 1) && lua_isnumber(L, 1))
+    if (PChar && !lua_isnil(L, 1) && lua_isnumber(L, 1))
     {
-        uint16 costum = (uint16)lua_tointeger(L, 1);
+        uint16 costume = static_cast<uint16>(lua_tointeger(L, 1));
 
-        if (PChar->m_Costume != costum &&
+        if (PChar->m_Costume != costume &&
             PChar->status != STATUS_SHUTDOWN &&
             PChar->status != STATUS_DISAPPEAR)
         {
-            PChar->m_Costume = costum;
-            PChar->updatemask |= UPDATE_POS;
+            PChar->m_Costume = costume;
+            PChar->updatemask |= UPDATE_LOOK;
+            PChar->pushPacket(new CCharUpdatePacket(PChar));
         }
         return 0;
     }
+
     lua_pushinteger(L, PChar->m_Costume);
     return 1;
 }

--- a/src/map/lua/lua_baseentity.cpp
+++ b/src/map/lua/lua_baseentity.cpp
@@ -4310,16 +4310,16 @@ inline int32 CLuaBaseEntity::costume(lua_State *L)
     {
         uint16 costum = (uint16)lua_tointeger(L, 1);
 
-        if (PChar->m_Costum != costum &&
+        if (PChar->m_Costume != costum &&
             PChar->status != STATUS_SHUTDOWN &&
             PChar->status != STATUS_DISAPPEAR)
         {
-            PChar->m_Costum = costum;
+            PChar->m_Costume = costum;
             PChar->updatemask |= UPDATE_POS;
         }
         return 0;
     }
-    lua_pushinteger(L, PChar->m_Costum);
+    lua_pushinteger(L, PChar->m_Costume);
     return 1;
 }
 

--- a/src/map/packet_system.cpp
+++ b/src/map/packet_system.cpp
@@ -632,7 +632,7 @@ void SmallPacket0x01A(map_session_data_t* session, CCharEntity* PChar, CBasicPac
         if (PChar->StatusEffectContainer->HasPreventActionEffect())
             return;
 
-        if (PChar->m_Costum != 0 || PChar->animation == ANIMATION_SYNTH)
+        if (PChar->m_Costume != 0 || PChar->animation == ANIMATION_SYNTH)
         {
             PChar->pushPacket(new CReleasePacket(PChar, RELEASE_STANDARD));
             return;

--- a/src/map/packets/char.cpp
+++ b/src/map/packets/char.cpp
@@ -62,7 +62,7 @@ CCharPacket::CCharPacket(CCharEntity * PChar, ENTITYUPDATE type, uint8 updatemas
                 ref<uint16>(0x1A) = PChar->m_TargID << 1;
                 ref<uint8>(0x1C) = PChar->GetSpeed();
                 ref<uint8>(0x1D) = PChar->speedsub;
-                ref<uint16>(0x30) = PChar->m_Costum;
+                ref<uint16>(0x30) = PChar->m_Costume;
             }
 
             if (updatemask & UPDATE_HP)

--- a/src/map/packets/char.cpp
+++ b/src/map/packets/char.cpp
@@ -62,7 +62,6 @@ CCharPacket::CCharPacket(CCharEntity * PChar, ENTITYUPDATE type, uint8 updatemas
                 ref<uint16>(0x1A) = PChar->m_TargID << 1;
                 ref<uint8>(0x1C) = PChar->GetSpeed();
                 ref<uint8>(0x1D) = PChar->speedsub;
-                ref<uint16>(0x30) = PChar->m_Costume;
             }
 
             if (updatemask & UPDATE_HP)
@@ -119,7 +118,10 @@ CCharPacket::CCharPacket(CCharEntity * PChar, ENTITYUPDATE type, uint8 updatemas
             {
                 ref<uint16>(0x3C) = PChar->PPet->targid;
             }
+
+            ref<uint16>(0x30) = PChar->m_Costume;
             ref<uint8>(0x43) = 0x04;
+
             if (updatemask & UPDATE_LOOK)
             {
                 look_t *look = (PChar->getStyleLocked() ? &PChar->mainlook : &PChar->look);

--- a/src/map/packets/char_update.cpp
+++ b/src/map/packets/char_update.cpp
@@ -97,7 +97,7 @@ CCharUpdatePacket::CCharUpdatePacket(CCharEntity* PChar)
 
     // Vanatime at which the player should be forced back to homepoint while dead. Vanatime is in seconds so we must convert the time remaining to seconds.
     ref<uint32>(0x40) = CVanaTime::getInstance()->getVanaTime() + timeRemainingToForcedHomepoint / 60;
-    ref<uint16>(0x44) = PChar->m_Costum;
+    ref<uint16>(0x44) = PChar->m_Costume;
 
     if (PChar->animation == ANIMATION_FISHING_START)
     {

--- a/src/map/zone.cpp
+++ b/src/map/zone.cpp
@@ -850,9 +850,9 @@ void CZone::CharZoneIn(CCharEntity* PChar)
         PChar->StatusEffectContainer->DelStatusEffectSilent(EFFECT_MOUNTED);
     }
 
-    if (PChar->m_Costum != 0)
+    if (PChar->m_Costume != 0)
     {
-        PChar->m_Costum = 0;
+        PChar->m_Costume = 0;
         PChar->StatusEffectContainer->DelStatusEffect(EFFECT_COSTUME);
     }
 


### PR DESCRIPTION
Fixes https://github.com/DarkstarProject/darkstar/issues/5400

- Fixed typo/misspelling of costume.
- costume() now sends CCharUpdate after running, to avoid the delay until the next natural update. (confirmed on retail)
- Costume ID is sent in every CCharPacket, regardless of mask. (confirmed on retail)