### PR TITLE
fix(blood pacts): Correct physical blood pact damage calculation

### DIFF
--- a/scripts/globals/abilities/pets/chaotic_strike.lua
+++ b/scripts/globals/abilities/pets/chaotic_strike.lua
@@ -15,7 +15,7 @@ function onPetAbility(target, pet, skill)
     local numhits = 3
     local accmod = 1
     local dmgmod = 9
-    local dmgmodsubsequent = 1
+    local dmgmodsubsequent = 2
     local totaldamage = 0
     local damage = AvatarPhysicalMove(pet,target,skill,numhits,accmod,dmgmod,dmgmodsubsequent,TP_NO_EFFECT,1,2,3)
     totaldamage = AvatarFinalAdjustments(damage.dmg,pet,skill,target,dsp.attackType.PHYSICAL,dsp.damageType.BLUNT,numhits)

--- a/scripts/globals/abilities/pets/crescent_fang.lua
+++ b/scripts/globals/abilities/pets/crescent_fang.lua
@@ -14,7 +14,7 @@ end
 function onPetAbility(target, pet, skill)
     local numhits = 1
     local accmod = 1
-    local dmgmod = 5
+    local dmgmod = 6
 
     local totaldamage = 0
     local damage = AvatarPhysicalMove(pet,target,skill,numhits,accmod,dmgmod,0,TP_NO_EFFECT,1,2,3)

--- a/scripts/globals/abilities/pets/eclipse_bite.lua
+++ b/scripts/globals/abilities/pets/eclipse_bite.lua
@@ -15,7 +15,7 @@ function onPetAbility(target, pet, skill)
     local numhits = 3
     local accmod = 1
     local dmgmod = 8
-    local dmgmodsubsequent = 1
+    local dmgmodsubsequent = 2
     local totaldamage = 0
     local damage = AvatarPhysicalMove(pet,target,skill,numhits,accmod,dmgmod,dmgmodsubsequent,TP_NO_EFFECT,1,2,3)
     totaldamage = AvatarFinalAdjustments(damage.dmg,pet,skill,target,dsp.attackType.PHYSICAL,dsp.damageType.SLASHING,numhits)

--- a/scripts/globals/summon.lua
+++ b/scripts/globals/summon.lua
@@ -1,241 +1,187 @@
 
-require("scripts/globals/common");
-require("scripts/globals/status");
-require("scripts/globals/msg");
+require("scripts/globals/common")
+require("scripts/globals/status")
+require("scripts/globals/msg")
 
-function AvatarPhysicalMove(avatar,target,skill,numberofhits,accmod,dmgmod1,dmgmodsubsequent,tpeffect,mtp100,mtp200,mtp300)
-    returninfo = {};
+function getSummoningSkillOverCap(summoner)
+    local summoningSkill = summoner:getSkillLevel(dsp.skill.SUMMONING_MAGIC)
+    local maxSkill = summoner:getMaxSkillLevel(summoner:getMainLvl(), dsp.job.SMN, dsp.skill.SUMMONING_MAGIC)
+    return math.max(summoningSkill - maxSkill, 0)
+end
 
-    -- Damage = (D+fSTR) * dmgmod * PDIF
-    -- printf("str: %f, vit: %f", avatar:getStat(dsp.mod.STR), target:getStat(dsp.mod.VIT));
-    fstr = avatarFSTR(avatar:getStat(dsp.mod.STR), target:getStat(dsp.mod.VIT));
+function AvatarPhysicalMove(avatar,target,skill,numberofhits,accmod,dmgmod,dmgmodsubsequent,tpeffect,mtp100,mtp200,mtp300)
 
-    lvluser = avatar:getMainLvl();
-    lvltarget = target:getMainLvl();
-    local master = avatar:getMaster();
-    local bonusacc = utils.clamp(master:getSkillLevel(dsp.skill.SUMMONING_MAGIC) - master:getMaxSkillLevel(avatar:getMainLvl(), dsp.job.SMN, dsp.skill.SUMMONING_MAGIC), 0, 200);
-    acc = avatar:getACC() + bonusacc;
-    eva = target:getEVA();
+    local returninfo = {}
 
-    local base = avatar:getWeaponDmg() + fstr;
-    local ratio = avatar:getStat(dsp.mod.ATT)/target:getStat(dsp.mod.DEF);
+    local acc = avatar:getACC() + utils.clamp(getSummoningSkillOverCap(avatar:getMaster()), 0, 200)
+    local eva = target:getEVA()
+    local dmg = avatar:getWeaponDmg()
+    local minFstr, maxFstr = avatarFSTR(avatar:getStat(dsp.mod.STR), target:getStat(dsp.mod.VIT))
+    local ratio = avatar:getStat(dsp.mod.ATT) / target:getStat(dsp.mod.DEF)
 
-    lvldiff = lvluser - lvltarget;
-
-    -- work out hit rate for mobs (bias towards them)
-    hitrate = (acc*accmod) - eva;
-    if (lvluser > lvltarget) then
-        hitrate = hitrate + ((lvluser-lvltarget)*5);
-    end
-    if (lvltarget > lvluser) then
-        hitrate = hitrate + ((lvltarget-lvluser)*3);
-    end
-    if (hitrate > 95) then
-        hitrate = 95;
-    end
-    if (hitrate < 20) then
-        hitrate = 20;
-    end
-
-    if (base < 1) then
-        base = 1;
-    end
-    hitdamage = base * dmgmod1;
-    subsequenthitdamage = base * dmgmodsubsequent;
-    if (ratio<=1) then
-        maxRatio = 1;
-        minRatio = 1/3;
-    elseif (ratio<1.6) then
-        maxRatio = ((4/6) * ratio) + (2/6);
-        minRatio = ((7/9) * ratio) - (4/9);
-    elseif (ratio<=1.8) then
-        maxRatio = 1.8;
-        minRatio = 1;
-    elseif (ratio<3.6) then
-        maxRatio = (2.4 * ratio) - 2.52;
-        minRatio = ((5/3) * ratio) - 2;
-    else
-        maxRatio = 4.2;
-        minRatio = 4;
-    end
-
-    if (tpeffect==TP_DMG_BONUS) then
-        hitdamage = hitdamage * avatarFTP(skill:getTP(), mtp100, mtp200, mtp300);
-    end
-    -- Applying pDIF
-    local pdif = 0;
-
-    -- start the hits
-    local hitchance = math.random();
-    finaldmg = 0;
-    hitsdone = 1; hitslanded = 0;
+    -- Note: Avatars do not have any level correction. This is why they are so good on Wyrms! // https://kegsay.livejournal.com/tag/smn!
+    local hitrate = utils.clamp(acc - eva, 20, 95)
 
     -- add on native crit hit rate (guesstimated, it actually follows an exponential curve)
