### PR TITLE
Correct spawn behavior of Lumber Jack - he does not spawn with enmity

### DIFF
--- a/scripts/zones/Batallia_Downs/mobs/Weeping_Willow.lua
+++ b/scripts/zones/Batallia_Downs/mobs/Weeping_Willow.lua
@@ -18,5 +18,7 @@ function onMobDeath(mob, player, isKiller)
 end
 
 function onMobDespawn(mob)
+    -- Retail behavior is for it to walk back to where willow died if unclaimed *unless* willow was pulled down the cliff
+    -- In that case, it will walk back near where Willow was spawned at.
     GetMobByID(mob:getID() + 6):setSpawn(mob:getXPos(), mob:getYPos(), mob:getZPos())
 end

--- a/scripts/zones/Batallia_Downs/mobs/Weeping_Willow.lua
+++ b/scripts/zones/Batallia_Downs/mobs/Weeping_Willow.lua
@@ -18,7 +18,5 @@ function onMobDeath(mob, player, isKiller)
 end
 
 function onMobDespawn(mob)
-    local JACK = mob:getID()+6
-    SpawnMob(JACK)
-    GetMobByID(JACK):setPos( mob:getXPos(), mob:getYPos(), mob:getZPos(), 0);
+    GetMobByID(mob:getID() + 6):setSpawn(mob:getXPos(), mob:getYPos(), mob:getZPos())
 end

--- a/scripts/zones/Batallia_Downs/mobs/Weeping_Willow.lua
+++ b/scripts/zones/Batallia_Downs/mobs/Weeping_Willow.lua
@@ -5,17 +5,20 @@
 
 function onMobFight(mob,target)
     if (mob:getHPP() <= 50 and mob:getLocalVar("Saplings") < 1) then
-        SpawnMob(mob:getID()+1):updateEnmity(target);
-        SpawnMob(mob:getID()+2):updateEnmity(target);
-        SpawnMob(mob:getID()+3):updateEnmity(target);
-        SpawnMob(mob:getID()+4):updateEnmity(target);
-        SpawnMob(mob:getID()+5):updateEnmity(target);
-        mob:setLocalVar("Saplings", 1);
+        SpawnMob(mob:getID()+1):updateEnmity(target)
+        SpawnMob(mob:getID()+2):updateEnmity(target)
+        SpawnMob(mob:getID()+3):updateEnmity(target)
+        SpawnMob(mob:getID()+4):updateEnmity(target)
+        SpawnMob(mob:getID()+5):updateEnmity(target)
+        mob:setLocalVar("Saplings", 1)
     end
-end;
+end
 
 function onMobDeath(mob, player, isKiller)
-    local JACK = mob:getID()+6;
-    SpawnMob(JACK):updateEnmity(player);
+end
+
+function onMobDespawn(mob)
+    local JACK = mob:getID()+6
+    SpawnMob(JACK)
     GetMobByID(JACK):setPos( mob:getXPos(), mob:getYPos(), mob:getZPos(), 0);
-end;
+end


### PR DESCRIPTION
Move far enough away before the Weeping Willows dead body fades and Lumber Jack doesn't even notice you are there, will wander around till you engage, catch agro from walking to close in his line of sight, or his 10 min despawn timer is up. so no `updateEnmity()` needed here.