### PR TITLE
review regimes obtained in zone A from zone B without crashiness

### DIFF
--- a/scripts/globals/regimes.lua
+++ b/scripts/globals/regimes.lua
@@ -925,18 +925,33 @@ local regimeInfo = {
 }
 
 local function getPageByRegimeId(regimeType, zoneId, regimeId)
-    local pages = regimeInfo[regimeType].zone[zoneId].page
-    for _, v in pairs(pages) do
+    local info = regimeInfo[regimeType]
+    if not info then return nil end
+
+    info = info.zone[zoneId]
+    if not info then return nil end
+
+    info = info.page
+    if not info then return nil end
+
+    for _, v in pairs(info) do
         if v[8] == regimeId then
             return v
         end
     end
+
     return nil
 end
 
 local function getPageByNum(regimeType, zoneId, pageNum)
-    local pages = regimeInfo[regimeType].zone[zoneId].page
-    return pages[pageNum]
+    local info = regimeInfo[regimeType]
+    if not info then return nil end
+
+    info = info.zone[zoneId]
+    if not info then return nil end
+
+    info = info.page
+    return info[pageNum]
 end
 
 local function getUpdateOpts(regimeType)
@@ -961,12 +976,22 @@ local function getFinishOpts(regimeType)
     return out
 end
 
+local function clearPlayerVars(player)
+    player:setVar("[regime]type", 0)
+    player:setVar("[regime]zone", 0)
+    player:setVar("[regime]id", 0)
+    player:setVar("[regime]repeat", 0)
+    player:setVar("[regime]lastReward", 0)
+
+    for i = 1, 4 do
+        player:setVar("[regime]needed" .. i, 0)
+        player:setVar("[regime]killed" .. i, 0)
+    end
+end
+
 dsp.regime.bookOnTrigger = function(player, regimeType)
     if (regimeType == dsp.regime.type.FIELDS and ENABLE_FIELD_MANUALS == 1) or (regimeType == dsp.regime.type.GROUNDS and ENABLE_GROUNDS_TOMES == 1) then
-        local zoneId = player:getZoneID()
-        local info = regimeInfo[regimeType].zone[zoneId]
-        local tabs = player:getCurrency("valor_point")
-        local regimeId = player:getVar("fov_regimeid")
+        local info = regimeInfo[regimeType].zone[player:getZoneID()]
 
         -- arg2 is a bitmask that controls which pages appear for examination
         -- here, we only show pages that have regime info
@@ -978,15 +1003,14 @@ dsp.regime.bookOnTrigger = function(player, regimeType)
             end
         end
 
-        player:startEvent(info.event, 0, arg2, 0, 0, 0, 0, tabs, regimeId)
+        player:startEvent(info.event, 0, arg2, 0, 0, 0, 0, player:getCurrency("valor_point"), player:getVar("[regime]id"))
     else
         player:PrintToPlayer("Disabled.")
     end
 end
 
 dsp.regime.bookOnEventUpdate = function(player, option, regimeType)
-    local pRegime = player:getVar("fov_regimeid")
-    local zoneId = player:getZoneID()
+    local page = getPageByRegimeId(player:getVar("[regime]type"), player:getVar("[regime]zone"), player:getVar("[regime]id"))
 
     -- check valid option
     local opts = getUpdateOpts(regimeType)
@@ -998,17 +1022,15 @@ dsp.regime.bookOnEventUpdate = function(player, option, regimeType)
     end
 
     -- review current training regime: progress on mobs
-    if opt.review then
-        local page = getPageByRegimeId(regimeType, zoneId, pRegime)
-        local n1 = (page[1] ~= 0) and player:getVar("fov_numkilled1") or 0
-        local n2 = (page[2] ~= 0) and player:getVar("fov_numkilled2") or 0
-        local n3 = (page[3] ~= 0) and player:getVar("fov_numkilled3") or 0
-        local n4 = (page[4] ~= 0) and player:getVar("fov_numkilled4") or 0
+    if opt.review and page then
+        local n1 = (page[1] ~= 0) and player:getVar("[regime]killed1") or 0
+        local n2 = (page[2] ~= 0) and player:getVar("[regime]killed2") or 0
+        local n3 = (page[3] ~= 0) and player:getVar("[regime]killed3") or 0
+        local n4 = (page[4] ~= 0) and player:getVar("[regime]killed4") or 0
         player:updateEvent(page[1], page[2], page[3], page[4], n1, n2, n3, n4)
 
     -- review current training regime: level range and training area
-    elseif opt.details then
-        local page = getPageByRegimeId(regimeType, zoneId, pRegime)
+    elseif opt.details and page then
         player:updateEvent(0, 0, 0, 0, 0, page[5], page[6], 0)
 
     -- TO DO: read about prowesses
@@ -1017,7 +1039,7 @@ dsp.regime.bookOnEventUpdate = function(player, option, regimeType)
 
     -- select a regime
     elseif opt.page then
-        local page = getPageByNum(regimeType, zoneId, opt.page)
+        local page = getPageByNum(regimeType, player:getZoneID(), opt.page)
         if page then
             player:updateEvent(page[1], page[2], page[3], page[4], 0, page[5], page[6], page[8])
         end
@@ -1058,11 +1080,7 @@ dsp.regime.bookOnEventFinish = function(player, option, regimeType)
         player:delCurrency("valor_point", opt.cost)
 
         if act == "CANCEL_REGIME" then
