### PR TITLE
ability(empathy): Add logic for Empathy

### DIFF
--- a/scripts/globals/abilities/spirit_link.lua
+++ b/scripts/globals/abilities/spirit_link.lua
@@ -7,6 +7,7 @@
 -----------------------------------
 require("scripts/globals/status")
 require("scripts/globals/msg")
+require("scripts/globals/wyvern")
 -----------------------------------
 
 function onAbilityCheck(player,target,ability)
@@ -69,6 +70,25 @@ function onUseAbility(player,target,ability)
     if (pet:getHP() < pet:getMaxHP()) then -- sleep is only removed if it heals the wyvern
         removeSleepEffects(pet)
     end
+
+    local empathy = player:getMerit(dsp.merit.EMPATHY)
+    if (empathy > 0) then
+        local effects = utils.shuffle(player:getStatusEffects())
+        local copied = 0
+        -- find a buff and copy it to the wyvern
+        for i, effect in ipairs(effects) do
+            if canCopyEffectToWyvern(effect) then
+                copyEffectToWyvern(pet, effect)
+                -- up to a max of empathy merits
+                copied = copied + 1
+                if (copied == empathy) then
+                    break
+                end
+            end
+        end
+        addWyvernExp(pet, empathy * 200)
+    end
+
 
     pet:addHP(healPet) --add the hp to pet
     pet:addStatusEffect(dsp.effect.REGEN,regenAmount,3,90,0,0,0) -- 90 seconds of regen

--- a/scripts/globals/abilities/spirit_link.lua
+++ b/scripts/globals/abilities/spirit_link.lua
@@ -7,7 +7,7 @@
 -----------------------------------
 require("scripts/globals/status")
 require("scripts/globals/msg")
-require("scripts/globals/wyvern")
+require("scripts/globals/pets/wyvern")
 -----------------------------------
 
 function onAbilityCheck(player,target,ability)

--- a/scripts/globals/pets/wyvern.lua
+++ b/scripts/globals/pets/wyvern.lua
@@ -287,14 +287,14 @@ function addWyvernExp(wyvern, exp)
 end
 
 function canCopyEffectToWyvern(effect)
-    return empathyEffects[effect.getType()] ~= nil
+    return empathyEffects[effect:getType()] ~= nil
 end
 
 function copyEffectToWyvern(pet, effect)
-    local type = effect.getType()
-    local power = effect.getPower()
-    local tick = effect.getTickTime()
-    local duration = effect.getDuration()
+    local type = effect:getType()
+    local power = effect:getPower()
+    local tick = effect:getTickTime()
+    local duration = effect:getDuration()
     pet:addStatusEffect(type, power, tick, duration)
 end
 

--- a/scripts/globals/pets/wyvern.lua
+++ b/scripts/globals/pets/wyvern.lua
@@ -33,6 +33,220 @@ local wyvernTypes = {
     [dsp.job.RUN] = WYVERN_MULTI
 }
 
