### PR TITLE
TransportTimer edits

### DIFF
--- a/scripts/zones/Kazham-Jeuno_Airship/IDs.lua
+++ b/scripts/zones/Kazham-Jeuno_Airship/IDs.lua
@@ -16,7 +16,7 @@ zones[dsp.zone.KAZHAM_JEUNO_AIRSHIP] =
         KEYITEM_OBTAINED        = 6391, -- Obtained key item: <keyitem>.
         WILL_REACH_JEUNO        = 7049, -- The airship will reach Jeuno in [less than an hour/about 1 hour/about 2 hours/about 3 hours/about 4 hours/about 5 hours/about 6 hours/about 7 hours] (# [minute/minutes] in Earth time).
         WILL_REACH_KAZHAM       = 7050, -- The airship will reach Kazham in [less than an hour/about 1 hour/about 2 hours/about 3 hours/about 4 hours/about 5 hours/about 6 hours/about 7 hours] (# [minute/minutes] in Earth time).
-        N_JEUNO_MOMENTARILY     = 7051, -- We will be arriving in Jeuno momentarily.
+        IN_JEUNO_MOMENTARILY     = 7051, -- We will be arriving in Jeuno momentarily.
         IN_KAZHAM_MOMENTARILY   = 7052, -- We will be arriving in Kazham momentarily.
     },
     mob =

--- a/scripts/zones/Kazham-Jeuno_Airship/npcs/Joosef.lua
+++ b/scripts/zones/Kazham-Jeuno_Airship/npcs/Joosef.lua
@@ -58,7 +58,7 @@ function onTrigger(player,npc)
         if ( message == ID.text.WILL_REACH_KAZHAM) then
             message = ID.text.IN_KAZHAM_MOMENTARILY;
         else -- ID.text.WILL_REACH_JEUNO
-            message = IN_JEUNO_MOMENTARILY;
+            message = ID.text.IN_JEUNO_MOMENTARILY;
         end
     elseif (vMinutes < 60) then
         vHour = 0;

--- a/scripts/zones/Port_Bastok/Zone.lua
+++ b/scripts/zones/Port_Bastok/Zone.lua
@@ -12,6 +12,7 @@ require("scripts/globals/zone")
 
 function onInitialize(zone)
     zone:registerRegion(1,-112,-3,-17,-96,3,-3);--event COP
+    zone:registerRegion(2, 53.5, 5, -165.3, 66.5, 6, -72)--drawbridge area
 end;
 
 function onConquestUpdate(zone, updatetype)

--- a/scripts/zones/Port_Bastok/npcs/_6kt.lua
+++ b/scripts/zones/Port_Bastok/npcs/_6kt.lua
@@ -12,16 +12,16 @@ function onSpawn(npc)
     bridge:updateToEntireZone(dsp.status.NORMAL, dsp.animation.OPEN_DOOR, true)
 
     --Events for when the airship arrives
-    npc:addPeriodicTrigger(0, 360, 4, 0, false)
-    npc:addPeriodicTrigger(1, 360, 8, 0, false)
+    npc:addPeriodicTrigger(0, 360, 4)
+    npc:addPeriodicTrigger(1, 360, 9)
     
     --Events for when the airship departs
-    npc:addPeriodicTrigger(2, 360, 80, 0, false)
-    npc:addPeriodicTrigger(3, 360, 84, 0, false)
+    npc:addPeriodicTrigger(2, 360, 80)
+    npc:addPeriodicTrigger(3, 360, 85)
 
     --Events for when the drawbridge has finished closing
-    npc:addPeriodicTrigger(4, 360, 12, 0, false)
-    npc:addPeriodicTrigger(5, 360, 88, 0, false)
+    npc:addPeriodicTrigger(4, 360, 13)
+    npc:addPeriodicTrigger(5, 360, 89)
 end;
 
 function onTimeTrigger(npc, triggerID)

--- a/scripts/zones/Port_Bastok/npcs/_6kt.lua
+++ b/scripts/zones/Port_Bastok/npcs/_6kt.lua
@@ -6,16 +6,57 @@ require("scripts/globals/status");
 -----------------------------------
 
 function onSpawn(npc)
+    local bridge = GetNPCByID(npc:getID() - 2)
+    local upperDoor = GetNPCByID(npc:getID() - 1)
 
-    local elevator =
-    {
-        id = dsp.elevator.PORT_BASTOK_DRWBRDG, -- id is usually 0, but 2 for port bastok drawbridge since it's special
-        lowerDoor = npc:getID(),           -- lowerDoor's npcid
-        upperDoor = npc:getID() - 1,       -- upperDoor usually has a smaller id than lowerDoor
-        elevator = npc:getID() - 2,        -- actual elevator npc's id is usually the smallest
-        started = 1,                       -- is the elevator already running
-        regime = 1                         --
-    };
+    bridge:updateToEntireZone(dsp.status.NORMAL, dsp.animation.OPEN_DOOR, true)
 
-    npc:setElevator(elevator.id, elevator.lowerDoor, elevator.upperDoor, elevator.elevator, elevator.started, elevator.regime);
+    --Events for when the airship arrives
+    npc:addPeriodicTrigger(0, 360, 4, 0, false)
+    npc:addPeriodicTrigger(1, 360, 8, 0, false)
+    
+    --Events for when the airship departs
+    npc:addPeriodicTrigger(2, 360, 80, 0, false)
+    npc:addPeriodicTrigger(3, 360, 84, 0, false)
+
+    --Events for when the drawbridge has finished closing
+    npc:addPeriodicTrigger(4, 360, 12, 0, false)
+    npc:addPeriodicTrigger(5, 360, 88, 0, false)
 end;
+
+function onTimeTrigger(npc, triggerID)
+--npc is the moghouse-side door to the bridge
+    local upperDoor = GetNPCByID(npc:getID() - 1)
+    local bridge = GetNPCByID(npc:getID() - 2)
+
+    if npc == nil or upperDoor == nil or bridge == nil then
+        error("Drawbridge NPC failure")
+        return
+    end
+
+    if (triggerID == 0 or triggerID == 2) then
+        --drawbridge needs to open        
+        local players = npc:getZone():getPlayers()
+
+        --If a player is on the bridge, kick them off
+        for _, player in pairs(players) do
+            if player:getPlayerRegionInZone() == 2 then
+                player:startEvent(70)
+            end
+        end
+        
+        bridge:updateToEntireZone(dsp.status.NORMAL, dsp.animation.CLOSE_DOOR, true)
+        upperDoor:setAnimation(dsp.animation.CLOSE_DOOR)
+        npc:setAnimation(dsp.animation.CLOSE_DOOR)
+
+    elseif (triggerID == 1 or triggerID == 3) then
+        --drawbridge needs to close
+        bridge:updateToEntireZone(dsp.status.NORMAL, dsp.animation.OPEN_DOOR, true)
+        
+    elseif (triggerID == 4 or triggerID == 5) then
+        --drawbridge has finished closing, reopen entry to walkers
+        upperDoor:setAnimation(dsp.animation.OPEN_DOOR)
+        npc:setAnimation(dsp.animation.OPEN_DOOR)
+    end
+
+end

--- a/src/map/lua/lua_baseentity.cpp
+++ b/src/map/lua/lua_baseentity.cpp
@@ -2006,17 +2006,11 @@ inline int32 CLuaBaseEntity::setElevator(lua_State *L)
 
 inline int32 CLuaBaseEntity::addPeriodicTrigger(lua_State *L)
 {
-    //Usage npc:addPeriodicTrigger( triggerID, minute offset, period, offset trigger, retroactive flag)
+    //Usage npc:addPeriodicTrigger( triggerID, minute offset, period )
+
     //triggerID is an ID unique to the NPC
-    //period is the time in vanadiel minutes that separates two triggers of this event
     //minute offset is the time in vanadiel minutes after the se epoch that the trigger period should synchronize to
-    //offset trigger is the time in vanadiel minutes from [0,period-1] that the trigger should activate
-    //NOTE: do not use a value too close to the period for the offset trigger (at least 3 less should be ok)
-    //retroactive flag is only used during initialization of the server.
-    //It denotes if the trigger should be activated when starting the server
-    //if the time offset is past the trigger offset.
-    //Example: the dock NPC in selbina should step out of the way of the ramp if the server
-    //starts with the boat docked. Her default position is standing in the way.
+    //period is the time in vanadiel minutes that separates two triggers of the event
 
     DSP_DEBUG_BREAK_IF(m_PBaseEntity == nullptr);
     DSP_DEBUG_BREAK_IF(m_PBaseEntity->objtype != TYPE_NPC);
@@ -2024,16 +2018,12 @@ inline int32 CLuaBaseEntity::addPeriodicTrigger(lua_State *L)
     DSP_DEBUG_BREAK_IF(lua_isnil(L, 1) || !lua_isnumber(L, 1)); 
     DSP_DEBUG_BREAK_IF(lua_isnil(L, 2) || !lua_isnumber(L, 2));
     DSP_DEBUG_BREAK_IF(lua_isnil(L, 3) || !lua_isnumber(L, 3));
-    DSP_DEBUG_BREAK_IF(lua_isnil(L, 4) || !lua_isnumber(L, 4));
-    DSP_DEBUG_BREAK_IF(lua_isnil(L, 5) || !lua_isboolean(L, 5));
     
     Trigger_t* trigger = new Trigger_t;
 
     trigger->id = (uint8)lua_tointeger(L, 1);
     trigger->period = (uint16)lua_tointeger(L, 2);
     trigger->minuteOffset = (uint16)lua_tointeger(L, 3);
-    trigger->triggerOffset = (uint16)lua_tointeger(L, 4);
-    trigger->retroactive = (bool)lua_toboolean(L, 5);
     trigger->npc = (CNpcEntity*)zoneutils::GetEntity((uint32)m_PBaseEntity->id, TYPE_NPC);
 
     if (!trigger->npc)

--- a/src/map/lua/lua_baseentity.cpp
+++ b/src/map/lua/lua_baseentity.cpp
@@ -52,6 +52,7 @@
 #include "../recast_container.h"
 #include "../spell.h"
 #include "../status_effect_container.h"
+#include "../timetriggers.h"
 #include "../trade_container.h"
 #include "../transport.h"
 #include "../treasure_pool.h"
@@ -1968,31 +1969,80 @@ inline int32 CLuaBaseEntity::setElevator(lua_State *L)
     DSP_DEBUG_BREAK_IF(lua_isnil(L, 3) || !lua_isnumber(L, 3));
     DSP_DEBUG_BREAK_IF(lua_isnil(L, 4) || !lua_isnumber(L, 3));
 
-    Elevator_t elevator;
+    Elevator_t* elevator = new Elevator_t;
 
     // ID should be 0 for most elevators, except special ones such as Port Bastok drawbridge
-    elevator.id = (uint8)lua_tointeger(L, 1);
-    elevator.LowerDoor = (CNpcEntity*)zoneutils::GetEntity((uint32)lua_tointeger(L, 2), TYPE_NPC);
-    elevator.UpperDoor = (CNpcEntity*)zoneutils::GetEntity((uint32)lua_tointeger(L, 3), TYPE_NPC);
-    elevator.Elevator = (CNpcEntity*)zoneutils::GetEntity((uint32)lua_tointeger(L, 4), TYPE_NPC);
+    elevator->id = (uint8)lua_tointeger(L, 1);
+    elevator->LowerDoor = (CNpcEntity*)zoneutils::GetEntity((uint32)lua_tointeger(L, 2), TYPE_NPC);
+    elevator->UpperDoor = (CNpcEntity*)zoneutils::GetEntity((uint32)lua_tointeger(L, 3), TYPE_NPC);
+    elevator->Elevator = (CNpcEntity*)zoneutils::GetEntity((uint32)lua_tointeger(L, 4), TYPE_NPC);
 
-    if (!elevator.Elevator)
+    if (!elevator->Elevator)
     {
         ShowWarning("Elevator id %d initialization failed - elevator ID resolved to no entity.", lua_tointeger(L, 4));
         return 0;
     }
 
-    elevator.isMoving = false;
-    elevator.isStarted = (!lua_isnil(L, 5) && lua_isnumber(L, 5)) ? (lua_tointeger(L, 5) != 0) : 0;
-    elevator.isPermanent = (!lua_isnil(L, 6) && lua_isnumber(L, 6)) ? (lua_tointeger(L, 6) != 0) : 0;
+    elevator->activated = (!lua_isnil(L, 5) && lua_isnumber(L, 5)) ? (lua_tointeger(L, 5) != 0) : 0;
+    elevator->isPermanent = (!lua_isnil(L, 6) && lua_isnumber(L, 6)) ? (lua_tointeger(L, 6) != 0) : 0;
 
-    elevator.movetime = ((elevator.UpperDoor == nullptr) || (elevator.LowerDoor == nullptr) ? 0 : 3);
-    elevator.interval = 8;// ((elevator.UpperDoor == nullptr) || (elevator.LowerDoor == nullptr) || (!elevator.isPermanent) ? 8 : 8);
+    elevator->movetime = 3;// ((elevator->UpperDoor == nullptr) || (elevator->LowerDoor == nullptr) ? 0 : 3);
+    elevator->interval = 8;// ((elevator.UpperDoor == nullptr) || (elevator.LowerDoor == nullptr) || (!elevator.isPermanent) ? 8 : 8);
 
-    elevator.zone = m_PBaseEntity->loc.zone->GetID();
+    elevator->zoneID = m_PBaseEntity->loc.zone->GetID();
 
-    elevator.Elevator->name.resize(10);
+    elevator->Elevator->name.resize(10);
     CTransportHandler::getInstance()->insertElevator(elevator);
+
+    return 0;
+}
+
+/************************************************************************
+*  Function: addPeriodicTrigger()
+*  Purpose : registers a periodic trigger for an NPC
+*  Example : BastokDrawbridge:addPeriodicTrigger(open at time x)
+*  Notes   : 
+************************************************************************/
+
+inline int32 CLuaBaseEntity::addPeriodicTrigger(lua_State *L)
+{
+    //Usage npc:addPeriodicTrigger( triggerID, minute offset, period, offset trigger, retroactive flag)
+    //triggerID is an ID unique to the NPC
+    //period is the time in vanadiel minutes that separates two triggers of this event
+    //minute offset is the time in vanadiel minutes after the se epoch that the trigger period should synchronize to
+    //offset trigger is the time in vanadiel minutes from [0,period-1] that the trigger should activate
+    //NOTE: do not use a value too close to the period for the offset trigger (at least 3 less should be ok)
+    //retroactive flag is only used during initialization of the server.
+    //It denotes if the trigger should be activated when starting the server
+    //if the time offset is past the trigger offset.
+    //Example: the dock NPC in selbina should step out of the way of the ramp if the server
+    //starts with the boat docked. Her default position is standing in the way.
+
+    DSP_DEBUG_BREAK_IF(m_PBaseEntity == nullptr);
+    DSP_DEBUG_BREAK_IF(m_PBaseEntity->objtype != TYPE_NPC);
+
+    DSP_DEBUG_BREAK_IF(lua_isnil(L, 1) || !lua_isnumber(L, 1)); 
+    DSP_DEBUG_BREAK_IF(lua_isnil(L, 2) || !lua_isnumber(L, 2));
+    DSP_DEBUG_BREAK_IF(lua_isnil(L, 3) || !lua_isnumber(L, 3));
+    DSP_DEBUG_BREAK_IF(lua_isnil(L, 4) || !lua_isnumber(L, 4));
+    DSP_DEBUG_BREAK_IF(lua_isnil(L, 5) || !lua_isboolean(L, 5));
+    
+    Trigger_t* trigger = new Trigger_t;
+
+    trigger->id = (uint8)lua_tointeger(L, 1);
+    trigger->period = (uint16)lua_tointeger(L, 2);
+    trigger->minuteOffset = (uint16)lua_tointeger(L, 3);
+    trigger->triggerOffset = (uint16)lua_tointeger(L, 4);
+    trigger->retroactive = (bool)lua_toboolean(L, 5);
+    trigger->npc = (CNpcEntity*)zoneutils::GetEntity((uint32)m_PBaseEntity->id, TYPE_NPC);
+
+    if (!trigger->npc)
+    {
+        ShowWarning("Trigger initialization failed - npc ID %d resolved to no entity.", m_PBaseEntity->id);
+        return 0;
+    }
+
+    CTriggerHandler::getInstance()->insertTrigger(trigger);
 
     return 0;
 }
@@ -2532,7 +2582,50 @@ inline int32 CLuaBaseEntity::isInMogHouse(lua_State* L)
     lua_pushboolean(L, ((CCharEntity*)m_PBaseEntity)->m_moghouseID);
     return 1;
 }
