### PR TITLE
replace hard-coded quest status values

### DIFF
--- a/scripts/zones/Aydeewa_Subterrane/Zone.lua
+++ b/scripts/zones/Aydeewa_Subterrane/Zone.lua
@@ -33,7 +33,7 @@ end
 function onRegionEnter(player,region)
     if region:GetRegionID() == 1 then
         local StoneID = player:getVar("EmptyVesselStone")
-        if player:getQuestStatus(AHT_URHGAN,AN_EMPTY_VESSEL) == 1 and player:getVar("AnEmptyVesselProgress") == 4 and player:hasItem(StoneID) then
+        if player:getQuestStatus(AHT_URHGAN,AN_EMPTY_VESSEL) == QUEST_ACCEPTED and player:getVar("AnEmptyVesselProgress") == 4 and player:hasItem(StoneID) then
             player:startEvent(3,StoneID)
         end
     end

--- a/scripts/zones/Horlais_Peak/npcs/Hot_Springs.lua
+++ b/scripts/zones/Horlais_Peak/npcs/Hot_Springs.lua
@@ -3,10 +3,10 @@
 --  NPC: Hot Springs
 -- !pos 444 -37 -18 139
 -----------------------------------
-require("scripts/globals/titles");
-require("scripts/globals/keyitems");
-require("scripts/globals/settings");
-local ID = require("scripts/zones/Horlais_Peak/IDs");
+local ID = require("scripts/zones/Horlais_Peak/IDs")
+require("scripts/globals/keyitems")
+require("scripts/globals/quests")
+require("scripts/globals/titles")
 -----------------------------------
 
 function onTrade(player,npc,trade)
@@ -16,7 +16,7 @@ function onTrade(player,npc,trade)
 end;
 
 function onTrigger(player,npc)
-    if (player:getQuestStatus(SANDORIA,THE_GENERAL_S_SECRET) == 1) and (player:hasKeyItem(dsp.ki.CURILLAS_BOTTLE_EMPTY) == true) then
+    if (player:getQuestStatus(SANDORIA,THE_GENERAL_S_SECRET) == QUEST_ACCEPTED) and (player:hasKeyItem(dsp.ki.CURILLAS_BOTTLE_EMPTY) == true) then
         player:addKeyItem(dsp.ki.CURILLAS_BOTTLE_FULL)
         player:messageSpecial(ID.text.KEYITEM_OBTAINED,dsp.ki.CURILLAS_BOTTLE_FULL);
         player:delKeyItem(dsp.ki.CURILLAS_BOTTLE_EMPTY);

--- a/scripts/zones/Tavnazian_Safehold/npcs/Pradiulot.lua
+++ b/scripts/zones/Tavnazian_Safehold/npcs/Pradiulot.lua
@@ -4,53 +4,36 @@
 -- Involved in Quest: Unforgiven
 -- !pos -20.814 -22 8.399 26
 -----------------------------------
-local ID = require("scripts/zones/Tavnazian_Safehold/IDs");
+local ID = require("scripts/zones/Tavnazian_Safehold/IDs")
 require("scripts/globals/keyitems")
-require("scripts/globals/quests");
+require("scripts/globals/quests")
 -----------------------------------
