### PR TITLE
add mob additional effects to -- and table functions in -- the mobs global

### DIFF
--- a/scripts/globals/mobs.lua
+++ b/scripts/globals/mobs.lua
@@ -7,6 +7,9 @@ require("scripts/globals/status")
 require("scripts/globals/zone")
 -----------------------------------
 
+dsp = dsp or {}
+dsp.mob = dsp.mob or {}
+
 -- onMobDeathEx is called from the core
 function onMobDeathEx(mob, player, isKiller, isWeaponSkillKill)
     -- Things that happen only to the person who landed killing blow
@@ -46,7 +49,7 @@ local function lotteryPrimed(phList)
 end
 
 -- potential lottery placeholder was killed
-function phOnDespawn(ph, phList, chance, cooldown, immediate)
+dsp.mob.phOnDespawn = function(ph, phList, chance, cooldown, immediate)
     if type(immediate) ~= "boolean" then immediate = false end
 
     local phId = ph:getID()
@@ -81,4 +84,3 @@ function phOnDespawn(ph, phList, chance, cooldown, immediate)
 
     return false
 end
-

--- a/scripts/globals/mobs.lua
+++ b/scripts/globals/mobs.lua
@@ -1,85 +1,84 @@
 -----------------------------------
 -- Global version of onMobDeath
 -----------------------------------
-package.loaded["scripts/globals/conquest"] = nil;
------------------------------------
-require("scripts/globals/conquest");
-require("scripts/globals/missions");
-require("scripts/globals/quests");
-require("scripts/globals/status");
+require("scripts/globals/missions")
+require("scripts/globals/quests")
+require("scripts/globals/status")
+require("scripts/globals/zone")
 -----------------------------------
 
+-- onMobDeathEx is called from the core
 function onMobDeathEx(mob, player, isKiller, isWeaponSkillKill)
     -- Things that happen only to the person who landed killing blow
-    if (isKiller == true) then
+    if isKiller then
         -- DRK quest - Blade Of Darkness
-        local BladeofDarkness = player:getQuestStatus(BASTOK, BLADE_OF_DARKNESS);
-        local BladeofDeath = player:getQuestStatus(BASTOK, BLADE_OF_DEATH);
-        local ChaosbringerKills = player:getVar("ChaosbringerKills");
-        if (BladeofDarkness == QUEST_ACCEPTED or BladeofDeath == QUEST_ACCEPTED) then
-            if (player:getEquipID(dsp.slot.MAIN) == 16607 and isWeaponSkillKill == false) then
-                if (ChaosbringerKills < 200) then
-                    player:setVar("ChaosbringerKills", ChaosbringerKills + 1);
-                end
-            end
+        if
+            (player:getQuestStatus(BASTOK, BLADE_OF_DARKNESS) == QUEST_ACCEPTED or player:getQuestStatus(BASTOK, BLADE_OF_DEATH) == QUEST_ACCEPTED) and
+            player:getEquipID(dsp.slot.MAIN) == 16607 and
+            player:getVar("ChaosbringerKills") < 200 and
+            not isWeaponSkillKill
+        then
+            player:setVar("ChaosbringerKills", ChaosbringerKills + 1)
         end
     end
 
     -- Things that happen to any player in the party/alliance
-    if (player:getCurrentMission(WINDURST) == A_TESTING_TIME) then
-        if (player:hasCompletedMission(WINDURST,A_TESTING_TIME) and player:getZoneID() == 118) then
-            player:setVar("testingTime_crea_count",player:getVar("testingTime_crea_count") + 1);
-        elseif (player:hasCompletedMission(WINDURST,A_TESTING_TIME) == false and player:getZoneID() == 117) then
-            player:setVar("testingTime_crea_count",player:getVar("testingTime_crea_count") + 1);
+    if player:getCurrentMission(WINDURST) == A_TESTING_TIME then
+        if
+            (player:getZoneID() == dsp.zone.BUBURIMU_PENINSULA and player:hasCompletedMission(WINDURST, A_TESTING_TIME)) or
+            (player:getZoneID() == dsp.zone.TAHRONGI_CANYON and not player:hasCompletedMission(WINDURST, A_TESTING_TIME))
+        then
+            player:addVar("testingTime_crea_count", 1)
         end
     end
 end
 
 -- is a lottery NM already spawned or primed to pop?
-function lotteryPrimed(phList)
-    local nm;
-    for k,v in pairs(phList) do
-        nm = GetMobByID(v);
-        if (nm ~= nil and (nm:isSpawned() or nm:getRespawnTime() ~= 0)) then
-            return true;
+local function lotteryPrimed(phList)
+    local nm
+    for k, v in pairs(phList) do
+        nm = GetMobByID(v)
+        if nm ~= nil and (nm:isSpawned() or nm:getRespawnTime() ~= 0) then
+            return true
         end
     end
-    return false;
+    return false
 end
 
 -- potential lottery placeholder was killed
-function phOnDespawn(ph,phList,chance,cooldown,immediate)
-    if (type(immediate) ~= "boolean") then immediate = false; end
+function phOnDespawn(ph, phList, chance, cooldown, immediate)
+    if type(immediate) ~= "boolean" then immediate = false end
 
-    local phId = ph:getID();
-    local nmId = phList[phId];
-    if (nmId ~= nil) then
-        local nm = GetMobByID(nmId);
-        if (nm ~= nil) then
-            local pop = nm:getLocalVar("pop");
-            if (os.time() > pop and not lotteryPrimed(phList) and math.random(100) <= chance) then
+    local phId = ph:getID()
+    local nmId = phList[phId]
+
+    if nmId ~= nil then
+        local nm = GetMobByID(nmId)
+        if nm ~= nil then
+            local pop = nm:getLocalVar("pop")
+
+            if os.time() > pop and not lotteryPrimed(phList) and math.random(100) <= chance then
 
                 -- on PH death, replace PH repop with NM repop
-                -- print(string.format("ph %i winner! nm %i will pop in place",phId,nmId));
-                DisallowRespawn(phId, true);
-                DisallowRespawn(nmId, false);
-                UpdateNMSpawnPoint(nmId);
-                nm:setRespawnTime(immediate and 1 or GetMobRespawnTime(phId)); -- if immediate is true, spawn the nm immediately (1ms) else use placeholder's timer
+                DisallowRespawn(phId, true)
+                DisallowRespawn(nmId, false)
+                UpdateNMSpawnPoint(nmId)
+                nm:setRespawnTime(immediate and 1 or GetMobRespawnTime(phId)) -- if immediate is true, spawn the nm immediately (1ms) else use placeholder's timer
 
-                nm:addListener("DESPAWN", "DESPAWN_"..nmId, function(m)
+                nm:addListener("DESPAWN", "DESPAWN_" .. nmId, function(m)
                     -- on NM death, replace NM repop with PH repop
-                    -- print(string.format("nm %i died. ph %i will pop in place",nmId,phId));
-                    DisallowRespawn(nmId, true);
-                    DisallowRespawn(phId, false);
-                    GetMobByID(phId):setRespawnTime(GetMobRespawnTime(phId));
-                    m:setLocalVar("pop", os.time() + cooldown);
-                    m:removeListener("DESPAWN_"..nmId);
-                end);
+                    DisallowRespawn(nmId, true)
+                    DisallowRespawn(phId, false)
+                    GetMobByID(phId):setRespawnTime(GetMobRespawnTime(phId))
+                    m:setLocalVar("pop", os.time() + cooldown)
+                    m:removeListener("DESPAWN_" .. nmId)
+                end)
 
-                return true;
+                return true
             end
         end
     end
 
-    return false;
+    return false
 end
+

--- a/scripts/globals/mobs.lua
+++ b/scripts/globals/mobs.lua
@@ -4,7 +4,10 @@
 require("scripts/globals/missions")
 require("scripts/globals/quests")
 require("scripts/globals/status")
+require("scripts/globals/magic")
+require("scripts/globals/utils")
 require("scripts/globals/zone")
+require("scripts/globals/msg")
 -----------------------------------
 
 dsp = dsp or {}
@@ -35,6 +38,10 @@ function onMobDeathEx(mob, player, isKiller, isWeaponSkillKill)
         end
     end
 end
+
+-------------------------------------------------
+-- placeholder / lottery NMs
+-------------------------------------------------
 
 -- is a lottery NM already spawned or primed to pop?
 local function lotteryPrimed(phList)
@@ -83,4 +90,366 @@ dsp.mob.phOnDespawn = function(ph, phList, chance, cooldown, immediate)
     end
 
     return false
+end
+
+-------------------------------------------------
+-- mob additional melee effects
+-------------------------------------------------
+
+dsp.mob.additionalEffect =
+{
+    BLIND      = 0,
+    ENAERO     = 1,
+    ENBLIZZARD = 2,
+    ENDARK     = 3,
+    ENFIRE     = 4,
+    ENLIGHT    = 5,
+    ENSTONE    = 6,
+    ENTHUNDER  = 7,
+    ENWATER    = 8,
+    HP_DRAIN   = 9,
+    MP_DRAIN   = 10,
+    PARALYZE   = 11,
+    PETRIFY    = 12,
+    PLAGUE     = 13,
+    POISON     = 14,
+    SILENCE    = 15,
+    SLOW       = 16,
+    STUN       = 17,
+    TERROR     = 18,
+    TP_DRAIN   = 19,
+}
+dsp.mob.ae = dsp.mob.additionalEffect
+
+local additionalEffects =
+{
+    [dsp.mob.ae.BLIND] =
+    {
+        chance = 25,
+        ele = dsp.magic.ele.DARK,
+        sub = dsp.subEffect.BLIND,
+        msg = dsp.msg.basic.ADD_EFFECT_STATUS,
+        applyEffect = true,
+        eff = dsp.effect.BLINDNESS,
+        power = 20,
+        duration = 30,
+        minDuration = 1,
+        maxDuration = 45,
+    },
+    [dsp.mob.ae.ENAERO] =
+    {
+        ele = dsp.magic.ele.WIND,
+        sub = dsp.subEffect.WIND_DAMAGE,
+        msg = dsp.msg.basic.ADD_EFFECT_DMG,
+        negMsg = dsp.msg.basic.ADD_EFFECT_HEAL,
+        mod = dsp.mod.INT,
+        bonusAbilityParams = {bonusmab = 0, includemab = false},
+    },
+    [dsp.mob.ae.ENBLIZZARD] =
+    {
+        ele = dsp.magic.ele.ICE,
+        sub = dsp.subEffect.ICE_DAMAGE,
+        msg = dsp.msg.basic.ADD_EFFECT_DMG,
+        negMsg = dsp.msg.basic.ADD_EFFECT_HEAL,
+        mod = dsp.mod.INT,
+        bonusAbilityParams = {bonusmab = 0, includemab = false},
+    },
+    [dsp.mob.ae.ENDARK] =
+    {
+        ele = dsp.magic.ele.DARK,
+        sub = dsp.subEffect.DARKNESS_DAMAGE,
+        msg = dsp.msg.basic.ADD_EFFECT_DMG,
+        negMsg = dsp.msg.basic.ADD_EFFECT_HEAL,
+        mod = dsp.mod.INT,
+        bonusAbilityParams = {bonusmab = 0, includemab = false},
+    },
+    [dsp.mob.ae.ENFIRE] =
+    {
+        ele = dsp.magic.ele.FIRE,
+        sub = dsp.subEffect.FIRE_DAMAGE,
+        msg = dsp.msg.basic.ADD_EFFECT_DMG,
+        negMsg = dsp.msg.basic.ADD_EFFECT_HEAL,
+        mod = dsp.mod.INT,
+        bonusAbilityParams = {bonusmab = 0, includemab = false},
+    },
+    [dsp.mob.ae.ENLIGHT] =
+    {
+        ele = dsp.magic.ele.LIGHT,
+        sub = dsp.subEffect.LIGHT_DAMAGE,
+        msg = dsp.msg.basic.ADD_EFFECT_DMG,
+        negMsg = dsp.msg.basic.ADD_EFFECT_HEAL,
+        mod = dsp.mod.INT,
+        bonusAbilityParams = {bonusmab = 0, includemab = false},
+    },
+    [dsp.mob.ae.ENSTONE] =
+    {
+        ele = dsp.magic.ele.EARTH,
+        sub = dsp.subEffect.EARTH_DAMAGE,
+        msg = dsp.msg.basic.ADD_EFFECT_DMG,
+        negMsg = dsp.msg.basic.ADD_EFFECT_HEAL,
+        mod = dsp.mod.INT,
+        bonusAbilityParams = {bonusmab = 0, includemab = false},
+    },
+    [dsp.mob.ae.ENTHUNDER] =
+    {
+        ele = dsp.magic.ele.LIGHTNING,
+        sub = dsp.subEffect.LIGHTNING_DAMAGE,
+        msg = dsp.msg.basic.ADD_EFFECT_DMG,
+        negMsg = dsp.msg.basic.ADD_EFFECT_HEAL,
+        mod = dsp.mod.INT,
+        bonusAbilityParams = {bonusmab = 0, includemab = false},
+    },
+    [dsp.mob.ae.ENWATER] =
+    {
+        ele = dsp.magic.ele.WATER,
+        sub = dsp.subEffect.WATER_DAMAGE,
+        msg = dsp.msg.basic.ADD_EFFECT_DMG,
+        negMsg = dsp.msg.basic.ADD_EFFECT_HEAL,
+        mod = dsp.mod.INT,
+        bonusAbilityParams = {bonusmab = 0, includemab = false},
+    },
+    [dsp.mob.ae.HP_DRAIN] =
+    {
+        chance = 10,
+        ele = dsp.magic.ele.DARK,
+        sub = dsp.subEffect.HP_DRAIN,
+        msg = dsp.msg.basic.ADD_EFFECT_HP_DRAIN,
+        mod = dsp.mod.INT,
+        bonusAbilityParams = {bonusmab = 0, includemab = false},
+        code = function(mob, target, power) mob:addHP(power) end,
+    },
+    [dsp.mob.ae.MP_DRAIN] =
+    {
+        chance = 10,
+        ele = dsp.magic.ele.DARK,
+        sub = dsp.subEffect.MP_DRAIN,
+        msg = dsp.msg.basic.ADD_EFFECT_MP_DRAIN,
+        mod = dsp.mod.INT,
+        bonusAbilityParams = {bonusmab = 0, includemab = false},
+        code = function(mob, target, power) local mp = math.min(power, target:getMP()); target:delMP(mp); mob:addMP(mp) end,
+    },
+    [dsp.mob.ae.PARALYZE] =
+    {
+        chance = 25,
+        ele = dsp.magic.ele.ICE,
+        sub = dsp.subEffect.PARALYSIS,
+        msg = dsp.msg.basic.ADD_EFFECT_STATUS,
+        applyEffect = true,
+        eff = dsp.effect.PARALYSIS,
+        power = 20,
+        duration = 30,
+        minDuration = 1,
+        maxDuration = 60,
+    },
+    [dsp.mob.ae.PETRIFY] =
+    {
+        chance = 20,
+        ele = dsp.magic.ele.EARTH,
+        sub = dsp.subEffect.PETRIFY,
+        msg = dsp.msg.basic.ADD_EFFECT_STATUS,
+        applyEffect = true,
+        eff = dsp.effect.PETRIFICATION,
+        power = 1,
+        duration = 30,
+        minDuration = 1,
+        maxDuration = 45,
+    },
+    [dsp.mob.ae.PLAGUE] =
+    {
+        chance = 25,
+        ele = dsp.magic.ele.WATER,
+        sub = dsp.subEffect.PLAGUE,
+        msg = dsp.msg.basic.ADD_EFFECT_STATUS,
+        applyEffect = true,
+        eff = dsp.effect.PLAGUE,
+        power = 1,
+        duration = 60,
+        minDuration = 1,
+        maxDuration = 60,
+    },
+    [dsp.mob.ae.POISON] =
+    {
+        chance = 25,
+        ele = dsp.magic.ele.WATER,
+        sub = dsp.subEffect.POISON,
+        msg = dsp.msg.basic.ADD_EFFECT_STATUS,
+        applyEffect = true,
+        eff = dsp.effect.POISON,
+        power = 1,
+        duration = 30,
+        minDuration = 1,
+        maxDuration = 30,
+        tick = 3,
+    },
+    [dsp.mob.ae.SILENCE] =
+    {
+        chance = 25,
+        ele = dsp.magic.ele.WIND,
+        sub = dsp.subEffect.SILENCE,
+        msg = dsp.msg.basic.ADD_EFFECT_STATUS,
+        applyEffect = true,
+        eff = dsp.effect.SILENCE,
+        power = 1,
+        duration = 30,
+        minDuration = 1,
+        maxDuration = 30,
+    },
+    [dsp.mob.ae.SLOW] =
+    {
+        chance = 25,
+        ele = dsp.magic.ele.EARTH,
+        sub = dsp.subEffect.DEFENSE_DOWN,
+        msg = dsp.msg.basic.ADD_EFFECT_STATUS,
+        applyEffect = true,
+        eff = dsp.effect.SLOW,
+        power = 1000,
+        duration = 30,
+        minDuration = 1,
+        maxDuration = 45,
+    },
+    [dsp.mob.ae.STUN] =
+    {
+        chance = 20,
+        ele = dsp.magic.ele.LIGHTNING,
+        sub = dsp.subEffect.STUN,
+        msg = dsp.msg.basic.ADD_EFFECT_STATUS,
+        applyEffect = true,
+        eff = dsp.effect.STUN,
+        duration = 5,
+    },
+    [dsp.mob.ae.TERROR] =
+    {
+        chance = 20,
+        sub = dsp.subEffect.PARALYSIS,
+        msg = dsp.msg.basic.ADD_EFFECT_STATUS,
+        applyEffect = true,
+        eff = dsp.effect.TERROR,
+        duration = 5,
+        code = function(mob, target, power) mob:resetEnmity(target) end,
+    },
+    [dsp.mob.ae.TP_DRAIN] =
+    {
+        chance = 25,
+        ele = dsp.magic.ele.DARK,
+        sub = dsp.subEffect.TP_DRAIN,
+        msg = dsp.msg.basic.ADD_EFFECT_TP_DRAIN,
+        mod = dsp.mod.INT,
+        bonusAbilityParams = {bonusmab = 0, includemab = false},
+        code = function(mob, target, power) local tp = math.min(power, target:getTP()); target:delTP(tp); mob:addTP(tp) end,
+    },
+}
+
+--[[
+    mob, target, and damage are passed from core into mob script's onAdditionalEffect
+    effect should be of type dsp.mob.additionalEffect (see above)
+    params is a table that can contain any of:
+        chance: percent chance that effect procs on hit (default 20)
+        power: power of effect
+        duration: duration of effect, in seconds
+        code: additional code that will run when effect procs, of form function(mob, target, power)
+    params will override effect's default settings
+--]]
+dsp.mob.onAddEffect = function(mob, target, damage, effect, params)
+    if type(params) ~= "table" then params = {} end
+
+    local ae = additionalEffects[effect]
+
+    if ae then
+        local chance = params.chance or ae.chance or 100
+        local dLevel = target:getMainLvl() - mob:getMainLvl()
+
+        if dLevel > 0 then
+            chance = chance - 5 * dLevel
+            chance = utils.clamp(chance, 5, 95)
+        end
+
+        -- target:PrintToPlayer(string.format("Chance: %i", chance)) -- DEBUG
+
+        if math.random(100) <= chance then
+
+            -- STATUS EFFECT
+            if ae.applyEffect then
+                local resist = 1
+                if ae.ele then
+                    resist = applyResistanceAddEffect(mob, target, ae.ele, ae.eff)
+                end
+
+                if resist > 0.5 and not target:hasStatusEffect(ae.eff) then
+                    local power = params.power or ae.power or 0
+                    local tick = ae.tick or 0
+                    local duration = params.duration or ae.duration
+
+                    if dLevel < 0 then
+                        duration = duration - dLevel
+                    end
+
+                    if ae.minDuration and duration < ae.minDuration then
+                        duration = ae.minDuration
+                    elseif ae.maxDuration and duration > ae.maxDuration then
+                        duration = ae.maxDuration
+                    end
+
+                    duration = duration * resist
+
+                    target:addStatusEffect(ae.eff, power, tick, duration)
+
+                    if params.code then
+                        params.code(mob, target, power)
+                    elseif ae.code then
+                        ae.code(mob, target, power)
+                    end
+
+                    return ae.sub, ae.msg, ae.eff
+                end
+
+            -- IMMEDIATE EFFECT
+            else
+                local power = 0
+
+                if params.power then
+                    power = params.power
+                elseif ae.mod then
+                    local dMod = mob:getStat(ae.mod) - target:getStat(ae.mod)
+
+                    if dMod > 20 then
+                        dMod = 20 + (dMod - 20) / 2
+                    end
+
+                    power = dMod + target:getMainLvl() - mob:getMainLvl() + damage / 2
+                end
+
+                -- target:PrintToPlayer(string.format("Initial Power: %f", power)) -- DEBUG
+
+                power = addBonusesAbility(mob, ae.ele, target, power, ae.bonusAbilityParams)
+                power = power * applyResistanceAddEffect(mob, target, ae.ele, 0)
+                power = adjustForTarget(target, power, ae.ele)
+                power = finalMagicNonSpellAdjustments(mob, target, ae.ele, power)
+
+                -- target:PrintToPlayer(string.format("Adjusted Power: %f", power)) -- DEBUG
+
+                local message = ae.msg
+                if power < 0 then
+                    if ae.negMsg then
+                        message = ae.negMsg
+                    else
+                        power = 0
+                    end
+                end
+
+                if power ~= 0 then
+                    if params.code then
+                        params.code(mob, target, power)
+                    elseif ae.code then
+                        ae.code(mob, target, power)
+                    end
+
+                    return ae.sub, message, power
+                end
+            end
+        end
+    else
+        printf("invalid additional effect for mobId %i", mob:getID())
+    end
+
+    return 0, 0, 0
 end

--- a/scripts/zones/Abyssea-La_Theine/mobs/Piasa.lua
+++ b/scripts/zones/Abyssea-La_Theine/mobs/Piasa.lua
@@ -2,29 +2,15 @@
 -- Area: Abyssea - La Theine
 --   NM: Piasa
 -----------------------------------
-require("scripts/globals/status")
-require("scripts/globals/magic")
-require("scripts/globals/msg")
+require("scripts/globals/mobs")
 -----------------------------------
 
 function onMobInitialize(mob)
     mob:setMobMod(dsp.mobMod.ADD_EFFECT, 1)
 end
 
-function onAdditionalEffect(mob,target,damage)
-    -- Resistance calcs should cause the addEffect damage to fall below 50 to get that 30-50 range wiki speaks of..
-    -- But our resists don't appear to be fully retail, so we are still using randomness here instead.
-    local basePower = math.random(40,50) -- Best guess off wiki and assumption of non lv/stat scaled dmg
-    local params = {}
-    params.bonusmab = 0
-    params.includemab = false
-
-    local dmg = addBonusesAbility(mob, dsp.magic.ele.WIND, target, basePower, params)
-    dmg = dmg * applyResistanceAddEffect(mob,target,dsp.magic.ele.WIND,0)
-    dmg = adjustForTarget(target,dmg,dsp.magic.ele.WIND)
-    dmg = finalMagicNonSpellAdjustments(mob,target,dsp.magic.ele.WIND,dmg)
-
-    return dsp.subEffect.WIND_DAMAGE, dsp.msg.basic.ADD_EFFECT_DMG, dmg
+function onAdditionalEffect(mob, target, damage)
+    return dsp.mob.onAddEffect(mob, target, damage, dsp.mob.ae.ENAERO)
 end
 
 function onMobDeath(mob,player,isKiller)

--- a/scripts/zones/AlTaieu/mobs/Jailer_of_Hope.lua
+++ b/scripts/zones/AlTaieu/mobs/Jailer_of_Hope.lua
@@ -1,8 +1,8 @@
 -----------------------------------
 -- Area: Al'Taieu
---  NM:  Jailer of Hope
+--   NM: Jailer of Hope
 -----------------------------------
-require("scripts/globals/status");
+require("scripts/globals/mobs")
 -----------------------------------
 
 function onMobInitialize(mob)
@@ -28,16 +28,9 @@ function onMobWeaponSkill(target, mob, skill)
     end;
 end;
 
-function onAdditionalEffect(mob,target,damage)
-    -- Guestimating 2 in 3 chance to stun on melee.
-    if ((math.random(1,100) >= 66) or (target:hasStatusEffect(dsp.effect.STUN) == true)) then
-        return 0,0,0;
-    else
-        local duration = math.random(4,8);
-        target:addStatusEffect(dsp.effect.STUN,5,0,duration);
-        return dsp.subEffect.STUN,0,dsp.effect.STUN;
-    end
-end;
+function onAdditionalEffect(mob, target, damage)
+    return dsp.mob.onAddEffect(mob, target, damage, dsp.mob.ae.STUN, {chance = 65, duration = math.random(4, 8)})
+end
 
 function onMobDeath(mob, player, isKiller)
 end;

--- a/scripts/zones/Alzadaal_Undersea_Ruins/mobs/Cookieduster_Lipiroon.lua
+++ b/scripts/zones/Alzadaal_Undersea_Ruins/mobs/Cookieduster_Lipiroon.lua
@@ -9,13 +9,8 @@ function onMobInitialize(mob)
     mob:setMobMod(dsp.mobMod.ADD_EFFECT, 1)
 end
 
-function onAdditionalEffect(mob,target,damage)
-    if math.random(100) >= 20 or target:hasStatusEffect(dsp.effect.POISON) then
-        return 0,0,0
-    else
-        target:addStatusEffect(dsp.effect.POISON, 70, 3, 30)
-        return dsp.subEffect.POISON, 0, dsp.effect.POISON
-    end
+function onAdditionalEffect(mob, target, damage)
+    return dsp.mob.onAddEffect(mob, target, damage, dsp.mob.ae.POISON, {power = 70})
 end
 
 function onMobDeath(mob, player, isKiller)

--- a/scripts/zones/Alzadaal_Undersea_Ruins/mobs/Qiqirn_Goldsmith.lua
+++ b/scripts/zones/Alzadaal_Undersea_Ruins/mobs/Qiqirn_Goldsmith.lua
@@ -11,5 +11,5 @@ function onMobDeath(mob, player, isKiller)
 end
 
 function onMobDespawn(mob)
-    phOnDespawn(mob, ID.mob.COOKIEDUSTER_LIPIROON_PH, 5, 3600) -- 1 hour
+    dsp.mob.phOnDespawn(mob, ID.mob.COOKIEDUSTER_LIPIROON_PH, 5, 3600) -- 1 hour
 end

--- a/scripts/zones/Apollyon/mobs/Proto-Omega.lua
+++ b/scripts/zones/Apollyon/mobs/Proto-Omega.lua
@@ -4,9 +4,7 @@
 -----------------------------------
 require("scripts/globals/limbus");
 require("scripts/globals/titles");
-require("scripts/globals/status");
-require("scripts/globals/magic");
-require("scripts/globals/msg");
+require("scripts/globals/mobs")
 -----------------------------------
 
 function onMobInitialize(mob)
@@ -59,19 +57,9 @@ function onMobFight(mob,target)
     end
 end;
 
-function onAdditionalEffect(mob, player)
-    local chance = 20; -- wiki lists ~20% stun chance
-    local resist = applyResistanceAddEffect(mob,player,dsp.magic.ele.THUNDER,dsp.effect.STUN);
-    if (math.random(0,99) >= chance or resist <= 0.5) then
-        return 0,0,0;
-    else
-        local duration = 5 * resist;
-        if (player:hasStatusEffect(dsp.effect.STUN) == false) then
-            player:addStatusEffect(dsp.effect.STUN, 0, 0, duration);
-        end
-        return dsp.subEffect.STUN, dsp.msg.basic.ADD_EFFECT_STATUS, dsp.effect.STUN;
-    end
-end;
+function onAdditionalEffect(mob, target, damage)
+    return dsp.mob.onAddEffect(mob, target, damage, dsp.mob.ae.STUN)
+end
 
 function onMobDeath(mob, player, isKiller)
     player:addTitle(dsp.title.APOLLYON_RAVAGER);

--- a/scripts/zones/Arrapago_Reef/mobs/Draugar_Servant.lua
+++ b/scripts/zones/Arrapago_Reef/mobs/Draugar_Servant.lua
@@ -11,5 +11,5 @@ function onMobDeath(mob, player, isKiller)
 end
 
 function onMobDespawn(mob)
-    phOnDespawn(mob, ID.mob.BLOODY_BONES_PH, 5, 75600) -- 21 hours
+    dsp.mob.phOnDespawn(mob, ID.mob.BLOODY_BONES_PH, 5, 75600) -- 21 hours
 end

--- a/scripts/zones/Attohwa_Chasm/mobs/Alastor_Antlion.lua
+++ b/scripts/zones/Attohwa_Chasm/mobs/Alastor_Antlion.lua
@@ -1,11 +1,10 @@
 -----------------------------------
 -- Area: Attohwa Chasm
---  NPC: Alastor Antlion
+--   NM: Alastor Antlion
 -----------------------------------
 mixins = {require("scripts/mixins/families/antlion_ambush_noaggro")}
-require("scripts/globals/status");
-require("scripts/globals/magic");
-require("scripts/globals/msg");
+require("scripts/globals/mobs")
+-----------------------------------
 
 function onMobInitialize(mob)
     mob:setMobMod(dsp.mobMod.ADD_EFFECT, 1);
@@ -16,24 +15,9 @@ function onMobInitialize(mob)
     mob:addMod(dsp.mod.SILENCERES,40);
 end;
 
-function onAdditionalEffect(mob, player)
-    local chance = 25;
-    local resist = applyResistanceAddEffect(mob,player,dsp.magic.ele.EARTH,dsp.effect.PETRIFICATION);
-    if (math.random(0,99) >= chance or resist <= 0.5) then
-        return 0,0,0;
-    else
-        local duration = 30;
-        if (mob:getMainLvl() > player:getMainLvl()) then
-            duration = duration + (mob:getMainLvl() - player:getMainLvl())
-        end
-        duration = utils.clamp(duration,1,45);
-        duration = duration * resist;
-        if (not player:hasStatusEffect(dsp.effect.PETRIFICATION)) then
-            player:addStatusEffect(dsp.effect.PETRIFICATION, 1, 0, duration);
-        end
-        return dsp.subEffect.PETRIFY, dsp.msg.basic.ADD_EFFECT_STATUS, dsp.effect.PETRIFICATION;
-    end
-end;
+function onAdditionalEffect(mob, target, damage)
+    return dsp.mob.onAddEffect(mob, target, damage, dsp.mob.ae.PETRIFY)
+end
 
 function onMobDeath(mob, player, isKiller)
 end;

--- a/scripts/zones/Attohwa_Chasm/mobs/Corse.lua
+++ b/scripts/zones/Attohwa_Chasm/mobs/Corse.lua
@@ -10,5 +10,5 @@ function onMobDeath(mob, player, isKiller)
 end;
 
 function onMobDespawn(mob)
-    phOnDespawn(mob,ID.mob.CITIPATI_PH,20,math.random(10800,21600)); -- 3 to 6 hours
+    dsp.mob.phOnDespawn(mob,ID.mob.CITIPATI_PH,20,math.random(10800,21600)); -- 3 to 6 hours
 end;

--- a/scripts/zones/Attohwa_Chasm/mobs/Sargas.lua
+++ b/scripts/zones/Attohwa_Chasm/mobs/Sargas.lua
@@ -2,9 +2,7 @@
 -- Area: Attohwa Chasm
 --   NM: Sargas
 -----------------------------------
-require("scripts/globals/status")
-require("scripts/globals/magic")
-require("scripts/globals/msg")
+require("scripts/globals/mobs")
 -----------------------------------
 
 function onMobInitialize(mob)
@@ -15,14 +13,7 @@ function onMobInitialize(mob)
 end
 
 function onAdditionalEffect(mob, target, damage)
-    -- Guestimating 2 in 3 chance to stun on melee.
-    if math.random(100) >= 66 or target:hasStatusEffect(dsp.effect.STUN) then
-        return 0, 0, 0
-    else
-        local duration = math.random(5, 15)
-        target:addStatusEffect(dsp.effect.STUN, 5, 0, duration)
-        return dsp.subEffect.STUN, 0, dsp.effect.STUN
-    end
+    return dsp.mob.onAddEffect(mob, target, damage, dsp.mob.ae.STUN, {chance = 65, duration = math.random(5, 15)})
 end
 
 function onSpikesDamage(mob, target, damage)

--- a/scripts/zones/Attohwa_Chasm/mobs/Sekhmet.lua
+++ b/scripts/zones/Attohwa_Chasm/mobs/Sekhmet.lua
@@ -1,10 +1,9 @@
 -----------------------------------
 -- Area: Attohwa Chasm
---  NM:  Sekhmet
+--   NM: Sekhmet
 -----------------------------------
-require("scripts/globals/status");
-require("scripts/globals/magic");
-require("scripts/globals/msg");
+require("scripts/globals/mobs")
+-----------------------------------
 
 function onMobInitialize(mob)
     mob:setMobMod(dsp.mobMod.ADD_EFFECT, 1);
