### PR TITLE
chocobo rewrite

### DIFF
--- a/scripts/globals/chocobo.lua
+++ b/scripts/globals/chocobo.lua
@@ -1,90 +1,150 @@
--------------------------------------------------
---  Chocobo functions
---  Info from:
---      http://wiki.ffxiclopedia.org/wiki/Chocobo_Renter
---      http://ffxi.allakhazam.com/wiki/Traveling_in_Vana'diel
--------------------------------------------------
+-----------------------------------
+-- Chocobo functions
+-- Info from:
+--     http://wiki.ffxiclopedia.org/wiki/Chocobo_Renter
+--     http://ffxi.allakhazam.com/wiki/Traveling_in_Vana'diel
+-----------------------------------
+require("scripts/globals/keyitems")
+require("scripts/globals/missions")
+require("scripts/globals/status")
+require("scripts/globals/zone")
+-----------------------------------
 
-require("scripts/globals/settings");
+dsp = dsp or {}
+dsp.chocobo = dsp.chocobo or {}
 
---[[-----------------------------------------------
+--[[
 Description:
-    chocobo = Zone, { [1] Base price, [2] Amount added to base price, [3] Amount discounted per time interval, [4] Amount of seconds before price decay, [5] Quest "A Chocobo Riding Game" chance }
---]]-----------------------------------------------
+[1] Level required to rent a chocobo
+[2] Base price
+[3] Amount added to base price
+[4] Amount discounted per time interval
+[5] Amount of seconds before price decay
+[6] Quest "A Chocobo Riding Game" chance
+[7] Shadowreign zone flag
+[8] Position player is sent to after event, if applicable
+--]]
 
-local chocobo = {230,{baseprice = 100,addedprice = 20,decayprice = 5,decaytime = 60,questchance = 0.10},  -- Southern San d'Oria
-                 234,{baseprice = 100,addedprice = 20,decayprice = 5,decaytime = 60,questchance = 0.10},  -- Bastok Mines
-                 241,{baseprice = 100,addedprice = 20,decayprice = 5,decaytime = 60,questchance = 0.10},  -- Windurst Woods
-                 244,{baseprice = 200,addedprice = 25,decayprice = 5,decaytime = 90,questchance = 0.00},  -- Upper Jeuno
-                 245,{baseprice = 200,addedprice = 25,decayprice = 5,decaytime = 90,questchance = 0.00},  -- Lower Jeuno
-                 246,{baseprice = 200,addedprice = 25,decayprice = 5,decaytime = 90,questchance = 0.00},  -- Port Jeuno
-                 250,{baseprice =  90,addedprice = 10,decayprice = 5,decaytime = 60,questchance = 0.10},  -- Kazham
-                 252,{baseprice =  90,addedprice = 10,decayprice = 5,decaytime = 60,questchance = 0.00},  -- Norg
-                 247,{baseprice =  90,addedprice = 10,decayprice = 5,decaytime = 60,questchance = 0.00},  -- Rabao
-                 102,{baseprice = 200,addedprice = 25,decayprice = 5,decaytime = 90,questchance = 0.00},  -- La Theine Plateau
-                 108,{baseprice = 200,addedprice = 25,decayprice = 5,decaytime = 90,questchance = 0.00},  -- Konschtat Highlands
-                 117,{baseprice = 200,addedprice = 25,decayprice = 5,decaytime = 90,questchance = 0.00},  -- Tahrongi Canyon
-                 114,{baseprice = 200,addedprice = 25,decayprice = 5,decaytime = 90,questchance = 0.00},  -- Eastern Altepa Desert
-                 124,{baseprice = 200,addedprice = 25,decayprice = 5,decaytime = 90,questchance = 0.00},  -- Yhoator Jungle
-                  48,{baseprice = 250,addedprice = 25,decayprice = 5,decaytime = 90,questchance = 0.00},  -- Al Zahbi
-                  51,{baseprice = 200,addedprice = 20,decayprice = 5,decaytime = 90,questchance = 0.00},  -- Wajaom Woodlands
-                  80,{baseprice = 150,addedprice = 20,decayprice = 5,decaytime = 90,questchance = 0.00},  -- Southern San d'Oria [S]
-                  87,{baseprice = 150,addedprice = 20,decayprice = 5,decaytime = 90,questchance = 0.00},  -- Bastok Markets [S]
-                  94,{baseprice = 150,addedprice = 20,decayprice = 5,decaytime = 90,questchance = 0.00},  -- Windurst Waters [S]
-                  82,{baseprice = 200,addedprice = 25,decayprice = 5,decaytime = 90,questchance = 0.00},  -- Jugner Forest [S]
-                  90,{baseprice = 200,addedprice = 25,decayprice = 5,decaytime = 90,questchance = 0.00},  -- Pashhow Marshlands [S]
-                  97,{baseprice = 200,addedprice = 25,decayprice = 5,decaytime = 90,questchance = 0.00}}; -- Meriphataud Mountains [S]
+local chocoboInfo =
+{
+    [dsp.zone.AL_ZAHBI]                = {levelReq = 20, basePrice = 250, addedPrice = 25, decayPrice = 5, decayTime = 90, questChance = 0.00, past = false, pos = {610, -24, 356, 128, 51}},
+    [dsp.zone.WAJAOM_WOODLANDS]        = {levelReq = 20, basePrice = 200, addedPrice = 20, decayPrice = 5, decayTime = 90, questChance = 0.00, past = false, pos = nil},
+    [dsp.zone.SOUTHERN_SAN_DORIA_S]    = {levelReq = 15, basePrice = 150, addedPrice = 20, decayPrice = 5, decayTime = 90, questChance = 0.00, past = true , pos = {94, -62, 266, 40, 81}},
+    [dsp.zone.JUGNER_FOREST_S]         = {levelReq = 20, basePrice = 200, addedPrice = 25, decayPrice = 5, decayTime = 90, questChance = 0.00, past = true , pos = nil},
+    [dsp.zone.BASTOK_MARKETS_S]        = {levelReq = 15, basePrice = 150, addedPrice = 20, decayPrice = 5, decayTime = 90, questChance = 0.00, past = true , pos = {380, 0, 147, 192, 88}},
+    [dsp.zone.PASHHOW_MARSHLANDS_S]    = {levelReq = 20, basePrice = 200, addedPrice = 25, decayPrice = 5, decayTime = 90, questChance = 0.00, past = true , pos = nil},
+    [dsp.zone.WINDURST_WATERS_S]       = {levelReq = 15, basePrice = 150, addedPrice = 20, decayPrice = 5, decayTime = 90, questChance = 0.00, past = true , pos = {320, -4, -46, 192, 95}},
+    [dsp.zone.MERIPHATAUD_MOUNTAINS_S] = {levelReq = 20, basePrice = 200, addedPrice = 25, decayPrice = 5, decayTime = 90, questChance = 0.00, past = true , pos = nil},
+    [dsp.zone.LA_THEINE_PLATEAU]       = {levelReq = 20, basePrice = 200, addedPrice = 25, decayPrice = 5, decayTime = 90, questChance = 0.00, past = false, pos = nil},
+    [dsp.zone.KONSCHTAT_HIGHLANDS]     = {levelReq = 20, basePrice = 200, addedPrice = 25, decayPrice = 5, decayTime = 90, questChance = 0.00, past = false, pos = nil},
+    [dsp.zone.EASTERN_ALTEPA_DESERT]   = {levelReq = 20, basePrice = 200, addedPrice = 25, decayPrice = 5, decayTime = 90, questChance = 0.00, past = false, pos = nil},
+    [dsp.zone.TAHRONGI_CANYON]         = {levelReq = 20, basePrice = 200, addedPrice = 25, decayPrice = 5, decayTime = 90, questChance = 0.00, past = false, pos = nil},
+    [dsp.zone.YHOATOR_JUNGLE]          = {levelReq = 20, basePrice = 200, addedPrice = 25, decayPrice = 5, decayTime = 90, questChance = 0.00, past = false, pos = nil},
+    [dsp.zone.SOUTHERN_SAN_DORIA]      = {levelReq = 15, basePrice = 100, addedPrice = 20, decayPrice = 5, decayTime = 60, questChance = 0.10, past = false, pos = {-126, -62, 274, 101, 100}},
+    [dsp.zone.BASTOK_MINES]            = {levelReq = 15, basePrice = 100, addedPrice = 20, decayPrice = 5, decayTime = 60, questChance = 0.10, past = false, pos = {580, 0, -305, 64, 107}},
+    [dsp.zone.WINDURST_WOODS]          = {levelReq = 15, basePrice = 100, addedPrice = 20, decayPrice = 5, decayTime = 60, questChance = 0.10, past = false, pos = {-122, -4, -520, 0, 116}},
+    [dsp.zone.UPPER_JEUNO]             = {levelReq = 20, basePrice = 200, addedPrice = 25, decayPrice = 5, decayTime = 90, questChance = 0.00, past = false, pos = {486, 8, -160, 128, 105}},
+    [dsp.zone.LOWER_JEUNO]             = {levelReq = 20, basePrice = 200, addedPrice = 25, decayPrice = 5, decayTime = 90, questChance = 0.00, past = false, pos = {340, 24, 608, 112, 110}},
+    [dsp.zone.PORT_JEUNO]              = {levelReq = 20, basePrice = 200, addedPrice = 25, decayPrice = 5, decayTime = 90, questChance = 0.00, past = false, pos = {-574, 2, 400, 0, 120}},
+    [dsp.zone.RABAO]                   = {levelReq = 20, basePrice =  90, addedPrice = 10, decayPrice = 5, decayTime = 60, questChance = 0.00, past = false, pos = {420, 8, 360, 64, 125}},
+    [dsp.zone.KAZHAM]                  = {levelReq = 20, basePrice =  90, addedPrice = 10, decayPrice = 5, decayTime = 60, questChance = 0.10, past = false, pos = {-240, 0, 528, 64, 123}},
+    [dsp.zone.NORG]                    = {levelReq = 20, basePrice =  90, addedPrice = 10, decayPrice = 5, decayTime = 60, questChance = 0.00, past = false, pos = {-456, 17, -348, 0, 123}},
+}
 
 ---------------------------------------
--- Set chocobo Prices on server start
+-- Local functions
 ---------------------------------------
 
-function setChocoboPrices()
-    for u = 1, #chocobo, 2 do
-        SetServerVariable("[CHOCOBO]["..chocobo[u].."]Price", chocobo[u + 1].baseprice);
-        SetServerVariable("[CHOCOBO]["..chocobo[u].."]Time", os.time(t));
-    end
-end;
+local function getPrice(zoneId, info)
+    local lastPrice = GetServerVariable("[CHOCOBO][" .. zoneId .. "]price")
+    local lastTime  = GetServerVariable("[CHOCOBO][" .. zoneId .. "]time")
+    local decay     = math.floor((os.time() - lastTime) / info.decayTime) * info.decayPrice
+    local price     = math.max(lastPrice - decay, info.basePrice)
 
----------------------------------------
--- return chocobo Price
----------------------------------------
+    return price
+end
 
