### PR TITLE
Added Vs. Ecosystem Latents

### DIFF
--- a/scripts/globals/items/a_loutrance.lua
+++ b/scripts/globals/items/a_loutrance.lua
@@ -1,0 +1,25 @@
+-----------------------------------------
+-- ID: 18041
+-- Item: A l'Outrance
+-- Additional Effect vs. beasts: Darkness Damage
+-----------------------------------------
+require("scripts/globals/magic")
+require("scripts/globals/msg")
+require("scripts/globals/status")
+-----------------------------------------
+
+function onAdditionalEffect(player, target, damage)
+    local dmg = player:getStat(dsp.mod.INT) - target:getStat(dsp.mod.INT)
+    if dmg > 25 then
+        dmg = 25 + (dmg - 25) / 2
+    end
+    
+    local params = {}
+    params.bonusmab = 0
+    params.includemab = false
+    dmg = addBonusesAbility(player, dsp.magic.ele.DARK, target, dmg, params)
+    dmg = dmg * applyResistanceAddEffect(player, target, dsp.magic.ele.DARK, 0)
+    dmg = adjustForTarget(target, dmg, dsp.magic.ele.DARK)
+    dmg = finalMagicNonSpellAdjustments(player, target, dsp.magic.ele.DARK, dmg)
+    return dsp.subEffect.DARKNESS_DAMAGE, dsp.msg.basic.ADD_EFFECT_DMG, dmg
+end

--- a/scripts/globals/items/ascalon.lua
+++ b/scripts/globals/items/ascalon.lua
@@ -1,0 +1,25 @@
+-----------------------------------------
+-- ID: 16943
+-- Item: Ascalaon
+-- Additional Effect vs. dragons: Light Damage
+-----------------------------------------
+require("scripts/globals/magic")
+require("scripts/globals/msg")
+require("scripts/globals/status")
+-----------------------------------------
+
+function onAdditionalEffect(player, target, damage)
+    local dmg = player:getStat(dsp.mod.MND) - target:getStat(dsp.mod.MND)
+    if dmg > 25 then
+        dmg = 25 + (dmg - 25) / 2
+    end
+    
+    local params = {}
+    params.bonusmab = 0
+    params.includemab = false
+    dmg = addBonusesAbility(player, dsp.magic.ele.LIGHT, target, dmg, params)
+    dmg = dmg * applyResistanceAddEffect(player, target, dsp.magic.ele.LIGHT, 0)
+    dmg = adjustForTarget(target, dmg, dsp.magic.ele.LIGHT)
+    dmg = finalMagicNonSpellAdjustments(player, target, dsp.magic.ele.LIGHT, dmg)
+    return dsp.subEffect.LIGHT_DAMAGE, dsp.msg.basic.ADD_EFFECT_DMG, dmg
+end

--- a/scripts/globals/items/ascention.lua
+++ b/scripts/globals/items/ascention.lua
@@ -1,0 +1,25 @@
+-----------------------------------------
+-- ID: 18042
+-- Item: Ascention
+-- Additional Effect vs. undead: Fire Damage
+-----------------------------------------
+require("scripts/globals/magic")
+require("scripts/globals/msg")
+require("scripts/globals/status")
+-----------------------------------------
+
+function onAdditionalEffect(player, target, damage)
+    local dmg = player:getStat(dsp.mod.INT) - target:getStat(dsp.mod.INT)
+    if dmg > 25 then
+        dmg = 25 + (dmg - 25) / 2
+    end
+    
+    local params = {}
+    params.bonusmab = 0
+    params.includemab = false
+    dmg = addBonusesAbility(player, dsp.magic.ele.FIRE, target, dmg, params)
+    dmg = dmg * applyResistanceAddEffect(player, target, dsp.magic.ele.FIRE, 0)
+    dmg = adjustForTarget(target, dmg, dsp.magic.ele.FIRE)
+    dmg = finalMagicNonSpellAdjustments(player, target, dsp.magic.ele.FIRE, dmg)
+    return dsp.subEffect.FIRE_DAMAGE, dsp.msg.basic.ADD_EFFECT_DMG, dmg
+end