-            player:setVar("fov_regimeid" , 0)
-            player:setVar("fov_numkilled1", 0)
-            player:setVar("fov_numkilled2", 0)
-            player:setVar("fov_numkilled3", 0)
-            player:setVar("fov_numkilled4", 0)
+            clearPlayerVars(player)
             player:showText(player, msgOffset + 2) -- Training regime canceled.
 
         elseif act == "REPATRIATION" then
@@ -1166,12 +1184,14 @@ dsp.regime.bookOnEventFinish = function(player, option, regimeType)
                 regimeRepeat = 1
             end
 
-            player:setVar("fov_regimeid", page[8])
-            player:setVar("fov_repeat", regimeRepeat)
+            player:setVar("[regime]type", regimeType)
+            player:setVar("[regime]zone", zoneId)
+            player:setVar("[regime]id", page[8])
+            player:setVar("[regime]repeat", regimeRepeat)
 
             for i = 1, 4 do
-                player:setVar("fov_numkilled" .. i, 0)
-                player:setVar("fov_numneeded" .. i, page[i])
+                player:setVar("[regime]killed" .. i, 0)
+                player:setVar("[regime]needed" .. i, page[i])
             end
 
             player:showText(player, msgOffset)
@@ -1183,7 +1203,7 @@ end
 dsp.regime.checkRegime = function(player, mob, regimeId, index, regimeType)
 
     -- dead players, or players not on this training regime, get no credit
-    if not player or player:getHP() == 0 or player:getVar("fov_regimeid") ~= regimeId then
+    if not player or player:getHP() == 0 or player:getVar("[regime]id") ~= regimeId then
         return
     end
 
@@ -1198,8 +1218,8 @@ dsp.regime.checkRegime = function(player, mob, regimeId, index, regimeType)
     end
 
     -- get number of this mob needed, and killed so far
-    local needed = player:getVar("fov_numneeded" .. index)
-    local killed = player:getVar("fov_numkilled" .. index)
+    local needed = player:getVar("[regime]needed" .. index)
+    local killed = player:getVar("[regime]killed" .. index)
 
     -- already finished with this mob
     if killed == needed then
@@ -1209,7 +1229,7 @@ dsp.regime.checkRegime = function(player, mob, regimeId, index, regimeType)
     -- increment number killed
     killed = killed + 1
     player:messageBasic(dsp.msg.basic.FOV_DEFEATED_TARGET, killed, needed)
-    player:setVar("fov_numkilled" .. index, killed)
+    player:setVar("[regime]killed" .. index, killed)
 
     -- this mob is not yet finished
     if needed > killed then
@@ -1217,12 +1237,14 @@ dsp.regime.checkRegime = function(player, mob, regimeId, index, regimeType)
     end
 
     -- get page information
-    local zoneId = player:getZoneID()
-    local page = getPageByRegimeId(regimeType, zoneId, regimeId)
+    local page = getPageByRegimeId(player:getVar("[regime]type"), player:getVar("[regime]zone"), player:getVar("[regime]id"))
+    if not page then
+        return
+    end
 
     -- this page is not yet finished
     for i = 1, 4 do
-        if player:getVar("fov_numkilled" .. i) < page[i] then
+        if player:getVar("[regime]killed" .. i) < page[i] then
             return
         end
     end
@@ -1310,7 +1332,7 @@ dsp.regime.checkRegime = function(player, mob, regimeId, index, regimeType)
 
     -- award gil and tabs once per day, or at every page completion if REGIME_WAIT is 0 in settings.lua
     local vanadielEpoch = vanaDay()
-    if REGIME_WAIT == 0 or player:getVar("fov_LastReward") < vanadielEpoch then
+    if REGIME_WAIT == 0 or player:getVar("[regime]lastReward") < vanadielEpoch then
         -- gil
         player:addGil(reward)
         player:messageBasic(dsp.msg.basic.FOV_OBTAINS_GIL, reward)
@@ -1321,24 +1343,20 @@ dsp.regime.checkRegime = function(player, mob, regimeId, index, regimeType)
         player:addCurrency("valor_point", tabs)
         player:messageBasic(dsp.msg.basic.FOV_OBTAINS_TABS, tabs, player:getCurrency("valor_point"))
 
-        player:setVar("fov_LastReward", vanadielEpoch)
+        player:setVar("[regime]lastReward", vanadielEpoch)
     end
 
     -- award XP every page completion
     player:addExp(reward)
 
-    -- clear player vars
-    for i = 1, 4 do
-        player:setVar("fov_numkilled" .. i, 0)
-    end
-
     -- repeating regimes
-    if player:getVar("fov_repeat") == 1 then
+    if player:getVar("[regime]repeat") == 1 then
+        for i = 1, 4 do
+            player:setVar("[regime]killed" .. i, 0)
+        end
+
         player:messageBasic(dsp.msg.basic.FOV_REGIME_BEGINS_ANEW)
     else
-        player:setVar("fov_regimeid", 0)
-        for i = 1, 4 do
-            player:setVar("fov_numneeded" .. i, 0)
-        end
+        clearPlayerVars(player)
     end
 end


### PR DESCRIPTION
fix so that regime global won't crash when checked across type or zone
standardize player var names with [regime] prefix
to cleanup no-longer-used player variables:
```DELETE FROM char_vars WHERE varname LIKE 'fov_%';```

for #5419