### PR TITLE
stop using getShortID for the value of a mobmod where that value never matters

### DIFF
--- a/scripts/zones/Crawlers_Nest/mobs/Aqrabuamelu.lua
+++ b/scripts/zones/Crawlers_Nest/mobs/Aqrabuamelu.lua
@@ -2,44 +2,44 @@
 -- Area: Crawlers' Nest
 --   NM: Aqrabuamelu
 -----------------------------------
-require("scripts/globals/status");
-require("scripts/globals/magic");
+require("scripts/globals/status")
+require("scripts/globals/magic")
 -----------------------------------
 
 function onMobInitialize(mob)
-    mob:setMobMod(dsp.mobMod.AUTO_SPIKES,mob:getShortID());
-    mob:addStatusEffect(dsp.effect.ICE_SPIKES,45,0,0);
-    mob:getStatusEffect(dsp.effect.ICE_SPIKES):setFlag(32);
-end;
+    mob:setMobMod(dsp.mobMod.AUTO_SPIKES, 1)
+    mob:addStatusEffect(dsp.effect.ICE_SPIKES,45,0,0)
+    mob:getStatusEffect(dsp.effect.ICE_SPIKES):setFlag(32)
+end
 
 function onSpikesDamage(mob,target,damage)
-    local INT_diff = mob:getStat(dsp.mod.INT) - target:getStat(dsp.mod.INT);
+    local INT_diff = mob:getStat(dsp.mod.INT) - target:getStat(dsp.mod.INT)
 
     if (INT_diff > 20) then
-        INT_diff = 20 + ((INT_diff - 20)*0.5); -- INT above 20 is half as effective.
+        INT_diff = 20 + ((INT_diff - 20)*0.5) -- INT above 20 is half as effective.
     end
 
-    local dmg = ((damage+INT_diff)*0.5); -- INT adjustment and base damage averaged together.
-    local params = {};
-    params.bonusmab = 0;
-    params.includemab = false;
-    dmg = addBonusesAbility(mob, dsp.magic.ele.ICE, target, dmg, params);
-    dmg = dmg * applyResistanceAddEffect(mob,target,dsp.magic.ele.ICE,0);
-    dmg = adjustForTarget(target,dmg,dsp.magic.ele.ICE);
-    dmg = finalMagicNonSpellAdjustments(mob,target,dsp.magic.ele.ICE,dmg);
+    local dmg = ((damage+INT_diff)*0.5) -- INT adjustment and base damage averaged together.
+    local params = {}
+    params.bonusmab = 0
+    params.includemab = false
+    dmg = addBonusesAbility(mob, dsp.magic.ele.ICE, target, dmg, params)
+    dmg = dmg * applyResistanceAddEffect(mob,target,dsp.magic.ele.ICE,0)
+    dmg = adjustForTarget(target,dmg,dsp.magic.ele.ICE)
+    dmg = finalMagicNonSpellAdjustments(mob,target,dsp.magic.ele.ICE,dmg)
 
     if (dmg < 0) then
-        dmg = 0;
+        dmg = 0
     end
 
-    return dsp.subEffect.ICE_SPIKES,44,dmg;
+    return dsp.subEffect.ICE_SPIKES,44,dmg
 
-end;
+end
 
 function onMobDeath(mob, player, isKiller)
-end;
+end
 
 function onMobDespawn(mob)
-    UpdateNMSpawnPoint(mob:getID());
-    mob:setRespawnTime(math.random(7200,7800)); -- 120 to 130 min
-end;
+    UpdateNMSpawnPoint(mob:getID())
+    mob:setRespawnTime(math.random(7200,7800)) -- 120 to 130 min
+end

--- a/scripts/zones/Mount_Zhayolm/mobs/Sarameya.lua
+++ b/scripts/zones/Mount_Zhayolm/mobs/Sarameya.lua
@@ -13,86 +13,86 @@ require("scripts/globals/msg")
 -----------------------------------
 
 function onMobInitialize(mob)
-    mob:setMobMod(dsp.mobMod.GA_CHANCE, 50);
-    mob:setMobMod(dsp.mobMod.ADD_EFFECT, mob:getShortID());
-end;
+    mob:setMobMod(dsp.mobMod.GA_CHANCE, 50)
+    mob:setMobMod(dsp.mobMod.ADD_EFFECT, 1)
+end
 
 function onMobSpawn(mob)