+-- It seems that the logic is:
+-- JOB ABILITIES
+    -- Includes physical job abilities with a duration, e.g. Berserk, Seigan, Meditate
+        -- i.e. Probably should include Cover
+    -- Excludes magical job abilities with a duration, e.g. Dark Arts, Light Arts
+        -- i.e. Probably should exclude Composure
+    -- Excludes on hit job abilities, e.g. Sneak Attack, Elemental Seal; EXCEPTION: Boost
+        -- i.e. Probably should exclude Barrage
+-- SPELLS
+    -- Includes battle spell buffs, e.g. stoneskin, spikes, regen, utsusemi, samba, minuet, rolls, sambas
+        -- i.e. Probably should include Migawari, Avatar's Favor
+    -- Excludes non-battle spell buffs, e.g. Monomi, Invisible
+        -- i.e. Probably should exclude Mazurka, Jigs
+-- CONSUMABLES
+    -- Includes attribute boosting medicines, e.g. Icarus Wing, Agility Potion, Giant's Drink
+    -- Excludes food, i.e. Instant Noodles, Meat Mithkabob
+local empathyEffects = {
+
+        -- JOB ABILITIES
+        [dsp.effect.BOOST] = true,
+        [dsp.effect.BERSERK] = true,
+        [dsp.effect.HOLY_CIRCLE] = true,
+        [dsp.effect.ARCANE_CIRCLE] = true,
+        [dsp.effect.WARDING_CIRCLE] = true,
+        [dsp.effect.ANCIENT_CIRCLE] = true,
+        [dsp.effect.DODGE] = true,
+        [dsp.effect.FLEE] = true,
+        [dsp.effect.FOCUS] = true,
+        [dsp.effect.HASSO] = true,
+        [dsp.effect.INTENSION] = true,
+        [dsp.effect.LAST_RESORT] = true,
+        [dsp.effect.PHYSICAL_SHIELD] = true,
+        [dsp.effect.ARROW_SHIELD] = true,
+        [dsp.effect.MAGIC_SHIELD] = true,
+        [dsp.effect.PAX] = true,
+        [dsp.effect.POTENCY] = true,
+        [dsp.effect.PROTECT] = true,
+        [dsp.effect.QUICKENING] = true,
+        [dsp.effect.REGAIN] = true,
+        [dsp.effect.DRAIN_SAMBA] = true,
+        [dsp.effect.ASPIR_SAMBA] = true,
+        [dsp.effect.HASTE_SAMBA] = true,
+        [dsp.effect.SEIGAN] = true,
+        [dsp.effect.SOULEATER] = true,
+        [dsp.effect.SUBLIMATION_ACTIVATED] = true,
+        [dsp.effect.SUBLIMATION_COMPLETE] = true,
+        [dsp.effect.THIRD_EYE] = true,
+        [dsp.effect.WARCRY] = true,
+
+        -- SPELLS
+        [dsp.effect.AQUAVEIL] = true,
+        [dsp.effect.BARFIRE] = true,
+        [dsp.effect.BARBLIZZARD] = true,
+        [dsp.effect.BARAERO] = true,
+        [dsp.effect.BARSTONE] = true,
+        [dsp.effect.BARTHUNDER] = true,
+        [dsp.effect.BARWATER] = true,
+        [dsp.effect.BARSLEEP] = true,
+        [dsp.effect.BARPOISON] = true,
+        [dsp.effect.BARPARALYZE] = true,
+        [dsp.effect.BARBLIND] = true,
+        [dsp.effect.BARSILENCE] = true,
+        [dsp.effect.BARPETRIFY] = true,
+        [dsp.effect.BARVIRUS] = true,
+        [dsp.effect.BARAMNESIA] = true,
+        [dsp.effect.BLINK] = true,
+        [dsp.effect.BLAZE_SPIKES] = true,
+        [dsp.effect.ICE_SPIKES] = true,
+        [dsp.effect.SHOCK_SPIKES] = true,
+        [dsp.effect.DAMAGE_SPIKES] = true,
+        [dsp.effect.DREAD_SPIKES] = true,
+        [dsp.effect.DELUGE_SPIKES] = true,
+        [dsp.effect.GALE_SPIKES] = true,
+        [dsp.effect.CLOD_SPIKES] = true,
+        [dsp.effect.GLINT_SPIKES] = true,
+        [dsp.effect.ENFIRE] = true,
+        [dsp.effect.ENBLIZZARD] = true,
+        [dsp.effect.ENAERO] = true,
+        [dsp.effect.ENSTONE] = true,
+        [dsp.effect.ENTHUNDER] = true,
+        [dsp.effect.ENWATER] = true,
+        [dsp.effect.ENCHANTMENT] = true,
+        [dsp.effect.ENLIGHT] = true,
+        [dsp.effect.ENFIRE_II] = true,
+        [dsp.effect.ENBLIZZARD_II] = true,
+        [dsp.effect.ENAERO_II] = true,
+        [dsp.effect.ENSTONE_II] = true,
+        [dsp.effect.ENTHUNDER_II] = true,
+        [dsp.effect.ENWATER_II] = true,
+        [dsp.effect.ENDARK] = true,
+        [dsp.effect.HASTE] = true,
+        [dsp.effect.REFRESH] = true,
+        [dsp.effect.REGEN] = true,
+        [dsp.effect.RERAISE] = true,
+        [dsp.effect.SHELL] = true,
+        [dsp.effect.SHINING_RUBY] = true,
+        [dsp.effect.COPY_IMAGE] = true,
+        [dsp.effect.COPY_IMAGE_1] = true,
+        [dsp.effect.COPY_IMAGE_2] = true,
+        [dsp.effect.COPY_IMAGE_3] = true,
+        [dsp.effect.COPY_IMAGE_4] = true,
+        [dsp.effect.STONESKIN] = true,
+        [dsp.effect.FIGHTERS_ROLL] = true,
+        [dsp.effect.MONKS_ROLL] = true,
+        [dsp.effect.HEALERS_ROLL] = true,
+        [dsp.effect.WIZARDS_ROLL] = true,
+        [dsp.effect.WARLOCKS_ROLL] = true,
+        [dsp.effect.ROGUES_ROLL] = true,
+        [dsp.effect.GALLANTS_ROLL] = true,
+        [dsp.effect.CHAOS_ROLL] = true,
+        [dsp.effect.BEAST_ROLL] = true,
+        [dsp.effect.CHORAL_ROLL] = true,
+        [dsp.effect.HUNTERS_ROLL] = true,
+        [dsp.effect.SAMURAI_ROLL] = true,
+        [dsp.effect.NINJA_ROLL] = true,
+        [dsp.effect.DRACHEN_ROLL] = true,
+        [dsp.effect.EVOKERS_ROLL] = true,
+        [dsp.effect.MAGUSS_ROLL] = true,
+        [dsp.effect.CORSAIRS_ROLL] = true,
+        [dsp.effect.PUPPET_ROLL] = true,
+        [dsp.effect.DANCERS_ROLL] = true,
+        [dsp.effect.SCHOLARS_ROLL] = true,
+        [dsp.effect.BOLTERS_ROLL] = true,
+        [dsp.effect.CASTERS_ROLL] = true,
+        [dsp.effect.COURSERS_ROLL] = true,
+        [dsp.effect.BLITZERS_ROLL] = true,
+        [dsp.effect.TACTICIANS_ROLL] = true,
+        [dsp.effect.ALLIES_ROLL] = true,
+        [dsp.effect.MISERS_ROLL] = true,
+        [dsp.effect.COMPANIONS_ROLL] = true,
+        [dsp.effect.AVENGERS_ROLL] = true,
+        [dsp.effect.NATURALISTS_ROLL] = true,
+        [dsp.effect.RUNEISTS_ROLL] = true,
+        [dsp.effect.CARBUNCLES_FAVOR] = true,
+        [dsp.effect.IFRITS_FAVOR] = true,
+        [dsp.effect.SHIVAS_FAVOR] = true,
+        [dsp.effect.GARUDAS_FAVOR] = true,
+        [dsp.effect.TITANS_FAVOR] = true,
+        [dsp.effect.RAMUHS_FAVOR] = true,
+        [dsp.effect.LEVIATHANS_FAVOR] = true,
+        [dsp.effect.FENRIRS_FAVOR] = true,
+        [dsp.effect.DIABOLOSS_FAVOR] = true,
+        [dsp.effect.AVATARS_FAVOR] = true,
+        [dsp.effect.CAIT_SITH_S_FAVOR] = true,
+        [dsp.effect.PAEON] = true,
+        [dsp.effect.BALLAD] = true,
+        [dsp.effect.MINNE] = true,
+        [dsp.effect.MINUET] = true,
+        [dsp.effect.MADRIGAL] = true,
+        [dsp.effect.PRELUDE] = true,
+        [dsp.effect.MAMBO] = true,
+        [dsp.effect.AUBADE] = true,
+        [dsp.effect.PASTORAL] = true,
+        -- [dsp.effect.HUM] = true,
+        [dsp.effect.FANTASIA] = true,
+        [dsp.effect.OPERETTA] = true,
+        [dsp.effect.CAPRICCIO] = true,
+        [dsp.effect.SERENADE] = true,
+        [dsp.effect.ROUND] = true,
+        [dsp.effect.GAVOTTE] = true,
+        -- [dsp.effect.FUGUE] = true,
+        -- [dsp.effect.RHAPSODY] = true,
+        -- [dsp.effect.ARIA] = true,
+        [dsp.effect.MARCH] = true,
+        [dsp.effect.ETUDE] = true,
+        [dsp.effect.CAROL] = true,
+        [dsp.effect.HYMNUS] = true,
+        [dsp.effect.SIRVENTE] = true,
+        [dsp.effect.DIRGE] = true,
+        [dsp.effect.SCHERZO] = true,
+
+        -- ATTRIBUTES
+        [dsp.effect.STR_BOOST] = true,
+        [dsp.effect.DEX_BOOST] = true,
+        [dsp.effect.VIT_BOOST] = true,
+        [dsp.effect.AGI_BOOST] = true,
+        [dsp.effect.INT_BOOST] = true,
+        [dsp.effect.MND_BOOST] = true,
+        [dsp.effect.CHR_BOOST] = true,
+        [dsp.effect.MAX_HP_BOOST] = true,
+        [dsp.effect.MAX_MP_BOOST] = true,
+        [dsp.effect.ACCURACY_BOOST] = true,
+        [dsp.effect.ATTACK_BOOST] = true,
+        [dsp.effect.EVASION_BOOST] = true,
+        [dsp.effect.DEFENSE_BOOST] = true,
+        [dsp.effect.STR_BOOST_2] = true,
+        [dsp.effect.DEX_BOOST_2] = true,
+        [dsp.effect.VIT_BOOST_2] = true,
+        [dsp.effect.AGI_BOOST_2] = true,
+        [dsp.effect.INT_BOOST_2] = true,
+        [dsp.effect.MND_BOOST_2] = true,
+        [dsp.effect.CHR_BOOST_2] = true,
+        [dsp.effect.MAGIC_ATK_BOOST] = true,
+        [dsp.effect.MAGIC_DEF_BOOST] = true,
+        [dsp.effect.ENMITY_BOOST] = true,
+        [dsp.effect.COUNTER_BOOST] = true,
+        [dsp.effect.STR_BOOST_III] = true,
+        [dsp.effect.DEX_BOOST_III] = true,
+        [dsp.effect.VIT_BOOST_III] = true,
+        [dsp.effect.AGI_BOOST_III] = true,
+        [dsp.effect.INT_BOOST_III] = true,
+        [dsp.effect.MND_BOOST_III] = true,
+        [dsp.effect.CHR_BOOST_III] = true,
+        [dsp.effect.ATTACK_BOOST_II] = true,
+        [dsp.effect.DEFENSE_BOOST_II] = true,
+        [dsp.effect.MAGIC_ATK_BOOST_II] = true,
+        [dsp.effect.MAGIC_DEF_BOOST_II] = true,
+        [dsp.effect.ACCURACY_BOOST_II] = true,
+        [dsp.effect.EVASION_BOOST_II] = true,
+        [dsp.effect.MAGIC_ACC_BOOST_II] = true,
+        [dsp.effect.MAGIC_EVASION_BOOST] = true,
+        [dsp.effect.MAGIC_EVASION_BOOST_II] = true
+    }
+
 function doHealingBreath(player, threshold, breath)
     if player:getHPP() < threshold then
         player:getPet():useJobAbility(breath, player)
