### PR TITLE
Fix Relic duration check for overwriting

### DIFF
--- a/scripts/globals/aftermath.lua
+++ b/scripts/globals/aftermath.lua
@@ -331,7 +331,7 @@ dsp.aftermath.canOverwrite = function(player, tp, aftermathId, aftermathType)
     {
         -- Relic
         [1] = function(x)
-            local newDuration = aftermath.duration(tp)
+            local newDuration = aftermath.duration(tp) * 1000
             canOverwrite = newDuration > effect:getTimeRemaining()
         end,
 


### PR DESCRIPTION
getTimeRemaining returns in milliseconds. So the duration check was always failing and relic aftermath was never overwriting itself. Woops!