@@ -13,24 +12,8 @@ function onMobInitialize(mob)
 end;
 
 function onAdditionalEffect(mob, target, damage)
-    local chance = 100;
-    local resist = applyResistanceAddEffect(mob,target,dsp.magic.ele.DARK,dsp.effect.ENASPIR);
-    if (math.random(0,99) >= chance or resist <= 0.5) then
-        return 0,0,0;
-    else
-        local mp = math.random(1,10);
-        if (target:getMP() < mp) then
-            mp = target:getMP();
-        end
-        if (mp == 0) then
-            return 0,0,0;
-        else
-            target:delMP(mp);
-            mob:addMP(mp);
-            return dsp.subEffect.MP_DRAIN, dsp.msg.basic.ADD_EFFECT_MP_DRAIN, mp;
-        end
-    end
-end;
+    return dsp.mob.onAddEffect(mob, target, damage, dsp.mob.ae.MP_DRAIN, {power = math.random(1, 10)})
+end
 
 function onMobDeath(mob, player, isKiller)
 end;

--- a/scripts/zones/Attohwa_Chasm/mobs/Trench_Antlion.lua
+++ b/scripts/zones/Attohwa_Chasm/mobs/Trench_Antlion.lua
@@ -11,5 +11,5 @@ function onMobDeath(mob, player, isKiller)
 end
 
 function onMobDespawn(mob)
-    phOnDespawn(mob,ID.mob.AMBUSHER_ANTLION_PH,10,3600) -- 1 hour
+    dsp.mob.phOnDespawn(mob,ID.mob.AMBUSHER_ANTLION_PH,10,3600) -- 1 hour
 end

--- a/scripts/zones/Aydeewa_Subterrane/mobs/Qiqirn_Archaeologist.lua
+++ b/scripts/zones/Aydeewa_Subterrane/mobs/Qiqirn_Archaeologist.lua
@@ -11,5 +11,5 @@ function onMobDeath(mob, player, isKiller)
 end
 
 function onMobDespawn(mob)
-    phOnDespawn(mob, ID.mob.BLUESTREAK_GYUGYUROON_PH, 10, 7200) -- 2 hours
+    dsp.mob.phOnDespawn(mob, ID.mob.BLUESTREAK_GYUGYUROON_PH, 10, 7200) -- 2 hours
 end

--- a/scripts/zones/Batallia_Downs/mobs/Evil_Weapon.lua
+++ b/scripts/zones/Batallia_Downs/mobs/Evil_Weapon.lua
@@ -11,5 +11,5 @@ function onMobDeath(mob, player, isKiller)
 end
 
 function onMobDespawn(mob)
-    phOnDespawn(mob, ID.mob.PRANKSTER_MAVERIX_PH, 5, 3600) -- 1 hour
+    dsp.mob.phOnDespawn(mob, ID.mob.PRANKSTER_MAVERIX_PH, 5, 3600) -- 1 hour
 end

--- a/scripts/zones/Batallia_Downs/mobs/Eyegouger.lua
+++ b/scripts/zones/Batallia_Downs/mobs/Eyegouger.lua
@@ -2,29 +2,15 @@
 -- Area: Batallia Downs
 --   NM: Eyegouger
 -----------------------------------
-require("scripts/globals/status")
-require("scripts/globals/magic")
+require("scripts/globals/mobs")
 -----------------------------------
 
 function onMobInitialize(mob)
     mob:setMobMod(dsp.mobMod.ADD_EFFECT, 1)
 end
 
-function onAdditionalEffect(mob, player)
-    local resist = applyResistanceAddEffect(mob, player, dsp.magic.ele.DARK, dsp.effect.BLINDNESS)
-
-    if math.random(100) > 20 or resist <= 0.5 then
-        return 0, 0, 0
-    else
-        local duration = 30
-        duration = duration * resist
-
-        if not player:hasStatusEffect(dsp.effect.BLINDNESS) then
-            player:addStatusEffect(dsp.effect.BLINDNESS, 0, 0, duration)
-        end
-
-        return dsp.subEffect.BLIND, dsp.msg.basic.ADD_EFFECT_STATUS, dsp.effect.BLINDNESS
-    end
+function onAdditionalEffect(mob, target, damage)
+    return dsp.mob.onAddEffect(mob, target, damage, dsp.mob.ae.BLIND)
 end
 
 function onMobDeath(mob, player, isKiller)

--- a/scripts/zones/Batallia_Downs/mobs/Lumber_Jack.lua
+++ b/scripts/zones/Batallia_Downs/mobs/Lumber_Jack.lua
@@ -1,9 +1,9 @@
 -----------------------------------
 -- Area: Batallia Downs (105)
---  MOB: Lumber Jack
+--   NM: Lumber Jack
 -----------------------------------
 mixins = {require("scripts/mixins/job_special")};
-require("scripts/globals/status");
+require("scripts/globals/mobs")
 -----------------------------------
 
 function onMobInitialize(mob)
@@ -11,18 +11,13 @@ function onMobInitialize(mob)
     mob:setMobMod(dsp.mobMod.IDLE_DESPAWN, 600);
 end;
 