-function getChocoboPrice(player)
-    local zone = player:getZoneID();
-    local price = 0;
-
-    for u = 1, #chocobo, 2 do
-        if (chocobo[u] == zone) then
-            local last_price = GetServerVariable("[CHOCOBO]["..zone.."]Price");
-            local last_time = GetServerVariable("[CHOCOBO]["..zone.."]Time");
-
-            price = last_price - (math.floor((os.time(t) - last_time) / chocobo[u + 1].decaytime) * chocobo[u + 1].decayprice);
-
-            if (price < chocobo[u + 1].baseprice) then
-                price = chocobo[u + 1].baseprice;
-            end
-
-            break;
-        end
-    end
-
-    return price;
+function updatePrice(zoneId, info, price)
+    SetServerVariable("[CHOCOBO][" .. zoneId .. "]price", price + info.addedPrice)
+    SetServerVariable("[CHOCOBO][" .. zoneId .. "]time", os.time())
 end
 
 ---------------------------------------
--- update chocobo Price
+-- Public functions
 ---------------------------------------
 
-function updateChocoboPrice(player, price)
-    local zone = player:getZoneID();
+dsp.chocobo.initZone = function(zone)
+    local zoneId = zone:getID()
+    local info = chocoboInfo[zoneId]
 
-    for u = 1, #chocobo, 2 do
-        if (chocobo[u] == zone) then
-            SetServerVariable("[CHOCOBO]["..chocobo[u].."]Price", price + chocobo[u + 1].addedprice);
-            SetServerVariable("[CHOCOBO]["..chocobo[u].."]Time", os.time(t));
+    if info then
+        SetServerVariable("[CHOCOBO][" .. zoneId .. "]price", info.basePrice)
+        SetServerVariable("[CHOCOBO][" .. zoneId .. "]time", os.time())
+    else
+        printf("[warning] bad zoneId %i in dsp.chocobo.initZone", zoneId)
+    end
+end
 
-            break;
+dsp.chocobo.renterOnTrigger = function(player, eventSucceed, eventFail)
+    local mLvl   = player:getMainLvl()
+    local zoneId = player:getZoneID()
+    local info   = chocoboInfo[zoneId]
+
+    if info then
+        if player:hasKeyItem(dsp.ki.CHOCOBO_LICENSE) and mLvl >= info.levelReq and (player:hasCompletedMission(WOTG, BACK_TO_THE_BEGINNING) or not info.past) then
+            local price = getPrice(zoneId, info)
+            player:setLocalVar("[CHOCOBO]price", price)
+
+            local currency = 0
+            if info.past then
+                currency = player:getCurrency("allied_notes")
+            else
+                currency = player:getGil()
+            end
+
+            local lowLevel = (mLvl < 20) and 1 or 0
+
+            player:startEvent(eventSucceed, price, currency, lowLevel)
+        else
+            player:startEvent(eventFail)
+        end
+    else
+        printf("[warning] player %s passed bad zoneId %i in dsp.chocobo.renterOnTrigger", player:getName(), zoneId)
+    end
+end
+
+dsp.chocobo.renterOnEventFinish = function(player, csid, option, eventSucceed)
+    if csid == eventSucceed and option == 0 then
+        local mLvl   = player:getMainLvl()
+        local zoneId = player:getZoneID()
+        local info   = chocoboInfo[zoneId]
+
+        if info then
+            local price = player:getLocalVar("[CHOCOBO]price")
+            player:setLocalVar("[CHOCOBO]price", 0)
+
+            if price and (info.past and player:getCurrency("allied_notes") >= price) or (not info.past and player:delGil(price)) then
+                if info.past then
+                    player:delCurrency("allied_notes", price)
+                end
+
+                updatePrice(zoneId, info, price)
+
+                local duration = 900
+                if mLvl >= 20 then
+                    duration = 1800 + (player:getMod(dsp.mod.CHOCOBO_RIDING_TIME) * 60)
+                end
+
+                player:addStatusEffectEx(dsp.effect.MOUNTED, dsp.effect.MOUNTED, 0, 0, duration, true)
+
+                if info.pos then
+                    player:setPos(unpack(info.pos))
+                end
+            else
+                printf("[warning] player %s reached succeed without enough currency in dsp.chocobo.renterOnEventFinish", player:getName())
+            end
+        else
+            printf("[warning] player %s passed bad zoneId %i in dsp.chocobo.renterOnEventFinish", player:getName(), zoneId)
         end
     end
-end;
+end

--- a/scripts/zones/Al_Zahbi/Zone.lua
+++ b/scripts/zones/Al_Zahbi/Zone.lua
@@ -4,9 +4,11 @@
 --
 -----------------------------------
 local ID = require("scripts/zones/Al_Zahbi/IDs")
+require("scripts/globals/chocobo")
 -----------------------------------
 
 function onInitialize(zone)
+    dsp.chocobo.initZone(zone)
 end
 
 function onZoneIn(player,prevZone)

--- a/scripts/zones/Al_Zahbi/npcs/Dahaaba.lua
+++ b/scripts/zones/Al_Zahbi/npcs/Dahaaba.lua
@@ -2,48 +2,24 @@
 -- Area: Al Zahbi
 --  NPC: Dahaaba
 -- Type: Chocobo Renter
--- !pos -65.309 -1 -39.585
+-- !pos -65.309 -1 -39.585 48
 -----------------------------------
-require("scripts/globals/settings")
-require("scripts/globals/keyitems")
 require("scripts/globals/chocobo")
-require("scripts/globals/status")
 -----------------------------------
+
+local eventSucceed = 270
+local eventFail    = 271
 
 function onTrade(player,npc,trade)
 end
 
 function onTrigger(player,npc)
-    local level = player:getMainLvl()
-    local gil = player:getGil()
-
-    if player:hasKeyItem(dsp.ki.CHOCOBO_LICENSE) and level >= 20 then
-        local price = getChocoboPrice(player)
-        player:setLocalVar("chocoboPriceOffer",price)
-
-        player:startEvent(270,price,gil)
-    else
-        player:startEvent(271)
-    end
-
+    dsp.chocobo.renterOnTrigger(player, eventSucceed, eventFail)
 end
 
 function onEventUpdate(player,csid,option)
 end
 
 function onEventFinish(player,csid,option)
-
-    local price = player:getLocalVar("chocoboPriceOffer")
-
-    if csid == 270 and option == 0 then
-        if player:delGil(price) then
-            updateChocoboPrice(player, price)
-
-            local duration = 1800 + player:getMod(dsp.mod.CHOCOBO_RIDING_TIME) * 60
-
-            player:addStatusEffectEx(dsp.effect.MOUNTED,dsp.effect.MOUNTED,0,0,duration,true)
-
-            player:setPos(610,-24,356,128,51)
-        end
-    end
+    dsp.chocobo.renterOnEventFinish(player, csid, option, eventSucceed)
 end

--- a/scripts/zones/Bastok_Markets/Zone.lua
+++ b/scripts/zones/Bastok_Markets/Zone.lua
@@ -3,7 +3,6 @@
 -- Zone: Bastok_Markets (235)
 --
 -----------------------------------
-require("scripts/globals/chocobo");
 require("scripts/globals/events/harvest_festivals");
 require("scripts/globals/settings");
 require("scripts/globals/zone");
@@ -12,8 +11,6 @@ local ID = require("scripts/zones/Bastok_Markets/IDs");
 
 function onInitialize(zone)
     applyHalloweenNpcCostumes(zone:getID())
-
-    setChocoboPrices();
 end;
 
 function onZoneIn(player,prevZone)

--- a/scripts/zones/Bastok_Markets_[S]/Zone.lua
+++ b/scripts/zones/Bastok_Markets_[S]/Zone.lua
@@ -4,9 +4,11 @@
 --
 -----------------------------------
 local ID = require("scripts/zones/Bastok_Markets_[S]/IDs")
+require("scripts/globals/chocobo")
 -----------------------------------
 
 function onInitialize(zone)
+    dsp.chocobo.initZone(zone)
 end;
 
 function onZoneIn(player,prevZone)

--- a/scripts/zones/Bastok_Markets_[S]/npcs/Melina.lua
+++ b/scripts/zones/Bastok_Markets_[S]/npcs/Melina.lua
@@ -1,14 +1,14 @@
 -----------------------------------
--- Area: Southern Sand'Oria [S]
---  NPC: Chauxnatte
+-- Area: Bastok Markets [S]
+--  NPC: Melina
 -- Type: Chocobo Renter
--- !pos 85 1 -51 80
+-- !pos -210.667 0.000 75.819 87
 -----------------------------------
 require("scripts/globals/chocobo")
 -----------------------------------
 
-local eventSucceed = 106
-local eventFail    = 107
+local eventSucceed = 6
+local eventFail    = 7
 
 function onTrade(player,npc,trade)
 end

--- a/scripts/zones/Bastok_Mines/Zone.lua
+++ b/scripts/zones/Bastok_Mines/Zone.lua
@@ -8,6 +8,7 @@ require("scripts/globals/events/harvest_festivals")
 require("scripts/globals/conquest")
 require("scripts/globals/missions")
 require("scripts/globals/settings")
+require("scripts/globals/chocobo")
 require("scripts/globals/zone")
 -----------------------------------
 
@@ -15,6 +16,7 @@ function onInitialize(zone)
     SetExplorerMoogles(ID.npc.EXPLORER_MOOGLE)
 
     applyHalloweenNpcCostumes(zone:getID())
+    dsp.chocobo.initZone(zone)
 end
 
 function onZoneIn(player,prevZone)

--- a/scripts/zones/Bastok_Mines/npcs/Azette.lua
+++ b/scripts/zones/Bastok_Mines/npcs/Azette.lua
@@ -2,54 +2,24 @@
 -- Area: Bastok Mines
 --  NPC: Azette
 -- Type: Chocobo Renter
+-- !pos 43.882 0.750 -108.629 234
 -----------------------------------
-require("scripts/globals/settings");
-require("scripts/globals/keyitems");
-require("scripts/globals/chocobo");
-require("scripts/globals/status");
+require("scripts/globals/chocobo")
 -----------------------------------
+
+local eventSucceed = 61
+local eventFail    = 64
 
 function onTrade(player,npc,trade)
-end;
+end
 
 function onTrigger(player,npc)
-    local level = player:getMainLvl();
-    local gil = player:getGil();
-
-    if (player:hasKeyItem(dsp.ki.CHOCOBO_LICENSE) and level >= 15) then
-        local price = getChocoboPrice(player);
-        player:setLocalVar("chocoboPriceOffer",price);
-
-        if (level >= 20) then
-            level = 0;
-        end
-
-        player:startEvent(61,price,gil,level);
-    else
-        player:startEvent(64);
-    end
-end;
+    dsp.chocobo.renterOnTrigger(player, eventSucceed, eventFail)
+end
 
 function onEventUpdate(player,csid,option)
-end;
+end
 
 function onEventFinish(player,csid,option)
-
-    local price = player:getLocalVar("chocoboPriceOffer");
-
-    if (csid == 61 and option == 0) then
-        if (player:delGil(price)) then
-            updateChocoboPrice(player, price);
-
-            if (player:getMainLvl() >= 20) then
-                local duration = 1800 + (player:getMod(dsp.mod.CHOCOBO_RIDING_TIME) * 60)
-
-                player:addStatusEffectEx(dsp.effect.MOUNTED,dsp.effect.MOUNTED,0,0,duration,true);
-            else
-                player:addStatusEffectEx(dsp.effect.MOUNTED,dsp.effect.MOUNTED,0,0,900,true);
-            end
-
-            player:setPos(580,0,-305,64,107);
-        end
-    end
-end;
+    dsp.chocobo.renterOnEventFinish(player, csid, option, eventSucceed)
+end

