### PR TITLE
Completable quest Old Man and the Harpoon with new quest system

### DIFF
--- a/scripts/globals/npc_util.lua
+++ b/scripts/globals/npc_util.lua
@@ -237,7 +237,7 @@ end
             fame = 120,                 -- fame defaults to 30 if not set
             bayld = 500,
             gil = 200,
-            xp = 1000,
+            exp = 1000,
             title = dsp.title.ENTRANCE_DENIED,
             var = {"foo1", "foo2"}      -- variable(s) to set to 0. string or table
         })
@@ -279,8 +279,8 @@ function npcUtil.completeQuest(player, area, quest, params)
         player:messageSpecial(ID.text.BAYLD_OBTAINED, params["bayld"] * BAYLD_RATE)
     end
 
-    if params["xp"] ~= nil and type(params["xp"]) == "number" then
-        player:addExp(params["xp"] * EXP_RATE)
+    if params["exp"] ~= nil and type(params["exp"]) == "number" then
+        player:addExp(params["exp"] * EXP_RATE)
     end
 
     if params["title"] ~= nil then

--- a/scripts/globals/quests.lua
+++ b/scripts/globals/quests.lua
@@ -1,4 +1,5 @@
 require("scripts/globals/log_ids")
+require("scripts/globals/npc_util")
 require("scripts/globals/zone")
 
 dsp = dsp or {}
@@ -12,6 +13,17 @@ dsp.quests.enums =
         JEUNO     = 3, OTHER_AREAS = 4,  OUTLANDS = 5,
         AHT_URGAN = 6, CRYSTAL_WAR = 7,  ABYSSEA  = 8,
         ADOULIN   = 9, COALITION   = 10
+    },
+
+    fame_areas =
+    {
+        SANDORIA          =  0, BASTOK           =  1, WINDURST           =  2,
+        JEUNO             =  3, SELBINA          =  4, MHAURA             =  2,
+        RABAO             =  4, KAZHAM           =  2, NORG               =  5,
+        ABYSSEA_KONSCHTAT =  6, ABYSSEA_TAHRONGI =  7, ABYSSEA_LATHEINE   =  8,
+        ABYSSEA_MISAREAUX =  9, ABYSSEA_VUNKERL  = 10, ABYSSEA_ATTOHWA    = 11,
+        ABYSSEA_ALTEPA    = 12, ABYSSEA_GRAUBERG = 13, ABYSSEA_ULEGUERAND = 14,
+        ADOULIN = 15
     },
 
     var_types =
@@ -306,9 +318,113 @@ dsp.quests.enums =
             WAKING_DREAMS                   = 93, -- + --
             LURE_OF_THE_WILDCAT_WINDURST    = 94,
             BABBAN_NY_MHEILLEA              = 95,
+        },
+
+        adoulin = {
+        -- These also do not match the DAT file order, had
+        -- discrepencies and swapped orders from the start.
+            TWITHERYM_DUST                  = 0,
+            TO_CATCH_A_PREDATOR             = 1,
+            EMPTY_NEST                      = 2,
+            DONT_CLAM_UP_ON_ME_NOW          = 5,
+            HOP_TO_IT                       = 6,
+            BOILING_OVER                    = 9,
+            POISONING_THE_WELL              = 10,
+            UNSULLIED_LANDS                 = 12,
+            NO_RIME_LIKE_THE_PRESENT        = 16,
+            A_GEOTHERMAL_EXPEDITION         = 18,
+            ENDEAVORING_TO_AWAKEN           = 22,
+            FORGING_NEW_BONDS               = 23,
+            LEGACIES_LOST_AND_FOUND         = 24,
+            DESTINYS_DEVICE                 = 25,
+            GRANDDADDY_DEAREST              = 26,
+            WAYWARD_WAYPOINTS               = 27,
+            ONE_GOOD_TURN                   = 28,
+            FAILURE_IS_NOT_AN_OPTION        = 29,
+            ORDER_UP                        = 30,
+            IT_NEVER_GOES_OUT_OF_STYLE      = 31,
+            WATER_WATER_EVERYWHERE          = 32,
+            DIRT_CHEAP                      = 33,
+            FLOWER_POWER                    = 34,
+            ELEMENTARY_MY_DEAR_SYLVIE       = 35,
+            FOR_WHOM_THE_BELL_TOLLS         = 36,
+            THE_BLOODLINE_OF_ZACARIAH       = 37,
+            THE_COMMUNION                   = 38,
+            FLAVORS_OF_OUR_LIVES            = 46,
+            WESTERN_WAYPOINTS_HO            = 50,
+            WESEASTERN_WAYPOINTS_HO         = 51,
+            GRIND_TO_SAWDUST                = 53,
+            BREAKING_THE_ICE                = 54,
+            IM_ON_A_BOAT                    = 55,
+            A_STONES_THROW_AWAY             = 56,
+            HIDE_AND_GO_PEAK                = 57,
+            THE_WHOLE_PLACE_IS_ABUZZ        = 58,
+            OROBON_APPETIT                  = 59,
+            TALK_ABOUT_WRINKLY_SKIN         = 60,
+            NO_LOVE_LOST                    = 61,
+            DID_YOU_FEEL_THAT               = 62,
+            DONT_EVER_LEAF_ME               = 70,
+            KEEP_YOUR_BLOOMERS_ON_ERISA     = 71,
+            SCAREDYCATS                     = 72,
+            RAPTOR_RAPTURE                  = 73,
+            EXOTIC_DELICACIES               = 74, -- + --
+            A_PIONEERS_BEST_IMAGINARY_FRIEND= 75, -- + --
+            HUNGER_STRIKES                  = 76, -- + --
+            THE_OLD_MAN_AND_THE_HARPOON     = 77, -- + --
+            A_CERTAIN_SUBSTITUTE_PATROLMAN  = 78, -- + --
+            IT_SETS_MY_HEART_AFLUTTER       = 79,
+            TRANSPORTING                    = 82,
+            THE_STARVING                    = 84, -- + --
+            FERTILE_GROUND                  = 85,
+            ALWAYS_MORE_QUOTH_THE_RAVENOUS  = 88, -- + --
+            MEGALOMANIAC                    = 89,
+            THE_LONGEST_WAY_ROUND           = 91,
+            A_GOOD_PAIR_OF_CROCS            = 93,
+            CAFETERIA                       = 94,
+            A_SHOT_IN_THE_DARK              = 96,
+            OPEN_THE_FLOODGATES             = 100,
+            NO_LAUGHING_MATTER              = 102,
+            ALL_THE_WAY_TO_THE_BANK         = 103,
+            TO_LAUGH_IS_TO_LOVE             = 104,
+            A_BARREL_OF_LAUGHS              = 105,
+            VEGETABLE_VEGETABLE_REVOLUTION  = 108,
+            VEGETABLE_VEGETABLE_EVOLUTION   = 109,
+            VEGETABLE_VEGETABLE_CRISIS      = 110,
+            VEGETABLE_VEGETABLE_FRUSTRATION = 111,
+            A_THIRST_FOR_THE_AGES           = 114,
+            A_THIRST_FOR_THE_EONS           = 115,
+            A_THIRST_FOR_ETERNITY           = 116,
+            A_THIRST_BEFORE_TIME            = 117,
+            DANCES_WITH_LUOPANS             = 118,
+            CHILDREN_OF_THE_RUNE            = 119,
+            FLOWERS_FOR_SVENJA              = 120,
+            THORN_IN_THE_SIDE               = 121,
+            DO_NOT_GO_INTO_THE_LIGHT        = 122,
+            VELKKOVERT_OPERATIONS           = 123,
+            HYPOCRITICAL_OATH               = 124,
+            THE_GOOD_THE_BAD_THE_CLEMENT    = 125,
+            LERENES_LAMENT                  = 126,
+            THE_SECRET_TO_SUCCESS           = 127,
+            NO_MERCY_FOR_THE_WICKED         = 128,
+            MISTRESS_OF_CEREMONIES          = 129,
+            SAVED_BY_THE_BELL               = 131,
+            QUIESCENCE                      = 132,
+            SICK_AND_TIRED                  = 133,
+            GEOMANCERRIFIC                  = 134,
+            RUNE_FENCING_THE_NIGHT_AWAY     = 135,
+            THE_WEATHERSPOON_INQUISITION    = 136,
+            EYE_OF_THE_BEHOLDER             = 137,
+            THE_CURIOUS_CASE_OF_MELVIEN     = 138,
+            NOTSOCLEAN_BILL                 = 139,
+            IN_THE_LAND_OF_THE_BLIND        = 140,
+            THE_WEATHERSPOON_WAR            = 141,
+            TREASURES_OF_THE_EARTH          = 142,
+            EPIPHANY                        = 143
         }
-    }
+    },
 }