-    mob:addMod(dsp.mod.MEVA, 95);
-    mob:addMod(dsp.mod.MDEF, 30);
-    mob:addMod(dsp.mod.SILENCERES, 20);
-    mob:addMod(dsp.mod.GRAVITYRES, 20);
-    mob:addMod(dsp.mod.LULLABYRES, 30);
+    mob:addMod(dsp.mod.MEVA, 95)
+    mob:addMod(dsp.mod.MDEF, 30)
+    mob:addMod(dsp.mod.SILENCERES, 20)
+    mob:addMod(dsp.mod.GRAVITYRES, 20)
+    mob:addMod(dsp.mod.LULLABYRES, 30)
     mob:setLocalVar("[rage]timer", 3600) -- 60 minutes
-end;
+end
 
 function onMobRoam(mob)
-end;
+end
 
 function onMobFight(mob, target)
 
-    local hpp = mob:getHPP();
-    local useChainspell = false;
+    local hpp = mob:getHPP()
+    local useChainspell = false
     if (hpp < 90 and mob:getLocalVar("chainspell89") == 0) then
-        mob:setLocalVar("chainspell89",1);
-        useChainspell = true;
+        mob:setLocalVar("chainspell89",1)
+        useChainspell = true
     elseif (hpp < 70 and mob:getLocalVar("chainspell69") == 0) then
-        mob:setLocalVar("chainspell69",1);
-        useChainspell = true;
+        mob:setLocalVar("chainspell69",1)
+        useChainspell = true
     elseif (hpp < 50 and mob:getLocalVar("chainspell49") == 0) then
-        mob:setLocalVar("chainspell49",1);
-        useChainspell = true;
+        mob:setLocalVar("chainspell49",1)
+        useChainspell = true
     elseif (hpp < 30 and mob:getLocalVar("chainspell29") == 0) then
-        mob:setLocalVar("chainspell29",1);
-        useChainspell = true;
+        mob:setLocalVar("chainspell29",1)
+        useChainspell = true
     elseif (hpp < 10 and mob:getLocalVar("chainspell9") == 0) then
-        mob:setLocalVar("chainspell9",1);
-        useChainspell = true;
-    end;
+        mob:setLocalVar("chainspell9",1)
+        useChainspell = true
+    end
 
     if (useChainspell == true) then
-        mob:useMobAbility(692); -- Chainspell
-        mob:setMobMod(dsp.mobMod.GA_CHANCE, 100);
+        mob:useMobAbility(692) -- Chainspell
+        mob:setMobMod(dsp.mobMod.GA_CHANCE, 100)
 
     end
 
     -- Spams TP moves and -ga spells
     if (mob:hasStatusEffect(dsp.effect.CHAINSPELL) == true) then
-        mob:setTP(2000);
+        mob:setTP(2000)
     else
         if (mob:getMobMod(dsp.mobMod.GA_CHANCE) == 100) then
-            mob:setMobMod(dsp.mobMod.GA_CHANCE, 50);
+            mob:setMobMod(dsp.mobMod.GA_CHANCE, 50)
         end
-    end;
+    end
 
     -- Regens 1% of his HP a tick with Blaze Spikes on
     if (mob:hasStatusEffect(dsp.effect.BLAZE_SPIKES) == true) then
-        mob:setMod(dsp.mod.REGEN, math.floor(mob:getMaxHP()/100));
+        mob:setMod(dsp.mod.REGEN, math.floor(mob:getMaxHP()/100))
     else
         if (mob:getMod(dsp.mod.REGEN) > 0) then
-            mob:setMod(dsp.mod.REGEN, 0);
+            mob:setMod(dsp.mod.REGEN, 0)
         end
     end
-end;
+end
 
 function onAdditionalEffect(mob, player)
-    local chance = 40;
-    local resist = applyResistanceAddEffect(mob,player,dsp.magic.ele.WATER,dsp.effect.POISON);
+    local chance = 40
+    local resist = applyResistanceAddEffect(mob,player,dsp.magic.ele.WATER,dsp.effect.POISON)
     if (math.random(0,99) >= chance or resist <= 0.5) then
-        return 0,0,0;
+        return 0,0,0
     else
-        local duration = 30;
+        local duration = 30
         if (mob:getMainLvl() > player:getMainLvl()) then
             duration = duration + (mob:getMainLvl() - player:getMainLvl())
         end