+/************************************************************************
+*  Function: getPlayerRegionInZone
+*  Purpose : Returns the player's current region inside the zone
+*  Example : local regionID = player:getPlayerRegionInZone()
+*  Notes   : This refers to regions added via the registerRegion function
+             Currently only used for port bastok drawbridge
+************************************************************************/
+inline int32 CLuaBaseEntity::getPlayerRegionInZone(lua_State* L)
+{
+    DSP_DEBUG_BREAK_IF(m_PBaseEntity == nullptr);
+    DSP_DEBUG_BREAK_IF(m_PBaseEntity->objtype != TYPE_PC);
 
+    CCharEntity* PChar = (CCharEntity*)m_PBaseEntity;
+    lua_pushinteger(L, PChar->m_InsideRegionID);
+    return 1;
+}
+/************************************************************************
+*  Function: updateToEntireZone
+*  Purpose : Updates an NPC zone-wide, immediately.
+*  Example : drawBridge:updateToEntireZone
+*  Notes   : Currently only used for port bastok drawbridge
+************************************************************************/
+inline int32 CLuaBaseEntity::updateToEntireZone(lua_State* L)
+{
+    DSP_DEBUG_BREAK_IF(m_PBaseEntity == nullptr);
+    DSP_DEBUG_BREAK_IF(m_PBaseEntity->objtype != TYPE_NPC);
+
+    DSP_DEBUG_BREAK_IF(lua_isnil(L, 1) || !lua_isnumber(L, 1));
+    DSP_DEBUG_BREAK_IF(lua_isnil(L, 2) || !lua_isnumber(L, 2));
+
+    CNpcEntity* PNpc = (CNpcEntity*)m_PBaseEntity;
+    PNpc->status = (STATUSTYPE)lua_tointeger(L, 1);
+    PNpc->animation = (UINT8)lua_tointeger(L,2);
+
+    if (!lua_isnil(L, 3) && (bool)lua_toboolean(L, 3) == true)
+    {
+        PNpc->name.resize(10);
+        ref<uint32>(&PNpc->name[0], 4) = CVanaTime::getInstance()->getVanaTime();
+        PNpc->name[8] = 8;
+    }
+
+    PNpc->loc.zone->PushPacket(nullptr, CHAR_INZONE, new CEntityUpdatePacket(PNpc, ENTITY_UPDATE, UPDATE_COMBAT));
+    return 1;
+}
 /************************************************************************
 *  Function: getPos()
 *  Purpose : Returns a table of signed coordinates (x,y,z,rot)
@@ -14067,6 +14160,7 @@ Lunar<CLuaBaseEntity>::Register_t CLuaBaseEntity::methods[] =
     LUNAR_DECLARE_METHOD(CLuaBaseEntity,closeDoor),
     LUNAR_DECLARE_METHOD(CLuaBaseEntity,setElevator),
 
+    LUNAR_DECLARE_METHOD(CLuaBaseEntity,addPeriodicTrigger),
     LUNAR_DECLARE_METHOD(CLuaBaseEntity,showNPC),
     LUNAR_DECLARE_METHOD(CLuaBaseEntity,hideNPC),
     LUNAR_DECLARE_METHOD(CLuaBaseEntity,updateNPCHideTime),
@@ -14641,6 +14735,8 @@ Lunar<CLuaBaseEntity>::Register_t CLuaBaseEntity::methods[] =
     LUNAR_DECLARE_METHOD(CLuaBaseEntity,getDespoilDebuff),
     LUNAR_DECLARE_METHOD(CLuaBaseEntity,itemStolen),
     LUNAR_DECLARE_METHOD(CLuaBaseEntity,getTHlevel),
+    LUNAR_DECLARE_METHOD(CLuaBaseEntity,getPlayerRegionInZone),
+    LUNAR_DECLARE_METHOD(CLuaBaseEntity,updateToEntireZone),
 
     {nullptr,nullptr}
 };

--- a/src/map/lua/lua_baseentity.h
+++ b/src/map/lua/lua_baseentity.h
@@ -125,6 +125,7 @@ public:
     int32 closeDoor(lua_State*);             // npc.closeDoor(timeToStayClosed)
     int32 setElevator(lua_State* L);
 
+    int32 addPeriodicTrigger(lua_State* L);  // Adds a periodic trigger to the NPC that allows time based scripting
     int32 showNPC(lua_State*);               // Show an NPC
     int32 hideNPC(lua_State*);               // hide an NPC
     int32 updateNPCHideTime(lua_State*);     // Updates the length of time a NPC remains hidden, if shorter than the original hide time.
@@ -153,6 +154,9 @@ public:
     int32 getCurrentRegion(lua_State*);      // Get Entity conquest region
     int32 getContinentID(lua_State*);        // узнаем континент, на котором находится сущность
     int32 isInMogHouse(lua_State*);          // Check if entity inside a mog house
+
+    int32 getPlayerRegionInZone(lua_State*); // Returns the player's current region in the zone. (regions made with registerRegion)
+    int32 updateToEntireZone(lua_State*);    // Forces an update packet to update the NPC entity zone-wide
 
     int32 getPos(lua_State*);                // Get Entity position (x,y,z)
     int32 showPosition(lua_State*);          // Display current position of character

--- a/src/map/lua/luautils.cpp
+++ b/src/map/lua/luautils.cpp
@@ -53,6 +53,7 @@
 #include "../weapon_skill.h"
 #include "../vana_time.h"
 #include "../utils/zoneutils.h"
+#include "../timetriggers.h"
 #include "../transport.h"
 #include "../packets/action.h"
 #include "../packets/char_update.h"
@@ -3677,6 +3678,30 @@ namespace luautils
         if (lua_pcall(LuaHandle, 2, 0, 0))
         {
             ShowError("luautils::onTransportEvent: %s\n", lua_tostring(LuaHandle, -1));
+            lua_pop(LuaHandle, 1);
+            return -1;
+        }
+
+        return 0;
+    }
+
+    int32 OnTimeTrigger(CNpcEntity* PNpc, uint8 triggerID)
+    {
+        lua_prepscript("scripts/zones/%s/npcs/%s.lua", PNpc->loc.zone->GetName(), PNpc->GetName());
+
+        if (prepFile(File, "onTimeTrigger"))
+        {
+            return -1;
+        }
+
+        CLuaBaseEntity LuaBaseEntity(PNpc);
+        Lunar<CLuaBaseEntity>::push(LuaHandle, &LuaBaseEntity);
+
+        lua_pushinteger(LuaHandle, triggerID);
+
+        if (lua_pcall(LuaHandle, 2, 0, 0))
+        {
+            ShowError("luautils::onTimeTrigger: %s\n", lua_tostring(LuaHandle, -1));
             lua_pop(LuaHandle, 1);
             return -1;
         }

--- a/src/map/lua/luautils.h
+++ b/src/map/lua/luautils.h
@@ -186,6 +186,7 @@ namespace luautils
     int32 OnRegionEnter(CCharEntity* PChar, CRegion* PRegion);                  // when player enters a region of a zone
     int32 OnRegionLeave(CCharEntity* PChar, CRegion* Pregion);                  // when player leaves a region of a zone
     int32 OnTransportEvent(CCharEntity* PChar, uint32 TransportID);
+    int32 OnTimeTrigger(CNpcEntity* PNpc, uint8 triggerID);
     int32 OnConquestUpdate(CZone* PZone, ConquestUpdate type);                  // hourly conquest update
 
     int32 OnTrigger(CCharEntity* PChar, CBaseEntity* PNpc);                     // triggered when user targets npc and clicks action button

--- a/src/map/time_server.cpp
+++ b/src/map/time_server.cpp
@@ -26,6 +26,7 @@
 #include "utils/guildutils.h"
 #include "utils/instanceutils.h"
 #include "time_server.h"
+#include "timetriggers.h"
 #include "transport.h"
 #include "vana_time.h"
 #include "utils/zoneutils.h"
@@ -125,7 +126,9 @@ int32 time_server(time_point tick,CTaskMgr::CTask* PTask)
         }
     }
 
+    CTriggerHandler::getInstance()->triggerTimer();
     CTransportHandler::getInstance()->TransportTimer();
+    
 	instanceutils::CheckInstance();
     return 0;
 }

--- a/src/map/timetriggers.cpp
+++ b/src/map/timetriggers.cpp
@@ -42,7 +42,6 @@ CTriggerHandler::CTriggerHandler()
 
 void CTriggerHandler::insertTrigger(Trigger_t* trigger)
 {
-    trigger->state = STATE_TRIGGER_FIRED;
     trigger->lastTrigger = (uint32)trunc((CVanaTime::getInstance()->getDate() - trigger->minuteOffset) / trigger->period);
     triggerList.push_back(trigger);
 }
@@ -50,7 +49,6 @@ void CTriggerHandler::insertTrigger(Trigger_t* trigger)
 void CTriggerHandler::triggerTimer()
 {
     uint32 vanaTime = CVanaTime::getInstance()->getDate();
-    uint32 timeOffset = 0;
     uint32 timeCount = 0;
     Trigger_t* trigger = nullptr;
 
@@ -59,33 +57,11 @@ void CTriggerHandler::triggerTimer()
         trigger = triggerList.at(i);
 
         timeCount = (uint32)trunc((vanaTime - trigger->minuteOffset) / trigger->period);
-        timeOffset = (vanaTime - trigger->minuteOffset) % trigger->period;
-        //printf(" %d ", timeOffset);
 
-        if (trigger->state == STATE_TRIGGER_LOADED)
+        if (timeCount > trigger->lastTrigger)
         {
-            if (timeOffset >= trigger->triggerOffset)
-            {
-                trigger->state = STATE_TRIGGER_FIRED;
-                trigger->lastTrigger = timeCount;
-                luautils::OnTimeTrigger(trigger->npc, trigger->id);
-            }
-        }
-        else if (trigger->state == STATE_TRIGGER_FIRED)
-        {
-            if (timeCount > trigger->lastTrigger)
-            {
-                trigger->state = STATE_TRIGGER_LOADED;
-
-                //This is needed for triggers that start with offsets close to 0
-                if (timeOffset >= trigger->triggerOffset)
-                {
-                    trigger->state = STATE_TRIGGER_FIRED;
-                    trigger->lastTrigger = timeCount;
-                    luautils::OnTimeTrigger(trigger->npc, trigger->id);
-                }
-            }
-
+            luautils::OnTimeTrigger(trigger->npc, trigger->id);
+            trigger->lastTrigger = timeCount;
         }
     }
 }

--- a/src/map/timetriggers.cpp
+++ b/src/map/timetriggers.cpp
@@ -1,0 +1,91 @@
+/*
+===========================================================================
+
+  Copyright (c) 2010-2015 Darkstar Dev Teams
+
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program.  If not, see http://www.gnu.org/licenses/
+
+  This file is part of DarkStar-server source code.
+
+===========================================================================
+*/
+
+#include "timetriggers.h"
+#include "vana_time.h"
+#include "lua/luautils.h"
+
+CTriggerHandler* CTriggerHandler::_instance = nullptr;
+
+CTriggerHandler* CTriggerHandler::getInstance()
+{
+    if (_instance == nullptr) {
+        _instance = new CTriggerHandler();
+    }
+    return _instance;
+}
+
+CTriggerHandler::CTriggerHandler()
+{
+
+}
+
+void CTriggerHandler::insertTrigger(Trigger_t* trigger)
+{
+    trigger->state = STATE_TRIGGER_FIRED;
+    trigger->lastTrigger = (uint32)trunc((CVanaTime::getInstance()->getDate() - trigger->minuteOffset) / trigger->period);
+    triggerList.push_back(trigger);
+}
+
+void CTriggerHandler::triggerTimer()
+{
+    uint32 vanaTime = CVanaTime::getInstance()->getDate();
+    uint32 timeOffset = 0;
+    uint32 timeCount = 0;
+    Trigger_t* trigger = nullptr;
+
+    for (uint32 i = 0; i < triggerList.size(); ++i)
+    {
+        trigger = triggerList.at(i);
+
+        timeCount = (uint32)trunc((vanaTime - trigger->minuteOffset) / trigger->period);
+        timeOffset = (vanaTime - trigger->minuteOffset) % trigger->period;
+        //printf(" %d ", timeOffset);
+
+        if (trigger->state == STATE_TRIGGER_LOADED)
+        {
+            if (timeOffset >= trigger->triggerOffset)
+            {
+                trigger->state = STATE_TRIGGER_FIRED;
+                trigger->lastTrigger = timeCount;
+                luautils::OnTimeTrigger(trigger->npc, trigger->id);
+            }
+        }
+        else if (trigger->state == STATE_TRIGGER_FIRED)
+        {
+            if (timeCount > trigger->lastTrigger)
+            {
+                trigger->state = STATE_TRIGGER_LOADED;
+
+                //This is needed for triggers that start with offsets close to 0
+                if (timeOffset >= trigger->triggerOffset)
+                {
+                    trigger->state = STATE_TRIGGER_FIRED;
+                    trigger->lastTrigger = timeCount;
+                    luautils::OnTimeTrigger(trigger->npc, trigger->id);
+                }
+            }
+
+        }
+    }
+}

