### PR TITLE
Fix heal/unheal stutter bug.

### DIFF
--- a/src/map/packet_system.cpp
+++ b/src/map/packet_system.cpp
@@ -4870,9 +4870,7 @@ void SmallPacket0x0E8(map_session_data_t* session, CCharEntity* PChar, CBasicPac
     case ANIMATION_NONE:
     {
         if (data.ref<uint8>(0x04) == 0x02)
-        {
             return;
-        }
 
         if (PChar->PPet == nullptr ||
             (PChar->PPet->m_EcoSystem != SYSTEM_AVATAR &&

--- a/src/map/packet_system.cpp
+++ b/src/map/packet_system.cpp
@@ -4895,8 +4895,8 @@ void SmallPacket0x0E8(map_session_data_t* session, CCharEntity* PChar, CBasicPac
     {
         PChar->StatusEffectContainer->DelStatusEffect(EFFECT_HEALING);
     }
+    break;
     }
-    
     return;
 }
 

--- a/src/map/packet_system.cpp
+++ b/src/map/packet_system.cpp
@@ -4865,9 +4865,15 @@ void SmallPacket0x0E8(map_session_data_t* session, CCharEntity* PChar, CBasicPac
     if(PChar->StatusEffectContainer->HasPreventActionEffect())
         return;
 
-    const uint8_t request = data.ref<uint8>(0x04);
-    if (PChar->animation == ANIMATION_NONE && request == 0x00)
+    switch (PChar->animation)
     {
+    case ANIMATION_NONE:
+    {
+        if (data.ref<uint8>(0x04) == 0x02)
+        {
+            return;
+        }
+
         if (PChar->PPet == nullptr ||
             (PChar->PPet->m_EcoSystem != SYSTEM_AVATAR &&
             PChar->PPet->m_EcoSystem != SYSTEM_ELEMENTAL &&
@@ -4884,9 +4890,11 @@ void SmallPacket0x0E8(map_session_data_t* session, CCharEntity* PChar, CBasicPac
         }
         PChar->pushPacket(new CMessageBasicPacket(PChar, PChar, 0, 0, 345));
     }
-    else if (PChar->animation == ANIMATION_HEALING && request == 0x02)
+    break;
+    case ANIMATION_HEALING:
     {
         PChar->StatusEffectContainer->DelStatusEffect(EFFECT_HEALING);
+    }
     }
     
     return;

--- a/src/map/packet_system.cpp
+++ b/src/map/packet_system.cpp
@@ -4865,9 +4865,8 @@ void SmallPacket0x0E8(map_session_data_t* session, CCharEntity* PChar, CBasicPac
     if(PChar->StatusEffectContainer->HasPreventActionEffect())
         return;
 
-    switch (PChar->animation)
-    {
-    case ANIMATION_NONE:
+    const uint8_t request = data.ref<uint8>(0x04);
+    if (PChar->animation == ANIMATION_NONE && request == 0x00)
     {
         if (PChar->PPet == nullptr ||
             (PChar->PPet->m_EcoSystem != SYSTEM_AVATAR &&
@@ -4885,13 +4884,11 @@ void SmallPacket0x0E8(map_session_data_t* session, CCharEntity* PChar, CBasicPac
         }
         PChar->pushPacket(new CMessageBasicPacket(PChar, PChar, 0, 0, 345));
     }
-    break;
-    case ANIMATION_HEALING:
+    else if (PChar->animation == ANIMATION_HEALING && request == 0x02)
     {
         PChar->StatusEffectContainer->DelStatusEffect(EFFECT_HEALING);
     }
-    break;
-    }
+    
     return;
 }
 


### PR DESCRIPTION
this fixes the bug where you re-rest after trying to stand up
it happens because darkstar is picks the action to take based on your current state instead of the field in the packet which says the requested action
the client will sometimes send multiple stop healing commands if you hold a movement key down while resting