@@ -45,6 +259,43 @@ function doHealingBreath(player, threshold, breath)
             end
         end
     end
+end
+
+function addWyvernExp(wyvern, exp)
+    local prev_exp = pet:getLocalVar("wyvern_exp")
+    if prev_exp < 1000 then
+    -- cap exp at 1000 to prevent wyvern leveling up many times from large exp awards
+        local currentExp = exp
+        if prev_exp + exp > 1000 then
+            currentExp = 1000 - prev_exp
+        end
+        local diff = math.floor((prev_exp + currentExp)/200) - math.floor(prev_exp/200)
+        if diff ~= 0 then
+            -- wyvern levelled up (diff is the number of level ups)
+            pet:addMod(dsp.mod.ACC,6*diff)
+            pet:addMod(dsp.mod.HPP,6*diff)
+            pet:addMod(dsp.mod.ATTP,5*diff)
+            pet:setHP(pet:getMaxHP())
+            player:messageBasic(dsp.msg.basic.STATUS_INCREASED, 0, 0, pet)
+            master:addMod(dsp.mod.ATTP, 4 * diff)
+            master:addMod(dsp.mod.DEFP, 4 * diff)
+            master:addMod(dsp.mod.HASTE_ABILITY, 200 * diff)
+        end
+        pet:setLocalVar("wyvern_exp", prev_exp + exp)
+        pet:setLocalVar("level_Ups", pet:getLocalVar("level_Ups") + diff)
+    end
+end
+
+function canCopyEffectToWyvern(effect)
+    return empathyEffects[effects.getType()] ~= nil
+end
+
+function copyEffectToWyvern(pet, effect)
+    local type = effect.getType()
+    local power = effect.getPower()
+    local tick = effect.getTickTime()
+    local duration = effect.getDuration()
+    pet:addStatusEffect(type, power, tick, duration)
 end
 
 function onMobSpawn(mob)