--- a/src/map/timetriggers.h
+++ b/src/map/timetriggers.h
@@ -28,25 +28,16 @@
 #include <vector>
 #include "entities/npcentity.h"
 
-enum TRIGGERSTATE
-{
-    STATE_TRIGGER_LOADED = 0,
-    STATE_TRIGGER_FIRED
-};
 struct Trigger_t
 {
     uint8 id;
-    uint8 state;
 
     CNpcEntity* npc;
 
     uint16 period;                  //The time 
     uint16 minuteOffset;
-    uint16 triggerOffset;
 
     uint32 lastTrigger;             //Used to store the last firing of the trigger
-
-    bool retroactive;
 };
 
 class CTriggerHandler

--- a/src/map/timetriggers.h
+++ b/src/map/timetriggers.h
@@ -1,0 +1,67 @@
+/*
+===========================================================================
+
+  Copyright (c) 2010-2015 Darkstar Dev Teams
+
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program.  If not, see http://www.gnu.org/licenses/
+
+  This file is part of DarkStar-server source code.
+
+===========================================================================
+*/
+
+#ifndef _CTIMETRIGGERS_H
+#define _CTIMETRIGGERS_H
+
+#include "../common/cbasetypes.h"
+#include <vector>
+#include "entities/npcentity.h"
+
+enum TRIGGERSTATE
+{
+    STATE_TRIGGER_LOADED = 0,
+    STATE_TRIGGER_FIRED
+};
+struct Trigger_t
+{
+    uint8 id;
+    uint8 state;
+
+    CNpcEntity* npc;
+
+    uint16 period;                  //The time 
+    uint16 minuteOffset;
+    uint16 triggerOffset;
+
+    uint32 lastTrigger;             //Used to store the last firing of the trigger
+
+    bool retroactive;
+};
+
+class CTriggerHandler
+{
+public:
+    static	CTriggerHandler * getInstance();
+    
+    void insertTrigger(Trigger_t*);
+    void triggerTimer();
+private:
+
+    static CTriggerHandler * _instance;
+
+    CTriggerHandler();
+
+    std::vector<Trigger_t*> triggerList;
+};
+#endif

