### PR TITLE
Resolved issue with food duration mod being reapplied

### DIFF
--- a/src/map/lua/lua_baseentity.cpp
+++ b/src/map/lua/lua_baseentity.cpp
@@ -10367,7 +10367,15 @@ inline int32 CLuaBaseEntity::addStatusEffect(lua_State *L)
             (n >= 6 ? (uint16)lua_tointeger(L, 6) : 0),  // Sub Power
             (n >= 7 ? (uint16)lua_tointeger(L, 7) : 0)); // Tier
 
-        lua_pushboolean(L, ((CBattleEntity*)m_PBaseEntity)->StatusEffectContainer->AddStatusEffect(PEffect));
+        CBattleEntity* PEntity = ((CBattleEntity*)m_PBaseEntity);
+        if (PEffect->GetStatusID() == EFFECT_FOOD && PEntity)
+        {
+            int16 durationModifier = PEntity->getMod(Mod::FOOD_DURATION);
+            if (durationModifier)
+                PEffect->SetDuration((uint32)(PEffect->GetDuration() + PEffect->GetDuration() * (durationModifier / 100.0f)));
+        }
+
+        lua_pushboolean(L, PEntity->StatusEffectContainer->AddStatusEffect(PEffect));
     }
 
     return 1;

--- a/src/map/status_effect_container.cpp
+++ b/src/map/status_effect_container.cpp
@@ -348,13 +348,6 @@ bool CStatusEffectContainer::AddStatusEffect(CStatusEffect* PStatusEffect, bool 
 
     if (CanGainStatusEffect(PStatusEffect))
     {
-        if (PStatusEffect->GetStatusID() == EFFECT_FOOD && m_POwner)
-        {
-            int16 durationModifier = m_POwner->getMod(Mod::FOOD_DURATION);
-            if (durationModifier)
-                PStatusEffect->SetDuration((uint32)(PStatusEffect->GetDuration() + PStatusEffect->GetDuration() * (durationModifier / 100.0f)));
-        }
-
         // check for minimum duration
         if (PStatusEffect->GetDuration() < effects::EffectsParams[statusId].MinDuration) {
             PStatusEffect->SetDuration(effects::EffectsParams[statusId].MinDuration);


### PR DESCRIPTION
Applying the mod inside of status_effect_container was happening anytime the character would be loaded. This fix this I moved the logic to when we add the status effect in the lua entity.

This fixes #5457.