+
+
 
 local check_enum =
 {
@@ -406,8 +522,12 @@ end
 
 dsp.quests.complete = function(player, quest, reward_set)
     if quest then
+        if reward_set == nil then
+            reward_set = quest.rewards.sets[1]
+        end
         if quest.rewards and reward_set then
             -- todo: check inventory (including stack space), award items, return false if cant complete
+            return npcUtil.completeQuest(player, quest.area, quest.questid, reward_set)
         end
 
         -- clear main CHAR_VAR if shouldnt be preserved
@@ -423,38 +543,50 @@ dsp.quests.complete = function(player, quest, reward_set)
 end
 
 dsp.quests.check = function(player, params)
-    local zoneid = player:getZoneID()
+    local quest = params.questTable
+    if quest then
+        local zoneid = player:getZoneID()
 
-    local cycle = player:getLocalVar("[quests]cycle")
-    local needsCycling = cycle < #params.questTable
-    local checkType = params.checkType
+        local cycle = tonumber(player:getLocalVar("[quests]cycle"))
+        --local needsCycling = cycle < #quest
+        local checkType = params.checkType
 
-    local targetName
-    if params.target then
-        targetName = params.target:getName()
-    end
-    if cycle > 0 and not needsCycling then
-        player:setLocalVar("[quests]cycle", 0)
-    end
-
-    for i, quest in ipairs(questTable) do
-        if quest and cycle < i then
-            local exitLoop
-            local checks =
-            {
-                [check_enum.onTrade] = function(player, params) return quest.npcs[zoneid][targetName].onTrade(player, params.target, params.trade) end,
-                [check_enum.onTrigger] = function(player, params) return quest.npcs[zoneid][targetName].onTrigger(player, params.target) end,
-                [check_enum.onEventUpdate] = function(player, params) return quest.npcs[zoneid][targetName].onEventUpdate(player, params.csid, params.option) end,
-                [check_enum.onEventFinish] = function(player, params) return quest.npcs[zoneid][targetName].onEventFinish(player, params.csid, params.option) end,
-                [check_enum.onZoneIn] = function(player, params) return quest.onZoneIn(player, params.zone) end,
-                [check_enum.onMobDeath] = function(player, params) return quest.mobs[zoneid][targetName].onMobDeath(params.target, player, params.isKiller, params.isWeaponSkillKill) end,
-            }
-            exitLoop = checks[params.checkType](player, params)
-            player:setLocalVar("[quests]cycle", i)
-            if exitLoop then
-                return true
-            end
+        local targetName
+        if params.target then
+            targetName = params.target:getName()
         end
+        if cycle > 0 and not needsCycling then
+            --player:setLocalVar("[quests]cycle", 0)
+        end
+
+        --for i, quest in ipairs(questTable) do
+            --if quest and cycle < i then
+                local exitLoop
+                local checks =
+                {
+                    [check_enum.onTrade] = function(player, params) return quest.npcs[zoneid][targetName].onTrade(player, params.target, params.trade) end,
+                    [check_enum.onTrigger] = function(player, params) return quest.npcs[zoneid][targetName].onTrigger(player, params.target) end,
+                    [check_enum.onEventUpdate] = function(player, params)
+                        if quest.events[zoneid][params.csid] then
+                            return quest.events[zoneid][params.csid].onEventUpdate(player, params.option)
+                        end
+                    end,
+                    [check_enum.onEventFinish] = function(player, params)
+                        if quest.events[zoneid][params.csid] then
+                            return quest.events[zoneid][params.csid].onEventFinish(player, params.option)
+                        end
+                    end,
+                    [check_enum.onZoneIn] = function(player, params) return quest.onZoneIn(player, params.zone) end,
+                    [check_enum.onMobDeath] = function(player, params) return quest.mobs[zoneid][targetName].onMobDeath(params.target, player, params.isKiller, params.isWeaponSkillKill) end,
+                }
+                --exitLoop = checks[params.checkType](player, params)
+                --player:setLocalVar("[quests]cycle", i)
+                if checks[params.checkType] then
+                    checks[params.checkType](player, params)
+                    return true
+                end
+            --end
+        --end
     end
     return nil
 end
@@ -473,6 +605,15 @@ dsp.quests.onTrigger = function(player, npc, questTable)
     params.target = npc
     params.trade = trade
     params.checkType = check_enum.onTrigger
+    params.questTable = questTable
+    return dsp.quests.check(player, params)
+end
+
+dsp.quests.onEventFinish = function(player, csid, option, questTable)
+    local params = {}
+    params.csid = csid
+    params.option = option
+    params.checkType = check_enum.onEventFinish
     params.questTable = questTable
     return dsp.quests.check(player, params)
 end

--- a/scripts/quests/adoulin/a_certain_substitute_patrolman.lua
+++ b/scripts/quests/adoulin/a_certain_substitute_patrolman.lua
@@ -1,0 +1,237 @@
+require("scripts/globals/missions")
+require("scripts/globals/quests")
+require("scripts/globals/zone")
+
+-- Stage 0: Talk to Rising Solstice, Western, to begin the quest
+-- Stage 1: Talk to Zaoso, Western Adoulin
+-- Stage 2: Talk to Clemmar, Western Adoulin
+-- Stage 3: Talk to Kongramm, Western Adoulin
+-- Stage 4: Talk to Virsaint, Western Adoulin
+-- Stage 5: Talk to Shipilolo, Western Adoulin
+-- Stage 6: Talk to Dangueubert, Western Adoulin
+-- Stage 7: Talk to Nylene, Western Adoulin
+-- Stage 8: Talk to Rising Solstice again, quest complete
+
+local this_quest = {}
+
+this_quest.name = "A Certain Substitute Patrolman"
+this_quest.area = ADOULIN
+this_quest.log_id = dsp.quests.enums.log_ids.ADOULIN
+this_quest.quest_id = dsp.quests.enums.quest_ids.adoulin.A_CERTAIN_SUBSTITUTE_PATROLMAN
+
+this_quest.repeatable = false
+this_quest.vars =
+{
+    stage = "[Q]".."["..this_quest.log_id.."]".."["..this_quest.quest_id.."]",
+    preserve_main_on_complete = false,
+    additional = {}
+}
+
+this_quest.requirements =
+{
+    quests_missions =
+    { 
+        quests = {},
+        {
+            -- [1] = { ['mission'] = require("scripts/globals/missions/adoulin/life_on_the_frontier") }
+        }
+    },
+    fame =
+    {
+        {this_quest.area, 1}
+    }
+}
+
+this_quest.rewards =
+{
+    sets =
+    {
+        [1] =
+        {
+            exp = 1000,
+            bayld = 500,
+            fame_area = dsp.quests.enums.fame_areas.ADOULIN
+        }
+    }
+}
+
+this_quest.temporary =
+{
+    items = {},
+    key_items = {dsp.ki.WESTERN_ADOULIN_PATROL_ROUTE}
+}
+
+this_quest.npcs =
+{
+    [dsp.zone.WESTERN_ADOULIN] =
+    {
+        ["Rising_Solstice"] =
+        {
+            onTrigger = function(player, npc)
+                local ACSP = player:getQuestStatus(ADOULIN, A_CERTAIN_SUBSTITUTE_PATROLMAN)
+                if ACSP == QUEST_ACCEPTED then
+                    if dsp.quests.getStage(player, this_quest) >= 1 then
+                        if dsp.quests.getStage(player, this_quest) == 8 then
+                            player:startEvent(2552) -- Finishes Quest: 'A Certain Substitute Patrolman'
+                        else
+                            player:startEvent(2551) -- Dialogue during Quest: 'A Certain Substitute Patrolman'
+                        end
+                        return true
+                    end
+                elseif ACSP == QUEST_AVAILABLE then
+                    player:startEvent(2550) -- Starts Quest: 'A Certain Substitute Patrolman'
+                    return true
+                end
+            end
+        },
+        ["Zaoso"] =
+        {
+            onTrigger = function(player, npc)
+                if dsp.quests.getStage(player, this_quest) == 1 then
+                    player:startEvent(2553) -- Progresses Quest: 'A Certain Substitute Patrolman'
+                    return true
+                end
+            end
+        },
+        ["Clemmar"] =
+        {
+            onTrigger = function(player, npc)
+                if dsp.quests.getStage(player, this_quest) == 2 then
+                    player:startEvent(2554) -- Progresses Quest: 'A Certain Substitute Patrolman'
+                    return true
+                end
+            end
+        },
+        ["Kongramm"] =
+        {
+            onTrigger = function(player, npc)
+                if dsp.quests.getStage(player, this_quest) == 3 then
+                    player:startEvent(2555) -- Progresses Quest: 'A Certain Substitute Patrolman'
+                    return true
+                end
+            end
+        },
+        ["Virsaint"] =
+        {
+            onTrigger = function(player, npc)
+                if dsp.quests.getStage(player, this_quest) == 4 then
+                    player:startEvent(2556) -- Progresses Quest: 'A Certain Substitute Patrolman'
+                    return true
+                end
+            end
+        },
+        ["Shipilolo"] =
+        {
+            onTrigger = function(player, npc)
+                if dsp.quests.getStage(player, this_quest) == 5 then
+                    player:startEvent(2557) -- Progresses Quest: 'A Certain Substitute Patrolman'
+                    return true
+                end
+            end
+        },
+        ["Dangueubert"] =
+        {
+            onTrigger = function(player, npc)
+                if dsp.quests.getStage(player, this_quest) == 6 then
+                    player:startEvent(2558) -- Progresses Quest: 'A Certain Substitute Patrolman'
+                    return true
+                end
+            end
+        },
+        ["Nylene"] =
+        {
+            onTrigger = function(player, npc)
+                if dsp.quests.getStage(player, this_quest) == 7 then
+                    player:startEvent(2559) -- Progresses Quest: 'A Certain Substitute Patrolman'
+                    return true
+                end
+            end
+        }
+    }
+}
+
+this_quest.events =
+{
+    [dsp.zone.WESTERN_ADOULIN] =
+    {
+        [2550] =
+        {
+            onEventFinish = function(player, option)
+                -- Rising Solstice, starts Quest: 'A Certain Substitute Patrolman'
+                if npcUtil.giveKeyItem(player, dsp.ki.WESTERN_ADOULIN_PATROL_ROUTE) then
+                    player:addQuest(this_quest.log_id, this_quest.quest_id)
+                    dsp.quests.setStage(player, this_quest, 1)
+                    return true
+                end
+            end
+        },
+        [2552] =
+        {
+            onEventFinish = function(player, option)
+                -- Rising Solstice, finishes Quest: 'A Certain Substitute Patrolman'
+                if dsp.quests.complete(player, this_quest) then
+                    player:delKeyItem(dsp.ki.WESTERN_ADOULIN_PATROL_ROUTE)
+                    return true
+                end
+            end
+        },
+        [2553] =
+        {
+            onEventFinish = function(player, option)
+                -- Zaoso, progresses Quest: 'A Certain Substitute Patrolman'
+                dsp.quests.setStage(player, this_quest, 2)
+                return true
+            end
+        },
+        [2554] =
+        {
+            onEventFinish = function(player, option)
+                -- Clemmar, progresses Quest: 'A Certain Substitute Patrolman'
+                dsp.quests.setStage(player, this_quest, 3)
+                return true
+            end
+        },
+        [2555] =
+        {
+            onEventFinish = function(player, option)
+                -- Kongramm, progresses Quest: 'A Certain Substitute Patrolman'
+                dsp.quests.setStage(player, this_quest, 4)
+                return true
+            end
+        },
+        [2556] =
+        {
+            onEventFinish = function(player, option)
+                -- Virsaint, progresses Quest: 'A Certain Substitute Patrolman'
+                dsp.quests.setStage(player, this_quest, 5)
+                return true
+            end
+        },
+        [2557] =
+        {
+            onEventFinish = function(player, option)
+                -- Shipilolo, progresses Quest: 'A Certain Substitute Patrolman'
+                dsp.quests.setStage(player, this_quest, 6)
+                return true
+            end
+        },
+        [2558] =
+        {
+            onEventFinish = function(player, option)
+                -- Dangueubert, progresses Quest: 'A Certain Substitute Patrolman'
+                dsp.quests.setStage(player, this_quest, 7)
+                return true
+            end
+        },
+        [2559] =
+        {
+            onEventFinish = function(player, option)
+                -- Nylene, progresses Quest: 'A Certain Substitute Patrolman'
+                dsp.quests.setStage(player, this_quest, 8)
+                return true
+            end
+        }
+    }
+}
+
+return this_quest

--- a/scripts/quests/adoulin/fertile_ground.lua
+++ b/scripts/quests/adoulin/fertile_ground.lua
@@ -1,0 +1,105 @@
+require("scripts/globals/missions")
+require("scripts/globals/quests")
+require("scripts/globals/zone")
+
+-- [TODO] Stage 0: Talk to Chalvava, Rala Waterways, to begin the quest
+-- Stage 1: Talk to Shipilolo, Western Adoulin, to get Bottle of Fertilizer X KI
+-- [TODO] Stage 2: Talk to Chalvava again, quest complete
+
+local this_quest = {}
+
+this_quest.name = "Fertile Ground"
+this_quest.area = ADOULIN
+this_quest.log_id = dsp.quests.enums.log_ids.ADOULIN
+this_quest.quest_id = dsp.quests.enums.quest_ids.adoulin.FERTILE_GROUND
+
+this_quest.repeatable = false
+this_quest.vars =
+{
+    stage = "[Q]".."["..this_quest.log_id.."]".."["..this_quest.quest_id.."]",
+    preserve_main_on_complete = false,
+    additional = {}
+}
+
+this_quest.requirements =
+{
+    quests_missions =
+    { 
+        quests =
+        {
+            -- [1] = { ['quest'] = require("scripts/globals/quests/adoulin/the_old_man_and_the_harpoon") }
+        },
+        missions = {}
+    },
+    fame =
+    {
+        {this_quest.area, 2}
+    }
+}
+
+this_quest.rewards =
+{
+    sets =
+    {
+        [1] =
+        {
+            exp = 500,
+            bayld = 300,
+            fame_area = dsp.quests.enums.fame_areas.ADOULIN
+        }
+    }
+}
+
+this_quest.temporary =
+{
+    items = {},
+    key_items = {dsp.ki.BOTTLE_OF_FERTILIZER_X}
+}
+
+this_quest.npcs =
+{
+    [dsp.zone.WESTERN_ADOULIN] =
+    {
+        ["Shipilolo"] =
+        {
+            onTrigger = function(player, npc)
+                if dsp.quests.getStage(player, this_quest) == 1 then
+                    player:startEvent(2850) -- Progresses Quest: 'Fertile Ground'
+                    return true
+                end
+            end
+        }
+    },
+    [dsp.zone.RALA_WATERWAYS] =
+    {
+        ["Chalvava"] =
+        {
+            onTrigger = function(player, npc)
+                -- TODO: Implement Chalvava's portions of the quest
+            end
+        }
+    }
+}
+
+this_quest.events =
+{
+    [dsp.zone.WESTERN_ADOULIN] =
+    {
+        [2850] =
+        {
+            onEventFinish = function(player, option)
+                -- Shipilolo, progresses Quest: 'Fertile Ground'
+                if npcUtil.giveKeyItem(player, dsp.ki.BOTTLE_OF_FERTILIZER_X) then
+                    dsp.quests.setStage(player, this_quest, 2)
+                    return true
+                end
+            end
+        }
+    },
+    [dsp.zone.RALA_WATERWAYS] =
+    {
+        -- TODO: find Chalvava's eventses and implement their onFinishes
+    }
+}
+
+return this_quest

--- a/scripts/quests/adoulin/the_old_man_and_the_harpoon.lua
+++ b/scripts/quests/adoulin/the_old_man_and_the_harpoon.lua
@@ -1,0 +1,115 @@
+require("scripts/globals/missions");
+require("scripts/globals/quests")
+require("scripts/globals/zone")
+
+local this_quest = {}
+
+this_quest.name = "The Old Man and the Harpoon"
+this_quest.area = ADOULIN
+this_quest.logid = dsp.quests.enums.log_ids.ADOULIN
+this_quest.questid = dsp.quests.enums.quest_ids.adoulin.THE_OLD_MAN_AND_THE_HARPOON
+
+this_quest.messageIDs =
+{
+    [dsp.zone.WESTERN_ADOULIN] = require("scripts/zones/Western_Adoulin/IDs")
+}
+
+this_quest.repeatable = false
+this_quest.vars =
+{
+    main = "[Q]".."["..this_quest.logid.."]".."["..this_quest.questid.."]",
+    preserve_main_on_complete = false, -- do we keep main var on quest completion
+    additional =
+    {
+        --["name"] = { id = 1, type = dsp.quests.enums.var_types.LOCAL_VAR, repeatable = false, preserve_on_complete = false },
+    }
+}
+
+this_quest.rewards =
+{
+    sets =
+    {
+        [1] =
+        {
+            exp = 500,
+            bayld = 300,
+            fame_area = dsp.quests.enums.fame_areas.ADOULIN
+        }
+    }
+}
+
+this_quest.npcs =
+{
+    [dsp.zone.WESTERN_ADOULIN] =
+    {
+        ["Jorin"] =
+        {
+            onTrade = function(player, npc, trade)
+            end,
+            onTrigger = function(player, npc)
+                local SOA_Mission = player:getCurrentMission(SOA)
+                local questStatus = player:getQuestStatus(this_quest.logid, this_quest.questid)
+                if questStatus == QUEST_ACCEPTED then
+                    if player:hasKeyItem(dsp.ki.EXTRAVAGANT_HARPOON) then
+                        player:startEvent(2542) -- Finishing Quest: 'The Old Man and the Harpoon'
+                    else
+                        player:startEvent(2541) -- Dialogue during Quest: 'The Old Man and the Harpoon'
+                    end
+                elseif (SOA_Mission >= LIFE_ON_THE_FRONTIER) and (questStatus == QUEST_AVAILABLE) then
+                    player:startEvent(2540) -- Starts Quest: 'The Old Man and the Harpoon'
+                end
+            end
+        },
+        ["Shipilolo"] =
+        {
+            onTrade = function(player, npc, trade)
+            end,
+            onTrigger = function(player, npc)
+                if player:hasKeyItem(dsp.ki.BROKEN_HARPOON) then
+                    player:startEvent(2543) -- Progresses Quest: 'The Old Man and the Harpoon'
+                end
+            end
+        }
+    }
+}
+
+this_quest.events = {
+    [dsp.zone.WESTERN_ADOULIN] =
+    {
+        [2540] =
+        {
+            onEventUpdate = function(player, csid, option)
+            end,
+            onEventFinish = function(player, option)
+                -- Jorin, starting Quest: 'The Old Man and the Harpoon'
+                if npcUtil.giveKeyItem(player, dsp.ki.BROKEN_HARPOON) then
+                    player:addQuest(this_quest.logid, this_quest.questid)
+                end
+            end
+        },
+        [2542] =
+        {
+            onEventUpdate = function(player, csid, option)
+            end,
+            onEventFinish = function(player, option)
+                -- Jorin, finishing Quest: 'The Old Man and the Harpoon'
+                if dsp.quests.complete(player, this_quest) then
+                    player:delKeyItem(dsp.ki.EXTRAVAGANT_HARPOON)
+                end
+            end
+        },
+        [2543] =
+        {
+            onEventUpdate = function(player, csid, option)
+            end,
+            onEventFinish = function(player, option)
+                -- Shipilolo, progresses Quest: 'The Old Man and the Harpoon'
+                if npcUtil.giveKeyItem(player, dsp.ki.EXTRAVAGANT_HARPOON) then
+                    player:delKeyItem(dsp.ki.BROKEN_HARPOON)
+                end
+            end
+        }
+    }
+}
+
+return this_quest

--- a/scripts/quests/adoulin/the_old_man_and_the_harpoon.lua
+++ b/scripts/quests/adoulin/the_old_man_and_the_harpoon.lua
@@ -2,27 +2,46 @@ require("scripts/globals/missions")
 require("scripts/globals/quests")
 require("scripts/globals/zone")
 
+-- Stage 0: Talk to Jorin, Western Adoulin, to get Broken Harpoon KI and start quest
+-- Stage 1: Talk to Shipilolo, Western Adoulin, to exchange Broken Harpoon KI for Extravagant Harpoon KI
+-- Stage 2: Talk to Jorin, quest complete
+
 local this_quest = {}
 
 this_quest.name = "The Old Man and the Harpoon"
 this_quest.area = ADOULIN
-this_quest.logid = dsp.quests.enums.log_ids.ADOULIN
-this_quest.questid = dsp.quests.enums.quest_ids.adoulin.THE_OLD_MAN_AND_THE_HARPOON
-
-this_quest.messageIDs =
-{
-    [dsp.zone.WESTERN_ADOULIN] = require("scripts/zones/Western_Adoulin/IDs")
-}
+this_quest.log_id = dsp.quests.enums.log_ids.ADOULIN
+this_quest.quest_id = dsp.quests.enums.quest_ids.adoulin.THE_OLD_MAN_AND_THE_HARPOON
 
 this_quest.repeatable = false
 this_quest.vars =
 {
-    main = "[Q]".."["..this_quest.logid.."]".."["..this_quest.questid.."]",
+    stage = "[Q]".."["..this_quest.log_id.."]".."["..this_quest.quest_id.."]",
     preserve_main_on_complete = false, -- do we keep main var on quest completion
     additional =
     {
         --["name"] = { id = 1, type = dsp.quests.enums.var_types.LOCAL_VAR, repeatable = false, preserve_on_complete = false },
     }
+}
+
+this_quest.requirements =
+{
+    quests_missions =
+    { 
+        quests = {},
+        missions =
+        {
+            -- [1] = { ['mission'] = require("scripts/globals/missions/adoulin/life_on_the_frontier") }
+            -- [1] = { ['quest'] = require("scripts/globals/missions/adoulin/life_on_the_frontier"), ['stage'] = x }
+        }
+    },
+    fame =
+    {
+        {this_quest.area, 1}
+    }
+    -- trade = { {item, qty} },
+    -- keyitems = {...},
+    -- etc..
 }
 
 this_quest.rewards =
@@ -47,17 +66,16 @@ this_quest.npcs =
             onTrade = function(player, npc, trade)
             end,
             onTrigger = function(player, npc)
-                local SOA_Mission = player:getCurrentMission(SOA)
-                local questStatus = player:getQuestStatus(this_quest.logid, this_quest.questid)
-                if questStatus == QUEST_ACCEPTED then
-                    if player:hasKeyItem(dsp.ki.EXTRAVAGANT_HARPOON) then
+                local questStatus = player:getQuestStatus(ADOULIN, THE_OLD_MAN_AND_THE_HARPOON)
+                if dsp.quests.getStage(player, this_quest) >= 1 then
+                    if dsp.quests.getStage(player, this_quest) == 2 then
                         player:startEvent(2542) -- Finishing Quest: 'The Old Man and the Harpoon'
                         return true
                     else
                         player:startEvent(2541) -- Dialogue during Quest: 'The Old Man and the Harpoon'
                         return true
                     end
-                elseif (SOA_Mission >= LIFE_ON_THE_FRONTIER) and (questStatus == QUEST_AVAILABLE) then
+                elseif (player:getCurrentMission(SOA) >= LIFE_ON_THE_FRONTIER) and (questStatus == QUEST_AVAILABLE) then
                     player:startEvent(2540) -- Starts Quest: 'The Old Man and the Harpoon'
                     return true
                 end
@@ -68,7 +86,7 @@ this_quest.npcs =
             onTrade = function(player, npc, trade)
             end,
             onTrigger = function(player, npc)
-                if player:hasKeyItem(dsp.ki.BROKEN_HARPOON) then
+                if dsp.quests.getStage(player, this_quest) == 1 then
                     player:startEvent(2543) -- Progresses Quest: 'The Old Man and the Harpoon'
                     return true
                 end
@@ -88,7 +106,8 @@ this_quest.events =
             onEventFinish = function(player, option)
                 -- Jorin, starting Quest: 'The Old Man and the Harpoon'
                 if npcUtil.giveKeyItem(player, dsp.ki.BROKEN_HARPOON) then
-                    player:addQuest(this_quest.logid, this_quest.questid)
+                    player:addQuest(this_quest.log_id, this_quest.quest_id)
+                    dsp.quests.setStage(player, this_quest, 1)
                     return true
                 end
             end
@@ -113,6 +132,7 @@ this_quest.events =
                 -- Shipilolo, progresses Quest: 'The Old Man and the Harpoon'
                 if npcUtil.giveKeyItem(player, dsp.ki.EXTRAVAGANT_HARPOON) then
                     player:delKeyItem(dsp.ki.BROKEN_HARPOON)
+                    dsp.quests.setStage(player, this_quest, 2)
                     return true
                 end
             end

--- a/scripts/quests/adoulin/the_old_man_and_the_harpoon.lua
+++ b/scripts/quests/adoulin/the_old_man_and_the_harpoon.lua
@@ -1,4 +1,4 @@
-require("scripts/globals/missions");
+require("scripts/globals/missions")
 require("scripts/globals/quests")
 require("scripts/globals/zone")
 
@@ -52,11 +52,14 @@ this_quest.npcs =
                 if questStatus == QUEST_ACCEPTED then
                     if player:hasKeyItem(dsp.ki.EXTRAVAGANT_HARPOON) then
                         player:startEvent(2542) -- Finishing Quest: 'The Old Man and the Harpoon'
+                        return true
                     else
                         player:startEvent(2541) -- Dialogue during Quest: 'The Old Man and the Harpoon'
+                        return true
                     end
                 elseif (SOA_Mission >= LIFE_ON_THE_FRONTIER) and (questStatus == QUEST_AVAILABLE) then
                     player:startEvent(2540) -- Starts Quest: 'The Old Man and the Harpoon'
+                    return true
                 end
             end
         },