--- a/src/map/transport.cpp
+++ b/src/map/transport.cpp
@@ -28,9 +28,10 @@
 #include "vana_time.h"
 #include "zone.h"
 #include "utils/zoneutils.h"
-
+#include "../common/timer.h"
 #include "packets/event.h"
 #include "packets/entity_update.h"
+#include <cstdlib>
 
 /************************************************************************
 *                                                                       *
@@ -40,23 +41,79 @@
 
 CTransportHandler* CTransportHandler::_instance = nullptr;
 
-CTransportHandler* CTransportHandler::getInstance() 
+CTransportHandler* CTransportHandler::getInstance()
 {
-	if(_instance == nullptr) {
-		_instance = new CTransportHandler();
-	}
-	return _instance;
+    if (_instance == nullptr) {
+        _instance = new CTransportHandler();
+    }
+    return _instance;
 }
 
-/************************************************************************
-*                                                                       *
-*  В конструкторе инициализируем всю транспортную систему               *
-*                                                                       *
-************************************************************************/
-
-CTransportHandler::CTransportHandler() 
+CTransportHandler::CTransportHandler()
 {
 
+}
+void Transport_Ship::setVisible(bool visible)
+{
+    if (visible)
+        this->npc->status = STATUS_NORMAL;
+    else
+        this->npc->status = STATUS_DISAPPEAR;
+}
+
+void Transport_Ship::animateSetup(uint8 animationID, uint32 horizonTime)
+{
+    this->npc->animation = animationID;
+    this->setName(horizonTime);
+}
+
+void Transport_Ship::spawn()
+{
+    this->npc->loc = this->dock;
+    this->setVisible(true);
+}
+
+void Transport_Ship::setName(uint32 value)
+{
+    ref<uint32>(&this->npc->name[0], 4) = value;
+}
+
+void TransportZone_Town::updateShip()
+{
+    this->ship.dock.zone->PushPacket(nullptr, CHAR_INZONE, new CEntityUpdatePacket(this->ship.npc, ENTITY_UPDATE, UPDATE_COMBAT));
+}
+
+void TransportZone_Town::openDoor(bool sendPacket)
+{
+    this->npcDoor->animation = ANIMATION_OPEN_DOOR;
+
+    if (sendPacket)
+        this->ship.dock.zone->PushPacket(this->npcDoor, CHAR_INRANGE, new CEntityUpdatePacket(this->npcDoor, ENTITY_UPDATE, UPDATE_COMBAT));
+}
+
+void TransportZone_Town::closeDoor(bool sendPacket)
+{
+    this->npcDoor->animation = ANIMATION_CLOSE_DOOR;
+
+    if (sendPacket)
+        this->ship.dock.zone->PushPacket(this->npcDoor, CHAR_INRANGE, new CEntityUpdatePacket(this->npcDoor, ENTITY_UPDATE, UPDATE_COMBAT));
+}
+
+void TransportZone_Town::depart()
+{
+    this->ship.dock.zone->TransportDepart(this->ship.npc->loc.boundary, this->ship.npc->loc.prevzone);
+}
+
+void Elevator_t::openDoor(CNpcEntity* npc)
+{
+    npc->animation = ANIMATION_OPEN_DOOR;
+    zoneutils::GetZone(this->zoneID)->PushPacket(npc, CHAR_INRANGE, new CEntityUpdatePacket(npc, ENTITY_SPAWN, UPDATE_ALL_MOB));
+}
+
+void Elevator_t::closeDoor(CNpcEntity* npc)
+{
+    npc->animation = ANIMATION_CLOSE_DOOR;
+    zoneutils::GetZone(this->zoneID)->PushPacket(npc, CHAR_INRANGE, new CEntityUpdatePacket(npc, ENTITY_SPAWN, UPDATE_ALL_MOB));
 }
 
 /************************************************************************
@@ -67,7 +124,7 @@ CTransportHandler::CTransportHandler()
 
 void CTransportHandler::InitializeTransport()
 {
-    DSP_DEBUG_BREAK_IF(TransportList.size() != 0);
+    DSP_DEBUG_BREAK_IF(townZoneList.size() != 0);
 
     const char* fmtQuery = "SELECT id, transport, door, dock_x, dock_y, dock_z, dock_rot, \
                             boundary, zone, anim_arrive, anim_depart, time_offset, time_interval, \
@@ -77,57 +134,63 @@ void CTransportHandler::InitializeTransport()
 
     int32 ret = Sql_Query(SqlHandle, fmtQuery, map_ip.s_addr, inet_ntoa(map_ip), map_port);
 
-	if (ret != SQL_ERROR && Sql_NumRows(SqlHandle) != 0)
-	{
-		while(Sql_NextRow(SqlHandle) == SQL_SUCCESS) 
-		{
-            Transport_t* PTransport = new Transport_t;
+    if (ret != SQL_ERROR && Sql_NumRows(SqlHandle) != 0)
+    {
+        while (Sql_NextRow(SqlHandle) == SQL_SUCCESS)
+        {
+            TransportZone_Town* zoneTown = new TransportZone_Town;
 
-            PTransport->Dock.zone = zoneutils::GetZone((Sql_GetUIntData(SqlHandle,1) >> 12) & 0x0FFF);
-            PTransport->Dock.p.x  = Sql_GetFloatData(SqlHandle,3);
-            PTransport->Dock.p.y  = Sql_GetFloatData(SqlHandle,4);
-            PTransport->Dock.p.z  = Sql_GetFloatData(SqlHandle,5);
-            PTransport->Dock.p.rotation = (uint8) Sql_GetIntData(SqlHandle,6);
-            PTransport->Dock.boundary   = (uint16)Sql_GetIntData(SqlHandle,7);
-            PTransport->Dock.prevzone   = (uint8) Sql_GetIntData(SqlHandle,8);
+            zoneTown->ship.dock.zone = zoneutils::GetZone((Sql_GetUIntData(SqlHandle, 1) >> 12) & 0x0FFF);
 
-            PTransport->PDoorNPC      = zoneutils::GetEntity(Sql_GetUIntData(SqlHandle,2), TYPE_NPC);
-            PTransport->PTransportNPC = zoneutils::GetEntity(Sql_GetUIntData(SqlHandle,1), TYPE_SHIP);
+            zoneTown->ship.dock.p.x = Sql_GetFloatData(SqlHandle, 3);
+            zoneTown->ship.dock.p.y = Sql_GetFloatData(SqlHandle, 4);
+            zoneTown->ship.dock.p.z = Sql_GetFloatData(SqlHandle, 5);
+            zoneTown->ship.dock.p.rotation = (uint8)Sql_GetIntData(SqlHandle, 6);
+            zoneTown->ship.dock.boundary = (uint16)Sql_GetIntData(SqlHandle, 7);
+            zoneTown->ship.dock.prevzone = (uint8)Sql_GetIntData(SqlHandle, 8);
 
-            PTransport->AnimationArrive = (uint8)Sql_GetIntData(SqlHandle, 9);
-            PTransport->AnimationDepart = (uint8)Sql_GetIntData(SqlHandle,10);
+            zoneTown->npcDoor = zoneutils::GetEntity(Sql_GetUIntData(SqlHandle, 2), TYPE_NPC);
+            zoneTown->ship.npc = zoneutils::GetEntity(Sql_GetUIntData(SqlHandle, 1), TYPE_SHIP);
+            zoneTown->ship.npc->name.resize(8);
 
-            PTransport->TimeOffset   = (uint16)Sql_GetIntData(SqlHandle,11);
-            PTransport->TimeInterval = (uint16)Sql_GetIntData(SqlHandle,12);
-            PTransport->TimeWaiting  = (uint16)Sql_GetIntData(SqlHandle,13);
-            PTransport->TimeAnimationArrive = (uint16)Sql_GetIntData(SqlHandle,14);
-            PTransport->TimeAnimationDepart = (uint16)Sql_GetIntData(SqlHandle,15);
+            zoneTown->ship.animationArrive = (uint8)Sql_GetIntData(SqlHandle, 9);
+            zoneTown->ship.animationDepart = (uint8)Sql_GetIntData(SqlHandle, 10);
 
-            if (PTransport->PDoorNPC == nullptr ||
-                PTransport->PTransportNPC == nullptr)
+            zoneTown->ship.timeOffset = (uint16)Sql_GetIntData(SqlHandle, 11);
+            zoneTown->ship.timeInterval = (uint16)Sql_GetIntData(SqlHandle, 12);
+            zoneTown->ship.timeArriveDock = (uint16)Sql_GetIntData(SqlHandle, 14);
+            zoneTown->ship.timeDepartDock = zoneTown->ship.timeArriveDock + (uint16)Sql_GetIntData(SqlHandle, 13);
+            zoneTown->ship.timeVoyageStart = zoneTown->ship.timeDepartDock + (uint16)Sql_GetIntData(SqlHandle, 15) - 1;
+            
+
+            zoneTown->ship.state = STATE_TRANSPORT_INIT;
+            zoneTown->ship.setVisible(false);
+            zoneTown->closeDoor(false);
+
+            if (zoneTown->npcDoor == nullptr || zoneTown->ship.npc == nullptr)
             {
-                ShowError("Transport <%u>: transport or door not found\n", (uint8)Sql_GetIntData(SqlHandle,0));
-                delete PTransport;
+                ShowError("Transport <%u>: transport or door not found\n", (uint8)Sql_GetIntData(SqlHandle, 0));
+                delete zoneTown;
                 continue;
             }
-            if (PTransport->TimeAnimationArrive < 10)
+            if (zoneTown->ship.timeArriveDock < 10)
             {
-                ShowError("Transport <%u>: time_anim_arrive must be > 10\n", (uint8)Sql_GetIntData(SqlHandle,0));
-                delete PTransport;
+                ShowError("Transport <%u>: time_anim_arrive must be > 10\n", (uint8)Sql_GetIntData(SqlHandle, 0));
+                delete zoneTown;
                 continue;
             }
-            if (PTransport->TimeInterval < PTransport->TimeAnimationArrive + PTransport->TimeWaiting + PTransport->TimeAnimationDepart)
+            if (zoneTown->ship.timeInterval < zoneTown->ship.timeVoyageStart)
             {
-                ShowError("Transport <%u>: time_interval must be > time_anim_arrive + time_waiting + time_anim_depart\n", (uint8)Sql_GetIntData(SqlHandle,0));
-                delete PTransport;
+                ShowError("Transport <%u>: time_interval must be > time_anim_arrive + time_waiting + time_anim_depart\n", (uint8)Sql_GetIntData(SqlHandle, 0));
+                delete zoneTown;
                 continue;
             }
-            PTransport->PTransportNPC->name.resize(8);
-            TransportList.push_back(PTransport);
+            
+            townZoneList.push_back(zoneTown);
         }
     }
 
-    fmtQuery = "SELECT zone, time_offset, time_interval, time_anim_arrive \
+    fmtQuery = "SELECT zone, time_offset, time_interval, time_waiting, time_anim_arrive, time_anim_depart \
                 FROM transport LEFT JOIN \
                 zone_settings ON zone = zoneid WHERE \
                 IF(%d <> 0, '%s' = zoneip AND %d = zoneport, TRUE)";
@@ -139,205 +202,276 @@ void CTransportHandler::InitializeTransport()
         while (Sql_NextRow(SqlHandle) == SQL_SUCCESS)
         {
 
-            TransportZone_t TransportZone;
+            TransportZone_Voyage* voyageZone = new TransportZone_Voyage;
 
-            TransportZone.zone = (uint8)Sql_GetIntData(SqlHandle, 0);
-            TransportZone.TimeOffset = (uint16)Sql_GetIntData(SqlHandle, 1);
-            TransportZone.TimeInterval = (uint16)Sql_GetIntData(SqlHandle, 2);
-            TransportZone.TimeAnimationArrive = (uint16)Sql_GetIntData(SqlHandle, 3);
+            voyageZone->voyageZone = nullptr;
+            voyageZone->voyageZone = zoneutils::GetZone((uint8)Sql_GetUIntData(SqlHandle, 0));
 
-            TransportZoneList.push_back(TransportZone);
+            if (voyageZone->voyageZone != nullptr && voyageZone->voyageZone->GetID() > 0)
+            {
+                voyageZone->timeOffset = (uint16)Sql_GetIntData(SqlHandle, 1);
+                voyageZone->timeInterval = (uint16)Sql_GetIntData(SqlHandle, 2);
+
+                voyageZone->timeArriveDock = (uint16)Sql_GetIntData(SqlHandle, 4);
+                voyageZone->timeDepartDock = voyageZone->timeArriveDock + (uint16)Sql_GetIntData(SqlHandle, 3);
+                voyageZone->timeVoyageStart = voyageZone->timeDepartDock + (uint16)Sql_GetIntData(SqlHandle, 5);
+
+                voyageZone->state = STATE_TRANSPORTZONE_INIT;
+
+                voyageZoneList.push_back(voyageZone);
+            }
+            else
+            {
+                ShowError("TransportZone <%u>: zone not found\n", (uint8)Sql_GetIntData(SqlHandle, 0));
+                delete voyageZone;
+            }
         }
     }
 }
 
 /************************************************************************
 *                                                                       *
-*  Все логика передвижения транспорта                                   *
+*  Main transportation controller                                  *
 *                                                                       *
 ************************************************************************/
 
