### PR TITLE
Add dsp.quests.checkRequirements()

### DIFF
--- a/scripts/quests/adoulin/a_certain_substitute_patrolman.lua
+++ b/scripts/quests/adoulin/a_certain_substitute_patrolman.lua
@@ -29,16 +29,17 @@ this_quest.vars =
 
 this_quest.requirements =
 {
-    quests_missions =
-    { 
-        quests = {},
+    missions =
+    {
         {
-            -- [1] = { ['mission'] = require("scripts/globals/missions/adoulin/life_on_the_frontier") }
+            ['mission_log'] = ADOULIN,
+            ['mission_id'] = LIFE_ON_THE_FRONTIER
         }
     },
     fame =
     {
-        {this_quest.area, 1}
+        ['area'] = this_quest.area,
+        ['level'] = 1
     }
 }
 
@@ -68,17 +69,14 @@ this_quest.npcs =
         ["Rising_Solstice"] =
         {
             onTrigger = function(player, npc)
-                local ACSP = player:getQuestStatus(ADOULIN, A_CERTAIN_SUBSTITUTE_PATROLMAN)
-                if ACSP == QUEST_ACCEPTED then
-                    if dsp.quests.getStage(player, this_quest) >= 1 then
-                        if dsp.quests.getStage(player, this_quest) == 8 then
-                            player:startEvent(2552) -- Finishes Quest: 'A Certain Substitute Patrolman'
-                        else
-                            player:startEvent(2551) -- Dialogue during Quest: 'A Certain Substitute Patrolman'
-                        end
-                        return true
+                if dsp.quests.getStage(player, this_quest) >= 1 then
+                    if dsp.quests.getStage(player, this_quest) == 8 then
+                        player:startEvent(2552) -- Finishes Quest: 'A Certain Substitute Patrolman'
+                    else
+                        player:startEvent(2551) -- Dialogue during Quest: 'A Certain Substitute Patrolman'
                     end
-                elseif ACSP == QUEST_AVAILABLE then
+                    return true
+                elseif dsp.quests.checkRequirements(player, this_quest) then
                     player:startEvent(2550) -- Starts Quest: 'A Certain Substitute Patrolman'
                     return true
                 end

--- a/scripts/quests/adoulin/fertile_ground.lua
+++ b/scripts/quests/adoulin/fertile_ground.lua
@@ -23,17 +23,18 @@ this_quest.vars =
 
 this_quest.requirements =
 {
-    quests_missions =
-    { 
-        quests =
+    quests =
+    {
         {
-            -- [1] = { ['quest'] = require("scripts/globals/quests/adoulin/the_old_man_and_the_harpoon") }
-        },
-        missions = {}
+            ['area'] = ADOULIN,
+            ['quest_id'] = dsp.quests.enums.quest_ids.adoulin.THE_OLD_MAN_AND_THE_HARPOON
+        }
+        -- [1] = { ['quest'] = require("scripts/globals/quests/adoulin/the_old_man_and_the_harpoon") }
     },
     fame =
     {
-        {this_quest.area, 2}
+        ['area'] = this_quest.area,
+        ['level'] = 2
     }
 }
 

--- a/scripts/quests/adoulin/the_old_man_and_the_harpoon.lua
+++ b/scripts/quests/adoulin/the_old_man_and_the_harpoon.lua
@@ -26,18 +26,18 @@ this_quest.vars =
 
 this_quest.requirements =
 {
-    quests_missions =
-    { 
-        quests = {},
-        missions =
+    missions =
+    {
         {
-            -- [1] = { ['mission'] = require("scripts/globals/missions/adoulin/life_on_the_frontier") }
-            -- [1] = { ['quest'] = require("scripts/globals/missions/adoulin/life_on_the_frontier"), ['stage'] = x }
+            ['mission_log'] = ADOULIN,
+            ['mission_id'] = LIFE_ON_THE_FRONTIER
         }
+        -- [1] = { ['quest'] = require("scripts/globals/missions/adoulin/life_on_the_frontier"), ['stage'] = x }
     },
     fame =
     {
-        {this_quest.area, 1}
+        ['area'] = this_quest.area,
+        ['level'] = 1
     }
     -- trade = { {item, qty} },
     -- keyitems = {...},
@@ -75,7 +75,7 @@ this_quest.npcs =
                         player:startEvent(2541) -- Dialogue during Quest: 'The Old Man and the Harpoon'
                         return true
                     end
-                elseif (player:getCurrentMission(SOA) >= LIFE_ON_THE_FRONTIER) and (questStatus == QUEST_AVAILABLE) then
+                elseif dsp.quests.checkRequirements(player, this_quest) then
                     player:startEvent(2540) -- Starts Quest: 'The Old Man and the Harpoon'
                     return true
                 end

--- a/scripts/quests/adoulin/wayward_waypoints.lua
+++ b/scripts/quests/adoulin/wayward_waypoints.lua
@@ -38,17 +38,17 @@ this_quest.vars =
 
 this_quest.requirements =
 {
-    quests_missions =
+    quests =
     { 
-        quests =
         {
-            -- [1] = { ['quest'] = require("scripts/globals/quests/adoulin/megalomaniac") }
-        },
-        missions = {}
+            ['area'] = ADOULIN,
+            ['quest_id'] = dsp.quests.enums.quest_ids.adoulin.MEGALOMANIAC
+        } 
     },
     fame =
     {
-        {this_quest.area, 4}
+        ['area'] = this_quest.area,
+        ['level'] = 4
     }
 }
 
@@ -60,7 +60,7 @@ this_quest.rewards =
         {
             exp = 1000,
             bayld = 500,
-            -- kinetic_units = 3000, -- Kinetic units need to be implemented before we reward them.
+            -- TODO: kinetic_units = 3000, -- Kinetic units need to be implemented before we reward them.
             fame_area = dsp.quests.enums.fame_areas.ADOULIN
         }
     }


### PR DESCRIPTION
As it says in the title, I added a function to go through a quest's requirements table and return whether or not a player meets all the requirements to be given the quest. So when talking to the starting NPC, instead of checking the quest status of the quest-to-be-started, the status of previous quests in the chain, player level, etc, you can just do:
```
if dsp.quests.checkRequirements(player, this_quest) then
    -- Start the quest!
end
```
Currently implemented checks are _completed_ quests, _completed_ missions, possessed key items, fame level, current main job, and current player level.

At the moment it can't check if a player is on/past a certain stage in another quest, because...

(Tagging potentially interested parties for input on these: @takhlaq @TeoTwawki @wrenffxi @ShelbyZ @KnowOne134 and anyone else that might be interested in quests and I'm sorry for not thinking of you) 

**Current Quest Thoughts Number 1:** I can't think of a way around eventually **needing a master table of quest tables**. Regardless of how we store/pass the previous-required-quests in a given quest's table, we will eventually need that previous-quest's full table to check the `stage` var. (Unless we remove all scripter control over naming the stage var, see Thought 2 later)

So whether we store/require the entire previous-quest table in the quest-we're-checking (which will eventually lead to long require chains consisting of most quests in the game)... 

Or if we store the previous-quest in quest-we're-checking as a simple area / quest ID, we're going to need to be able to pull the previous-quest-table from just those area / quest ID enums.

Also, I was going to implement a `!resetquest` command this PR, but the command will need a way to pull the table of the quest-to-be-reset to delete it from the log, clear the quest variables, and delete any temporary key items. So whether it's invoked by `!resetquest ADOULIN 78` or `!resetquest ADOULIN A_CERTAIN_SUBSTITUTE_PATROLMAN`, the second argument has to be _some_ key in some table to pull the quest table.

Something like:
```
dsp.quests.quest_tables =
{
    adoulin =
    {
        [dsp.quests.enums.quest_ids.adoulin.A_CERTAIN_SUBSTITUTE_PATROLMAN] = require('scripts/quests/adoulin/a_certain_substitute_patrolman')
    }
}
```
And then store previous-quest-requirements as the area / quest IDs like I currently am, fetching the full quest tables when needed by consulting the table. This prevents long required-file _chains_. Of course, since this would have to be a global stored in globals/quests, the end result is that every quest DSP has will end up loading/requiring every other quest in the game by proxy.

Also, are there any thoughts on empty quest templates/tables for quests not currently implemented?

In other words, should DSP have lua files for quests it doesn't really have scripted, and then just have the master quest-table table just require everything _now_ (at the expense of a bunch of mostly-empty boilerplate files), or only add a quest-require to the master table when work has been done on it (at the expense of someone potentially trying to pull a nil table)?

Personally, I'm leaning towards a bunch of empty boilerplate, because even though it may not have events scripted, they could still have _some_ use now: like the quest's name at the very least. Things like `!addquest` could be modified to consult the master quest-table table and print the name of the quest from the otherwise-empty-boilerplate instead of some integer ID like it does now.

Let me know thoughts and I can start something for the next PR.

**Current Quest Thoughts Number 2:** **Should non-stage vars for a quest _always_ prefix a tag** for `player:get/setVar` purposes? I don't think they are at the moment.

I really, really think they should to 100% guarantee against any accidental playerVar collisions between quests (for example, I just have a var named 'waypoints' for Wayward Waypoints, and that's probably going to be used by someone else as well). I also think that the prefix/tag should be built by `dsp.quests.set/getVar` itself, instead of trusting the quest scripter to do so.

This always-prefix should also apply to the main/stage var, so instead of them being set as "[Q][Area][Quest ID]" in the quest table by the scripter, it's just called "stage" or something, and dsp.quests will handle the prefix.

**Alternatively, completely abstract the stage var. Remove it from the quest tables altogether, and dsp.quests.set/getStage will just use the "[Q][A][ID]" automatically.** This also makes it possible to check the stage of required-previous-quests _without_ the previous-quest's table, because we'll always know which playerVar to check since scripters won't have _any_ control over the name of the stage/main var.

So in the quest table, it'd look something like:
```
this_quest.vars =
{
    ["waypoints"] = { id = 1, type = dsp.quests.enums.var_types.LOCAL_VAR, repeatable = false, preserve_on_complete = false }   
}

some_npc_event = function(player, csid)
    dsp.quests.setQuestVar(player, this_quest, "waypoints", 5)
    dsp.quests.setStage(player, this_quest, 2)
end
```

And in dsp.quests:
```
dsp.quests.handleQuestVar = function(player, quest, varname, val)
    local varPrefix = "[Q]" .. "[" .. quest.area_id .. "][" .. quest.quest_id .. "]"
    if varname then
        -- Do other stuff based on contents of quest.vars.varname
        player:setVar(varPrefix .. varname, val)
    else
        -- Stage var
        player:setVar(varPrefix .. "[S]", val)
    end
end

dsp.quests.setQuestVar = function(player, quest, varname, val)
    dsp.quests.handleQuestVar(player, quest, varname, val)
end

dsp.quests.setStage = function(player, quest, stage)
    dsp.quests.setQuestVar(player, quest, "", stage)
end
```

@takhlaq: "I hate that magic number in calls to setStage()"...

**Current Quest Thoughts Number 3:** **How should stage enums be styled?** When you first mentioned them, I thought you meant stage enums might be set per-quest:
```
this_quest.enums.stages =
{
    ["got_broken_harpoon"]= 1,
    ["talked_shippilolo"] = 2
}

npc_event = function(player, csid)
    dsp.quests.setStage(player, this_quest, "talked_shippilolo")
end

--------------------------

dsp.quests.setStage = function(player, quest, stage)
    dsp.quests.setQuestVar(player, quest, "", quest.enums.stages[stage])
end
```

Which would make stages self-documenting. But potentially easier to screw up / mistype, And maybe more difficult for reviewers to track, oddly enough ("So what weird stage names is this person using, again? Need to scroll up to check").

But you also could have meant just generic enums:
```
dsp.quests.enums.stages =
{
    ['stage1'] = 1,
    ['stage2'] = 2
}

--------------------------

npc_event = function(player, csid)
    dsp.quests.setStage(player, this_quest, dsp.quests.enums.stage1)
end
```

Which would be easier to implement and also avoid the issues of magic numbers in code (for example, if you need to shift a stage, you can Ctrl+F the enum without having to worry about messing other 1's or 2's up).

I don't know if your concern about magic numbers is just making them clearly separate from other integer values, or "stage 1" or "stage 2" not being descriptive... descriptors.