--- a/scripts/zones/Bastok_Mines/npcs/Eulaphe.lua
+++ b/scripts/zones/Bastok_Mines/npcs/Eulaphe.lua
@@ -2,54 +2,24 @@
 -- Area: Bastok Mines
 --  NPC: Eulaphe
 -- Type: Chocobo Renter
+-- !pos 38.975 0.750 -108.629 234
 -----------------------------------
-require("scripts/globals/settings");
-require("scripts/globals/keyitems");
-require("scripts/globals/chocobo");
-require("scripts/globals/status");
+require("scripts/globals/chocobo")
 -----------------------------------
+
+local eventSucceed = 62
+local eventFail    = 65
 
 function onTrade(player,npc,trade)
-end;
+end
 
 function onTrigger(player,npc)
-    local level = player:getMainLvl();
-    local gil = player:getGil();
-
-    if (player:hasKeyItem(dsp.ki.CHOCOBO_LICENSE) and level >= 15) then
-        local price = getChocoboPrice(player);
-        player:setLocalVar("chocoboPriceOffer",price);
-
-        if (level >= 20) then
-            level = 0;
-        end
-
-        player:startEvent(62,price,gil,level);
-    else
-        player:startEvent(65);
-    end
-end;
+    dsp.chocobo.renterOnTrigger(player, eventSucceed, eventFail)
+end
 
 function onEventUpdate(player,csid,option)
-end;
+end
 
 function onEventFinish(player,csid,option)
-
-    local price = player:getLocalVar("chocoboPriceOffer");
-
-    if (csid == 62 and option == 0) then
-        if (player:delGil(price)) then
-            updateChocoboPrice(player, price);
-
-            if (player:getMainLvl() >= 20) then
-                local duration = 1800 + (player:getMod(dsp.mod.CHOCOBO_RIDING_TIME) * 60)
-
-                player:addStatusEffectEx(dsp.effect.MOUNTED,dsp.effect.MOUNTED,0,0,duration,true);
-            else
-                player:addStatusEffectEx(dsp.effect.MOUNTED,dsp.effect.MOUNTED,0,0,900,true);
-            end
-
-            player:setPos(580,0,-305,64,107);
-        end
-    end
-end;
+    dsp.chocobo.renterOnEventFinish(player, csid, option, eventSucceed)
+end

--- a/scripts/zones/Bastok_Mines/npcs/Quelle.lua
+++ b/scripts/zones/Bastok_Mines/npcs/Quelle.lua
@@ -2,54 +2,24 @@
 -- Area: Bastok Mines
 --  NPC: Quelle
 -- Type: Chocobo Renter
+-- !pos 33.998 0.750 -108.625 234
 -----------------------------------
-require("scripts/globals/settings");
-require("scripts/globals/keyitems");
-require("scripts/globals/chocobo");
-require("scripts/globals/status");
+require("scripts/globals/chocobo")
 -----------------------------------
+
+local eventSucceed = 63
+local eventFail    = 66
 
 function onTrade(player,npc,trade)
-end;
+end
 
 function onTrigger(player,npc)
-    local level = player:getMainLvl();
-    local gil = player:getGil();
-
-    if (player:hasKeyItem(dsp.ki.CHOCOBO_LICENSE) and level >= 15) then
-        local price = getChocoboPrice(player);
-        player:setLocalVar("chocoboPriceOffer",price);
-
-        if (level >= 20) then
-            level = 0;
-        end
-
-        player:startEvent(63,price,gil,level);
-    else
-        player:startEvent(66);
-    end
-end;
+    dsp.chocobo.renterOnTrigger(player, eventSucceed, eventFail)
+end
 
 function onEventUpdate(player,csid,option)
-end;
+end
 
 function onEventFinish(player,csid,option)
-
-    local price = player:getLocalVar("chocoboPriceOffer");
-
-    if (csid == 63 and option == 0) then
-        if (player:delGil(price)) then
-            updateChocoboPrice(player, price);
-
-            if (player:getMainLvl() >= 20) then
-                local duration = 1800 + (player:getMod(dsp.mod.CHOCOBO_RIDING_TIME) * 60)
-
-                player:addStatusEffectEx(dsp.effect.MOUNTED,dsp.effect.MOUNTED,0,0,duration,true);
-            else
-                player:addStatusEffectEx(dsp.effect.MOUNTED,dsp.effect.MOUNTED,0,0,900,true);
-            end
-
-            player:setPos(580,0,-305,64,107);
-        end
-    end
-end;
+    dsp.chocobo.renterOnEventFinish(player, csid, option, eventSucceed)
+end

--- a/scripts/zones/Eastern_Altepa_Desert/Zone.lua
+++ b/scripts/zones/Eastern_Altepa_Desert/Zone.lua
@@ -7,6 +7,7 @@ local ID = require("scripts/zones/Eastern_Altepa_Desert/IDs")
 require("scripts/globals/icanheararainbow")
 require("scripts/globals/chocobo_digging")
 require("scripts/globals/conquest")
+require("scripts/globals/chocobo")
 -----------------------------------
 
 function onChocoboDig(player, precheck)
@@ -21,6 +22,7 @@ function onInitialize(zone)
     GetMobByID(ID.mob.CENTURIO_XII_I):setRespawnTime(math.random(900, 10800))
 
     dsp.conq.setRegionalConquestOverseers(zone:getRegionID())
+    dsp.chocobo.initZone(zone)
 end
 
 function onConquestUpdate(zone, updatetype)

--- a/scripts/zones/Eastern_Altepa_Desert/npcs/Eulaclaire.lua
+++ b/scripts/zones/Eastern_Altepa_Desert/npcs/Eulaclaire.lua
@@ -2,44 +2,24 @@
 -- Area: Eastern Altepa Desert
 --  NPC: Eulaclaire
 -- Type: Chocobo Renter
+-- !pos -55.715 3.949 232.524 114
 -----------------------------------
-require("scripts/globals/settings");
-require("scripts/globals/keyitems");
-require("scripts/globals/chocobo");
-require("scripts/globals/status");
+require("scripts/globals/chocobo")
 -----------------------------------
+
+local eventSucceed = 6
+local eventFail    = 7
 
 function onTrade(player,npc,trade)
-end;
+end
 
 function onTrigger(player,npc)
-    local level = player:getMainLvl();
-    local gil = player:getGil();
-
-    if (player:hasKeyItem(dsp.ki.CHOCOBO_LICENSE) and level >= 20) then
-        local price = getChocoboPrice(player);
-        player:setLocalVar("chocoboPriceOffer",price);
-
-        player:startEvent(6,price,gil,1)
-    else
-        player:startEvent(7);
-    end
-end;
+    dsp.chocobo.renterOnTrigger(player, eventSucceed, eventFail)
+end
 
 function onEventUpdate(player,csid,option)
-end;
+end
 
 function onEventFinish(player,csid,option)
-
-    local price = player:getLocalVar("chocoboPriceOffer");
-
-    if (csid == 6 and option == 0) then
-        if (player:delGil(price)) then
-            updateChocoboPrice(player, price);
-
-            local duration = 1800 + (player:getMod(dsp.mod.CHOCOBO_RIDING_TIME) * 60)
-
-            player:addStatusEffectEx(dsp.effect.MOUNTED,dsp.effect.MOUNTED,0,0,duration,true);
-        end
-    end
-end;
+    dsp.chocobo.renterOnEventFinish(player, csid, option, eventSucceed)
+end

--- a/scripts/zones/Jugner_Forest_[S]/Zone.lua
+++ b/scripts/zones/Jugner_Forest_[S]/Zone.lua
@@ -4,12 +4,14 @@
 --
 -----------------------------------
 local ID = require("scripts/zones/Jugner_Forest_[S]/IDs")
+require("scripts/globals/chocobo")
 require("scripts/globals/quests")
 require("scripts/globals/helm")
 -----------------------------------
 
 function onInitialize(zone)
     dsp.helm.initZone(zone, dsp.helm.type.LOGGING)
+    dsp.chocobo.initZone(zone)
 end;
 
 function onZoneIn(player,prevZone)

--- a/scripts/zones/Jugner_Forest_[S]/npcs/Helmyre.lua
+++ b/scripts/zones/Jugner_Forest_[S]/npcs/Helmyre.lua
@@ -4,41 +4,22 @@
 -- Type: Chocobo Renter
 -- !pos -120.853 0.000 -152.582 82
 -----------------------------------
-require("scripts/globals/settings")
-require("scripts/globals/keyitems")
-require("scripts/globals/missions")
 require("scripts/globals/chocobo")
-require("scripts/globals/status")
+-----------------------------------
+
+local eventSucceed = 208
+local eventFail    = 209
 
 function onTrade(player,npc,trade)
 end
 
 function onTrigger(player,npc)
-    local level = player:getMainLvl()
-    local notes = player:getCurrency("allied_notes")
-
-    if player:hasKeyItem(dsp.ki.CHOCOBO_LICENSE) and level >= 20 and player:hasCompletedMission(WOTG,BACK_TO_THE_BEGINNING) then
-        local price = getChocoboPrice(player)
-        player:setLocalVar("chocoboPriceOffer",price)
-
-        player:startEvent(208,price,notes)
-    else
-        player:startEvent(209)
-    end
+    dsp.chocobo.renterOnTrigger(player, eventSucceed, eventFail)
 end
 
 function onEventUpdate(player,csid,option)
 end
 
 function onEventFinish(player,csid,option)
-    local price = player:getLocalVar("chocoboPriceOffer")
-
-    if csid == 208 and option == 0 then
-        player:delCurrency("allied_notes", price)
-        updateChocoboPrice(player, price)
-
-        local duration = 1800 + (player:getMod(dsp.mod.CHOCOBO_RIDING_TIME) * 60)
-
-        player:addStatusEffectEx(dsp.effect.MOUNTED,dsp.effect.MOUNTED,0,0,duration,true)
-    end
+    dsp.chocobo.renterOnEventFinish(player, csid, option, eventSucceed)
 end

--- a/scripts/zones/Kazham/Zone.lua
+++ b/scripts/zones/Kazham/Zone.lua
@@ -5,10 +5,12 @@
 -----------------------------------
 local ID = require("scripts/zones/Kazham/IDs")
 require("scripts/globals/conquest")
+require("scripts/globals/chocobo")
 require("scripts/globals/zone")
 -----------------------------------
 
 function onInitialize(zone)
+    dsp.chocobo.initZone(zone)
 end;
 
 function onConquestUpdate(zone, updatetype)

--- a/scripts/zones/Kazham/npcs/Tielleque.lua
+++ b/scripts/zones/Kazham/npcs/Tielleque.lua
@@ -2,46 +2,24 @@
 -- Area: Kazham
 --  NPC: Tielleque
 -- Type: Chocobo Renter
+-- !pos -55.339 -9.999 -94.936 250
 -----------------------------------
-require("scripts/globals/settings");
-require("scripts/globals/keyitems");
-require("scripts/globals/chocobo");
-require("scripts/globals/status");
+require("scripts/globals/chocobo")
 -----------------------------------
+
+local eventSucceed = 10016
+local eventFail    = 10017
 
 function onTrade(player,npc,trade)
-end;
+end
 
 function onTrigger(player,npc)