-function onAdditionalEffect(mob,target,damage)
-    -- Guesstimating the chance to stun before resistance applied (it's fairly low rate on retail).
-    -- Does not proc if Jack's enstone is up.
-    if (math.random(1,100) <= 75 or mob:hasStatusEffect(dsp.effect.ENSTONE)
-    or applyResistanceAddEffect(mob, target, dsp.magic.ele.LIGHTNING, 0) <= 0.5) then
-        return 0,0,0;
+function onAdditionalEffect(mob, target, damage)
+    if mob:hasStatusEffect(dsp.effect.ENSTONE) then
+        return 0, 0, 0
     else
-        local duration = math.random(5,15);
-        target:addStatusEffect(dsp.effect.STUN,5,0,duration);
-        return dsp.subEffect.STUN,0,dsp.effect.STUN; -- Todo: confirm retail message. Unsure if says "is stunned" on proc.
+        return dsp.mob.onAddEffect(mob, target, damage, dsp.mob.ae.STUN)
     end
-end;
+end
 
 function onMobDeath(mob, player, isKiller)
 end;

--- a/scripts/zones/Batallia_Downs/mobs/Stalking_Sapling.lua
+++ b/scripts/zones/Batallia_Downs/mobs/Stalking_Sapling.lua
@@ -13,5 +13,5 @@ function onMobDeath(mob, player, isKiller)
 end;
 
 function onMobDespawn(mob)
-    phOnDespawn(mob,ID.mob.TOTTERING_TOBY_PH,20,3600); -- 1 hour
+    dsp.mob.phOnDespawn(mob,ID.mob.TOTTERING_TOBY_PH,20,3600); -- 1 hour
 end;

--- a/scripts/zones/Batallia_Downs_[S]/mobs/Ba.lua
+++ b/scripts/zones/Batallia_Downs_[S]/mobs/Ba.lua
@@ -11,5 +11,5 @@ function onMobDeath(mob, player, isKiller)
 end
 
 function onMobDespawn(mob)
-    phOnDespawn(mob, ID.mob.HABERGOASS_PH, 10, 5400) -- 90 minutes
+    dsp.mob.phOnDespawn(mob, ID.mob.HABERGOASS_PH, 10, 5400) -- 90 minutes
 end

--- a/scripts/zones/Batallia_Downs_[S]/mobs/Chaneque.lua
+++ b/scripts/zones/Batallia_Downs_[S]/mobs/Chaneque.lua
@@ -1,35 +1,17 @@
 -----------------------------------
 -- Area: Batallia Downs (S)
---  NM:  Chaneque
+--   NM: Chaneque
 -----------------------------------
-require("scripts/globals/status");
-require("scripts/globals/msg");
+require("scripts/globals/mobs")
 -----------------------------------
 
 function onMobInitialize(mob)
     mob:setMobMod(dsp.mobMod.ADD_EFFECT, 1);
 end;
 
-function onAdditionalEffect(mob,target,damage)
-    local chance = 10;
-
-    if (math.random(0,99) >= chance) then
-        return 0,0,0;
-    else
-        local power = 10;
-        local params = {};
-        params.bonusmab = 0;
-        params.includemab = false;
-        power = addBonusesAbility(mob, dsp.magic.ele.DARK, target, power, params);
-        power = power * applyResistanceAddEffect(mob,target,dsp.magic.ele.DARK,0);
-        power = adjustForTarget(target,power,dsp.magic.ele.DARK);
-        power = finalMagicNonSpellAdjustments(mob,target,dsp.magic.ele.DARK,power);
-        if (power < 0) then
-            power = 0
-        end
-        return dsp.subEffect.HP_DRAIN, dsp.msg.basic.ADD_EFFECT_HP_DRAIN, mob:addHP(power);
-    end
-end;
+function onAdditionalEffect(mob, target, damage)
+    return dsp.mob.onAddEffect(mob, target, damage, dsp.mob.ae.HP_DRAIN)
+end
 
 function onMobDeath(mob, player, isKiller)
 end;

--- a/scripts/zones/Batallia_Downs_[S]/mobs/Goblin_Blastmaster.lua
+++ b/scripts/zones/Batallia_Downs_[S]/mobs/Goblin_Blastmaster.lua
@@ -11,5 +11,5 @@ function onMobDeath(mob, player, isKiller)
 end
 
 function onMobDespawn(mob)
-    phOnDespawn(mob, ID.mob.BURLIBIX_BRAWNBACK_PH, 10, 10800) -- 3 hours
+    dsp.mob.phOnDespawn(mob, ID.mob.BURLIBIX_BRAWNBACK_PH, 10, 10800) -- 3 hours
 end

--- a/scripts/zones/Batallia_Downs_[S]/mobs/Smilodon.lua
+++ b/scripts/zones/Batallia_Downs_[S]/mobs/Smilodon.lua
@@ -11,5 +11,5 @@ function onMobDeath(mob, player, isKiller)
 end
 
 function onMobDespawn(mob)
-    phOnDespawn(mob, ID.mob.LA_VELUE_PH, 10, 3600) -- 1 hour
+    dsp.mob.phOnDespawn(mob, ID.mob.LA_VELUE_PH, 10, 3600) -- 1 hour
 end

--- a/scripts/zones/Beadeaux/mobs/Brass_Quadav.lua
+++ b/scripts/zones/Beadeaux/mobs/Brass_Quadav.lua
@@ -10,5 +10,5 @@ function onMobDeath(mob, player, isKiller)
 end;
 
 function onMobDespawn(mob)
-    phOnDespawn(mob,ID.mob.BI_GHO_HEADTAKER_PH,10,math.random(3600,10800)); -- 1 to 3 hours
+    dsp.mob.phOnDespawn(mob,ID.mob.BI_GHO_HEADTAKER_PH,10,math.random(3600,10800)); -- 1 to 3 hours
 end;

--- a/scripts/zones/Beadeaux/mobs/Copper_Quadav.lua
+++ b/scripts/zones/Beadeaux/mobs/Copper_Quadav.lua
@@ -19,5 +19,5 @@ function onMobDeath(mob, player, isKiller)
 end;
 
 function onMobDespawn(mob)
-    phOnDespawn(mob,ID.mob.DA_DHA_HUNDREDMASK_PH,10,5400); -- 90 minutes
+    dsp.mob.phOnDespawn(mob,ID.mob.DA_DHA_HUNDREDMASK_PH,10,5400); -- 90 minutes
 end;

--- a/scripts/zones/Beadeaux/mobs/Emerald_Quadav.lua
+++ b/scripts/zones/Beadeaux/mobs/Emerald_Quadav.lua
@@ -10,5 +10,5 @@ function onMobDeath(mob, player, isKiller)
 end;
 
 function onMobDespawn(mob)
-    phOnDespawn(mob,ID.mob.GA_BHU_UNVANQUISHED_PH,10,3600); -- 1 hour
+    dsp.mob.phOnDespawn(mob,ID.mob.GA_BHU_UNVANQUISHED_PH,10,3600); -- 1 hour
 end;

--- a/scripts/zones/Beadeaux/mobs/Old_Quadav.lua
+++ b/scripts/zones/Beadeaux/mobs/Old_Quadav.lua
@@ -10,5 +10,5 @@ function onMobDeath(mob, player, isKiller)
 end;
 
 function onMobDespawn(mob)
-    phOnDespawn(mob,ID.mob.GE_DHA_EVILEYE_PH,25,math.random(3600,7200)); -- 1 to 2 hours
+    dsp.mob.phOnDespawn(mob,ID.mob.GE_DHA_EVILEYE_PH,25,math.random(3600,7200)); -- 1 to 2 hours
 end;

--- a/scripts/zones/Beadeaux/mobs/Zircon_Quadav.lua
+++ b/scripts/zones/Beadeaux/mobs/Zircon_Quadav.lua
@@ -10,5 +10,5 @@ function onMobDeath(mob, player, isKiller)
 end;
 
 function onMobDespawn(mob)
-    phOnDespawn(mob,ID.mob.ZO_KHU_BLACKCLOUD_PH,10,math.random(3600,18000)); -- 1 to 5 hours
+    dsp.mob.phOnDespawn(mob,ID.mob.ZO_KHU_BLACKCLOUD_PH,10,math.random(3600,18000)); -- 1 to 5 hours
 end;

--- a/scripts/zones/Beadeaux_[S]/mobs/Adaman_Quadav.lua
+++ b/scripts/zones/Beadeaux_[S]/mobs/Adaman_Quadav.lua
@@ -11,6 +11,6 @@ function onMobDeath(mob, player, isKiller)
 end
 
 function onMobDespawn(mob)
-    phOnDespawn(mob, ID.mob.EATHO_CRUELHEART_PH, 10, 7200) -- 2 hours
-    phOnDespawn(mob, ID.mob.BATHO_MERCIFULHEART_PH, 10, 7200) -- 2 hours
+    dsp.mob.phOnDespawn(mob, ID.mob.EATHO_CRUELHEART_PH, 10, 7200) -- 2 hours
+    dsp.mob.phOnDespawn(mob, ID.mob.BATHO_MERCIFULHEART_PH, 10, 7200) -- 2 hours
 end

--- a/scripts/zones/Beadeaux_[S]/mobs/Gold_Quadav.lua
+++ b/scripts/zones/Beadeaux_[S]/mobs/Gold_Quadav.lua
@@ -11,5 +11,5 @@ function onMobDeath(mob, player, isKiller)
 end;
 
 function onMobDespawn(mob)
-    phOnDespawn(mob,ID.mob.DA_DHA_HUNDREDMASK_PH,12,7200); -- 2 hours
+    dsp.mob.phOnDespawn(mob,ID.mob.DA_DHA_HUNDREDMASK_PH,12,7200); -- 2 hours
 end;

--- a/scripts/zones/Beaucedine_Glacier/mobs/Calcabrina.lua
+++ b/scripts/zones/Beaucedine_Glacier/mobs/Calcabrina.lua
@@ -1,54 +1,17 @@
 -----------------------------------
 -- Area: Beaucedine Glacier
---  NM:  Calcabrina
+--   NM: Calcabrina
 -----------------------------------
-require("scripts/globals/status");
-require("scripts/globals/magic");
-require("scripts/globals/msg");
+require("scripts/globals/mobs")
 -----------------------------------
 
 function onMobInitialize(mob)
     mob:setMobMod(dsp.mobMod.ADD_EFFECT, 1);
 end;
 
-function onAdditionalEffect(mob,target,damage)
-    -- wiki just says "low proc rate". No actual data to go on - going with 15% for now.
-    local chance = 15;
-    local LV_diff = target:getMainLvl() - mob:getMainLvl();
-
-    if (target:getMainLvl() > mob:getMainLvl()) then
-        chance = chance - 5 * LV_diff
-        chance = utils.clamp(chance, 5, 95);
-    end
-
-    if (math.random(0,99) >= chance) then
-        return 0,0,0;
-    else
-        local INT_diff = mob:getStat(dsp.mod.INT) - target:getStat(dsp.mod.INT);
-
-        if (INT_diff > 20) then
-            INT_diff = 20 + (INT_diff - 20) / 2;
-        end
-
-        local drain = INT_diff+LV_diff+damage/2;
-        local params = {};
-        params.bonusmab = 0;
-        params.includemab = false;
-        drain = addBonusesAbility(mob, dsp.magic.ele.DARK, target, drain, params);
-        drain = drain * applyResistanceAddEffect(mob,target,dsp.magic.ele.DARK,0);
-        drain = adjustForTarget(target,drain,dsp.magic.ele.DARK);
-        drain = finalMagicNonSpellAdjustments(target,mob,dsp.magic.ele.DARK,drain);
-
-        if (drain <= 0) then
-            drain = 0;
-        else
-            mob:addHP(drain);
-        end
-
-        return dsp.subEffect.HP_DRAIN, dsp.msg.basic.ADD_EFFECT_HP_DRAIN, drain;
-    end
-
-end;
+function onAdditionalEffect(mob, target, damage)
+    return dsp.mob.onAddEffect(mob, target, damage, dsp.mob.ae.HP_DRAIN)
+end
 
 function onMobDeath(mob, player, isKiller)
 end;

--- a/scripts/zones/Beaucedine_Glacier/mobs/Stone_Golem.lua
+++ b/scripts/zones/Beaucedine_Glacier/mobs/Stone_Golem.lua
@@ -10,5 +10,5 @@ function onMobDeath(mob, player, isKiller)
 end;
 
 function onMobDespawn(mob)
-    phOnDespawn(mob,ID.mob.GARGANTUA_PH,5,math.random(3600,25200)); -- 1 to 7 hours
+    dsp.mob.phOnDespawn(mob,ID.mob.GARGANTUA_PH,5,math.random(3600,25200)); -- 1 to 7 hours
 end;

--- a/scripts/zones/Beaucedine_Glacier/mobs/Tundra_Tiger.lua
+++ b/scripts/zones/Beaucedine_Glacier/mobs/Tundra_Tiger.lua
@@ -13,6 +13,6 @@ function onMobDeath(mob, player, isKiller)
 end;
 
 function onMobDespawn(mob)
-    phOnDespawn(mob,ID.mob.KIRATA_PH,7,math.random(3600,28800)); -- 1 to 8 hours
-    phOnDespawn(mob,ID.mob.NUE_PH,7,math.random(3600,7200)); -- 1 to 2 hours
+    dsp.mob.phOnDespawn(mob,ID.mob.KIRATA_PH,7,math.random(3600,28800)); -- 1 to 8 hours
+    dsp.mob.phOnDespawn(mob,ID.mob.NUE_PH,7,math.random(3600,7200)); -- 1 to 2 hours
 end;

--- a/scripts/zones/Beaucedine_Glacier_[S]/mobs/Gargouille.lua
+++ b/scripts/zones/Beaucedine_Glacier_[S]/mobs/Gargouille.lua
@@ -11,5 +11,5 @@ function onMobDeath(mob, player, isKiller)
 end
 
 function onMobDespawn(mob)
-    phOnDespawn(mob, ID.mob.GRANDGOULE_PH, 10, 3600) -- 1 hour
+    dsp.mob.phOnDespawn(mob, ID.mob.GRANDGOULE_PH, 10, 3600) -- 1 hour
 end

--- a/scripts/zones/Beaucedine_Glacier_[S]/mobs/GrandGoule.lua
+++ b/scripts/zones/Beaucedine_Glacier_[S]/mobs/GrandGoule.lua
@@ -2,31 +2,15 @@
 -- Area: Beaucedine Glacier (S)
 --   NM: Grand'Goule
 -----------------------------------
-require("scripts/globals/status")
+require("scripts/globals/mobs")
 -----------------------------------
 
 function onMobInitialize(mob)
     mob:setMobMod(dsp.mobMod.ADD_EFFECT, 1)
 end
 
-function onAdditionalEffect(mob, player)
-    local chance = 25
-    local resist = applyResistanceAddEffect(mob,player,dsp.magic.ele.EARTH,dsp.effect.PETRIFICATION)
-
-    if math.random(0,99) >= chance or resist <= 0.5 then
-        return 0,0,0
-    else
-        local duration = 30
-        if mob:getMainLvl() > player:getMainLvl() then
-            duration = duration + mob:getMainLvl() - player:getMainLvl()
-        end
-        duration = utils.clamp(duration, 1, 45)
-        duration = duration * resist
-        if not player:hasStatusEffect(dsp.effect.PETRIFICATION) then
-            player:addStatusEffect(dsp.effect.PETRIFICATION, 1, 0, duration)
-        end
-        return dsp.subEffect.PETRIFY, dsp.msg.basic.ADD_EFFECT_STATUS, dsp.effect.PETRIFICATION
-    end
+function onAdditionalEffect(mob, target, damage)
+    return dsp.mob.onAddEffect(mob, target, damage, dsp.mob.ae.PETRIFY)
 end
 
 function onMobDeath(mob, player, isKiller)

--- a/scripts/zones/Bhaflau_Thickets/mobs/Harvestman.lua
+++ b/scripts/zones/Bhaflau_Thickets/mobs/Harvestman.lua
@@ -1,25 +1,18 @@
 -----------------------------------
 -- Area: Bhaflau Thickets
---  MOB: Harvestman
+--   NM: Harvestman
 -- !pos 398.130 -10.675 179.169 52
 -----------------------------------
-require("scripts/globals/msg");
+require("scripts/globals/mobs")
 -----------------------------------
 
 function onMobInitialize(mob)
     mob:setMobMod(dsp.mobMod.ADD_EFFECT, 1);
 end;
 
-function onAdditionalEffect(mob,target,damage)
-    -- Guesstimating 1 in 4 chance to poison on melee.
-    if ((math.random(1,100) >= 25) or (target:hasStatusEffect(dsp.effect.POISON) == true)) then
-        return 0,0,0;
-    else
-        local duration = math.random(6,9); -- 2-3 Tick's
-        target:addStatusEffect(dsp.effect.POISON,100,3,duration);
-        return dsp.subEffect.POISON,dsp.msg.basic.ADD_EFFECT_STATUS,dsp.effect.POISON;
-    end
-end;
+function onAdditionalEffect(mob, target, damage)
+    return dsp.mob.onAddEffect(mob, target, damage, dsp.mob.ae.POISON, {power = 100, duration = math.random(6, 9)})
+end
 
 function onMobDeath(mob, player, isKiller)
 end;

--- a/scripts/zones/Bhaflau_Thickets/mobs/Marid.lua
+++ b/scripts/zones/Bhaflau_Thickets/mobs/Marid.lua
@@ -10,5 +10,5 @@ function onMobDeath(mob, player, isKiller)
 end;
 
 function onMobDespawn(mob)
-    phOnDespawn(mob,ID.mob.MAHISHASURA_PH,5,10800); -- 3 hours
+    dsp.mob.phOnDespawn(mob,ID.mob.MAHISHASURA_PH,5,10800); -- 3 hours
 end;

--- a/scripts/zones/Bhaflau_Thickets/mobs/Olden_Treant.lua
+++ b/scripts/zones/Bhaflau_Thickets/mobs/Olden_Treant.lua
@@ -10,5 +10,5 @@ function onMobDeath(mob, player, isKiller)
 end;
 
 function onMobDespawn(mob)
-    phOnDespawn(mob,ID.mob.EMERGENT_ELM_PH,5,14400); -- 4 hours
+    dsp.mob.phOnDespawn(mob,ID.mob.EMERGENT_ELM_PH,5,14400); -- 4 hours
 end;

--- a/scripts/zones/Bhaflau_Thickets/mobs/Sea_Puk.lua
+++ b/scripts/zones/Bhaflau_Thickets/mobs/Sea_Puk.lua
@@ -10,5 +10,5 @@ function onMobDeath(mob, player, isKiller)
 end;
 
 function onMobDespawn(mob)
-    phOnDespawn(mob,ID.mob.NIS_PUK_PH,5,43200); -- 12 hours
+    dsp.mob.phOnDespawn(mob,ID.mob.NIS_PUK_PH,5,43200); -- 12 hours
 end;

--- a/scripts/zones/Bibiki_Bay/mobs/Eft.lua
+++ b/scripts/zones/Bibiki_Bay/mobs/Eft.lua
@@ -11,5 +11,5 @@ function onMobDeath(mob, player, isKiller)
 end
 
 function onMobDespawn(mob)
-    phOnDespawn(mob, ID.mob.INTULO_PH, 10, 3600) -- 1 hour
+    dsp.mob.phOnDespawn(mob, ID.mob.INTULO_PH, 10, 3600) -- 1 hour
 end

--- a/scripts/zones/Bibiki_Bay/mobs/Jagil.lua
+++ b/scripts/zones/Bibiki_Bay/mobs/Jagil.lua
@@ -11,5 +11,5 @@ function onMobDeath(mob, player, isKiller)
 end
 
 function onMobDespawn(mob)
-    phOnDespawn(mob, ID.mob.SERRA_PH, 10, 3600) -- 1 hour
+    dsp.mob.phOnDespawn(mob, ID.mob.SERRA_PH, 10, 3600) -- 1 hour
 end

--- a/scripts/zones/Bibiki_Bay/mobs/Tartarus_Eft.lua
+++ b/scripts/zones/Bibiki_Bay/mobs/Tartarus_Eft.lua
@@ -11,5 +11,5 @@ function onMobDeath(mob, player, isKiller)
 end
 
 function onMobDespawn(mob)
-    phOnDespawn(mob, ID.mob.SPLACKNUCK_PH, 10, 3600) -- 1 hour
+    dsp.mob.phOnDespawn(mob, ID.mob.SPLACKNUCK_PH, 10, 3600) -- 1 hour
 end

--- a/scripts/zones/Bostaunieux_Oubliette/mobs/Dark_Aspic.lua
+++ b/scripts/zones/Bostaunieux_Oubliette/mobs/Dark_Aspic.lua
@@ -12,5 +12,5 @@ function onMobDeath(mob, player, isKiller)
 end;
 
 function onMobDespawn(mob)
-    phOnDespawn(mob,ID.mob.SEWER_SYRUP_PH,10,math.random(7200,14400)); -- 2 to 4 hours
+    dsp.mob.phOnDespawn(mob,ID.mob.SEWER_SYRUP_PH,10,math.random(7200,14400)); -- 2 to 4 hours
 end;

--- a/scripts/zones/Bostaunieux_Oubliette/mobs/Garm.lua
+++ b/scripts/zones/Bostaunieux_Oubliette/mobs/Garm.lua
@@ -13,5 +13,5 @@ function onMobDeath(mob, player, isKiller)
 end
 
 function onMobDespawn(mob)
-    phOnDespawn(mob,ID.mob.SHII_PH, 5, 3600) -- 1 hour
+    dsp.mob.phOnDespawn(mob,ID.mob.SHII_PH, 5, 3600) -- 1 hour
 end

--- a/scripts/zones/Bostaunieux_Oubliette/mobs/Gespenst.lua
+++ b/scripts/zones/Bostaunieux_Oubliette/mobs/Gespenst.lua
@@ -11,5 +11,5 @@ function onMobDeath(mob, player, isKiller)
 end
 
 function onMobDespawn(mob)
-    phOnDespawn(mob, ID.mob.MANES_PH, 5, 3600) -- 1 hour
+    dsp.mob.phOnDespawn(mob, ID.mob.MANES_PH, 5, 3600) -- 1 hour
 end

--- a/scripts/zones/Bostaunieux_Oubliette/mobs/Manes.lua
+++ b/scripts/zones/Bostaunieux_Oubliette/mobs/Manes.lua
@@ -2,7 +2,7 @@
 -- Area: Bostaunieux Oubliette (167)
 --   NM: Manes
 -----------------------------------
-require("scripts/globals/status")
+require("scripts/globals/mobs")
 -----------------------------------
 
 function onMobInitialize(mob)
@@ -10,12 +10,7 @@ function onMobInitialize(mob)
 end
 
 function onAdditionalEffect(mob, target, damage)
-    if math.random(1, 100) < 20 or target:hasStatusEffect(dsp.effect.TERROR) then
-        return 0,0,0
-    else
-        target:addStatusEffect(dsp.effect.TERROR, 1, 0, 5)
-        return dsp.subEffect.NONE, 0, dsp.effect.TERROR
-    end
+    return dsp.mob.onAddEffect(mob, target, damage, dsp.mob.ae.TERROR)
 end
 
 function onMobDeath(mob, player, isKiller)

--- a/scripts/zones/Bostaunieux_Oubliette/mobs/Werebat.lua
+++ b/scripts/zones/Bostaunieux_Oubliette/mobs/Werebat.lua
@@ -13,5 +13,5 @@ function onMobDeath(mob, player, isKiller)
 end
 
 function onMobDespawn(mob)
-    phOnDespawn(mob, ID.mob.ARIOCH_PH, 10, 3600) -- 1 hour
+    dsp.mob.phOnDespawn(mob, ID.mob.ARIOCH_PH, 10, 3600) -- 1 hour
 end

--- a/scripts/zones/Buburimu_Peninsula/mobs/Shoal_Pugil.lua
+++ b/scripts/zones/Buburimu_Peninsula/mobs/Shoal_Pugil.lua
@@ -12,5 +12,5 @@ function onMobDeath(mob, player, isKiller)
 end;
 
 function onMobDespawn(mob)
-    phOnDespawn(mob,ID.mob.BUBURIMBOO_PH,5,math.random(3600,7200)); -- 1 to 2 hours
+    dsp.mob.phOnDespawn(mob,ID.mob.BUBURIMBOO_PH,5,math.random(3600,7200)); -- 1 to 2 hours
 end;

--- a/scripts/zones/Buburimu_Peninsula/mobs/Zu.lua
+++ b/scripts/zones/Buburimu_Peninsula/mobs/Zu.lua
@@ -10,5 +10,5 @@ function onMobDeath(mob, player, isKiller)
 end;
 
 function onMobDespawn(mob)
-    phOnDespawn(mob,ID.mob.HELLDIVER_PH,5,math.random(3600,28800)); -- 1 to 8 hours
+    dsp.mob.phOnDespawn(mob,ID.mob.HELLDIVER_PH,5,math.random(3600,28800)); -- 1 to 8 hours
 end;

--- a/scripts/zones/Caedarva_Mire/mobs/Wild_Karakul.lua
+++ b/scripts/zones/Caedarva_Mire/mobs/Wild_Karakul.lua
@@ -11,5 +11,5 @@ function onMobDeath(mob, player, isKiller)
 end
 
 function onMobDespawn(mob)
-    phOnDespawn(mob, ID.mob.PEALLAIDH_PH, 5, 3600) -- 1 hour
+    dsp.mob.phOnDespawn(mob, ID.mob.PEALLAIDH_PH, 5, 3600) -- 1 hour
 end

--- a/scripts/zones/Cape_Teriggan/mobs/Greater_Manticore.lua
+++ b/scripts/zones/Cape_Teriggan/mobs/Greater_Manticore.lua
@@ -12,5 +12,5 @@ function onMobDeath(mob, player, isKiller)
 end;
 
 function onMobDespawn(mob)
-    phOnDespawn(mob,ID.mob.FROSTMANE_PH,5,math.random(3600,21600)); -- 1 to 6 hours
+    dsp.mob.phOnDespawn(mob,ID.mob.FROSTMANE_PH,5,math.random(3600,21600)); -- 1 to 6 hours
 end;

--- a/scripts/zones/Cape_Teriggan/mobs/Tegmine.lua
+++ b/scripts/zones/Cape_Teriggan/mobs/Tegmine.lua
@@ -1,50 +1,17 @@
 ----------------------------------
 -- Area: Cape Teriggan
---  NM:  Tegmine
+--   NM: Tegmine
 -----------------------------------
-require("scripts/globals/status");
-require("scripts/globals/magic");
-require("scripts/globals/msg");
+require("scripts/globals/mobs")
 -----------------------------------
 
 function onMobInitialize(mob)
     mob:setMobMod(dsp.mobMod.ADD_EFFECT, 1);
 end;
 
-function onAdditionalEffect(mob,target,damage)
-    -- Wiki says nothing about proc rate, going with 80% for now.
-    -- I remember it going off every hit when I fought him.
-    local chance = 80;
-    local LV_diff = target:getMainLvl() - mob:getMainLvl();
-
-    if (target:getMainLvl() > mob:getMainLvl()) then
-        chance = chance - 5 * LV_diff;
-        chance = utils.clamp(chance, 5, 95);
-    end
-
-    if (math.random(0,99) >= chance) then
-        return 0,0,0;
-    else
-        local INT_diff = mob:getStat(dsp.mod.INT) - target:getStat(dsp.mod.INT);
-
-        if (INT_diff > 20) then
-            INT_diff = 20 + (INT_diff - 20) / 2;
-        end
-
-        local dmg = INT_diff+LV_diff+damage/2;
-        local params = {};
-        params.bonusmab = 0;
-        params.includemab = false;
-        dmg = addBonusesAbility(mob, dsp.magic.ele.WATER, target, dmg, params);
-        dmg = dmg * applyResistanceAddEffect(mob,target,dsp.magic.ele.WATER,0);
-        dmg = adjustForTarget(target,dmg,dsp.magic.ele.WATER);
-
-        dmg = finalMagicNonSpellAdjustments(mob,target,dsp.magic.ele.WATER,dmg);
-
-        return dsp.subEffect.WATER_DAMAGE, dsp.msg.basic.ADD_EFFECT_DMG, dmg;
-    end
-
-end;
+function onAdditionalEffect(mob, target, damage)
+    return dsp.mob.onAddEffect(mob, target, damage, dsp.mob.ae.ENWATER)
+end
 
 function onMobDeath(mob, player, isKiller)
 end;

--- a/scripts/zones/Carpenters_Landing/mobs/Birdtrap.lua
+++ b/scripts/zones/Carpenters_Landing/mobs/Birdtrap.lua
@@ -10,5 +10,5 @@ function onMobDeath(mob, player, isKiller)
 end;
 
 function onMobDespawn(mob)
-    phOnDespawn(mob,ID.mob.ORCTRAP_PH,5,math.random(3600,25200)); -- 1 to 7 hours
+    dsp.mob.phOnDespawn(mob,ID.mob.ORCTRAP_PH,5,math.random(3600,25200)); -- 1 to 7 hours
 end;

--- a/scripts/zones/Castle_Oztroja/mobs/Tzee_Xicu_the_Manifest.lua
+++ b/scripts/zones/Castle_Oztroja/mobs/Tzee_Xicu_the_Manifest.lua
@@ -3,10 +3,10 @@
 --   NM: Tzee Xicu the Manifest
 -- TODO: messages should be zone-wide
 -----------------------------------
-mixins = {require("scripts/mixins/job_special")}
 local ID = require("scripts/zones/Castle_Oztroja/IDs")
-require("scripts/globals/status")
+mixins = {require("scripts/mixins/job_special")}
 require("scripts/globals/titles")
+require("scripts/globals/mobs")
 -----------------------------------
 
 function onMobInitialize(mob)
@@ -17,19 +17,8 @@ function onMobEngaged(mob,target)
     mob:showText(mob, ID.text.YAGUDO_KING_ENGAGE)
 end
 
-function onAdditionalEffect(mob, player)
-    local resist = applyResistanceAddEffect(mob,player,dsp.magic.ele.ICE,dsp.effect.PARALYSIS)
-    if resist <= 0.5 then
-        return 0,0,0
-    else
-        local duration = 60
-        local power = 20
-        duration = duration * resist
-        if not player:hasStatusEffect(dsp.effect.PARALYSIS) then
-            player:addStatusEffect(dsp.effect.PARALYSIS, power, 0, duration)
-        end
-        return dsp.subEffect.PARALYSIS, dsp.msg.basic.ADD_EFFECT_STATUS, dsp.effect.PARALYSIS
-    end
+function onAdditionalEffect(mob, target, damage)
+    return dsp.mob.onAddEffect(mob, target, damage, dsp.mob.ae.PARALYZE, {duration = 60})
 end
 
 function onMobDeath(mob, player, isKiller)

--- a/scripts/zones/Castle_Oztroja/mobs/Yagudo_Conquistador.lua
+++ b/scripts/zones/Castle_Oztroja/mobs/Yagudo_Conquistador.lua
@@ -11,5 +11,5 @@ function onMobDeath(mob, player, isKiller)
 end
 
 function onMobDespawn(mob)
-    phOnDespawn(mob,ID.mob.YAA_HAQA_THE_PROFANE_PH,5,3600) -- 1 hour
+    dsp.mob.phOnDespawn(mob,ID.mob.YAA_HAQA_THE_PROFANE_PH,5,3600) -- 1 hour
 end

--- a/scripts/zones/Castle_Oztroja/mobs/Yagudo_Drummer.lua
+++ b/scripts/zones/Castle_Oztroja/mobs/Yagudo_Drummer.lua
@@ -11,5 +11,5 @@ function onMobDeath(mob, player, isKiller)
 end
 
 function onMobDespawn(mob)
-    phOnDespawn(mob,ID.mob.MEE_DEGGI_THE_PUNISHER_PH,5,3000) -- 50 minutes
+    dsp.mob.phOnDespawn(mob,ID.mob.MEE_DEGGI_THE_PUNISHER_PH,5,3000) -- 50 minutes
 end

--- a/scripts/zones/Castle_Oztroja/mobs/Yagudo_Herald.lua
+++ b/scripts/zones/Castle_Oztroja/mobs/Yagudo_Herald.lua
@@ -11,5 +11,5 @@ function onMobDeath(mob, player, isKiller)
 end
 
 function onMobDespawn(mob)
-    phOnDespawn(mob,ID.mob.QUU_DOMI_THE_GALLANT_PH,5,3600) -- 1 hour
+    dsp.mob.phOnDespawn(mob,ID.mob.QUU_DOMI_THE_GALLANT_PH,5,3600) -- 1 hour
 end

--- a/scripts/zones/Castle_Oztroja/mobs/Yagudo_Interrogator.lua
+++ b/scripts/zones/Castle_Oztroja/mobs/Yagudo_Interrogator.lua
@@ -11,5 +11,5 @@ function onMobDeath(mob, player, isKiller)
 end
 
 function onMobDespawn(mob)
-    phOnDespawn(mob,ID.mob.MEE_DEGGI_THE_PUNISHER_PH,5,3000) -- 50 minutes
+    dsp.mob.phOnDespawn(mob,ID.mob.MEE_DEGGI_THE_PUNISHER_PH,5,3000) -- 50 minutes
 end

--- a/scripts/zones/Castle_Oztroja/mobs/Yagudo_Lutenist.lua
+++ b/scripts/zones/Castle_Oztroja/mobs/Yagudo_Lutenist.lua
@@ -11,5 +11,5 @@ function onMobDeath(mob, player, isKiller)
 end
 
 function onMobDespawn(mob)
-    phOnDespawn(mob,ID.mob.YAA_HAQA_THE_PROFANE_PH,5,3600) -- 1 hour
+    dsp.mob.phOnDespawn(mob,ID.mob.YAA_HAQA_THE_PROFANE_PH,5,3600) -- 1 hour
 end

--- a/scripts/zones/Castle_Oztroja/mobs/Yagudo_Oracle.lua
+++ b/scripts/zones/Castle_Oztroja/mobs/Yagudo_Oracle.lua
@@ -11,5 +11,5 @@ function onMobDeath(mob, player, isKiller)
 end
 
 function onMobDespawn(mob)
-    phOnDespawn(mob,ID.mob.QUU_DOMI_THE_GALLANT_PH,5,3600) -- 1 hour
+    dsp.mob.phOnDespawn(mob,ID.mob.QUU_DOMI_THE_GALLANT_PH,5,3600) -- 1 hour
 end

--- a/scripts/zones/Castle_Oztroja/mobs/Yagudo_Prior.lua
+++ b/scripts/zones/Castle_Oztroja/mobs/Yagudo_Prior.lua
@@ -11,5 +11,5 @@ function onMobDeath(mob, player, isKiller)
 end
 
 function onMobDespawn(mob)
-    phOnDespawn(mob,ID.mob.YAA_HAQA_THE_PROFANE_PH,5,3600) -- 1 hour
+    dsp.mob.phOnDespawn(mob,ID.mob.YAA_HAQA_THE_PROFANE_PH,5,3600) -- 1 hour
 end

--- a/scripts/zones/Castle_Oztroja/mobs/Yagudo_Theologist.lua
+++ b/scripts/zones/Castle_Oztroja/mobs/Yagudo_Theologist.lua
@@ -11,5 +11,5 @@ function onMobDeath(mob, player, isKiller)
 end
 
 function onMobDespawn(mob)
-    phOnDespawn(mob,ID.mob.MOO_OUZI_THE_SWIFTBLADE_PH,5,3600) -- 1 hour
+    dsp.mob.phOnDespawn(mob,ID.mob.MOO_OUZI_THE_SWIFTBLADE_PH,5,3600) -- 1 hour
 end

--- a/scripts/zones/Castle_Oztroja/mobs/Yagudo_Zealot.lua
+++ b/scripts/zones/Castle_Oztroja/mobs/Yagudo_Zealot.lua
@@ -11,5 +11,5 @@ function onMobDeath(mob, player, isKiller)
 end
 
 function onMobDespawn(mob)
-    phOnDespawn(mob,ID.mob.YAA_HAQA_THE_PROFANE_PH,5,3600) -- 1 hours
+    dsp.mob.phOnDespawn(mob,ID.mob.YAA_HAQA_THE_PROFANE_PH,5,3600) -- 1 hours
 end

--- a/scripts/zones/Castle_Oztroja_[S]/mobs/Yagudo_Sentinel.lua
+++ b/scripts/zones/Castle_Oztroja_[S]/mobs/Yagudo_Sentinel.lua
@@ -11,6 +11,6 @@ function onMobDeath(mob, player, isKiller)
 end
 
 function onMobDespawn(mob)
-    phOnDespawn(mob, ID.mob.AA_XALMO_THE_SAVAGE_PH, 10, 7200) -- 2 hour
-    phOnDespawn(mob, ID.mob.ZHUU_BUXU_THE_SILENT_PH, 10, 7200) -- 2 hour
+    dsp.mob.phOnDespawn(mob, ID.mob.AA_XALMO_THE_SAVAGE_PH, 10, 7200) -- 2 hour
+    dsp.mob.phOnDespawn(mob, ID.mob.ZHUU_BUXU_THE_SILENT_PH, 10, 7200) -- 2 hour
 end

--- a/scripts/zones/Castle_Zvahl_Baileys/mobs/Abyssal_Demon.lua
+++ b/scripts/zones/Castle_Zvahl_Baileys/mobs/Abyssal_Demon.lua
@@ -11,5 +11,5 @@ function onMobDeath(mob, player, isKiller)
 end
 
 function onMobDespawn(mob)
-    phOnDespawn(mob, ID.mob.MARQUIS_SABNOCK_PH, 10, 7200) -- 2 hour
+    dsp.mob.phOnDespawn(mob, ID.mob.MARQUIS_SABNOCK_PH, 10, 7200) -- 2 hour
 end

--- a/scripts/zones/Castle_Zvahl_Baileys/mobs/Doom_Demon.lua
+++ b/scripts/zones/Castle_Zvahl_Baileys/mobs/Doom_Demon.lua
@@ -11,5 +11,5 @@ function onMobDeath(mob, player, isKiller)
 end
 
 function onMobDespawn(mob)
-    phOnDespawn(mob, ID.mob.MARQUIS_SABNOCK_PH, 10, 7200) -- 2 hour
+    dsp.mob.phOnDespawn(mob, ID.mob.MARQUIS_SABNOCK_PH, 10, 7200) -- 2 hour
 end

--- a/scripts/zones/Castle_Zvahl_Keep/mobs/Demon_Knight.lua
+++ b/scripts/zones/Castle_Zvahl_Keep/mobs/Demon_Knight.lua
@@ -10,5 +10,5 @@ function onMobDeath(mob, player, isKiller)
 end;
 
 function onMobDespawn(mob)
-    phOnDespawn(mob,ID.mob.COUNT_BIFRONS_PH,10,math.random(3600,28800)); -- 1 to 8 hours
+    dsp.mob.phOnDespawn(mob,ID.mob.COUNT_BIFRONS_PH,10,math.random(3600,28800)); -- 1 to 8 hours
 end;

--- a/scripts/zones/Castle_Zvahl_Keep/mobs/Demon_Pawn.lua
+++ b/scripts/zones/Castle_Zvahl_Keep/mobs/Demon_Pawn.lua
@@ -10,5 +10,5 @@ function onMobDeath(mob, player, isKiller)
 end;
 
 function onMobDespawn(mob)
-    phOnDespawn(mob,ID.mob.BARONET_ROMWE_PH,10,math.random(3600,28800)); -- 1 to 8 hours
+    dsp.mob.phOnDespawn(mob,ID.mob.BARONET_ROMWE_PH,10,math.random(3600,28800)); -- 1 to 8 hours
 end;

--- a/scripts/zones/Castle_Zvahl_Keep/mobs/Demon_Warlock.lua
+++ b/scripts/zones/Castle_Zvahl_Keep/mobs/Demon_Warlock.lua
@@ -10,5 +10,5 @@ function onMobDeath(mob, player, isKiller)
 end;
 
 function onMobDespawn(mob)
-    phOnDespawn(mob,ID.mob.VISCOUNT_MORAX_PH,10,math.random(3600,28800)); -- 1 to 8 hours
+    dsp.mob.phOnDespawn(mob,ID.mob.VISCOUNT_MORAX_PH,10,math.random(3600,28800)); -- 1 to 8 hours
 end;

--- a/scripts/zones/Castle_Zvahl_Keep/mobs/Demon_Wizard.lua
+++ b/scripts/zones/Castle_Zvahl_Keep/mobs/Demon_Wizard.lua
@@ -10,5 +10,5 @@ function onMobDeath(mob, player, isKiller)
 end;
 
 function onMobDespawn(mob)
-    phOnDespawn(mob,ID.mob.BARON_VAPULA_PH,10,math.random(3600,28800)); -- 1 to 8 hours
+    dsp.mob.phOnDespawn(mob,ID.mob.BARON_VAPULA_PH,10,math.random(3600,28800)); -- 1 to 8 hours
 end;

--- a/scripts/zones/Crawlers_Nest/mobs/Wespe.lua
+++ b/scripts/zones/Crawlers_Nest/mobs/Wespe.lua
@@ -12,5 +12,5 @@ function onMobDeath(mob, player, isKiller)
 end;
 
 function onMobDespawn(mob)
-    phOnDespawn(mob,ID.mob.DEMONIC_TIPHIA_PH,5,math.random(7200,28800)); -- 2 to 8 hours
+    dsp.mob.phOnDespawn(mob,ID.mob.DEMONIC_TIPHIA_PH,5,math.random(7200,28800)); -- 2 to 8 hours
 end;

--- a/scripts/zones/Crawlers_Nest_[S]/mobs/Morille_Mortelle.lua
+++ b/scripts/zones/Crawlers_Nest_[S]/mobs/Morille_Mortelle.lua
@@ -1,11 +1,10 @@
 -----------------------------------
 -- Area: Crawlers nest [S] (171)
---  NM:  Morille Mortelle
+--   NM: Morille Mortelle
 -- !pos 59.788 -0.939 22.316 171
 -----------------------------------
-require("scripts/globals/status");
-require("scripts/globals/magic");
-require("scripts/globals/msg");
+require("scripts/globals/mobs")
+-----------------------------------
 
 function onMobInitialize(mob)
     mob:setMobMod(dsp.mobMod.ADD_EFFECT, 1)
@@ -16,24 +15,9 @@ function onMobSpawn(mob)
     mob:setMod(dsp.mod.STORETP, 10);
 end;
 
-function onAdditionalEffect(mob, player)
-    local chance = 25;
-    local resist = applyResistanceAddEffect(mob,player,dsp.magic.ele.WATER,dsp.effect.PLAGUE);
-    if (math.random(0,99) >= chance or resist <= 0.5) then
-        return 0,0,0;
-    else
-        local duration = 30;
-        if (mob:getMainLvl() > player:getMainLvl()) then
-            duration = duration + (mob:getMainLvl() - player:getMainLvl())
-        end
-        duration = utils.clamp(duration,1,45);
-        duration = duration * resist;
-        if (not player:hasStatusEffect(dsp.effect.PLAGUE)) then
-            player:addStatusEffect(dsp.effect.PLAGUE, 1, 0, duration);
-        end
-        return dsp.subEffect.PLAGUE, dsp.msg.basic.ADD_EFFECT_STATUS, dsp.effect.PLAGUE;
-    end
-end;
+function onAdditionalEffect(mob, target, damage)
+    return dsp.mob.onAddEffect(mob, target, damage, dsp.mob.ae.PLAGUE)
+end
 
 function onMobDeath(mob, player, isKiller)
 end;

--- a/scripts/zones/Crawlers_Nest_[S]/mobs/Witch_Hazel.lua
+++ b/scripts/zones/Crawlers_Nest_[S]/mobs/Witch_Hazel.lua
@@ -10,5 +10,5 @@ function onMobDeath(mob, player, isKiller)
 end;
 
 function onMobDespawn(mob)
-    phOnDespawn(mob,ID.mob.MORILLE_MORTELLE_PH,12,18000); -- 5 hours
+    dsp.mob.phOnDespawn(mob,ID.mob.MORILLE_MORTELLE_PH,12,18000); -- 5 hours
 end;

--- a/scripts/zones/Dangruf_Wadi/mobs/Hoarder_Hare.lua
+++ b/scripts/zones/Dangruf_Wadi/mobs/Hoarder_Hare.lua
@@ -10,5 +10,5 @@ function onMobDeath(mob, player, isKiller)
 end;
 
 function onMobDespawn(mob)
-    phOnDespawn(mob,ID.mob.TEPORINGO_PH,20,3600); -- 1 hour
+    dsp.mob.phOnDespawn(mob,ID.mob.TEPORINGO_PH,20,3600); -- 1 hour
 end;

--- a/scripts/zones/Davoi/mobs/Davoi_Mush.lua
+++ b/scripts/zones/Davoi/mobs/Davoi_Mush.lua
@@ -10,5 +10,5 @@ function onMobDeath(mob, player, isKiller)
 end;
 
 function onMobDespawn(mob)
-    phOnDespawn(mob,ID.mob.BLUBBERY_BULGE_PH,20,3600); -- 1 hour
+    dsp.mob.phOnDespawn(mob,ID.mob.BLUBBERY_BULGE_PH,20,3600); -- 1 hour
 end;

--- a/scripts/zones/Davoi/mobs/Orcish_Beastrider.lua
+++ b/scripts/zones/Davoi/mobs/Orcish_Beastrider.lua
@@ -11,5 +11,5 @@ function onMobDeath(mob, player, isKiller)
 end
 
 function onMobDespawn(mob)
-    phOnDespawn(mob, ID.mob.POISONHAND_GNADGAD_PH, 10, 3600) -- 1 hour
+    dsp.mob.phOnDespawn(mob, ID.mob.POISONHAND_GNADGAD_PH, 10, 3600) -- 1 hour
 end

--- a/scripts/zones/Davoi/mobs/Orcish_Brawler.lua
+++ b/scripts/zones/Davoi/mobs/Orcish_Brawler.lua
@@ -11,5 +11,5 @@ function onMobDeath(mob, player, isKiller)
 end
 
 function onMobDespawn(mob)
-    phOnDespawn(mob, ID.mob.POISONHAND_GNADGAD_PH, 10, 3600) -- 1 hour
+    dsp.mob.phOnDespawn(mob, ID.mob.POISONHAND_GNADGAD_PH, 10, 3600) -- 1 hour
 end

--- a/scripts/zones/Davoi/mobs/Orcish_Cursemaker.lua
+++ b/scripts/zones/Davoi/mobs/Orcish_Cursemaker.lua
@@ -11,5 +11,5 @@ function onMobDeath(mob, player, isKiller)
 end
 
 function onMobDespawn(mob)
-    phOnDespawn(mob, ID.mob.HAWKEYED_DNATBAT_PH, 10, 3600) -- 1 hour
+    dsp.mob.phOnDespawn(mob, ID.mob.HAWKEYED_DNATBAT_PH, 10, 3600) -- 1 hour
 end

--- a/scripts/zones/Davoi/mobs/Orcish_Firebelcher.lua
+++ b/scripts/zones/Davoi/mobs/Orcish_Firebelcher.lua
@@ -11,5 +11,5 @@ function onMobDeath(mob, player, isKiller)
 end
 
 function onMobDespawn(mob)
-    phOnDespawn(mob, ID.mob.POISONHAND_GNADGAD_PH, 10, 3600) -- 1 hour
+    dsp.mob.phOnDespawn(mob, ID.mob.POISONHAND_GNADGAD_PH, 10, 3600) -- 1 hour
 end

--- a/scripts/zones/Davoi/mobs/Orcish_Impaler.lua
+++ b/scripts/zones/Davoi/mobs/Orcish_Impaler.lua
@@ -11,6 +11,6 @@ function onMobDeath(mob, player, isKiller)
 end
 
 function onMobDespawn(mob)
-    phOnDespawn(mob, ID.mob.POISONHAND_GNADGAD_PH, 10, 3600) -- 1 hour
-    phOnDespawn(mob, ID.mob.STEELBITER_GUDRUD_PH, 10, 3600) -- 1 hour
+    dsp.mob.phOnDespawn(mob, ID.mob.POISONHAND_GNADGAD_PH, 10, 3600) -- 1 hour
+    dsp.mob.phOnDespawn(mob, ID.mob.STEELBITER_GUDRUD_PH, 10, 3600) -- 1 hour
 end

--- a/scripts/zones/Davoi/mobs/Orcish_Nightraider.lua
+++ b/scripts/zones/Davoi/mobs/Orcish_Nightraider.lua
@@ -11,5 +11,5 @@ function onMobDeath(mob, player, isKiller)
 end
 
 function onMobDespawn(mob)
-    phOnDespawn(mob, ID.mob.POISONHAND_GNADGAD_PH, 10, 3600) -- 1 hour
+    dsp.mob.phOnDespawn(mob, ID.mob.POISONHAND_GNADGAD_PH, 10, 3600) -- 1 hour
 end

--- a/scripts/zones/Davoi/mobs/War_Lizard.lua
+++ b/scripts/zones/Davoi/mobs/War_Lizard.lua
@@ -11,5 +11,5 @@ function onMobDeath(mob, player, isKiller)
 end
 
 function onMobDespawn(mob)
-    phOnDespawn(mob, ID.mob.TIGERBANE_BAKDAK_PH, 10, 3600) -- 1 hour
+    dsp.mob.phOnDespawn(mob, ID.mob.TIGERBANE_BAKDAK_PH, 10, 3600) -- 1 hour
 end

--- a/scripts/zones/Den_of_Rancor/mobs/Bifrons.lua
+++ b/scripts/zones/Den_of_Rancor/mobs/Bifrons.lua
@@ -11,5 +11,5 @@ function onMobDeath(mob, player, isKiller)
 end
 
 function onMobDespawn(mob)
-    phOnDespawn(mob, ID.mob.FRIAR_RUSH_PH, 10, 3600) -- 1 hour
+    dsp.mob.phOnDespawn(mob, ID.mob.FRIAR_RUSH_PH, 10, 3600) -- 1 hour
 end

--- a/scripts/zones/Den_of_Rancor/mobs/Doom_Toad.lua
+++ b/scripts/zones/Den_of_Rancor/mobs/Doom_Toad.lua
@@ -13,5 +13,5 @@ function onMobDeath(mob, player, isKiller)
 end
 
 function onMobDespawn(mob)
-    phOnDespawn(mob, ID.mob.OGAMA_PH, 5, 3600) -- 1 hour
+    dsp.mob.phOnDespawn(mob, ID.mob.OGAMA_PH, 5, 3600) -- 1 hour
 end

--- a/scripts/zones/Den_of_Rancor/mobs/Tonberry_Beleaguerer.lua
+++ b/scripts/zones/Den_of_Rancor/mobs/Tonberry_Beleaguerer.lua
@@ -16,5 +16,5 @@ function onMobDeath(mob, player, isKiller)
 end
 
 function onMobDespawn(mob)
-    phOnDespawn(mob, ID.mob.BISTRE_HEARTED_MALBERRY_PH, 10, 3600) -- 1 hour
+    dsp.mob.phOnDespawn(mob, ID.mob.BISTRE_HEARTED_MALBERRY_PH, 10, 3600) -- 1 hour
 end

--- a/scripts/zones/Den_of_Rancor/mobs/Tonberry_Imprecator.lua
+++ b/scripts/zones/Den_of_Rancor/mobs/Tonberry_Imprecator.lua
@@ -16,5 +16,5 @@ function onMobDeath(mob, player, isKiller)
 end
 
 function onMobDespawn(mob)
-    phOnDespawn(mob, ID.mob.CARMINE_TAILED_JANBERRY_PH, 5, 3600) -- 1 hour
+    dsp.mob.phOnDespawn(mob, ID.mob.CARMINE_TAILED_JANBERRY_PH, 5, 3600) -- 1 hour
 end

--- a/scripts/zones/Den_of_Rancor/mobs/Tonberry_Slasher.lua
+++ b/scripts/zones/Den_of_Rancor/mobs/Tonberry_Slasher.lua
@@ -16,5 +16,5 @@ function onMobDeath(mob, player, isKiller)
 end
 
 function onMobDespawn(mob)
-    phOnDespawn(mob, ID.mob.TAWNY_FINGERED_MUGBERRY_PH, 5, 3600) -- 1 hour
+    dsp.mob.phOnDespawn(mob, ID.mob.TAWNY_FINGERED_MUGBERRY_PH, 5, 3600) -- 1 hour
 end

--- a/scripts/zones/Den_of_Rancor/mobs/Tonberry_Trailer.lua
+++ b/scripts/zones/Den_of_Rancor/mobs/Tonberry_Trailer.lua
@@ -16,5 +16,5 @@ function onMobDeath(mob, player, isKiller)
 end
 
 function onMobDespawn(mob)
-    phOnDespawn(mob, ID.mob.CELESTE_EYED_TOZBERRY_PH, 10, 7200) -- 2 hours
+    dsp.mob.phOnDespawn(mob, ID.mob.CELESTE_EYED_TOZBERRY_PH, 10, 7200) -- 2 hours
 end

--- a/scripts/zones/East_Ronfaure/mobs/Carrion_Worm.lua
+++ b/scripts/zones/East_Ronfaure/mobs/Carrion_Worm.lua
@@ -12,5 +12,5 @@ function onMobDeath(mob, player, isKiller)
 end;
 
 function onMobDespawn(mob)
-    phOnDespawn(mob,ID.mob.BIGMOUTH_BILLY_PH,7,math.random(3600,7200)); -- 1 to 2 hours
+    dsp.mob.phOnDespawn(mob,ID.mob.BIGMOUTH_BILLY_PH,7,math.random(3600,7200)); -- 1 to 2 hours
 end;

--- a/scripts/zones/East_Ronfaure/mobs/Pugil.lua
+++ b/scripts/zones/East_Ronfaure/mobs/Pugil.lua
@@ -12,5 +12,5 @@ function onMobDeath(mob, player, isKiller)
 end;
 
 function onMobDespawn(mob)
-    phOnDespawn(mob,ID.mob.SWAMFISK_PH,7,math.random(3600,10800)); -- 1 to 3 hours
+    dsp.mob.phOnDespawn(mob,ID.mob.SWAMFISK_PH,7,math.random(3600,10800)); -- 1 to 3 hours
 end;

--- a/scripts/zones/East_Ronfaure_[S]/mobs/Battrap.lua
+++ b/scripts/zones/East_Ronfaure_[S]/mobs/Battrap.lua
@@ -11,5 +11,5 @@ function onMobDeath(mob, player, isKiller)
 end
 
 function onMobDespawn(mob)
-    phOnDespawn(mob, ID.mob.GOBLINTRAP_PH, 5, 3600) -- 1 hour
+    dsp.mob.phOnDespawn(mob, ID.mob.GOBLINTRAP_PH, 5, 3600) -- 1 hour
 end

--- a/scripts/zones/East_Ronfaure_[S]/mobs/Ladybug.lua
+++ b/scripts/zones/East_Ronfaure_[S]/mobs/Ladybug.lua
@@ -11,5 +11,5 @@ function onMobDeath(mob, player, isKiller)
 end
 
 function onMobDespawn(mob)
-    phOnDespawn(mob, ID.mob.SKOGS_FRU_PH, 5, 3600) -- 1 hour
+    dsp.mob.phOnDespawn(mob, ID.mob.SKOGS_FRU_PH, 5, 3600) -- 1 hour
 end

--- a/scripts/zones/East_Sarutabaruta/mobs/Crawler.lua
+++ b/scripts/zones/East_Sarutabaruta/mobs/Crawler.lua
@@ -14,5 +14,5 @@ function onMobDeath(mob, player, isKiller)
 end
 
 function onMobDespawn(mob)
-    phOnDespawn(mob, ID.mob.SPINY_SPIPI_PH, 10, math.random(2700,7200)) -- 45 to 120 minutes
+    dsp.mob.phOnDespawn(mob, ID.mob.SPINY_SPIPI_PH, 10, math.random(2700,7200)) -- 45 to 120 minutes
 end

--- a/scripts/zones/East_Sarutabaruta/mobs/Savanna_Rarab.lua
+++ b/scripts/zones/East_Sarutabaruta/mobs/Savanna_Rarab.lua
@@ -12,5 +12,5 @@ function onMobDeath(mob, player, isKiller)
 end;
 
 function onMobDespawn(mob)
-    phOnDespawn(mob,ID.mob.SHARP_EARED_ROPIPI_PH,20,300); -- 5 minutes
+    dsp.mob.phOnDespawn(mob,ID.mob.SHARP_EARED_ROPIPI_PH,20,300); -- 5 minutes
 end;

--- a/scripts/zones/Eastern_Altepa_Desert/mobs/Giant_Spider.lua
+++ b/scripts/zones/Eastern_Altepa_Desert/mobs/Giant_Spider.lua
@@ -13,5 +13,5 @@ function onMobDeath(mob, player, isKiller)
 end
 
 function onMobDespawn(mob)
-    phOnDespawn(mob, ID.mob.DUNE_WIDOW_PH, 10, math.random(3600,18000)) -- 1 to 5 hours
+    dsp.mob.phOnDespawn(mob, ID.mob.DUNE_WIDOW_PH, 10, math.random(3600,18000)) -- 1 to 5 hours
 end

--- a/scripts/zones/Eastern_Altepa_Desert/mobs/Nandi.lua
+++ b/scripts/zones/Eastern_Altepa_Desert/mobs/Nandi.lua
@@ -2,35 +2,15 @@
 -- Area: Eastern Altepa Desert (114)
 --   NM: Nandi
 -----------------------------------
-require("scripts/globals/status")
-require("scripts/globals/magic")
+require("scripts/globals/mobs")
 -----------------------------------
 
 function onMobInitialize(mob)
     mob:setMobMod(dsp.mobMod.ADD_EFFECT, 1)
 end
 
-function onAdditionalEffect(mob, player)
-    local resist = applyResistanceAddEffect(mob, player, dsp.magic.ele.EARTH, dsp.effect.SLOW)
-
-    if math.random(100) > 20 or resist <= 0.5 then
-        return 0, 0, 0
-    else
-        local power = 1000
-        local duration = 30
-
-        if mob:getMainLvl() > player:getMainLvl() then
-            duration = duration + (mob:getMainLvl() - player:getMainLvl())
-        end
-        duration = utils.clamp(duration, 1, 45)
-        duration = duration * resist
-
-        if not player:hasStatusEffect(dsp.effect.SLOW) then
-            player:addStatusEffect(dsp.effect.SLOW, power, 0, duration)
-        end
-
-        return dsp.subEffect.NONE, dsp.msg.basic.ADD_EFFECT_STATUS, dsp.effect.SLOW
-    end
+function onAdditionalEffect(mob, target, damage)
+    return dsp.mob.onAddEffect(mob, target, damage, dsp.mob.ae.SLOW)
 end
 
 function onMobDeath(mob, player, isKiller)

--- a/scripts/zones/Eastern_Altepa_Desert/mobs/Sand_Beetle.lua
+++ b/scripts/zones/Eastern_Altepa_Desert/mobs/Sand_Beetle.lua
@@ -13,5 +13,5 @@ function onMobDeath(mob, player, isKiller)
 end
 
 function onMobDespawn(mob)
-    phOnDespawn(mob, ID.mob.DONNERGUGI_PH, 10, 3600) -- 1 hour
+    dsp.mob.phOnDespawn(mob, ID.mob.DONNERGUGI_PH, 10, 3600) -- 1 hour
 end

--- a/scripts/zones/FeiYin/mobs/Clockwork_Pod.lua
+++ b/scripts/zones/FeiYin/mobs/Clockwork_Pod.lua
@@ -17,5 +17,5 @@ function onMobDeath(mob, player, isKiller)
 end
 
 function onMobDespawn(mob)
-    phOnDespawn(mob, ID.mob.DONNERGUGI_PH, 10, 3600) -- 1 hour
+    dsp.mob.phOnDespawn(mob, ID.mob.DONNERGUGI_PH, 10, 3600) -- 1 hour
 end

--- a/scripts/zones/FeiYin/mobs/Colossus.lua
+++ b/scripts/zones/FeiYin/mobs/Colossus.lua
@@ -20,5 +20,5 @@ function onMobDeath(mob, player, isKiller)
 end
 
 function onMobDespawn(mob)
-    phOnDespawn(mob, ID.mob.GOLIATH_PH, 10, 3600) -- 1 hour
+    dsp.mob.phOnDespawn(mob, ID.mob.GOLIATH_PH, 10, 3600) -- 1 hour
 end

--- a/scripts/zones/FeiYin/mobs/Specter.lua
+++ b/scripts/zones/FeiYin/mobs/Specter.lua
@@ -12,8 +12,8 @@ function onMobDeath(mob, player, isKiller)
 end;
 
 function onMobDespawn(mob)
-    phOnDespawn(mob,ID.mob.NORTHERN_SHADOW_PH,5,57600); -- 16 hours
-    phOnDespawn(mob,ID.mob.EASTERN_SHADOW_PH,5,36000); -- 10 hours
-    phOnDespawn(mob,ID.mob.WESTERN_SHADOW_PH,5,36000); -- 10 hours
-    phOnDespawn(mob,ID.mob.SOUTHERN_SHADOW_PH,5,57600); -- 16 hours
+    dsp.mob.phOnDespawn(mob,ID.mob.NORTHERN_SHADOW_PH,5,57600); -- 16 hours
+    dsp.mob.phOnDespawn(mob,ID.mob.EASTERN_SHADOW_PH,5,36000); -- 10 hours
+    dsp.mob.phOnDespawn(mob,ID.mob.WESTERN_SHADOW_PH,5,36000); -- 10 hours
+    dsp.mob.phOnDespawn(mob,ID.mob.SOUTHERN_SHADOW_PH,5,57600); -- 16 hours
 end;

--- a/scripts/zones/Fort_Ghelsba/mobs/Kegpaunch_Doshgnosh.lua
+++ b/scripts/zones/Fort_Ghelsba/mobs/Kegpaunch_Doshgnosh.lua
@@ -2,8 +2,7 @@
 -- Area: Fort Ghelsba
 --   NM: Kegpaunch Doshgnosh
 -----------------------------------
-require("scripts/globals/status")
-require("scripts/globals/magic")
+require("scripts/globals/mobs")
 -----------------------------------
 
 function onMobInitialize(mob)
@@ -11,17 +10,7 @@ function onMobInitialize(mob)
 end
 
 function onAdditionalEffect(mob, target, damage)
-    local dmg = math.ceil(damage * 0.50) -- "he hit me 40-ish excluding another 20 fire effect."
-    local params = {}
-    params.bonusmab = 0
-    params.includemab = false
-
-    dmg = addBonusesAbility(mob, dsp.magic.ele.FIRE, target, dmg, params)
-    dmg = dmg * applyResistanceAddEffect(mob, target, dsp.magic.ele.FIRE, 0)
-    dmg = adjustForTarget(target, dmg, dsp.magic.ele.FIRE)
-    dmg = finalMagicNonSpellAdjustments(mob, target, dsp.magic.ele.FIRE, dmg)
-
-    return dsp.subEffect.FIRE_DAMAGE, dsp.msg.basic.ADD_EFFECT_DMG, dmg
+    return dsp.mob.onAddEffect(mob, target, damage, dsp.mob.ae.ENFIRE)
 end
 
 function onMobDeath(mob, player, isKiller)

--- a/scripts/zones/Fort_Ghelsba/mobs/Orcish_Fodder.lua
+++ b/scripts/zones/Fort_Ghelsba/mobs/Orcish_Fodder.lua
@@ -11,5 +11,5 @@ function onMobDeath(mob, player, isKiller)
 end
 
 function onMobDespawn(mob)
-    phOnDespawn(mob, ID.mob.HUNDREDSCAR_HAJWAJ_PH, 10, 3600) -- 1 hour
+    dsp.mob.phOnDespawn(mob, ID.mob.HUNDREDSCAR_HAJWAJ_PH, 10, 3600) -- 1 hour
 end

--- a/scripts/zones/Fort_Karugo-Narugo_[S]/mobs/Demoiselle_Desolee.lua
+++ b/scripts/zones/Fort_Karugo-Narugo_[S]/mobs/Demoiselle_Desolee.lua
@@ -2,27 +2,15 @@
 -- Area: Fort Karugo-Narugo [S]
 --   NM: Demoiselle Desolee
 -----------------------------------
-require("scripts/globals/status")
+require("scripts/globals/mobs")
 -----------------------------------
 
 function onMobInitialize(mob)
     mob:setMobMod(dsp.mobMod.ADD_EFFECT, 1)
 end
 
-function onAdditionalEffect(mob, player)
-    local resist = applyResistanceAddEffect(mob, player, dsp.magic.ele.ICE, dsp.effect.PARALYSIS)
-
-    if resist <= 0.5 then
-        return 0,0,0
-    else
-        local duration = 60
-        local power = 20
-        duration = duration * resist
-        if not player:hasStatusEffect(dsp.effect.PARALYSIS) then
-            player:addStatusEffect(dsp.effect.PARALYSIS, power, 0, duration)
-        end
-        return dsp.subEffect.PARALYSIS, dsp.msg.basic.ADD_EFFECT_STATUS, dsp.effect.PARALYSIS
-    end
+function onAdditionalEffect(mob, target, damage)
+    return dsp.mob.onAddEffect(mob, target, damage, dsp.mob.ae.PARALYZE, {duration = 60})
 end
 
 function onMobDeath(mob, player, isKiller)

--- a/scripts/zones/Fort_Karugo-Narugo_[S]/mobs/Dragonfly.lua
+++ b/scripts/zones/Fort_Karugo-Narugo_[S]/mobs/Dragonfly.lua
@@ -11,5 +11,5 @@ function onMobDeath(mob, player, isKiller)
 end
 
 function onMobDespawn(mob)
-    phOnDespawn(mob, ID.mob.DEMOISELLE_DESOLEE_PH, 5, 3600) -- 1 hour
+    dsp.mob.phOnDespawn(mob, ID.mob.DEMOISELLE_DESOLEE_PH, 5, 3600) -- 1 hour
 end

--- a/scripts/zones/Fort_Karugo-Narugo_[S]/mobs/Rafflesia.lua
+++ b/scripts/zones/Fort_Karugo-Narugo_[S]/mobs/Rafflesia.lua
@@ -11,5 +11,5 @@ function onMobDeath(mob, player, isKiller)
 end
 
 function onMobDespawn(mob)
-    phOnDespawn(mob, ID.mob.KIRTIMUKHA_PH, 5, 3600) -- 1 hour
+    dsp.mob.phOnDespawn(mob, ID.mob.KIRTIMUKHA_PH, 5, 3600) -- 1 hour
 end

--- a/scripts/zones/Fort_Karugo-Narugo_[S]/mobs/Vorpal_Bunny.lua
+++ b/scripts/zones/Fort_Karugo-Narugo_[S]/mobs/Vorpal_Bunny.lua
@@ -11,5 +11,5 @@ function onMobDeath(mob, player, isKiller)
 end
 
 function onMobDespawn(mob)
-    phOnDespawn(mob, ID.mob.RATATOSKR_PH, 10, 5400) -- 90 minutes
+    dsp.mob.phOnDespawn(mob, ID.mob.RATATOSKR_PH, 10, 5400) -- 90 minutes
 end

--- a/scripts/zones/Garlaige_Citadel/mobs/Explosure.lua
+++ b/scripts/zones/Garlaige_Citadel/mobs/Explosure.lua
@@ -13,5 +13,5 @@ function onMobDeath(mob, player, isKiller)
 end
 
 function onMobDespawn(mob)
-    phOnDespawn(mob, ID.mob.HAZMAT_PH, 10, 3600) -- 1 hour
+    dsp.mob.phOnDespawn(mob, ID.mob.HAZMAT_PH, 10, 3600) -- 1 hour
 end

--- a/scripts/zones/Garlaige_Citadel/mobs/Fallen_Mage.lua
+++ b/scripts/zones/Garlaige_Citadel/mobs/Fallen_Mage.lua
@@ -12,5 +12,5 @@ function onMobDeath(mob, player, isKiller)
 end;
 
 function onMobDespawn(mob)
-    phOnDespawn(mob,ID.mob.HOVERING_HOTPOT_PH,20,math.random(1800,3600)); -- 30 to 60 minutes
+    dsp.mob.phOnDespawn(mob,ID.mob.HOVERING_HOTPOT_PH,20,math.random(1800,3600)); -- 30 to 60 minutes
 end;

--- a/scripts/zones/Garlaige_Citadel/mobs/Fallen_Major.lua
+++ b/scripts/zones/Garlaige_Citadel/mobs/Fallen_Major.lua
@@ -12,5 +12,5 @@ function onMobDeath(mob, player, isKiller)
 end;
 
 function onMobDespawn(mob)
-    phOnDespawn(mob,ID.mob.HOVERING_HOTPOT_PH,20,math.random(1800,3600)); -- 30 to 60 minutes
+    dsp.mob.phOnDespawn(mob,ID.mob.HOVERING_HOTPOT_PH,20,math.random(1800,3600)); -- 30 to 60 minutes
 end;

--- a/scripts/zones/Ghelsba_Outpost/mobs/Orcish_Grunt.lua
+++ b/scripts/zones/Ghelsba_Outpost/mobs/Orcish_Grunt.lua
@@ -10,5 +10,5 @@ function onMobDeath(mob, player, isKiller)
 end;
 
 function onMobDespawn(mob)
-    phOnDespawn(mob,ID.mob.THOUSANDARM_DESHGLESH_PH,5,math.random(3600,10800)); -- 1 to 3 hours
+    dsp.mob.phOnDespawn(mob,ID.mob.THOUSANDARM_DESHGLESH_PH,5,math.random(3600,10800)); -- 1 to 3 hours
 end;

--- a/scripts/zones/Ghelsba_Outpost/mobs/Orcish_Neckchopper.lua
+++ b/scripts/zones/Ghelsba_Outpost/mobs/Orcish_Neckchopper.lua
@@ -10,5 +10,5 @@ function onMobDeath(mob, player, isKiller)
 end;
 
 function onMobDespawn(mob)
-    phOnDespawn(mob,ID.mob.THOUSANDARM_DESHGLESH_PH,5,math.random(3600,10800)); -- 1 to 3 hours
+    dsp.mob.phOnDespawn(mob,ID.mob.THOUSANDARM_DESHGLESH_PH,5,math.random(3600,10800)); -- 1 to 3 hours
 end;

--- a/scripts/zones/Ghelsba_Outpost/mobs/Orcish_Stonechucker.lua
+++ b/scripts/zones/Ghelsba_Outpost/mobs/Orcish_Stonechucker.lua
@@ -10,5 +10,5 @@ function onMobDeath(mob, player, isKiller)
 end;
 
 function onMobDespawn(mob)
-    phOnDespawn(mob,ID.mob.THOUSANDARM_DESHGLESH_PH,5,math.random(3600,10800)); -- 1 to 3 hours
+    dsp.mob.phOnDespawn(mob,ID.mob.THOUSANDARM_DESHGLESH_PH,5,math.random(3600,10800)); -- 1 to 3 hours
 end;

--- a/scripts/zones/Giddeus/mobs/Yagudo_Mendicant.lua
+++ b/scripts/zones/Giddeus/mobs/Yagudo_Mendicant.lua
@@ -9,5 +9,5 @@ function onMobDeath(mob, player, isKiller)
 end;
 
 function onMobDespawn(mob)
-    phOnDespawn(mob,ID.mob.HOO_MJUU_THE_TORRENT_PH,5,3600); -- 1 hour
+    dsp.mob.phOnDespawn(mob,ID.mob.HOO_MJUU_THE_TORRENT_PH,5,3600); -- 1 hour
 end;

--- a/scripts/zones/Giddeus/mobs/Yagudo_Persecutor.lua
+++ b/scripts/zones/Giddeus/mobs/Yagudo_Persecutor.lua
@@ -9,5 +9,5 @@ function onMobDeath(mob, player, isKiller)
 end;
 
 function onMobDespawn(mob)
-    phOnDespawn(mob,ID.mob.JUU_DUZU_THE_WHIRLWIND_PH,5,math.random(3600,7200)); -- 1 to 2 hours
+    dsp.mob.phOnDespawn(mob,ID.mob.JUU_DUZU_THE_WHIRLWIND_PH,5,math.random(3600,7200)); -- 1 to 2 hours
 end;

--- a/scripts/zones/Giddeus/mobs/Yagudo_Piper.lua
+++ b/scripts/zones/Giddeus/mobs/Yagudo_Piper.lua
@@ -11,5 +11,5 @@ function onMobDeath(mob, player, isKiller)
 end
 
 function onMobDespawn(mob)
-    phOnDespawn(mob,ID.mob.VUU_PUQU_THE_BEGUILER_PH,5,900) -- 15 minutes
+    dsp.mob.phOnDespawn(mob,ID.mob.VUU_PUQU_THE_BEGUILER_PH,5,900) -- 15 minutes
 end

--- a/scripts/zones/Grauberg_[S]/mobs/Ajattara.lua
+++ b/scripts/zones/Grauberg_[S]/mobs/Ajattara.lua
@@ -11,5 +11,5 @@ function onMobDeath(mob, player, isKiller)
 end
 
 function onMobDespawn(mob)
-    phOnDespawn(mob, ID.mob.SCITALIS_PH, 5, 3600) -- 1 hour
+    dsp.mob.phOnDespawn(mob, ID.mob.SCITALIS_PH, 5, 3600) -- 1 hour
 end

--- a/scripts/zones/Grauberg_[S]/mobs/Grauberg_Hippogryph.lua
+++ b/scripts/zones/Grauberg_[S]/mobs/Grauberg_Hippogryph.lua
@@ -11,5 +11,5 @@ function onMobDeath(mob, player, isKiller)
 end
 
 function onMobDespawn(mob)
-    phOnDespawn(mob, ID.mob.KOTAN_KOR_KAMUY_PH, 5, 10800) -- 3 hours
+    dsp.mob.phOnDespawn(mob, ID.mob.KOTAN_KOR_KAMUY_PH, 5, 10800) -- 3 hours
 end

--- a/scripts/zones/Gustav_Tunnel/mobs/Antares.lua
+++ b/scripts/zones/Gustav_Tunnel/mobs/Antares.lua
@@ -12,5 +12,5 @@ function onMobDeath(mob, player, isKiller)
 end;
 
 function onMobDespawn(mob)
-    phOnDespawn(mob,ID.mob.AMIKIRI_PH,5,math.random(25200,32400)); -- 7 to 9 hours
+    dsp.mob.phOnDespawn(mob,ID.mob.AMIKIRI_PH,5,math.random(25200,32400)); -- 7 to 9 hours
 end;

--- a/scripts/zones/Gustav_Tunnel/mobs/Doom_Warlock.lua
+++ b/scripts/zones/Gustav_Tunnel/mobs/Doom_Warlock.lua
@@ -14,5 +14,5 @@ function onMobDeath(mob, player, isKiller)
 end;
 
 function onMobDespawn(mob)
-    phOnDespawn(mob,ID.mob.TAXIM_PH,5,7200); -- 2 hours
+    dsp.mob.phOnDespawn(mob,ID.mob.TAXIM_PH,5,7200); -- 2 hours
 end;

--- a/scripts/zones/Gustav_Tunnel/mobs/Erlik.lua
+++ b/scripts/zones/Gustav_Tunnel/mobs/Erlik.lua
@@ -12,5 +12,5 @@ function onMobDeath(mob, player, isKiller)
 end;
 
 function onMobDespawn(mob)
-    phOnDespawn(mob,ID.mob.BAOBHAN_SITH_PH,5,math.random(14400,28800)); -- 4 to 8 hours
+    dsp.mob.phOnDespawn(mob,ID.mob.BAOBHAN_SITH_PH,5,math.random(14400,28800)); -- 4 to 8 hours
 end;

--- a/scripts/zones/Gustav_Tunnel/mobs/Goblin_Mercenary.lua
+++ b/scripts/zones/Gustav_Tunnel/mobs/Goblin_Mercenary.lua
@@ -13,5 +13,5 @@ function onMobDeath(mob, player, isKiller)
 end;
 
 function onMobDespawn(mob)
-    phOnDespawn(mob,ID.mob.WYVERNPOACHER_DRACHLOX_PH,5,math.random(7200,28800)); -- 2 to 8 hours
+    dsp.mob.phOnDespawn(mob,ID.mob.WYVERNPOACHER_DRACHLOX_PH,5,math.random(7200,28800)); -- 2 to 8 hours
 end;

--- a/scripts/zones/Gustav_Tunnel/mobs/Goblin_Reaper.lua
+++ b/scripts/zones/Gustav_Tunnel/mobs/Goblin_Reaper.lua
@@ -13,5 +13,5 @@ function onMobDeath(mob, player, isKiller)
 end;
 
 function onMobDespawn(mob)
-    phOnDespawn(mob,ID.mob.GOBLINSAVIOR_HERONOX_PH,5,math.random(10800,18000)); -- 3 to 5 hours
+    dsp.mob.phOnDespawn(mob,ID.mob.GOBLINSAVIOR_HERONOX_PH,5,math.random(10800,18000)); -- 3 to 5 hours
 end;

--- a/scripts/zones/Gustav_Tunnel/mobs/Typhoon_Wyvern.lua
+++ b/scripts/zones/Gustav_Tunnel/mobs/Typhoon_Wyvern.lua
@@ -12,5 +12,5 @@ function onMobDeath(mob, player, isKiller)
 end;
 
 function onMobDespawn(mob)
-    phOnDespawn(mob,ID.mob.UNGUR_PH,5,7200); -- 2 hours
+    dsp.mob.phOnDespawn(mob,ID.mob.UNGUR_PH,5,7200); -- 2 hours
 end;

--- a/scripts/zones/Ifrits_Cauldron/mobs/Eotyrannus.lua
+++ b/scripts/zones/Ifrits_Cauldron/mobs/Eotyrannus.lua
@@ -13,5 +13,5 @@ function onMobDeath(mob, player, isKiller)
 end
 
 function onMobDespawn(mob)
-    phOnDespawn(mob, ID.mob.LINDWURM_PH, 5, 3600) -- 1 hour
+    dsp.mob.phOnDespawn(mob, ID.mob.LINDWURM_PH, 5, 3600) -- 1 hour
 end

--- a/scripts/zones/Ifrits_Cauldron/mobs/Hurricane_Wyvern.lua
+++ b/scripts/zones/Ifrits_Cauldron/mobs/Hurricane_Wyvern.lua
@@ -13,5 +13,5 @@ function onMobDeath(mob, player, isKiller)
 end
 
 function onMobDespawn(mob)
-    phOnDespawn(mob, ID.mob.VOUIVRE_PH, 5, 7200) -- 2 hours
+    dsp.mob.phOnDespawn(mob, ID.mob.VOUIVRE_PH, 5, 7200) -- 2 hours
 end

--- a/scripts/zones/Ifrits_Cauldron/mobs/Sulfur_Scorpion.lua
+++ b/scripts/zones/Ifrits_Cauldron/mobs/Sulfur_Scorpion.lua
@@ -13,5 +13,5 @@ function onMobDeath(mob, player, isKiller)
 end
 
 function onMobDespawn(mob)
-    phOnDespawn(mob, ID.mob.TYRANNIC_TURROK_PH, 5, 3600) -- 1 hour
+    dsp.mob.phOnDespawn(mob, ID.mob.TYRANNIC_TURROK_PH, 5, 3600) -- 1 hour
 end

--- a/scripts/zones/Inner_Horutoto_Ruins/mobs/Boggart.lua
+++ b/scripts/zones/Inner_Horutoto_Ruins/mobs/Boggart.lua
@@ -12,5 +12,5 @@ function onMobDeath(mob, player, isKiller)
 end;
 
 function onMobDespawn(mob)
-    phOnDespawn(mob,ID.mob.NOCUOUS_WEAPON_PH,5,3600); -- 1 hour
+    dsp.mob.phOnDespawn(mob,ID.mob.NOCUOUS_WEAPON_PH,5,3600); -- 1 hour
 end;

--- a/scripts/zones/Inner_Horutoto_Ruins/mobs/Goblin_Leecher.lua
+++ b/scripts/zones/Inner_Horutoto_Ruins/mobs/Goblin_Leecher.lua
@@ -11,5 +11,5 @@ function onMobDeath(mob, player, isKiller)
 end
 
 function onMobDespawn(mob)
-    phOnDespawn(mob, ID.mob.SLENDLIX_SPINDLETHUMB_PH, 10, 3600) -- 1 hour
+    dsp.mob.phOnDespawn(mob, ID.mob.SLENDLIX_SPINDLETHUMB_PH, 10, 3600) -- 1 hour
 end

--- a/scripts/zones/Inner_Horutoto_Ruins/mobs/Nocuous_Weapon.lua
+++ b/scripts/zones/Inner_Horutoto_Ruins/mobs/Nocuous_Weapon.lua
@@ -1,33 +1,17 @@
 -----------------------------------
 -- Area: Inner Horutoto Ruins
---  NM: Nocuous Weapon
+--   NM: Nocuous Weapon
 -----------------------------------
-require("scripts/globals/status");
-require("scripts/globals/magic");
-require("scripts/globals/msg");
+require("scripts/globals/mobs")
+-----------------------------------
 
 function onMobInitialize(mob)
     mob:setMobMod(dsp.mobMod.ADD_EFFECT, 1);
 end;
 
-function onAdditionalEffect(mob, player)
-    local chance = 25;
-    local resist = applyResistanceAddEffect(mob,player,dsp.magic.ele.WATER,dsp.effect.POISON);
-    if (math.random(0,99) >= chance or resist <= 0.5) then
-        return 0,0,0;
-    else
-        local duration = 30;
-        if (mob:getMainLvl() > player:getMainLvl()) then
-            duration = duration + (mob:getMainLvl() - player:getMainLvl())
-        end
-        duration = utils.clamp(duration,1,45);
-        duration = duration * resist;
-        if (not player:hasStatusEffect(dsp.effect.POISON)) then
-            player:addStatusEffect(dsp.effect.POISON, 1, 3, duration); -- Don't know potency on the poison.
-        end
-        return dsp.subEffect.POISON, dsp.msg.basic.ADD_EFFECT_STATUS, dsp.effect.POISON;
-    end
-end;
+function onAdditionalEffect(mob, target, damage)
+    return dsp.mob.onAddEffect(mob, target, damage, dsp.mob.ae.POISON)
+end
 
 function onMobDeath(mob, player, isKiller)
 end;

--- a/scripts/zones/Jugner_Forest/mobs/King_Arthro.lua
+++ b/scripts/zones/Jugner_Forest/mobs/King_Arthro.lua
@@ -7,8 +7,7 @@ mixins =
     require("scripts/mixins/job_special"),
     require("scripts/mixins/rage")
 }
