### PR TITLE
Fix PUP Skillchains occasionally crashing

### DIFF
--- a/src/map/ai/controllers/automaton_controller.cpp
+++ b/src/map/ai/controllers/automaton_controller.cpp
@@ -1280,28 +1280,14 @@ bool CAutomatonController::TryTPMove()
             if (PSCEffect && PSCEffect->GetStartTime() + 3s < server_clock::now())
             {
                 std::list<SKILLCHAIN_ELEMENT> resonanceProperties;
-                if (PSCEffect->GetTier() == 0)
+                if (PSCEffect->GetStartTime() + 3s < m_Tick)
                 {
-                    if (PSCEffect->GetStartTime() + 3s < m_Tick)
+                    if (uint16 power = PSCEffect->GetPower())
                     {
-                        if (PSCEffect->GetPower())
-                        {
-                            CWeaponSkill* PWeaponSkill = battleutils::GetWeaponSkill(PSCEffect->GetPower());
-                            resonanceProperties.push_back((SKILLCHAIN_ELEMENT)PWeaponSkill->getPrimarySkillchain());
-                            resonanceProperties.push_back((SKILLCHAIN_ELEMENT)PWeaponSkill->getSecondarySkillchain());
-                            resonanceProperties.push_back((SKILLCHAIN_ELEMENT)PWeaponSkill->getTertiarySkillchain());
-                        }
-                        else
-                        {
-                            CBlueSpell* oldSpell = (CBlueSpell*)spell::GetSpell(static_cast<SpellID>(PSCEffect->GetSubPower()));
-                            resonanceProperties.push_back((SKILLCHAIN_ELEMENT)oldSpell->getPrimarySkillchain());
-                            resonanceProperties.push_back((SKILLCHAIN_ELEMENT)oldSpell->getSecondarySkillchain());
-                        }
+                        resonanceProperties.push_back((SKILLCHAIN_ELEMENT)(power & 0xF));
+                        resonanceProperties.push_back((SKILLCHAIN_ELEMENT)(power >> 4 & 0xF));
+                        resonanceProperties.push_back((SKILLCHAIN_ELEMENT)(power >> 8));
                     }
-                }
-                else
-                {
-                    resonanceProperties.push_back((SKILLCHAIN_ELEMENT)PSCEffect->GetPower());
                 }
 
                 for (auto PSkill : validSkills)


### PR DESCRIPTION
Core was not handling skillchain properties correctly at all. I fixed this on HomepointXI awhile back and have been meaning to port it back to DSP.

The skillchain properties are bitpacked into the Skillchain Effect's Power variable. This code properly unpacks them and also removes some superfluous code that appeared to have been copy+pasted from somewhere else.