--- a/scripts/globals/items/erebuss_lance.lua
+++ b/scripts/globals/items/erebuss_lance.lua
@@ -1,0 +1,20 @@
+-----------------------------------------
+-- ID: 19315
+-- Item: Erebus's Lance
+-- Additional Effect vs. Empty: Damage varies with TP
+-----------------------------------------
+require("scripts/globals/magic")
+require("scripts/globals/msg")
+require("scripts/globals/status")
+-----------------------------------------
+
+function onAdditionalEffect(player, target, damage)
+    local chance = 5
+    
+    if math.random(100) <= chance then
+        local dmg = math.floor(player:getTP() / 14)
+        return dsp.subEffect.LIGHT_DAMAGE, dsp.msg.basic.ADD_EFFECT_DMG, dmg
+    end
+    
+    return 0, 0, 0
+end

--- a/scripts/globals/items/kogitsunemaru.lua
+++ b/scripts/globals/items/kogitsunemaru.lua
@@ -1,0 +1,20 @@
+-----------------------------------------
+-- ID: 18428
+-- Item: Kogitsunemaru
+-- Additional Effect vs. vermin: HP Drain
+-----------------------------------------
+require("scripts/globals/magic")
+require("scripts/globals/msg")
+require("scripts/globals/status")
+-----------------------------------------
+
+function onAdditionalEffect(player, target, damage)
+    local chance = 10
+    if math.random(100) <= chance then
+        local hp = 30 + (player:getMainLvl() - target:getMainLvl()) / 2 -- Guesstimate
+        player:addHP(hp)
+        return dsp.subEffect.HP_DRAIN, dsp.msg.basic.ADD_EFFECT_HP_DRAIN, hp
+    end
+    
+    return 0, 0, 0
+end

--- a/scripts/globals/items/lizard_piercer.lua
+++ b/scripts/globals/items/lizard_piercer.lua
@@ -1,0 +1,25 @@
+-----------------------------------------
+-- ID: 16853
+-- Item: Lizard Piercer
+-- Additional Effect vs. lizards: Ice Damage
+-----------------------------------------
+require("scripts/globals/magic")
+require("scripts/globals/msg")
+require("scripts/globals/status")
+-----------------------------------------
+
+function onAdditionalEffect(player, target, damage)
+    local dmg = player:getStat(dsp.mod.INT) - target:getStat(dsp.mod.INT)
+    if dmg > 25 then
+        dmg = 25 + (dmg - 25) / 2
+    end
+    
+    local params = {}
+    params.bonusmab = 0
+    params.includemab = false
+    dmg = addBonusesAbility(player, dsp.magic.ele.ICE, target, dmg, params)
+    dmg = dmg * applyResistanceAddEffect(player, target, dsp.magic.ele.ICE, 0)
+    dmg = adjustForTarget(target, dmg, dsp.magic.ele.ICE)
+    dmg = finalMagicNonSpellAdjustments(player, target, dsp.magic.ele.ICE, dmg)
+    return dsp.subEffect.ICE_DAMAGE, dsp.msg.basic.ADD_EFFECT_DMG, dmg
+end

--- a/scripts/globals/items/narval.lua
+++ b/scripts/globals/items/narval.lua
@@ -1,0 +1,31 @@
+-----------------------------------------
+-- ID: 16884
+-- Item: Narval
+-- Additional Effect vs. undead: Water Damage
+-----------------------------------------
+require("scripts/globals/magic")
+require("scripts/globals/msg")
+require("scripts/globals/status")
+-----------------------------------------
+
+function onAdditionalEffect(player, target, damage)
+    local chance = 10
+    
+    if math.random(100) <= chance then
+        local dmg = player:getStat(dsp.mod.INT) - target:getStat(dsp.mod.INT)
+        if dmg > 40 then
+            dmg = 40 + (dmg - 40) / 2
+        end
+        
+        local params = {}
+        params.bonusmab = 0
+        params.includemab = false
+        dmg = addBonusesAbility(player, dsp.magic.ele.WATER, target, dmg, params)
+        dmg = dmg * applyResistanceAddEffect(player, target, dsp.magic.ele.WATER, 0)
+        dmg = adjustForTarget(target, dmg, dsp.magic.ele.WATER)
+        dmg = finalMagicNonSpellAdjustments(player, target, dsp.magic.ele.WATER, dmg)
+        return dsp.subEffect.WATER_DAMAGE, dsp.msg.basic.ADD_EFFECT_DMG, dmg
+    end
+    
+    return 0, 0, 0
+end