-require("scripts/globals/status");
-require("scripts/globals/msg");
+require("scripts/globals/mobs")
 -----------------------------------
 
 function onMobInitialize(mob)
@@ -24,17 +23,13 @@ function onMobSpawn(mob)
     end
 end;
 
-function onAdditionalEffect(mob,target,damage)
-    local procRate = 10; -- No retail data, so we guessed at it.
-    -- Can't proc it if enwater is up, if player full resists, or is just plain lucky.
-    if (procRate > math.random(1,100) or mob:hasStatusEffect(dsp.effect.ENWATER)
-    or applyResistanceAddEffect(mob, target, dsp.magic.ele.ICE, 0) <= 0.5) then
-        return 0,0,0;
+function onAdditionalEffect(mob, target, damage)
+    if mob:hasStatusEffect(dsp.effect.ENWATER) then
+        return 0, 0, 0
     else
-        target:addStatusEffect(dsp.effect.PARALYSIS, 20, 0, 30); -- Potency unconfirmed
-        return dsp.subEffect.PARALYSIS, dsp.msg.basic.ADD_EFFECT_STATUS, dsp.effect.PARALYSIS;
+        return dsp.mob.onAddEffect(mob, target, damage, dsp.mob.ae.PARALYZE)
     end
-end;
+end
 
 function onMonsterMagicPrepare(mob, target)
     -- Instant cast on spells - Waterga IV, Poisonga II, Drown, and Enwater

--- a/scripts/zones/Jugner_Forest/mobs/Orcish_Grunt.lua
+++ b/scripts/zones/Jugner_Forest/mobs/Orcish_Grunt.lua
@@ -11,5 +11,5 @@ function onMobDeath(mob, player, isKiller)
 end
 
 function onMobDespawn(mob)
-    phOnDespawn(mob, ID.mob.SUPPLESPINE_MUJWUJ_PH, 10, 3600) -- 1 hour
+    dsp.mob.phOnDespawn(mob, ID.mob.SUPPLESPINE_MUJWUJ_PH, 10, 3600) -- 1 hour
 end

--- a/scripts/zones/Jugner_Forest/mobs/Sappy_Sycamore.lua
+++ b/scripts/zones/Jugner_Forest/mobs/Sappy_Sycamore.lua
@@ -1,9 +1,8 @@
 ----------------------------------
 -- Area: Jugner_Forest
---  NM:  Sappy Sycamore
+--   NM: Sappy Sycamore
 -----------------------------------
-require("scripts/globals/status")
-require("scripts/globals/msg")
+require("scripts/globals/mobs")
 -----------------------------------
 
 function onMobInitialize(mob)
@@ -13,15 +12,8 @@ function onMobInitialize(mob)
 end
 
 function onAdditionalEffect(mob, target, damage)
-    -- Guesstimating 1 in 4 chance to slow on melee.
-    if math.random(1, 100) >= 25 or target:hasStatusEffect(dsp.effect.SLOW) then
-        return 0, 0, 0
-    else
-        local duration = math.random(15, 25)
-        target:addStatusEffect(dsp.effect.SLOW, 1500, 0, duration) -- sproud smack like
-        return dsp.subEffect.NONE, dsp.msg.basic.ADD_EFFECT_STATUS, dsp.effect.SLOW
-    end
-end;
+    return dsp.mob.onAddEffect(mob, target, damage, dsp.mob.ae.SLOW, {power = 1500, duration = math.random(15, 25)})
+end
 
 function onMobDeath(mob, player, isKiller)
 end

--- a/scripts/zones/Jugner_Forest/mobs/Stag_Beetle.lua
+++ b/scripts/zones/Jugner_Forest/mobs/Stag_Beetle.lua
@@ -14,5 +14,5 @@ function onMobDeath(mob, player, isKiller)
 end
 
 function onMobDespawn(mob)
-    phOnDespawn(mob, ID.mob.PANZER_PERCIVAL_PH, 10, 3600) -- 1 hour
+    dsp.mob.phOnDespawn(mob, ID.mob.PANZER_PERCIVAL_PH, 10, 3600) -- 1 hour
 end

--- a/scripts/zones/Jugner_Forest_[S]/mobs/Orcish_Veteran.lua
+++ b/scripts/zones/Jugner_Forest_[S]/mobs/Orcish_Veteran.lua
@@ -11,5 +11,5 @@ function onMobDeath(mob, player, isKiller)
 end
 
 function onMobDespawn(mob)
-    phOnDespawn(mob, ID.mob.DRUMSKULL_ZOGDREGG_PH, 10, 3600) -- 1 hour
+    dsp.mob.phOnDespawn(mob, ID.mob.DRUMSKULL_ZOGDREGG_PH, 10, 3600) -- 1 hour
 end

--- a/scripts/zones/King_Ranperres_Tomb/mobs/Nachzehrer.lua
+++ b/scripts/zones/King_Ranperres_Tomb/mobs/Nachzehrer.lua
@@ -11,5 +11,5 @@ function onMobDeath(mob, player, isKiller)
 end
 
 function onMobDespawn(mob)
-    phOnDespawn(mob, ID.mob.GWYLLGI_PH, 10, 3600) -- 1 hour
+    dsp.mob.phOnDespawn(mob, ID.mob.GWYLLGI_PH, 10, 3600) -- 1 hour
 end

--- a/scripts/zones/King_Ranperres_Tomb/mobs/Tomb_Bat.lua
+++ b/scripts/zones/King_Ranperres_Tomb/mobs/Tomb_Bat.lua
@@ -10,5 +10,5 @@ function onMobDeath(mob, player, isKiller)
 end;
 
 function onMobDespawn(mob)
-    phOnDespawn(mob,ID.mob.CRYPT_GHOST_PH,5,3600); -- 1 hour
+    dsp.mob.phOnDespawn(mob,ID.mob.CRYPT_GHOST_PH,5,3600); -- 1 hour
 end;

--- a/scripts/zones/Konschtat_Highlands/mobs/Ghillie_Dhu.lua
+++ b/scripts/zones/Konschtat_Highlands/mobs/Ghillie_Dhu.lua
@@ -1,11 +1,10 @@
 -----------------------------------
 -- Area: Konschtat Highlands
---  NM:  Ghillie Dhu
+--   NM: Ghillie Dhu
 -----------------------------------
 require("scripts/globals/regimes")
-require("scripts/globals/status");
-require("scripts/globals/utils");
-require("scripts/globals/msg");
+require("scripts/globals/utils")
+require("scripts/globals/mobs")
 -----------------------------------
 
 function onMobInitialize(mob)
@@ -32,17 +31,9 @@ function onMobFight(mob,target)
     end
 end;
 
-function onAdditionalEffect(mob,target,damage)
-    -- wiki just says "29%" so thats what I am using (for now).
-    local CHANCE = 29;
-    if (CHANCE > math.random(0,99)) then
-        local DRAIN = math.random(10,30); -- Its a pretty weaksauce drain.
-        target:delTP(DRAIN);
-        return dsp.subEffect.TP_DRAIN, dsp.msg.basic.ADD_EFFECT_TP_DRAIN, DRAIN;
-    else
-        return 0,0,0;
-    end
-end;
+function onAdditionalEffect(mob, target, damage)
+    return dsp.mob.onAddEffect(mob, target, damage, dsp.mob.ae.TP_DRAIN, {power = math.random(10, 30)})
+end
 
 function onMobDeath(mob, player, isKiller)
     -- I think he still counts for the FoV page? Most NM's do not though.

--- a/scripts/zones/Konschtat_Highlands/mobs/Mad_Sheep.lua
+++ b/scripts/zones/Konschtat_Highlands/mobs/Mad_Sheep.lua
@@ -10,5 +10,5 @@ function onMobDeath(mob, player, isKiller)
 end;
 
 function onMobDespawn(mob)
-    phOnDespawn(mob,ID.mob.STRAY_MARY_PH,5,math.random(300,3600)); -- 5-60 minutes
+    dsp.mob.phOnDespawn(mob,ID.mob.STRAY_MARY_PH,5,math.random(300,3600)); -- 5-60 minutes
 end;

--- a/scripts/zones/Konschtat_Highlands/mobs/Rampaging_Ram.lua
+++ b/scripts/zones/Konschtat_Highlands/mobs/Rampaging_Ram.lua
@@ -11,5 +11,5 @@ function onMobDeath(mob, player, isKiller)
 end
 
 function onMobDespawn(mob)
-    phOnDespawn(mob, ID.mob.STEELFLEECE_PH, 10, math.random(75600, 86400)) -- 21-24 hours
+    dsp.mob.phOnDespawn(mob, ID.mob.STEELFLEECE_PH, 10, math.random(75600, 86400)) -- 21-24 hours
 end

--- a/scripts/zones/Konschtat_Highlands/mobs/Tremor_Ram.lua
+++ b/scripts/zones/Konschtat_Highlands/mobs/Tremor_Ram.lua
@@ -12,7 +12,7 @@ end
 
 function onMobDespawn(mob)
     -- If Steelflect doesn't pop next, fallback onto Rampaging Ram
-    if not phOnDespawn(mob, ID.mob.STEELFLEECE_PH, 10, math.random(75600, 86400)) then -- 21-24 hours
-        phOnDespawn(mob, ID.mob.RAMPAGING_RAM_PH, 10, 1200) -- 20 min
+    if not dsp.mob.phOnDespawn(mob, ID.mob.STEELFLEECE_PH, 10, math.random(75600, 86400)) then -- 21-24 hours
+        dsp.mob.phOnDespawn(mob, ID.mob.RAMPAGING_RAM_PH, 10, 1200) -- 20 min
     end
 end

--- a/scripts/zones/Korroloka_Tunnel/mobs/Bogy.lua
+++ b/scripts/zones/Korroloka_Tunnel/mobs/Bogy.lua
@@ -12,5 +12,5 @@ function onMobDeath(mob, player, isKiller)
 end;
 
 function onMobDespawn(mob)
-    phOnDespawn(mob,ID.mob.DAME_BLANCHE_PH,5,math.random(7200,28800)); -- 2 to 8 hours
+    dsp.mob.phOnDespawn(mob,ID.mob.DAME_BLANCHE_PH,5,math.random(7200,28800)); -- 2 to 8 hours
 end;

--- a/scripts/zones/Korroloka_Tunnel/mobs/Clipper.lua
+++ b/scripts/zones/Korroloka_Tunnel/mobs/Clipper.lua
@@ -12,5 +12,5 @@ function onMobDeath(mob, player, isKiller)
 end;
 
 function onMobDespawn(mob)
-    phOnDespawn(mob,ID.mob.CARGO_CRAB_COLIN_PH,5,math.random(7200,21600)); -- 1 to 6 hours
+    dsp.mob.phOnDespawn(mob,ID.mob.CARGO_CRAB_COLIN_PH,5,math.random(7200,21600)); -- 1 to 6 hours
 end;

--- a/scripts/zones/Korroloka_Tunnel/mobs/Huge_Spider.lua
+++ b/scripts/zones/Korroloka_Tunnel/mobs/Huge_Spider.lua
@@ -12,5 +12,5 @@ function onMobDeath(mob, player, isKiller)
 end
 
 function onMobDespawn(mob)