-        duration = utils.clamp(duration,1,30);
-        duration = duration * resist;
+        duration = utils.clamp(duration,1,30)
+        duration = duration * resist
         if (player:hasStatusEffect(dsp.effect.POISON) == false) then
-            player:addStatusEffect(dsp.effect.POISON, 50, 3, duration); -- Don't know potency on the poison.
+            player:addStatusEffect(dsp.effect.POISON, 50, 3, duration) -- Don't know potency on the poison.
         end
-        return dsp.subEffect.POISON, dsp.msg.basic.ADD_EFFECT_STATUS, dsp.effect.POISON;
+        return dsp.subEffect.POISON, dsp.msg.basic.ADD_EFFECT_STATUS, dsp.effect.POISON
     end
-end;
+end
 
 function onMobDeath(mob, player, isKiller)
-end;
+end

--- a/scripts/zones/RoMaeve/mobs/Martinet.lua
+++ b/scripts/zones/RoMaeve/mobs/Martinet.lua
@@ -2,44 +2,44 @@
 -- Area: RoMaeve
 --  NM:  Martinet
 -----------------------------------
-require("scripts/globals/status");
-require("scripts/globals/magic");
+require("scripts/globals/status")
+require("scripts/globals/magic")
 -----------------------------------
 
 function onMobInitialize(mob)
-    mob:setMobMod(dsp.mobMod.AUTO_SPIKES,mob:getShortID());
-    mob:addStatusEffect(dsp.effect.SHOCK_SPIKES,55,0,0);
-    mob:getStatusEffect(dsp.effect.SHOCK_SPIKES):setFlag(32);
-end;
+    mob:setMobMod(dsp.mobMod.AUTO_SPIKES, 1)
+    mob:addStatusEffect(dsp.effect.SHOCK_SPIKES,55,0,0)
+    mob:getStatusEffect(dsp.effect.SHOCK_SPIKES):setFlag(32)
+end
 
 function onSpikesDamage(mob,target,damage)
-    local INT_diff = mob:getStat(dsp.mod.INT) - target:getStat(dsp.mod.INT);
+    local INT_diff = mob:getStat(dsp.mod.INT) - target:getStat(dsp.mod.INT)
 
     if (INT_diff > 20) then
-        INT_diff = 20 + ((INT_diff - 20)*0.5); -- INT above 20 is half as effective.
+        INT_diff = 20 + ((INT_diff - 20)*0.5) -- INT above 20 is half as effective.
     end
 
-    local dmg = ((damage+INT_diff)*0.5); -- INT adjustment and base damage averaged together.
-    local params = {};
-    params.bonusmab = 0;
-    params.includemab = false;
-    dmg = addBonusesAbility(mob, dsp.magic.ele.THUNDER, target, dmg, params);
-    dmg = dmg * applyResistanceAddEffect(mob,target,dsp.magic.ele.THUNDER,0);
-    dmg = adjustForTarget(target,dmg,dsp.magic.ele.THUNDER);
-    dmg = finalMagicNonSpellAdjustments(mob,target,dsp.magic.ele.THUNDER,dmg);
+    local dmg = ((damage+INT_diff)*0.5) -- INT adjustment and base damage averaged together.
+    local params = {}
+    params.bonusmab = 0
+    params.includemab = false
+    dmg = addBonusesAbility(mob, dsp.magic.ele.THUNDER, target, dmg, params)
+    dmg = dmg * applyResistanceAddEffect(mob,target,dsp.magic.ele.THUNDER,0)
+    dmg = adjustForTarget(target,dmg,dsp.magic.ele.THUNDER)
+    dmg = finalMagicNonSpellAdjustments(mob,target,dsp.magic.ele.THUNDER,dmg)
 
     if (dmg < 0) then
-        dmg = 0;
+        dmg = 0
     end
 
-    return dsp.subEffect.SHOCK_SPIKES,44,dmg;
+    return dsp.subEffect.SHOCK_SPIKES,44,dmg
 
-end;
+end
 
 function onMobDeath(mob, player, isKiller)
-end;
+end
 
 function onMobDespawn(mob)
-    -- UpdateNMSpawnPoint(mob:getID());
-    -- mob:setRespawnTime(math.random((?),(?))); -- Uncertain repop time
-end;
+    -- UpdateNMSpawnPoint(mob:getID())
+    -- mob:setRespawnTime(math.random((?),(?))) -- Uncertain repop time
+end