@@ -134,28 +385,7 @@ function onMobSpawn(mob)
 
     master:addListener("EXPERIENCE_POINTS", "PET_WYVERN_EXP", function(player, exp)
         local pet = player:getPet()
-        local prev_exp = pet:getLocalVar("wyvern_exp")
-        if prev_exp < 1000 then
-        -- cap exp at 1000 to prevent wyvern leveling up many times from large exp awards
-            local currentExp = exp
-            if prev_exp+exp > 1000 then
-                currentExp = 1000 - prev_exp
-            end
-            local diff = math.floor((prev_exp + currentExp)/200) - math.floor(prev_exp/200)
-            if diff ~= 0 then
-                -- wyvern levelled up (diff is the number of level ups)
-                pet:addMod(dsp.mod.ACC,6*diff)
-                pet:addMod(dsp.mod.HPP,6*diff)
-                pet:addMod(dsp.mod.ATTP,5*diff)
-                pet:setHP(pet:getMaxHP())
-                player:messageBasic(dsp.msg.basic.STATUS_INCREASED, 0, 0, pet)
-                master:addMod(dsp.mod.ATTP, 4 * diff)
-                master:addMod(dsp.mod.DEFP, 4 * diff)
-                master:addMod(dsp.mod.HASTE_ABILITY, 200 * diff)
-            end
-            pet:setLocalVar("wyvern_exp", prev_exp + exp)
-            pet:setLocalVar("level_Ups", pet:getLocalVar("level_Ups") + diff)
-        end
+        addWyvernExp(pet, exp)
     end)
 end
 

--- a/scripts/globals/pets/wyvern.lua
+++ b/scripts/globals/pets/wyvern.lua
@@ -287,7 +287,7 @@ function addWyvernExp(wyvern, exp)
 end
 
 function canCopyEffectToWyvern(effect)
-    return empathyEffects[effects.getType()] ~= nil
+    return empathyEffects[effect.getType()] ~= nil
 end
 
 function copyEffectToWyvern(pet, effect)


### PR DESCRIPTION
Gives 200 experience points to the Wyvern and copies one status effect from the Dragoon to the Wyvern when Spirit Link is used for each merit point in Empathy.

This still needs a bit of testing, but I wanted to make sure this was on the right track first.