### PR TITLE
Disable submodules in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,9 @@ sudo: required
 
 cache: ccache
 
+git:
+  submodules: false
+
 addons:
   apt:
     sources:


### PR DESCRIPTION
No reason we need to pull them for CI, and Travis has failed/timed out pulling them on more than a dozen occasions.