-    phOnDespawn(mob,ID.mob.FALCATUS_ARANEI_PH,5,math.random(7200,14400)); -- 2 to 4 hours
+    dsp.mob.phOnDespawn(mob,ID.mob.FALCATUS_ARANEI_PH,5,math.random(7200,14400)); -- 2 to 4 hours
 end

--- a/scripts/zones/Kuftal_Tunnel/mobs/Deinonychus.lua
+++ b/scripts/zones/Kuftal_Tunnel/mobs/Deinonychus.lua
@@ -12,5 +12,5 @@ function onMobDeath(mob, player, isKiller)
 end;
 
 function onMobDespawn(mob)
-    phOnDespawn(mob,ID.mob.YOWIE_PH,5,math.random(7200,28800)); -- 2 to 8 hours
+    dsp.mob.phOnDespawn(mob,ID.mob.YOWIE_PH,5,math.random(7200,28800)); -- 2 to 8 hours
 end;

--- a/scripts/zones/Kuftal_Tunnel/mobs/Goblin_Mercenary.lua
+++ b/scripts/zones/Kuftal_Tunnel/mobs/Goblin_Mercenary.lua
@@ -12,5 +12,5 @@ function onMobDeath(mob, player, isKiller)
 end;
 
 function onMobDespawn(mob)
-    phOnDespawn(mob,ID.mob.BLOODTHIRSTER_MADKIX_PH,5,math.random(7200,28800)); -- 2 to 8 hours
+    dsp.mob.phOnDespawn(mob,ID.mob.BLOODTHIRSTER_MADKIX_PH,5,math.random(7200,28800)); -- 2 to 8 hours
 end;

--- a/scripts/zones/Kuftal_Tunnel/mobs/Greater_Cockatrice.lua
+++ b/scripts/zones/Kuftal_Tunnel/mobs/Greater_Cockatrice.lua
@@ -12,5 +12,5 @@ function onMobDeath(mob, player, isKiller)
 end;
 
 function onMobDespawn(mob)
-    phOnDespawn(mob,ID.mob.PELICAN_PH,5,math.random(10800,43200)); -- 4 to 12 hours
+    dsp.mob.phOnDespawn(mob,ID.mob.PELICAN_PH,5,math.random(10800,43200)); -- 4 to 12 hours
 end;

--- a/scripts/zones/Kuftal_Tunnel/mobs/Recluse_Spider.lua
+++ b/scripts/zones/Kuftal_Tunnel/mobs/Recluse_Spider.lua
@@ -13,5 +13,5 @@ function onMobDeath(mob, player, isKiller)
 end;
 
 function onMobDespawn(mob)
-    phOnDespawn(mob,ID.mob.ARACHNE_PH,5,math.random(7200,28800)); -- 2 to 8 hours
+    dsp.mob.phOnDespawn(mob,ID.mob.ARACHNE_PH,5,math.random(7200,28800)); -- 2 to 8 hours
 end;

--- a/scripts/zones/Kuftal_Tunnel/mobs/Sabotender_Sediendo.lua
+++ b/scripts/zones/Kuftal_Tunnel/mobs/Sabotender_Sediendo.lua
@@ -12,5 +12,5 @@ function onMobDeath(mob, player, isKiller)
 end;
 
 function onMobDespawn(mob)
-    phOnDespawn(mob,ID.mob.SABOTENDER_MARIACHI_PH,5,math.random(10800,28800)); -- 3 to 8 hours
+    dsp.mob.phOnDespawn(mob,ID.mob.SABOTENDER_MARIACHI_PH,5,math.random(10800,28800)); -- 3 to 8 hours
 end;

--- a/scripts/zones/Kuftal_Tunnel/mobs/Sand_Lizard.lua
+++ b/scripts/zones/Kuftal_Tunnel/mobs/Sand_Lizard.lua
@@ -12,5 +12,5 @@ function onMobDeath(mob, player, isKiller)
 end;
 
 function onMobDespawn(mob)
-    phOnDespawn(mob,ID.mob.AMEMET_PH,5,math.random(7200,43200)); -- 2 to 12 hours
+    dsp.mob.phOnDespawn(mob,ID.mob.AMEMET_PH,5,math.random(7200,43200)); -- 2 to 12 hours
 end;

--- a/scripts/zones/La_Theine_Plateau/mobs/Battering_Ram.lua
+++ b/scripts/zones/La_Theine_Plateau/mobs/Battering_Ram.lua
@@ -11,7 +11,7 @@ function onMobDeath(mob, player, isKiller)
 end
 
 function onMobDespawn(mob)
-    if not phOnDespawn(mob, ID.mob.BLOODTEAR_PH, 10, math.random(75600, 86400)) then -- 21-24 hours
-        phOnDespawn(mob, ID.mob.LUMBERING_LAMBERT_PH, 10, 1200) -- 20 min
+    if not dsp.mob.phOnDespawn(mob, ID.mob.BLOODTEAR_PH, 10, math.random(75600, 86400)) then -- 21-24 hours
+        dsp.mob.phOnDespawn(mob, ID.mob.LUMBERING_LAMBERT_PH, 10, 1200) -- 20 min
     end
 end

--- a/scripts/zones/La_Theine_Plateau/mobs/Lumbering_Lambert.lua
+++ b/scripts/zones/La_Theine_Plateau/mobs/Lumbering_Lambert.lua
@@ -11,5 +11,5 @@ function onMobDeath(mob, player, isKiller)
 end
 
 function onMobDespawn(mob)
-    phOnDespawn(mob, ID.mob.BLOODTEAR_PH, 10, math.random(75600, 86400)) -- 21-24 hours
+    dsp.mob.phOnDespawn(mob, ID.mob.BLOODTEAR_PH, 10, math.random(75600, 86400)) -- 21-24 hours
 end

--- a/scripts/zones/La_Theine_Plateau/mobs/Poison_Funguar.lua
+++ b/scripts/zones/La_Theine_Plateau/mobs/Poison_Funguar.lua
@@ -11,5 +11,5 @@ function onMobDeath(mob, player, isKiller)
 end;
 
 function onMobDespawn(mob)
-    phOnDespawn(mob,ID.mob.TUMBLING_TRUFFLE_PH,5,math.random(3600,28800)); -- 1 to 8 hours
+    dsp.mob.phOnDespawn(mob,ID.mob.TUMBLING_TRUFFLE_PH,5,math.random(3600,28800)); -- 1 to 8 hours
 end;

--- a/scripts/zones/La_Vaule_[S]/mobs/Orcish_Augur.lua
+++ b/scripts/zones/La_Vaule_[S]/mobs/Orcish_Augur.lua
@@ -11,5 +11,5 @@ function onMobDeath(mob, player, isKiller)
 end
 
 function onMobDespawn(mob)
-    phOnDespawn(mob, ID.mob.ASHMAKER_GOTBLUT_PH, 10, 3600) -- 1 hour
+    dsp.mob.phOnDespawn(mob, ID.mob.ASHMAKER_GOTBLUT_PH, 10, 3600) -- 1 hour
 end

--- a/scripts/zones/La_Vaule_[S]/mobs/Orcish_Bowshooter.lua
+++ b/scripts/zones/La_Vaule_[S]/mobs/Orcish_Bowshooter.lua
@@ -11,5 +11,5 @@ function onMobDeath(mob, player, isKiller)
 end
 
 function onMobDespawn(mob)
-    phOnDespawn(mob, ID.mob.HAWKEYED_DNATBAT_PH, 10, 3600) -- 1 hour
+    dsp.mob.phOnDespawn(mob, ID.mob.HAWKEYED_DNATBAT_PH, 10, 3600) -- 1 hour
 end

--- a/scripts/zones/Labyrinth_of_Onzozo/mobs/Flying_Manta.lua
+++ b/scripts/zones/Labyrinth_of_Onzozo/mobs/Flying_Manta.lua
@@ -12,6 +12,6 @@ function onMobDeath(mob, player, isKiller)
 end;
 
 function onMobDespawn(mob)
-    phOnDespawn(mob,ID.mob.LORD_OF_ONZOZO_PH,4,math.random(75600,86400)); -- 18 to 24 hours
-    phOnDespawn(mob,ID.mob.PEG_POWLER_PH,4,math.random(7200,57600)); -- 2 to 16 hours
+    dsp.mob.phOnDespawn(mob,ID.mob.LORD_OF_ONZOZO_PH,4,math.random(75600,86400)); -- 18 to 24 hours
+    dsp.mob.phOnDespawn(mob,ID.mob.PEG_POWLER_PH,4,math.random(7200,57600)); -- 2 to 16 hours
 end;

--- a/scripts/zones/Labyrinth_of_Onzozo/mobs/Goblin_Alchemist.lua
+++ b/scripts/zones/Labyrinth_of_Onzozo/mobs/Goblin_Alchemist.lua
@@ -14,5 +14,5 @@ function onMobDeath(mob, player, isKiller)
 end;
 
 function onMobDespawn(mob)
-    phOnDespawn(mob,ID.mob.SOULSTEALER_SKULLNIX_PH,5,math.random(7200,10800)); -- 2 to 3 hours
+    dsp.mob.phOnDespawn(mob,ID.mob.SOULSTEALER_SKULLNIX_PH,5,math.random(7200,10800)); -- 2 to 3 hours
 end;

--- a/scripts/zones/Labyrinth_of_Onzozo/mobs/Goblin_Bandit.lua
+++ b/scripts/zones/Labyrinth_of_Onzozo/mobs/Goblin_Bandit.lua
@@ -14,5 +14,5 @@ function onMobDeath(mob, player, isKiller)
 end;
 
 function onMobDespawn(mob)
-    phOnDespawn(mob,ID.mob.SOULSTEALER_SKULLNIX_PH,5,math.random(7200,10800)); -- 2 to 3 hours
+    dsp.mob.phOnDespawn(mob,ID.mob.SOULSTEALER_SKULLNIX_PH,5,math.random(7200,10800)); -- 2 to 3 hours
 end;

--- a/scripts/zones/Labyrinth_of_Onzozo/mobs/Goblin_Mercenary.lua
+++ b/scripts/zones/Labyrinth_of_Onzozo/mobs/Goblin_Mercenary.lua
@@ -14,5 +14,5 @@ function onMobDeath(mob, player, isKiller)
 end;
 
 function onMobDespawn(mob)
-    phOnDespawn(mob,ID.mob.SOULSTEALER_SKULLNIX_PH,5,math.random(7200,10800)); -- 2 to 3 hours
+    dsp.mob.phOnDespawn(mob,ID.mob.SOULSTEALER_SKULLNIX_PH,5,math.random(7200,10800)); -- 2 to 3 hours
 end;

--- a/scripts/zones/Labyrinth_of_Onzozo/mobs/Goblin_Shepherd.lua
+++ b/scripts/zones/Labyrinth_of_Onzozo/mobs/Goblin_Shepherd.lua
@@ -14,5 +14,5 @@ function onMobDeath(mob, player, isKiller)
 end;
 
 function onMobDespawn(mob)
-    phOnDespawn(mob,ID.mob.SOULSTEALER_SKULLNIX_PH,5,math.random(7200,10800)); -- 2 to 3 hours
+    dsp.mob.phOnDespawn(mob,ID.mob.SOULSTEALER_SKULLNIX_PH,5,math.random(7200,10800)); -- 2 to 3 hours
 end;

--- a/scripts/zones/Labyrinth_of_Onzozo/mobs/Labyrinth_Manticore.lua
+++ b/scripts/zones/Labyrinth_of_Onzozo/mobs/Labyrinth_Manticore.lua
@@ -12,5 +12,5 @@ function onMobDeath(mob, player, isKiller)
 end;
 
 function onMobDespawn(mob)
-    phOnDespawn(mob,ID.mob.NARASIMHA_PH,5,math.random(21600,36000)); -- 6 to 10 hours
+    dsp.mob.phOnDespawn(mob,ID.mob.NARASIMHA_PH,5,math.random(21600,36000)); -- 6 to 10 hours
 end;

--- a/scripts/zones/Labyrinth_of_Onzozo/mobs/Tainted_Flesh.lua
+++ b/scripts/zones/Labyrinth_of_Onzozo/mobs/Tainted_Flesh.lua
@@ -10,5 +10,5 @@ function onMobDeath(mob, player, isKiller)
 end;
 
 function onMobDespawn(mob)
-    phOnDespawn(mob,ID.mob.HELLION_PH,5,math.random(7200,14400)); -- 2 to 4 hours
+    dsp.mob.phOnDespawn(mob,ID.mob.HELLION_PH,5,math.random(7200,14400)); -- 2 to 4 hours
 end;

--- a/scripts/zones/Labyrinth_of_Onzozo/mobs/Torama.lua
+++ b/scripts/zones/Labyrinth_of_Onzozo/mobs/Torama.lua
@@ -12,5 +12,5 @@ function onMobDeath(mob, player, isKiller)
 end;
 
 function onMobDespawn(mob)
-    phOnDespawn(mob,ID.mob.OSE_PH,5,3600); -- 1 hour
+    dsp.mob.phOnDespawn(mob,ID.mob.OSE_PH,5,3600); -- 1 hour
 end;

--- a/scripts/zones/Lower_Delkfutts_Tower/mobs/Giant_Gatekeeper.lua
+++ b/scripts/zones/Lower_Delkfutts_Tower/mobs/Giant_Gatekeeper.lua
@@ -13,6 +13,6 @@ function onMobDeath(mob, player, isKiller)
 end;
 
 function onMobDespawn(mob)
-    phOnDespawn(mob,ID.mob.EPIALTES_PH,5,1); -- no cooldown
-    phOnDespawn(mob,ID.mob.HIPPOLYTOS_PH,5,1); -- no cooldown
+    dsp.mob.phOnDespawn(mob,ID.mob.EPIALTES_PH,5,1); -- no cooldown
+    dsp.mob.phOnDespawn(mob,ID.mob.HIPPOLYTOS_PH,5,1); -- no cooldown
 end;

--- a/scripts/zones/Lower_Delkfutts_Tower/mobs/Giant_Sentry.lua
+++ b/scripts/zones/Lower_Delkfutts_Tower/mobs/Giant_Sentry.lua
@@ -13,6 +13,6 @@ function onMobDeath(mob, player, isKiller)
 end;
 
 function onMobDespawn(mob)
-    phOnDespawn(mob,ID.mob.HIPPOLYTOS_PH,5,1); -- no cooldown
-    phOnDespawn(mob,ID.mob.EURYMEDON_PH,5,1); -- no cooldown
+    dsp.mob.phOnDespawn(mob,ID.mob.HIPPOLYTOS_PH,5,1); -- no cooldown
+    dsp.mob.phOnDespawn(mob,ID.mob.EURYMEDON_PH,5,1); -- no cooldown
 end;

--- a/scripts/zones/Lufaise_Meadows/mobs/Gigantobugard.lua
+++ b/scripts/zones/Lufaise_Meadows/mobs/Gigantobugard.lua
@@ -11,5 +11,5 @@ function onMobDeath(mob, player, isKiller)
 end
 
 function onMobDespawn(mob)
-    phOnDespawn(mob, ID.mob.MEGALOBUGARD_PH, 10, 3600) -- 1 hour
+    dsp.mob.phOnDespawn(mob, ID.mob.MEGALOBUGARD_PH, 10, 3600) -- 1 hour
 end

--- a/scripts/zones/Mamook/mobs/Watch_Wyvern.lua
+++ b/scripts/zones/Mamook/mobs/Watch_Wyvern.lua
@@ -11,5 +11,5 @@ function onMobDeath(mob, player, isKiller)
 end
 
 function onMobDespawn(mob)
-    phOnDespawn(mob, ID.mob.FIREDANCE_MAGMAAL_JA_PH, 5, 3600) -- 1 hour
+    dsp.mob.phOnDespawn(mob, ID.mob.FIREDANCE_MAGMAAL_JA_PH, 5, 3600) -- 1 hour
 end

--- a/scripts/zones/Mamook/mobs/Ziz.lua
+++ b/scripts/zones/Mamook/mobs/Ziz.lua
@@ -12,5 +12,5 @@ function onMobDeath(mob, player, isKiller)
 end
 
 function onMobDespawn(mob)
-    phOnDespawn(mob, ID.mob.ZIZZY_ZILLAH_PH, 5, 3600) -- 1 hour
+    dsp.mob.phOnDespawn(mob, ID.mob.ZIZZY_ZILLAH_PH, 5, 3600) -- 1 hour
 end

--- a/scripts/zones/Maze_of_Shakhrami/mobs/Maze_Maker.lua
+++ b/scripts/zones/Maze_of_Shakhrami/mobs/Maze_Maker.lua
@@ -13,5 +13,5 @@ function onMobDeath(mob, player, isKiller)
 end
 
 function onMobDespawn(mob)
-    phOnDespawn(mob, ID.mob.TREMBLER_TABITHA_PH, 10, 3600) -- 1 hour
+    dsp.mob.phOnDespawn(mob, ID.mob.TREMBLER_TABITHA_PH, 10, 3600) -- 1 hour
 end

--- a/scripts/zones/Meriphataud_Mountains/mobs/Coeurl.lua
+++ b/scripts/zones/Meriphataud_Mountains/mobs/Coeurl.lua
@@ -12,5 +12,5 @@ function onMobDeath(mob, player, isKiller)
 end;
 
 function onMobDespawn(mob)
-    phOnDespawn(mob,ID.mob.PATRIPATAN_PH,5,math.random(3600,10800)); -- 1 to 3 hours
+    dsp.mob.phOnDespawn(mob,ID.mob.PATRIPATAN_PH,5,math.random(3600,10800)); -- 1 to 3 hours
 end;

--- a/scripts/zones/Meriphataud_Mountains/mobs/Raptor.lua
+++ b/scripts/zones/Meriphataud_Mountains/mobs/Raptor.lua
@@ -13,5 +13,5 @@ function onMobDeath(mob, player, isKiller)
 end
 
 function onMobDespawn(mob)
-    phOnDespawn(mob, ID.mob.DAGGERCLAW_DRACOS_PH, 10, 3600) -- 1 hour
+    dsp.mob.phOnDespawn(mob, ID.mob.DAGGERCLAW_DRACOS_PH, 10, 3600) -- 1 hour
 end

--- a/scripts/zones/Meriphataud_Mountains/mobs/Yagudo_Persecutor.lua
+++ b/scripts/zones/Meriphataud_Mountains/mobs/Yagudo_Persecutor.lua
@@ -11,5 +11,5 @@ function onMobDeath(mob, player, isKiller)
 end
 
 function onMobDespawn(mob)
-    phOnDespawn(mob, ID.mob.NAA_ZEKU_THE_UNWAITING_PH, 10, 3600) -- 1 hour
+    dsp.mob.phOnDespawn(mob, ID.mob.NAA_ZEKU_THE_UNWAITING_PH, 10, 3600) -- 1 hour
 end

--- a/scripts/zones/Meriphataud_Mountains_[S]/mobs/Centipedal_Centruroides.lua
+++ b/scripts/zones/Meriphataud_Mountains_[S]/mobs/Centipedal_Centruroides.lua
@@ -2,8 +2,7 @@
 -- Area: Meriphataud Mountains [S]
 --   NM: Centipedal Centruroides
 -----------------------------------
-require("scripts/globals/status")
-require("scripts/globals/magic")
+require("scripts/globals/mobs")
 -----------------------------------
 
 function onMobInitialize(mob)
@@ -14,23 +13,8 @@ function onMobSpawn(mob)
     mob:addMod(dsp.mod.MOVE, 13)
 end
 
-function onAdditionalEffect(mob, player)
-    local chance = 40
-    local resist = applyResistanceAddEffect(mob, player, dsp.magic.ele.WATER, dsp.effect.POISON)
-    if math.random(0, 99) >= chance or resist <= 0.5 then
-        return 0, 0, 0
-    else
-        local duration = 30
-        if mob:getMainLvl() > player:getMainLvl() then
-            duration = duration + mob:getMainLvl() - player:getMainLvl()
-        end
-        duration = utils.clamp(duration, 1, 30)
-        duration = duration * resist
-        if not player:hasStatusEffect(dsp.effect.POISON) then
-            player:addStatusEffect(dsp.effect.POISON, 30, 3, duration)
-        end
-        return dsp.subEffect.POISON, dsp.msg.basic.ADD_EFFECT_STATUS, dsp.effect.POISON
-    end
+function onAdditionalEffect(mob, target, damage)
+    return dsp.mob.onAddEffect(mob, target, damage, dsp.mob.ae.POISON, {power = 30})
 end
 
 function onMobDeath(mob, player, isKiller)

--- a/scripts/zones/Meriphataud_Mountains_[S]/mobs/Mountain_Scolopendrid.lua
+++ b/scripts/zones/Meriphataud_Mountains_[S]/mobs/Mountain_Scolopendrid.lua
@@ -11,5 +11,5 @@ function onMobDeath(mob, player, isKiller)
 end
 
 function onMobDespawn(mob)
-    phOnDespawn(mob, ID.mob.CENTIPEDAL_CENTRUROIDES_PH, 10, 3600) -- 1 hour
+    dsp.mob.phOnDespawn(mob, ID.mob.CENTIPEDAL_CENTRUROIDES_PH, 10, 3600) -- 1 hour
 end

--- a/scripts/zones/Middle_Delkfutts_Tower/mobs/Giant_Gatekeeper.lua
+++ b/scripts/zones/Middle_Delkfutts_Tower/mobs/Giant_Gatekeeper.lua
@@ -14,6 +14,6 @@ function onMobDeath(mob, player, isKiller)
 end;
 
 function onMobDespawn(mob)
