### PR TITLE
Fix BLU spell Self-Destruct area damage

### DIFF
--- a/scripts/globals/spells/bluemagic/self-destruct.lua
+++ b/scripts/globals/spells/bluemagic/self-destruct.lua
@@ -29,7 +29,7 @@ function onSpellCast(caster,target,spell)
     local damage = playerHP - 1
 
     if damage > 0 then
-        target:delHP(playerHP)
+        target:takeDamage(playerHP, caster, dsp.attackType.MAGICAL, dsp.damageType.FIRE)
         caster:setHP(1)
         caster:delStatusEffect(dsp.effect.WEAKNESS)
         caster:addStatusEffect(dsp.effect.WEAKNESS,1,0,duration)

--- a/scripts/globals/spells/bluemagic/self-destruct.lua
+++ b/scripts/globals/spells/bluemagic/self-destruct.lua
@@ -19,23 +19,21 @@ require("scripts/globals/status")
 require("scripts/globals/bluemagic")
 
 function onMagicCastingCheck(caster,target,spell)
+    caster:setLocalVar("self-destruct_hp", caster:getHP())
     return 0
 end
 
 function onSpellCast(caster,target,spell)
     local duration = 300
-    local playerHP = caster:getHP()
-    local damage = caster:getHP() -1
+    local playerHP = caster:getLocalVar("self-destruct_hp")
+    local damage = playerHP - 1
 
-
-    if (damage > 0) then
-        target:takeDamage(playerHP, caster, dsp.attackType.MAGICAL, dsp.damageType.FIRE)
+    if damage > 0 then
+        target:delHP(playerHP)
         caster:setHP(1)
         caster:delStatusEffect(dsp.effect.WEAKNESS)
         caster:addStatusEffect(dsp.effect.WEAKNESS,1,0,duration)
-
     end
 
     return damage
-
 end


### PR DESCRIPTION
It now uses a local player var to calculate the damage.
I tested this fix locally and it appears to be working fine.

![destruct_test](https://user-images.githubusercontent.com/45569089/50739302-23095b00-11d6-11e9-813c-023bde769308.png)
