### PR TITLE
remove core functionality related to hidden models / 0x80 entityFlag

### DIFF
--- a/src/map/entities/baseentity.h
+++ b/src/map/entities/baseentity.h
@@ -150,7 +150,6 @@ enum ENTITYFLAGS
     FLAG_NONE          = 0x000,
     FLAG_HIDE_NAME     = 0x008,
     FLAG_CALL_FOR_HELP = 0x020,
-    FLAG_HIDE_MODEL    = 0x080,
     FLAG_HIDE_HP       = 0x100,
     FLAG_UNTARGETABLE  = 0x800,
 };
@@ -173,12 +172,12 @@ class CZone;
 
 struct location_t
 {
-    position_t	p;              // позиция сущности
-    uint16		destination;    // текущая зона
+    position_t  p;              // позиция сущности
+    uint16      destination;    // текущая зона
     CZone*      zone;           // текущая зона
-    uint16		prevzone;       // предыдущая зона (для монстров и npc не используется)
-    bool		zoning;         // флаг сбрасывается при каждом входе в новую зону. необходим для реализации логики игровых задач ("quests")
-    uint16		boundary;       // определенная область в зоне, в которой находится сущность (используется персонажами и транспортом)
+    uint16      prevzone;       // предыдущая зона (для монстров и npc не используется)
+    bool        zoning;         // флаг сбрасывается при каждом входе в новую зону. необходим для реализации логики игровых задач ("quests")
+    uint16      boundary;       // определенная область в зоне, в которой находится сущность (используется персонажами и транспортом)
 };
 
 class CAIContainer;
@@ -186,30 +185,30 @@ class CInstance;
 class CBattlefield;
 
 /************************************************************************
-*																		*
-*  Базовый класс для всех сущностей в игре								*
-*																		*
+*                                                                       *
+*  Базовый класс для всех сущностей в игре                              *
+*                                                                       *
 ************************************************************************/
 
 class CBaseEntity
 {
 public:
 
-    CBaseEntity();						// конструктор
-    virtual ~CBaseEntity();				// деструктор
+    CBaseEntity();                      // конструктор
+    virtual ~CBaseEntity();             // деструктор
 
     virtual void    Spawn();
     virtual void    FadeOut();
     virtual const int8* GetName();      // имя сущности
-    uint16			getZone();			// текущая зона
-    float			GetXPos();			// позиция по координате X
-    float			GetYPos();			// позиция по координате Y
-    float			GetZPos();			// позиция по координате Z
-    uint8			GetRotPos();
-    void			HideName(bool hide); // hide / show name
-    bool			IsNameHidden();		// checks if name is hidden
+    uint16          getZone();          // текущая зона
+    float           GetXPos();          // позиция по координате X
+    float           GetYPos();          // позиция по координате Y
+    float           GetZPos();          // позиция по координате Z
+    uint8           GetRotPos();
+    void            HideName(bool hide); // hide / show name
+    bool            IsNameHidden();     // checks if name is hidden
 
-    CBaseEntity*	GetEntity(uint16 targid, uint8 filter = -1);
+    CBaseEntity*    GetEntity(uint16 targid, uint8 filter = -1);
 
     void            ResetLocalVars();
     uint32          GetLocalVar(const char* var);
@@ -225,26 +224,26 @@ public:
 
     virtual void    HandleErrorMessage(std::unique_ptr<CBasicPacket>&) {};
 
-    uint32			id;					// глобальный идентификатор, уникальный на сервере
-    uint16			targid;				// локалный идентификатор, уникальный в зоне
-    ENTITYTYPE		objtype;			// тип сущности
-    STATUSTYPE		status;				// статус сущности (разные сущности - разные статусы)
-    uint16			m_TargID;			// targid объекта, на который смотрит сущность
-    string_t		name;				// имя сущности
-    look_t			look;				// внешний вид всех сущностей
-    look_t			mainlook;			// only used if mob use changeSkin() or player /lockstyle
-    location_t		loc;				// местоположение сущности
-    uint8			animation;			// анимация
-    uint8			animationsub;		// дополнительный параметры анимации
-    uint8			speed;				// скорость передвижения
-    uint8			speedsub;			// подолнительный параметр скорости передвижения
-    uint8			namevis;
-    uint8			allegiance;			// what types of targets the entity can fight
+    uint32          id;                 // глобальный идентификатор, уникальный на сервере
+    uint16          targid;             // локалный идентификатор, уникальный в зоне
+    ENTITYTYPE      objtype;            // тип сущности
+    STATUSTYPE      status;             // статус сущности (разные сущности - разные статусы)
+    uint16          m_TargID;           // targid объекта, на который смотрит сущность
+    string_t        name;               // имя сущности
+    look_t          look;               // внешний вид всех сущностей
+    look_t          mainlook;           // only used if mob use changeSkin() or player /lockstyle
+    location_t      loc;                // местоположение сущности
+    uint8           animation;          // анимация
+    uint8           animationsub;       // дополнительный параметры анимации
+    uint8           speed;              // скорость передвижения
+    uint8           speedsub;           // подолнительный параметр скорости передвижения
+    uint8           namevis;
+    uint8           allegiance;         // what types of targets the entity can fight
     uint8           updatemask;         // what to update next server tick to players nearby
 
     std::unique_ptr<CAIContainer> PAI;       // AI container
-    CBattlefield*	PBCNM;              // pointer to bcnm (if in one)
-    CInstance*		PInstance;
+    CBattlefield*   PBCNM;              // pointer to bcnm (if in one)
+    CInstance*      PInstance;
 protected:
     std::map<std::string, uint32> m_localVars;
 };