--- a/scripts/globals/items/plantbane.lua
+++ b/scripts/globals/items/plantbane.lua
@@ -1,0 +1,25 @@
+-----------------------------------------
+-- ID: 16720
+-- Item: Plantbane
+-- Additional Effect vs. plantoids: Fire Damage
+-----------------------------------------
+require("scripts/globals/magic")
+require("scripts/globals/msg")
+require("scripts/globals/status")
+-----------------------------------------
+
+function onAdditionalEffect(player, target, damage)
+    local dmg = player:getStat(dsp.mod.INT) - target:getStat(dsp.mod.INT)
+    if dmg > 25 then
+        dmg = 25 + (dmg - 25) / 2
+    end
+    
+    local params = {}
+    params.bonusmab = 0
+    params.includemab = false
+    dmg = addBonusesAbility(player, dsp.magic.ele.FIRE, target, dmg, params)
+    dmg = dmg * applyResistanceAddEffect(player, target, dsp.magic.ele.FIRE, 0)
+    dmg = adjustForTarget(target, dmg, dsp.magic.ele.FIRE)
+    dmg = finalMagicNonSpellAdjustments(player, target, dsp.magic.ele.FIRE, dmg)
+    return dsp.subEffect.FIRE_DAMAGE, dsp.msg.basic.ADD_EFFECT_DMG, dmg
+end

--- a/scripts/globals/items/webcutter.lua
+++ b/scripts/globals/items/webcutter.lua
@@ -1,0 +1,18 @@
+-----------------------------------------
+-- ID: 18040
+-- Item: Webcutter
+-- Additional Effect vs. vermin: Stun
+-----------------------------------------
+require("scripts/globals/magic")
+require("scripts/globals/msg")
+require("scripts/globals/status")
+-----------------------------------
+
+function onAdditionalEffect(player, target, damage)
+    local chance = 40
+
+    if math.random(100) <= chance and applyResistanceAddEffect(player, target, dsp.magic.ele.LIGHTNING, 0) > 0.5 then
+        target:addStatusEffect(dsp.effect.STUN, 1, 0, 3)
+        return dsp.subEffect.STUN, dsp.msg.basic.ADD_EFFECT_STATUS, dsp.effect.STUN
+    end
+end

--- a/sql/item_latents.sql
+++ b/sql/item_latents.sql
@@ -85,9 +85,20 @@ INSERT INTO `item_latents` VALUES(16030, 26, 1, 22, 17); -- Soarer Earring, RACC
 INSERT INTO `item_latents` VALUES(16014, 23, 4, 22, 1); -- Stormer Earring, ATT+4 if WAR is in party
 INSERT INTO `item_latents` VALUES(16020, 10, 1, 22, 7); -- Survivor Earring, VIT+1 if PLD is in party
 INSERT INTO `item_latents` VALUES(16033, 71, 1, 22, 20); -- Sylph Earring, Healing MP +1 if SCH is in party