-    local level = player:getMainLvl();
-    local gil = player:getGil();
-
-    if (player:hasKeyItem(dsp.ki.CHOCOBO_LICENSE) and level >= 20) then
-        local price = getChocoboPrice(player);
-        player:setLocalVar("chocoboPriceOffer",price);
-
-        player:startEvent(10016,price,gil);
-    else
-        player:startEvent(10017);
-    end
-end;
+    dsp.chocobo.renterOnTrigger(player, eventSucceed, eventFail)
+end
 
 function onEventUpdate(player,csid,option)
-end;
+end
 
 function onEventFinish(player,csid,option)
-
-    local price = player:getLocalVar("chocoboPriceOffer");
-
-    if (csid == 10016 and option == 0) then
-        if (player:delGil(price)) then
-            updateChocoboPrice(player, price);
-
-            local duration = 1800 + (player:getMod(dsp.mod.CHOCOBO_RIDING_TIME) * 60)
-
-            player:addStatusEffectEx(dsp.effect.MOUNTED,dsp.effect.MOUNTED,0,0,duration,true);
-
-            player:setPos(-240,0,528,64,123);
-        end
-    end
-end;
+    dsp.chocobo.renterOnEventFinish(player, csid, option, eventSucceed)
+end

--- a/scripts/zones/Konschtat_Highlands/Zone.lua
+++ b/scripts/zones/Konschtat_Highlands/Zone.lua
@@ -8,6 +8,7 @@ require("scripts/globals/icanheararainbow");
 require("scripts/globals/chocobo_digging");
 require("scripts/globals/conquest");
 require("scripts/globals/missions");
+require("scripts/globals/chocobo")
 -----------------------------------
 
 function onChocoboDig(player, precheck)
@@ -15,6 +16,7 @@ function onChocoboDig(player, precheck)
 end;
 
 function onInitialize(zone)
+    dsp.chocobo.initZone(zone)
 end;
 
 function onZoneIn( player, prevZone)

--- a/scripts/zones/Konschtat_Highlands/npcs/Plaiaude.lua
+++ b/scripts/zones/Konschtat_Highlands/npcs/Plaiaude.lua
@@ -4,43 +4,22 @@
 -- Type: Chocobo Renter
 -- !pos 244.705 24.034 296.973 108
 -----------------------------------
-require("scripts/globals/settings");
-require("scripts/globals/keyitems");
-require("scripts/globals/chocobo");
-require("scripts/globals/status");
+require("scripts/globals/chocobo")
 -----------------------------------
 
+local eventSucceed = 910
+local eventFail    = 911
+
 function onTrade(player,npc,trade)
-end;
+end
 
 function onTrigger(player,npc)
-    local level = player:getMainLvl();
-    local gil = player:getGil();
-
-    if (player:hasKeyItem(dsp.ki.CHOCOBO_LICENSE) and level >= 20) then
-        local price = getChocoboPrice(player);
-        player:setLocalVar("chocoboPriceOffer",price);
-
-        player:startEvent(910,price,gil,1)
-    else
-        player:startEvent(911);
-    end
-end;
+    dsp.chocobo.renterOnTrigger(player, eventSucceed, eventFail)
+end
 
 function onEventUpdate(player,csid,option)
-end;
+end
 
 function onEventFinish(player,csid,option)
-
-    local price = player:getLocalVar("chocoboPriceOffer");
-
-    if (csid == 910 and option == 0) then
-        if (player:delGil(price)) then
-            updateChocoboPrice(player, price);
-
-            local duration = 1800 + (player:getMod(dsp.mod.CHOCOBO_RIDING_TIME) * 60)
-
-            player:addStatusEffectEx(dsp.effect.MOUNTED,dsp.effect.MOUNTED,0,0,duration,true);
-        end
-    end
-end;
+    dsp.chocobo.renterOnEventFinish(player, csid, option, eventSucceed)
+end

--- a/scripts/zones/La_Theine_Plateau/Zone.lua
+++ b/scripts/zones/La_Theine_Plateau/Zone.lua
@@ -11,6 +11,7 @@ require("scripts/globals/conquest");
 require("scripts/globals/missions");
 require("scripts/globals/npc_util");
 require("scripts/globals/settings");
+require("scripts/globals/chocobo")
 require("scripts/globals/weather");
 require("scripts/globals/quests");
 require("scripts/globals/status");
@@ -23,6 +24,7 @@ end;
 
 function onInitialize(zone)
     LA_THEINE_PLATEAU.moveFallenEgg();
+    dsp.chocobo.initZone(zone)
 end;
 
 function onZoneIn( player, prevZone)

--- a/scripts/zones/La_Theine_Plateau/npcs/Coumaine.lua
+++ b/scripts/zones/La_Theine_Plateau/npcs/Coumaine.lua
@@ -2,44 +2,24 @@
 -- Area: La Theine Plateau
 --  NPC: Coumaine
 -- Type: Chocobo Vendor
+-- !pos 441.782 24.231 20.254 102
 -----------------------------------
-require("scripts/globals/settings");
-require("scripts/globals/keyitems");
-require("scripts/globals/chocobo");
-require("scripts/globals/status");
+require("scripts/globals/chocobo")
 -----------------------------------
+
+local eventSucceed = 120
+local eventFail    = 121
 
 function onTrade(player,npc,trade)
-end;
+end
 
 function onTrigger(player,npc)
-    local level = player:getMainLvl();
-    local gil = player:getGil();
-
-    if (player:hasKeyItem(dsp.ki.CHOCOBO_LICENSE) and level >= 20) then
-        local price = getChocoboPrice(player);
-        player:setLocalVar("chocoboPriceOffer",price);
-
-        player:startEvent(120,price,gil,1)
-    else
-        player:startEvent(121);
-    end
-end;
+    dsp.chocobo.renterOnTrigger(player, eventSucceed, eventFail)
+end
 
 function onEventUpdate(player,csid,option)
-end;
+end
 
 function onEventFinish(player,csid,option)
-
-    local price = player:getLocalVar("chocoboPriceOffer");
-
-    if (csid == 120 and option == 0) then
-        if (player:delGil(price)) then
-            updateChocoboPrice(player, price);
-
-            local duration = 1800 + (player:getMod(dsp.mod.CHOCOBO_RIDING_TIME) * 60)
-
-            player:addStatusEffectEx(dsp.effect.MOUNTED,dsp.effect.MOUNTED,0,0,duration,true);
-        end
-    end
-end;
+    dsp.chocobo.renterOnEventFinish(player, csid, option, eventSucceed)
+end

--- a/scripts/zones/Lower_Jeuno/Zone.lua
+++ b/scripts/zones/Lower_Jeuno/Zone.lua
@@ -10,11 +10,13 @@ require("scripts/globals/keyitems");
 require("scripts/globals/missions");
 require("scripts/globals/pathfind");
 require("scripts/globals/settings");
+require("scripts/globals/chocobo")
 require("scripts/globals/status");
 -----------------------------------
 
 function onInitialize(zone)
     zone:registerRegion(1, 23, 0, -43, 44, 7, -39); -- Inside Tenshodo HQ
+    dsp.chocobo.initZone(zone)
 end;
 
 function onZoneIn(player,prevZone)

--- a/scripts/zones/Lower_Jeuno/npcs/Audee.lua
+++ b/scripts/zones/Lower_Jeuno/npcs/Audee.lua
@@ -2,46 +2,24 @@
 -- Area: Lower Jeuno
 --  NPC: Audee
 -- Type: Chocobo Renter
+-- !pos -89.6 -0.100 -197.4 245
 -----------------------------------
-require("scripts/globals/settings");
-require("scripts/globals/keyitems");
-require("scripts/globals/chocobo");
-require("scripts/globals/status");
+require("scripts/globals/chocobo")
 -----------------------------------
+
+local eventSucceed = 10002
+local eventFail    = 10005
 
 function onTrade(player,npc,trade)
-end;
+end
 
 function onTrigger(player,npc)
-    local level = player:getMainLvl();
-    local gil = player:getGil();
-
-    if (player:hasKeyItem(dsp.ki.CHOCOBO_LICENSE) and level >= 20) then
-        local price = getChocoboPrice(player);
-        player:setLocalVar("chocoboPriceOffer",price);
-
-        player:startEvent(10002,price,gil);
-    else
-        player:startEvent(10005);
-    end
-end;
+    dsp.chocobo.renterOnTrigger(player, eventSucceed, eventFail)
+end
 
 function onEventUpdate(player,csid,option)
-end;
+end
 
 function onEventFinish(player,csid,option)
-
-    local price = player:getLocalVar("chocoboPriceOffer");
-
-    if (csid == 10002 and option == 0) then
-        if (player:delGil(price)) then
-            updateChocoboPrice(player, price);
-
-            local duration = 1800 + (player:getMod(dsp.mod.CHOCOBO_RIDING_TIME) * 60)
-
-            player:addStatusEffectEx(dsp.effect.MOUNTED,dsp.effect.MOUNTED,0,0,duration,true);
-
-            player:setPos(340,24,608,112,110);
-        end
-    end
-end;
+    dsp.chocobo.renterOnEventFinish(player, csid, option, eventSucceed)
+end

--- a/scripts/zones/Lower_Jeuno/npcs/Fephita.lua
+++ b/scripts/zones/Lower_Jeuno/npcs/Fephita.lua
@@ -2,46 +2,24 @@
 -- Area: Lower Jeuno
 --  NPC: Fephita
 -- Type: Chocobo Renter
+-- !pos -89.6 -0.100 -197.4 245
 -----------------------------------
-require("scripts/globals/settings");
-require("scripts/globals/keyitems");
-require("scripts/globals/chocobo");
-require("scripts/globals/status");
+require("scripts/globals/chocobo")
 -----------------------------------
+
+local eventSucceed = 10003
+local eventFail    = 10006
 
 function onTrade(player,npc,trade)
-end;
+end
 
 function onTrigger(player,npc)
-    local level = player:getMainLvl();
-    local gil = player:getGil();
-
-    if (player:hasKeyItem(dsp.ki.CHOCOBO_LICENSE) and level >= 20) then
-        local price = getChocoboPrice(player);
-        player:setLocalVar("chocoboPriceOffer",price);
-
-        player:startEvent(10003,price,gil);
-    else
-        player:startEvent(10006);
-    end
-end;
+    dsp.chocobo.renterOnTrigger(player, eventSucceed, eventFail)
+end
 
 function onEventUpdate(player,csid,option)
-end;
+end
 
 function onEventFinish(player,csid,option)
-
-    local price = player:getLocalVar("chocoboPriceOffer");
-
-    if (csid == 10003 and option == 0) then
-        if (player:delGil(price)) then
-            updateChocoboPrice(player, price);
-
-            local duration = 1800 + (player:getMod(dsp.mod.CHOCOBO_RIDING_TIME) * 60)
-
-            player:addStatusEffectEx(dsp.effect.MOUNTED,dsp.effect.MOUNTED,0,0,duration,true);
-
-            player:setPos(340,24,608,112,110);
-        end
-    end
-end;
+    dsp.chocobo.renterOnEventFinish(player, csid, option, eventSucceed)
+end

--- a/scripts/zones/Meriphataud_Mountains_[S]/Zone.lua
+++ b/scripts/zones/Meriphataud_Mountains_[S]/Zone.lua
@@ -4,10 +4,12 @@
 --
 -----------------------------------
 local ID = require("scripts/zones/Meriphataud_Mountains_[S]/IDs");
+require("scripts/globals/chocobo")
 require("scripts/globals/status");
 -----------------------------------
 
 function onInitialize(zone)
+    dsp.chocobo.initZone(zone)
 end;
 
 function onZoneIn(player,prevZone)