-void CTransportHandler::TransportTimer() 
-{
-	uint32 VanaTime = CVanaTime::getInstance()->getDate();
+void CTransportHandler::TransportTimer()
+{//FIRST TRY
 
-    // в портовых зонах необходимо написать макросы на случай, если персонаж вышел из игры в корабле. 
-    // при входе в игру он должен оказаться на пристани
+    uint32 vanaTime = CVanaTime::getInstance()->getDate();
+    uint16 shipTimerOffset = 0;
 
-    for(uint32 i = 0; i < TransportList.size(); ++i)
+    //Loop through town zones and update transportion accordingly
+    for (uint32 i = 0; i < townZoneList.size(); ++i)
     {
-        Transport_t* PTransport = TransportList.at(i);
+        TransportZone_Town* townZone = townZoneList.at(i);
+ 
+        shipTimerOffset = ((vanaTime - townZone->ship.timeOffset) % townZone->ship.timeInterval);
 
-        uint16 ShipTimerOffset = ((VanaTime - PTransport->TimeOffset) % PTransport->TimeInterval);
-
-        // корабль появляется на горизонте
-        if (ShipTimerOffset == 0)
+        if (townZone->ship.state == STATE_TRANSPORT_AWAY)
         {
-            PTransport->PTransportNPC->status = STATUS_NORMAL;
-            PTransport->PTransportNPC->animation = PTransport->AnimationArrive;
-            PTransport->PTransportNPC->loc = PTransport->Dock;
-
-            ref<uint32>(&PTransport->PTransportNPC->name[0],4) = CVanaTime::getInstance()->getVanaTime();
-
-			PTransport->Dock.zone->PushPacket(nullptr, CHAR_INZONE, new CEntityUpdatePacket(PTransport->PTransportNPC, ENTITY_SPAWN, UPDATE_ALL_MOB));
-        }
-        // персонажи видят корабль, иначе ждем следующего прибытия
-        else if (PTransport->PTransportNPC->status == STATUS_NORMAL) 
-        {
-            // корабль причалил, открываем двери пассажирам
-            if (ShipTimerOffset == PTransport->TimeAnimationArrive)
+            if (shipTimerOffset < townZone->ship.timeArriveDock)
             {
-                PTransport->PDoorNPC->animation = ANIMATION_OPEN_DOOR;
-				PTransport->Dock.zone->PushPacket(PTransport->PDoorNPC, CHAR_INRANGE, new CEntityUpdatePacket(PTransport->PDoorNPC, ENTITY_UPDATE, UPDATE_COMBAT));
-            }
-            //корабль отчаливает
-            else if (ShipTimerOffset == PTransport->TimeAnimationArrive + PTransport->TimeWaiting)
-            {
-                PTransport->PDoorNPC->animation = ANIMATION_CLOSE_DOOR;
-                PTransport->PTransportNPC->animation = PTransport->AnimationDepart;
-                PTransport->PTransportNPC->loc.boundary = PTransport->Dock.boundary;
+                townZone->ship.state = STATE_TRANSPORT_ARRIVING;
+                townZone->ship.animateSetup(townZone->ship.animationArrive, CVanaTime::getInstance()->getVanaTime());
+                townZone->ship.spawn();
 
-                ref<uint32>(&PTransport->PTransportNPC->name[0],4) = CVanaTime::getInstance()->getVanaTime();
-
-                PTransport->Dock.zone->TransportDepart(PTransport->PTransportNPC->loc.boundary, PTransport->PTransportNPC->loc.prevzone);
-				PTransport->Dock.zone->PushPacket(PTransport->PDoorNPC, CHAR_INRANGE, new CEntityUpdatePacket(PTransport->PDoorNPC, ENTITY_UPDATE, UPDATE_COMBAT));
-				PTransport->Dock.zone->PushPacket(nullptr, CHAR_INZONE, new CEntityUpdatePacket(PTransport->PTransportNPC, ENTITY_UPDATE, UPDATE_COMBAT));
-            }
-            //корабль исчезает
-            else if (ShipTimerOffset == PTransport->TimeAnimationArrive + PTransport->TimeWaiting + PTransport->TimeAnimationDepart)
-            {
-                PTransport->PTransportNPC->status = STATUS_DISAPPEAR;
-                PTransport->Dock.zone->PushPacket(nullptr, CHAR_INZONE, new CEntityUpdatePacket(PTransport->PTransportNPC, ENTITY_DESPAWN,UPDATE_NONE));
+                townZone->updateShip();
             }
         }
+        else if (townZone->ship.state == STATE_TRANSPORT_DEPARTING)
+        {
+            if (shipTimerOffset >= townZone->ship.timeVoyageStart)
+            {
+                townZone->ship.state = STATE_TRANSPORT_AWAY;
+                townZone->ship.setVisible(false);
+
+                townZone->updateShip();
+            }
+        }
+        else if (townZone->ship.state == STATE_TRANSPORT_DOCKED)
+        {
+            if (shipTimerOffset >= townZone->ship.timeDepartDock)
+            {
+                townZone->ship.state = STATE_TRANSPORT_DEPARTING;
+                townZone->ship.animateSetup(townZone->ship.animationDepart, CVanaTime::getInstance()->getVanaTime());
+
+                townZone->closeDoor(true);
+                townZone->depart();
+                townZone->updateShip();
+            }
+        }
+        else if (townZone->ship.state == STATE_TRANSPORT_ARRIVING)
+        {
+            if (shipTimerOffset >= townZone->ship.timeArriveDock)
+            {
+                townZone->ship.state = STATE_TRANSPORT_DOCKED;
+                townZone->openDoor(true);
+
+            }
+        }
+        else if (townZone->ship.state == STATE_TRANSPORT_INIT)
+        {
+            if (shipTimerOffset >= townZone->ship.timeVoyageStart)
+                townZone->ship.state = STATE_TRANSPORT_AWAY;
+
+            else if (shipTimerOffset >= townZone->ship.timeDepartDock)
+            {
+                UINT32 departTime = shipTimerOffset - townZone->ship.timeDepartDock;
+                townZone->ship.state = STATE_TRANSPORT_DEPARTING;
+                townZone->ship.spawn();
+                townZone->ship.animateSetup(townZone->ship.animationDepart, (UINT32)(CVanaTime::getInstance()->getVanaTime() - departTime * 2.4));
+            }
+            else if (shipTimerOffset >= townZone->ship.timeArriveDock)
+            {
+                townZone->ship.state = STATE_TRANSPORT_DOCKED;
+                townZone->openDoor(false);
+                townZone->ship.spawn();
+                townZone->ship.animateSetup(townZone->ship.animationArrive, (UINT32)(CVanaTime::getInstance()->getVanaTime() - shipTimerOffset * 2.4));
+            }
+            else
+            {
+                townZone->ship.state = STATE_TRANSPORT_ARRIVING;
+
+                townZone->ship.spawn();
+                townZone->ship.animateSetup(townZone->ship.animationArrive, (UINT32)(CVanaTime::getInstance()->getVanaTime() - shipTimerOffset * 2.4));
+            }
+        }
+        else
+            ShowError("Unexpected state reached for transportation %d\n", townZone->ship.npc->id);
     }
 
-    for (auto transportZone : TransportZoneList)
+    //Loop through voyage zones and zone passengers accordingly
+    for (uint32 i = 0; i < voyageZoneList.size(); i++)
     {
-        uint16 ShipTimerOffset = ((VanaTime - transportZone.TimeOffset) % transportZone.TimeInterval);
+        TransportZone_Voyage* zoneIterator = voyageZoneList.at(i);
 
-        if (ShipTimerOffset == transportZone.TimeAnimationArrive - 10)
+        shipTimerOffset = ((vanaTime - zoneIterator->timeOffset) % zoneIterator->timeInterval);
+
+        if (zoneIterator->state == STATE_TRANSPORTZONE_VOYAGE)
         {
-            CZone* PZone = zoneutils::GetZone(transportZone.zone);
-            if (PZone)
-                PZone->TransportDepart(0, transportZone.zone);
+            //Zone them out 10 Van minutes before the boat reaches the dock
+            if (shipTimerOffset < zoneIterator->timeVoyageStart && shipTimerOffset > zoneIterator->timeArriveDock - 10)
+                zoneIterator->state = STATE_TRANSPORTZONE_EVICT;
+
+        }
+        else if (zoneIterator->state == STATE_TRANSPORTZONE_EVICT)
+        {
+            zoneIterator->voyageZone->TransportDepart(0, zoneIterator->voyageZone->GetID());
+            zoneIterator->state = STATE_TRANSPORTZONE_WAIT;
+        }
+        else if (zoneIterator->state == STATE_TRANSPORTZONE_WAIT)
+        {
+            if (shipTimerOffset < zoneIterator->timeDepartDock)
+                zoneIterator->state = STATE_TRANSPORTZONE_EVICT;
+            else
+                zoneIterator->state = STATE_TRANSPORTZONE_DOCKED;
+        }
+        else if (zoneIterator->state == STATE_TRANSPORTZONE_DOCKED)
+        {
+            if (shipTimerOffset > zoneIterator->timeVoyageStart)
+                zoneIterator->state = STATE_TRANSPORTZONE_VOYAGE;
+        }
+        else if (zoneIterator->state == STATE_TRANSPORTZONE_INIT)
+        {
+            if (shipTimerOffset < zoneIterator->timeVoyageStart)
+                zoneIterator->state = STATE_TRANSPORTZONE_EVICT;
+            else
+                zoneIterator->state = STATE_TRANSPORTZONE_VOYAGE;
+        }
+        else
+            ShowError("Unexpected state reached for travel zone %d\n", zoneIterator->voyageZone->GetID());
+
+    }
+
+    for (uint32 i = 0; i < ElevatorList.size(); ++i)
+    {
+        Elevator_t * elevator = ElevatorList.at(i);
+
+        if (elevator->activated)
+        {
+            uint16 elevatorOffset = vanaTime % elevator->interval;
+
+            if (elevator->state == STATE_ELEVATOR_TOP)
+            {
+                if (vanaTime >= elevator->lastTrigger + elevator->interval)
+                {
+                    elevator->state = STATE_ELEVATOR_DESCEND;
+                    elevator->Elevator->animation = ANIMATION_ELEVATOR_DOWN;
+                    startElevator(elevator);
+                }
+            }
+            else if (elevator->state == STATE_ELEVATOR_BOTTOM)
+            {
+                if (vanaTime >= elevator->lastTrigger + elevator->interval)
+                {
+                    elevator->state = STATE_ELEVATOR_ASCEND;
+                    elevator->Elevator->animation = ANIMATION_ELEVATOR_UP;
+                    startElevator(elevator);
+                }
+            }
+            else if (elevator->state == STATE_ELEVATOR_DESCEND)
+            {
+                if (vanaTime >= elevator->lastTrigger + elevator->movetime)
+                {
+                    elevator->state = STATE_ELEVATOR_BOTTOM;
+                    arriveElevator(elevator);
+                }
+            }
+            else if (elevator->state == STATE_ELEVATOR_ASCEND)
+            {
+                if (vanaTime >= elevator->lastTrigger + elevator->movetime)
+                {
+                    elevator->state = STATE_ELEVATOR_TOP;
+                    arriveElevator(elevator);
+                }
+
+            }
+            else
+                ShowError("Unexpected state reached for elevator %d\n", elevator->Elevator->id);
         }
     }
-
-	for(uint32 i = 0; i < ElevatorList.size(); ++i) 
-	{
-		Elevator_t * elevator = &ElevatorList.at(i);
-
-		if (elevator->isStarted)
-		{
-			uint16 TimerOffset = (VanaTime % elevator->interval);
-			
-			if (elevator->id == ELEVATOR_PORT_BASTOK_DRWBRDG)
-			{
-				TimerOffset = (VanaTime % INTERVAL_PORT_BASTOK_DRWBRDG);
-
-				if (TimerOffset == 0 || TimerOffset == 76)
-				{
-					CZone* PZone = zoneutils::GetZone(elevator->zone);
-
-					PZone->ForEachChar([](CCharEntity* PChar){
-						if ((PChar->GetXPos() > 54 && PChar->GetXPos() < 66) && (PChar->GetZPos() > -160 && PChar->GetZPos() < -80))
-						{
-							PChar->pushPacket(new CEventPacket(PChar, 70, 0, 0, 0, 0, 0, 0, 0, 0, 0, -1));
-						}
-					});
-				}
-				else if (TimerOffset == 4 || TimerOffset == 80)
-				{
-					elevator->isMoving = true;
-					startElevator(elevator);
-				}
-				else if (TimerOffset == 8 || TimerOffset == 84)
-				{
-					elevator->isMoving = true;
-					startElevator(elevator);
-				}
-				else if (TimerOffset == 12 || TimerOffset == 88)
-				{
-					elevator->isMoving = false;
-					arriveElevator(elevator);
-				}
-			}
-			else if (elevator->id == ELEVATOR_KUFTAL_TUNNEL_DSPPRNG_RCK)
-			{
-				TimerOffset = (VanaTime % INTERVAL_KUFTAL_TUNNEL_DSPPRNG_RCK);
-
-				if (TimerOffset == 60)
-				{
-					elevator->isMoving = true;
-					startElevator(elevator);
-				}
-			}
-			else
-			{
-				if (TimerOffset == 0)
-				{
-					elevator->isMoving = true;
-					startElevator(elevator);
-				}
-				else if (TimerOffset == elevator->movetime)
-				{
-					if (elevator->isMoving)
-					{
-						if (!elevator->isPermanent)
-						{
-							elevator->isStarted = false;
-						}
-						elevator->isMoving = false;
-						arriveElevator(elevator);
-					}
-				}
-			}
-		}
-	}
 }
-
 /************************************************************************
 *                                                                       *
 *                                                                       *
 *                                                                       *
 ************************************************************************/
 
-void CTransportHandler::startElevator(int32 elevatorID)
-{
-    for(uint32 i = 0; i < ElevatorList.size(); ++i) 
-	{		
-	    Elevator_t * elevator = &ElevatorList.at(i);
-
-		if (elevator->id == elevatorID)
-		{
-			CTransportHandler::startElevator(elevator);
-            return;
-		}
-    }
-}
-
-/************************************************************************
-*                                                                       *
-*                                                                       *
-*                                                                       *
-************************************************************************/
-
-void CTransportHandler::insertElevator(Elevator_t elevator)
-{
-    Elevator_t* Elevator = &elevator;
-
+void CTransportHandler::insertElevator(Elevator_t* elevator)
+{    
     // check to see if this elevator already exists
     for (uint32 i = 0; i < ElevatorList.size(); ++i)
     {
-        Elevator_t* PElevator = &ElevatorList.at(i);
+        Elevator_t* PElevator = ElevatorList.at(i);
 
-        if (PElevator->Elevator->GetName() == Elevator->Elevator->GetName() && PElevator->zone == Elevator->zone)
+        if (PElevator->Elevator->GetName() == elevator->Elevator->GetName() && PElevator->zoneID == elevator->zoneID)
         {
             DSP_DEBUG_BREAK_IF(true);
         }
     }
 
+    //Double check that the NPC entities all exist
+    if (elevator->LowerDoor == nullptr || elevator->UpperDoor == nullptr || elevator->Elevator == nullptr)
+    {
+        ShowError("Elevator %d could not load NPC entity. Ignoring this elevator.\n", elevator->Elevator->id);
+        return;
+    }
+    //Have permanent elevators wait until their next cycle to begin moving
+    uint32 VanaTime = CVanaTime::getInstance()->getDate();
+    elevator->lastTrigger = VanaTime - (VanaTime % elevator->interval) + elevator->interval;
+    elevator->Elevator->name[8] = 8;
+
+    //Initialize the elevator into the correct state based on
+    //its animation value in the database. 
+    if (elevator->Elevator->animation == ANIMATION_ELEVATOR_DOWN)
+        elevator->state = STATE_ELEVATOR_BOTTOM;
+    else if (elevator->Elevator->animation == ANIMATION_ELEVATOR_UP)
+        elevator->state = STATE_ELEVATOR_TOP;
+    else
+    {
+        ShowError("Elevator %d has unexpected animation. Ignoring this elevator.\n", elevator->Elevator->id);
+        return;
+    }
+
+    //Note that permanent elevators (ones that always move, ie metalworks)
+    //require opposite animations from lever-triggered elevators
+    if (!elevator->isPermanent)
+        elevator->state ^= 1;
+
+    //Ensure that the doors start in the correct positions
+    //regardless of their values in the database.
+    if (elevator->state == STATE_ELEVATOR_TOP)
+    {
+        elevator->LowerDoor->animation = ANIMATION_CLOSE_DOOR;
+        elevator->UpperDoor->animation = ANIMATION_OPEN_DOOR;
+    }
+    else
+    {
+        elevator->LowerDoor->animation = ANIMATION_OPEN_DOOR;
+        elevator->UpperDoor->animation = ANIMATION_CLOSE_DOOR;
+    }
+     
     ElevatorList.push_back(elevator);
     return;
 }
@@ -348,47 +482,68 @@ void CTransportHandler::insertElevator(Elevator_t elevator)
 *                                                                       *
 ************************************************************************/
 
+void CTransportHandler::startElevator(int32 elevatorID)
+{
+    for (uint32 i = 0; i < ElevatorList.size(); ++i)
+    {
+        Elevator_t * elevator = ElevatorList.at(i);
+
+        if (elevator->id == elevatorID)
+        {
+            CTransportHandler::startElevator(elevator);
+            return;
+        }
+    }
+}
+
+/************************************************************************
+*                                                                       *
+*                                                                       *
+*                                                                       *
+************************************************************************/
 void CTransportHandler::startElevator(Elevator_t * elevator)
 {
-	elevator->Elevator->animation ^= 1; 
-	
-	elevator->Elevator->name[8] = 8;
-    ref<uint32>(&elevator->Elevator->name[0],4) = CVanaTime::getInstance()->getVanaTime();
-  
-	if ((elevator->LowerDoor != nullptr) && (elevator->UpperDoor != nullptr)) 
-	{
-		if (elevator->id == ELEVATOR_PORT_BASTOK_DRWBRDG)
-		{
-			elevator->LowerDoor->animation = ANIMATION_CLOSE_DOOR;
-			zoneutils::GetZone(elevator->zone)->PushPacket(nullptr,CHAR_INZONE, new CEntityUpdatePacket(elevator->LowerDoor,ENTITY_SPAWN,UPDATE_ALL_MOB));
-			elevator->UpperDoor->animation = ANIMATION_CLOSE_DOOR;
-			zoneutils::GetZone(elevator->zone)->PushPacket(nullptr,CHAR_INZONE, new CEntityUpdatePacket(elevator->UpperDoor,ENTITY_SPAWN,UPDATE_ALL_MOB));
-		}
-		else
-		{
-			if (elevator->Elevator->animation == ANIMATION_ELEVATOR_DOWN) 
-			{
-				elevator->LowerDoor->animation = ANIMATION_CLOSE_DOOR;
-				zoneutils::GetZone(elevator->zone)->PushPacket(nullptr,CHAR_INZONE, new CEntityUpdatePacket(elevator->LowerDoor,ENTITY_SPAWN,UPDATE_ALL_MOB));
-				if (!elevator->isPermanent) 
-				{
-					elevator->UpperDoor->animation = ANIMATION_OPEN_DOOR;
-					zoneutils::GetZone(elevator->zone)->PushPacket(nullptr,CHAR_INZONE, new CEntityUpdatePacket(elevator->UpperDoor,ENTITY_SPAWN,UPDATE_ALL_MOB));
-				}
-			}
-			else
-			{
-				elevator->UpperDoor->animation = ANIMATION_CLOSE_DOOR;
-				zoneutils::GetZone(elevator->zone)->PushPacket(nullptr,CHAR_INZONE, new CEntityUpdatePacket(elevator->UpperDoor,ENTITY_SPAWN,UPDATE_ALL_MOB));
-				if (!elevator->isPermanent) 
-				{
-					elevator->LowerDoor->animation = ANIMATION_OPEN_DOOR;
-					zoneutils::GetZone(elevator->zone)->PushPacket(nullptr,CHAR_INZONE, new CEntityUpdatePacket(elevator->LowerDoor,ENTITY_SPAWN,UPDATE_ALL_MOB));
-				}
-			}
-		}
-	}
-	zoneutils::GetZone(elevator->zone)->PushPacket(nullptr,CHAR_INZONE, new CEntityUpdatePacket(elevator->Elevator,ENTITY_SPAWN,UPDATE_ALL_MOB));
+    uint32 VanaTime = CVanaTime::getInstance()->getDate();
+
+    //Called when a lever is pulled in the field
+    if (!elevator->isPermanent)
+    {
+        if (elevator->state == STATE_ELEVATOR_TOP)
+        {
+            elevator->state = STATE_ELEVATOR_DESCEND;
+            elevator->Elevator->animation = ANIMATION_ELEVATOR_UP;
+        }
+        else if (elevator->state == STATE_ELEVATOR_BOTTOM)
+        {
+            elevator->state = STATE_ELEVATOR_ASCEND;
+            elevator->Elevator->animation = ANIMATION_ELEVATOR_DOWN;
+        }
+        else
+            return; //the platform isn't settled yet
+
+        elevator->lastTrigger = VanaTime;
+        elevator->activated = true;
+    }
+    else
+        elevator->lastTrigger = VanaTime -  VanaTime % elevator->interval; //Keep the elevators synced to Vanadiel time
+
+    ref<uint32>(&elevator->Elevator->name[0], 4) = CVanaTime::getInstance()->getVanaTime();
+
+    //Take care of doors
+    if ((elevator->LowerDoor != nullptr) && (elevator->UpperDoor != nullptr))
+    {
+        if (elevator->state == STATE_ELEVATOR_ASCEND)
+            elevator->closeDoor(elevator->LowerDoor);
+        else if (elevator->state == STATE_ELEVATOR_DESCEND)
+            elevator->closeDoor(elevator->UpperDoor);
+        else
+        {
+            ShowError("Elevator %d has malfunctioned\n", elevator->Elevator->id);
+            return;
+        }
+    }
+
+    zoneutils::GetZone(elevator->zoneID)->PushPacket(nullptr, CHAR_INZONE, new CEntityUpdatePacket(elevator->Elevator, ENTITY_UPDATE, UPDATE_COMBAT));
 }
 
 /************************************************************************
@@ -399,24 +554,13 @@ void CTransportHandler::startElevator(Elevator_t * elevator)
 
 void CTransportHandler::arriveElevator(Elevator_t * elevator)
 {
-	if (elevator->id == ELEVATOR_PORT_BASTOK_DRWBRDG)
-	{
-		elevator->LowerDoor->animation = ANIMATION_OPEN_DOOR;
-		zoneutils::GetZone(elevator->zone)->PushPacket(nullptr,CHAR_INZONE, new CEntityUpdatePacket(elevator->LowerDoor,ENTITY_SPAWN,UPDATE_ALL_MOB));
-		elevator->UpperDoor->animation = ANIMATION_OPEN_DOOR;
-		zoneutils::GetZone(elevator->zone)->PushPacket(nullptr,CHAR_INZONE, new CEntityUpdatePacket(elevator->UpperDoor,ENTITY_SPAWN,UPDATE_ALL_MOB));
-	}
-	else
-	{
-		if (elevator->Elevator->animation == ANIMATION_ELEVATOR_DOWN)
-		{
-			elevator->LowerDoor->animation = ANIMATION_OPEN_DOOR;
-			zoneutils::GetZone(elevator->zone)->PushPacket(nullptr,CHAR_INZONE, new CEntityUpdatePacket(elevator->LowerDoor,ENTITY_SPAWN, UPDATE_ALL_MOB));
-		}
-		else
-		{
-			elevator->UpperDoor->animation = ANIMATION_OPEN_DOOR;
-			zoneutils::GetZone(elevator->zone)->PushPacket(nullptr,CHAR_INZONE, new CEntityUpdatePacket(elevator->UpperDoor,ENTITY_SPAWN, UPDATE_ALL_MOB));
-		}
-	}
+    if (!elevator->isPermanent)
+        elevator->activated = false;
+
+    if (elevator->state == STATE_ELEVATOR_BOTTOM)
+        elevator->openDoor(elevator->LowerDoor);
+    else if (elevator->state == STATE_ELEVATOR_TOP)
+        elevator->openDoor(elevator->UpperDoor);
+    else
+        ShowError("Elevator %d has malfunctioned\n", elevator->Elevator->id);
 }

--- a/src/map/zone_entities.cpp
+++ b/src/map/zone_entities.cpp
@@ -209,8 +209,23 @@ void CZoneEntities::TransportDepart(uint16 boundary, uint16 zone)
 
         if (PCurrentChar->loc.boundary == boundary)
         {
+            if (PCurrentChar->m_event.Target != nullptr)
+            {
+                //The player talked to one of the guys on the boat, and the event target is wrong.
+                //This leads to the wrong script being loaded and you get stuck on a black screen
+                //instead of loading into the port.
+                
+                //Attempt to load the proper script
+                PCurrentChar->m_event.Target = nullptr;
+                size_t deleteStart = PCurrentChar->m_event.Script.find("npcs/");
+                size_t deleteEnd = PCurrentChar->m_event.Script.find(".lua");
+
+                if (deleteStart != std::string::npos && deleteEnd != std::string::npos)
+                    PCurrentChar->m_event.Script.replace(deleteStart, deleteEnd - deleteStart, "Zone");
+            }
             luautils::OnTransportEvent(PCurrentChar, zone);
         }
+            
     }
 }
 

--- a/win32/vcxproj/DSGame-server.vcxproj
+++ b/win32/vcxproj/DSGame-server.vcxproj
@@ -431,6 +431,7 @@
     <ClInclude Include="..\..\src\map\spell.h" />
     <ClInclude Include="..\..\src\map\status_effect.h" />
     <ClInclude Include="..\..\src\map\status_effect_container.h" />
+    <ClInclude Include="..\..\src\map\timetriggers.h" />
     <ClInclude Include="..\..\src\map\time_server.h" />
     <ClInclude Include="..\..\src\map\trade_container.h" />
     <ClInclude Include="..\..\src\map\trait.h" />
@@ -461,6 +462,7 @@
     <ClInclude Include="..\..\src\map\zone_entities.h" />
     <ClInclude Include="..\..\src\map\zone_instance.h" />
     <ClInclude Include="gameserver.h" />
+    <ClInclude Include="timetriggers.h" />
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="..\..\src\common\blowfish.cpp" />
@@ -676,6 +678,7 @@
     <ClCompile Include="..\..\src\map\spell.cpp" />
     <ClCompile Include="..\..\src\map\status_effect.cpp" />
     <ClCompile Include="..\..\src\map\status_effect_container.cpp" />
+    <ClCompile Include="..\..\src\map\timetriggers.cpp" />
     <ClCompile Include="..\..\src\map\time_server.cpp" />
     <ClCompile Include="..\..\src\map\trade_container.cpp" />
     <ClCompile Include="..\..\src\map\trait.cpp" />

--- a/win32/vcxproj/DSGame-server.vcxproj.filters
+++ b/win32/vcxproj/DSGame-server.vcxproj.filters
@@ -872,6 +872,12 @@
     <ClInclude Include="..\..\src\map\packets\map_marker.h">
       <Filter>Source Files\packets</Filter>
     </ClInclude>
+    <ClInclude Include="timetriggers.h">
+      <Filter>Source Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\map\timetriggers.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="..\..\src\map\ability.cpp">
@@ -1599,6 +1605,9 @@
     </ClCompile>
     <ClCompile Include="..\..\src\map\packets\map_marker.cpp">
       <Filter>Source Files\packets</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\map\timetriggers.cpp">
+      <Filter>Source Files</Filter>
     </ClCompile>
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
Increases the reliability of boats and elevators through the use of state machines. Also adds support for periodic triggers on npcs. I intended to use the triggers for npcs that could benefit from time-based scripting outside of OnGameHour. Ie the bastok drawbridge, kuftal tunnel rock and npcs related to transportation that yell things periodically. I wasn't sure if there was already something in place to support this or not, so let me know if it's a bad idea.

Also new to git so be gentle ~