@@ -67,13 +70,15 @@ this_quest.npcs =
             onTrigger = function(player, npc)
                 if player:hasKeyItem(dsp.ki.BROKEN_HARPOON) then
                     player:startEvent(2543) -- Progresses Quest: 'The Old Man and the Harpoon'
+                    return true
                 end
             end
         }
     }
 }
 
-this_quest.events = {
+this_quest.events =
+{
     [dsp.zone.WESTERN_ADOULIN] =
     {
         [2540] =
@@ -84,6 +89,7 @@ this_quest.events = {
                 -- Jorin, starting Quest: 'The Old Man and the Harpoon'
                 if npcUtil.giveKeyItem(player, dsp.ki.BROKEN_HARPOON) then
                     player:addQuest(this_quest.logid, this_quest.questid)
+                    return true
                 end
             end
         },
@@ -95,6 +101,7 @@ this_quest.events = {
                 -- Jorin, finishing Quest: 'The Old Man and the Harpoon'
                 if dsp.quests.complete(player, this_quest) then
                     player:delKeyItem(dsp.ki.EXTRAVAGANT_HARPOON)
+                    return true
                 end
             end
         },
@@ -106,6 +113,7 @@ this_quest.events = {
                 -- Shipilolo, progresses Quest: 'The Old Man and the Harpoon'
                 if npcUtil.giveKeyItem(player, dsp.ki.EXTRAVAGANT_HARPOON) then
                     player:delKeyItem(dsp.ki.BROKEN_HARPOON)
+                    return true
                 end
             end
         }

--- a/scripts/quests/adoulin/wayward_waypoints.lua
+++ b/scripts/quests/adoulin/wayward_waypoints.lua
@@ -1,0 +1,130 @@
+require("scripts/globals/missions")
+require("scripts/globals/quests")
+require("scripts/globals/zone")
+
+-- [TODO] Stage 0: Speak to Sharuru in Eastern Adoulin to start the quest and receive a Waypoint Scanner Kit KI
+-- [TODO] Stage 1: Adjust waypoints at Frontier Stations in Ceizak, Yahse, Foret, Morimar, Yorcia, Marjami, and Kamihr
+-- [TODO] Stage 2: Try adjusting waypoint in Lower Jeuno
+-- [TODO] Stage 3: Talk to Sharuru again.
+-- Stage 4: Talk to Shipilolo in Western Adoulin and get Waypoint Recalibration Kit KI
+-- [TODO] Stage 5: Try Lower Jeuno waypoint again
+-- [TODO] Stage 6: Return to Sharuru, quest complete
+
+local waypointEventFinish = function(player, waypoint)
+    -- Make sure player is working on stage 1
+    -- Bitmask the bit in the waypoints var for the given waypoint
+    -- Check value of the waypoint var, if all are set, advance to stage 2
+    -- Return true if we did something
+end
+
+local this_quest = {}
+
+this_quest.name = "Wayward Waypoints"
+this_quest.area = ADOULIN
+this_quest.log_id = dsp.quests.enums.log_ids.ADOULIN
+this_quest.quest_id = dsp.quests.enums.quest_ids.adoulin.WAYWARD_WAYPOINTS
+
+this_quest.repeatable = false
+this_quest.vars =
+{
+    stage = "[Q]".."["..this_quest.log_id.."]".."["..this_quest.quest_id.."]",
+    preserve_main_on_complete = false, -- do we keep main var on quest completion
+    additional =
+    {
+        -- Bitmask of waypoints calibrated during the second stage.
+        ["waypoints"] = { id = 1, type = dsp.quests.enums.var_types.LOCAL_VAR, repeatable = false, preserve_on_complete = false }, 
+    }
+}
+
+this_quest.requirements =
+{
+    quests_missions =
+    { 
+        quests =
+        {
+            -- [1] = { ['quest'] = require("scripts/globals/quests/adoulin/megalomaniac") }
+        },
+        missions = {}
+    },
+    fame =
+    {
+        {this_quest.area, 4}
+    }
+}
+
+this_quest.rewards =
+{
+    sets =
+    {
+        [1] =
+        {
+            exp = 1000,
+            bayld = 500,
+            -- kinetic_units = 3000, -- Kinetic units need to be implemented before we reward them.
+            fame_area = dsp.quests.enums.fame_areas.ADOULIN
+        }
+    }
+}
+
+this_quest.temporary =
+{
+    items = {},
+    key_items =
+    {
+        dsp.ki.WAYPOINT_SCANNER_KIT,
+        dsp.ki.WAYPOINT_RECALIBRATION_KIT
+    }
+}
+
+this_quest.npcs =
+{
+    [dsp.zone.WESTERN_ADOULIN] =
+    {
+        ["Shipilolo"] =
+        {
+            onTrigger = function(player, npc)
+                if dsp.quests.getStage(player, this_quest) == 4 then
+                    player:startEvent(79) -- Progresses Quest: 'Wayward Waypoints'
+                    return true
+                end
+            end
+        }
+    },
+    [dsp.zone.EASTERN_ADOULIN] =
+    {
+        ["Sharuru"] =
+        {
+            onTrigger = function(player, npc)
+                -- TODO: Implement Sharuru's portions of the quest
+            end
+        }
+    }
+    -- TODO: Find/implement the onTriggers for the Adoulin waypoints
+    -- TODO: Find/implement the onTrigger for the Lower Jeuno waypoint
+}
+
+this_quest.events =
+{
+    [dsp.zone.WESTERN_ADOULIN] =
+    {
+        [79] =
+        {
+            onEventFinish = function(player, option)
+                -- Shipilolo, progresses Quest: 'Wayward Waypoints'
+                if npcUtil.giveKeyItem(player, dsp.ki.WAYPOINT_RECALIBRATION_KIT) then
+                    player:delKeyItem(dsp.ki.WAYPOINT_SCANNER_KIT)
+                    dsp.quests.setStage(player, this_quest, 5)
+                    return true
+                end
+            end
+        }
+    },
+    [dsp.zone.EASTERN_ADOULIN] =
+    {
+        -- TODO: find Sharuru's events and implement their onFinishes
+    }
+    -- TODO: Implement the event onFinishes for the Adoulin waypoints, just call waypointEventFinish() with their number
+    -- TODO: Implement the Lower Jeuno onFinish events
+}
+
+return this_quest

--- a/scripts/zones/Western_Adoulin/npcs/Clemmar.lua
+++ b/scripts/zones/Western_Adoulin/npcs/Clemmar.lua
@@ -7,25 +7,25 @@
 -----------------------------------
 require("scripts/globals/missions");
 require("scripts/globals/quests");
+
+local quest_table =
+{
+    require("scripts/quests/adoulin/a_certain_substitute_patrolman")
+}
 -----------------------------------
 
 function onTrade(player,npc,trade)
 end;
 
 function onTrigger(player,npc)
-    local ACSP = player:getQuestStatus(ADOULIN, A_CERTAIN_SUBSTITUTE_PATROLMAN);
-    local SOA_Mission = player:getCurrentMission(SOA);
-    if (SOA_Mission >= LIFE_ON_THE_FRONTIER) then
-        if ((ACSP == QUEST_ACCEPTED) and (player:getVar("ACSP_NPCs_Visited") == 2)) then
-            -- Progresses Quest: 'A Certain Substitute Patrolman'
-            player:startEvent(2554);
-        else
+    if not dsp.quests.onTrigger(player, npc, quest_table) then
+        if player:getCurrentMission(SOA) >= LIFE_ON_THE_FRONTIER then
             -- Standard dialogue
-            player:startEvent(570);
+            player:startEvent(570)
+        else
+            -- Dialogue prior to joining colonization effort
+            player:startEvent(519)
         end
-    else
-        -- Dialogue prior to joining colonization effort
-        player:startEvent(519);
     end
 end;
 
@@ -33,8 +33,5 @@ function onEventUpdate(player,csid,option)
 end;
 
 function onEventFinish(player,csid,option)
-    if (csid == 2554) then
-        -- Progresses Quest: 'A Certain Substitute Patrolman'
-        player:setVar("ACSP_NPCs_Visited", 3);
-    end
+    dsp.quests.onEventFinish(player, csid, option, quest_table)
 end;

--- a/scripts/zones/Western_Adoulin/npcs/Dangueubert.lua
+++ b/scripts/zones/Western_Adoulin/npcs/Dangueubert.lua
@@ -7,25 +7,25 @@
 -----------------------------------
 require("scripts/globals/missions");
 require("scripts/globals/quests");
+
+local quest_table =
+{
+    require("scripts/quests/adoulin/a_certain_substitute_patrolman")
+}
 -----------------------------------
 
 function onTrade(player,npc,trade)
 end;
 
 function onTrigger(player,npc)
-    local SOA_Mission = player:getCurrentMission(SOA);
-
-    if (SOA_Mission >= LIFE_ON_THE_FRONTIER) then
-        if ((ACSP == QUEST_ACCEPTED) and (player:getVar("ACSP_NPCs_Visited") == 6)) then
-            -- Progresses Quest: 'A Certain Substitute Patrolman'
-            player:startEvent(2558);
-        else
+    if not dsp.quests.onTrigger(player, npc, quest_table) then
+        if player:getCurrentMission(SOA) >= LIFE_ON_THE_FRONTIER then
             -- Standard dialogue
-            player:startEvent(546, 0, 1);
+            player:startEvent(546, 0, 1)
+        else
+            -- Dialogue prior to joining colonization effort
+            player:startEvent(546)
         end
-    else
-        -- Dialogue prior to joining colonization effort
-        player:startEvent(546);
     end
 end;
 
@@ -33,13 +33,12 @@ function onEventUpdate(player,csid,option)
 end;
 
 function onEventFinish(player,csid,option)
-    if (csid == 2558) then
-        -- Progresses Quest: 'A Certain Substitute Patrolman'
-        player:setVar("ACSP_NPCs_Visited", 7);
-    elseif (csid == 546) then
-        if (option == 1) then
-            -- Warps player to Mog Garden
-            player:setPos(0, 0, 0, 0, 280);
+    if not dsp.quests.onEventFinish(player, csid, option, quest_table) then
+        if (csid == 546) then
+            if (option == 1) then
+                -- Warps player to Mog Garden
+                player:setPos(0, 0, 0, 0, 280);
+            end
         end
     end
 end;

--- a/scripts/zones/Western_Adoulin/npcs/Jorin.lua
+++ b/scripts/zones/Western_Adoulin/npcs/Jorin.lua
@@ -5,29 +5,16 @@
 -- Starts, Involved with, and Finishes Quest: 'The Old Man and the Harpoon'
 -- !pos 92 32 152 256
 -----------------------------------
-require("scripts/globals/quests");
-local ID = require("scripts/zones/Western_Adoulin/IDs");
+require("scripts/globals/quests")
+local THE_OLD_MAN_AND_THE_HARPOON = require("scripts/quests/adoulin/the_old_man_and_the_harpoon")
 -----------------------------------
 
 function onTrade(player,npc,trade)
 end;
 
 function onTrigger(player,npc)
-    local TOMATH = player:getQuestStatus(ADOULIN, THE_OLD_MAN_AND_THE_HARPOON);
-    if (TOMATH == QUEST_ACCEPTED) then
-        if (player:hasKeyItem(dsp.ki.EXTRAVAGANT_HARPOON)) then
-            -- Finishing Quest: 'The Old Man and the Harpoon'
-            player:startEvent(2542);
-        else
-            -- Dialgoue during Quest: 'The Old Man and the Harpoon'
-            player:startEvent(2541);
-        end
-    elseif (TOMATH == QUEST_AVAILABLE) then
-        -- Starts Quest: 'The Old Man and the Harpoon'
-        player:startEvent(2540);
-    else
-        -- Standard dialogue
-        player:startEvent(560);
+    if not dsp.quests.onTrigger(player, npc, THE_OLD_MAN_AND_THE_HARPOON) then
+        player:startEvent(560) -- Standard dialogue
     end
 end;
 
@@ -35,18 +22,5 @@ function onEventUpdate(player,csid,option)
 end;
 
 function onEventFinish(player,csid,option)
-    if (csid == 2540) then
-        -- Starting Quest: 'The Old Man and the Harpoon'
-        player:addQuest(ADOULIN, THE_OLD_MAN_AND_THE_HARPOON);
-        player:addKeyItem(dsp.ki.BROKEN_HARPOON);
-        player:messageSpecial(ID.text.KEYITEM_OBTAINED, dsp.ki.BROKEN_HARPOON);
-    elseif (csid == 2542) then
-        -- Finishing Quest: 'The Old Man and the Harpoon'
-        player:completeQuest(ADOULIN, THE_OLD_MAN_AND_THE_HARPOON);
-        player:addExp(500 * EXP_RATE);
-        player:addCurrency('bayld', 300 * BAYLD_RATE);
-        player:messageSpecial(ID.text.BAYLD_OBTAINED, 300 * BAYLD_RATE);
-        player:delKeyItem(dsp.ki.EXTRAVAGANT_HARPOON);
-        player:addFame(ADOULIN);
-    end
+    dsp.quests.onEventFinish(player, csid, option, THE_OLD_MAN_AND_THE_HARPOON)
 end;

--- a/scripts/zones/Western_Adoulin/npcs/Jorin.lua
+++ b/scripts/zones/Western_Adoulin/npcs/Jorin.lua
@@ -6,21 +6,25 @@
 -- !pos 92 32 152 256
 -----------------------------------
 require("scripts/globals/quests")
-local THE_OLD_MAN_AND_THE_HARPOON = require("scripts/quests/adoulin/the_old_man_and_the_harpoon")
+
+local quest_table =
+{
+    require("scripts/quests/adoulin/the_old_man_and_the_harpoon"),
+}
 -----------------------------------
 
 function onTrade(player,npc,trade)
 end;
 
 function onTrigger(player,npc)
-    if not dsp.quests.onTrigger(player, npc, THE_OLD_MAN_AND_THE_HARPOON) then
+    if not dsp.quests.onTrigger(player, npc, quest_table) then
         player:startEvent(560) -- Standard dialogue
     end
-end;
+end
 
 function onEventUpdate(player,csid,option)
 end;
 
 function onEventFinish(player,csid,option)
-    dsp.quests.onEventFinish(player, csid, option, THE_OLD_MAN_AND_THE_HARPOON)
-end;
+    dsp.quests.onEventFinish(player, csid, option, quest_table)
+end

--- a/scripts/zones/Western_Adoulin/npcs/Kongramm.lua
+++ b/scripts/zones/Western_Adoulin/npcs/Kongramm.lua
@@ -9,6 +9,11 @@
 require("scripts/globals/missions");
 require("scripts/globals/quests");
 require("scripts/globals/keyitems");
+
+local quest_table =
+{
+    require("scripts/quests/adoulin/a_certain_substitute_patrolman")
+}
 -----------------------------------
 
 function onTrade(player,npc,trade)
@@ -16,7 +21,6 @@ end;
 
 function onTrigger(player,npc)
     local SOA_Mission = player:getCurrentMission(SOA);
-    local ACSP = player:getQuestStatus(ADOULIN, A_CERTAIN_SUBSTITUTE_PATROLMAN);
     local Transporting = player:getQuestStatus(ADOULIN, TRANSPORTING);
 
     if ((SOA_Mission == A_CURSE_FROM_THE_PAST) and (not player:hasKeyItem(dsp.ki.PIECE_OF_A_STONE_WALL))) then
@@ -27,15 +31,16 @@ function onTrigger(player,npc)
             -- Reminds player of hint for SOA Mission: 'A Curse From the Past'
             player:startEvent(149);
         end
-    elseif ((Transporting == QUEST_ACCEPTED) and (player:getVar("Transporting_Status") < 1)) then
-        -- Progresses Quest: 'Transporting'
-        player:startEvent(2592);
-    elseif ((ACSP == QUEST_ACCEPTED) and (player:getVar("ACSP_NPCs_Visited") == 3)) then
-        -- Progresses Quest: 'A Certain Substitute Patrolman'
-        player:startEvent(2555);
     else
-        -- Standard dialogue
-        player:startEvent(558);
+        if not dsp.quests.onTrigger(player, npc, quest_table) then
+            if ((Transporting == QUEST_ACCEPTED) and (player:getVar("Transporting_Status") < 1)) then
+                -- Progresses Quest: 'Transporting'
+                player:startEvent(2592);
+            else
+                -- Standard dialogue
+                player:startEvent(558);
+            end
+        end
     end
 end;
 
@@ -43,14 +48,13 @@ function onEventUpdate(player,csid,option)
 end;
 
 function onEventFinish(player,csid,option)
-    if (csid == 148) then
-        -- Gave hint for SOA Mission: 'A Curse From the Past'
-        player:setVar("SOA_ACFTP_Kongramm", 1);
-    elseif (csid == 2592) then
-        -- Progresses Quest: 'Transporting'
-        player:setVar("Transporting_Status", 1);
-    elseif (csid == 2555) then
-        -- Progresses Quest: 'A Certain Substitute Patrolman'
-        player:setVar("ACSP_NPCs_Visited", 4);
+    if not dsp.quests.onEventFinish(player, csid, option, quest_table) then
+        if (csid == 148) then
+            -- Gave hint for SOA Mission: 'A Curse From the Past'
+            player:setVar("SOA_ACFTP_Kongramm", 1);
+        elseif (csid == 2592) then
+            -- Progresses Quest: 'Transporting'
+            player:setVar("Transporting_Status", 1);
+        end
     end
 end;

--- a/scripts/zones/Western_Adoulin/npcs/Nylene.lua
+++ b/scripts/zones/Western_Adoulin/npcs/Nylene.lua
@@ -7,25 +7,25 @@
 -----------------------------------
 require("scripts/globals/missions");
 require("scripts/globals/quests");
+
+local quest_table =
+{
+    require("scripts/quests/adoulin/a_certain_substitute_patrolman")
+}
 -----------------------------------
 
 function onTrade(player,npc,trade)
 end;
 
 function onTrigger(player,npc)
-    local ACSP = player:getQuestStatus(ADOULIN, A_CERTAIN_SUBSTITUTE_PATROLMAN);
-    local SOA_Mission = player:getCurrentMission(SOA);
-    if (SOA_Mission >= LIFE_ON_THE_FRONTIER) then
-        if ((ACSP == QUEST_ACCEPTED) and (player:getVar("ACSP_NPCs_Visited") == 7)) then
-            -- Progresses Quest: 'A Certain Substitute Patrolman'
-            player:startEvent(2559);
-        else
+    if not dsp.quests.onTrigger(player, npc, quest_table) then
+        if player:getCurrentMission(SOA) >= LIFE_ON_THE_FRONTIER then
             -- Standard dialogue
-            player:startEvent(562);
+            player:startEvent(562)
+        else
+            -- Dialogue prior to joining colonization effort
+            player:startEvent(533)
         end
-    else
-        -- Dialogue prior to joining colonization effort
-        player:startEvent(533);
     end
 end;
 
@@ -33,8 +33,5 @@ function onEventUpdate(player,csid,option)
 end;
 
 function onEventFinish(player,csid,option)
-    if (csid == 2559) then
-        -- Progresses Quest: 'A Certain Substitute Patrolman'
-        player:setVar("ACSP_NPCs_Visited", 8);
-    end
+    dsp.quests.onEventFinish(player, csid, option, quest_table)
 end;

--- a/scripts/zones/Western_Adoulin/npcs/Rising_Solstice.lua
+++ b/scripts/zones/Western_Adoulin/npcs/Rising_Solstice.lua
@@ -8,33 +8,25 @@
 require("scripts/globals/missions");
 require("scripts/globals/quests");
 require("scripts/globals/keyitems");
-local ID = require("scripts/zones/Western_Adoulin/IDs");
+
+local quest_table =
+{
+    require("scripts/quests/adoulin/a_certain_substitute_patrolman")
+}
 -----------------------------------
 
 function onTrade(player,npc,trade)
 end;
 
 function onTrigger(player,npc)
-    local ACSP = player:getQuestStatus(ADOULIN, A_CERTAIN_SUBSTITUTE_PATROLMAN);
     local SOA_Mission = player:getCurrentMission(SOA);
 
-    if (SOA_Mission >= LIFE_ON_THE_FRONTIER) then
-        if (ACSP == QUEST_ACCEPTED) then
-            -- Finishing Quest: 'A Certain Substitute Patrolman'
-            if (player:getVar("ACSP_NPCs_Visited") >= 8) then
-                player:startEvent(2552);
-            -- During Quest: 'A Certain Substitute Patrolman'
-            else
-                player:startEvent(2551);
-            end
-        -- Starts Quest: 'A Certain Substitute Patrolman'
-        elseif (ACSP == QUEST_AVAILABLE) then
-            player:startEvent(2550);
+    if SOA_Mission >= LIFE_ON_THE_FRONTIER then
+        if (SOA_Mission >= BEAUTY_AND_THE_BEAST) and (SOA_Mission <= SALVATION) then
+            -- Speech while Arciela is 'kidnapped'
+            player:startEvent(150);
         else
-            if ((SOA_Mission >= BEAUTY_AND_THE_BEAST) and (SOA_Mission <= SALVATION)) then
-                -- Speech while Arciela is 'kidnapped'
-                player:startEvent(150);
-            else
+            if not dsp.quests.onTrigger(player, npc, quest_table) then
                 -- Standard dialogue, after joining colonization effort
                 player:startEvent(580);
             end
@@ -49,20 +41,5 @@ function onEventUpdate(player,csid,option)
 end;
 
 function onEventFinish(player,csid,option)
-    if (csid == 2550) then
-        -- Starting Quest: 'A Certain Substitute Patrolman'
-        player:addQuest(ADOULIN, A_CERTAIN_SUBSTITUTE_PATROLMAN);
-        player:addKeyItem(dsp.ki.WESTERN_ADOULIN_PATROL_ROUTE);
-        player:messageSpecial(ID.text.KEYITEM_OBTAINED, dsp.ki.WESTERN_ADOULIN_PATROL_ROUTE);
-        player:setVar("ACSP_NPCs_Visited", 1);
-    elseif (csid == 2552) then
-        -- Finishing Quest: 'A Certain Substitute Patrolman'
-        player:completeQuest(ADOULIN, A_CERTAIN_SUBSTITUTE_PATROLMAN);
-        player:addExp(1000 * EXP_RATE);
-        player:addCurrency('bayld', 500 * BAYLD_RATE);
-        player:messageSpecial(ID.text.BAYLD_OBTAINED, 500 * BAYLD_RATE);
-        player:delKeyItem(dsp.ki.WESTERN_ADOULIN_PATROL_ROUTE);
-        player:addFame(ADOULIN);
-        player:setVar("ACSP_NPCs_Visited", 0);
-    end
+    dsp.quests.onEventFinish(player, csid, option, quest_table)
 end;

--- a/scripts/zones/Western_Adoulin/npcs/Shipilolo.lua
+++ b/scripts/zones/Western_Adoulin/npcs/Shipilolo.lua
@@ -12,39 +12,38 @@ require("scripts/globals/missions");
 require("scripts/globals/quests");
 require("scripts/globals/keyitems");
 local ID = require("scripts/zones/Western_Adoulin/IDs");
+local THE_OLD_MAN_AND_THE_HARPOON = require("scripts/quests/adoulin/the_old_man_and_the_harpoon")
 -----------------------------------
 
 function onTrade(player,npc,trade)
 end;
 
 function onTrigger(player,npc)
-    local TOMATH = player:getQuestStatus(ADOULIN, THE_OLD_MAN_AND_THE_HARPOON);
     local Fertile_Ground = player:getQuestStatus(ADOULIN, FERTILE_GROUND);
     local Wayward_Waypoints = player:getQuestStatus(ADOULIN, WAYWARD_WAYPOINTS);
     Wayward_Waypoints = (Wayward_Waypoints == QUEST_ACCEPTED) and (player:getVar("WW_Need_Shipilolo") > 0)
     local ACSP = player:getQuestStatus(ADOULIN, A_CERTAIN_SUBSTITUTE_PATROLMAN);
     local SOA_Mission = player:getCurrentMission(SOA);
 
-    if (SOA_Mission >= LIFE_ON_THE_FRONTIER) then
-        if ((TOMATH == QUEST_ACCEPTED) and player:hasKeyItem(dsp.ki.BROKEN_HARPOON)) then
-            -- Progresses Quest: 'The Old Man and the Harpoon'
-            player:startEvent(2543);
-        elseif ((Fertile_Ground == QUEST_ACCEPTED) and (not player:hasKeyItem(dsp.ki.BOTTLE_OF_FERTILIZER_X))) then
-            -- Progresses Quest: 'Fertile Ground'
-            player:startEvent(2850);
-        elseif (Wayward_Waypoints and (not player:hasKeyItem(dsp.ki.WAYPOINT_RECALIBRATION_KIT))) then
-            -- Progresses Quest: 'Wayward Waypoints'
-            player:startEvent(79);
-        elseif ((ACSP == QUEST_ACCEPTED) and (player:getVar("ACSP_NPCs_Visited") == 5)) then
-            -- Progresses Quest: 'A Certain Substitute Patrolman'
-            player:startEvent(2557);
+    if not dsp.quests.onTrigger(player, npc, THE_OLD_MAN_AND_THE_HARPOON) then
+        if (SOA_Mission >= LIFE_ON_THE_FRONTIER) then
+            if ((Fertile_Ground == QUEST_ACCEPTED) and (not player:hasKeyItem(dsp.ki.BOTTLE_OF_FERTILIZER_X))) then
+                -- Progresses Quest: 'Fertile Ground'
+                player:startEvent(2850);
+            elseif (Wayward_Waypoints and (not player:hasKeyItem(dsp.ki.WAYPOINT_RECALIBRATION_KIT))) then
+                -- Progresses Quest: 'Wayward Waypoints'
+                player:startEvent(79);
+            elseif ((ACSP == QUEST_ACCEPTED) and (player:getVar("ACSP_NPCs_Visited") == 5)) then
+                -- Progresses Quest: 'A Certain Substitute Patrolman'
+                player:startEvent(2557);
+            else
+                -- Standard dialogue
+                player:startEvent(535);
+            end
         else
-            -- Standard dialogue
-            player:startEvent(535);
+            -- Dialogue prior to joining colonization effort
+            player:startEvent(526);
         end
-    else
-        -- Dialogue prior to joining colonization effort
-        player:startEvent(526);
     end
 end;
 
@@ -52,19 +51,16 @@ function onEventUpdate(player,csid,option)
 end;
 
 function onEventFinish(player,csid,option)
-    if (csid == 2543) then
-        -- Progresses Quest: 'The Old Man and the Harpoon'
-        player:delKeyItem(dsp.ki.BROKEN_HARPOON);
-        player:addKeyItem(dsp.ki.EXTRAVAGANT_HARPOON);
-        player:messageSpecial(ID.text.KEYITEM_OBTAINED, dsp.ki.EXTRAVAGANT_HARPOON);
-    elseif (csid == 2850) then
-        -- Progresses Quest: 'Fertile Ground'
-        player:addKeyItem(dsp.ki.BOTTLE_OF_FERTILIZER_X);
-    elseif (csid == 79) then
-        player:addKeyItem(dsp.ki.WAYPOINT_RECALIBRATION_KIT);
-        player:setVar("WW_Need_Shipilolo", 0);
-    elseif (csid == 2557) then
-        -- Progresses Quest: 'A Certain Substitute Patrolman'
-        player:setVar("ACSP_NPCs_Visited", 6);
+    if not dsp.quests.onEventFinish(player, csid, option, THE_OLD_MAN_AND_THE_HARPOON) then
+        if (csid == 2850) then
+            -- Progresses Quest: 'Fertile Ground'
+            player:addKeyItem(dsp.ki.BOTTLE_OF_FERTILIZER_X);
+        elseif (csid == 79) then
+            player:addKeyItem(dsp.ki.WAYPOINT_RECALIBRATION_KIT);
+            player:setVar("WW_Need_Shipilolo", 0);
+        elseif (csid == 2557) then
+            -- Progresses Quest: 'A Certain Substitute Patrolman'
+            player:setVar("ACSP_NPCs_Visited", 6);
+        end
     end
 end;

--- a/scripts/zones/Western_Adoulin/npcs/Shipilolo.lua
+++ b/scripts/zones/Western_Adoulin/npcs/Shipilolo.lua
@@ -8,14 +8,16 @@
 --                        'Wayward Waypoints'
 -- !pos 84 0 -60 256
 -----------------------------------
-require("scripts/globals/missions");
-require("scripts/globals/quests");
-require("scripts/globals/keyitems");
-local ID = require("scripts/zones/Western_Adoulin/IDs");
+require("scripts/globals/missions")
+require("scripts/globals/quests")
+require("scripts/globals/keyitems")
 
 local quest_table =
 {
+    require("scripts/quests/adoulin/a_certain_substitute_patrolman"),
     require("scripts/quests/adoulin/the_old_man_and_the_harpoon"),
+    require("scripts/quests/adoulin/fertile_ground"),
+    require("scripts/quests/adoulin/wayward_waypoints")
 }
 -----------------------------------
 
@@ -23,27 +25,10 @@ function onTrade(player,npc,trade)
 end;
 
 function onTrigger(player,npc)
-    local Fertile_Ground = player:getQuestStatus(ADOULIN, FERTILE_GROUND);
-    local Wayward_Waypoints = player:getQuestStatus(ADOULIN, WAYWARD_WAYPOINTS);
-    Wayward_Waypoints = (Wayward_Waypoints == QUEST_ACCEPTED) and (player:getVar("WW_Need_Shipilolo") > 0)
-    local ACSP = player:getQuestStatus(ADOULIN, A_CERTAIN_SUBSTITUTE_PATROLMAN);
-    local SOA_Mission = player:getCurrentMission(SOA);
-
     if not dsp.quests.onTrigger(player, npc, quest_table) then
-        if (SOA_Mission >= LIFE_ON_THE_FRONTIER) then
-            if ((Fertile_Ground == QUEST_ACCEPTED) and (not player:hasKeyItem(dsp.ki.BOTTLE_OF_FERTILIZER_X))) then
-                -- Progresses Quest: 'Fertile Ground'
-                player:startEvent(2850);
-            elseif (Wayward_Waypoints and (not player:hasKeyItem(dsp.ki.WAYPOINT_RECALIBRATION_KIT))) then
-                -- Progresses Quest: 'Wayward Waypoints'
-                player:startEvent(79);
-            elseif ((ACSP == QUEST_ACCEPTED) and (player:getVar("ACSP_NPCs_Visited") == 5)) then
-                -- Progresses Quest: 'A Certain Substitute Patrolman'
-                player:startEvent(2557);
-            else
-                -- Standard dialogue
-                player:startEvent(535);
-            end
+        if player:getCurrentMission(SOA) >= LIFE_ON_THE_FRONTIER then
+            -- Standard dialogue
+            player:startEvent(535);
         else
             -- Dialogue prior to joining colonization effort
             player:startEvent(526);
@@ -55,16 +40,5 @@ function onEventUpdate(player,csid,option)
 end;
 
 function onEventFinish(player,csid,option)
-    if not dsp.quests.onEventFinish(player, csid, option, quest_table) then
-        if (csid == 2850) then
-            -- Progresses Quest: 'Fertile Ground'
-            player:addKeyItem(dsp.ki.BOTTLE_OF_FERTILIZER_X);
-        elseif (csid == 79) then
-            player:addKeyItem(dsp.ki.WAYPOINT_RECALIBRATION_KIT);
-            player:setVar("WW_Need_Shipilolo", 0);
-        elseif (csid == 2557) then
-            -- Progresses Quest: 'A Certain Substitute Patrolman'
-            player:setVar("ACSP_NPCs_Visited", 6);
-        end
-    end
-end;
+    dsp.quests.onEventFinish(player, csid, option, quest_table)
+end

--- a/scripts/zones/Western_Adoulin/npcs/Shipilolo.lua
+++ b/scripts/zones/Western_Adoulin/npcs/Shipilolo.lua
@@ -12,7 +12,11 @@ require("scripts/globals/missions");
 require("scripts/globals/quests");
 require("scripts/globals/keyitems");
 local ID = require("scripts/zones/Western_Adoulin/IDs");
-local THE_OLD_MAN_AND_THE_HARPOON = require("scripts/quests/adoulin/the_old_man_and_the_harpoon")
+
+local quest_table =
+{
+    require("scripts/quests/adoulin/the_old_man_and_the_harpoon"),
+}
 -----------------------------------
 
 function onTrade(player,npc,trade)
@@ -25,7 +29,7 @@ function onTrigger(player,npc)
     local ACSP = player:getQuestStatus(ADOULIN, A_CERTAIN_SUBSTITUTE_PATROLMAN);
     local SOA_Mission = player:getCurrentMission(SOA);
 
-    if not dsp.quests.onTrigger(player, npc, THE_OLD_MAN_AND_THE_HARPOON) then
+    if not dsp.quests.onTrigger(player, npc, quest_table) then
         if (SOA_Mission >= LIFE_ON_THE_FRONTIER) then
             if ((Fertile_Ground == QUEST_ACCEPTED) and (not player:hasKeyItem(dsp.ki.BOTTLE_OF_FERTILIZER_X))) then
                 -- Progresses Quest: 'Fertile Ground'
@@ -51,7 +55,7 @@ function onEventUpdate(player,csid,option)
 end;
 
 function onEventFinish(player,csid,option)
-    if not dsp.quests.onEventFinish(player, csid, option, THE_OLD_MAN_AND_THE_HARPOON) then
+    if not dsp.quests.onEventFinish(player, csid, option, quest_table) then
         if (csid == 2850) then
             -- Progresses Quest: 'Fertile Ground'
             player:addKeyItem(dsp.ki.BOTTLE_OF_FERTILIZER_X);

--- a/scripts/zones/Western_Adoulin/npcs/Virsaint.lua
+++ b/scripts/zones/Western_Adoulin/npcs/Virsaint.lua
@@ -6,19 +6,20 @@
 -- !pos 32 0 -5 256
 -----------------------------------
 require("scripts/globals/quests");
+
+local quest_table =
+{
+    require("scripts/quests/adoulin/a_certain_substitute_patrolman")
+}
 -----------------------------------
 
 function onTrade(player,npc,trade)
 end;
 
 function onTrigger(player,npc)
-    local ACSP = player:getQuestStatus(ADOULIN, A_CERTAIN_SUBSTITUTE_PATROLMAN);
-    if ((ACSP == QUEST_ACCEPTED) and (player:getVar("ACSP_NPCs_Visited") == 4)) then
-        -- Progresses Quest: 'A Certain Substitute Patrolman'
-        player:startEvent(2556);
-    else
+    if not dsp.quests.onTrigger(player, npc, quest_table) then
         -- Standard dialogue
-        player:startEvent(540);
+        player:startEvent(540)
     end
 end;
 
@@ -26,8 +27,5 @@ function onEventUpdate(player,csid,option)
 end;
 
 function onEventFinish(player,csid,option)
-    if (csid == 2556) then
-        -- Progresses Quest: 'A Certain Substitute Patrolman'
-        player:setVar("ACSP_NPCs_Visited", 5);
-    end
+    dsp.quests.onEventFinish(player, csid, option, quest_table)
 end;

--- a/scripts/zones/Western_Adoulin/npcs/Zaoso.lua
+++ b/scripts/zones/Western_Adoulin/npcs/Zaoso.lua
@@ -7,25 +7,25 @@
 -----------------------------------
 require("scripts/globals/missions");
 require("scripts/globals/quests");
+
+local quest_table =
+{
+    require("scripts/quests/adoulin/a_certain_substitute_patrolman")
+}
 -----------------------------------
 
 function onTrade(player,npc,trade)
 end;
 
 function onTrigger(player,npc)
-    local ACSP = player:getQuestStatus(ADOULIN, A_CERTAIN_SUBSTITUTE_PATROLMAN);
-    local SOA_Mission = player:getCurrentMission(SOA);
-    if (SOA_Mission >= LIFE_ON_THE_FRONTIER) then
-        if ((ACSP == QUEST_ACCEPTED) and (player:getVar("ACSP_NPCs_Visited") == 1)) then
-            -- Progresses Quest: 'A Certain Substitute Patrolman'
-            player:startEvent(2553);
-        else
+    if not dsp.quests.onTrigger(player, npc, quest_table) then
+        if player:getCurrentMission(SOA) >= LIFE_ON_THE_FRONTIER then
             -- Standard dialogue
-            player:startEvent(574);
+            player:startEvent(574)
+        else
+            -- Dialogue prior to joining colonization effort
+            player:startEvent(506)
         end
-    else
-        -- Dialogue prior to joining colonization effort
-        player:startEvent(506);
     end
 end;
 
@@ -33,8 +33,5 @@ function onEventUpdate(player,csid,option)
 end;
 
 function onEventFinish(player,csid,option)
-    if (csid == 2553) then
-        -- Progresses Quest: 'A Certain Substitute Patrolman'
-        player:setVar("ACSP_NPCs_Visited", 2);
-    end
+    dsp.quests.onEventFinish(player, csid, option, quest_table)
 end;


### PR DESCRIPTION
@takhlaq @ShelbyZ @wrenffxi @TeoTwawki

So I decided to take a stab at getting a basic quest working via a newer quest system, using tables which are all stored within a single lua file. I don't know exactly what the plans are for this, but tried to intuit based off what was already there and a conversation I had with @takhlaq over a year ago.

I chose 'The Old Man and the Harpoon' because it's incredibly simple, and as an Adoulin quest, suitable as a testing bed since I imagine I might be the only one who ever enters the zone. It involves just two NPCs, and can be completed like so:
```
!zone 256
!addmission ADOULIN LIFE_ON_THE_FRONTIER
!pos 92 32 152
Talk to Jorin
!pos 84 0 -60
Talk to Shipilolo
!pos 92 32 152
Talk to Jorin again, done
```
(Note: The message IDs on this branch are out of date, so the KI message will probably be gil obtained, and the bayld obtained message will probably be blank. They are firing though.)

Some changes were made to the global quests.lua to get it working, which brings me to my first question:
**I have no idea what the `cycle`, `needsCycling`, etc are meant for.** I commented them out from this because they weren't working (trying to ipairs over tables with non-integer keys) and I didn't need them. Whoever is responsible for them, please feel free to chime in!

The second issue is, at the moment, this **locks out anything that isn't part of the quest**, due to how `dsp.quest.check` is now currently executing functions. The problem stems from it needing to return something to prevent multiple events from firing - see Jorin.lua. At the moment I have `dsp.quest.check` just return `true` after invoking an appropriate `onTrigger` function from the quest table. This prevents the standard dialogue event from firing while he's rambling about his harpoon. Because if he's not talking about the quest, he's "supposed" to revert to his usual standard dialogue. 

Problem is, this setup has the `onTrigger` function from the quest table always fire - it kind of has to, since we need to check the status of the quest each time the player talks to the NPC. But if there's nothing for it to do (ie: the quest has been completed), `dsp.quest.check` will still return true after invoking the quest's associated `onTrigger` function, so Jorin won't reach his standard dialogue. Or in Shipilolo's case, she won't reach her other quest triggers.

I don't know the best way around this. My only idea at the moment is changing `onTrigger`s from firing `startEvents` themselves to simply return just the event ID as an integer. Then, have `dsp.quest.check` fire the event, and only return `true` to the NPC script if it did so.

Despite that issue though, **the quest is complete and in a single file** - with the exceptions of the single references to check for it in the two NPCs' `onTrigger`s and `onEventFinish`.

In the future, the references in the NPCs' `onEventFinish` might be removable with a master table linking CS IDs to what quest they're associated to, and core calling the quest file directly upon finish / update, bypassing the NPC.

I do think there will still have to be references in `onTrigger`s so we can direct which missions / quests take priority over others. But at least they'll be a single line, which will handle all the scripting from a unified location.

Comments, questions, edits welcome. I was absent when this branch was being shaped, so I'm probably a bit out of the loop if these issues already have answers.