--- a/scripts/zones/Meriphataud_Mountains_[S]/npcs/Lidaise.lua
+++ b/scripts/zones/Meriphataud_Mountains_[S]/npcs/Lidaise.lua
@@ -4,41 +4,22 @@
 -- Type: Chocobo Renter
 -- !pos 312.021 -10.921 28.494 97
 -----------------------------------
-require("scripts/globals/settings")
-require("scripts/globals/keyitems")
-require("scripts/globals/missions")
 require("scripts/globals/chocobo")
-require("scripts/globals/status")
+-----------------------------------
+
+local eventSucceed = 106
+local eventFail    = 107
 
 function onTrade(player,npc,trade)
 end
 
 function onTrigger(player,npc)
-    local level = player:getMainLvl()
-    local notes = player:getCurrency("allied_notes")
-
-    if player:hasKeyItem(dsp.ki.CHOCOBO_LICENSE) and level >= 20 and player:hasCompletedMission(WOTG,BACK_TO_THE_BEGINNING) then
-        local price = getChocoboPrice(player)
-        player:setLocalVar("chocoboPriceOffer",price)
-
-        player:startEvent(106,price,notes)
-    else
-        player:startEvent(107)
-    end
+    dsp.chocobo.renterOnTrigger(player, eventSucceed, eventFail)
 end
 
 function onEventUpdate(player,csid,option)
 end
 
 function onEventFinish(player,csid,option)
-    local price = player:getLocalVar("chocoboPriceOffer")
-
-    if csid == 106 and option == 0 then
-        player:delCurrency("allied_notes", price)
-        updateChocoboPrice(player, price)
-
-        local duration = 1800 + (player:getMod(dsp.mod.CHOCOBO_RIDING_TIME) * 60)
-
-        player:addStatusEffectEx(dsp.effect.MOUNTED,dsp.effect.MOUNTED,0,0,duration,true)
-    end
+    dsp.chocobo.renterOnEventFinish(player, csid, option, eventSucceed)
 end

--- a/scripts/zones/Norg/Zone.lua
+++ b/scripts/zones/Norg/Zone.lua
@@ -7,9 +7,11 @@ local ID = require("scripts/zones/Norg/IDs")
 require("scripts/globals/conquest")
 require("scripts/globals/keyitems")
 require("scripts/globals/missions")
+require("scripts/globals/chocobo")
 -----------------------------------
 
 function onInitialize(zone)
+    dsp.chocobo.initZone(zone)
 end;
 
 function onConquestUpdate(zone, updatetype)

--- a/scripts/zones/Norg/npcs/Marilleune.lua
+++ b/scripts/zones/Norg/npcs/Marilleune.lua
@@ -2,46 +2,24 @@
 -- Area: Norg
 --  NPC: Marilleune
 -- Type: Chocobo Renter
+-- !pos -11.309 -0.749 -51.162 252
 -----------------------------------
-require("scripts/globals/settings");
-require("scripts/globals/keyitems");
-require("scripts/globals/chocobo");
-require("scripts/globals/status");
+require("scripts/globals/chocobo")
 -----------------------------------
+
+local eventSucceed = 131
+local eventFail    = 132
 
 function onTrade(player,npc,trade)
-end;
+end
 
 function onTrigger(player,npc)
-    local level = player:getMainLvl();
-    local gil = player:getGil();
-
-    if (player:hasKeyItem(dsp.ki.CHOCOBO_LICENSE) and level >= 20) then
-        local price = getChocoboPrice(player);
-        player:setLocalVar("chocoboPriceOffer",price);
-
-        player:startEvent(131,price,gil);
-    else
-        player:startEvent(132);
-    end
-end;
+    dsp.chocobo.renterOnTrigger(player, eventSucceed, eventFail)
+end
 
 function onEventUpdate(player,csid,option)
-end;
+end
 
 function onEventFinish(player,csid,option)
-
-    local price = player:getLocalVar("chocoboPriceOffer");
-
-    if (csid == 131 and option == 0) then
-        if (player:delGil(price)) then
-            updateChocoboPrice(player, price);
-
-            local duration = 1800 + (player:getMod(dsp.mod.CHOCOBO_RIDING_TIME) * 60)
-
-            player:addStatusEffectEx(dsp.effect.MOUNTED,dsp.effect.MOUNTED,0,0,duration,true);
-
-            player:setPos(-456,17,-348,0,123);
-        end
-    end
-end;
+    dsp.chocobo.renterOnEventFinish(player, csid, option, eventSucceed)
+end

--- a/scripts/zones/Pashhow_Marshlands_[S]/Zone.lua
+++ b/scripts/zones/Pashhow_Marshlands_[S]/Zone.lua
@@ -4,11 +4,13 @@
 --
 -----------------------------------
 local ID = require("scripts/zones/Pashhow_Marshlands_[S]/IDs");
+require("scripts/globals/chocobo")
 require("scripts/globals/weather");
 require("scripts/globals/status");
 -----------------------------------
 
 function onInitialize(zone)
+    dsp.chocobo.initZone(zone)
 end;
 
 function onZoneIn(player,prevZone)

--- a/scripts/zones/Pashhow_Marshlands_[S]/npcs/Milloure.lua
+++ b/scripts/zones/Pashhow_Marshlands_[S]/npcs/Milloure.lua
@@ -4,41 +4,22 @@
 -- Type: Chocobo Renter
 -- !pos 336.765 24.416 -124.592 90
 -----------------------------------
-require("scripts/globals/settings")
-require("scripts/globals/keyitems")
-require("scripts/globals/missions")
 require("scripts/globals/chocobo")
-require("scripts/globals/status")
+-----------------------------------
+
+local eventSucceed = 103
+local eventFail    = 104
 
 function onTrade(player,npc,trade)
 end
 
 function onTrigger(player,npc)
-    local level = player:getMainLvl()
-    local notes = player:getCurrency("allied_notes")
-
-    if player:hasKeyItem(dsp.ki.CHOCOBO_LICENSE) and level >= 20 and player:hasCompletedMission(WOTG,BACK_TO_THE_BEGINNING) then
-        local price = getChocoboPrice(player)
-        player:setLocalVar("chocoboPriceOffer",price)
-
-        player:startEvent(103,price,notes)
-    else
-        player:startEvent(104)
-    end
+    dsp.chocobo.renterOnTrigger(player, eventSucceed, eventFail)
 end
 
 function onEventUpdate(player,csid,option)
 end
 
 function onEventFinish(player,csid,option)
-    local price = player:getLocalVar("chocoboPriceOffer")
-
-    if csid == 103 and option == 0 then
-        player:delCurrency("allied_notes", price)
-        updateChocoboPrice(player, price)
-
-        local duration = 1800 + (player:getMod(dsp.mod.CHOCOBO_RIDING_TIME) * 60)
-
-        player:addStatusEffectEx(dsp.effect.MOUNTED,dsp.effect.MOUNTED,0,0,duration,true)
-    end
+    dsp.chocobo.renterOnEventFinish(player, csid, option, eventSucceed)
 end

--- a/scripts/zones/Port_Jeuno/Zone.lua
+++ b/scripts/zones/Port_Jeuno/Zone.lua
@@ -6,11 +6,13 @@
 local ID = require("scripts/zones/Port_Jeuno/IDs")
 require("scripts/globals/conquest")
 require("scripts/globals/settings")
+require("scripts/globals/chocobo")
 require("scripts/globals/quests")
 require("scripts/globals/zone")
 -----------------------------------
 
 function onInitialize(zone)
+    dsp.chocobo.initZone(zone)
 end;
 
 function onZoneIn(player,prevZone)

--- a/scripts/zones/Port_Jeuno/npcs/Caffie.lua
+++ b/scripts/zones/Port_Jeuno/npcs/Caffie.lua
@@ -2,46 +2,24 @@
 -- Area: Port Jeuno
 --  NPC: Caffie
 -- Type: Chocobo Renter
+-- !pos -2.51 8 -1 246
 -----------------------------------
-require("scripts/globals/settings");
-require("scripts/globals/keyitems");
-require("scripts/globals/chocobo");
-require("scripts/globals/status");
+require("scripts/globals/chocobo")
 -----------------------------------
+
+local eventSucceed = 10002
+local eventFail    = 10005
 
 function onTrade(player,npc,trade)
-end;
+end
 
 function onTrigger(player,npc)
-    local level = player:getMainLvl();
-    local gil = player:getGil();
-
-    if (player:hasKeyItem(dsp.ki.CHOCOBO_LICENSE) and level >= 20) then
-        local price = getChocoboPrice(player);
-        player:setLocalVar("chocoboPriceOffer",price);
-
-        player:startEvent(10002,price,gil);
-    else
-        player:startEvent(10005);
-    end
-end;
+    dsp.chocobo.renterOnTrigger(player, eventSucceed, eventFail)
+end
 
 function onEventUpdate(player,csid,option)
-end;
+end
 
 function onEventFinish(player,csid,option)
-
-    local price = player:getLocalVar("chocoboPriceOffer");
-
-    if (csid == 10002 and option == 0) then
-        if (player:delGil(price)) then
-            updateChocoboPrice(player, price);
-
-            local duration = 1800 + (player:getMod(dsp.mod.CHOCOBO_RIDING_TIME) * 60)
-
-            player:addStatusEffectEx(dsp.effect.MOUNTED,dsp.effect.MOUNTED,0,0,duration,true);
-
-            player:setPos(-574,2,400,0,120);
-        end
-    end
-end;
+    dsp.chocobo.renterOnEventFinish(player, csid, option, eventSucceed)
+end

--- a/scripts/zones/Port_Jeuno/npcs/Narsha.lua
+++ b/scripts/zones/Port_Jeuno/npcs/Narsha.lua
@@ -2,46 +2,24 @@
 -- Area: Port Jeuno
 --  NPC: Narsha
 -- Type: Chocobo Renter
+-- !pos -2.51 8 -1 246
 -----------------------------------
-require("scripts/globals/settings");
-require("scripts/globals/keyitems");
-require("scripts/globals/chocobo");
-require("scripts/globals/status");
+require("scripts/globals/chocobo")
 -----------------------------------
+
+local eventSucceed = 10003
+local eventFail    = 10006
 
 function onTrade(player,npc,trade)
-end;
+end
 
 function onTrigger(player,npc)
-    local level = player:getMainLvl();
-    local gil = player:getGil();
-
-    if (player:hasKeyItem(dsp.ki.CHOCOBO_LICENSE) and level >= 20) then
-        local price = getChocoboPrice(player);
-        player:setLocalVar("chocoboPriceOffer",price);
-
-        player:startEvent(10003,price,gil);
-    else
-        player:startEvent(10006);
-    end
-end;
+    dsp.chocobo.renterOnTrigger(player, eventSucceed, eventFail)
+end
 
 function onEventUpdate(player,csid,option)
-end;
+end
 
 function onEventFinish(player,csid,option)
-
-    local price = player:getLocalVar("chocoboPriceOffer");
-
-    if (csid == 10003 and option == 0) then
-        if (player:delGil(price)) then
-            updateChocoboPrice(player, price);
-
-            local duration = 1800 + (player:getMod(dsp.mod.CHOCOBO_RIDING_TIME) * 60)
-
-            player:addStatusEffectEx(dsp.effect.MOUNTED,dsp.effect.MOUNTED,0,0,duration,true);
-
-            player:setPos(-574,2,400,0,120);
-        end
-    end
-end;
+    dsp.chocobo.renterOnEventFinish(player, csid, option, eventSucceed)
+end