--- a/src/map/entities/mobentity.cpp
+++ b/src/map/entities/mobentity.cpp
@@ -387,25 +387,6 @@ void CMobEntity::restoreMobModifiers()
     m_mobModStat = m_mobModStatSave;
 }
 
-void CMobEntity::HideModel(bool hide)
-{
-    if (hide)
-    {
-        // I got this from ambush antlion
-        // i'm not sure if this is right
-        m_flags |= FLAG_HIDE_MODEL;
-    }
-    else
-    {
-        m_flags &= ~FLAG_HIDE_MODEL;
-    }
-}
-
-bool CMobEntity::IsModelHidden()
-{
-    return m_flags & FLAG_HIDE_MODEL;
-}
-
 void CMobEntity::HideHP(bool hide)
 {
     if (hide)

--- a/src/map/entities/mobentity.h
+++ b/src/map/entities/mobentity.h
@@ -147,8 +147,6 @@ public:
     void      saveMobModifiers();                      // save current state of modifiers
     void      restoreMobModifiers();                   // restore to saved state
 
-    void      HideModel(bool hide);                    // hide / show model
-    bool      IsModelHidden();
     void      CallForHelp(bool call);
     bool      CalledForHelp();
     void      HideHP(bool hide);

--- a/src/map/entities/npcentity.cpp
+++ b/src/map/entities/npcentity.cpp
@@ -30,17 +30,17 @@
 #include "../packets/entity_update.h"
 
 /************************************************************************
-*																		*
-*																		*
-*																		*
+*                                                                       *
+*                                                                       *
+*                                                                       *
 ************************************************************************/
 
 CNpcEntity::CNpcEntity()
 {
-	objtype = TYPE_NPC;
-	look.face = 0x32;
+    objtype = TYPE_NPC;
+    look.face = 0x32;
         widescan = 1;
-	allegiance = ALLEGIANCE_MOB;
+    allegiance = ALLEGIANCE_MOB;
     PAI = std::make_unique<CAIContainer>(this);
 }
 
@@ -57,25 +57,6 @@ uint32 CNpcEntity::getEntityFlags()
 void CNpcEntity::setEntityFlags(uint32 EntityFlags)
 {
     m_flags = EntityFlags;
-}
-
-void CNpcEntity::HideModel(bool hide)
-{
-    if (hide)
-    {
-        // Copied over from mobentity
-        // i'm not sure if this is right
-        m_flags |= 0x80;
-    }
-    else
-    {
-        m_flags &= ~0x80;
-    }
-}
-
-bool CNpcEntity::IsModelHidden()
-{
-    return (m_flags & 0x80) == 0x80;
 }
 
 void CNpcEntity::HideHP(bool hide)

--- a/src/map/entities/npcentity.h
+++ b/src/map/entities/npcentity.h
@@ -37,8 +37,6 @@ public:
     uint8       widescan;
     uint32      getEntityFlags();                        // Returns the current value in m_flags
     void        setEntityFlags(uint32 EntityFlags);      // Change the current value in m_flags
-    void        HideModel(bool hide);                    // hide / show model
-    bool        IsModelHidden();
     void        HideHP(bool hide);
     bool        IsHPHidden();
     void        Untargetable(bool untargetable);
@@ -46,8 +44,8 @@ public:
     virtual void PostTick() override;
     virtual void Tick(time_point) override {}
 
-	 CNpcEntity();				// конструктор
-	~CNpcEntity();				// деструктор
+     CNpcEntity();              // конструктор
+    ~CNpcEntity();              // деструктор
 
 
 private:

--- a/src/map/lua/lua_baseentity.cpp
+++ b/src/map/lua/lua_baseentity.cpp
@@ -9856,31 +9856,6 @@ int32 CLuaBaseEntity::canChangeState(lua_State* L)
 }
 
 /************************************************************************
-*  Function: hideModel()
-*  Purpose : Toggles an NPC or Mob to either hidden or visible
-*  Example : npc:hideModel(true) -- or false to show
-*  Notes   :
-************************************************************************/
-
-inline int32 CLuaBaseEntity::hideModel(lua_State* L)
-{
-    DSP_DEBUG_BREAK_IF(m_PBaseEntity == nullptr);
-    DSP_DEBUG_BREAK_IF(lua_isnil(L, 1) || !lua_isboolean(L, 1));
-    DSP_DEBUG_BREAK_IF(m_PBaseEntity->objtype != TYPE_MOB && m_PBaseEntity->objtype != TYPE_NPC);
-
-    if (m_PBaseEntity->objtype == TYPE_MOB)
-    {
-        ((CMobEntity*)m_PBaseEntity)->HideModel(lua_toboolean(L, 1));
-    }
-    else if (m_PBaseEntity->objtype == TYPE_NPC)
-    {
-        ((CNpcEntity*)m_PBaseEntity)->HideModel(lua_toboolean(L, 1));
-    }
-    m_PBaseEntity->updatemask |= UPDATE_HP;
-    return 0;
-}
-
-/************************************************************************
 *  Function: wakeUp()
 *  Purpose : Removes any Sleep Effect from the Entity's Status Effect Container
 *  Example : target:wakeUp()
@@ -14423,7 +14398,6 @@ Lunar<CLuaBaseEntity>::Register_t CLuaBaseEntity::methods[] =
     LUNAR_DECLARE_METHOD(CLuaBaseEntity,getNearbyEntities),
     LUNAR_DECLARE_METHOD(CLuaBaseEntity,canChangeState),
 
-    LUNAR_DECLARE_METHOD(CLuaBaseEntity,hideModel),
     LUNAR_DECLARE_METHOD(CLuaBaseEntity,wakeUp),
 
     LUNAR_DECLARE_METHOD(CLuaBaseEntity,recalculateStats),

--- a/src/map/lua/lua_baseentity.h
+++ b/src/map/lua/lua_baseentity.h
@@ -484,7 +484,6 @@ public:
     int32 getNearbyEntities(lua_State* L);
     int32 canChangeState(lua_State* L);
 
-    int32 hideModel(lua_State* L);
     int32 wakeUp(lua_State*);                  //wakes target if necessary
 
     int32 recalculateStats(lua_State* L);


### PR DESCRIPTION
per discussion in discord dev channel.
strip from core functionality related to 0x80 bit on entity flags.
doesn't seem to do what we think it does, and nothing uses these functions.