--- For those who don't know
--- at the end of if (player:getQuestStatus(REGION,QUEST_NAME)
--- == 0 means QUEST_AVAILABLE
--- == 1 means QUEST_ACCEPTED
--- == 2 means QUEST_COMPLETED
--- e.g. if (player:getQuestStatus(OTHER_AREAS_LOG,UNFORGIVEN) == 0
--- means if (player:getQuestStatus(OTHER_AREAS_LOG,UNFORGIVEN) == QUEST AVAILABLE
 
 function onTrade(player,npc,trade)
-
-if (player:getQuestStatus(OTHER_AREAS_LOG,UNFORGIVEN) == 2 and trade:getGil() == 1 == true) then
-        player:startEvent(206); -- Dialogue after completing quest (optional)
-        end
-
-end;
+end
 
 function onTrigger(player,npc)
+    local unforgiven = player:getQuestStatus(OTHER_AREAS_LOG, UNFORGIVEN)
 
-local Unforgiven = player:getQuestStatus(OTHER_AREAS_LOG,UNFORGIVEN);
-
-if (Unforgiven == 1 and player:getVar("UnforgivenVar") == 1) then
-    player:startEvent(204); -- Dialogue for final stage of Unforgiven Quest
-
-elseif (player:getQuestStatus(OTHER_AREAS_LOG,UNFORGIVEN) == 2 and player:getVar("UnforgivenVar") == 2) then
-    player:startEvent(206); -- Dialogue after completing quest (optional)
-
-else
-    player:startEvent(371); -- Default Dialogue
+    if unforgiven == QUEST_ACCEPTED and player:getVar("UnforgivenVar") == 1 then
+        player:startEvent(204) -- Dialogue for final stage of Unforgiven Quest
+    elseif unforgiven == QUEST_COMPLETED and player:getVar("UnforgivenVar") == 2 then
+        player:startEvent(206) -- Dialogue after completing quest (optional)
+    else
+        player:startEvent(371) -- Default Dialogue
+    end
 end
-end;
 
 function onEventUpdate(player,csid,option)
-end;
+end
 
 function onEventFinish(player,csid,option)
-if (csid == 204) then
-    player:setVar("UnforgivenVar",2);
-    player:addKeyItem(dsp.ki.MAP_OF_TAVNAZIA)
-    player:messageSpecial(ID.text.KEYITEM_OBTAINED,dsp.ki.MAP_OF_TAVNAZIA); -- Map of Tavnazia
-    player:completeQuest(OTHER_AREAS_LOG,UNFORGIVEN);
-
-elseif (csid == 206) then
-    player:setVar("UnforgivenVar",0);
-
+    if csid == 204 then
+        player:setVar("UnforgivenVar", 2)
+        player:addKeyItem(dsp.ki.MAP_OF_TAVNAZIA)
+        player:messageSpecial(ID.text.KEYITEM_OBTAINED, dsp.ki.MAP_OF_TAVNAZIA) -- Map of Tavnazia
+        player:completeQuest(OTHER_AREAS_LOG, UNFORGIVEN)
+    elseif csid == 206 then
+        player:setVar("UnforgivenVar", 0)
     end
-end;
+end

--- a/scripts/zones/Windurst_Walls/npcs/Koru-Moru.lua
+++ b/scripts/zones/Windurst_Walls/npcs/Koru-Moru.lua
@@ -5,11 +5,11 @@
 -- Involved in Quest: Making the Grade, Riding on the Clouds
 -- !pos -120 -6 124 239
 -----------------------------------
-local ID = require("scripts/zones/Windurst_Walls/IDs");
-require("scripts/globals/settings");
-require("scripts/globals/titles");
-require("scripts/globals/keyitems");
-require("scripts/globals/quests");
+local ID = require("scripts/zones/Windurst_Walls/IDs")
+require("scripts/globals/keyitems")
+require("scripts/globals/settings")
+require("scripts/globals/quests")
+require("scripts/globals/titles")
 -----------------------------------
 
 function onTrade(player,npc,trade)
@@ -48,7 +48,7 @@ function onTrade(player,npc,trade)
             player:setVar("rootProblem",2);
         end
     elseif (trade:hasItemQty(17299,4) and count == 4 and trade:getGil() == 0) then -- trade:getItemCount() is apparently checking total of all 8 slots combined. Could have sworn that wasn't how it worked before.
-        if (player:getQuestStatus(WINDURST,CLASS_REUNION) == 1 and player:getVar("ClassReunionProgress") == 2) then
+        if (player:getQuestStatus(WINDURST,CLASS_REUNION) == QUEST_ACCEPTED and player:getVar("ClassReunionProgress") == 2) then
             player:startEvent(407); -- now Koru remembers something that you need to inquire his former students.
         end;
     end;


### PR DESCRIPTION
replace hard-coded quest status values
clean up Pradiulot script. what's with the one gil onTrade? can't find any reference to it, and the onTrigger calls that event. removing the onTrade.