--- a/scripts/zones/Rabao/Zone.lua
+++ b/scripts/zones/Rabao/Zone.lua
@@ -5,9 +5,11 @@
 -----------------------------------
 local ID = require("scripts/zones/Rabao/IDs")
 require("scripts/globals/conquest")
+require("scripts/globals/chocobo")
 -----------------------------------
 
 function onInitialize(zone)
+    dsp.chocobo.initZone(zone)
 end;
 
 function onZoneIn(player,prevZone)

--- a/scripts/zones/Rabao/npcs/Guinavie.lua
+++ b/scripts/zones/Rabao/npcs/Guinavie.lua
@@ -1,47 +1,25 @@
 -----------------------------------
 -- Area: Rabao
 --  NPC: Guinavie
--- Chocobo Vendor
+-- Type: Chocobo Vendor
+-- !pos 6.666 -0.515 -77.944 247
 -----------------------------------
-require("scripts/globals/settings");
-require("scripts/globals/keyitems");
-require("scripts/globals/chocobo");
-require("scripts/globals/status");
+require("scripts/globals/chocobo")
 -----------------------------------
+
+local eventSucceed = 79
+local eventFail    = 80
 
 function onTrade(player,npc,trade)
-end;
+end
 
 function onTrigger(player,npc)
-    local level = player:getMainLvl();
-    local gil = player:getGil();
-
-    if (player:hasKeyItem(dsp.ki.CHOCOBO_LICENSE) and level >= 20) then
-        local price = getChocoboPrice(player);
-        player:setLocalVar("chocoboPriceOffer",price);
-
-        player:startEvent(79,price,gil);
-    else
-        player:startEvent(80);
-    end
-end;
+    dsp.chocobo.renterOnTrigger(player, eventSucceed, eventFail)
+end
 
 function onEventUpdate(player,csid,option)
-end;
+end
 
 function onEventFinish(player,csid,option)
-
-    local price = player:getLocalVar("chocoboPriceOffer");
-
-    if (csid == 79 and option == 0) then
-        if (player:delGil(price)) then
-            updateChocoboPrice(player, price);
-
-            local duration = 1800 + (player:getMod(dsp.mod.CHOCOBO_RIDING_TIME) * 60)
-
-            player:addStatusEffectEx(dsp.effect.MOUNTED,dsp.effect.MOUNTED,0,0,duration,true);
-
-            player:setPos(420,8,360,64,125);
-        end
-    end
-end;
+    dsp.chocobo.renterOnEventFinish(player, csid, option, eventSucceed)
+end

--- a/scripts/zones/Southern_San_dOria/Zone.lua
+++ b/scripts/zones/Southern_San_dOria/Zone.lua
@@ -7,12 +7,14 @@ local ID = require("scripts/zones/Southern_San_dOria/IDs");
 require("scripts/globals/events/harvest_festivals");
 require("scripts/globals/conquest");
 require("scripts/globals/settings");
+require("scripts/globals/chocobo")
 require("scripts/globals/zone");
 -----------------------------------
 
 function onInitialize(zone)
     zone:registerRegion(1, -292,-10,90 ,-258,10,105);
     applyHalloweenNpcCostumes(zone:getID())
+    dsp.chocobo.initZone(zone)
 end;
 
 function onZoneIn(player,prevZone)

--- a/scripts/zones/Southern_San_dOria/npcs/Camereine.lua
+++ b/scripts/zones/Southern_San_dOria/npcs/Camereine.lua
@@ -2,64 +2,29 @@
 -- Area: Southern San d'Oria
 --  NPC: Camereine
 -- Type: Chocobo Renter
--- !pos -8 1 -100
+-- !pos -12.3 1.4 -98 230
 -----------------------------------
-require("scripts/globals/settings");
-require("scripts/globals/keyitems");
-require("scripts/globals/chocobo");
-require("scripts/globals/status");
+local ID = require("scripts/zones/Southern_San_dOria/IDs")
+require("scripts/globals/npc_util")
+require("scripts/globals/chocobo")
+-----------------------------------
 
-local ID = require("scripts/zones/Southern_San_dOria/IDs");
------------------------------------
+local eventSucceed = 599
+local eventFail    = 602
 
 function onTrade(player,npc,trade)
-    if (FlyerForRegine == 1) then
-        count = trade:getItemCount();
-        MagicFlyer = trade:hasItemQty(532,1);
-        if (MagicFlyer == true and count == 1) then
-            player:messageSpecial(ID.text.FLYER_REFUSED);
-        end
+    if player:getQuestStatus(SANDORIA,FLYERS_FOR_REGINE) == QUEST_ACCEPTED and npcUtil.tradeHas(trade, 532) then
+        player:messageSpecial(ID.text.FLYER_REFUSED)
     end
-end;
+end
 
 function onTrigger(player,npc)
-    local level = player:getMainLvl();
-    local gil = player:getGil();
-
-    if (player:hasKeyItem(dsp.ki.CHOCOBO_LICENSE) and level >= 15) then
-        local price = getChocoboPrice(player);
-        player:setLocalVar("chocoboPriceOffer",price);
-
-        if (level >= 20) then
-            level = 0;
-        end
-
-        player:startEvent(599,price,gil,level);
-    else
-        player:startEvent(602);
-    end
-end;
+    dsp.chocobo.renterOnTrigger(player, eventSucceed, eventFail)
+end
 
 function onEventUpdate(player,csid,option)
-end;
+end
 
 function onEventFinish(player,csid,option)
-
-    local price = player:getLocalVar("chocoboPriceOffer");
-
-    if (csid == 599 and option == 0) then
-        if (player:delGil(price)) then
-            updateChocoboPrice(player, price);
-
-            if (player:getMainLvl() >= 20) then
-                local duration = 1800 + (player:getMod(dsp.mod.CHOCOBO_RIDING_TIME) * 60)
-
-                player:addStatusEffectEx(dsp.effect.MOUNTED,dsp.effect.MOUNTED,0,0,duration,true);
-            else
-                player:addStatusEffectEx(dsp.effect.MOUNTED,dsp.effect.MOUNTED,0,0,900,true);
-            end
-
-            player:setPos(-126,-62,274,101,100);
-        end
-    end
-end;
+    dsp.chocobo.renterOnEventFinish(player, csid, option, eventSucceed)
+end

--- a/scripts/zones/Southern_San_dOria/npcs/Emoussine.lua
+++ b/scripts/zones/Southern_San_dOria/npcs/Emoussine.lua
@@ -2,64 +2,29 @@
 -- Area: Southern San d'Oria
 --  NPC: Emoussine
 -- Type: Chocobo Renter
--- !pos -11 1 -100
+-- !pos -12.3 1.4 -98 230
 -----------------------------------
-require("scripts/globals/settings");
-require("scripts/globals/keyitems");
-require("scripts/globals/chocobo");
-require("scripts/globals/status");
+local ID = require("scripts/zones/Southern_San_dOria/IDs")
+require("scripts/globals/npc_util")
+require("scripts/globals/chocobo")
+-----------------------------------
 
-local ID = require("scripts/zones/Southern_San_dOria/IDs");
------------------------------------
+local eventSucceed = 600
+local eventFail    = 603
 
 function onTrade(player,npc,trade)
-    if (FlyerForRegine == 1) then
-        count = trade:getItemCount();
-        MagicFlyer = trade:hasItemQty(532,1);
-        if (MagicFlyer == true and count == 1) then
-            player:messageSpecial(ID.text.FLYER_REFUSED);
-        end
+    if player:getQuestStatus(SANDORIA,FLYERS_FOR_REGINE) == QUEST_ACCEPTED and npcUtil.tradeHas(trade, 532) then
+        player:messageSpecial(ID.text.FLYER_REFUSED)
     end
-end;
+end
 
 function onTrigger(player,npc)
-    local level = player:getMainLvl();
-    local gil = player:getGil();
-
-    if (player:hasKeyItem(dsp.ki.CHOCOBO_LICENSE) and level >= 15) then
-        local price = getChocoboPrice(player);
-        player:setLocalVar("chocoboPriceOffer",price);
-
-        if (level >= 20) then
-            level = 0;
-        end
-
-        player:startEvent(600,price,gil,level);
-    else
-        player:startEvent(603);
-    end
-end;
+    dsp.chocobo.renterOnTrigger(player, eventSucceed, eventFail)
+end
 
 function onEventUpdate(player,csid,option)
-end;
+end
 
 function onEventFinish(player,csid,option)
-
-    local price = player:getLocalVar("chocoboPriceOffer");
-
-    if (csid == 600 and option == 0) then
-        if (player:delGil(price)) then
-            updateChocoboPrice(player, price);
-
-            if (player:getMainLvl() >= 20) then
-                local duration = 1800 + (player:getMod(dsp.mod.CHOCOBO_RIDING_TIME) * 60)
-
-                player:addStatusEffectEx(dsp.effect.MOUNTED,dsp.effect.MOUNTED,0,0,duration,true);
-            else
-                player:addStatusEffectEx(dsp.effect.MOUNTED,dsp.effect.MOUNTED,0,0,900,true);
-            end
-
-            player:setPos(-126,-62,274,101,100);
-        end
-    end
-end;
+    dsp.chocobo.renterOnEventFinish(player, csid, option, eventSucceed)
+end

--- a/scripts/zones/Southern_San_dOria/npcs/Meuneille.lua
+++ b/scripts/zones/Southern_San_dOria/npcs/Meuneille.lua
@@ -2,54 +2,29 @@
 -- Area: Southern San d'Oria
 --  NPC: Meuneille
 -- Type: Chocobo Renter
+-- !pos -12.3 1.4 -98 230
 -----------------------------------
-require("scripts/globals/settings");
-require("scripts/globals/keyitems");
-require("scripts/globals/chocobo");
-require("scripts/globals/status");
+local ID = require("scripts/zones/Southern_San_dOria/IDs")
+require("scripts/globals/npc_util")
+require("scripts/globals/chocobo")
 -----------------------------------
+
+local eventSucceed = 601
+local eventFail    = 604
 
 function onTrade(player,npc,trade)
-end;
+    if player:getQuestStatus(SANDORIA,FLYERS_FOR_REGINE) == QUEST_ACCEPTED and npcUtil.tradeHas(trade, 532) then
+        player:messageSpecial(ID.text.FLYER_REFUSED)
+    end
+end
 
 function onTrigger(player,npc)
-    local level = player:getMainLvl();
-    local gil = player:getGil();
-
-    if (player:hasKeyItem(dsp.ki.CHOCOBO_LICENSE) and level >= 15) then
-        local price = getChocoboPrice(player);
-        player:setLocalVar("chocoboPriceOffer",price);
-
-        if (level >= 20) then
-            level = 0;
-        end
-
-        player:startEvent(601,price,gil,level);
-    else
-        player:startEvent(604);
-    end
-end;
+    dsp.chocobo.renterOnTrigger(player, eventSucceed, eventFail)
+end
 
 function onEventUpdate(player,csid,option)
-end;
+end
 
 function onEventFinish(player,csid,option)