--- a/scripts/zones/RuAun_Gardens/mobs/Byakko.lua
+++ b/scripts/zones/RuAun_Gardens/mobs/Byakko.lua
@@ -8,7 +8,7 @@ require("scripts/globals/magic")
 -----------------------------------
 
 function onMobInitialize(mob)
-    mob:setMobMod(dsp.mobMod.ADD_EFFECT, mob:getShortID())
+    mob:setMobMod(dsp.mobMod.ADD_EFFECT, 1)
 end
 
 function onAdditionalEffect(mob, target, damage)

--- a/scripts/zones/RuAun_Gardens/mobs/Genbu.lua
+++ b/scripts/zones/RuAun_Gardens/mobs/Genbu.lua
@@ -8,7 +8,7 @@ require("scripts/globals/magic")
 -----------------------------------
 
 function onMobInitialize(mob)
-    mob:setMobMod(dsp.mobMod.ADD_EFFECT, mob:getShortID())
+    mob:setMobMod(dsp.mobMod.ADD_EFFECT, 1)
 end
 
 function onAdditionalEffect(mob, target, damage)

--- a/scripts/zones/RuAun_Gardens/mobs/Seiryu.lua
+++ b/scripts/zones/RuAun_Gardens/mobs/Seiryu.lua
@@ -8,7 +8,7 @@ require("scripts/globals/magic")
 -----------------------------------
 
 function onMobInitialize(mob)
-    mob:setMobMod(dsp.mobMod.ADD_EFFECT, mob:getShortID())
+    mob:setMobMod(dsp.mobMod.ADD_EFFECT, 1)
 end
 
 function onMonsterMagicPrepare(mob, target)

--- a/scripts/zones/RuAun_Gardens/mobs/Suzaku.lua
+++ b/scripts/zones/RuAun_Gardens/mobs/Suzaku.lua
@@ -8,7 +8,7 @@ require("scripts/globals/magic")
 -----------------------------------
 
 function onMobInitialize(mob)
-    mob:setMobMod(dsp.mobMod.ADD_EFFECT, mob:getShortID())
+    mob:setMobMod(dsp.mobMod.ADD_EFFECT, 1)
 end
 
 -- Return the selected spell ID.

--- a/scripts/zones/Upper_Delkfutts_Tower/mobs/Autarch.lua
+++ b/scripts/zones/Upper_Delkfutts_Tower/mobs/Autarch.lua
@@ -7,7 +7,7 @@ require("scripts/globals/magic")
 -----------------------------------
 
 function onMobInitialize(mob)
-    mob:setMobMod(dsp.mobMod.AUTO_SPIKES, mob:getShortID())
+    mob:setMobMod(dsp.mobMod.AUTO_SPIKES, 1)
     mob:addStatusEffect(dsp.effect.SHOCK_SPIKES, 40, 0, 0)
     mob:getStatusEffect(dsp.effect.SHOCK_SPIKES):setFlag(32)
 end

--- a/scripts/zones/VeLugannon_Palace/mobs/Brigandish_Blade.lua
+++ b/scripts/zones/VeLugannon_Palace/mobs/Brigandish_Blade.lua
@@ -7,7 +7,7 @@ require("scripts/globals/status")
 -----------------------------------
 
 function onMobInitialize(mob)
-    mob:setMobMod(dsp.mobMod.ADD_EFFECT, mob:getShortID())
+    mob:setMobMod(dsp.mobMod.ADD_EFFECT, 1)
 end
 
 function onAdditionalEffect(mob,target,damage)

--- a/scripts/zones/West_Sarutabaruta_[S]/mobs/Ramponneau.lua
+++ b/scripts/zones/West_Sarutabaruta_[S]/mobs/Ramponneau.lua
@@ -8,7 +8,7 @@ require("scripts/globals/msg")
 -----------------------------------
 
 function onMobInitialize(mob)
-    mob:setMobMod(dsp.mobMod.ADD_EFFECT, mob:getShortID())
+    mob:setMobMod(dsp.mobMod.ADD_EFFECT, 1)
     mob:addStatusEffect(dsp.effect.SHOCK_SPIKES, 10, 0, 0)
     mob:getStatusEffect(dsp.effect.SHOCK_SPIKES):setFlag(32)
 end


### PR DESCRIPTION
This began as just being copy pasted from an existing script from an author that isn't around, we have no idea what his original intent was but whatever it was, it never happened. the value is never used the code just checks if this is zero or non zero.