### PR TITLE
ws(dragon_kick): Update dragon kick parameters

### DIFF
--- a/scripts/globals/weaponskills/dragon_kick.lua
+++ b/scripts/globals/weaponskills/dragon_kick.lua
@@ -9,7 +9,7 @@
 -- Element: None
 -- Modifiers: STR:50%  VIT:50%
 -- 100%TP    200%TP    300%TP
--- 2.00      2.75      3.50
+-- 2.00      2.50      3.50
 -----------------------------------
 require("scripts/globals/status")
 require("scripts/globals/settings")
@@ -20,7 +20,7 @@ function onUseWeaponSkill(player, target, wsID, tp, primary, action, taChar)
 
     local params = {}
     params.numHits = 1
-    params.ftp100 = 2 params.ftp200 = 2.75 params.ftp300 = 3.5
+    params.ftp100 = 2 params.ftp200 = 2.5 params.ftp300 = 3.5
     params.str_wsc = 0.5 params.dex_wsc = 0.0 params.vit_wsc = 0.5 params.agi_wsc = 0.0 params.int_wsc = 0.0 params.mnd_wsc = 0.0 params.chr_wsc = 0.0
     params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
     params.canCrit = false
@@ -29,8 +29,7 @@ function onUseWeaponSkill(player, target, wsID, tp, primary, action, taChar)
     params.kick = true -- https://www.bluegartr.com/threads/112776-Dev-Tracker-Findings-Posts-%28NO-DISCUSSION%29?p=6712150&viewfull=1#post6712150
 
     if (USE_ADOULIN_WEAPON_SKILL_CHANGES == true) then
-        params.ftp100 = 2.0 params.ftp200 = 3.6 params.ftp300 = 6.5
-        params.dex_wsc = 0.5 params.vit_wsc = 0.0
+        params.ftp100 = 2.0 params.ftp200 = 3.875 params.ftp300 = 7.0
     end
 
     local damage, criticalHit, tpHits, extraHits = doPhysicalWeaponskill(player, target, wsID, tp, primary, action, taChar, params)


### PR DESCRIPTION
[In the bg-wiki forums, they found that the official SE values were incorrect](https://www.bluegartr.com/threads/104123-Weapon-Skills?p=6802164&viewfull=1#post6802164). They noted that jp wiki had already found this information out [and listed the correct values](http://wiki.ffo.jp/html/2423.html). This change reflects those values.

Changes:

- pre-soa ftp is 2, 2.5, 3.5
- post-soa ftp is 2, 3.875, 7
- post-soa wsc remains 50% str 50% vit, **NOT** 50% str 50% dex as SE claimed

Sources:

- https://www.bluegartr.com/threads/104123-Weapon-Skills?p=6802164&viewfull=1#post6802164
- http://wiki.ffo.jp/html/2423.html