-
-    local price = player:getLocalVar("chocoboPriceOffer");
-
-    if (csid == 601 and option == 0) then
-        if (player:delGil(price)) then
-            updateChocoboPrice(player, price);
-
-            if (player:getMainLvl() >= 20) then
-                local duration = 1800 + (player:getMod(dsp.mod.CHOCOBO_RIDING_TIME) * 60)
-
-                player:addStatusEffectEx(dsp.effect.MOUNTED,dsp.effect.MOUNTED,0,0,duration,true);
-            else
-                player:addStatusEffectEx(dsp.effect.MOUNTED,dsp.effect.MOUNTED,0,0,900,true);
-            end
-
-            player:setPos(-126,-62,274,101,100);
-        end
-    end
-end;
+    dsp.chocobo.renterOnEventFinish(player, csid, option, eventSucceed)
+end

--- a/scripts/zones/Southern_San_dOria_[S]/Zone.lua
+++ b/scripts/zones/Southern_San_dOria_[S]/Zone.lua
@@ -6,11 +6,13 @@
 local ID = require("scripts/zones/Southern_San_dOria_[S]/IDs");
 require("scripts/globals/missions");
 require("scripts/globals/settings");
+require("scripts/globals/chocobo")
 require("scripts/globals/quests");
 require("scripts/globals/zone")
 -----------------------------------
 
 function onInitialize(zone)
+    dsp.chocobo.initZone(zone)
 end;
 
 function onZoneIn(player,prevZone)

--- a/scripts/zones/Tahrongi_Canyon/Zone.lua
+++ b/scripts/zones/Tahrongi_Canyon/Zone.lua
@@ -7,6 +7,7 @@ local ID = require("scripts/zones/Tahrongi_Canyon/IDs")
 require("scripts/globals/icanheararainbow")
 require("scripts/globals/chocobo_digging")
 require("scripts/globals/conquest")
+require("scripts/globals/chocobo")
 require("scripts/globals/weather")
 require("scripts/globals/helm")
 require("scripts/globals/zone")
@@ -18,6 +19,7 @@ end;
 
 function onInitialize(zone)
     dsp.helm.initZone(zone, dsp.helm.type.EXCAVATION)
+    dsp.chocobo.initZone(zone)
 end;
 
 function onZoneIn( player, prevZone)

--- a/scripts/zones/Tahrongi_Canyon/npcs/Pucotte.lua
+++ b/scripts/zones/Tahrongi_Canyon/npcs/Pucotte.lua
@@ -4,42 +4,22 @@
 -- Type: Chocobo Renter
 -- !pos 101.591 39.999 360.898 117
 -----------------------------------
-require("scripts/globals/settings");
-require("scripts/globals/keyitems");
-require("scripts/globals/chocobo");
-require("scripts/globals/status");
+require("scripts/globals/chocobo")
 -----------------------------------
 
+local eventSucceed = 910
+local eventFail    = 911
+
 function onTrade(player,npc,trade)
-end;
+end
 
 function onTrigger(player,npc)
-    local level = player:getMainLvl();
-    local gil = player:getGil();
-
-    if (player:hasKeyItem(dsp.ki.CHOCOBO_LICENSE) and level >= 20) then
-        local price = getChocoboPrice(player);
-        player:setLocalVar("chocoboPriceOffer",price);
-
-        player:startEvent(910,price,gil,1)
-    else
-        player:startEvent(911);
-    end
-end;
+    dsp.chocobo.renterOnTrigger(player, eventSucceed, eventFail)
+end
 
 function onEventUpdate(player,csid,option)
-end;
+end
 
 function onEventFinish(player,csid,option)
-    local price = player:getLocalVar("chocoboPriceOffer");
-
-    if (csid == 910 and option == 0) then
-        if (player:delGil(price)) then
-            updateChocoboPrice(player, price);
-
-            local duration = 1800 + (player:getMod(dsp.mod.CHOCOBO_RIDING_TIME) * 60)
-
-            player:addStatusEffectEx(dsp.effect.MOUNTED,dsp.effect.MOUNTED,0,0,duration,true);
-        end
-    end
-end;
+    dsp.chocobo.renterOnEventFinish(player, csid, option, eventSucceed)
+end

--- a/scripts/zones/Upper_Jeuno/Zone.lua
+++ b/scripts/zones/Upper_Jeuno/Zone.lua
@@ -6,9 +6,11 @@
 local ID = require("scripts/zones/Upper_Jeuno/IDs")
 require("scripts/globals/conquest")
 require("scripts/globals/missions")
+require("scripts/globals/chocobo")
 -----------------------------------
 
 function onInitialize(zone)
+    dsp.chocobo.initZone(zone)
 end;
 
 function onZoneIn(player,prevZone)

--- a/scripts/zones/Upper_Jeuno/npcs/Couvoullie.lua
+++ b/scripts/zones/Upper_Jeuno/npcs/Couvoullie.lua
@@ -2,46 +2,24 @@
 -- Area: Upper Jeuno
 --  NPC: Couvoullie
 -- Type: Chocobo Renter
+-- !pos -58.435 7.999 113.210 244
 -----------------------------------
-require("scripts/globals/settings");
-require("scripts/globals/keyitems");
-require("scripts/globals/chocobo");
-require("scripts/globals/status");
+require("scripts/globals/chocobo")
 -----------------------------------
+
+local eventSucceed = 10003
+local eventFail    = 10006
 
 function onTrade(player,npc,trade)
-end;
+end
 
 function onTrigger(player,npc)
-    local level = player:getMainLvl();
-    local gil = player:getGil();
-
-    if (player:hasKeyItem(dsp.ki.CHOCOBO_LICENSE) and level >= 20) then
-        local price = getChocoboPrice(player);
-        player:setLocalVar("chocoboPriceOffer",price);
-
-        player:startEvent(10003,price,gil);
-    else
-        player:startEvent(10006);
-    end
-end;
+    dsp.chocobo.renterOnTrigger(player, eventSucceed, eventFail)
+end
 
 function onEventUpdate(player,csid,option)
-end;
+end
 
 function onEventFinish(player,csid,option)
-
-    local price = player:getLocalVar("chocoboPriceOffer");
-
-    if (csid == 10003 and option == 0) then
-        if (player:delGil(price)) then
-            updateChocoboPrice(player, price);
-
-            local duration = 1800 + (player:getMod(dsp.mod.CHOCOBO_RIDING_TIME) * 60)
-
-            player:addStatusEffectEx(dsp.effect.MOUNTED,dsp.effect.MOUNTED,0,0,duration,true);
-
-            player:setPos(486,8,-160,128,105);
-        end
-    end
-end;
+    dsp.chocobo.renterOnEventFinish(player, csid, option, eventSucceed)
+end

--- a/scripts/zones/Upper_Jeuno/npcs/Mairee.lua
+++ b/scripts/zones/Upper_Jeuno/npcs/Mairee.lua
@@ -2,46 +2,24 @@
 -- Area: Upper Jeuno
 --  NPC: Mairee
 -- Type: Chocobo Renter
+-- !pos -56.308 7.999 109.080 244
 -----------------------------------
-require("scripts/globals/settings");
-require("scripts/globals/keyitems");
-require("scripts/globals/chocobo");
-require("scripts/globals/status");
+require("scripts/globals/chocobo")
 -----------------------------------
+
+local eventSucceed = 10002
+local eventFail    = 10005
 
 function onTrade(player,npc,trade)
-end;
+end
 
 function onTrigger(player,npc)
-    local level = player:getMainLvl();
-    local gil = player:getGil();
-
-    if (player:hasKeyItem(dsp.ki.CHOCOBO_LICENSE) and level >= 20) then
-        local price = getChocoboPrice(player);
-        player:setLocalVar("chocoboPriceOffer",price);
-
-        player:startEvent(10002,price,gil);
-    else
-        player:startEvent(10005);
-    end
-end;
+    dsp.chocobo.renterOnTrigger(player, eventSucceed, eventFail)
+end
 
 function onEventUpdate(player,csid,option)
-end;
+end
 
 function onEventFinish(player,csid,option)
-
-    local price = player:getLocalVar("chocoboPriceOffer");
-
-    if (csid == 10002 and option == 0) then
-        if (player:delGil(price)) then
-            updateChocoboPrice(player, price);
-
-            local duration = 1800 + (player:getMod(dsp.mod.CHOCOBO_RIDING_TIME) * 60)
-
-            player:addStatusEffectEx(dsp.effect.MOUNTED,dsp.effect.MOUNTED,0,0,duration,true);
-
-            player:setPos(486,8,-160,128,105);
-        end
-    end
-end;
+    dsp.chocobo.renterOnEventFinish(player, csid, option, eventSucceed)
+end

--- a/scripts/zones/Wajaom_Woodlands/Zone.lua
+++ b/scripts/zones/Wajaom_Woodlands/Zone.lua
@@ -7,6 +7,7 @@ local ID = require("scripts/zones/Wajaom_Woodlands/IDs");
 require("scripts/globals/chocobo_digging");
 require("scripts/globals/settings");
 require("scripts/globals/missions");
+require("scripts/globals/chocobo")
 require("scripts/globals/quests");
 require("scripts/globals/titles");
 require("scripts/globals/helm")
@@ -19,6 +20,7 @@ end;
 
 function onInitialize(zone)
     dsp.helm.initZone(zone, dsp.helm.type.HARVESTING)
+    dsp.chocobo.initZone(zone)
 end;
 
 function onZoneIn(player,prevZone)

--- a/scripts/zones/Wajaom_Woodlands/npcs/Watisa.lua
+++ b/scripts/zones/Wajaom_Woodlands/npcs/Watisa.lua
@@ -1,46 +1,25 @@
 -----------------------------------
 -- Area: Wajaom Woodlands
---   NPC: Watisa
+--  NPC: Watisa
 -- Type: Chocobo Renter
 -- !pos -201 -11 93 51
 -----------------------------------
-require("scripts/globals/settings");
-require("scripts/globals/keyitems");
-require("scripts/globals/chocobo");
-require("scripts/globals/status");
+require("scripts/globals/chocobo")
 -----------------------------------
 
+local eventSucceed = 9
+local eventFail    = 10
+
 function onTrade(player,npc,trade)
-end;
+end
 
 function onTrigger(player,npc)
-    local level = player:getMainLvl();
-    local gil = player:getGil();
-
-    if (player:hasKeyItem(dsp.ki.CHOCOBO_LICENSE) and level >= 20) then
-        local price = getChocoboPrice(player);
-        player:setLocalVar("chocoboPriceOffer",price);
-
-        player:startEvent(9,price,gil,1)
-    else
-        player:startEvent(10);
-    end
-end;
+    dsp.chocobo.renterOnTrigger(player, eventSucceed, eventFail)
+end
 
 function onEventUpdate(player,csid,option)
-end;
+end
 
 function onEventFinish(player,csid,option)
-
-    local price = player:getLocalVar("chocoboPriceOffer");
-
-    if (csid == 9 and option == 0) then
-        if (player:delGil(price)) then
-            updateChocoboPrice(player, price);
-
-            local duration = 1800 + (player:getMod(dsp.mod.CHOCOBO_RIDING_TIME) * 60)
-
-            player:addStatusEffectEx(dsp.effect.MOUNTED,dsp.effect.MOUNTED,0,0,duration,true);
-        end
-    end
-end;
+    dsp.chocobo.renterOnEventFinish(player, csid, option, eventSucceed)
+end

--- a/scripts/zones/Windurst_Waters_[S]/Zone.lua
+++ b/scripts/zones/Windurst_Waters_[S]/Zone.lua
@@ -4,9 +4,11 @@
 --
 -----------------------------------
 local ID = require("scripts/zones/Windurst_Waters_[S]/IDs")