-    nativecrit = (avatar:getStat(dsp.mod.DEX) - target:getStat(dsp.mod.AGI))*0.005; --assumes +0.5% crit rate per 1 dDEX
-    nativecrit = nativecrit + (avatar:getMod(dsp.mod.CRITHITRATE)/100);
+    local critrate = (avatar:getStat(dsp.mod.DEX) - target:getStat(dsp.mod.AGI)) * 0.005 -- assumes +0.5% crit rate per 1 dDEX
+    critrate = critrate + avatar:getMod(dsp.mod.CRITHITRATE) / 100
+    critrate = utils.clamp(critrate, 0.05, 0.2);
 
-    if (nativecrit > 0.2) then --caps!
-        nativecrit = 0.2;
-    elseif (nativecrit < 0.05) then
-        nativecrit = 0.05;
-    end
-
-    local critchance = math.random();
-    local hitchance = 0;
-    local crit = false;
-    if critchance <= nativecrit then
-        crit = true;
+    -- Applying pDIF
+    if (ratio <= 1) then
+        maxRatio = 1
+        minRatio = 1/3
+    elseif (ratio < 1.6) then
+        maxRatio = ((2/3) * ratio) + (1/3)
+        minRatio = ((7/9) * ratio) - (4/9)
+    elseif (ratio <= 1.8) then
+        maxRatio = 1.8
+        minRatio = 1
+    elseif (ratio < 3.6) then
+        maxRatio = (2.4 * ratio) - 2.52
+        minRatio = ((5/3) * ratio) - 2
     else
-        hitchance = math.random();
+        maxRatio = 4.2
+        minRatio = 4
     end
 
-    if crit == true or hitchance*100 <= 95 then
-        pdif = math.random((minRatio * 1000), (maxRatio * 1000));
-        pdif = pdif/1000;
-        if crit == true then
-            pdif = pdif + 1;
-            if pdif > 4.2 then
-                pdif = 4.2
-            end
-        end
-        finaldmg = finaldmg + hitdamage * pdif;
-        hitslanded = hitslanded + 1;
+    -- start the hits
+    local hitsdone = 1
+    local hitslanded = 0
+    local hitdmg = 0
+    local finaldmg = 0
+
+    if math.random() <= hitrate then
+        hitdmg = avatarHitDmg(dmg, minRatio, maxRatio, minFstr, maxFstr, critrate)
+        finaldmg = finaldmg + hitdmg * dmgmod
+        hitslanded = hitslanded + 1
     end
-    while (hitsdone < numberofhits) do
-        chance = math.random();
-        if ((chance*100)<=hitrate) then
-            pdif = math.random((minRatio * 1000), (maxRatio * 1000));
-            pdif = pdif/1000;
-            finaldmg = finaldmg + subsequenthitdamage * pdif;
-            hitslanded = hitslanded + 1;
+
+    while hitsdone < numberofhits do
+        if math.random() <= hitrate then
+            hitdmg = avatarHitDmg(dmg, minRatio, maxRatio, minFstr, maxFstr, critrate)
+            finaldmg = finaldmg + hitdmg * dmgmodsubsequent
+            hitslanded = hitslanded + 1
         end
-        hitsdone = hitsdone + 1;
+        hitsdone = hitsdone + 1
     end
 
     -- all hits missed
     if (hitslanded == 0 or finaldmg == 0) then
-        finaldmg = 0;
-        hitslanded = 0;
-        skill:setMsg(dsp.msg.basic.SKILL_MISS);
-    end
+        finaldmg = 0
+        hitslanded = 0
+        skill:setMsg(dsp.msg.basic.SKILL_MISS)
 
-    if finaldmg > 0 then
+    -- some hits hit
+    else
         target:wakeUp()
     end
 
-    returninfo.dmg = finaldmg;
-    returninfo.hitslanded = hitslanded;
-
-    return returninfo;
-end;
-
--- Given the attacker's str and the mob's vit, fSTR is calculated
-function avatarFSTR(atk_str,def_vit)
-    local dSTR = atk_str - def_vit;
-    if (dSTR >= 12) then
-        fSTR2 = ((dSTR+4)/2);
-    elseif (dSTR >= 6) then
-        fSTR2 = ((dSTR+6)/2);
-    elseif (dSTR >= 1) then
-        fSTR2 = ((dSTR+7)/2);
-    elseif (dSTR >= -2) then
-        fSTR2 = ((dSTR+8)/2);
-    elseif (dSTR >= -7) then
-        fSTR2 = ((dSTR+9)/2);
-    elseif (dSTR >= -15) then
-        fSTR2 = ((dSTR+10)/2);
-    elseif (dSTR >= -21) then
-        fSTR2 = ((dSTR+12)/2);
-    else
-        fSTR2 = ((dSTR+13)/2);
+    -- apply ftp bonus
+    if (tpeffect == TP_DMG_BONUS) then
+        finaldmg = finaldmg * avatarFTP(skill:getTP(), mtp100, mtp200, mtp300)
     end