+INSERT INTO `item_latents` VALUES(16686, 165, 7, 59, 3); -- Arcanabane - Vs. arcana: Critical hit rate +7%
+INSERT INTO `item_latents` VALUES(16720, 431, 1, 59, 17); -- Plantbane - Additional effect vs. plantoids: Fire damage
+INSERT INTO `item_latents` VALUES(16792, 25, 7, 59, 19); -- Goshisho's Scythe - Vs. undead: Accuracy+7
+INSERT INTO `item_latents` VALUES(16853, 431, 1, 59, 14); -- Lizard Piercer - Additional effect vs. lizards: Ice damage
+INSERT INTO `item_latents` VALUES(16884, 431, 1, 59, 19); -- Narval - Additional effect vs. undead: Water damage
 INSERT INTO `item_latents` VALUES(16899, 110, 5, 25, 0); -- Hototogisu, parry skill +5 song/roll active
+INSERT INTO `item_latents` VALUES(16912, 165, 5, 59, 17); -- Kitsutsuki - Vs. plantoids: Critical hit rate +5%
+INSERT INTO `item_latents` VALUES(16943, 431, 1, 59, 10); -- Ascalon - Additional effect vs. dragons: Light damage
+INSERT INTO `item_latents` VALUES(16968, 165, 7, 59, 3); -- Kamewari - Vs. arcana: Critical hit rate +7%
+INSERT INTO `item_latents` VALUES(16969, 165, 5, 59, 9); -- Onikiri - Vs. demons: Critical hit rate +5%
 INSERT INTO `item_latents` VALUES(17073, 406, 30, 7, 2); -- Mistilteinn drains 30TP if TP >= 30
 INSERT INTO `item_latents` VALUES(17073, 369, 1, 7, 2); -- Mistilteinn adds Refresh 1MP per tick
+INSERT INTO `item_latents` VALUES(17208, 26, 10, 59, 12); -- Hamayumi - Vs. Empty: Ranged Accuracy+10
+INSERT INTO `item_latents` VALUES(17208, 66, 10, 59, 12); -- Vs. Empty: Ranged Attack+10%
 INSERT INTO `item_latents` VALUES(17365, 8, 4, 25, 0); -- Frenzy Fife, STR+4 song/roll active
 
 INSERT INTO `item_latents` VALUES(17590, 171, 83, 49, 4468); -- Primate Staff
@@ -103,10 +114,26 @@ INSERT INTO `item_latents` VALUES(17592, 25, 10, 49, 4468);
 INSERT INTO `item_latents` VALUES(17592, 171, 83, 49, 4596);
 INSERT INTO `item_latents` VALUES(17592, 25, 10, 49, 4596);
 
+INSERT INTO `item_latents` VALUES(17759, 165, 7, 59, 20); -- Koggelmander - Vs. vermin: Critical hit rate +7%
+INSERT INTO `item_latents` VALUES(17804, 25, 7, 59, 6); -- Ushikirimaru - Vs. beasts: Accuracy+7
+INSERT INTO `item_latents` VALUES(17964, 165, 7, 59, 17); -- Barkborer - Vs. plantoid: Critical hit rate +7%
+INSERT INTO `item_latents` VALUES(18040, 431, 1, 59, 20); -- Webcutter - Additional effect vs. vermin: "Stun"
+INSERT INTO `item_latents` VALUES(18041, 431, 1, 59, 6); -- A l'Outrance - Additional effect vs. beasts: Darkness damage
+INSERT INTO `item_latents` VALUES(18042, 431, 1, 59, 19); -- Ascention - Addtional effect vs. undead: Fire Damage
 INSERT INTO `item_latents` VALUES(18256, 25, 1, 25, 0); -- Orphic Egg, ACC+1 song/roll active
 INSERT INTO `item_latents` VALUES(18256, 23, 1, 25, 0); -- Orphic Egg, ATT+1 song/roll active
 INSERT INTO `item_latents` VALUES(18256, 68, 1, 25, 0); -- Orphic Egg, EVA+1 song/roll active
+INSERT INTO `item_latents` VALUES(18428, 431, 1, 59, 20); -- Kogitsunemaru - Additional Effect vs. vermin: HP Drain
+INSERT INTO `item_latents` VALUES(18438, 165, 8, 59, 20); -- Kumokirimaru - Vs. vermin: Critical hit rate +8%
 INSERT INTO `item_latents` VALUES(18486, 171, -30, 25, 0); -- Wardancer, Delay: 474 (504 - 30) song/roll active