+require("scripts/globals/chocobo")
 -----------------------------------
 
 function onInitialize(zone)
+    dsp.chocobo.initZone(zone)
 end
 
 function onZoneIn(player,prevZone)

--- a/scripts/zones/Windurst_Waters_[S]/npcs/Yasmina.lua
+++ b/scripts/zones/Windurst_Waters_[S]/npcs/Yasmina.lua
@@ -4,16 +4,22 @@
 -- Type: Chocobo Renter
 -- !pos -34.972 -5.815 221.845 94
 -----------------------------------
+require("scripts/globals/chocobo")
+-----------------------------------
+
+local eventSucceed = 6
+local eventFail    = 7
 
 function onTrade(player,npc,trade)
 end
 
 function onTrigger(player,npc)
-    player:startEvent(6, 10, 10)
+    dsp.chocobo.renterOnTrigger(player, eventSucceed, eventFail)
 end
 
 function onEventUpdate(player,csid,option)
 end
 
 function onEventFinish(player,csid,option)
+    dsp.chocobo.renterOnEventFinish(player, csid, option, eventSucceed)
 end

--- a/scripts/zones/Windurst_Woods/Zone.lua
+++ b/scripts/zones/Windurst_Woods/Zone.lua
@@ -7,11 +7,13 @@ local ID = require("scripts/zones/Windurst_Woods/IDs")
 require("scripts/globals/events/harvest_festivals")
 require("scripts/globals/conquest")
 require("scripts/globals/settings")
+require("scripts/globals/chocobo")
 require("scripts/globals/zone")
 -----------------------------------
 
 function onInitialize(zone)
     applyHalloweenNpcCostumes(zone:getID())
+    dsp.chocobo.initZone(zone)
 end
 
 function onZoneIn(player,prevZone)

--- a/scripts/zones/Windurst_Woods/npcs/Amimi.lua
+++ b/scripts/zones/Windurst_Woods/npcs/Amimi.lua
@@ -2,52 +2,24 @@
 -- Area: Windurst Woods
 --  NPC: Amimi
 -- Type: Chocobo Renter
+-- !pos 133.24 -5.250 -126.76 241
 -----------------------------------
-require("scripts/globals/keyitems")
 require("scripts/globals/chocobo")
-require("scripts/globals/status")
 -----------------------------------
+
+local eventSucceed = 10004
+local eventFail    = 10007
 
 function onTrade(player,npc,trade)
 end
 
 function onTrigger(player,npc)
-    local level = player:getMainLvl()
-    local gil = player:getGil()
-
-    if player:hasKeyItem(dsp.ki.CHOCOBO_LICENSE) and level >= 15 then
-        local price = getChocoboPrice(player)
-        player:setLocalVar("chocoboPriceOffer",price)
-
-        if level >= 20 then
-            level = 0
-        end
-
-        player:startEvent(10004,price,gil,level)
-    else
-        player:startEvent(10007)
-    end
+    dsp.chocobo.renterOnTrigger(player, eventSucceed, eventFail)
 end
 
 function onEventUpdate(player,csid,option)
 end
 
 function onEventFinish(player,csid,option)
-    local price = player:getLocalVar("chocoboPriceOffer")
-
-    if csid == 10004 and option == 0 then
-        if player:delGil(price) then
-            updateChocoboPrice(player, price)
-
-            if player:getMainLvl() >= 20 then
-                local duration = 1800 + (player:getMod(dsp.mod.CHOCOBO_RIDING_TIME) * 60)
-
-                player:addStatusEffectEx(dsp.effect.MOUNTED,dsp.effect.MOUNTED,0,0,duration,true)
-            else
-                player:addStatusEffectEx(dsp.effect.MOUNTED,dsp.effect.MOUNTED,0,0,900,true)
-            end
-
-            player:setPos(-122,-4,-520,0,116)
-        end
-    end
+    dsp.chocobo.renterOnEventFinish(player, csid, option, eventSucceed)
 end

--- a/scripts/zones/Windurst_Woods/npcs/Orlaine.lua
+++ b/scripts/zones/Windurst_Woods/npcs/Orlaine.lua
@@ -1,53 +1,25 @@
 -----------------------------------
 -- Area: Windurst Woods
 --  NPC: Orlaine
--- Chocobo Vendor
+-- Type: Chocobo Vendor
+-- !pos 133.24 -5.250 -126.76 241
 -----------------------------------
-require("scripts/globals/keyitems")
 require("scripts/globals/chocobo")
-require("scripts/globals/status")
 -----------------------------------
+
+local eventSucceed = 10002
+local eventFail    = 10005
 
 function onTrade(player,npc,trade)
 end
 
 function onTrigger(player,npc)
-    local level = player:getMainLvl()
-    local gil = player:getGil()
-
-    if player:hasKeyItem(dsp.ki.CHOCOBO_LICENSE) and level >= 15 then
-        local price = getChocoboPrice(player)
-        player:setLocalVar("chocoboPriceOffer",price)
-
-        if level >= 20 then
-            level = 0
-        end
-
-        player:startEvent(10002,price,gil,level)
-    else
-        player:startEvent(10005)
-    end
+    dsp.chocobo.renterOnTrigger(player, eventSucceed, eventFail)
 end
 
 function onEventUpdate(player,csid,option)
 end
 
 function onEventFinish(player,csid,option)
-    local price = player:getLocalVar("chocoboPriceOffer")
-
-    if csid == 10002 and option == 0 then
-        if player:delGil(price) then
-            updateChocoboPrice(player, price)
-
-            if player:getMainLvl() >= 20 then
-                local duration = 1800 + (player:getMod(dsp.mod.CHOCOBO_RIDING_TIME) * 60)
-
-                player:addStatusEffectEx(dsp.effect.MOUNTED,dsp.effect.MOUNTED,0,0,duration,true)
-            else
-                player:addStatusEffectEx(dsp.effect.MOUNTED,dsp.effect.MOUNTED,0,0,900,true)
-            end
-
-            player:setPos(-122,-4,-520,0,116)
-        end
-    end
+    dsp.chocobo.renterOnEventFinish(player, csid, option, eventSucceed)
 end

--- a/scripts/zones/Windurst_Woods/npcs/Sariale.lua
+++ b/scripts/zones/Windurst_Woods/npcs/Sariale.lua
@@ -2,52 +2,24 @@
 -- Area: Windurst Woods
 --  NPC: Sariale
 -- Type: Chocobo Renter
+-- !pos 133.24 -5.250 -126.76 241
 -----------------------------------
-require("scripts/globals/keyitems")
 require("scripts/globals/chocobo")
-require("scripts/globals/status")
 -----------------------------------
+
+local eventSucceed = 10003
+local eventFail    = 10006
 
 function onTrade(player,npc,trade)
 end
 
 function onTrigger(player,npc)
-    local level = player:getMainLvl()
-    local gil = player:getGil()
-
-    if player:hasKeyItem(dsp.ki.CHOCOBO_LICENSE) and level >= 15 then
-        local price = getChocoboPrice(player)
-        player:setLocalVar("chocoboPriceOffer",price)
-
-        if level >= 20 then
-            level = 0
-        end
-
-        player:startEvent(10003,price,gil)
-    else
-        player:startEvent(10006)
-    end
+    dsp.chocobo.renterOnTrigger(player, eventSucceed, eventFail)
 end
 
 function onEventUpdate(player,csid,option)
 end
 
 function onEventFinish(player,csid,option)
-    local price = player:getLocalVar("chocoboPriceOffer")
-
-    if csid == 10003 and option == 0 then
-        if player:delGil(price) then
-            updateChocoboPrice(player, price)
-
-            if player:getMainLvl() >= 20 then
-                local duration = 1800 + (player:getMod(dsp.mod.CHOCOBO_RIDING_TIME) * 60)
-
-                player:addStatusEffectEx(dsp.effect.MOUNTED,dsp.effect.MOUNTED,0,0,duration,true)
-            else
-                player:addStatusEffectEx(dsp.effect.MOUNTED,dsp.effect.MOUNTED,0,0,900,true)
-            end
-
-            player:setPos(-122,-4,-520,0,116)
-        end
-    end
+    dsp.chocobo.renterOnEventFinish(player, csid, option, eventSucceed)
 end

--- a/scripts/zones/Yhoator_Jungle/Zone.lua
+++ b/scripts/zones/Yhoator_Jungle/Zone.lua
@@ -7,6 +7,7 @@ local ID = require("scripts/zones/Yhoator_Jungle/IDs")
 require("scripts/globals/icanheararainbow")
 require("scripts/globals/chocobo_digging")
 require("scripts/globals/conquest")
+require("scripts/globals/chocobo")
 require("scripts/globals/helm")
 require("scripts/globals/zone")
 -----------------------------------
@@ -29,6 +30,7 @@ function onInitialize(zone)
 
     dsp.helm.initZone(zone, dsp.helm.type.HARVESTING)
     dsp.helm.initZone(zone, dsp.helm.type.LOGGING)
+    dsp.chocobo.initZone(zone)
 end
 
 function onConquestUpdate(zone, updatetype)

--- a/scripts/zones/Yhoator_Jungle/npcs/Paurelde.lua
+++ b/scripts/zones/Yhoator_Jungle/npcs/Paurelde.lua
@@ -2,43 +2,24 @@
 -- Area: Yhoator Jungle
 --  NPC: Paurelde
 -- Type: Chocobo Renter
+-- !pos -273.301 0.300 -149.800 124
 -----------------------------------
-require("scripts/globals/settings")
-require("scripts/globals/keyitems")
 require("scripts/globals/chocobo")
-require("scripts/globals/status")
 -----------------------------------
+
+local eventSucceed = 12
+local eventFail    = 13
 
 function onTrade(player,npc,trade)
 end
 
 function onTrigger(player,npc)
-    local level = player:getMainLvl()
-    local gil = player:getGil()
-
-    if player:hasKeyItem(dsp.ki.CHOCOBO_LICENSE) and level >= 20 then
-        local price = getChocoboPrice(player)
-        player:setLocalVar("chocoboPriceOffer",price)
-
-        player:startEvent(12,price,gil,1)
-    else
-        player:startEvent(13)
-    end
+    dsp.chocobo.renterOnTrigger(player, eventSucceed, eventFail)
 end
 
 function onEventUpdate(player,csid,option)
 end
 
 function onEventFinish(player,csid,option)
-    local price = player:getLocalVar("chocoboPriceOffer")
-
-    if csid == 12 and option == 0 then
-        if player:delGil(price) then
-            updateChocoboPrice(player, price)
-
-            local duration = 1800 + (player:getMod(dsp.mod.CHOCOBO_RIDING_TIME) * 60)
-
-            player:addStatusEffectEx(dsp.effect.MOUNTED,dsp.effect.MOUNTED,0,0,duration,true)
-        end
-    end
+    dsp.chocobo.renterOnEventFinish(player, csid, option, eventSucceed)
 end


### PR DESCRIPTION
* Moved all the chocobo logic into the global.
* Added missing chocobo renters in Bastok Markets [S], and fixed a broken one in Windurst Waters [S].
* Code is now compatible with multi-server setups.  Previously, the server variables would only be generated on the server hosting Bastok Markets (*edit: actually, scratch that. server variables go to DB and so would have been be shared across all map servers I guess.  Still, it's weird to have them all initialized by one particular zone that doesn't even have a renter in it.*)