-    phOnDespawn(mob,ID.mob.RHOITOS_PH,5,math.random(7200,14400)); -- 2 to 4 hours (could not find info, so using Ogygos' cooldown)
-    phOnDespawn(mob,ID.mob.POLYBOTES_PH,5,math.random(7200,14400)); -- 2 to 4 hours (could not find info, so using Ogygos' cooldown)
+    dsp.mob.phOnDespawn(mob,ID.mob.RHOITOS_PH,5,math.random(7200,14400)); -- 2 to 4 hours (could not find info, so using Ogygos' cooldown)
+    dsp.mob.phOnDespawn(mob,ID.mob.POLYBOTES_PH,5,math.random(7200,14400)); -- 2 to 4 hours (could not find info, so using Ogygos' cooldown)
 end;

--- a/scripts/zones/Middle_Delkfutts_Tower/mobs/Giant_Guard.lua
+++ b/scripts/zones/Middle_Delkfutts_Tower/mobs/Giant_Guard.lua
@@ -14,6 +14,6 @@ function onMobDeath(mob, player, isKiller)
 end;
 
 function onMobDespawn(mob)
-    phOnDespawn(mob,ID.mob.RHOITOS_PH,5,math.random(7200,14400)); -- 2 to 4 hours (could not find info, so using Ogygos' cooldown)
-    phOnDespawn(mob,ID.mob.POLYBOTES_PH,5,math.random(7200,14400)); -- 2 to 4 hours (could not find info, so using Ogygos' cooldown)
+    dsp.mob.phOnDespawn(mob,ID.mob.RHOITOS_PH,5,math.random(7200,14400)); -- 2 to 4 hours (could not find info, so using Ogygos' cooldown)
+    dsp.mob.phOnDespawn(mob,ID.mob.POLYBOTES_PH,5,math.random(7200,14400)); -- 2 to 4 hours (could not find info, so using Ogygos' cooldown)
 end;

--- a/scripts/zones/Middle_Delkfutts_Tower/mobs/Giant_Lobber.lua
+++ b/scripts/zones/Middle_Delkfutts_Tower/mobs/Giant_Lobber.lua
@@ -14,6 +14,6 @@ function onMobDeath(mob, player, isKiller)
 end;
 
 function onMobDespawn(mob)
-    phOnDespawn(mob,ID.mob.RHOITOS_PH,5,math.random(7200,14400)); -- 2 to 4 hours (could not find info, so using Ogygos' cooldown)
-    phOnDespawn(mob,ID.mob.POLYBOTES_PH,5,math.random(7200,14400)); -- 2 to 4 hours (could not find info, so using Ogygos' cooldown)
+    dsp.mob.phOnDespawn(mob,ID.mob.RHOITOS_PH,5,math.random(7200,14400)); -- 2 to 4 hours (could not find info, so using Ogygos' cooldown)
+    dsp.mob.phOnDespawn(mob,ID.mob.POLYBOTES_PH,5,math.random(7200,14400)); -- 2 to 4 hours (could not find info, so using Ogygos' cooldown)
 end;

--- a/scripts/zones/Middle_Delkfutts_Tower/mobs/Giant_Sentry.lua
+++ b/scripts/zones/Middle_Delkfutts_Tower/mobs/Giant_Sentry.lua
@@ -14,6 +14,6 @@ function onMobDeath(mob, player, isKiller)
 end;
 
 function onMobDespawn(mob)
-    phOnDespawn(mob,ID.mob.RHOITOS_PH,5,math.random(7200,14400)); -- 2 to 4 hours (could not find info, so using Ogygos' cooldown)
-    phOnDespawn(mob,ID.mob.EURYTOS_PH,5,math.random(7200,14400)); -- 2 to 4 hours (could not find info, so using Ogygos' cooldown)
+    dsp.mob.phOnDespawn(mob,ID.mob.RHOITOS_PH,5,math.random(7200,14400)); -- 2 to 4 hours (could not find info, so using Ogygos' cooldown)
+    dsp.mob.phOnDespawn(mob,ID.mob.EURYTOS_PH,5,math.random(7200,14400)); -- 2 to 4 hours (could not find info, so using Ogygos' cooldown)
 end;

--- a/scripts/zones/Middle_Delkfutts_Tower/mobs/Gigas_Kettlemaster.lua
+++ b/scripts/zones/Middle_Delkfutts_Tower/mobs/Gigas_Kettlemaster.lua
@@ -14,5 +14,5 @@ function onMobDeath(mob, player, isKiller)
 end;
 
 function onMobDespawn(mob)
-    phOnDespawn(mob,ID.mob.OPHION_PH,5,math.random(7200,14400)); -- 2 to 4 hours (could not find info, so using Ogygos' cooldown)
+    dsp.mob.phOnDespawn(mob,ID.mob.OPHION_PH,5,math.random(7200,14400)); -- 2 to 4 hours (could not find info, so using Ogygos' cooldown)
 end;

--- a/scripts/zones/Middle_Delkfutts_Tower/mobs/Gigas_Quarrier.lua
+++ b/scripts/zones/Middle_Delkfutts_Tower/mobs/Gigas_Quarrier.lua
@@ -14,5 +14,5 @@ function onMobDeath(mob, player, isKiller)
 end;
 
 function onMobDespawn(mob)
-    phOnDespawn(mob,ID.mob.RHOIKOS_PH,5,math.random(7200,14400)); -- 2 to 4 hours (could not find info, so using Ogygos' cooldown)
+    dsp.mob.phOnDespawn(mob,ID.mob.RHOIKOS_PH,5,math.random(7200,14400)); -- 2 to 4 hours (could not find info, so using Ogygos' cooldown)
 end;

--- a/scripts/zones/Middle_Delkfutts_Tower/mobs/Gigas_Wallwatcher.lua
+++ b/scripts/zones/Middle_Delkfutts_Tower/mobs/Gigas_Wallwatcher.lua
@@ -14,5 +14,5 @@ function onMobDeath(mob, player, isKiller)
 end;
 
 function onMobDespawn(mob)
-    phOnDespawn(mob,ID.mob.OGYGOS_PH,5,math.random(7200,14400)); -- 2 to 4 hours
+    dsp.mob.phOnDespawn(mob,ID.mob.OGYGOS_PH,5,math.random(7200,14400)); -- 2 to 4 hours
 end;

--- a/scripts/zones/Misareaux_Coast/mobs/Diatryma.lua
+++ b/scripts/zones/Misareaux_Coast/mobs/Diatryma.lua
@@ -11,5 +11,5 @@ function onMobDeath(mob, player, isKiller)
 end
 
 function onMobDespawn(mob)
-    phOnDespawn(mob, ID.mob.OKYUPETE_PH, 10, 3600) -- 1 hour
+    dsp.mob.phOnDespawn(mob, ID.mob.OKYUPETE_PH, 10, 3600) -- 1 hour
 end

--- a/scripts/zones/Mount_Zhayolm/mobs/Ignamoth.lua
+++ b/scripts/zones/Mount_Zhayolm/mobs/Ignamoth.lua
@@ -1,30 +1,18 @@
 -----------------------------------
 -- Area: Mount Zhayolm
---  MOB: Ignamoth
+--   NM: Ignamoth
 -----------------------------------
-require("scripts/globals/status")
+require("scripts/globals/mobs")
 -----------------------------------
 
-function onMobSpawn(mob)
-    mob:addMod(dsp.mod.DOUBLE_ATTACK, 50)
-    mob:addMod(dsp.mod.REGAIN, 200)
+function onMobInitialize(mob)
     mob:setMobMod(dsp.mobMod.ADD_EFFECT, 1)
+    mob:setMod(dsp.mod.DOUBLE_ATTACK, 50)
+    mob:setMod(dsp.mod.REGAIN, 200)
 end
 
 function onAdditionalEffect(mob, target, damage)
-    -- Todo adding damage on addition effect
-    local resist = applyResistanceAddEffect(mob,player,dsp.magic.ele.ICE,dsp.effect.PARALYSIS)
-    if resist <= 0.5 then
-        return 0,0,0
-    else
-        local duration = 60
-        local power = 20
-        duration = duration * resist
-        if not player:hasStatusEffect(dsp.effect.PARALYSIS) then
-            player:addStatusEffect(dsp.effect.PARALYSIS, power, 0, duration)
-        end
-        return dsp.subEffect.PARALYSIS, dsp.msg.basic.ADD_EFFECT_STATUS, dsp.effect.PARALYSIS
-    end
+    return dsp.mob.onAddEffect(mob, target, damage, dsp.mob.ae.PARALYZE, {duration = 60})
 end
 
 function onMobDeath(mob)

--- a/scripts/zones/Mount_Zhayolm/mobs/Magmatic_Eruca.lua
+++ b/scripts/zones/Mount_Zhayolm/mobs/Magmatic_Eruca.lua
@@ -10,5 +10,5 @@ function onMobDeath(mob, player, isKiller)
 end;
 
 function onMobDespawn(mob)
-    phOnDespawn(mob,ID.mob.ENERGETIC_ERUCA_PH,10,86400); -- 24 hours
+    dsp.mob.phOnDespawn(mob,ID.mob.ENERGETIC_ERUCA_PH,10,86400); -- 24 hours
 end;

--- a/scripts/zones/Mount_Zhayolm/mobs/Sarameya.lua
+++ b/scripts/zones/Mount_Zhayolm/mobs/Sarameya.lua
@@ -75,23 +75,8 @@ function onMobFight(mob, target)
     end
 end
 
-function onAdditionalEffect(mob, player)
-    local chance = 40
-    local resist = applyResistanceAddEffect(mob,player,dsp.magic.ele.WATER,dsp.effect.POISON)
-    if (math.random(0,99) >= chance or resist <= 0.5) then
-        return 0,0,0
-    else
-        local duration = 30
-        if (mob:getMainLvl() > player:getMainLvl()) then
-            duration = duration + (mob:getMainLvl() - player:getMainLvl())
-        end
-        duration = utils.clamp(duration,1,30)
-        duration = duration * resist
-        if (player:hasStatusEffect(dsp.effect.POISON) == false) then
-            player:addStatusEffect(dsp.effect.POISON, 50, 3, duration) -- Don't know potency on the poison.
-        end
-        return dsp.subEffect.POISON, dsp.msg.basic.ADD_EFFECT_STATUS, dsp.effect.POISON
-    end
+function onAdditionalEffect(mob, target, damage)
+    return dsp.mob.onAddEffect(mob, target, damage, dsp.mob.ae.POISON, {chance = 40, power = 50})
 end
 
 function onMobDeath(mob, player, isKiller)

--- a/scripts/zones/Mount_Zhayolm/mobs/Wamoura.lua
+++ b/scripts/zones/Mount_Zhayolm/mobs/Wamoura.lua
@@ -10,5 +10,5 @@ function onMobDeath(mob)
 end
 
 function onMobDespawn(mob)
-    phOnDespawn(mob,ID.mob.IGNAMOTH_PH,10,7200) -- 2 hours
+    dsp.mob.phOnDespawn(mob,ID.mob.IGNAMOTH_PH,10,7200) -- 2 hours
 end

--- a/scripts/zones/North_Gustaberg/mobs/Maneating_Hornet.lua
+++ b/scripts/zones/North_Gustaberg/mobs/Maneating_Hornet.lua
@@ -12,5 +12,5 @@ function onMobDeath(mob, player, isKiller)
 end;
 
 function onMobDespawn(mob)
-    phOnDespawn(mob,ID.mob.STINGING_SOPHIE_PH,5,math.random(1200,3600)); -- 20 to 60 minutes
+    dsp.mob.phOnDespawn(mob,ID.mob.STINGING_SOPHIE_PH,5,math.random(1200,3600)); -- 20 to 60 minutes
 end;

--- a/scripts/zones/North_Gustaberg/mobs/Walking_Sapling.lua
+++ b/scripts/zones/North_Gustaberg/mobs/Walking_Sapling.lua
@@ -12,5 +12,5 @@ function onMobDeath(mob, player, isKiller)
 end;
 
 function onMobDespawn(mob)
-    phOnDespawn(mob,ID.mob.MAIGHDEAN_UAINE_PH,5,math.random(900,10800)); -- 15 to 180 minutes
+    dsp.mob.phOnDespawn(mob,ID.mob.MAIGHDEAN_UAINE_PH,5,math.random(900,10800)); -- 15 to 180 minutes
 end;

--- a/scripts/zones/North_Gustaberg_[S]/mobs/Coppercap.lua
+++ b/scripts/zones/North_Gustaberg_[S]/mobs/Coppercap.lua
@@ -11,5 +11,5 @@ function onMobDeath(mob, player, isKiller)
 end
 
 function onMobDespawn(mob)
-    phOnDespawn(mob,ID.mob.GLOOMANITA_PH,10,3600) -- 1 hour
+    dsp.mob.phOnDespawn(mob,ID.mob.GLOOMANITA_PH,10,3600) -- 1 hour
 end

--- a/scripts/zones/North_Gustaberg_[S]/mobs/Huge_Spider.lua
+++ b/scripts/zones/North_Gustaberg_[S]/mobs/Huge_Spider.lua
@@ -10,5 +10,5 @@ function onMobDeath(mob, player, isKiller)
 end
 
 function onMobDespawn(mob)
-    phOnDespawn(mob,ID.mob.ANKABUT_PH,10,3600) -- 1 hour
+    dsp.mob.phOnDespawn(mob,ID.mob.ANKABUT_PH,10,3600) -- 1 hour
 end

--- a/scripts/zones/Oldton_Movalpolos/mobs/Bugbear_Bondman.lua
+++ b/scripts/zones/Oldton_Movalpolos/mobs/Bugbear_Bondman.lua
@@ -11,5 +11,5 @@ function onMobDeath(mob, player, isKiller)
 end
 
 function onMobDespawn(mob)
-    phOnDespawn(mob, ID.mob.BUGBEAR_STRONGMAN_PH, 10, 1) -- no cooldown
+    dsp.mob.phOnDespawn(mob, ID.mob.BUGBEAR_STRONGMAN_PH, 10, 1) -- no cooldown
 end

--- a/scripts/zones/Ordelles_Caves/mobs/Jelly.lua
+++ b/scripts/zones/Ordelles_Caves/mobs/Jelly.lua
@@ -13,5 +13,5 @@ function onMobDeath(mob, player, isKiller)
 end
 
 function onMobDespawn(mob)
-    phOnDespawn(mob, ID.mob.AGAR_AGAR_PH, 5, 3600) -- 1 hour
+    dsp.mob.phOnDespawn(mob, ID.mob.AGAR_AGAR_PH, 5, 3600) -- 1 hour
 end

--- a/scripts/zones/Outer_Horutoto_Ruins/mobs/Desmodont.lua
+++ b/scripts/zones/Outer_Horutoto_Ruins/mobs/Desmodont.lua
@@ -2,28 +2,16 @@
 -- Area: Outer Horutoto Ruins
 --   NM: Desmodont
 -----------------------------------
-require("scripts/globals/status")
-require("scripts/globals/magic")
-require("scripts/globals/msg")
+require("scripts/globals/mobs")
 -----------------------------------
 
 function onMobInitialize(mob)
     mob:setMobMod(dsp.mobMod.ADD_EFFECT, 1)
 end
 
-function onAdditionalEffect(mob, player)
-    local resist = applyResistanceAddEffect(mob, player, dsp.magic.ele.DARK, dsp.effect.BLINDNESS)
+function onAdditionalEffect(mob, target, damage)
+    return dsp.mob.onAddEffect(mob, target, damage, dsp.mob.ae.BLIND)
+end
 
-    if math.random(100) > 20 or resist <= 0.5 then
-        return 0, 0, 0
-    else
-        local duration = 30
-        duration = duration * resist
-
-        if not player:hasStatusEffect(dsp.effect.BLINDNESS) then
-            player:addStatusEffect(dsp.effect.BLINDNESS, 0, 0, duration)
-        end
-
-        return dsp.subEffect.BLIND, dsp.msg.basic.ADD_EFFECT_STATUS, dsp.effect.BLINDNESS
-    end
+function onMobDeath(mob, player, isKiller)
 end

--- a/scripts/zones/Outer_Horutoto_Ruins/mobs/Ghoul.lua
+++ b/scripts/zones/Outer_Horutoto_Ruins/mobs/Ghoul.lua
@@ -10,5 +10,5 @@ function onMobDeath(mob, player, isKiller)
 end;
 
 function onMobDespawn(mob)
-    phOnDespawn(mob,ID.mob.AH_PUCH_PH,20,math.random(3600,10800)); -- 1 to 3 hours
+    dsp.mob.phOnDespawn(mob,ID.mob.AH_PUCH_PH,20,math.random(3600,10800)); -- 1 to 3 hours
 end;

--- a/scripts/zones/Outer_Horutoto_Ruins/mobs/Stink_Bats.lua
+++ b/scripts/zones/Outer_Horutoto_Ruins/mobs/Stink_Bats.lua
@@ -11,5 +11,5 @@ function onMobDeath(mob, player, isKiller)
 end
 
 function onMobDespawn(mob)
-    phOnDespawn(mob, ID.mob.DESMODONT_PH, 10, 3600) -- 1 hour
+    dsp.mob.phOnDespawn(mob, ID.mob.DESMODONT_PH, 10, 3600) -- 1 hour
 end

--- a/scripts/zones/Palborough_Mines/mobs/Copper_Beetle.lua
+++ b/scripts/zones/Palborough_Mines/mobs/Copper_Beetle.lua
@@ -10,5 +10,5 @@ function onMobDeath(mob, player, isKiller)
 end;
 
 function onMobDespawn(mob)
-    phOnDespawn(mob,ID.mob.BU_GHI_HOWLBLADE_PH,10,3600); -- 1 hour
+    dsp.mob.phOnDespawn(mob,ID.mob.BU_GHI_HOWLBLADE_PH,10,3600); -- 1 hour
 end;

--- a/scripts/zones/Palborough_Mines/mobs/Copper_Quadav.lua
+++ b/scripts/zones/Palborough_Mines/mobs/Copper_Quadav.lua
@@ -11,5 +11,5 @@ function onMobDeath(mob, player, isKiller)
 end
 
 function onMobDespawn(mob)
-    phOnDespawn(mob, ID.mob.BEHYA_HUNDREDWALL_PH, 10, 3600) -- 1 hour
+    dsp.mob.phOnDespawn(mob, ID.mob.BEHYA_HUNDREDWALL_PH, 10, 3600) -- 1 hour
 end

--- a/scripts/zones/Palborough_Mines/mobs/Old_Quadav.lua
+++ b/scripts/zones/Palborough_Mines/mobs/Old_Quadav.lua
@@ -11,5 +11,5 @@ function onMobDeath(mob, player, isKiller)
 end
 
 function onMobDespawn(mob)
-    phOnDespawn(mob, ID.mob.BEHYA_HUNDREDWALL_PH, 10, 3600) -- 1 hour
+    dsp.mob.phOnDespawn(mob, ID.mob.BEHYA_HUNDREDWALL_PH, 10, 3600) -- 1 hour
 end

--- a/scripts/zones/Palborough_Mines/mobs/Veteran_Quadav.lua
+++ b/scripts/zones/Palborough_Mines/mobs/Veteran_Quadav.lua
@@ -10,5 +10,5 @@ function onMobDeath(mob, player, isKiller)
 end;
 
 function onMobDespawn(mob)
-    phOnDespawn(mob,ID.mob.ZI_GHI_BONEEATER_PH,20,3600); -- 1 hour
+    dsp.mob.phOnDespawn(mob,ID.mob.ZI_GHI_BONEEATER_PH,20,3600); -- 1 hour
 end;

--- a/scripts/zones/Pashhow_Marshlands/mobs/Goobbue.lua
+++ b/scripts/zones/Pashhow_Marshlands/mobs/Goobbue.lua
@@ -13,5 +13,5 @@ function onMobDeath(mob, player, isKiller)
 end;
 
 function onMobDespawn(mob)
-    phOnDespawn(mob,ID.mob.JOLLY_GREEN_PH,5,1); -- 1 second / no cooldown
+    dsp.mob.phOnDespawn(mob,ID.mob.JOLLY_GREEN_PH,5,1); -- 1 second / no cooldown
 end;

--- a/scripts/zones/Pashhow_Marshlands/mobs/Thread_Leech.lua
+++ b/scripts/zones/Pashhow_Marshlands/mobs/Thread_Leech.lua
@@ -14,5 +14,5 @@ function onMobDeath(mob, player, isKiller)
 end;
 
 function onMobDespawn(mob)
-    phOnDespawn(mob,ID.mob.BLOODPOOL_VORAX_PH,5,600); -- 10 minutes
+    dsp.mob.phOnDespawn(mob,ID.mob.BLOODPOOL_VORAX_PH,5,600); -- 10 minutes
 end;

--- a/scripts/zones/Pashhow_Marshlands/mobs/Veteran_Quadav.lua
+++ b/scripts/zones/Pashhow_Marshlands/mobs/Veteran_Quadav.lua
@@ -13,5 +13,5 @@ function onMobDeath(mob, player, isKiller)
 end;
 
 function onMobDespawn(mob)
-    phOnDespawn(mob,ID.mob.NI_ZHO_BLADEBENDER_PH,10,3600); -- 1 hour
+    dsp.mob.phOnDespawn(mob,ID.mob.NI_ZHO_BLADEBENDER_PH,10,3600); -- 1 hour
 end;

--- a/scripts/zones/Pashhow_Marshlands_[S]/mobs/Lou_Carcolh.lua
+++ b/scripts/zones/Pashhow_Marshlands_[S]/mobs/Lou_Carcolh.lua
@@ -11,5 +11,5 @@ function onMobDeath(mob, player, isKiller)
 end
 
 function onMobDespawn(mob)
-    phOnDespawn(mob, ID.mob.NOMMO_PH, 5, 3600) -- 1 hour
+    dsp.mob.phOnDespawn(mob, ID.mob.NOMMO_PH, 5, 3600) -- 1 hour
 end

--- a/scripts/zones/Pashhow_Marshlands_[S]/mobs/Virulent_Peiste.lua
+++ b/scripts/zones/Pashhow_Marshlands_[S]/mobs/Virulent_Peiste.lua
@@ -11,5 +11,5 @@ function onMobDeath(mob, player, isKiller)
 end
 
 function onMobDespawn(mob)
-    phOnDespawn(mob, ID.mob.SUGAAR_PH, 5, 3600) -- 1 hour
+    dsp.mob.phOnDespawn(mob, ID.mob.SUGAAR_PH, 5, 3600) -- 1 hour
 end

--- a/scripts/zones/Qufim_Island/mobs/Dancing_Weapon.lua
+++ b/scripts/zones/Qufim_Island/mobs/Dancing_Weapon.lua
@@ -11,5 +11,5 @@ function onMobDeath(mob, player, isKiller)
 end
 
 function onMobDespawn(mob)
-    phOnDespawn(mob, ID.mob.TRICKSTER_KINETIX_PH, 5, 3600) -- 1 hour
+    dsp.mob.phOnDespawn(mob, ID.mob.TRICKSTER_KINETIX_PH, 5, 3600) -- 1 hour
 end

--- a/scripts/zones/Qufim_Island/mobs/Giant_Ascetic.lua
+++ b/scripts/zones/Qufim_Island/mobs/Giant_Ascetic.lua
@@ -14,5 +14,5 @@ function onMobDeath(mob, player, isKiller)
 end
 
 function onMobDespawn(mob)
-    phOnDespawn(mob, ID.mob.SLIPPERY_SUCKER_PH, 10, 600) -- 10 minutes
+    dsp.mob.phOnDespawn(mob, ID.mob.SLIPPERY_SUCKER_PH, 10, 600) -- 10 minutes
 end

--- a/scripts/zones/Qufim_Island/mobs/Giant_Hunter.lua
+++ b/scripts/zones/Qufim_Island/mobs/Giant_Hunter.lua
@@ -14,5 +14,5 @@ function onMobDeath(mob, player, isKiller)
 end
 
 function onMobDespawn(mob)
-    phOnDespawn(mob, ID.mob.SLIPPERY_SUCKER_PH, 10, 600) -- 10 minutes
+    dsp.mob.phOnDespawn(mob, ID.mob.SLIPPERY_SUCKER_PH, 10, 600) -- 10 minutes
 end

--- a/scripts/zones/Qufim_Island/mobs/Giant_Ranger.lua
+++ b/scripts/zones/Qufim_Island/mobs/Giant_Ranger.lua
@@ -14,5 +14,5 @@ function onMobDeath(mob, player, isKiller)
 end
 
 function onMobDespawn(mob)
-    phOnDespawn(mob, ID.mob.SLIPPERY_SUCKER_PH, 10, 600) -- 10 minutes
+    dsp.mob.phOnDespawn(mob, ID.mob.SLIPPERY_SUCKER_PH, 10, 600) -- 10 minutes
 end

--- a/scripts/zones/Qufim_Island/mobs/Giant_Trapper.lua
+++ b/scripts/zones/Qufim_Island/mobs/Giant_Trapper.lua
@@ -14,5 +14,5 @@ function onMobDeath(mob, player, isKiller)
 end
 
 function onMobDespawn(mob)
-    phOnDespawn(mob, ID.mob.SLIPPERY_SUCKER_PH, 10, 600) -- 10 minutes
+    dsp.mob.phOnDespawn(mob, ID.mob.SLIPPERY_SUCKER_PH, 10, 600) -- 10 minutes
 end

--- a/scripts/zones/Qufim_Island/mobs/Slippery_Sucker.lua
+++ b/scripts/zones/Qufim_Island/mobs/Slippery_Sucker.lua
@@ -2,23 +2,15 @@
 -- Area: Qufim Island
 --   NM: Slippery Sucker
 -----------------------------------
-require("scripts/globals/status")
-require("scripts/globals/magic")
+require("scripts/globals/mobs")
 -----------------------------------
 
 function onMobInitialize(mob)
     mob:setMobMod(dsp.mobMod.ADD_EFFECT, 1)
 end
 
-function onAdditionalEffect(mob, player)
-    if math.random(100) > 20 or applyResistanceAddEffect(mob, player, dsp.magic.ele.THUNDER, dsp.effect.STUN) <= 0.5 then
-        return 0, 0, 0
-    else
-        if not player:hasStatusEffect(dsp.effect.STUN) then
-            player:addStatusEffect(dsp.effect.STUN, 0, 0, 5 * resist)
-        end
-        return dsp.subEffect.STUN, dsp.msg.basic.ADD_EFFECT_STATUS, dsp.effect.STUN
-    end
+function onAdditionalEffect(mob, target, damage)
+    return dsp.mob.onAddEffect(mob, target, damage, dsp.mob.ae.STUN)
 end
 
 function onMobDeath(mob, player, isKiller)

--- a/scripts/zones/Quicksand_Caves/mobs/Antican_Aedilis.lua
+++ b/scripts/zones/Quicksand_Caves/mobs/Antican_Aedilis.lua
@@ -20,5 +20,5 @@ function onMobDeath(mob, player, isKiller)
 end;
 
 function onMobDespawn(mob)
-    phOnDespawn(mob, ID.mob.ANTICAN_TRIBUNUS_PH, 10, 3600) -- 1 hour
+    dsp.mob.phOnDespawn(mob, ID.mob.ANTICAN_TRIBUNUS_PH, 10, 3600) -- 1 hour
 end

--- a/scripts/zones/Quicksand_Caves/mobs/Antican_Hastatus.lua
+++ b/scripts/zones/Quicksand_Caves/mobs/Antican_Hastatus.lua
@@ -20,5 +20,5 @@ function onMobDeath(mob, player, isKiller)
 end
 
 function onMobDespawn(mob)
-    phOnDespawn(mob, ID.mob.ANTICAN_MAGISTER_PH, 10, 3600) -- 1 hour
+    dsp.mob.phOnDespawn(mob, ID.mob.ANTICAN_MAGISTER_PH, 10, 3600) -- 1 hour
 end

--- a/scripts/zones/Quicksand_Caves/mobs/Antican_Princeps.lua
+++ b/scripts/zones/Quicksand_Caves/mobs/Antican_Princeps.lua
@@ -20,6 +20,6 @@ function onMobDeath(mob, player, isKiller)
 end
 
 function onMobDespawn(mob)
-    phOnDespawn(mob,ID.mob.SAGITTARIUS_X_XIII_PH,10,14400) -- 4 hours
-    phOnDespawn(mob,ID.mob.ANTICAN_PRAEFECTUS_PH,10,3600) -- 1 hour
+    dsp.mob.phOnDespawn(mob,ID.mob.SAGITTARIUS_X_XIII_PH,10,14400) -- 4 hours
+    dsp.mob.phOnDespawn(mob,ID.mob.ANTICAN_PRAEFECTUS_PH,10,3600) -- 1 hour
 end

--- a/scripts/zones/Quicksand_Caves/mobs/Antican_Signifer.lua
+++ b/scripts/zones/Quicksand_Caves/mobs/Antican_Signifer.lua
@@ -20,6 +20,6 @@ function onMobDeath(mob, player, isKiller)
 end
 
 function onMobDespawn(mob)
-    phOnDespawn(mob, ID.mob.CENTURIO_X_I_PH, 10, 9000) -- 2.5 hours
-    phOnDespawn(mob, ID.mob.ANTICAN_PROCONSUL_PH, 10, 3600) -- 1 hour
+    dsp.mob.phOnDespawn(mob, ID.mob.CENTURIO_X_I_PH, 10, 9000) -- 2.5 hours
+    dsp.mob.phOnDespawn(mob, ID.mob.ANTICAN_PROCONSUL_PH, 10, 3600) -- 1 hour
 end

--- a/scripts/zones/Quicksand_Caves/mobs/Antican_Triarius.lua
+++ b/scripts/zones/Quicksand_Caves/mobs/Antican_Triarius.lua
@@ -20,6 +20,6 @@ function onMobDeath(mob, player, isKiller)
 end
 
 function onMobDespawn(mob)
-    phOnDespawn(mob, ID.mob.TRIARIUS_X_XV_PH, 10, 7200) -- 2 hours
-    phOnDespawn(mob, ID.mob.HASTATUS_XI_XII_PH, 10, 3600) -- 1 hour
+    dsp.mob.phOnDespawn(mob, ID.mob.TRIARIUS_X_XV_PH, 10, 7200) -- 2 hours
+    dsp.mob.phOnDespawn(mob, ID.mob.HASTATUS_XI_XII_PH, 10, 3600) -- 1 hour
 end

--- a/scripts/zones/Quicksand_Caves/mobs/Helm_Beetle.lua
+++ b/scripts/zones/Quicksand_Caves/mobs/Helm_Beetle.lua
@@ -13,5 +13,5 @@ function onMobDeath(mob, player, isKiller)
 end
 
 function onMobDespawn(mob)
-    phOnDespawn(mob, ID.mob.DIAMOND_DAIG_PH, 10, 3600) -- 1 hour
+    dsp.mob.phOnDespawn(mob, ID.mob.DIAMOND_DAIG_PH, 10, 3600) -- 1 hour
 end

--- a/scripts/zones/Quicksand_Caves/mobs/Sand_Lizard.lua
+++ b/scripts/zones/Quicksand_Caves/mobs/Sand_Lizard.lua
@@ -13,5 +13,5 @@ function onMobDeath(mob, player, isKiller)
 end
 
 function onMobDespawn(mob)
-    phOnDespawn(mob, ID.mob.NUSSKNACKER_PH, 5, 3600) -- 1 hour
+    dsp.mob.phOnDespawn(mob, ID.mob.NUSSKNACKER_PH, 5, 3600) -- 1 hour
 end

--- a/scripts/zones/Qulun_Dome/mobs/ZaDha_Adamantking.lua
+++ b/scripts/zones/Qulun_Dome/mobs/ZaDha_Adamantking.lua
@@ -3,12 +3,10 @@
 --   NM: Za'Dha Adamantking
 -- TODO: messages should be zone-wide
 -----------------------------------
-mixins = {require("scripts/mixins/job_special")}
 local ID = require("scripts/zones/Qulun_Dome/IDs")
-require("scripts/globals/status")
+mixins = {require("scripts/mixins/job_special")}
 require("scripts/globals/titles")
-require("scripts/globals/magic")
-require("scripts/globals/msg")
+require("scripts/globals/mobs")
 -----------------------------------
 
 function onMobInitialize(mob)
@@ -19,23 +17,8 @@ function onMobEngaged(mob,target)
     mob:showText(mob, ID.text.QUADAV_KING_ENGAGE)
 end
 
-function onAdditionalEffect(mob, player)
-    local resist = applyResistanceAddEffect(mob,player,dsp.magic.ele.EARTH,dsp.effect.SLOW)
-    if resist <= 0.5 then
-        return 0,0,0
-    else
-        local power = 3000
-        local duration = 30
-        if mob:getMainLvl() > player:getMainLvl() then
-            duration = duration + (mob:getMainLvl() - player:getMainLvl())
-        end
-        duration = utils.clamp(duration,1,45)
-        duration = duration * resist
-        if not player:hasStatusEffect(dsp.effect.SLOW) then
-            player:addStatusEffect(dsp.effect.SLOW, power, 0, duration)
-        end
-        return dsp.subEffect.NONE, dsp.msg.basic.ADD_EFFECT_STATUS, dsp.effect.SLOW
-    end
+function onAdditionalEffect(mob, target, damage)
+    return dsp.mob.onAddEffect(mob, target, damage, dsp.mob.ae.SLOW, {power = 3000})
 end
 
 function onMobDeath(mob, player, isKiller)

--- a/scripts/zones/Ranguemont_Pass/mobs/Seeker_Bats.lua
+++ b/scripts/zones/Ranguemont_Pass/mobs/Seeker_Bats.lua
@@ -13,5 +13,5 @@ function onMobDeath(mob, player, isKiller)
 end
 
 function onMobDespawn(mob)
-    phOnDespawn(mob, ID.mob.GLOOM_EYE_PH, 10, 3600) -- 1 hour
+    dsp.mob.phOnDespawn(mob, ID.mob.GLOOM_EYE_PH, 10, 3600) -- 1 hour
 end

--- a/scripts/zones/Riverne-Site_B01/mobs/Nimbus_Hippogryph.lua
+++ b/scripts/zones/Riverne-Site_B01/mobs/Nimbus_Hippogryph.lua
@@ -10,5 +10,5 @@ function onMobDeath(mob, player, isKiller)
 end;
 
 function onMobDespawn(mob)
-    phOnDespawn(mob,ID.mob.IMDUGUD_PH,10,75600); -- 21 hours
+    dsp.mob.phOnDespawn(mob,ID.mob.IMDUGUD_PH,10,75600); -- 21 hours
 end;

--- a/scripts/zones/RoMaeve/mobs/Magic_Flagon.lua
+++ b/scripts/zones/RoMaeve/mobs/Magic_Flagon.lua
@@ -13,5 +13,5 @@ function onMobDeath(mob, player, isKiller)
 end
 
 function onMobDespawn(mob)
-    phOnDespawn(mob, ID.mob.NIGHTMARE_VASE_PH, 10, 3600) -- 1 hour
+    dsp.mob.phOnDespawn(mob, ID.mob.NIGHTMARE_VASE_PH, 10, 3600) -- 1 hour
 end

--- a/scripts/zones/RoMaeve/mobs/Nargun.lua
+++ b/scripts/zones/RoMaeve/mobs/Nargun.lua
@@ -1,24 +1,16 @@
 -----------------------------------
 -- Area: RoMaeve
--- NM  : Nargun
+--   NM: Nargun
 -----------------------------------
-require("scripts/globals/status")
-require("scripts/globals/magic")
+require("scripts/globals/mobs")
 -----------------------------------
 
 function onMobInitialize(mob)
     mob:setMobMod(dsp.mobMod.ADD_EFFECT, 1)
 end
 
-function onAdditionalEffect(mob,target,damage)
-    -- probably incorrect rate of stun copied from another NM
-    if math.random(1,100) >= 66 or target:hasStatusEffect(dsp.effect.STUN) then
-        return 0,0,0
-    else
-        local duration = math.random(5,15) -- Todo: actually calculate duration correctly..
-        target:addStatusEffect(dsp.effect.STUN, 5, 0, duration)
-        return dsp.subEffect.STUN, 0, dsp.effect.STUN
-    end
+function onAdditionalEffect(mob, target, damage)
+    return dsp.mob.onAddEffect(mob, target, damage, dsp.mob.ae.STUN)
 end
 
 function onMobDeath(mob, player, isKiller)

--- a/scripts/zones/Rolanberry_Fields/mobs/Evil_Weapon.lua
+++ b/scripts/zones/Rolanberry_Fields/mobs/Evil_Weapon.lua
@@ -11,5 +11,5 @@ function onMobDeath(mob, player, isKiller)
 end
 
 function onMobDespawn(mob)
-    phOnDespawn(mob, ID.mob.ELDRITCH_EDGE_PH, 20, math.random(5400, 7200)) -- 90 to 120 minutes
+    dsp.mob.phOnDespawn(mob, ID.mob.ELDRITCH_EDGE_PH, 20, math.random(5400, 7200)) -- 90 to 120 minutes
 end

--- a/scripts/zones/Rolanberry_Fields/mobs/Midnight_Wings.lua
+++ b/scripts/zones/Rolanberry_Fields/mobs/Midnight_Wings.lua
@@ -11,5 +11,5 @@ function onMobDeath(mob, player, isKiller)
 end
 
 function onMobDespawn(mob)
-    phOnDespawn(mob, ID.mob.BLACK_TRIPLE_STARS_PH, 10, 3600) -- 1 hour
+    dsp.mob.phOnDespawn(mob, ID.mob.BLACK_TRIPLE_STARS_PH, 10, 3600) -- 1 hour
 end

--- a/scripts/zones/Rolanberry_Fields/mobs/Ochu.lua
+++ b/scripts/zones/Rolanberry_Fields/mobs/Ochu.lua
@@ -13,5 +13,5 @@ function onMobDeath(mob, player, isKiller)
 end
 
 function onMobDespawn(mob)
-    phOnDespawn(mob, ID.mob.DROOLING_DAISY_PH, 10, 3600) -- 1 hour
+    dsp.mob.phOnDespawn(mob, ID.mob.DROOLING_DAISY_PH, 10, 3600) -- 1 hour
 end

--- a/scripts/zones/Rolanberry_Fields_[S]/mobs/Lamina.lua
+++ b/scripts/zones/Rolanberry_Fields_[S]/mobs/Lamina.lua
@@ -2,32 +2,15 @@
 -- Area: Rolanberry Fields [S]
 --   NM: Lamina
 -----------------------------------
-require("scripts/globals/status")
-require("scripts/globals/magic")
+require("scripts/globals/mobs")
 -----------------------------------
 
 function onMobInitialize(mob)
     mob:setMobMod(dsp.mobMod.ADD_EFFECT, 1)
 end
 
-function onAdditionalEffect(mob, player)
-    local resist = applyResistanceAddEffect(mob, player, dsp.magic.ele.EARTH, dsp.effect.SLOW)
-
-    if resist <= 0.5 then
-        return 0, 0, 0
-    else
-        local power = 1000
-        local duration = 30
-        if mob:getMainLvl() > player:getMainLvl() then
-            duration = duration + (mob:getMainLvl() - player:getMainLvl())
-        end
-        duration = utils.clamp(duration, 1, 45)
-        duration = duration * resist
-        if not player:hasStatusEffect(dsp.effect.SLOW) then
-            player:addStatusEffect(dsp.effect.SLOW, power, 0, duration)
-        end
-        return dsp.subEffect.NONE, dsp.msg.basic.ADD_EFFECT_STATUS, dsp.effect.SLOW
-    end
+function onAdditionalEffect(mob, target, damage)
+    return dsp.mob.onAddEffect(mob, target, damage, dsp.mob.ae.SLOW)
 end
 
 function onMobDeath(mob, player, isKiller)

--- a/scripts/zones/Rolanberry_Fields_[S]/mobs/Ochu.lua
+++ b/scripts/zones/Rolanberry_Fields_[S]/mobs/Ochu.lua
@@ -11,5 +11,5 @@ function onMobDeath(mob, player, isKiller)
 end
 
 function onMobDespawn(mob)
-    phOnDespawn(mob, ID.mob.DELICIEUSE_DELPHINE_PH, 10, 3600) -- 1 hour
+    dsp.mob.phOnDespawn(mob, ID.mob.DELICIEUSE_DELPHINE_PH, 10, 3600) -- 1 hour
 end

--- a/scripts/zones/RuAun_Gardens/mobs/Byakko.lua
+++ b/scripts/zones/RuAun_Gardens/mobs/Byakko.lua
@@ -4,7 +4,7 @@
 -----------------------------------
 local ID = require("scripts/zones/RuAun_Gardens/IDs")
 mixins = {require("scripts/mixins/job_special")}
-require("scripts/globals/magic")
+require("scripts/globals/mobs")
 -----------------------------------
 
 function onMobInitialize(mob)
@@ -12,17 +12,7 @@ function onMobInitialize(mob)
 end
 
 function onAdditionalEffect(mob, target, damage)
-    local dmg = math.random(35, 50)
-    local params = {}
-    params.bonusmab = 0
-    params.includemab = false
-
-    dmg = addBonusesAbility(mob, dsp.magic.ele.LIGHT, target, dmg, params)
-    dmg = dmg * applyResistanceAddEffect(mob, target, dsp.magic.ele.LIGHT, 0)
-    dmg = adjustForTarget(target, dmg, dsp.magic.ele.LIGHT)
-    dmg = finalMagicNonSpellAdjustments(mob, target, dsp.magic.ele.LIGHT, dmg)
-
-    return dsp.subEffect.LIGHT_DAMAGE, dsp.msg.basic.ADD_EFFECT_DMG, dmg
+    return dsp.mob.onAddEffect(mob, target, damage, dsp.mob.ae.ENLIGHT)
 end
 
 function onMobDeath(mob, player, isKiller)

--- a/scripts/zones/RuAun_Gardens/mobs/Genbu.lua
+++ b/scripts/zones/RuAun_Gardens/mobs/Genbu.lua
@@ -4,7 +4,7 @@
 -----------------------------------
 local ID = require("scripts/zones/RuAun_Gardens/IDs")
 mixins = {require("scripts/mixins/job_special")}
-require("scripts/globals/magic")
+require("scripts/globals/mobs")
 -----------------------------------
 
 function onMobInitialize(mob)
@@ -12,17 +12,7 @@ function onMobInitialize(mob)
 end
 
 function onAdditionalEffect(mob, target, damage)
-    local dmg = math.random(140, 160)
-    local params = {}
-    params.bonusmab = 0
-    params.includemab = false
-
-    dmg = addBonusesAbility(mob, dsp.magic.ele.WATER, target, dmg, params)
-    dmg = dmg * applyResistanceAddEffect(mob, target, dsp.magic.ele.WATER, 0)
-    dmg = adjustForTarget(target, dmg, dsp.magic.ele.WATER)
-    dmg = finalMagicNonSpellAdjustments(mob, target, dsp.magic.ele.WATER, dmg)
-
-    return dsp.subEffect.WATER_DAMAGE, dsp.msg.basic.ADD_EFFECT_DMG, dmg
+    return dsp.mob.onAddEffect(mob, target, damage, dsp.mob.ae.ENWATER)
 end
 
 function onMobDeath(mob, player, isKiller)

--- a/scripts/zones/RuAun_Gardens/mobs/Groundskeeper.lua
+++ b/scripts/zones/RuAun_Gardens/mobs/Groundskeeper.lua
@@ -13,5 +13,5 @@ function onMobDeath(mob, player, isKiller)
 end;
 
 function onMobDespawn(mob)
-    phOnDespawn(mob,ID.mob.DESPOT_PH,5,7200); -- 2 hours
+    dsp.mob.phOnDespawn(mob,ID.mob.DESPOT_PH,5,7200); -- 2 hours
 end;

--- a/scripts/zones/RuAun_Gardens/mobs/Seiryu.lua
+++ b/scripts/zones/RuAun_Gardens/mobs/Seiryu.lua
@@ -4,7 +4,7 @@
 -----------------------------------
 local ID = require("scripts/zones/RuAun_Gardens/IDs")
 mixins = {require("scripts/mixins/job_special")}
-require("scripts/globals/magic")
+require("scripts/globals/mobs")
 -----------------------------------
 
 function onMobInitialize(mob)
@@ -28,17 +28,7 @@ function onMonsterMagicPrepare(mob, target)
 end
 
 function onAdditionalEffect(mob, target, damage)
-    local dmg = math.random(130, 150)
-    local params = {}
-    params.bonusmab = 0
-    params.includemab = false
-
-    dmg = addBonusesAbility(mob, dsp.magic.ele.WIND, target, dmg, params)
-    dmg = dmg * applyResistanceAddEffect(mob, target, dsp.magic.ele.WIND, 0)
-    dmg = adjustForTarget(target, dmg, dsp.magic.ele.WIND)
-    dmg = finalMagicNonSpellAdjustments(mob, target, dsp.magic.ele.WIND, dmg)
-
-    return dsp.subEffect.WIND_DAMAGE, dsp.msg.basic.ADD_EFFECT_DMG, dmg
+    return dsp.mob.onAddEffect(mob, target, damage, dsp.mob.ae.ENAERO)
 end
 
 function onMobDeath(mob, player, isKiller)

--- a/scripts/zones/RuAun_Gardens/mobs/Suzaku.lua
+++ b/scripts/zones/RuAun_Gardens/mobs/Suzaku.lua
@@ -4,7 +4,7 @@
 -----------------------------------
 local ID = require("scripts/zones/RuAun_Gardens/IDs")
 mixins = {require("scripts/mixins/job_special")}
-require("scripts/globals/magic")
+require("scripts/globals/mobs")
 -----------------------------------
 
 function onMobInitialize(mob)
@@ -29,17 +29,7 @@ function onMonsterMagicPrepare(mob, target)
 end
 
 function onAdditionalEffect(mob, target, damage)
-    local dmg = math.random(110, 130)
-    local params = {}
-    params.bonusmab = 0
-    params.includemab = false
-
-    dmg = addBonusesAbility(mob, dsp.magic.ele.FIRE, target, dmg, params)
-    dmg = dmg * applyResistanceAddEffect(mob, target, dsp.magic.ele.FIRE, 0)
-    dmg = adjustForTarget(target, dmg, dsp.magic.ele.FIRE)
-    dmg = finalMagicNonSpellAdjustments(mob, target, dsp.magic.ele.FIRE, dmg)
-
-    return dsp.subEffect.FIRE_DAMAGE, dsp.msg.basic.ADD_EFFECT_DMG, dmg
+    return dsp.mob.onAddEffect(mob, target, damage, dsp.mob.ae.ENFIRE)
 end
 
 function onMobDeath(mob, player, isKiller)

--- a/scripts/zones/Sauromugue_Champaign/mobs/Evil_Weapon.lua
+++ b/scripts/zones/Sauromugue_Champaign/mobs/Evil_Weapon.lua
@@ -13,5 +13,5 @@ function onMobDeath(mob, player, isKiller)
 end
 
 function onMobDespawn(mob)
-    phOnDespawn(mob, ID.mob.BLIGHTING_BRAND_PH, 20, math.random(5400, 7200)) -- 90 to 120 minutes
+    dsp.mob.phOnDespawn(mob, ID.mob.BLIGHTING_BRAND_PH, 20, math.random(5400, 7200)) -- 90 to 120 minutes
 end

--- a/scripts/zones/Sauromugue_Champaign/mobs/Tabar_Beak.lua
+++ b/scripts/zones/Sauromugue_Champaign/mobs/Tabar_Beak.lua
@@ -13,5 +13,5 @@ function onMobDeath(mob, player, isKiller)
 end
 
 function onMobDespawn(mob)
-    phOnDespawn(mob, ID.mob.DEADLY_DODO_PH, 33, 3600) -- 1 hour
+    dsp.mob.phOnDespawn(mob, ID.mob.DEADLY_DODO_PH, 33, 3600) -- 1 hour
 end

--- a/scripts/zones/Sauromugue_Champaign_[S]/mobs/Lynx.lua
+++ b/scripts/zones/Sauromugue_Champaign_[S]/mobs/Lynx.lua
@@ -11,5 +11,5 @@ function onMobDeath(mob, player, isKiller)
 end
 
 function onMobDespawn(mob)
-    phOnDespawn(mob, ID.mob.BALAM_QUITZ_PH, 10, 3600) -- 1 hour
+    dsp.mob.phOnDespawn(mob, ID.mob.BALAM_QUITZ_PH, 10, 3600) -- 1 hour
 end

--- a/scripts/zones/Sea_Serpent_Grotto/mobs/Bog_Sahagin.lua
+++ b/scripts/zones/Sea_Serpent_Grotto/mobs/Bog_Sahagin.lua
@@ -15,5 +15,5 @@ function onMobDeath(mob, player, isKiller)
 end
 
 function onMobDespawn(mob)
-    phOnDespawn(mob, ID.mob.MOUU_THE_WAVERIDER_PH, 10, 7200) -- 2 hours
+    dsp.mob.phOnDespawn(mob, ID.mob.MOUU_THE_WAVERIDER_PH, 10, 7200) -- 2 hours
 end

--- a/scripts/zones/Sea_Serpent_Grotto/mobs/Brook_Sahagin.lua
+++ b/scripts/zones/Sea_Serpent_Grotto/mobs/Brook_Sahagin.lua
@@ -15,5 +15,5 @@ function onMobDeath(mob, player, isKiller)
 end
 
 function onMobDespawn(mob)
-    phOnDespawn(mob, ID.mob.QULL_THE_SHELLBUSTER_PH, 10, 7200) -- 2 hours
+    dsp.mob.phOnDespawn(mob, ID.mob.QULL_THE_SHELLBUSTER_PH, 10, 7200) -- 2 hours
 end

--- a/scripts/zones/Sea_Serpent_Grotto/mobs/Coastal_Sahagin.lua
+++ b/scripts/zones/Sea_Serpent_Grotto/mobs/Coastal_Sahagin.lua
@@ -15,5 +15,5 @@ function onMobDeath(mob, player, isKiller)
 end
 
 function onMobDespawn(mob)
-    phOnDespawn(mob, ID.mob.DENN_THE_ORCAVOICED_PH, 10, 7200) -- 2 hours
+    dsp.mob.phOnDespawn(mob, ID.mob.DENN_THE_ORCAVOICED_PH, 10, 7200) -- 2 hours
 end

--- a/scripts/zones/Sea_Serpent_Grotto/mobs/Delta_Sahagin.lua
+++ b/scripts/zones/Sea_Serpent_Grotto/mobs/Delta_Sahagin.lua
@@ -15,5 +15,5 @@ function onMobDeath(mob, player, isKiller)
 end
 
 function onMobDespawn(mob)
-    phOnDespawn(mob, ID.mob.ZUUG_THE_SHORELEAPER_PH, 10, 7200) -- 2 hours
+    dsp.mob.phOnDespawn(mob, ID.mob.ZUUG_THE_SHORELEAPER_PH, 10, 7200) -- 2 hours
 end

--- a/scripts/zones/Sea_Serpent_Grotto/mobs/Devil_Manta.lua
+++ b/scripts/zones/Sea_Serpent_Grotto/mobs/Devil_Manta.lua
@@ -13,5 +13,5 @@ function onMobDeath(mob, player, isKiller)
 end
 
 function onMobDespawn(mob)
-    phOnDespawn(mob, ID.mob.CHARYBDIS_PH, 10, math.random(28800, 43200)) -- 8 - 12 hours
+    dsp.mob.phOnDespawn(mob, ID.mob.CHARYBDIS_PH, 10, math.random(28800, 43200)) -- 8 - 12 hours
 end

--- a/scripts/zones/Sea_Serpent_Grotto/mobs/Ghast.lua
+++ b/scripts/zones/Sea_Serpent_Grotto/mobs/Ghast.lua
@@ -13,5 +13,5 @@ function onMobDeath(mob, player, isKiller)
 end
 
 function onMobDespawn(mob)
-    phOnDespawn(mob, ID.mob.NAMTAR_PH, 10, 3600) -- 1 hour
+    dsp.mob.phOnDespawn(mob, ID.mob.NAMTAR_PH, 10, 3600) -- 1 hour
 end

--- a/scripts/zones/Sea_Serpent_Grotto/mobs/Lagoon_Sahagin.lua
+++ b/scripts/zones/Sea_Serpent_Grotto/mobs/Lagoon_Sahagin.lua
@@ -15,6 +15,6 @@ function onMobDeath(mob, player, isKiller)
 end
 
 function onMobDespawn(mob)
-    phOnDespawn(mob, ID.mob.YARR_THE_PEARLEYED_PH, 10, 3600) -- 1 hour
-    phOnDespawn(mob, ID.mob.NOVV_THE_WHITEHEARTED_PH, 10, 7200) -- 2 hours
+    dsp.mob.phOnDespawn(mob, ID.mob.YARR_THE_PEARLEYED_PH, 10, 3600) -- 1 hour
+    dsp.mob.phOnDespawn(mob, ID.mob.NOVV_THE_WHITEHEARTED_PH, 10, 7200) -- 2 hours
 end

--- a/scripts/zones/Sea_Serpent_Grotto/mobs/Marsh_Sahagin.lua
+++ b/scripts/zones/Sea_Serpent_Grotto/mobs/Marsh_Sahagin.lua
@@ -15,6 +15,6 @@ function onMobDeath(mob, player, isKiller)
 end
 
 function onMobDespawn(mob)
-    phOnDespawn(mob, ID.mob.WORR_THE_CLAWFISTED_PH, 10, 7200) -- 2 hours
-    phOnDespawn(mob, ID.mob.VOLL_THE_SHARKFINNED_PH, 10, 7200) -- 2 hours
+    dsp.mob.phOnDespawn(mob, ID.mob.WORR_THE_CLAWFISTED_PH, 10, 7200) -- 2 hours
+    dsp.mob.phOnDespawn(mob, ID.mob.VOLL_THE_SHARKFINNED_PH, 10, 7200) -- 2 hours
 end

--- a/scripts/zones/Sea_Serpent_Grotto/mobs/Razorjaw_Pugil.lua
+++ b/scripts/zones/Sea_Serpent_Grotto/mobs/Razorjaw_Pugil.lua
@@ -11,5 +11,5 @@ function onMobDeath(mob, player, isKiller)
 end
 
 function onMobDespawn(mob)
-    phOnDespawn(mob, ID.mob.SEA_HOG_PH, 10, 3600) -- 1 hour
+    dsp.mob.phOnDespawn(mob, ID.mob.SEA_HOG_PH, 10, 3600) -- 1 hour
 end

--- a/scripts/zones/Sea_Serpent_Grotto/mobs/Riparian_Sahagin.lua
+++ b/scripts/zones/Sea_Serpent_Grotto/mobs/Riparian_Sahagin.lua
@@ -15,6 +15,6 @@ function onMobDeath(mob, player, isKiller)
 end
 
 function onMobDespawn(mob)
-    phOnDespawn(mob, ID.mob.SEWW_THE_SQUIDLIMBED_PH, 10, 7200) -- 2 hours
-    phOnDespawn(mob, ID.mob.FYUU_THE_SEABELLOW_PH, 10, 7200) -- 2 hours
+    dsp.mob.phOnDespawn(mob, ID.mob.SEWW_THE_SQUIDLIMBED_PH, 10, 7200) -- 2 hours
+    dsp.mob.phOnDespawn(mob, ID.mob.FYUU_THE_SEABELLOW_PH, 10, 7200) -- 2 hours
 end

--- a/scripts/zones/Sea_Serpent_Grotto/mobs/Royal_Leech.lua
+++ b/scripts/zones/Sea_Serpent_Grotto/mobs/Royal_Leech.lua
@@ -13,5 +13,5 @@ function onMobDeath(mob, player, isKiller)
 end
 
 function onMobDespawn(mob)
-    phOnDespawn(mob, ID.mob.MASAN_PH, 10, 14400) -- 4 hours
+    dsp.mob.phOnDespawn(mob, ID.mob.MASAN_PH, 10, 14400) -- 4 hours
 end

--- a/scripts/zones/Sea_Serpent_Grotto/mobs/Spring_Sahagin.lua
+++ b/scripts/zones/Sea_Serpent_Grotto/mobs/Spring_Sahagin.lua
@@ -15,5 +15,5 @@ function onMobDeath(mob, player, isKiller)
 end
 
 function onMobDespawn(mob)
-    phOnDespawn(mob, ID.mob.WUUR_THE_SANDCOMBER_PH, 10, 7200) -- 2 hours
+    dsp.mob.phOnDespawn(mob, ID.mob.WUUR_THE_SANDCOMBER_PH, 10, 7200) -- 2 hours
 end

--- a/scripts/zones/Sea_Serpent_Grotto/mobs/Swamp_Sahagin.lua
+++ b/scripts/zones/Sea_Serpent_Grotto/mobs/Swamp_Sahagin.lua
@@ -15,5 +15,5 @@ function onMobDeath(mob, player, isKiller)
 end
 
 function onMobDespawn(mob)
-    phOnDespawn(mob, ID.mob.PAHH_THE_GULLCALLER_PH, 10, 7200) -- 2 hours
+    dsp.mob.phOnDespawn(mob, ID.mob.PAHH_THE_GULLCALLER_PH, 10, 7200) -- 2 hours
 end

--- a/scripts/zones/Sealions_Den/mobs/Omega.lua
+++ b/scripts/zones/Sealions_Den/mobs/Omega.lua
@@ -3,9 +3,8 @@
 --  MOB: Omega
 -----------------------------------
 local ID = require("scripts/zones/Sealions_Den/IDs");
-require("scripts/globals/status");
 require("scripts/globals/titles");
-require("scripts/globals/msg");
+require("scripts/globals/mobs")
 -----------------------------------
 
 function onMobInitialize(mob)
@@ -20,20 +19,9 @@ function onMobFight(mob,target)
     end
 end;
 
-function onAdditionalEffect(mob, player)
-    local chance = 20;
-    local resist = applyResistanceAddEffect(mob,player,dsp.magic.ele.THUNDER,dsp.effect.STUN);
-    if (math.random(0,99) >= chance or resist <= 0.5) then
-        return 0,0,0;
-    else
-        local duration = 5;
-        duration = duration * resist;
-        if (not player:hasStatusEffect(dsp.effect.STUN)) then
-            player:addStatusEffect(dsp.effect.STUN, 0, 0, duration);
-        end
-        return dsp.subEffect.STUN, dsp.msg.basic.ADD_EFFECT_STATUS, dsp.effect.STUN;
-    end
-end;
+function onAdditionalEffect(mob, target, damage)
+    return dsp.mob.onAddEffect(mob, target, damage, dsp.mob.ae.STUN)
+end
 
 function onMobDeath(mob, player, isKiller)
     player:addTitle(dsp.title.OMEGA_OSTRACIZER);

--- a/scripts/zones/Sealions_Den/mobs/Ultima.lua
+++ b/scripts/zones/Sealions_Den/mobs/Ultima.lua
@@ -1,10 +1,9 @@
 -----------------------------------
 -- Area: Sealions Den
---  MOB: Ultima
+--   NM: Ultima
 -----------------------------------
-require("scripts/globals/status");
 require("scripts/globals/titles");
-require("scripts/globals/msg");
+require("scripts/globals/mobs")
 -----------------------------------
 
 function onMobInitialize(mob)
@@ -19,21 +18,9 @@ function onMobFight(mob,target)
     end
 end;
 
-function onAdditionalEffect(mob, player)
-    local chance = 20;
-    local resist = applyResistanceAddEffect(mob,player,dsp.magic.ele.ICE,dsp.effect.PARALYSIS);
-    if (math.random(0,99) >= chance or resist <= 0.5) then
-        return 0,0,0;
-    else
-        local duration = 60;
-        local power = 20;
-        duration = duration * resist;
-        if (player:hasStatusEffect(dsp.effect.PARALYSIS) == false) then
-            player:addStatusEffect(dsp.effect.PARALYSIS, power, 0, duration);
-        end
-        return dsp.subEffect.PARALYSIS, dsp.msg.basic.ADD_EFFECT_STATUS, dsp.effect.PARALYSIS;
-    end
-end;
+function onAdditionalEffect(mob, target, damage)
+    return dsp.mob.onAddEffect(mob, target, damage, dsp.mob.ae.PARALYZE, {duration = 60})
+end
 
 function onMobDeath(mob, player, isKiller)
     player:addTitle(dsp.title.ULTIMA_UNDERTAKER);

--- a/scripts/zones/South_Gustaberg/mobs/Ornery_Sheep.lua
+++ b/scripts/zones/South_Gustaberg/mobs/Ornery_Sheep.lua
@@ -11,5 +11,5 @@ function onMobDeath(mob, player, isKiller)
 end
 
 function onMobDespawn(mob)
-    phOnDespawn(mob, ID.mob.CARNERO_PH, 5, math.random(300, 3600)) -- 5-60 minutes
+    dsp.mob.phOnDespawn(mob, ID.mob.CARNERO_PH, 5, math.random(300, 3600)) -- 5-60 minutes
 end

--- a/scripts/zones/South_Gustaberg/mobs/Rock_Lizard.lua
+++ b/scripts/zones/South_Gustaberg/mobs/Rock_Lizard.lua
@@ -13,5 +13,5 @@ function onMobDeath(mob, player, isKiller)
 end
 
 function onMobDespawn(mob)
-    phOnDespawn(mob, ID.mob.LEAPING_LIZZY_PH, 5, 3600) -- 1 hour
+    dsp.mob.phOnDespawn(mob, ID.mob.LEAPING_LIZZY_PH, 5, 3600) -- 1 hour
 end

--- a/scripts/zones/South_Gustaberg/mobs/Tococo.lua
+++ b/scripts/zones/South_Gustaberg/mobs/Tococo.lua
@@ -2,7 +2,7 @@
 -- Area: South Gustaberg
 --   NM: Tococo
 -----------------------------------
-require("scripts/globals/status")
+require("scripts/globals/mobs")
 -----------------------------------
 
 function onMobInitialize(mob)
@@ -10,14 +10,7 @@ function onMobInitialize(mob)
 end
 
 function onAdditionalEffect(mob, target, damage)
-    -- Guesstimating 1 in 3 chance to poison on melee.
-    if math.random(100) >= 33 or target:hasStatusEffect(dsp.effect.POISON) then
-        return 0, 0, 0
-    else
-        local duration = math.random(5, 15)
-        target:addStatusEffect(dsp.effect.POISON, 5, 3, duration)
-        return dsp.subEffect.POISON, 0, dsp.effect.POISON
-    end
+    return dsp.mob.onAddEffect(mob, target, damage, dsp.mob.ae.POISON, {power = 5, duration = math.random(5, 15)})
 end
 
 function onMobDeath(mob, player, isKiller)

--- a/scripts/zones/Tahrongi_Canyon/mobs/Canyon_Crawler.lua
+++ b/scripts/zones/Tahrongi_Canyon/mobs/Canyon_Crawler.lua
@@ -13,5 +13,5 @@ function onMobDeath(mob, player, isKiller)
 end
 
 function onMobDespawn(mob)
-    phOnDespawn(mob,ID.mob.HERBAGE_HUNTER_PH,10,math.random(3600,7200)) -- 1 to 2 hours
+    dsp.mob.phOnDespawn(mob,ID.mob.HERBAGE_HUNTER_PH,10,math.random(3600,7200)) -- 1 to 2 hours
 end

--- a/scripts/zones/Tahrongi_Canyon/mobs/Wild_Dhalmel.lua
+++ b/scripts/zones/Tahrongi_Canyon/mobs/Wild_Dhalmel.lua
@@ -13,5 +13,5 @@ function onMobDeath(mob, player, isKiller)
 end
 
 function onMobDespawn(mob)
-    phOnDespawn(mob, ID.mob.SERPOPARD_ISHTAR_PH, 10, 3600) -- 1 hour
+    dsp.mob.phOnDespawn(mob, ID.mob.SERPOPARD_ISHTAR_PH, 10, 3600) -- 1 hour
 end

--- a/scripts/zones/Temple_of_Uggalepih/mobs/Habetrot.lua
+++ b/scripts/zones/Temple_of_Uggalepih/mobs/Habetrot.lua
@@ -3,34 +3,15 @@
 --   NM: Habetrot
 -- !pos -60 -8 58 220
 -----------------------------------
-require("scripts/globals/status")
-require("scripts/globals/magic")
+require("scripts/globals/mobs")
 -----------------------------------
 
 function onMobInitialize(mob)
     mob:setMobMod(dsp.mobMod.ADD_EFFECT, 1)
 end
 
-function onAdditionalEffect(mob, player)
-    local resist = applyResistanceAddEffect(mob, player, dsp.magic.ele.EARTH, dsp.effect.SLOW)
-
-    if resist <= 0.5 then
-        return 0, 0, 0
-    else
-        local power = 1000
-        local duration = 30
-        if mob:getMainLvl() > player:getMainLvl() then
-            duration = duration + mob:getMainLvl() - player:getMainLvl()
-        end
-        duration = utils.clamp(duration, 1, 45)
-        duration = duration * resist
-
-        if not player:hasStatusEffect(dsp.effect.SLOW) then
-            player:addStatusEffect(dsp.effect.SLOW, power, 0, duration)
-        end
-
-        return dsp.subEffect.NONE, dsp.msg.basic.ADD_EFFECT_STATUS, dsp.effect.SLOW
-    end
+function onAdditionalEffect(mob, target, damage)
+    return dsp.mob.onAddEffect(mob, target, damage, dsp.mob.ae.SLOW)
 end
 
 function onMobDeath(mob, player, isKiller)

--- a/scripts/zones/Temple_of_Uggalepih/mobs/Tonberry_Cutter.lua
+++ b/scripts/zones/Temple_of_Uggalepih/mobs/Tonberry_Cutter.lua
@@ -19,5 +19,5 @@ function onMobDeath(mob, player, isKiller)
 end
 
 function onMobDespawn(mob)
-    phOnDespawn(mob, ID.mob.SOZU_SARBERRY_PH, 10, 3600) -- 1 hour
+    dsp.mob.phOnDespawn(mob, ID.mob.SOZU_SARBERRY_PH, 10, 3600) -- 1 hour
 end

--- a/scripts/zones/Temple_of_Uggalepih/mobs/Tonberry_Dismayer.lua
+++ b/scripts/zones/Temple_of_Uggalepih/mobs/Tonberry_Dismayer.lua
@@ -19,5 +19,5 @@ function onMobDeath(mob, player, isKiller)
 end
 
 function onMobDespawn(mob)
-    phOnDespawn(mob, ID.mob.TONBERRY_KINQ_PH, 10, 21600) -- 6 hours, 10% pop chance
+    dsp.mob.phOnDespawn(mob, ID.mob.TONBERRY_KINQ_PH, 10, 21600) -- 6 hours, 10% pop chance
 end

--- a/scripts/zones/Temple_of_Uggalepih/mobs/Tonberry_Harrier.lua
+++ b/scripts/zones/Temple_of_Uggalepih/mobs/Tonberry_Harrier.lua
@@ -19,5 +19,5 @@ function onMobDeath(mob, player, isKiller)
 end
 
 function onMobDespawn(mob)
-    phOnDespawn(mob, ID.mob.SOZU_TERBERRY_PH, 10, 3600) -- 1 hour
+    dsp.mob.phOnDespawn(mob, ID.mob.SOZU_TERBERRY_PH, 10, 3600) -- 1 hour
 end

--- a/scripts/zones/Temple_of_Uggalepih/mobs/Torama.lua
+++ b/scripts/zones/Temple_of_Uggalepih/mobs/Torama.lua
@@ -11,5 +11,5 @@ function onMobDeath(mob, player, isKiller)
 end
 
 function onMobDespawn(mob)
-    phOnDespawn(mob, ID.mob.FLAUROS_PH, 10, 3600) -- 1 hour
+    dsp.mob.phOnDespawn(mob, ID.mob.FLAUROS_PH, 10, 3600) -- 1 hour
 end

--- a/scripts/zones/The_Boyahda_Tree/mobs/Boyahda_Sapling.lua
+++ b/scripts/zones/The_Boyahda_Tree/mobs/Boyahda_Sapling.lua
@@ -13,5 +13,5 @@ function onMobDeath(mob, player, isKiller)
 end
 
 function onMobDespawn(mob)
-    phOnDespawn(mob, ID.mob.LESHONKI_PH, 5, 3600) -- 1 hour
+    dsp.mob.phOnDespawn(mob, ID.mob.LESHONKI_PH, 5, 3600) -- 1 hour
 end

--- a/scripts/zones/The_Boyahda_Tree/mobs/Death_Cap.lua
+++ b/scripts/zones/The_Boyahda_Tree/mobs/Death_Cap.lua
@@ -13,5 +13,5 @@ function onMobDeath(mob, player, isKiller)
 end
 
 function onMobDespawn(mob)
-    phOnDespawn(mob, ID.mob.ELLYLLON_PH, 10, math.random(7200,10800)) -- 2 to 3 hours
+    dsp.mob.phOnDespawn(mob, ID.mob.ELLYLLON_PH, 10, math.random(7200,10800)) -- 2 to 3 hours
 end

--- a/scripts/zones/The_Boyahda_Tree/mobs/Demonic_Rose.lua
+++ b/scripts/zones/The_Boyahda_Tree/mobs/Demonic_Rose.lua
@@ -11,5 +11,5 @@ function onMobDeath(mob, player, isKiller)
 end
 
 function onMobDespawn(mob)
-    phOnDespawn(mob, ID.mob.VOLUPTUOUS_VIVIAN_PH, 10, math.random(57600,86400)) -- 16 to 24 hours
+    dsp.mob.phOnDespawn(mob, ID.mob.VOLUPTUOUS_VIVIAN_PH, 10, math.random(57600,86400)) -- 16 to 24 hours
 end

--- a/scripts/zones/The_Boyahda_Tree/mobs/Moss_Eater.lua
+++ b/scripts/zones/The_Boyahda_Tree/mobs/Moss_Eater.lua
@@ -13,5 +13,5 @@ function onMobDeath(mob, player, isKiller)
 end
 
 function onMobDespawn(mob)
-    phOnDespawn(mob, ID.mob.UNUT_PH, 5, 7200) -- 2 hours
+    dsp.mob.phOnDespawn(mob, ID.mob.UNUT_PH, 5, 7200) -- 2 hours
 end

--- a/scripts/zones/The_Boyahda_Tree/mobs/Robber_Crab.lua
+++ b/scripts/zones/The_Boyahda_Tree/mobs/Robber_Crab.lua
@@ -13,5 +13,5 @@ function onMobDeath(mob, player, isKiller)
 end
 
 function onMobDespawn(mob)
-    phOnDespawn(mob, ID.mob.AQUARIUS_PH, 5, 1) -- can repop instantly
+    dsp.mob.phOnDespawn(mob, ID.mob.AQUARIUS_PH, 5, 1) -- can repop instantly
 end

--- a/scripts/zones/The_Eldieme_Necropolis/mobs/Tomb_Wolf.lua
+++ b/scripts/zones/The_Eldieme_Necropolis/mobs/Tomb_Wolf.lua
@@ -13,5 +13,5 @@ function onMobDeath(mob, player, isKiller)
 end
 
 function onMobDespawn(mob)
-    phOnDespawn(mob, ID.mob.CWN_CYRFF_PH, 5, math.random(3600, 14400)) -- 1-4 hours
+    dsp.mob.phOnDespawn(mob, ID.mob.CWN_CYRFF_PH, 5, math.random(3600, 14400)) -- 1-4 hours
 end

--- a/scripts/zones/The_Sanctuary_of_ZiTah/mobs/Elusive_Edwin.lua
+++ b/scripts/zones/The_Sanctuary_of_ZiTah/mobs/Elusive_Edwin.lua
@@ -2,9 +2,7 @@
 -- Area: The Sanctuary of Zi'Tah
 --   NM: Elusive Edwin
 -----------------------------------
-require("scripts/globals/status")
-require("scripts/globals/magic")
-require("scripts/globals/msg")
+require("scripts/globals/mobs")
 -----------------------------------
 
 function onMobInitialize(mob)
@@ -12,22 +10,7 @@ function onMobInitialize(mob)
 end
 
 function onAdditionalEffect(mob, target, damage)
-    if math.random(100) > 20 or applyResistanceAddEffect(mob, target, dsp.magic.ele.WIND, dsp.effect.SILENCE) <= 0.5 then
-        return 0, 0, 0
-    else
-        local duration = 30
-        if mob:getMainLvl() > target:getMainLvl() then
-            duration = duration + mob:getMainLvl() - target:getMainLvl()
-        end
-        duration = utils.clamp(duration, 1, 30)
-        duration = duration * resist
-
-        if not target:hasStatusEffect(dsp.effect.SILENCE) then
-            target:addStatusEffect(dsp.effect.SILENCE, 1, 0, duration)
-        end
-
-        return dsp.subEffect.SILENCE, dsp.msg.basic.ADD_EFFECT_STATUS, dsp.effect.SILENCE
-    end
+    return dsp.mob.onAddEffect(mob, target, damage, dsp.mob.ae.SILENCE)
 end
 
 function onMobDeath(mob, player, isKiller)

--- a/scripts/zones/The_Sanctuary_of_ZiTah/mobs/Goobbue_Gardener.lua
+++ b/scripts/zones/The_Sanctuary_of_ZiTah/mobs/Goobbue_Gardener.lua
@@ -13,5 +13,5 @@ function onMobDeath(mob, player, isKiller)
 end
 
 function onMobDespawn(mob)
-    phOnDespawn(mob, ID.mob.KEEPER_OF_HALIDOM_PH, 10, 7200) -- 2 hours
+    dsp.mob.phOnDespawn(mob, ID.mob.KEEPER_OF_HALIDOM_PH, 10, 7200) -- 2 hours
 end

--- a/scripts/zones/The_Sanctuary_of_ZiTah/mobs/Myxomycete.lua
+++ b/scripts/zones/The_Sanctuary_of_ZiTah/mobs/Myxomycete.lua
@@ -13,7 +13,7 @@ function onMobRoam(mob)
     local weather = mob:getWeather()
 
     if weather == dsp.weather.RAIN or weather == dsp.weather.SQUALL then
-        if phOnDespawn(mob, ID.mob.NOBLE_MOLD_PH, 100, math.random(43200, 57600), true) then -- 12 to 16 hours
+        if dsp.mob.phOnDespawn(mob, ID.mob.NOBLE_MOLD_PH, 100, math.random(43200, 57600), true) then -- 12 to 16 hours
             local p = mob:getPos()
             GetMobByID(ID.mob.NOBLE_MOLD):setSpawn(p.x, p.y, p.z, p.rot)
             DespawnMob(mob:getID())

--- a/scripts/zones/The_Shrine_of_RuAvitau/mobs/Kirin.lua
+++ b/scripts/zones/The_Shrine_of_RuAvitau/mobs/Kirin.lua
@@ -1,12 +1,12 @@
 -----------------------------------
 -- Area: The Shrine of Ru'Avitau
---  MOB: Kirin
+--   NM: Kirin
 -----------------------------------
-mixins = {require("scripts/mixins/job_special")};
-
 local ID = require("scripts/zones/The_Shrine_of_RuAvitau/IDs");
-require("scripts/globals/status");
+mixins = {require("scripts/mixins/job_special")};
 require("scripts/globals/titles");
+require("scripts/globals/mobs")
+-----------------------------------
 
 function onMobInitialize( mob )
     mob:setMobMod(dsp.mobMod.IDLE_DESPAWN, 180);
@@ -53,18 +53,8 @@ function onMobFight( mob, target )
 end
 
 function onAdditionalEffect(mob, target, damage)
-    local dmg = math.random(90,110)
-    local params = {};
-    params.bonusmab = 0;
-    params.includemab = false;
-
-    dmg = addBonusesAbility(mob, dsp.magic.ele.EARTH, target, dmg, params);
-    dmg = dmg * applyResistanceAddEffect(mob,target,dsp.magic.ele.EARTH,0);
-    dmg = adjustForTarget(target,dmg,dsp.magic.ele.EARTH);
-    dmg = finalMagicNonSpellAdjustments(mob,target,dsp.magic.ele.EARTH,dmg);
-
-    return dsp.subEffect.EARTH_DAMAGE, dsp.msg.basic.ADD_EFFECT_DMG, dmg;
-end;
+    return dsp.mob.onAddEffect(mob, target, damage, dsp.mob.ae.ENSTONE)
+end
 
 function onMobDeath(mob, player, isKiller)
     player:addTitle( dsp.title.KIRIN_CAPTIVATOR );

--- a/scripts/zones/Toraimarai_Canal/mobs/Bouncing_Ball.lua
+++ b/scripts/zones/Toraimarai_Canal/mobs/Bouncing_Ball.lua
@@ -11,5 +11,5 @@ function onMobDeath(mob, player, isKiller)
 end
 
 function onMobDespawn(mob)
-    phOnDespawn(mob, ID.mob.CANAL_MOOCHER_PH, 10, 3600) -- 1 hour
+    dsp.mob.phOnDespawn(mob, ID.mob.CANAL_MOOCHER_PH, 10, 3600) -- 1 hour
 end

--- a/scripts/zones/Toraimarai_Canal/mobs/Canal_Moocher.lua
+++ b/scripts/zones/Toraimarai_Canal/mobs/Canal_Moocher.lua
@@ -2,34 +2,15 @@
 -- Area: Toraimorai Canal
 --   NM: Canal Moocher
 -----------------------------------
-require("scripts/globals/status")
-require("scripts/globals/magic")
-require("scripts/globals/msg")
+require("scripts/globals/mobs")
 -----------------------------------
 
 function onMobInitialize(mob)
     mob:setMobMod(dsp.mobMod.ADD_EFFECT, 1)
 end
 
-function onAdditionalEffect(mob, player)
-    local resist = applyResistanceAddEffect(mob, player, dsp.magic.ele.WATER, dsp.effect.PLAGUE)
-
-    if math.random(100) > 25 or resist <= 0.5 then
-        return 0, 0, 0
-    else
-        local duration = 30
-        if mob:getMainLvl() > player:getMainLvl() then
-            duration = duration + mob:getMainLvl() - player:getMainLvl()
-        end
-        duration = utils.clamp(duration, 1, 45)
-        duration = duration * resist
-
-        if not player:hasStatusEffect(dsp.effect.PLAGUE) then
-            player:addStatusEffect(dsp.effect.PLAGUE, 1, 0, duration)
-        end
-
-        return dsp.subEffect.PLAGUE, dsp.msg.basic.ADD_EFFECT_STATUS, dsp.effect.PLAGUE
-    end
+function onAdditionalEffect(mob, target, damage)
+    return dsp.mob.onAddEffect(mob, target, damage, dsp.mob.ae.PLAGUE)
 end
 
 function onMobDeath(mob, player, isKiller)

--- a/scripts/zones/Toraimarai_Canal/mobs/Konjac.lua
+++ b/scripts/zones/Toraimarai_Canal/mobs/Konjac.lua
@@ -2,9 +2,7 @@
 -- Area: Toraimorai Canal
 --   NM: Konjac
 -----------------------------------
-require("scripts/globals/status")
-require("scripts/globals/magic")
-require("scripts/globals/msg")
+require("scripts/globals/mobs")
 -----------------------------------
 
 function onMobInitialize(mob)
@@ -12,23 +10,7 @@ function onMobInitialize(mob)
 end
 
 function onAdditionalEffect(mob, target, damage)
-    if math.random(100) > 20 then
-        return 0, 0, 0
-    else
-        local power = math.random(10, 20)
-        local params = {}
-        params.bonusmab = 0
-        params.includemab = false
-        power = addBonusesAbility(mob, dsp.magic.ele.DARK, target, power, params)
-        power = power * applyResistanceAddEffect(mob,target,dsp.magic.ele.DARK,0)
-        power = adjustForTarget(target,power,dsp.magic.ele.DARK)
-        power = finalMagicNonSpellAdjustments(mob,target,dsp.magic.ele.DARK,power)
-        if power < 0 then
-            power = 0
-        end
-
-        return dsp.subEffect.HP_DRAIN, dsp.msg.basic.ADD_EFFECT_HP_DRAIN, mob:addHP(power)
-    end
+    return dsp.mob.onAddEffect(mob, target, damage, dsp.mob.ae.HP_DRAIN, {chance = 20})
 end
 
 function onMobDeath(mob, player, isKiller)

--- a/scripts/zones/Toraimarai_Canal/mobs/Mousse.lua
+++ b/scripts/zones/Toraimarai_Canal/mobs/Mousse.lua
@@ -11,5 +11,5 @@ function onMobDeath(mob, player, isKiller)
 end
 
 function onMobDespawn(mob)
-    phOnDespawn(mob, ID.mob.KONJAC_PH, 10, 3600) -- 1 hour
+    dsp.mob.phOnDespawn(mob, ID.mob.KONJAC_PH, 10, 3600) -- 1 hour
 end

--- a/scripts/zones/Uleguerand_Range/mobs/Bonnacon.lua
+++ b/scripts/zones/Uleguerand_Range/mobs/Bonnacon.lua
@@ -2,7 +2,7 @@
 -- Area: Uleguerand Range
 --   NM: Bonnacon
 -----------------------------------
-require("scripts/globals/status")
+require("scripts/globals/mobs")
 -----------------------------------
 
 function onMobInitialize(mob)
@@ -10,13 +10,7 @@ function onMobInitialize(mob)
 end
 
 function onAdditionalEffect(mob, target, damage)
-    if math.random(100) >= 66 or target:hasStatusEffect(dsp.effect.STUN) then
-        return 0, 0, 0
-    else
-        local duration = math.random(5, 15)
-        target:addStatusEffect(dsp.effect.STUN, 5, 0, duration)
-        return dsp.subEffect.STUN, 0, dsp.effect.STUN
-    end
+    return dsp.mob.onAddEffect(mob, target, damage, dsp.mob.ae.STUN, {chance = 65, duration = math.random(5, 15)})
 end
 
 function onMobDeath(mob, player, isKiller)

--- a/scripts/zones/Uleguerand_Range/mobs/Buffalo.lua
+++ b/scripts/zones/Uleguerand_Range/mobs/Buffalo.lua
@@ -11,5 +11,5 @@ function onMobDeath(mob, player, isKiller)
 end
 
 function onMobDespawn(mob)
-    phOnDespawn(mob, ID.mob.BONNACON_PH, 5, math.random(3600, 86400)) -- 1 to 24 hours
+    dsp.mob.phOnDespawn(mob, ID.mob.BONNACON_PH, 5, math.random(3600, 86400)) -- 1 to 24 hours
 end

--- a/scripts/zones/Uleguerand_Range/mobs/Molech.lua
+++ b/scripts/zones/Uleguerand_Range/mobs/Molech.lua
@@ -11,5 +11,5 @@ function onMobDeath(mob, player, isKiller)
 end
 
 function onMobDespawn(mob)
-    phOnDespawn(mob, ID.mob.MAGNOTAUR_PH, 10, 3600) -- 1 hour
+    dsp.mob.phOnDespawn(mob, ID.mob.MAGNOTAUR_PH, 10, 3600) -- 1 hour
 end

--- a/scripts/zones/Uleguerand_Range/mobs/Polar_Hare.lua
+++ b/scripts/zones/Uleguerand_Range/mobs/Polar_Hare.lua
@@ -11,5 +11,5 @@ function onMobDeath(mob, player, isKiller)
 end
 
 function onMobDespawn(mob)
-    phOnDespawn(mob, ID.mob.SKVADER_PH, 10, 3600) -- 1 hour
+    dsp.mob.phOnDespawn(mob, ID.mob.SKVADER_PH, 10, 3600) -- 1 hour
 end

--- a/scripts/zones/Upper_Delkfutts_Tower/mobs/Gigas_Bonecutter.lua
+++ b/scripts/zones/Upper_Delkfutts_Tower/mobs/Gigas_Bonecutter.lua
@@ -13,5 +13,5 @@ function onMobDeath(mob, player, isKiller)
 end
 
 function onMobDespawn(mob)
-    phOnDespawn(mob, ID.mob.ENKELADOS_PH, 5, 1) -- no cooldown
+    dsp.mob.phOnDespawn(mob, ID.mob.ENKELADOS_PH, 5, 1) -- no cooldown
 end

--- a/scripts/zones/Upper_Delkfutts_Tower/mobs/Phasma.lua
+++ b/scripts/zones/Upper_Delkfutts_Tower/mobs/Phasma.lua
@@ -11,5 +11,5 @@ function onMobDeath(mob, player, isKiller)
 end
 
 function onMobDespawn(mob)
-    phOnDespawn(mob, ID.mob.IXTAB_PH, 5, 3600) -- 1 hour
+    dsp.mob.phOnDespawn(mob, ID.mob.IXTAB_PH, 5, 3600) -- 1 hour
 end

--- a/scripts/zones/Valkurm_Dunes/mobs/Damselfly.lua
+++ b/scripts/zones/Valkurm_Dunes/mobs/Damselfly.lua
@@ -13,5 +13,5 @@ function onMobDeath(mob, player, isKiller)
 end;
 
 function onMobDespawn(mob)
-    phOnDespawn(mob,ID.mob.VALKURM_EMPEROR_PH,5,3600); -- 1 hour
+    dsp.mob.phOnDespawn(mob,ID.mob.VALKURM_EMPEROR_PH,5,3600); -- 1 hour
 end;

--- a/scripts/zones/Valkurm_Dunes/mobs/Giant_Bat.lua
+++ b/scripts/zones/Valkurm_Dunes/mobs/Giant_Bat.lua
@@ -10,5 +10,5 @@ function onMobDeath(mob, player, isKiller)
 end;
 
 function onMobDespawn(mob)
-    phOnDespawn(mob,ID.mob.GOLDEN_BAT_PH,5,math.random(3600,18000)); -- 1 to 5 hours
+    dsp.mob.phOnDespawn(mob,ID.mob.GOLDEN_BAT_PH,5,math.random(3600,18000)); -- 1 to 5 hours
 end;

--- a/scripts/zones/Valkurm_Dunes/mobs/Metal_Shears.lua
+++ b/scripts/zones/Valkurm_Dunes/mobs/Metal_Shears.lua
@@ -1,24 +1,17 @@
 -----------------------------------
 -- Area: Valkurm Dunes
---  MOB: Metal Shears
+--   NM: Metal Shears
 -----------------------------------
-require("scripts/globals/msg");
+require("scripts/globals/mobs")
 -----------------------------------
 
 function onMobInitialize(mob)
     mob:setMobMod(dsp.mobMod.ADD_EFFECT, 1);
 end;
 
-function onAdditionalEffect(mob,target,damage)
-    -- Guesstimating 1 in 3 chance to poison on melee.
-    if ((math.random(1,100) >= 33) or (target:hasStatusEffect(dsp.effect.POISON) == true)) then
-        return 0,0,0;
-    else
-        local duration = math.random(10,25);
-        target:addStatusEffect(dsp.effect.POISON,15,3,duration);
-        return dsp.subEffect.POISON,dsp.msg.basic.ADD_EFFECT_STATUS,dsp.effect.POISON;
-    end
-end;
+function onAdditionalEffect(mob, target, damage)
+    return dsp.mob.onAddEffect(mob, target, damage, dsp.mob.ae.POISON, {power = 15, duration = math.random(10, 25)})
+end
 
 function onMobDeath(mob, player, isKiller)
 end;

--- a/scripts/zones/VeLugannon_Palace/mobs/Brigandish_Blade.lua
+++ b/scripts/zones/VeLugannon_Palace/mobs/Brigandish_Blade.lua
@@ -2,22 +2,15 @@
 -- Area: VeLugannon Palace
 --   NM: Brigandish Blade
 -----------------------------------
-local ID = require("scripts/zones/VeLugannon_Palace/IDs")
-require("scripts/globals/status")
+require("scripts/globals/mobs")
 -----------------------------------
 
 function onMobInitialize(mob)
     mob:setMobMod(dsp.mobMod.ADD_EFFECT, 1)
 end
 
-function onAdditionalEffect(mob,target,damage)
-    if math.random(10) > 3 or target:hasStatusEffect(dsp.effect.TERROR) then -- 30% chance to terror
-        return 0,0,0
-    else
-        local duration = math.random(3,5)
-        target:addStatusEffect(dsp.effect.TERROR,1,0,duration)
-        return dsp.subEffect.NONE,0,dsp.effect.TERROR
-    end
+function onAdditionalEffect(mob, target, damage)
+    return dsp.mob.onAddEffect(mob, target, damage, dsp.mob.ae.TERROR, {chance = 30})
 end
 
 function onMobDeath(mob, player, isKiller)

--- a/scripts/zones/Wajaom_Woodlands/mobs/Great_Ameretat.lua
+++ b/scripts/zones/Wajaom_Woodlands/mobs/Great_Ameretat.lua
@@ -11,5 +11,5 @@ function onMobDeath(mob, player, isKiller)
 end
 
 function onMobDespawn(mob)
-    phOnDespawn(mob, ID.mob.JADED_JODY_PH, 10, 7200) -- 2 hours
+    dsp.mob.phOnDespawn(mob, ID.mob.JADED_JODY_PH, 10, 7200) -- 2 hours
 end

--- a/scripts/zones/Wajaom_Woodlands/mobs/Lesser_Colibri.lua
+++ b/scripts/zones/Wajaom_Woodlands/mobs/Lesser_Colibri.lua
@@ -10,5 +10,5 @@ function onMobDeath(mob, player, isKiller)
 end;
 
 function onMobDespawn(mob)
-    phOnDespawn(mob,ID.mob.ZORAAL_JA_S_PKUUCHA_PH,5,math.random(1800, 43200)); -- 30 minutes to 12 hours
+    dsp.mob.phOnDespawn(mob,ID.mob.ZORAAL_JA_S_PKUUCHA_PH,5,math.random(1800, 43200)); -- 30 minutes to 12 hours
 end;

--- a/scripts/zones/West_Ronfaure/mobs/Forest_Hare.lua
+++ b/scripts/zones/West_Ronfaure/mobs/Forest_Hare.lua
@@ -11,5 +11,5 @@ function onMobDeath(mob, player, isKiller)
 end;
 
 function onMobDespawn(mob)
-    phOnDespawn(mob,ID.mob.JAGGEDY_EARED_JACK_PH,5,math.random(3000,21600)); -- 50 minutes to 6 hours
+    dsp.mob.phOnDespawn(mob,ID.mob.JAGGEDY_EARED_JACK_PH,5,math.random(3000,21600)); -- 50 minutes to 6 hours
 end;

--- a/scripts/zones/West_Ronfaure/mobs/Scarab_Beetle.lua
+++ b/scripts/zones/West_Ronfaure/mobs/Scarab_Beetle.lua
@@ -13,5 +13,5 @@ function onMobDeath(mob, player, isKiller)
 end;
 
 function onMobDespawn(mob)
-    phOnDespawn(mob,ID.mob.FUNGUS_BEETLE_PH,10,math.random(900,10800)); -- 15 minutes to 3 hours
+    dsp.mob.phOnDespawn(mob,ID.mob.FUNGUS_BEETLE_PH,10,math.random(900,10800)); -- 15 minutes to 3 hours
 end;

--- a/scripts/zones/West_Sarutabaruta/mobs/Carrion_Crow.lua
+++ b/scripts/zones/West_Sarutabaruta/mobs/Carrion_Crow.lua
@@ -13,5 +13,5 @@ function onMobDeath(mob, player, isKiller)
 end
 
 function onMobDespawn(mob)
-    phOnDespawn(mob, ID.mob.NUNYENUNC_PH, 10, math.random(7200,10800)) -- 2 to 3 hours
+    dsp.mob.phOnDespawn(mob, ID.mob.NUNYENUNC_PH, 10, math.random(7200,10800)) -- 2 to 3 hours
 end

--- a/scripts/zones/West_Sarutabaruta/mobs/Mandragora.lua
+++ b/scripts/zones/West_Sarutabaruta/mobs/Mandragora.lua
@@ -13,5 +13,5 @@ function onMobDeath(mob, player, isKiller)
 end
 
 function onMobDespawn(mob)
-    phOnDespawn(mob, ID.mob.TOM_TIT_TAT_PH, 7, math.random(3600,7200)) -- 1 to 2 hours
+    dsp.mob.phOnDespawn(mob, ID.mob.TOM_TIT_TAT_PH, 7, math.random(3600,7200)) -- 1 to 2 hours
 end

--- a/scripts/zones/West_Sarutabaruta/mobs/Numbing_Norman.lua
+++ b/scripts/zones/West_Sarutabaruta/mobs/Numbing_Norman.lua
@@ -3,23 +3,15 @@
 --   NM: Numbing Norman
 -----------------------------------
 require("scripts/globals/regimes")
-require("scripts/globals/status")
-require("scripts/globals/msg")
+require("scripts/globals/mobs")
 -----------------------------------
 
 function onMobInitialize(mob)
     mob:setMobMod(dsp.mobMod.ADD_EFFECT, 1)
 end
 
-function onAdditionalEffect(mob,target,damage)
-    -- Guesstimating 1 in 4 chance to paralysis on melee.
-    if math.random(1,100) >= 25 or target:hasStatusEffect(dsp.effect.PARALYSIS) then
-        return 0,0,0
-    else
-        local duration = math.random(5, 15)
-        target:addStatusEffect(dsp.effect.PARALYSIS, 5, 3, duration)
-        return dsp.subEffect.PARALYSIS, dsp.msg.basic.ADD_EFFECT_STATUS, dsp.effect.PARALYSIS
-    end
+function onAdditionalEffect(mob, target, damage)
+    return dsp.mob.onAddEffect(mob, target, damage, dsp.mob.ae.PARALYZE)
 end
 
 function onMobDeath(mob, player, isKiller)

--- a/scripts/zones/West_Sarutabaruta_[S]/mobs/Ramponneau.lua
+++ b/scripts/zones/West_Sarutabaruta_[S]/mobs/Ramponneau.lua
@@ -2,9 +2,7 @@
 -- Area: West Sarutabaruta (S)
 --   NM: Ramponneau
 -----------------------------------
-require("scripts/globals/status")
-require("scripts/globals/magic")
-require("scripts/globals/msg")
+require("scripts/globals/mobs")
 -----------------------------------
 
 function onMobInitialize(mob)
@@ -17,22 +15,8 @@ function onMobFight(mob,target)
     mob:SetMobAbilityEnabled(false)
 end
 
-function onAdditionalEffect(mob,target,damage)
-    local power = math.random(4, 15)
-    local params = {}
-    params.bonusmab = 0
-    params.includemab = false
-    power = addBonusesAbility(mob, dsp.magic.ele.ICE, target, power, params)
-    power = power * applyResistanceAddEffect(mob, target, dsp.magic.ele.ICE, 0)
-    power = adjustForTarget(target, power, dsp.magic.ele.ICE)
-    power = finalMagicNonSpellAdjustments(mob, target, dsp.magic.ele.ICE, power)
-
-    local message = dsp.msg.basic.ADD_EFFECT_DMG
-    if power < 0 then
-        message = dsp.msg.basic.ADD_EFFECT_HEAL
-    end
-
-    return dsp.subEffect.ICE_DAMAGE, message, power
+function onAdditionalEffect(mob, target, damage)
+    return dsp.mob.onAddEffect(mob, target, damage, dsp.mob.ae.ENBLIZZARD)
 end
 
 function onMobDeath(mob, player, isKiller)

--- a/scripts/zones/West_Sarutabaruta_[S]/mobs/Tiny_Lycopodium.lua
+++ b/scripts/zones/West_Sarutabaruta_[S]/mobs/Tiny_Lycopodium.lua
@@ -11,5 +11,5 @@ function onMobDeath(mob, player, isKiller)
 end
 
 function onMobDespawn(mob)
-    phOnDespawn(mob, ID.mob.JEDUAH_PH, 10, 3600) -- 1 hour
+    dsp.mob.phOnDespawn(mob, ID.mob.JEDUAH_PH, 10, 3600) -- 1 hour
 end

--- a/scripts/zones/West_Sarutabaruta_[S]/mobs/Toad.lua
+++ b/scripts/zones/West_Sarutabaruta_[S]/mobs/Toad.lua
@@ -11,5 +11,5 @@ function onMobDeath(mob, player, isKiller)
 end
 
 function onMobDespawn(mob)
-    phOnDespawn(mob, ID.mob.RAMPONNEAU_PH, 20, 5400) -- 90 minutes
+    dsp.mob.phOnDespawn(mob, ID.mob.RAMPONNEAU_PH, 20, 5400) -- 90 minutes
 end

--- a/scripts/zones/Western_Altepa_Desert/mobs/Cactuar.lua
+++ b/scripts/zones/Western_Altepa_Desert/mobs/Cactuar.lua
@@ -13,5 +13,5 @@ function onMobDeath(mob, player, isKiller)
 end
 
 function onMobDespawn(mob)
-    phOnDespawn(mob, ID.mob.CACTUAR_CANTAUTOR_PH, 5, math.random(3600,43200)) -- 1 to 12 hours
+    dsp.mob.phOnDespawn(mob, ID.mob.CACTUAR_CANTAUTOR_PH, 5, math.random(3600,43200)) -- 1 to 12 hours
 end

--- a/scripts/zones/Western_Altepa_Desert/mobs/Desert_Dhalmel.lua
+++ b/scripts/zones/Western_Altepa_Desert/mobs/Desert_Dhalmel.lua
@@ -13,5 +13,5 @@ function onMobDeath(mob, player, isKiller)
 end
 
 function onMobDespawn(mob)
-    phOnDespawn(mob, ID.mob.CELPHIE_PH, 5, math.random(7200,28800)) -- 2 to 8 hours
+    dsp.mob.phOnDespawn(mob, ID.mob.CELPHIE_PH, 5, math.random(7200,28800)) -- 2 to 8 hours
 end

--- a/scripts/zones/Western_Altepa_Desert/mobs/King_Vinegarroon.lua
+++ b/scripts/zones/Western_Altepa_Desert/mobs/King_Vinegarroon.lua
@@ -3,9 +3,8 @@
 --   NM: King Vinegarroon
 -----------------------------------
 require("scripts/globals/weather")
-require("scripts/globals/status")
 require("scripts/globals/titles")
-require("scripts/globals/msg")
+require("scripts/globals/mobs")
 -----------------------------------
 
 function onMobInitialize(mob)
@@ -15,6 +14,10 @@ end
 function onMobDrawIn(mob, target)
     -- todo make him use AoE tp move
     mob:addTP(3000)
+end
+
+function onAdditionalEffect(mob, target, damage)
+    return dsp.mob.onAddEffect(mob, target, damage, dsp.mob.ae.PETRIFY, {chance = 100})
 end
 
 function onMobDisengage(mob, weather)
@@ -30,22 +33,4 @@ end
 function onMobDespawn(mob)
     UpdateNMSpawnPoint(mob:getID())
     mob:setRespawnTime(math.random(75600, 86400)) -- 21 to 24 hours
-end
-
-function onAdditionalEffect(mob, player)
-    local resist = applyResistanceAddEffect(mob,player,dsp.magic.ele.EARTH,dsp.effect.PETRIFICATION)
-    if (resist <= 0.5) then -- "Has an innate Additional Effect of Petrification on all of its physical attacks. "
-        return 0,0,0
-    else
-        local duration = 30
-        if mob:getMainLvl() > player:getMainLvl() then
-            duration = duration + mob:getMainLvl() - player:getMainLvl()
-        end
-        duration = utils.clamp(duration,1,45)
-        duration = duration * resist
-        if not player:hasStatusEffect(dsp.effect.PETRIFICATION) then
-            player:addStatusEffect(dsp.effect.PETRIFICATION, 1, 0, duration)
-        end
-        return dsp.subEffect.PETRIFY, dsp.msg.basic.ADD_EFFECT_STATUS, dsp.effect.PETRIFICATION
-    end
 end

--- a/scripts/zones/Western_Altepa_Desert/mobs/Tulwar_Scorpion.lua
+++ b/scripts/zones/Western_Altepa_Desert/mobs/Tulwar_Scorpion.lua
@@ -13,5 +13,5 @@ function onMobDeath(mob, player, isKiller)
 end
 
 function onMobDespawn(mob)
-    phOnDespawn(mob, ID.mob.CALCHAS_PH, 10, 3600) -- 1 hour
+    dsp.mob.phOnDespawn(mob, ID.mob.CALCHAS_PH, 10, 3600) -- 1 hour
 end

--- a/scripts/zones/Xarcabard/mobs/Biast.lua
+++ b/scripts/zones/Xarcabard/mobs/Biast.lua
@@ -2,30 +2,22 @@
 -- Area: Xarcabard
 --   NM: Biast
 -----------------------------------
-require("scripts/globals/status")
+require("scripts/globals/mobs")
 -----------------------------------
 
 function onMobInitialize(mob)
     mob:setMobMod(dsp.mobMod.ADD_EFFECT, 1)
 end
 
+function onAdditionalEffect(mob, target, damage)
+    return dsp.mob.onAddEffect(mob, target, damage, dsp.mob.ae.TERROR, {chance = 7})
+end
+
 function onMobDeath(mob, player, isKiller)
 end
 
 function onMobDespawn(mob)
-    -- Set Biast's ToD
     SetServerVariable("[POP]Biast", os.time() + 75600) -- 21 hour
     DisallowRespawn(mob:getID()-1, false)
     GetMobByID(mob:getID()-1):setRespawnTime(GetMobRespawnTime(mob:getID()-1))
-end
-
-function onAdditionalEffect(mob,target,damage)
-    if math.random(1,15) ~= 5 or target:hasStatusEffect(dsp.effect.TERROR) then
-        return 0,0,0
-    else
-        local duration = 5
-        target:addStatusEffect(dsp.effect.TERROR,1,0,duration)
-        mob:resetEnmity(target)
-        return dsp.subEffect.NONE,0,dsp.effect.TERROR
-    end
 end

--- a/scripts/zones/Xarcabard/mobs/Evil_Eye.lua
+++ b/scripts/zones/Xarcabard/mobs/Evil_Eye.lua
@@ -15,5 +15,5 @@ function onMobDeath(mob, player, isKiller)
 end
 
 function onMobDespawn(mob)
-    phOnDespawn(mob, ID.mob.SHADOW_EYE_PH, 5, 3600) -- 1 hour
+    dsp.mob.phOnDespawn(mob, ID.mob.SHADOW_EYE_PH, 5, 3600) -- 1 hour
 end

--- a/scripts/zones/Xarcabard/mobs/Lost_Soul.lua
+++ b/scripts/zones/Xarcabard/mobs/Lost_Soul.lua
@@ -16,5 +16,5 @@ function onMobDeath(mob, player, isKiller)
 end
 
 function onMobDespawn(mob)
-    phOnDespawn(mob, ID.mob.TIMEWORN_WARRIOR_PH, 5, 5400) -- 90 minutes
+    dsp.mob.phOnDespawn(mob, ID.mob.TIMEWORN_WARRIOR_PH, 5, 5400) -- 90 minutes
 end

--- a/scripts/zones/Xarcabard/mobs/Timeworn_Warrior.lua
+++ b/scripts/zones/Xarcabard/mobs/Timeworn_Warrior.lua
@@ -2,9 +2,7 @@
 -- Area: Xarcabard
 --   NM: Timeworn Warrior
 -----------------------------------
-require("scripts/globals/status")
-require("scripts/globals/magic")
-require("scripts/globals/msg")
+require("scripts/globals/mobs")
 -----------------------------------
 
 function onMobInitialize(mob)
@@ -12,22 +10,7 @@ function onMobInitialize(mob)
 end
 
 function onAdditionalEffect(mob, target, damage)
-    if math.random(100) > 10 then
-        return 0, 0, 0
-    else
-        local power = math.random(10, 20)
-        local params = {}
-        params.bonusmab = 0
-        params.includemab = false
-        power = addBonusesAbility(mob, dsp.magic.ele.DARK, target, power, params)
-        power = power * applyResistanceAddEffect(mob,target,dsp.magic.ele.DARK,0)
-        power = adjustForTarget(target,power,dsp.magic.ele.DARK)
-        power = finalMagicNonSpellAdjustments(mob,target,dsp.magic.ele.DARK,power)
-        if power < 0 then
-            power = 0
-        end
-        return dsp.subEffect.HP_DRAIN, dsp.msg.basic.ADD_EFFECT_HP_DRAIN, mob:addHP(power)
-    end
+    return dsp.mob.onAddEffect(mob, target, damage, dsp.mob.ae.HP_DRAIN)
 end
 
 function onMobDeath(mob, player, isKiller)

--- a/scripts/zones/Xarcabard_[S]/mobs/Dire_Gargouille.lua
+++ b/scripts/zones/Xarcabard_[S]/mobs/Dire_Gargouille.lua
@@ -11,5 +11,5 @@ function onMobDeath(mob, player, isKiller)
 end
 
 function onMobDespawn(mob)
-    phOnDespawn(mob, ID.mob.GRAOULLY_PH, 10, 3600) -- 1 hour
+    dsp.mob.phOnDespawn(mob, ID.mob.GRAOULLY_PH, 10, 3600) -- 1 hour
 end

--- a/scripts/zones/Yhoator_Jungle/mobs/Acolnahuacatl.lua
+++ b/scripts/zones/Yhoator_Jungle/mobs/Acolnahuacatl.lua
@@ -2,30 +2,15 @@
 -- Area: Yhoator Jungle
 --   NM: Acolnahuacatl
 -----------------------------------
-require("scripts/globals/status")
-require("scripts/globals/magic")
-require("scripts/globals/msg")
+require("scripts/globals/mobs")
 -----------------------------------
 
 function onMobInitialize(mob)
     mob:setMobMod(dsp.mobMod.ADD_EFFECT, 1)
 end
 
-function onAdditionalEffect(mob, player)
-    local resist = applyResistanceAddEffect(mob, player, dsp.magic.ele.THUNDER, dsp.effect.STUN)
-
-    if math.random(100) > 20 or resist <= 0.5 then
-        return 0, 0, 0
-    else
-        local duration = 5
-        duration = duration * resist
-
-        if not player:hasStatusEffect(dsp.effect.STUN) then
-            player:addStatusEffect(dsp.effect.STUN, 0, 0, duration)
-        end
-
-        return dsp.subEffect.STUN, dsp.msg.basic.ADD_EFFECT_STATUS, dsp.effect.STUN
-    end
+function onAdditionalEffect(mob, target, damage)
+    return dsp.mob.onAddEffect(mob, target, damage, dsp.mob.ae.STUN)
 end
 
 function onMobDeath(mob, player, isKiller)

--- a/scripts/zones/Yhoator_Jungle/mobs/Tonberry_Creeper.lua
+++ b/scripts/zones/Yhoator_Jungle/mobs/Tonberry_Creeper.lua
@@ -14,5 +14,5 @@ function onMobDeath(mob, player, isKiller)
 end
 
 function onMobDespawn(mob)
-    phOnDespawn(mob, ID.mob.HOAR_KNUCKLED_RIMBERRY_PH, 10, math.random(5400, 7200)) -- 90 to 120 minutes
+    dsp.mob.phOnDespawn(mob, ID.mob.HOAR_KNUCKLED_RIMBERRY_PH, 10, math.random(5400, 7200)) -- 90 to 120 minutes
 end

--- a/scripts/zones/Yhoator_Jungle/mobs/Tonberry_Shadower.lua
+++ b/scripts/zones/Yhoator_Jungle/mobs/Tonberry_Shadower.lua
@@ -14,5 +14,5 @@ function onMobDeath(mob, player, isKiller)
 end
 
 function onMobDespawn(mob)
-    phOnDespawn(mob, ID.mob.HOAR_KNUCKLED_RIMBERRY_PH, 10, math.random(5400, 7200)) -- 90 to 120 minutes
+    dsp.mob.phOnDespawn(mob, ID.mob.HOAR_KNUCKLED_RIMBERRY_PH, 10, math.random(5400, 7200)) -- 90 to 120 minutes
 end

--- a/scripts/zones/Yughott_Grotto/mobs/Orcish_Grunt.lua
+++ b/scripts/zones/Yughott_Grotto/mobs/Orcish_Grunt.lua
@@ -10,5 +10,5 @@ function onMobDeath(mob, player, isKiller)
 end;
 
 function onMobDespawn(mob)
-    phOnDespawn(mob,ID.mob.ASHMAKER_GOTBLUT_PH,5,math.random(7200,10800)); -- 2 to 3 hours
+    dsp.mob.phOnDespawn(mob,ID.mob.ASHMAKER_GOTBLUT_PH,5,math.random(7200,10800)); -- 2 to 3 hours
 end;

--- a/scripts/zones/Yughott_Grotto/mobs/Orcish_Stonechucker.lua
+++ b/scripts/zones/Yughott_Grotto/mobs/Orcish_Stonechucker.lua
@@ -10,5 +10,5 @@ function onMobDeath(mob, player, isKiller)
 end;
 
 function onMobDespawn(mob)
-    phOnDespawn(mob,ID.mob.ASHMAKER_GOTBLUT_PH,5,math.random(7200,10800)); -- 2 to 3 hours
+    dsp.mob.phOnDespawn(mob,ID.mob.ASHMAKER_GOTBLUT_PH,5,math.random(7200,10800)); -- 2 to 3 hours
 end;

--- a/scripts/zones/Yuhtunga_Jungle/mobs/Young_Opo-opo.lua
+++ b/scripts/zones/Yuhtunga_Jungle/mobs/Young_Opo-opo.lua
@@ -13,5 +13,5 @@ function onMobDeath(mob, player, isKiller)
 end;
 
 function onMobDespawn(mob)
-    phOnDespawn(mob,ID.mob.MISCHIEVOUS_MICHOLAS_PH,20,3600); -- 1 hour
+    dsp.mob.phOnDespawn(mob,ID.mob.MISCHIEVOUS_MICHOLAS_PH,20,3600); -- 1 hour
 end;


### PR DESCRIPTION
I notice that we have mob additional melee effects coded all over the place, often with slightly different implementations.  This is my attempt to consolidate all the logic and move it into one place, so that adding additional effects to mobs will be a one-line add from now on (okay, two if you count the mobMod).

While I was in there I tabled the phOnDespawn function too.  In separate commit for reviewer's sanity.

