### PR TITLE
fix bomb queen

### DIFF
--- a/scripts/zones/Ifrits_Cauldron/mobs/Bomb_Bastard.lua
+++ b/scripts/zones/Ifrits_Cauldron/mobs/Bomb_Bastard.lua
@@ -1,25 +1,22 @@
 -----------------------------------
 -- Area: Ifrit's Cauldron
---  MOB: Bomb Bastard
+--   NM: Bomb Bastard
+-----------------------------------
+require("scripts/globals/status")
 -----------------------------------
 
-require("scripts/globals/status");
-
 function onMobInitialize(mob)
-    mob:setMobMod(dsp.mobMod.EXP_BONUS, -100);
-    mob:setMobMod(dsp.mobMod.GIL_BONUS, -100);
-    mob:setMobMod(dsp.mobMod.NO_DROPS, 1);
-end;
+    mob:setMobMod(dsp.mobMod.EXP_BONUS, -100)
+    mob:setMobMod(dsp.mobMod.GIL_BONUS, -100)
+    mob:setMobMod(dsp.mobMod.NO_DROPS, 1)
+    mob:setMod(dsp.mod.STUNRES, 50)
+end
 
-function onMobSpawn(mob)
-    mob:addMod(dsp.mod.STUNRES, 50);
-end;
-
-function onMobFight(mob,target)
-    if (mob:getBattleTime() > 10) then
-        mob:useMobAbility(511);
+function onMobFight(mob, target)
+    if mob:getBattleTime() > 10 then
+        mob:useMobAbility(511)
     end
-end;
+end
 
 function onMobDeath(mob, player, isKiller)
-end;
+end

--- a/scripts/zones/Ifrits_Cauldron/mobs/Bomb_Prince.lua
+++ b/scripts/zones/Ifrits_Cauldron/mobs/Bomb_Prince.lua
@@ -1,25 +1,22 @@
 -----------------------------------
 -- Area: Ifrit's Cauldron
---  MOB: Bomb Prince
+--   NM: Bomb Prince
+-----------------------------------
+require("scripts/globals/status")
 -----------------------------------
 
-require("scripts/globals/status");
-
 function onMobInitialize(mob)
-    mob:setMobMod(dsp.mobMod.EXP_BONUS, -100);
-    mob:setMobMod(dsp.mobMod.GIL_BONUS, -100);
-    mob:setMobMod(dsp.mobMod.NO_DROPS, 1);
-end;
+    mob:setMobMod(dsp.mobMod.EXP_BONUS, -100)
+    mob:setMobMod(dsp.mobMod.GIL_BONUS, -100)
+    mob:setMobMod(dsp.mobMod.NO_DROPS, 1)
+    mob:setMod(dsp.mod.STUNRES, 50)
+end
 
-function onMobSpawn(mob)
-    mob:addMod(dsp.mod.STUNRES, 50);
-end;
-
-function onMobFight(mob,target)
-    if (mob:getBattleTime() > 10) then
-        mob:useMobAbility(511);
+function onMobFight(mob, target)
+    if mob:getBattleTime() > 10 then
+        mob:useMobAbility(511)
     end
-end;
+end
 
 function onMobDeath(mob, player, isKiller)
-end;
+end

--- a/scripts/zones/Ifrits_Cauldron/mobs/Bomb_Princess.lua
+++ b/scripts/zones/Ifrits_Cauldron/mobs/Bomb_Princess.lua
@@ -1,25 +1,22 @@
 -----------------------------------
 -- Area: Ifrit's Cauldron
---  MOB: Bomb Princess
+--   NM: Bomb Princess
+-----------------------------------
+require("scripts/globals/status")
 -----------------------------------
 
-require("scripts/globals/status");
-
 function onMobInitialize(mob)
