### PR TITLE
Don't convert uint8 to short (h)

### DIFF
--- a/src/search/search.cpp
+++ b/src/search/search.cpp
@@ -121,7 +121,7 @@ void PrintPacket(char* data, int size)
     {
         char msgtmp[50];
         memset(&msgtmp, 0, 50);
-        sprintf(msgtmp, "%s %02hx", message, (uint8)data[y]);
+        sprintf(msgtmp, "%s %02x", message, (uint8)data[y]);
         strncpy(message, msgtmp, 50);
         if (((y + 1) % 16) == 0)
         {


### PR DESCRIPTION
- tested 32/64 without corruption of buffers/crash