+
+INSERT INTO `item_latents` VALUES(18504, 165, 7, 59, 17); -- Eventreuse - Vs. plantoid: Critical hit rate +7%
+INSERT INTO `item_latents` VALUES(18767, 25, 3, 59, 8); -- Birdbanes - Vs. birds: Accuracy+3
+INSERT INTO `item_latents` VALUES(18865, 165, 7, 59, 20); -- Zonure - Vs. vermin: Critical hit rate +7%
+INSERT INTO `item_latents` VALUES(19113, 165, 7, 59, 14); -- Ermine's Tail - Vs. lizards: Critical hit rate +7%
+INSERT INTO `item_latents` VALUES(19158, 165, 7, 59, 14); -- Scheherazade - Vs. lizards: Critical hit rate +7%
+INSERT INTO `item_latents` VALUES(19273, 165, 7, 59, 6); -- Onishibari - Vs. beasts: Critical hit rate +7%
+INSERT INTO `item_latents` VALUES(19315, 431, 1, 59, 12); -- Erebus's Lance - Addtional effect vs. Empty: Damage varies with current TP
 
 INSERT INTO `item_latents` VALUES(27342, 63, 10, 13, 64); -- Fallen's Sollerets, "Last Resort"+1
 INSERT INTO `item_latents` VALUES(27343, 63, 10, 13, 64); -- Fallen's Sollerets +1, "Last Resort"+1

--- a/src/map/latent_effect.h
+++ b/src/map/latent_effect.h
@@ -87,7 +87,8 @@ enum LATENT
     LATENT_MP_OVER                  = 55, //mp greater than # - PARAM: MP #
     LATENT_WEAPON_DRAWN_MP_OVER     = 56, //while weapon is drawn and mp greater than # - PARAM: MP #
     LATENT_ELEVEN_ROLL_ACTIVE       = 57, //corsair roll of 11 active
-    LATENT_IN_ASSAULT               = 58  // is in an Instance battle in a TOAU zone
+    LATENT_IN_ASSAULT               = 58, // is in an Instance battle in a TOAU zone
+    LATENT_VS_ECOSYSTEM             = 59  // Vs. Ecosystem (e.g. Vs. Birds: Accuracy+3)
 };
 
 #define MAX_LATENTEFFECTID    58

--- a/src/map/latent_effect_container.cpp
+++ b/src/map/latent_effect_container.cpp
@@ -652,8 +652,14 @@ void CLatentEffectContainer::CheckLatentsTargetChange()
 {
     ProcessLatentEffects([this](CLatentEffect& latentEffect)
     {
-        if (latentEffect.GetConditionsID() == LATENT_SIGNET_BONUS)
+        switch (latentEffect.GetConditionsID())
+        {
+        case LATENT_SIGNET_BONUS:
+        case LATENT_VS_ECOSYSTEM:
             return ProcessLatentEffect(latentEffect);
+        default:
+            break;
+        }
         return false;
     });
 }
@@ -1102,6 +1108,12 @@ bool CLatentEffectContainer::ProcessLatentEffect(CLatentEffect& latentEffect)
         break;
     case LATENT_ELEVEN_ROLL_ACTIVE:
         expression = m_POwner->StatusEffectContainer->CheckForElevenRoll();
+        break;
+    case LATENT_VS_ECOSYSTEM:
+        if (CBattleEntity* PTarget = m_POwner->GetBattleTarget())
+        {
+            expression = PTarget->m_EcoSystem == latentEffect.GetConditionsValue();
+        }
         break;
     default:
         latentFound = false;


### PR DESCRIPTION
Left out some Additional Effects because they require additional research into the correct sub effects and proc rates.

There are other "vs. [blank]" text that are more specific than ecosystem. E.G. Orcs, Quadavs, slimes, tigers, etc. Left those ones out, as well. Should probably be a separate latent ID.