-    -- Apply fSTR caps.
-    if (fSTR2< -1) then
-        fSTR2 = -1;
-    elseif (fSTR2>8) then
-        fSTR2 = 8;
+
+    returninfo.dmg = finaldmg
+    returninfo.hitslanded = hitslanded
+
+    return returninfo
+end
+
+-- minFstr = dSTR/4 + 0.5
+-- maxFstr = dSTR/4 + 0.25
+function avatarFSTR(str, def_vit)
+    local dSTR = atk_str - def_vit
+    return math.floor(dSTR/4 + 0.5), math.floor(dSTR/4 + 0.25)
+end
+
+function avatarHitDmg(dmg, pdifMin, pdifMax, fstrMin, fstrMax, critrate)
+    local fstr = math.random(fstrMin, fstrMax)
+    local pdif = math.random(pdifMin * 1000, pdifMax * 1000) / 1000
+    if math.random() <= critrate then
+        pdif = math.min(pdif + 1, 4.2)
     end
-    return fSTR2;
-end;
+    return (dmg + fstr) * pdif
+end
 
 function AvatarFinalAdjustments(dmg,mob,skill,target,skilltype,skillparam,shadowbehav)
 
     -- physical attack missed, skip rest
     if (skilltype == dsp.attackType.PHYSICAL and dmg == 0) then
-        return 0;
+        return 0
     end
 
     -- set message to damage
     -- this is for AoE because its only set once
-    skill:setMsg(dsp.msg.basic.DAMAGE);
+    skill:setMsg(dsp.msg.basic.DAMAGE)
 
     --Handle shadows depending on shadow behaviour / skilltype
     if (shadowbehav < 5 and shadowbehav ~= MOBPARAM_IGNORE_SHADOWS) then --remove 'shadowbehav' shadows.
-        targShadows = target:getMod(dsp.mod.UTSUSEMI);
-        shadowType = dsp.mod.UTSUSEMI;
+        targShadows = target:getMod(dsp.mod.UTSUSEMI)
+        shadowType = dsp.mod.UTSUSEMI
         if (targShadows==0) then --try blink, as utsusemi always overwrites blink this is okay
-            targShadows = target:getMod(dsp.mod.BLINK);
-            shadowType = dsp.mod.BLINK;
+            targShadows = target:getMod(dsp.mod.BLINK)
+            shadowType = dsp.mod.BLINK
         end
 
         if (targShadows>0) then
         -- Blink has a VERY high chance of blocking tp moves, so im assuming its 100% because its easier!
             if (targShadows >= shadowbehav) then --no damage, just suck the shadows
-                skill:setMsg(dsp.msg.basic.SHADOW_ABSORB);
-                target:setMod(shadowType,(targShadows-shadowbehav));
+                skill:setMsg(dsp.msg.basic.SHADOW_ABSORB)
+                target:setMod(shadowType,(targShadows-shadowbehav))
                 if (shadowType == dsp.mod.UTSUSEMI) then --update icon
-                    effect = target:getStatusEffect(dsp.effect.COPY_IMAGE);
+                    effect = target:getStatusEffect(dsp.effect.COPY_IMAGE)
                     if (effect ~= nil) then
                         if ((targShadows-shadowbehav) == 0) then
-                            target:delStatusEffect(dsp.effect.COPY_IMAGE);
-                            target:delStatusEffect(dsp.effect.BLINK);
+                            target:delStatusEffect(dsp.effect.COPY_IMAGE)
+                            target:delStatusEffect(dsp.effect.BLINK)
                         elseif ((targShadows-shadowbehav) == 1) then
-                            effect:setIcon(dsp.effect.COPY_IMAGE);
+                            effect:setIcon(dsp.effect.COPY_IMAGE)
                         elseif ((targShadows-shadowbehav) == 2) then
-                            effect:setIcon(dsp.effect.COPY_IMAGE_2);
+                            effect:setIcon(dsp.effect.COPY_IMAGE_2)
                         elseif ((targShadows-shadowbehav) == 3) then
-                            effect:setIcon(dsp.effect.COPY_IMAGE_3);
+                            effect:setIcon(dsp.effect.COPY_IMAGE_3)
                         end
                     end
                 end
-                return shadowbehav;
+                return shadowbehav
             else -- less shadows than this move will take, remove all and factor damage down
-                dmg = dmg * ((shadowbehav-targShadows)/shadowbehav);
-                target:setMod(dsp.mod.UTSUSEMI,0);
-                target:setMod(dsp.mod.BLINK,0);
-                target:delStatusEffect(dsp.effect.COPY_IMAGE);
-                target:delStatusEffect(dsp.effect.BLINK);
+                dmg = dmg * ((shadowbehav-targShadows)/shadowbehav)
+                target:setMod(dsp.mod.UTSUSEMI,0)
+                target:setMod(dsp.mod.BLINK,0)
+                target:delStatusEffect(dsp.effect.COPY_IMAGE)
+                target:delStatusEffect(dsp.effect.BLINK)
             end
         end
     elseif (shadowbehav == MOBPARAM_WIPE_SHADOWS) then --take em all!
-        target:setMod(dsp.mod.UTSUSEMI,0);
-        target:setMod(dsp.mod.BLINK,0);
-        target:delStatusEffect(dsp.effect.COPY_IMAGE);
-        target:delStatusEffect(dsp.effect.BLINK);
+        target:setMod(dsp.mod.UTSUSEMI,0)
+        target:setMod(dsp.mod.BLINK,0)
+        target:delStatusEffect(dsp.effect.COPY_IMAGE)
+        target:delStatusEffect(dsp.effect.BLINK)
     end
 
     -- handle Third Eye using shadowbehav as a guide
-    teye = target:getStatusEffect(dsp.effect.THIRD_EYE);
+    teye = target:getStatusEffect(dsp.effect.THIRD_EYE)
     if (teye ~= nil and skilltype==dsp.attackType.PHYSICAL) then --T.Eye only procs when active with PHYSICAL stuff
         if (shadowbehav == MOBPARAM_WIPE_SHADOWS) then --e.g. aoe moves
-            target:delStatusEffect(dsp.effect.THIRD_EYE);
+            target:delStatusEffect(dsp.effect.THIRD_EYE)
         elseif (shadowbehav ~= MOBPARAM_IGNORE_SHADOWS) then --it can be absorbed by shadows
             --third eye doesnt care how many shadows, so attempt to anticipate, but reduce
             --chance of anticipate based on previous successful anticipates.
-            prevAnt = teye:getPower();
+            prevAnt = teye:getPower()
             if (prevAnt == 0) then
                 --100% proc