-    mob:setMobMod(dsp.mobMod.EXP_BONUS, -100);
-    mob:setMobMod(dsp.mobMod.GIL_BONUS, -100);
-    mob:setMobMod(dsp.mobMod.NO_DROPS, 1);
-end;
+    mob:setMobMod(dsp.mobMod.EXP_BONUS, -100)
+    mob:setMobMod(dsp.mobMod.GIL_BONUS, -100)
+    mob:setMobMod(dsp.mobMod.NO_DROPS, 1)
+    mob:setMod(dsp.mod.STUNRES, 50)
+end
 
-function onMobSpawn(mob)
-    mob:addMod(dsp.mod.STUNRES, 50);
-end;
-
-function onMobFight(mob,target)
-    if (mob:getBattleTime() > 10) then
-        mob:useMobAbility(511);
+function onMobFight(mob, target)
+    if mob:getBattleTime() > 10 then
+        mob:useMobAbility(511)
     end
-end;
+end
 
 function onMobDeath(mob, player, isKiller)
-end;
+end

--- a/scripts/zones/Ifrits_Cauldron/mobs/Bomb_Queen.lua
+++ b/scripts/zones/Ifrits_Cauldron/mobs/Bomb_Queen.lua
@@ -1,35 +1,53 @@
 -----------------------------------
 -- Area: Ifrit's Cauldron
 --   NM: Bomb Queen
+--  Vid: https://www.youtube.com/watch?v=AVsEbYjSAHM
 -----------------------------------
 local ID = require("scripts/zones/Ifrits_Cauldron/IDs")
 require("scripts/globals/status")
 -----------------------------------
 
 function onMobInitialize(mob)
+    mob:setMobMod(dsp.mobMod.IDLE_DESPAWN, 180)
     mob:setMobMod(dsp.mobMod.HP_STANDBACK, -1)
     mob:setMobMod(dsp.mobMod.DRAW_IN, 1)
-    mob:setMobMod(dsp.mobMod.IDLE_DESPAWN, 180)
+    mob:setMod(dsp.mod.STUNRES, 50)
 end
 
 function onMobSpawn(mob)
-    mob:addMod(dsp.mod.STUNRES, 50)
+    mob:setLocalVar("petCooldown", os.time() + 5) -- five seconds for first pet
 end
 
-function onMobFight(mob,target)
-    local battleTime = mob:getBattleTime()
+function onMobFight(mob, target)
+    -- every ~20 seconds after first pet, a new pet will spawn around queen's position.
+    -- 50% chance for Prince/Princess. 1% chance for Bastard.
 
-    if (battleTime - 5) % 20 == 0 then -- every 20 seconds after 5 seconds, source: https://www.youtube.com/watch?v=AVsEbYjSAHM
-        local random = math.random(1,100);
-        local petId = mob:getID() + 1 + math.floor(random / 25); -- approximately 1% chance to spawn bomb bastard
+    local mobId = mob:getID()
+
+    if os.time() > mob:getLocalVar("petCooldown") then
+        local petId = mob:getID() + 1 + math.floor(math.random(0, 100) / 25)
         local pet = GetMobByID(petId)
-        local pos = mob:getPos()
-        pet:setSpawn(unpack(pos))
-        pet:spawn()
-        pet:updateEnmity(target)
-    end
 
+        if pet and not pet:isSpawned() then
+            local pos = mob:getPos()
+            pet:setSpawn(pos.x + math.random(-2, 2), pos.y, pos.z + math.random(-2, 2), pos.rot)
+            pet:spawn()
+            pet:updateEnmity(target)
+
+            mob:setLocalVar("petCooldown", os.time() + 20)
+        end
+    end
 end
 
 function onMobDeath(mob, player, isKiller)
+    -- pets die with queen
+    if isKiller then
+        local mobId = mob:getID()
+        for i = mobId + 1, mobId + 5 do
+            local pet = GetMobByID(i)
+            if pet:isAlive() then
+                pet:setHP(0)
+            end
+        end
+    end
 end


### PR DESCRIPTION
For #5621 .
Fix crashiness.
Prevent queen from attempting to spawn multiple pets per cycle.
Prevent queen from attempting to spawn an already-spawned pet.
Clean up pets when queen dies.