-                teye:setPower(1);
-                skill:setMsg(dsp.msg.basic.ANTICIPATE);
-                return 0;
+                teye:setPower(1)
+                skill:setMsg(dsp.msg.basic.ANTICIPATE)
+                return 0
             end
             if ( (math.random()*100) < (80-(prevAnt*10)) ) then
                 --anticipated!
-                teye:setPower(prevAnt+1);
-                skill:setMsg(dsp.msg.basic.ANTICIPATE);
-                return 0;
+                teye:setPower(prevAnt+1)
+                skill:setMsg(dsp.msg.basic.ANTICIPATE)
+                return 0
             end
-            target:delStatusEffect(dsp.effect.THIRD_EYE);
+            target:delStatusEffect(dsp.effect.THIRD_EYE)
         end
     end
 
@@ -244,85 +190,85 @@ function AvatarFinalAdjustments(dmg,mob,skill,target,skilltype,skillparam,shadow
 
 
     if (skilltype == dsp.attackType.PHYSICAL and target:hasStatusEffect(dsp.effect.PHYSICAL_SHIELD)) then
-        return 0;
+        return 0
     end
 
     if (skilltype == dsp.attackType.RANGED and target:hasStatusEffect(dsp.effect.ARROW_SHIELD)) then
-        return 0;
+        return 0
     end
 
     -- handle elemental resistence
     if (skilltype == dsp.attackType.MAGICAL and target:hasStatusEffect(dsp.effect.MAGIC_SHIELD)) then
-        return 0;
+        return 0
     end
 
     -- handling phalanx
-    dmg = dmg - target:getMod(dsp.mod.PHALANX);
+    dmg = dmg - target:getMod(dsp.mod.PHALANX)
     if (dmg<0) then
-        return 0;
+        return 0
     end
 
     --handle invincible
     if (target:hasStatusEffect(dsp.effect.INVINCIBLE) and skilltype==dsp.attackType.PHYSICAL) then
-        return 0;
+        return 0
     end
     -- handle pd
     if ((target:hasStatusEffect(dsp.effect.PERFECT_DODGE) or target:hasStatusEffect(dsp.effect.ALL_MISS) )
             and skilltype==dsp.attackType.PHYSICAL) then
-        return 0;
+        return 0
     end
-    
+
     -- Calculate Blood Pact Damage before stoneskin
     dmg = dmg + dmg * mob:getMod(dsp.mod.BP_DAMAGE) / 100
 
     -- handling stoneskin
-    skin = target:getMod(dsp.mod.STONESKIN);
+    skin = target:getMod(dsp.mod.STONESKIN)
     if (skin>0) then
         if (skin >= dmg) then --absorb all damage
-            target:delMod(dsp.mod.STONESKIN,dmg);
+            target:delMod(dsp.mod.STONESKIN,dmg)
             if (target:getMod(dsp.mod.STONESKIN)==0) then
-                target:delStatusEffect(dsp.effect.STONESKIN);
+                target:delStatusEffect(dsp.effect.STONESKIN)
             end
-            return 0;
+            return 0
         else -- absorbs some damage then wear
-            target:delMod(dsp.mod.STONESKIN,skin);
-            target:delStatusEffect(dsp.effect.STONESKIN);
-            return dmg - skin;
+            target:delMod(dsp.mod.STONESKIN,skin)
+            target:delStatusEffect(dsp.effect.STONESKIN)
+            return dmg - skin
         end
     end
 
-    return dmg;
-end;
+    return dmg
+end
 
 -- returns true if mob attack hit
 -- used to stop tp move status effects
 function AvatarPhysicalHit(skill, dmg)
     -- if message is not the default. Then there was a miss, shadow taken etc
-    return skill:getMsg() == dsp.msg.basic.DAMAGE;
-end;
+    return skill:getMsg() == dsp.msg.basic.DAMAGE
+end
 
 function avatarFTP(tp,ftp1,ftp2,ftp3)
     if (tp < 1000) then
-        tp = 1000;
+        tp = 1000
     end
     if (tp >= 1000 and tp < 2000) then
-        return ftp1 + ( ((ftp2-ftp1)/100) * (tp-1000));
+        return ftp1 + ( ((ftp2-ftp1)/100) * (tp-1000))
     elseif (tp >= 2000 and tp <= 3000) then
         -- generate a straight line between ftp2 and ftp3 and find point @ tp
-        return ftp2 + ( ((ftp3-ftp2)/100) * (tp-2000));
+        return ftp2 + ( ((ftp3-ftp2)/100) * (tp-2000))
     end
-    return 1; -- no ftp mod
-end;
+    return 1 -- no ftp mod
+end
 
 -- Checks if the summoner is in a Trial Size Avatar Mini Fight (used to restrict summoning while in bcnm)
 function avatarMiniFightCheck(caster)
-    local result = 0;
-    local bcnmid;
+    local result = 0
+    local bcnmid
     if (caster:hasStatusEffect(dsp.effect.BATTLEFIELD) == true) then
-        bcnmid = caster:getStatusEffect(dsp.effect.BATTLEFIELD):getPower();
+        bcnmid = caster:getStatusEffect(dsp.effect.BATTLEFIELD):getPower()
         if (bcnmid == 418 or bcnmid == 609 or bcnmid == 450 or bcnmid == 482 or bcnmid == 545 or bcnmid == 578) then -- Mini Avatar Fights
-            result = 40; -- Cannot use <spell> in this area.
+            result = 40 -- Cannot use <spell> in this area.
         end
     end
-      return result;
-end;
+      return result
+end

--- a/scripts/globals/summon.lua
+++ b/scripts/globals/summon.lua
@@ -3,9 +3,10 @@ require("scripts/globals/common")
 require("scripts/globals/status")
 require("scripts/globals/msg")
 
-function getSummoningSkillOverCap(summoner)
+function getSummoningSkillOverCap(avatar)
+    local summoner = avatar:getMaster()
     local summoningSkill = summoner:getSkillLevel(dsp.skill.SUMMONING_MAGIC)
-    local maxSkill = summoner:getMaxSkillLevel(summoner:getMainLvl(), dsp.job.SMN, dsp.skill.SUMMONING_MAGIC)
+    local maxSkill = summoner:getMaxSkillLevel(avatar:getMainLvl(), dsp.job.SMN, dsp.skill.SUMMONING_MAGIC)
     return math.max(summoningSkill - maxSkill, 0)
 end
 
@@ -13,7 +14,7 @@ function AvatarPhysicalMove(avatar,target,skill,numberofhits,accmod,dmgmod,dmgmo
 
     local returninfo = {}
 
-    local acc = avatar:getACC() + utils.clamp(getSummoningSkillOverCap(avatar:getMaster()), 0, 200)
+    local acc = avatar:getACC() + utils.clamp(getSummoningSkillOverCap(avatar), 0, 200)
     local eva = target:getEVA()
     local dmg = avatar:getWeaponDmg()
     local minFstr, maxFstr = avatarFSTR(avatar:getStat(dsp.mod.STR), target:getStat(dsp.mod.VIT))

--- a/scripts/globals/summon.lua
+++ b/scripts/globals/summon.lua
@@ -29,18 +29,18 @@ function AvatarPhysicalMove(avatar,target,skill,numberofhits,accmod,dmgmod,dmgmo
     critrate = utils.clamp(critrate, 0.05, 0.2);
 
     -- Applying pDIF
-    if (ratio <= 1) then
+    if ratio <= 1 then
         maxRatio = 1
         minRatio = 1/3
-    elseif (ratio < 1.6) then
-        maxRatio = ((2/3) * ratio) + (1/3)
-        minRatio = ((7/9) * ratio) - (4/9)
-    elseif (ratio <= 1.8) then
+    elseif ratio < 1.6 then
+        maxRatio = (2 * ratio + 1) / 3
+        minRatio = (7 * ratio - 4) / 9
+    elseif ratio <= 1.8 then
         maxRatio = 1.8
         minRatio = 1
-    elseif (ratio < 3.6) then
-        maxRatio = (2.4 * ratio) - 2.52
-        minRatio = ((5/3) * ratio) - 2
+    elseif ratio < 3.6 then
+        maxRatio = 2.4 * ratio - 2.52
+        minRatio = 5 * ratio / 3 - 2
     else
         maxRatio = 4.2
         minRatio = 4
@@ -52,14 +52,14 @@ function AvatarPhysicalMove(avatar,target,skill,numberofhits,accmod,dmgmod,dmgmo
     local hitdmg = 0
     local finaldmg = 0
 
-    if math.random() <= hitrate then
+    if math.random() < hitrate then
         hitdmg = avatarHitDmg(dmg, minRatio, maxRatio, minFstr, maxFstr, critrate)
         finaldmg = finaldmg + hitdmg * dmgmod
         hitslanded = hitslanded + 1
     end
 
     while hitsdone < numberofhits do
-        if math.random() <= hitrate then
+        if math.random() < hitrate then
             hitdmg = avatarHitDmg(dmg, minRatio, maxRatio, minFstr, maxFstr, critrate)
             finaldmg = finaldmg + hitdmg * dmgmodsubsequent
             hitslanded = hitslanded + 1
@@ -68,7 +68,7 @@ function AvatarPhysicalMove(avatar,target,skill,numberofhits,accmod,dmgmod,dmgmo
     end
 
     -- all hits missed
-    if (hitslanded == 0 or finaldmg == 0) then
+    if hitslanded == 0 or finaldmg == 0 then
         finaldmg = 0
         hitslanded = 0
         skill:setMsg(dsp.msg.basic.SKILL_MISS)
@@ -79,7 +79,7 @@ function AvatarPhysicalMove(avatar,target,skill,numberofhits,accmod,dmgmod,dmgmo
     end
 
     -- apply ftp bonus
-    if (tpeffect == TP_DMG_BONUS) then
+    if tpeffect == TP_DMG_BONUS then
         finaldmg = finaldmg * avatarFTP(skill:getTP(), mtp100, mtp200, mtp300)
     end
 
@@ -91,15 +91,15 @@ end
 
 -- minFstr = dSTR/4 + 0.5
 -- maxFstr = dSTR/4 + 0.25
-function avatarFSTR(str, def_vit)
-    local dSTR = atk_str - def_vit
-    return math.floor(dSTR/4 + 0.5), math.floor(dSTR/4 + 0.25)
+function avatarFSTR(att_str, def_vit)
+    local dSTR = att_str - def_vit
+    return math.floor(dSTR / 4 + 0.5), math.floor(dSTR / 4 + 0.25)
 end
 
 function avatarHitDmg(dmg, pdifMin, pdifMax, fstrMin, fstrMax, critrate)
     local fstr = math.random(fstrMin, fstrMax)
     local pdif = math.random(pdifMin * 1000, pdifMax * 1000) / 1000
-    if math.random() <= critrate then
+    if math.random() < critrate then
         pdif = math.min(pdif + 1, 4.2)
     end
     return (dmg + fstr) * pdif
@@ -108,7 +108,7 @@ end
 function AvatarFinalAdjustments(dmg,mob,skill,target,skilltype,skillparam,shadowbehav)
 
     -- physical attack missed, skip rest
-    if (skilltype == dsp.attackType.PHYSICAL and dmg == 0) then
+    if skilltype == dsp.attackType.PHYSICAL and dmg == 0 then
         return 0
     end
 
@@ -117,66 +117,66 @@ function AvatarFinalAdjustments(dmg,mob,skill,target,skilltype,skillparam,shadow
     skill:setMsg(dsp.msg.basic.DAMAGE)
 
     --Handle shadows depending on shadow behaviour / skilltype
-    if (shadowbehav < 5 and shadowbehav ~= MOBPARAM_IGNORE_SHADOWS) then --remove 'shadowbehav' shadows.
+    if shadowbehav < 5 and shadowbehav ~= MOBPARAM_IGNORE_SHADOWS then --remove 'shadowbehav' shadows.
         targShadows = target:getMod(dsp.mod.UTSUSEMI)
         shadowType = dsp.mod.UTSUSEMI
-        if (targShadows==0) then --try blink, as utsusemi always overwrites blink this is okay
+        if targShadows == 0 then --try blink, as utsusemi always overwrites blink this is okay
             targShadows = target:getMod(dsp.mod.BLINK)
             shadowType = dsp.mod.BLINK
         end
 
-        if (targShadows>0) then
+        if targShadows > 0 then
         -- Blink has a VERY high chance of blocking tp moves, so im assuming its 100% because its easier!
-            if (targShadows >= shadowbehav) then --no damage, just suck the shadows
+            if targShadows >= shadowbehav then --no damage, just suck the shadows
                 skill:setMsg(dsp.msg.basic.SHADOW_ABSORB)
-                target:setMod(shadowType,(targShadows-shadowbehav))
-                if (shadowType == dsp.mod.UTSUSEMI) then --update icon
+                target:setMod(shadowType, targShadows - shadowbehav)
+                if shadowType == dsp.mod.UTSUSEMI then --update icon
                     effect = target:getStatusEffect(dsp.effect.COPY_IMAGE)
-                    if (effect ~= nil) then
-                        if ((targShadows-shadowbehav) == 0) then
+                    if effect ~= nil then
+                        if targShadows - shadowbehav == 0 then
                             target:delStatusEffect(dsp.effect.COPY_IMAGE)
                             target:delStatusEffect(dsp.effect.BLINK)
-                        elseif ((targShadows-shadowbehav) == 1) then
+                        elseif targShadows - shadowbehav == 1 then
                             effect:setIcon(dsp.effect.COPY_IMAGE)
-                        elseif ((targShadows-shadowbehav) == 2) then
+                        elseif targShadows - shadowbehav == 2 then
                             effect:setIcon(dsp.effect.COPY_IMAGE_2)
-                        elseif ((targShadows-shadowbehav) == 3) then
+                        elseif targShadows - shadowbehav == 3 then
                             effect:setIcon(dsp.effect.COPY_IMAGE_3)
                         end
                     end
                 end
                 return shadowbehav
             else -- less shadows than this move will take, remove all and factor damage down
-                dmg = dmg * ((shadowbehav-targShadows)/shadowbehav)
-                target:setMod(dsp.mod.UTSUSEMI,0)
-                target:setMod(dsp.mod.BLINK,0)
+                dmg = dmg * (shadowbehav - targShadows) / shadowbehav
+                target:setMod(dsp.mod.UTSUSEMI, 0)
+                target:setMod(dsp.mod.BLINK, 0)
                 target:delStatusEffect(dsp.effect.COPY_IMAGE)
                 target:delStatusEffect(dsp.effect.BLINK)
             end
         end
-    elseif (shadowbehav == MOBPARAM_WIPE_SHADOWS) then --take em all!
-        target:setMod(dsp.mod.UTSUSEMI,0)
-        target:setMod(dsp.mod.BLINK,0)
+    elseif shadowbehav == MOBPARAM_WIPE_SHADOWS then --take em all!
+        target:setMod(dsp.mod.UTSUSEMI, 0)
+        target:setMod(dsp.mod.BLINK, 0)
         target:delStatusEffect(dsp.effect.COPY_IMAGE)
         target:delStatusEffect(dsp.effect.BLINK)
     end
 
     -- handle Third Eye using shadowbehav as a guide
     teye = target:getStatusEffect(dsp.effect.THIRD_EYE)
-    if (teye ~= nil and skilltype==dsp.attackType.PHYSICAL) then --T.Eye only procs when active with PHYSICAL stuff
-        if (shadowbehav == MOBPARAM_WIPE_SHADOWS) then --e.g. aoe moves
+    if teye ~= nil and skilltype == dsp.attackType.PHYSICAL then --T.Eye only procs when active with PHYSICAL stuff
+        if shadowbehav == MOBPARAM_WIPE_SHADOWS then --e.g. aoe moves
             target:delStatusEffect(dsp.effect.THIRD_EYE)
-        elseif (shadowbehav ~= MOBPARAM_IGNORE_SHADOWS) then --it can be absorbed by shadows
+        elseif shadowbehav ~= MOBPARAM_IGNORE_SHADOWS then --it can be absorbed by shadows
             --third eye doesnt care how many shadows, so attempt to anticipate, but reduce
             --chance of anticipate based on previous successful anticipates.
             prevAnt = teye:getPower()
-            if (prevAnt == 0) then
+            if prevAnt == 0 then
                 --100% proc
                 teye:setPower(1)
                 skill:setMsg(dsp.msg.basic.ANTICIPATE)
                 return 0
             end
-            if ( (math.random()*100) < (80-(prevAnt*10)) ) then
+            if math.random() * 10 < 8 - prevAnt then
                 --anticipated!
                 teye:setPower(prevAnt+1)
                 skill:setMsg(dsp.msg.basic.ANTICIPATE)
@@ -186,36 +186,32 @@ function AvatarFinalAdjustments(dmg,mob,skill,target,skilltype,skillparam,shadow
         end
     end
 
-
     --TODO: Handle anything else (e.g. if you have Magic Shield and its a Magic skill, then do 0 damage.
-
-
-    if (skilltype == dsp.attackType.PHYSICAL and target:hasStatusEffect(dsp.effect.PHYSICAL_SHIELD)) then
+    if skilltype == dsp.attackType.PHYSICAL and target:hasStatusEffect(dsp.effect.PHYSICAL_SHIELD) then
         return 0
     end
 
-    if (skilltype == dsp.attackType.RANGED and target:hasStatusEffect(dsp.effect.ARROW_SHIELD)) then
+    if skilltype == dsp.attackType.RANGED and target:hasStatusEffect(dsp.effect.ARROW_SHIELD) then
         return 0
     end
 
     -- handle elemental resistence
-    if (skilltype == dsp.attackType.MAGICAL and target:hasStatusEffect(dsp.effect.MAGIC_SHIELD)) then
+    if skilltype == dsp.attackType.MAGICAL and target:hasStatusEffect(dsp.effect.MAGIC_SHIELD) then
         return 0
     end
 
     -- handling phalanx
     dmg = dmg - target:getMod(dsp.mod.PHALANX)
-    if (dmg<0) then
+    if dmg < 0 then
         return 0
     end
 
     --handle invincible
-    if (target:hasStatusEffect(dsp.effect.INVINCIBLE) and skilltype==dsp.attackType.PHYSICAL) then
+    if target:hasStatusEffect(dsp.effect.INVINCIBLE) and skilltype == dsp.attackType.PHYSICAL then
         return 0
     end
     -- handle pd
-    if ((target:hasStatusEffect(dsp.effect.PERFECT_DODGE) or target:hasStatusEffect(dsp.effect.ALL_MISS) )
-            and skilltype==dsp.attackType.PHYSICAL) then
+    if target:hasStatusEffect(dsp.effect.PERFECT_DODGE) or target:hasStatusEffect(dsp.effect.ALL_MISS) and skilltype == dsp.attackType.PHYSICAL then
         return 0
     end
 
@@ -223,20 +219,7 @@ function AvatarFinalAdjustments(dmg,mob,skill,target,skilltype,skillparam,shadow
     dmg = dmg + dmg * mob:getMod(dsp.mod.BP_DAMAGE) / 100
 
     -- handling stoneskin
-    skin = target:getMod(dsp.mod.STONESKIN)
-    if (skin>0) then
-        if (skin >= dmg) then --absorb all damage
-            target:delMod(dsp.mod.STONESKIN,dmg)
-            if (target:getMod(dsp.mod.STONESKIN)==0) then
-                target:delStatusEffect(dsp.effect.STONESKIN)
-            end
-            return 0
-        else -- absorbs some damage then wear
-            target:delMod(dsp.mod.STONESKIN,skin)
-            target:delStatusEffect(dsp.effect.STONESKIN)
-            return dmg - skin
-        end
-    end
+    dmg = utils.stoneskin(target, dmg)
 
     return dmg
 end
@@ -249,14 +232,14 @@ function AvatarPhysicalHit(skill, dmg)
 end
 
 function avatarFTP(tp,ftp1,ftp2,ftp3)
-    if (tp < 1000) then
+    if tp < 1000 then
         tp = 1000
     end
-    if (tp >= 1000 and tp < 2000) then
-        return ftp1 + ( ((ftp2-ftp1)/100) * (tp-1000))
-    elseif (tp >= 2000 and tp <= 3000) then
+    if tp >= 1000 and tp < 2000 then
+        return ftp1 + (ftp2 - ftp1) / 100 * (tp - 1000)
+    elseif tp >= 2000 and tp <= 3000 then
         -- generate a straight line between ftp2 and ftp3 and find point @ tp
-        return ftp2 + ( ((ftp3-ftp2)/100) * (tp-2000))
+        return ftp2 + (ftp3 - ftp2) / 100 * (tp - 2000)
     end
     return 1 -- no ftp mod
 end
@@ -265,9 +248,9 @@ end
 function avatarMiniFightCheck(caster)
     local result = 0
     local bcnmid
-    if (caster:hasStatusEffect(dsp.effect.BATTLEFIELD) == true) then
+    if caster:hasStatusEffect(dsp.effect.BATTLEFIELD) then
         bcnmid = caster:getStatusEffect(dsp.effect.BATTLEFIELD):getPower()
-        if (bcnmid == 418 or bcnmid == 609 or bcnmid == 450 or bcnmid == 482 or bcnmid == 545 or bcnmid == 578) then -- Mini Avatar Fights
+        if bcnmid == 418 or bcnmid == 609 or bcnmid == 450 or bcnmid == 482 or bcnmid == 545 or bcnmid == 578 then -- Mini Avatar Fights
             result = 40 -- Cannot use <spell> in this area.
         end
     end

--- a/scripts/globals/utils.lua
+++ b/scripts/globals/utils.lua
@@ -25,6 +25,7 @@ function utils.clamp(input, min_val, max_val)
     return input;
 end;
 
+-- returns unabsorbed damage
 function utils.stoneskin(target, dmg)
     --handling stoneskin
     if (dmg > 0) then

--- a/sql/item_mods_pet.sql
+++ b/sql/item_mods_pet.sql
@@ -114,7 +114,7 @@ INSERT INTO `item_mods_pet` VALUES (13975,27,-2,1);     -- Evoker's Bracers Avat
 INSERT INTO `item_mods_pet` VALUES (14103,27,-2,1);     -- Evoker's Pigaches Avatar: Enmity -2
 INSERT INTO `item_mods_pet` VALUES (14103,68,5,1);      -- Avatar: Enhances evasion +5 (?)
 INSERT INTO `item_mods_pet` VALUES (14227,3,10,2);      -- Drachen Brais Wyvern: HP+10%
-INSERT INTO `item_mods_pet` VALUES (14228,25,10,1);     -- Evoker's Spats Avatar: Enhances accuracy +10 (?)
+INSERT INTO `item_mods_pet` VALUES (14228,25,14,1);     -- Evoker's Spats Avatar: Enhances accuracy +14
 INSERT INTO `item_mods_pet` VALUES (14228,27,-2,1);     -- Avatar: Enmity -2
 INSERT INTO `item_mods_pet` VALUES (14405,2,65,2);      -- Wyvern Mail Wyvern: HP+65
 INSERT INTO `item_mods_pet` VALUES (14405,72,65,2);     -- Wyvern: HP recovered while healing +1
@@ -135,7 +135,7 @@ INSERT INTO `item_mods_pet` VALUES (14958,63,5,0);      -- Beast Bazubands Pet: 
 INSERT INTO `item_mods_pet` VALUES (15031,384,300,3);    -- Pantin Dastanas Automaton: Haste +3%
 INSERT INTO `item_mods_pet` VALUES (15032,384,300,3);    -- Pantin Dastanas +1 Automaton: Haste +3%
 INSERT INTO `item_mods_pet` VALUES (15101,165,3,1);     -- Summoner's Dblt. Avatar: Critical Hit Rate +3%
-INSERT INTO `item_mods_pet` VALUES (15116,25,7,1);      -- Summoner's Brcr. Avatar: Enhances accuracy +7 (?)
+INSERT INTO `item_mods_pet` VALUES (15116,25,14,1);      -- Summoner's Brcr. Avatar: Enhances accuracy +14
 -- INSERT INTO `item_mods_pet` VALUES (15131,unimplemented,1,1); -- Summoner's Spats Avatar: Shortens magic recast time for spirits
 INSERT INTO `item_mods_pet` VALUES (15146,23,7,1);      -- Summoner's Pgch. Avatar: Enhances attack +7
 INSERT INTO `item_mods_pet` VALUES (15146,357,-2,1);    -- "Blood Pact" ability delay -2
@@ -230,7 +230,7 @@ INSERT INTO `item_mods_pet` VALUES (22063,126,40,1);    -- Nirvana 119 III Avata
 INSERT INTO `item_mods_pet` VALUES (23057,25,31,3);     -- Foire Taj +2 Automaton: Accuracy +31
 INSERT INTO `item_mods_pet` VALUES (23057,369,1,3);     -- Automaton: Refresh +1
 INSERT INTO `item_mods_pet` VALUES (23057,370,3,3);     -- Automaton: Regen +3
-INSERT INTO `item_mods_pet` VALUES (23057,384,600,3);   -- Automaton: Haste +6% 
+INSERT INTO `item_mods_pet` VALUES (23057,384,600,3);   -- Automaton: Haste +6%
 INSERT INTO `item_mods_pet` VALUES (23120,370,10,2);    -- Vishap Mail +2 Wyvern: "Regen"+10
 INSERT INTO `item_mods_pet` VALUES (23121,25,35,1);     -- Convoker's Doublet +2 Avatar: Accuracy+35
 INSERT INTO `item_mods_pet` VALUES (23121,30,35,1);     -- Magic Accuracy+35

--- a/sql/item_mods_pet.sql
+++ b/sql/item_mods_pet.sql
@@ -114,7 +114,7 @@ INSERT INTO `item_mods_pet` VALUES (13975,27,-2,1);     -- Evoker's Bracers Avat
 INSERT INTO `item_mods_pet` VALUES (14103,27,-2,1);     -- Evoker's Pigaches Avatar: Enmity -2
 INSERT INTO `item_mods_pet` VALUES (14103,68,5,1);      -- Avatar: Enhances evasion +5 (?)
 INSERT INTO `item_mods_pet` VALUES (14227,3,10,2);      -- Drachen Brais Wyvern: HP+10%
-INSERT INTO `item_mods_pet` VALUES (14228,25,14,1);     -- Evoker's Spats Avatar: Enhances accuracy +14
+INSERT INTO `item_mods_pet` VALUES (14228,25,10,1);     -- Evoker's Spats Avatar: Enhances accuracy +10
 INSERT INTO `item_mods_pet` VALUES (14228,27,-2,1);     -- Avatar: Enmity -2
 INSERT INTO `item_mods_pet` VALUES (14405,2,65,2);      -- Wyvern Mail Wyvern: HP+65
 INSERT INTO `item_mods_pet` VALUES (14405,72,65,2);     -- Wyvern: HP recovered while healing +1
@@ -135,7 +135,7 @@ INSERT INTO `item_mods_pet` VALUES (14958,63,5,0);      -- Beast Bazubands Pet: 
 INSERT INTO `item_mods_pet` VALUES (15031,384,300,3);    -- Pantin Dastanas Automaton: Haste +3%
 INSERT INTO `item_mods_pet` VALUES (15032,384,300,3);    -- Pantin Dastanas +1 Automaton: Haste +3%
 INSERT INTO `item_mods_pet` VALUES (15101,165,3,1);     -- Summoner's Dblt. Avatar: Critical Hit Rate +3%
-INSERT INTO `item_mods_pet` VALUES (15116,25,14,1);      -- Summoner's Brcr. Avatar: Enhances accuracy +14
+INSERT INTO `item_mods_pet` VALUES (15116,25,7,1);      -- Summoner's Brcr. Avatar: Enhances accuracy +7
 -- INSERT INTO `item_mods_pet` VALUES (15131,unimplemented,1,1); -- Summoner's Spats Avatar: Shortens magic recast time for spirits
 INSERT INTO `item_mods_pet` VALUES (15146,23,7,1);      -- Summoner's Pgch. Avatar: Enhances attack +7
 INSERT INTO `item_mods_pet` VALUES (15146,357,-2,1);    -- "Blood Pact" ability delay -2


### PR DESCRIPTION
A lot of the info out there quotes a forum post from allakazham that has since been deleted. The author was presumably kegsay and he wrote a lot of the same findings in his livejournal here: https://kegsay.livejournal.com/tag/smn!. This pr implements those findings more faithfully.

Specifically:

- removed lv diff calculation, does not apply https://kegsay.livejournal.com/5510.html
- removed fstr cap https://kegsay.livejournal.com/5510.html
- added fstr_min and fstr_max calculations https://kegsay.livejournal.com/5510.html
- allow crits on all hits of multi-hit blood pact
- updated M/S values on chaotic strike, crescent fang, eclipse bite https://kegsay.livejournal.com/4169.html
- updated accuracy bonus on evokers spats, summoners bracers to +14 https://kegsay.livejournal.com/4471.html

All of the above are found in Kegsay's posts except the crit change. The current code prevented crits on subsequent hits completely, and I couldn't find any justification for this, so I removed it.

Please note that wiki has information from Kegsay's research copy pasted out of context. Take for example this, found on this page: https://ffxiclopedia.fandom.com/wiki/Calculating_Blood_Pact_Damage

```
Celestial Avatars + Fenrir
BASE DAMAGE = (AVATARS LEVEL * 0.74) - MONSTER VIT/4

Carbuncle
BASE DAMAGE = (AVATARS LEVEL * 2/3) - MONSTER VIT/4
```

The original text reads:

```
For the sake of purpose, a few generalisations are going to be made in order to provide a rough estimation of how much base damage your avatar has:

Avatar base damage = (AVATAR LEVEL x 0.74) - (Monster VIT/4)
```

In other words, this wasn't a formula, but an estimate for testing purposes.