### PR TITLE
ws: Make the attack multiplier vary by TP

### DIFF
--- a/scripts/globals/weaponskills.lua
+++ b/scripts/globals/weaponskills.lua
@@ -15,7 +15,7 @@ require("scripts/globals/magic")
 require("scripts/globals/utils")
 require("scripts/globals/msg")
 
--- params contains: ftp100, ftp200, ftp300, str_wsc, dex_wsc, vit_wsc, int_wsc, mnd_wsc, canCrit, crit100, crit200, crit300, acc100, acc200, acc300, ignoresDef, ignore100, ignore200, ignore300, atkmulti, kick
+-- params contains: ftp100, ftp200, ftp300, str_wsc, dex_wsc, vit_wsc, int_wsc, mnd_wsc, canCrit, crit100, crit200, crit300, acc100, acc200, acc300, ignoresDef, ignore100, ignore200, ignore300, atk100, atk200, atk300, kick
 function doPhysicalWeaponskill(attacker, target, wsID, tp, primary, action, taChar, params)
     local criticalHit = false
     local bonusTP = 0
@@ -496,7 +496,8 @@ function cMeleeRatio(attacker, defender, params, ignoredDef)
     if flourisheffect ~= nil and flourisheffect:getPower() > 1 then
         attacker:addMod(dsp.mod.ATTP, 25 + flourisheffect:getSubPower() / 2)
     end
-    local cratio = (attacker:getStat(dsp.mod.ATT) * params.atkmulti) / (defender:getStat(dsp.mod.DEF) - ignoredDef)
+    local atkmulti = fTP(params.atk100, params.atk200, params.atk300)
+    local cratio = (attacker:getStat(dsp.mod.ATT) * atkmulti) / (defender:getStat(dsp.mod.DEF) - ignoredDef)
     cratio = utils.clamp(cratio, 0, 2.25)
     if flourisheffect ~= nil and flourisheffect:getPower() > 1 then
         attacker:delMod(dsp.mod.ATTP, 25 + flourisheffect:getSubPower() / 2)
@@ -590,6 +591,7 @@ end
 
 function cRangedRatio(attacker, defender, params, ignoredDef)
 
+    local atkmulti = fTP(params.atk100, params.atk200, params.atk300)
     local cratio = attacker:getRATT() / (defender:getStat(dsp.mod.DEF) - ignoredDef)
 
     local levelcor = 0
@@ -599,7 +601,7 @@ function cRangedRatio(attacker, defender, params, ignoredDef)
 
     cratio = cratio - levelcor
 
-    cratio = cratio * params.atkmulti
+    cratio = cratio * atkmulti
 
     if (cratio > 3 - levelcor) then
         cratio = 3 - levelcor
@@ -721,7 +723,7 @@ function getAlpha(level)
     return alpha
 end
 
- -- params contains: ftp100, ftp200, ftp300, str_wsc, dex_wsc, vit_wsc, int_wsc, mnd_wsc, canCrit, crit100, crit200, crit300, acc100, acc200, acc300, ignoresDef, ignore100, ignore200, ignore300, atkmulti
+ -- params contains: ftp100, ftp200, ftp300, str_wsc, dex_wsc, vit_wsc, int_wsc, mnd_wsc, canCrit, crit100, crit200, crit300, acc100, acc200, acc300, ignoresDef, ignore100, ignore200, ignore300, atk100, atk200, atk300
  function doRangedWeaponskill(attacker, target, wsID, params, tp, primary, action)
     local bonusTP = 0
     if (params.bonusTP ~= nil) then

--- a/scripts/globals/weaponskills/apex_arrow.lua
+++ b/scripts/globals/weaponskills/apex_arrow.lua
@@ -27,7 +27,7 @@ function onUseWeaponSkill(player, target, wsID, tp, primary, action, taChar)
     params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
     params.canCrit = false
     params.acc100 = 0.0 params.acc200= 0.0 params.acc300= 0.0
-    params.atkmulti = 1
+    params.atk100 = 1; params.atk200 = 1; params.atk300 = 1;
     params.ignoresDef = true
     params.ignored100 = 0.15
     params.ignored200 = 0.35

--- a/scripts/globals/weaponskills/arching_arrow.lua
+++ b/scripts/globals/weaponskills/arching_arrow.lua
@@ -24,7 +24,7 @@ function onUseWeaponSkill(player, target, wsID, tp, primary, action, taChar)
     params.crit100 = 0.1 params.crit200 = 0.3 params.crit300 = 0.5
     params.canCrit = true
     params.acc100 = 0.0 params.acc200= 0.0 params.acc300= 0.0
-    params.atkmulti = 1
+    params.atk100 = 1; params.atk200 = 1; params.atk300 = 1;
 
     if (USE_ADOULIN_WEAPON_SKILL_CHANGES == true) then
         params.str_wsc = 0.20 params.agi_wsc = 0.50

--- a/scripts/globals/weaponskills/armor_break.lua
+++ b/scripts/globals/weaponskills/armor_break.lua
@@ -27,7 +27,7 @@ function onUseWeaponSkill(player, target, wsID, tp, primary, action, taChar)
     params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
     params.canCrit = false
     params.acc100 = 0.0 params.acc200= 0.0 params.acc300= 0.0
-    params.atkmulti = 1
+    params.atk100 = 1; params.atk200 = 1; params.atk300 = 1;
 
     if (USE_ADOULIN_WEAPON_SKILL_CHANGES == true) then
         params.str_wsc = 0.6 params.vit_wsc = 0.6

--- a/scripts/globals/weaponskills/ascetics_fury.lua
+++ b/scripts/globals/weaponskills/ascetics_fury.lua
@@ -26,11 +26,11 @@ function onUseWeaponSkill(player, target, wsID, tp, primary, action, taChar)
     params.crit100 = 0.1 params.crit200 = 0.3 params.crit300 = 0.5
     params.canCrit = true
     params.acc100 = 0.0 params.acc200 = 0.0 params.acc300 = 0.0
-    params.atkmulti = 1
+    params.atk100 = 1; params.atk200 = 1; params.atk300 = 1;
 
     if USE_ADOULIN_WEAPON_SKILL_CHANGES then
         params.crit100 = 0.2 params.crit200 = 0.3 params.crit300 = 0.5
-        params.atkmulti = 2.6
+        params.atk100 = 2.6; params.atk200 = 2.6; params.atk300 = 2.6;
     end
 
 

--- a/scripts/globals/weaponskills/asuran_fists.lua
+++ b/scripts/globals/weaponskills/asuran_fists.lua
@@ -27,7 +27,7 @@ function onUseWeaponSkill(player, target, wsID, tp, primary, action, taChar)
     params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
     params.canCrit = false
     params.acc100 = 0.8 params.acc200= 0.9 params.acc300= 1
-    params.atkmulti = 1
+    params.atk100 = 1; params.atk200 = 1; params.atk300 = 1;
 
     if (USE_ADOULIN_WEAPON_SKILL_CHANGES == true) then
         params.str_wsc = 0.15 params.vit_wsc = 0.15

--- a/scripts/globals/weaponskills/atonement.lua
+++ b/scripts/globals/weaponskills/atonement.lua
@@ -35,7 +35,7 @@ function onUseWeaponSkill(player, target, wsID, tp, primary, action, taChar)
     params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
     params.canCrit = false
     params.acc100 = 0.0 params.acc200 = 0.0 params.acc300 = 0.0
-    params.atkmulti = 1
+    params.atk100 = 1; params.atk200 = 1; params.atk300 = 1;
 
     local tpHits = 0
     local extraHits = 0

--- a/scripts/globals/weaponskills/avalanche_axe.lua
+++ b/scripts/globals/weaponskills/avalanche_axe.lua
@@ -25,7 +25,7 @@ function onUseWeaponSkill(player, target, wsID, tp, primary, action, taChar)
     params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
     params.canCrit = false
     params.acc100 = 0.0 params.acc200= 0.0 params.acc300= 0.0
-    params.atkmulti = 1
+    params.atk100 = 1; params.atk200 = 1; params.atk300 = 1;
 
     if (USE_ADOULIN_WEAPON_SKILL_CHANGES == true) then
         params.str_wsc = 0.6

--- a/scripts/globals/weaponskills/backhand_blow.lua
+++ b/scripts/globals/weaponskills/backhand_blow.lua
@@ -24,7 +24,7 @@ function onUseWeaponSkill(player, target, wsID, tp, primary, action, taChar)
     params.crit100 = 0.4 params.crit200 = 0.6 params.crit300 = 0.8
     params.canCrit = true
     params.acc100 = 0.0 params.acc200= 0.0 params.acc300= 0.0
-    params.atkmulti = 1
+    params.atk100 = 1; params.atk200 = 1; params.atk300 = 1;
 
     if (USE_ADOULIN_WEAPON_SKILL_CHANGES == true) then
         params.str_wsc = 0.5 params.dex_wsc = 0.5

--- a/scripts/globals/weaponskills/black_halo.lua
+++ b/scripts/globals/weaponskills/black_halo.lua
@@ -26,7 +26,7 @@ function onUseWeaponSkill(player, target, wsID, tp, primary, action, taChar)
     params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
     params.canCrit = false
     params.acc100 = 0.0 params.acc200= 0.0 params.acc300= 0.0
-    params.atkmulti = 1
+    params.atk100 = 1; params.atk200 = 1; params.atk300 = 1;
 
     if (USE_ADOULIN_WEAPON_SKILL_CHANGES == true) then
         params.ftp100 = 3.0 params.ftp200 = 7.25 params.ftp300 = 9.75

--- a/scripts/globals/weaponskills/blade_chi.lua
+++ b/scripts/globals/weaponskills/blade_chi.lua
@@ -24,7 +24,7 @@ function onUseWeaponSkill(player, target, wsID, tp, primary, action, taChar)
     params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
     params.canCrit = false
     params.acc100 = 0.0 params.acc200= 0.0 params.acc300= 0.0
-    params.atkmulti = 1
+    params.atk100 = 1; params.atk200 = 1; params.atk300 = 1;
 
     if (USE_ADOULIN_WEAPON_SKILL_CHANGES == true) then
         params.ftp100 = 0.5 params.ftp200 = 0.75 params.ftp300 = 1

--- a/scripts/globals/weaponskills/blade_hi.lua
+++ b/scripts/globals/weaponskills/blade_hi.lua
@@ -31,7 +31,7 @@ function onUseWeaponSkill(player, target, wsID, tp, primary, action, taChar)
     params.crit100 = 0.15 params.crit200 = 0.2 params.crit300 = 0.25
     params.canCrit = true
     params.acc100 = 0.0 params.acc200 = 0.0 params.acc300 = 0.0
-    params.atkmulti = 1
+    params.atk100 = 1; params.atk200 = 1; params.atk300 = 1;
 
     if USE_ADOULIN_WEAPON_SKILL_CHANGES then
         params.ftp100 = 5 params.ftp200 = 5 params.ftp300 = 5

--- a/scripts/globals/weaponskills/blade_jin.lua
+++ b/scripts/globals/weaponskills/blade_jin.lua
@@ -25,7 +25,7 @@ function onUseWeaponSkill(player, target, wsID, tp, primary, action, taChar)
     params.crit100 = 0.1 params.crit200 = 0.3 params.crit300 = 0.5
     params.canCrit = true
     params.acc100 = 0.0 params.acc200= 0.0 params.acc300= 0.0
-    params.atkmulti = 1
+    params.atk100 = 1; params.atk200 = 1; params.atk300 = 1;
 
     if (USE_ADOULIN_WEAPON_SKILL_CHANGES == true) then
         params.ftp100 = 1.375 params.ftp200 = 1.375 params.ftp300 = 1.375

--- a/scripts/globals/weaponskills/blade_kamu.lua
+++ b/scripts/globals/weaponskills/blade_kamu.lua
@@ -27,11 +27,11 @@ function onUseWeaponSkill(player, target, wsID, tp, primary, action, taChar)
     params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
     params.canCrit = false
     params.acc100 = 0.0 params.acc200 = 0.0 params.acc300 = 0.0
-    params.atkmulti = 1
+    params.atk100 = 1; params.atk200 = 1; params.atk300 = 1;
 
     if USE_ADOULIN_WEAPON_SKILL_CHANGES then
         params.str_wsc = 0.6 params.int_wsc = 0.6
-        params.atkmulti = 1.3125
+        params.atk100 = 1.3125; params.atk200 = 1.3125; params.atk300 = 1.3125;
     end
 
     local damage, criticalHit, tpHits, extraHits = doPhysicalWeaponskill(player, target, wsID, tp, primary, action, taChar, params)

--- a/scripts/globals/weaponskills/blade_ku.lua
+++ b/scripts/globals/weaponskills/blade_ku.lua
@@ -30,7 +30,7 @@ function onUseWeaponSkill(player, target, wsID, tp, primary, action, taChar)
     params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
     params.canCrit = false
     params.acc100 = 0.8 params.acc200= 0.9 params.acc300= 1.0
-    params.atkmulti = 1
+    params.atk100 = 1; params.atk200 = 1; params.atk300 = 1;
 
     if (USE_ADOULIN_WEAPON_SKILL_CHANGES == true) then
         params.ftp100 = 1.25 params.ftp200 = 1.25 params.ftp300 = 1.25

--- a/scripts/globals/weaponskills/blade_metsu.lua
+++ b/scripts/globals/weaponskills/blade_metsu.lua
@@ -28,7 +28,7 @@ function onUseWeaponSkill(player, target, wsID, tp, primary, action, taChar)
     params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
     params.canCrit = false
     params.acc100 = 0.0 params.acc200 = 0.0 params.acc300 = 0.0
-    params.atkmulti = 1
+    params.atk100 = 1; params.atk200 = 1; params.atk300 = 1;
 
     if USE_ADOULIN_WEAPON_SKILL_CHANGES then
         params.ftp100 = 5 params.ftp200 = 5 params.ftp300 = 5
@@ -41,7 +41,7 @@ function onUseWeaponSkill(player, target, wsID, tp, primary, action, taChar)
             local duration = 60 * applyResistanceAddEffect(player, target, dsp.magic.ele.ICE, 0)
             target:addStatusEffect(dsp.effect.PARALYSIS, 10, 0, duration)
         end
-        
+
         -- Apply aftermath
         dsp.aftermath.addStatusEffect(player, tp, dsp.slot.MAIN, dsp.aftermath.type.RELIC)
     end

--- a/scripts/globals/weaponskills/blade_retsu.lua
+++ b/scripts/globals/weaponskills/blade_retsu.lua
@@ -26,7 +26,7 @@ function onUseWeaponSkill(player, target, wsID, tp, primary, action, taChar)
     params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
     params.canCrit = false
     params.acc100 = 0.0 params.acc200= 0.0 params.acc300= 0.0
-    params.atkmulti = 1
+    params.atk100 = 1; params.atk200 = 1; params.atk300 = 1;
 
     if (USE_ADOULIN_WEAPON_SKILL_CHANGES == true) then
         params.dex_wsc = 0.6

--- a/scripts/globals/weaponskills/blade_rin.lua
+++ b/scripts/globals/weaponskills/blade_rin.lua
@@ -25,7 +25,7 @@ function onUseWeaponSkill(player, target, wsID, tp, primary, action, taChar)
     params.crit100 = 0.3 params.crit200 = 0.6 params.crit300 = 0.9
     params.canCrit = true
     params.acc100 = 0.0 params.acc200= 0.0 params.acc300= 0.0
-    params.atkmulti = 1
+    params.atk100 = 1; params.atk200 = 1; params.atk300 = 1;
 
     if (USE_ADOULIN_WEAPON_SKILL_CHANGES == true) then
         params.str_wsc = 0.6 params.dex_wsc = 0.6

--- a/scripts/globals/weaponskills/blade_shun.lua
+++ b/scripts/globals/weaponskills/blade_shun.lua
@@ -28,7 +28,7 @@ function onUseWeaponSkill(player, target, wsID, tp, primary, action, taChar)
     params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
     params.canCrit = false
     params.acc100 = 0.0 params.acc200= 0.0 params.acc300= 0.0
-    params.atkmulti = 1
+    params.atk100 = 1; params.atk200 = 1; params.atk300 = 1;
 
     if (USE_ADOULIN_WEAPON_SKILL_CHANGES == true) then
         params.ftp100 = 1 params.ftp200 = 1 params.ftp300 = 1

--- a/scripts/globals/weaponskills/blade_ten.lua
+++ b/scripts/globals/weaponskills/blade_ten.lua
@@ -25,7 +25,7 @@ function onUseWeaponSkill(player, target, wsID, tp, primary, action, taChar)
     params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
     params.canCrit = false
     params.acc100 = 0.0 params.acc200= 0.0 params.acc300= 0.0
-    params.atkmulti = 1
+    params.atk100 = 1; params.atk200 = 1; params.atk300 = 1;
 
     if (USE_ADOULIN_WEAPON_SKILL_CHANGES == true) then
         params.ftp100 = 4.5 params.ftp200 = 11.5 params.ftp300 = 15.5

--- a/scripts/globals/weaponskills/blast_arrow.lua
+++ b/scripts/globals/weaponskills/blast_arrow.lua
@@ -24,7 +24,7 @@ function onUseWeaponSkill(player, target, wsID, tp, primary, action, taChar)
     params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
     params.canCrit = false
     params.acc100 = 0.8 params.acc200= 0.9 params.acc300= 1
-    params.atkmulti = 1
+    params.atk100 = 1; params.atk200 = 1; params.atk300 = 1;
 
     if (USE_ADOULIN_WEAPON_SKILL_CHANGES == true) then
         params.str_wsc = 0.2 params.agi_wsc = 0.5

--- a/scripts/globals/weaponskills/blast_shot.lua
+++ b/scripts/globals/weaponskills/blast_shot.lua
@@ -24,7 +24,7 @@ function onUseWeaponSkill(player, target, wsID, tp, primary, action, taChar)
     params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
     params.canCrit = false
     params.acc100 = 0.8 params.acc200= 0.9 params.acc300= 1
-    params.atkmulti = 1
+    params.atk100 = 1; params.atk200 = 1; params.atk300 = 1;
 
     if (USE_ADOULIN_WEAPON_SKILL_CHANGES == true) then
         params.agi_wsc = 0.7

--- a/scripts/globals/weaponskills/bora_axe.lua
+++ b/scripts/globals/weaponskills/bora_axe.lua
@@ -26,12 +26,12 @@ function onUseWeaponSkill(player, target, wsID, tp, primary, action, taChar)
     params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
     params.canCrit = false
     params.acc100 = 0.0 params.acc200= 0.0 params.acc300= 0.0
-    params.atkmulti = 3.5
+    params.atk100 = 3.5; params.atk200 = 3.5; params.atk300 = 3.5;
 
     if (USE_ADOULIN_WEAPON_SKILL_CHANGES == true) then
         params.ftp100 = 4.5 params.ftp200 = 4.5 params.ftp300 = 4.5
         params.dex_wsc = 1.0
-        params.atkmulti = 1.0
+        params.atk100 = 1.0; params.atk200 = 1.0; params.atk300 = 1.0;
     end
 
     local damage, criticalHit, tpHits, extraHits = doPhysicalWeaponskill(player, target, wsID, tp, primary, action, taChar, params)

--- a/scripts/globals/weaponskills/brainshaker.lua
+++ b/scripts/globals/weaponskills/brainshaker.lua
@@ -25,7 +25,7 @@ function onUseWeaponSkill(player, target, wsID, tp, primary, action, taChar)
     params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
     params.canCrit = false
     params.acc100 = 0.0 params.acc200= 0.0 params.acc300= 0.0
-    params.atkmulti = 1
+    params.atk100 = 1; params.atk200 = 1; params.atk300 = 1;
 
     if (USE_ADOULIN_WEAPON_SKILL_CHANGES == true) then
         params.str_wsc = 1.0

--- a/scripts/globals/weaponskills/calamity.lua
+++ b/scripts/globals/weaponskills/calamity.lua
@@ -25,7 +25,7 @@ function onUseWeaponSkill(player, target, wsID, tp, primary, action, taChar)
     params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
     params.canCrit = false
     params.acc100 = 0.0 params.acc200= 0.0 params.acc300= 0.0
-    params.atkmulti = 1
+    params.atk100 = 1; params.atk200 = 1; params.atk300 = 1;
 
     if (USE_ADOULIN_WEAPON_SKILL_CHANGES == true) then
         params.ftp100 = 2.5 params.ftp200 = 6.5 params.ftp300 = 10.375

--- a/scripts/globals/weaponskills/camlanns_torment.lua
+++ b/scripts/globals/weaponskills/camlanns_torment.lua
@@ -23,7 +23,7 @@ function onUseWeaponSkill(player, target, wsID, tp, primary, action, taChar)
     params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
     params.canCrit = false
     params.acc100 = 0.0 params.acc200 = 0.0 params.acc300 = 0.0
-    params.atkmulti = 1
+    params.atk100 = 1; params.atk200 = 1; params.atk300 = 1;
     params.ignoresDef = true
     params.ignored100 = 0.15
     params.ignored200 = 0.35

--- a/scripts/globals/weaponskills/catastrophe.lua
+++ b/scripts/globals/weaponskills/catastrophe.lua
@@ -26,7 +26,7 @@ function onUseWeaponSkill(player, target, wsID, tp, primary, action, taChar)
     params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
     params.canCrit = false
     params.acc100 = 0.0 params.acc200 = 0.0 params.acc300 = 0.0
-    params.atkmulti = 1
+    params.atk100 = 1; params.atk200 = 1; params.atk300 = 1;
 
     if USE_ADOULIN_WEAPON_SKILL_CHANGES then
         params.str_wsc = 0.4 params.agi_wsc = 0.0 params.int_wsc = 0.4
@@ -38,7 +38,7 @@ function onUseWeaponSkill(player, target, wsID, tp, primary, action, taChar)
         local drain = math.floor(damage * 0.4)
         player:addHP(drain)
     end
-    
+
     -- Apply aftermath
     if damage > 0 then
         dsp.aftermath.addStatusEffect(player, tp, dsp.slot.MAIN, dsp.aftermath.type.RELIC)

--- a/scripts/globals/weaponskills/chant_du_cygne.lua
+++ b/scripts/globals/weaponskills/chant_du_cygne.lua
@@ -23,7 +23,7 @@ function onUseWeaponSkill(player, target, wsID, tp, primary, action, taChar)
     params.crit100 = 0.1 params.crit200 = 0.3 params.crit300 = 0.5
     params.canCrit = true
     params.acc100 = 0.0 params.acc200 = 0.0 params.acc300 = 0.0
-    params.atkmulti = 1
+    params.atk100 = 1; params.atk200 = 1; params.atk300 = 1;
 
     if USE_ADOULIN_WEAPON_SKILL_CHANGES then
         params.dex_wsc = 0.8

--- a/scripts/globals/weaponskills/circle_blade.lua
+++ b/scripts/globals/weaponskills/circle_blade.lua
@@ -24,7 +24,7 @@ function onUseWeaponSkill(player, target, wsID, tp, primary, action, taChar)
     params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
     params.canCrit = false
     params.acc100 = 0.0 params.acc200= 0.0 params.acc300= 0.0
-    params.atkmulti = 1
+    params.atk100 = 1; params.atk200 = 1; params.atk300 = 1;
 
     if (USE_ADOULIN_WEAPON_SKILL_CHANGES == true) then
         params.str_wsc = 1.0

--- a/scripts/globals/weaponskills/combo.lua
+++ b/scripts/globals/weaponskills/combo.lua
@@ -25,7 +25,7 @@ function onUseWeaponSkill(player, target, wsID, tp, primary, action, taChar)
     params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
     params.canCrit = false
     params.acc100 = 0.0 params.acc200= 0.0 params.acc300= 0.0
-    params.atkmulti = 1
+    params.atk100 = 1; params.atk200 = 1; params.atk300 = 1;
 
     if (USE_ADOULIN_WEAPON_SKILL_CHANGES == true) then
         params.ftp100 = 1 params.ftp200 = 3.75 params.ftp300 = 5.5

--- a/scripts/globals/weaponskills/coronach.lua
+++ b/scripts/globals/weaponskills/coronach.lua
@@ -31,7 +31,7 @@ function onUseWeaponSkill(player, target, wsID, tp, primary, action, taChar)
     params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
     params.canCrit = false
     params.acc100 = 0.0 params.acc200 = 0.0 params.acc300 = 0.0
-    params.atkmulti = 1
+    params.atk100 = 1; params.atk200 = 1; params.atk300 = 1;
     params.overrideCE = 80
     params.overrideVE = 240
 

--- a/scripts/globals/weaponskills/crescent_moon.lua
+++ b/scripts/globals/weaponskills/crescent_moon.lua
@@ -25,7 +25,7 @@ function onUseWeaponSkill(player, target, wsID, tp, primary, action, taChar)
     -- params.accuracy mods (ONLY USE FOR ACCURACY VARIES WITH TP) , should be the acc at those %s NOT the penalty values. Leave 0 if acc doesnt vary with tp.
     params.acc100 = 0 params.acc200=0 params.acc300=0
     -- attack multiplier (only some WSes use this, this varies the actual ratio value, see Tachi: Kasha) 1 is default.
-    params.atkmulti = 1
+    params.atk100 = 1; params.atk200 = 1; params.atk300 = 1;
 
     if (USE_ADOULIN_WEAPON_SKILL_CHANGES == true) then
         params.ftp100 = 1.5 params.ftp200 = 1.75 params.ftp300 = 2.75

--- a/scripts/globals/weaponskills/cross_reaper.lua
+++ b/scripts/globals/weaponskills/cross_reaper.lua
@@ -24,7 +24,7 @@ function onUseWeaponSkill(player, target, wsID, tp, primary, action, taChar)
     -- params.accuracy mods (ONLY USE FOR ACCURACY VARIES WITH TP) , should be the acc at those %s NOT the penalty values. Leave 0 if acc doesnt vary with tp.
     params.acc100 = 0 params.acc200=0 params.acc300=0
     -- attack multiplier (only some WSes use this, this varies the actual ratio value, see Tachi: Kasha) 1 is default.
-    params.atkmulti = 1
+    params.atk100 = 1; params.atk200 = 1; params.atk300 = 1;
 
     if (USE_ADOULIN_WEAPON_SKILL_CHANGES == true) then
         params.ftp100 = 2.0 params.ftp200 = 4.0 params.ftp300 = 7.0

--- a/scripts/globals/weaponskills/dancing_edge.lua
+++ b/scripts/globals/weaponskills/dancing_edge.lua
@@ -26,7 +26,7 @@ function onUseWeaponSkill(player, target, wsID, tp, primary, action, taChar)
     params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
     params.canCrit = false
     params.acc100 = 0.8 params.acc200= 0.9 params.acc300= 1
-    params.atkmulti = 1
+    params.atk100 = 1; params.atk200 = 1; params.atk300 = 1;
 
     if (USE_ADOULIN_WEAPON_SKILL_CHANGES == true) then
         params.dex_wsc = 0.4

--- a/scripts/globals/weaponskills/death_blossom.lua
+++ b/scripts/globals/weaponskills/death_blossom.lua
@@ -31,8 +31,8 @@ function onUseWeaponSkill(player, target, wsID, tp, primary, action, taChar)
     -- accuracy mods (ONLY USE FOR accURACY VARIES WITH TP) , should be the acc at those %s NOT the penalty values. Leave 0 if acc doesnt vary with tp.
     params.acc100 = 0.0 params.acc200 = 0.0 params.acc300 = 0.0
     -- attack multiplier (only some WSes use this, this varies the actual ratio value, see Tachi: Kasha) 1 is default.
-    params.atkmulti = 1
-    
+    params.atk100 = 1; params.atk200 = 1; params.atk300 = 1;
+
     if USE_ADOULIN_WEAPON_SKILL_CHANGES then
         params.ftp100 = 4.0 params.ftp200 = 4.0 params.ftp300 = 4.0
     end

--- a/scripts/globals/weaponskills/decimation.lua
+++ b/scripts/globals/weaponskills/decimation.lua
@@ -26,7 +26,7 @@ function onUseWeaponSkill(player, target, wsID, tp, primary, action, taChar)
     params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
     params.canCrit = false
     params.acc100 = 0.8 params.acc200= 0.9 params.acc300= 1
-    params.atkmulti = 1
+    params.atk100 = 1; params.atk200 = 1; params.atk300 = 1;
 
     if (USE_ADOULIN_WEAPON_SKILL_CHANGES == true) then
         params.ftp100 = 1.75 params.ftp200 = 1.75 params.ftp300 = 1.75

--- a/scripts/globals/weaponskills/detonator.lua
+++ b/scripts/globals/weaponskills/detonator.lua
@@ -26,7 +26,7 @@ function onUseWeaponSkill(player, target, wsID, tp, primary, action, taChar)
     params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
     params.canCrit = false
     params.acc100 = 0.0 params.acc200= 0.0 params.acc300= 0.0
-    params.atkmulti = 1
+    params.atk100 = 1; params.atk200 = 1; params.atk300 = 1;
 
     if (USE_ADOULIN_WEAPON_SKILL_CHANGES == true) then
         params.ftp100 = 1.5 params.ftp200 = 2.5 params.ftp300 = 5.0

--- a/scripts/globals/weaponskills/double_thrust.lua
+++ b/scripts/globals/weaponskills/double_thrust.lua
@@ -25,7 +25,7 @@ function onUseWeaponSkill(player, target, wsID, tp, primary, action, taChar)
     params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
     params.canCrit = false
     params.acc100 = 0.0 params.acc200= 0.0 params.acc300= 0.0
-    params.atkmulti = 1
+    params.atk100 = 1; params.atk200 = 1; params.atk300 = 1;
 
     if (USE_ADOULIN_WEAPON_SKILL_CHANGES == true) then
         params.dex_wsc = 0.3

--- a/scripts/globals/weaponskills/dragon_kick.lua
+++ b/scripts/globals/weaponskills/dragon_kick.lua
@@ -25,7 +25,7 @@ function onUseWeaponSkill(player, target, wsID, tp, primary, action, taChar)
     params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
     params.canCrit = false
     params.acc100 = 0.0 params.acc200= 0.0 params.acc300= 0.0
-    params.atkmulti = 1
+    params.atk100 = 1; params.atk200 = 1; params.atk300 = 1;
     params.kick = true -- https://www.bluegartr.com/threads/112776-Dev-Tracker-Findings-Posts-%28NO-DISCUSSION%29?p=6712150&viewfull=1#post6712150
 
     if (USE_ADOULIN_WEAPON_SKILL_CHANGES == true) then

--- a/scripts/globals/weaponskills/drakesbane.lua
+++ b/scripts/globals/weaponskills/drakesbane.lua
@@ -26,10 +26,10 @@ function onUseWeaponSkill(player, target, wsID, tp, primary, action, taChar)
     params.crit100 = 0.1 params.crit200 = 0.3 params.crit300 = 0.5
     params.canCrit = true
     params.acc100 = 0.0 params.acc200 = 0.0 params.acc300 = 0.0
-    params.atkmulti = 1
+    params.atk100 = 1; params.atk200 = 1; params.atk300 = 1;
 
     if USE_ADOULIN_WEAPON_SKILL_CHANGES then
-        params.atkmulti = 0.8125
+        params.atk100 = 0.8125; params.atk200 = 0.8125; params.atk300 = 0.8125;
         params.crit100 = 0.1 params.crit200 = 0.25 params.crit300 = 0.4
     end
 

--- a/scripts/globals/weaponskills/dulling_arrow.lua
+++ b/scripts/globals/weaponskills/dulling_arrow.lua
@@ -24,7 +24,7 @@ function onUseWeaponSkill(player, target, wsID, tp, primary, action, taChar)
     params.crit100 = 0.1 params.crit200 = 0.3 params.crit300 = 0.5
     params.canCrit = true
     params.acc100 = 0.0 params.acc200= 0.0 params.acc300= 0.0
-    params.atkmulti = 1
+    params.atk100 = 1; params.atk200 = 1; params.atk300 = 1;
 
     if (USE_ADOULIN_WEAPON_SKILL_CHANGES == true) then
         params.str_wsc = 0.2 params.agi_wsc = 0.5

--- a/scripts/globals/weaponskills/empyreal_arrow.lua
+++ b/scripts/globals/weaponskills/empyreal_arrow.lua
@@ -25,12 +25,12 @@ function onUseWeaponSkill(player, target, wsID, tp, primary, action, taChar)
     params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
     params.canCrit = false
     params.acc100 = 0.0 params.acc200= 0.0 params.acc300= 0.0
-    params.atkmulti = 1
+    params.atk100 = 1; params.atk200 = 1; params.atk300 = 1;
 
     if (USE_ADOULIN_WEAPON_SKILL_CHANGES == true) then
         params.ftp100 = 1.5 params.ftp200 = 2.5 params.ftp300 = 5
         params.str_wsc = 0.20 params.agi_wsc = 0.50
-        params.atkmulti = 2
+        params.atk100 = 2; params.atk200 = 2; params.atk300 = 2;
     end
 
     local damage, criticalHit, tpHits, extraHits = doRangedWeaponskill(player, target, wsID, params, tp, primary, action)

--- a/scripts/globals/weaponskills/entropy.lua
+++ b/scripts/globals/weaponskills/entropy.lua
@@ -26,7 +26,7 @@ function onUseWeaponSkill(player, target, wsID, tp, primary, action, taChar)
     params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
     params.canCrit = false
     params.acc100 = 0.0 params.acc200= 0.0 params.acc300= 0.0
-    params.atkmulti = 1
+    params.atk100 = 1; params.atk200 = 1; params.atk300 = 1;
 
     if (USE_ADOULIN_WEAPON_SKILL_CHANGES == true) then
         params.int_wsc = 0.7 + (player:getMerit(dsp.merit.ENTROPY) / 100)

--- a/scripts/globals/weaponskills/evisceration.lua
+++ b/scripts/globals/weaponskills/evisceration.lua
@@ -26,7 +26,7 @@ function onUseWeaponSkill(player, target, wsID, tp, primary, action, taChar)
     params.crit100 = 0.1 params.crit200 = 0.3 params.crit300 = 0.5
     params.canCrit = true
     params.acc100 = 0.0 params.acc200= 0.0 params.acc300= 0.0
-    params.atkmulti = 1
+    params.atk100 = 1; params.atk200 = 1; params.atk300 = 1;
 
     if (USE_ADOULIN_WEAPON_SKILL_CHANGES == true) then
         params.ftp100 = 1.25 params.ftp200 = 1.25 params.ftp300 = 1.25

--- a/scripts/globals/weaponskills/exenterator.lua
+++ b/scripts/globals/weaponskills/exenterator.lua
@@ -27,7 +27,7 @@ function onUseWeaponSkill(player, target, wsID, tp, primary, action, taChar)
     params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
     params.canCrit = false
     params.acc100 = 0.0 params.acc200= 0.0 params.acc300= 0.0
-    params.atkmulti = 1.0
+    params.atk100 = 1.0; params.atk200 = 1.0; params.atk300 = 1.0;
 
     if (USE_ADOULIN_WEAPON_SKILL_CHANGES == true) then
         params.agi_wsc = 0.7 + (player:getMerit(dsp.merit.EXENTERATOR) / 100)

--- a/scripts/globals/weaponskills/expiacion.lua
+++ b/scripts/globals/weaponskills/expiacion.lua
@@ -26,7 +26,7 @@ function onUseWeaponSkill(player, target, wsID, tp, primary, action, taChar)
     params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
     params.canCrit = false
     params.acc100 = 0.0 params.acc200 = 0.0 params.acc300 = 0.0
-    params.atkmulti = 1
+    params.atk100 = 1; params.atk200 = 1; params.atk300 = 1;
 
     if USE_ADOULIN_WEAPON_SKILL_CHANGES then
         params.ftp100 = 3.75 params.ftp200 = 10.25 params.ftp300 = 12.5

--- a/scripts/globals/weaponskills/fast_blade.lua
+++ b/scripts/globals/weaponskills/fast_blade.lua
@@ -25,7 +25,7 @@ function onUseWeaponSkill(player, target, wsID, tp, primary, action, taChar)
     params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
     params.canCrit = false
     params.acc100 = 0.0 params.acc200= 0.0 params.acc300= 0.0
-    params.atkmulti = 1
+    params.atk100 = 1; params.atk200 = 1; params.atk300 = 1;
 
     if (USE_ADOULIN_WEAPON_SKILL_CHANGES == true) then
         params.str_wsc = 0.4 params.dex_wsc = 0.4

--- a/scripts/globals/weaponskills/fell_cleave.lua
+++ b/scripts/globals/weaponskills/fell_cleave.lua
@@ -24,7 +24,7 @@ function onUseWeaponSkill(player, target, wsID, tp, primary, action, taChar)
     params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
     params.canCrit = false
     params.acc100 = 0.0 params.acc200= 0.0 params.acc300= 0.0
-    params.atkmulti = 1
+    params.atk100 = 1; params.atk200 = 1; params.atk300 = 1;
 
     if (USE_ADOULIN_WEAPON_SKILL_CHANGES == true) then
         params.ftp100 = 2.75 params.ftp200 = 2.75 params.ftp300 = 2.75

--- a/scripts/globals/weaponskills/final_heaven.lua
+++ b/scripts/globals/weaponskills/final_heaven.lua
@@ -30,7 +30,7 @@ function onUseWeaponSkill(player, target, wsID, tp, primary, action, taChar)
     -- accuracy modifiers (0.0 = 0%, 0.2 = 20%, 0.5 = 50%..etc) Keep 0 if ws doesn't have accuracy modification.
     params.acc100 = 0.0 params.acc200 = 0.0 params.acc300 = 0.0
     -- attack multiplier (only some WSes use this, this varies the actual ratio value, see Tachi: Kasha) 1 is default.
-    params.atkmulti = 1
+    params.atk100 = 1; params.atk200 = 1; params.atk300 = 1;
 
     if USE_ADOULIN_WEAPON_SKILL_CHANGES then
         params.vit_wsc = 0.8

--- a/scripts/globals/weaponskills/flaming_arrow.lua
+++ b/scripts/globals/weaponskills/flaming_arrow.lua
@@ -24,7 +24,7 @@ function onUseWeaponSkill(player, target, wsID, tp, primary, action, taChar)
     params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
     params.canCrit = false
     params.acc100 = 0.0 params.acc200= 0.0 params.acc300= 0.0
-    params.atkmulti = 1
+    params.atk100 = 1; params.atk200 = 1; params.atk300 = 1;
 
     if (USE_ADOULIN_WEAPON_SKILL_CHANGES == true) then
         params.ftp100 = 0.5 params.ftp200 = 0.75 params.ftp300 = 1

--- a/scripts/globals/weaponskills/flat_blade.lua
+++ b/scripts/globals/weaponskills/flat_blade.lua
@@ -25,7 +25,7 @@ function onUseWeaponSkill(player, target, wsID, tp, primary, action, taChar)
     params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
     params.canCrit = false
     params.acc100 = 0.0 params.acc200= 0.0 params.acc300= 0.0
-    params.atkmulti = 1
+    params.atk100 = 1; params.atk200 = 1; params.atk300 = 1;
 
     if (USE_ADOULIN_WEAPON_SKILL_CHANGES == true) then
         params.str_wsc = 1.0

--- a/scripts/globals/weaponskills/full_break.lua
+++ b/scripts/globals/weaponskills/full_break.lua
@@ -29,7 +29,7 @@ function onUseWeaponSkill(player, target, wsID, tp, primary, action, taChar)
     params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
     params.canCrit = false
     params.acc100 = 0.0 params.acc200= 0.0 params.acc300= 0.0
-    params.atkmulti = 1
+    params.atk100 = 1; params.atk200 = 1; params.atk300 = 1;
     local damage, criticalHit, tpHits, extraHits = doPhysicalWeaponskill(player, target, wsID, tp, primary, action, taChar, params)
 
     if (damage > 0) then

--- a/scripts/globals/weaponskills/full_swing.lua
+++ b/scripts/globals/weaponskills/full_swing.lua
@@ -25,7 +25,7 @@ function onUseWeaponSkill(player, target, wsID, tp, primary, action, taChar)
     params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
     params.canCrit = false
     params.acc100 = 0.0 params.acc200= 0.0 params.acc300= 0.0
-    params.atkmulti = 1
+    params.atk100 = 1; params.atk200 = 1; params.atk300 = 1;
     local damage, criticalHit, tpHits, extraHits = doPhysicalWeaponskill(player, target, wsID, tp, primary, action, taChar, params)
     return tpHits, extraHits, criticalHit, damage
 

--- a/scripts/globals/weaponskills/gale_axe.lua
+++ b/scripts/globals/weaponskills/gale_axe.lua
@@ -25,7 +25,7 @@ function onUseWeaponSkill(player, target, wsID, tp, primary, action, taChar)
     params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
     params.canCrit = false
     params.acc100 = 0.0 params.acc200= 0.0 params.acc300= 0.0
-    params.atkmulti = 1
+    params.atk100 = 1; params.atk200 = 1; params.atk300 = 1;
 
     if (USE_ADOULIN_WEAPON_SKILL_CHANGES == true) then
         params.str_wsc = 1.0

--- a/scripts/globals/weaponskills/gate_of_tartarus.lua
+++ b/scripts/globals/weaponskills/gate_of_tartarus.lua
@@ -27,7 +27,7 @@ function onUseWeaponSkill(player, target, wsID, tp, primary, action, taChar)
     params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
     params.canCrit = false
     params.acc100 = 0.0 params.acc200 = 0.0 params.acc300 = 0.0
-    params.atkmulti = 1
+    params.atk100 = 1; params.atk200 = 1; params.atk300 = 1;
 
     if USE_ADOULIN_WEAPON_SKILL_CHANGES then
         params.chr_wsc = 0.8

--- a/scripts/globals/weaponskills/geirskogul.lua
+++ b/scripts/globals/weaponskills/geirskogul.lua
@@ -25,7 +25,7 @@ function onUseWeaponSkill(player, target, wsID, tp, primary, action, taChar)
     params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
     params.canCrit = false
     params.acc100 = 0.0 params.acc200 = 0.0 params.acc300 = 0.0
-    params.atkmulti = 1
+    params.atk100 = 1; params.atk200 = 1; params.atk300 = 1;
 
     if USE_ADOULIN_WEAPON_SKILL_CHANGES then
         params.dex_wsc = 0.8 params.agi_wsc = 0.0

--- a/scripts/globals/weaponskills/glory_slash.lua
+++ b/scripts/globals/weaponskills/glory_slash.lua
@@ -25,7 +25,7 @@ function onUseWeaponSkill(player, target, wsID, tp, primary, action, taChar)
     params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
     params.canCrit = false
     params.acc100 = 0.0 params.acc200= 0.0 params.acc300= 0.0
-    params.atkmulti = 1
+    params.atk100 = 1; params.atk200 = 1; params.atk300 = 1;
 
     if (damage > 0 and target:hasStatusEffect(dsp.effect.STUN) == false) then
         local duration = (tp/500) * applyResistanceAddEffect(player,target,dsp.magic.ele.LIGHTNING,0)

--- a/scripts/globals/weaponskills/ground_strike.lua
+++ b/scripts/globals/weaponskills/ground_strike.lua
@@ -25,7 +25,7 @@ function onUseWeaponSkill(player, target, wsID, tp, primary, action, taChar)
     -- accuracy mods (ONLY USE FOR ACCURACY VARIES WITH TP) , should be the params.acc at those %s NOT the penalty values. Leave 0 if params.acc doesnt vary with tp.
     params.acc100 = 0 params.acc200=0 params.acc300=0
     -- attack multiplier (only some WSes use this, this varies the actual ratio value, see Tachi: Kasha) 1 is default.
-    params.atkmulti = 1.75
+    params.atk100 = 1.75; params.atk200 = 1.75; params.atk300 = 1.75;
 
     local damage, criticalHit, tpHits, extraHits = doPhysicalWeaponskill(player, target, wsID, tp, primary, action, taChar, params)
     return tpHits, extraHits, criticalHit, damage

--- a/scripts/globals/weaponskills/guillotine.lua
+++ b/scripts/globals/weaponskills/guillotine.lua
@@ -24,7 +24,7 @@ function onUseWeaponSkill(player, target, wsID, tp, primary, action, taChar)
     -- accuracy mods (ONLY USE FOR accURACY VARIES WITH TP) , should be the params.acc at those %s NOT the penalty values. Leave 0 if acc doesnt vary with tp.
     params.acc100 = 0 params.acc200=0 params.acc300=0
     -- attack multiplier (only some WSes use this, this varies the actual ratio value, see Tachi: Kasha) 1 is default.
-    params.atkmulti = 1
+    params.atk100 = 1; params.atk200 = 1; params.atk300 = 1;
 
     if (USE_ADOULIN_WEAPON_SKILL_CHANGES == true) then
         params.str_wsc = 0.3 params.mnd_wsc = 0.5

--- a/scripts/globals/weaponskills/hard_slash.lua
+++ b/scripts/globals/weaponskills/hard_slash.lua
@@ -23,7 +23,7 @@ function onUseWeaponSkill(player, target, wsID, tp, primary, action, taChar)
     -- accuracy mods (ONLY USE FOR accURACY VARIES WITH TP) , should be the acc at those %s NOT the penalty values. Leave 0 if acc doesnt vary with tp.
     params.acc100 = 0 params.acc200=0 params.acc300=0
     -- attack multiplier (only some WSes use this, this varies the actual ratio value, see Tachi: Kasha) 1 is default.
-    params.atkmulti = 1
+    params.atk100 = 1; params.atk200 = 1; params.atk300 = 1;
 
     if (USE_ADOULIN_WEAPON_SKILL_CHANGES == true) then
         params.str_wsc = 1.0

--- a/scripts/globals/weaponskills/heavy_shot.lua
+++ b/scripts/globals/weaponskills/heavy_shot.lua
@@ -24,7 +24,7 @@ function onUseWeaponSkill(player, target, wsID, tp, primary, action, taChar)
     params.crit100 = 0.1 params.crit200 = 0.3 params.crit300 = 0.5
     params.canCrit = true
     params.acc100 = 0.0 params.acc200= 0.0 params.acc300= 0.0
-    params.atkmulti = 1
+    params.atk100 = 1; params.atk200 = 1; params.atk300 = 1;
 
     if (USE_ADOULIN_WEAPON_SKILL_CHANGES == true) then
         params.agi_wsc = 0.7

--- a/scripts/globals/weaponskills/heavy_swing.lua
+++ b/scripts/globals/weaponskills/heavy_swing.lua
@@ -25,7 +25,7 @@ function onUseWeaponSkill(player, target, wsID, tp, primary, action, taChar)
     params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
     params.canCrit = false
     params.acc100 = 0.0 params.acc200= 0.0 params.acc300= 0.0
-    params.atkmulti = 1
+    params.atk100 = 1; params.atk200 = 1; params.atk300 = 1;
 
     if (USE_ADOULIN_WEAPON_SKILL_CHANGES == true) then
         params.str_wsc = 1.0

--- a/scripts/globals/weaponskills/hexa_strike.lua
+++ b/scripts/globals/weaponskills/hexa_strike.lua
@@ -25,7 +25,7 @@ function onUseWeaponSkill(player, target, wsID, tp, primary, action, taChar)
     params.crit100 = 0.1 params.crit200 = 0.3 params.crit300 = 0.5
     params.canCrit = true
     params.acc100 = 0.0 params.acc200= 0.0 params.acc300= 0.0
-    params.atkmulti = 1
+    params.atk100 = 1; params.atk200 = 1; params.atk300 = 1;
 
     if (USE_ADOULIN_WEAPON_SKILL_CHANGES == true) then
         params.ftp100 = 1.125 params.ftp200 = 1.125 params.ftp300 = 1.125

--- a/scripts/globals/weaponskills/hot_shot.lua
+++ b/scripts/globals/weaponskills/hot_shot.lua
@@ -24,7 +24,7 @@ function onUseWeaponSkill(player, target, wsID, tp, primary, action, taChar)
     params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
     params.canCrit = false
     params.acc100 = 0.0 params.acc200= 0.0 params.acc300= 0.0
-    params.atkmulti = 1
+    params.atk100 = 1; params.atk200 = 1; params.atk300 = 1;
 
     if (USE_ADOULIN_WEAPON_SKILL_CHANGES == true) then
         params.ftp200 = 1.55 params.ftp300 = 2.1

--- a/scripts/globals/weaponskills/howling_fist.lua
+++ b/scripts/globals/weaponskills/howling_fist.lua
@@ -26,7 +26,7 @@ function onUseWeaponSkill(player, target, wsID, tp, primary, action, taChar)
     params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
     params.canCrit = false
     params.acc100 = 0.0 params.acc200= 0.0 params.acc300= 0.0
-    params.atkmulti = 1
+    params.atk100 = 1; params.atk200 = 1; params.atk300 = 1;
 
     if (USE_ADOULIN_WEAPON_SKILL_CHANGES == true) then
         params.ftp200 = 4.75 params.ftp300 = 8

--- a/scripts/globals/weaponskills/impulse_drive.lua
+++ b/scripts/globals/weaponskills/impulse_drive.lua
@@ -26,7 +26,7 @@ function onUseWeaponSkill(player, target, wsID, tp, primary, action, taChar)
     params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
     params.canCrit = false
     params.acc100 = 0.0 params.acc200= 0.0 params.acc300= 0.0
-    params.atkmulti = 1
+    params.atk100 = 1; params.atk200 = 1; params.atk300 = 1;
 
     if (USE_ADOULIN_WEAPON_SKILL_CHANGES == true) then
         params.ftp200 = 3 params.ftp300 = 5.5

--- a/scripts/globals/weaponskills/insurgency.lua
+++ b/scripts/globals/weaponskills/insurgency.lua
@@ -27,7 +27,7 @@ function onUseWeaponSkill(player, target, wsID, tp, primary, action, taChar)
     params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
     params.canCrit = false
     params.acc100 = 0.0 params.acc200 = 0.0 params.acc300 = 0.0
-    params.atkmulti = 1
+    params.atk100 = 1; params.atk200 = 1; params.atk300 = 1;
 
     if USE_ADOULIN_WEAPON_SKILL_CHANGES then
         params.ftp200 = 3.25 params.ftp300 = 6

--- a/scripts/globals/weaponskills/iron_tempest.lua
+++ b/scripts/globals/weaponskills/iron_tempest.lua
@@ -25,11 +25,10 @@ function onUseWeaponSkill(player, target, wsID, tp, primary, action, taChar)
     params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
     params.canCrit = false
     params.acc100 = 0.0 params.acc200= 0.0 params.acc300= 0.0
-    params.atkmulti = 1
+    params.atk100 = 1; params.atk200 = 2; params.atk300 = 3.5;
 
     if (USE_ADOULIN_WEAPON_SKILL_CHANGES == true) then
         params.str_wsc = 0.6
-        params.atkmulti = 1.25
     end
 
 

--- a/scripts/globals/weaponskills/jishnus_radiance.lua
+++ b/scripts/globals/weaponskills/jishnus_radiance.lua
@@ -27,7 +27,7 @@ function onUseWeaponSkill(player, target, wsID, tp, primary, action, taChar)
     params.crit100 = 0.15 params.crit200 = 0.2 params.crit300 = 0.25
     params.canCrit = true
     params.acc100 = 0.0 params.acc200 = 0.0 params.acc300 = 0.0
-    params.atkmulti = 1
+    params.atk100 = 1; params.atk200 = 1; params.atk300 = 1;
     params.multiHitfTP = true
 
     if USE_ADOULIN_WEAPON_SKILL_CHANGES then

--- a/scripts/globals/weaponskills/judgment.lua
+++ b/scripts/globals/weaponskills/judgment.lua
@@ -26,7 +26,7 @@ function onUseWeaponSkill(player, target, wsID, tp, primary, action, taChar)
     params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
     params.canCrit = false
     params.acc100 = 0.0 params.acc200= 0.0 params.acc300= 0.0
-    params.atkmulti = 1
+    params.atk100 = 1; params.atk200 = 1; params.atk300 = 1;
 
     if (USE_ADOULIN_WEAPON_SKILL_CHANGES == true) then
         params.ftp100 = 3.5 params.ftp200 = 8.75 params.ftp300 = 12

--- a/scripts/globals/weaponskills/keen_edge.lua
+++ b/scripts/globals/weaponskills/keen_edge.lua
@@ -25,7 +25,7 @@ function onUseWeaponSkill(player, target, wsID, tp, primary, action, taChar)
     params.crit100 = 0.3 params.crit200 = 0.6 params.crit300 = 0.9
     params.canCrit = true
     params.acc100 = 0.0 params.acc200= 0.0 params.acc300= 0.0
-    params.atkmulti = 1
+    params.atk100 = 1; params.atk200 = 1; params.atk300 = 1;
 
     if (USE_ADOULIN_WEAPON_SKILL_CHANGES == true) then
         params.str_wsc = 1.0

--- a/scripts/globals/weaponskills/kings_justice.lua
+++ b/scripts/globals/weaponskills/kings_justice.lua
@@ -27,7 +27,7 @@ function onUseWeaponSkill(player, target, wsID, tp, primary, action, taChar)
     params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
     params.canCrit = false
     params.acc100 = 0.0 params.acc200 = 0.0 params.acc300 = 0.0
-    params.atkmulti = 1
+    params.atk100 = 1; params.atk200 = 1; params.atk300 = 1;
 
     if USE_ADOULIN_WEAPON_SKILL_CHANGES then
         params.ftp200 = 3 params.ftp300 = 5

--- a/scripts/globals/weaponskills/knights_of_round.lua
+++ b/scripts/globals/weaponskills/knights_of_round.lua
@@ -28,7 +28,7 @@ function onUseWeaponSkill(player, target, wsID, tp, primary, action, taChar)
     params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
     params.canCrit = false
     params.acc100 = 0.0 params.acc200 = 0.0 params.acc300 = 0.0
-    params.atkmulti = 1
+    params.atk100 = 1; params.atk200 = 1; params.atk300 = 1;
 
     if USE_ADOULIN_WEAPON_SKILL_CHANGES then
         params.ftp100 = 5 params.ftp200 = 5 params.ftp300 = 5

--- a/scripts/globals/weaponskills/last_stand.lua
+++ b/scripts/globals/weaponskills/last_stand.lua
@@ -31,7 +31,7 @@ function onUseWeaponSkill(player, target, wsID, tp, primary, action, taChar)
     params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
     params.canCrit = false
     params.acc100 = 0.0 params.acc200= 0.0 params.acc300= 0.0
-    params.atkmulti = 1
+    params.atk100 = 1; params.atk200 = 1; params.atk300 = 1;
     params.multiHitfTP = true
 
     if (USE_ADOULIN_WEAPON_SKILL_CHANGES == true) then

--- a/scripts/globals/weaponskills/leg_sweep.lua
+++ b/scripts/globals/weaponskills/leg_sweep.lua
@@ -25,7 +25,7 @@ function onUseWeaponSkill(player, target, wsID, tp, primary, action, taChar)
     params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
     params.canCrit = false
     params.acc100 = 0.0 params.acc200= 0.0 params.acc300= 0.0
-    params.atkmulti = 1
+    params.atk100 = 1; params.atk200 = 1; params.atk300 = 1;
 
     if (USE_ADOULIN_WEAPON_SKILL_CHANGES == true) then
         params.str_wsc = 1.0

--- a/scripts/globals/weaponskills/mandalic_stab.lua
+++ b/scripts/globals/weaponskills/mandalic_stab.lua
@@ -28,12 +28,12 @@ function onUseWeaponSkill(player, target, wsID, tp, primary, action, taChar)
     params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
     params.canCrit = false
     params.acc100 = 0.0 params.acc200 = 0.0 params.acc300 = 0.0
-    params.atkmulti = 1.66
+    params.atk100 = 1.66; params.atk200 = 1.66; params.atk300 = 1.66;
 
     if USE_ADOULIN_WEAPON_SKILL_CHANGES then
         params.ftp100 = 4 params.ftp200 = 6.09 params.ftp300 = 8.5
         params.dex_wsc = 0.6
-        params.atkmulti = 1.75
+        params.atk100 = 1.75; params.atk200 = 1.75; params.atk300 = 1.75;
     end
 
     local damage, criticalHit, tpHits, extraHits = doPhysicalWeaponskill(player, target, wsID, tp, primary, action, taChar, params)

--- a/scripts/globals/weaponskills/mercy_stroke.lua
+++ b/scripts/globals/weaponskills/mercy_stroke.lua
@@ -25,7 +25,7 @@ function onUseWeaponSkill(player, target, wsID, tp, primary, action, taChar)
     params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
     params.canCrit = false
     params.acc100 = 0.0 params.acc200 = 0.0 params.acc300 = 0.0
-    params.atkmulti = 1
+    params.atk100 = 1; params.atk200 = 1; params.atk300 = 1;
 
     if USE_ADOULIN_WEAPON_SKILL_CHANGES then
         params.ftp100 = 5 params.ftp200 = 5 params.ftp300 = 5

--- a/scripts/globals/weaponskills/metatron_torment.lua
+++ b/scripts/globals/weaponskills/metatron_torment.lua
@@ -31,7 +31,7 @@ function onUseWeaponSkill(player, target, wsID, tp, primary, action, taChar)
     params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
     params.canCrit = false
     params.acc100 = 0.0 params.acc200= 0.0 params.acc300= 0.0
-    params.atkmulti = 1
+    params.atk100 = 1; params.atk200 = 1; params.atk300 = 1;
 
     if USE_ADOULIN_WEAPON_SKILL_CHANGES then
         params.str_wsc = 0.8

--- a/scripts/globals/weaponskills/mistral_axe.lua
+++ b/scripts/globals/weaponskills/mistral_axe.lua
@@ -25,7 +25,7 @@ function onUseWeaponSkill(player, target, wsID, tp, primary, action, taChar)
     params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
     params.canCrit = false
     params.acc100 = 0.0 params.acc200= 0.0 params.acc300= 0.0
-    params.atkmulti = 1
+    params.atk100 = 1; params.atk200 = 1; params.atk300 = 1;
 
     if (USE_ADOULIN_WEAPON_SKILL_CHANGES == true) then
         params.ftp100 = 4 params.ftp200 = 10.5 params.ftp300 = 13.625

--- a/scripts/globals/weaponskills/mordant_rime.lua
+++ b/scripts/globals/weaponskills/mordant_rime.lua
@@ -27,7 +27,7 @@ function onUseWeaponSkill(player, target, wsID, tp, primary, action, taChar)
     params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
     params.canCrit = false
     params.acc100 = 0.0 params.acc200 = 0.0 params.acc300 = 0.0
-    params.atkmulti = 1
+    params.atk100 = 1; params.atk200 = 1; params.atk300 = 1;
 
     if USE_ADOULIN_WEAPON_SKILL_CHANGES then
         params.ftp100 = 5 params.ftp200 = 5 params.ftp300 = 5
@@ -42,7 +42,7 @@ function onUseWeaponSkill(player, target, wsID, tp, primary, action, taChar)
                 target:addStatusEffect(dsp.effect.WEIGHT, 50, 0, 60)
             end
         end
-        
+
         -- Apply aftermath
         dsp.aftermath.addStatusEffect(player, tp, dsp.slot.MAIN, dsp.aftermath.type.MYTHIC)
     end

--- a/scripts/globals/weaponskills/mystic_boon.lua
+++ b/scripts/globals/weaponskills/mystic_boon.lua
@@ -26,7 +26,7 @@ function onUseWeaponSkill(player, target, wsID, tp, primary, action, taChar)
     params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
     params.canCrit = false
     params.acc100 = 0.0 params.acc200 = 0.0 params.acc300 = 0.0
-    params.atkmulti = 1
+    params.atk100 = 1; params.atk200 = 1; params.atk300 = 1;
 
     if USE_ADOULIN_WEAPON_SKILL_CHANGES then
         params.ftp100 = 2.5 params.ftp200 = 4 params.ftp300 = 7

--- a/scripts/globals/weaponskills/namas_arrow.lua
+++ b/scripts/globals/weaponskills/namas_arrow.lua
@@ -27,7 +27,7 @@ function onUseWeaponSkill(player, target, wsID, tp, primary, action, taChar)
     params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
     params.canCrit = false
     params.acc100 = 0.0 params.acc200 = 0.0 params.acc300 = 0.0
-    params.atkmulti = 1
+    params.atk100 = 1; params.atk200 = 1; params.atk300 = 1;
     params.overrideCE = 160
     params.overrideVE = 480
 

--- a/scripts/globals/weaponskills/nightmare_scythe.lua
+++ b/scripts/globals/weaponskills/nightmare_scythe.lua
@@ -25,7 +25,7 @@ function onUseWeaponSkill(player, target, wsID, tp, primary, action, taChar)
     params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
     params.canCrit = false
     params.acc100 = 0.0 params.acc200= 0.0 params.acc300= 0.0
-    params.atkmulti = 1
+    params.atk100 = 1; params.atk200 = 1; params.atk300 = 1;
 
     if (USE_ADOULIN_WEAPON_SKILL_CHANGES == true) then
         params.str_wsc = 0.6 params.mnd_wsc = 0.6

--- a/scripts/globals/weaponskills/numbing_shot.lua
+++ b/scripts/globals/weaponskills/numbing_shot.lua
@@ -24,7 +24,7 @@ function onUseWeaponSkill(player, target, wsID, tp, primary, action, taChar)
     params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
     params.canCrit = false
     params.acc100 = 0.0 params.acc200= 0.0 params.acc300= 0.0
-    params.atkmulti = 1
+    params.atk100 = 1; params.atk200 = 1; params.atk300 = 1;
 
     if (USE_ADOULIN_WEAPON_SKILL_CHANGES == true) then
         params.agi_wsc = 0.8

--- a/scripts/globals/weaponskills/one_inch_punch.lua
+++ b/scripts/globals/weaponskills/one_inch_punch.lua
@@ -24,7 +24,7 @@ function onUseWeaponSkill(player, target, wsID, tp, primary, action, taChar)
     params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
     params.canCrit = false
     params.acc100 = 0.0 params.acc200= 0.0 params.acc300= 0.0
-    params.atkmulti = 1
+    params.atk100 = 1; params.atk200 = 1; params.atk300 = 1;
     -- Defense ignored is 0%, 25%, 50% as per http://www.bg-wiki.com/bg/One_Inch_Punch
     params.ignoresDef = true
     params.ignored100 = 0

--- a/scripts/globals/weaponskills/onslaught.lua
+++ b/scripts/globals/weaponskills/onslaught.lua
@@ -28,7 +28,7 @@ function onUseWeaponSkill(player, target, wsID, tp, primary, action, taChar)
     params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
     params.canCrit = false
     params.acc100 = 0.0 params.acc200 = 0.0 params.acc300 = 0.0
-    params.atkmulti = 1
+    params.atk100 = 1; params.atk200 = 1; params.atk300 = 1;
 
     if USE_ADOULIN_WEAPON_SKILL_CHANGES then
         params.dex_wsc = 0.8

--- a/scripts/globals/weaponskills/penta_thrust.lua
+++ b/scripts/globals/weaponskills/penta_thrust.lua
@@ -26,7 +26,7 @@ function onUseWeaponSkill(player, target, wsID, tp, primary, action, taChar)
     params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
     params.canCrit = false
     params.acc100 = 0.8 params.acc200= 0.9 params.acc300= 1
-    params.atkmulti = 0.875
+    params.atk100 = 0.875; params.atk200 = 0.875; params.atk300 = 0.875;
     local damage, criticalHit, tpHits, extraHits = doPhysicalWeaponskill(player, target, wsID, tp, primary, action, taChar, params)
     return tpHits, extraHits, criticalHit, damage
 

--- a/scripts/globals/weaponskills/piercing_arrow.lua
+++ b/scripts/globals/weaponskills/piercing_arrow.lua
@@ -26,7 +26,7 @@ function onUseWeaponSkill(player, target, wsID, tp, primary, action, taChar)
     params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
     params.canCrit = false
     params.acc100 = 0.0 params.acc200= 0.0 params.acc300= 0.0
-    params.atkmulti = 1
+    params.atk100 = 1; params.atk200 = 1; params.atk300 = 1;
     -- Defense ignored is 0%, 35%, 50% as per wiki.bluegartr.com
     params.ignoresDef = true
     params.ignored100 = 0

--- a/scripts/globals/weaponskills/power_slash.lua
+++ b/scripts/globals/weaponskills/power_slash.lua
@@ -26,7 +26,7 @@ function onUseWeaponSkill(player, target, wsID, tp, primary, action, taChar)
     -- accuracy mods (ONLY USE FOR ACCURACY VARIES WITH TP) , should be the acc at those %s NOT the penalty values. Leave 0 if acc doesnt vary with tp.
     params.acc100 = 0 params.acc200=0 params.acc300=0
     -- attack multiplier (only some WSes use this, this varies the actual ratio value, see Tachi: Kasha) 1 is default.
-    params.atkmulti = 1
+    params.atk100 = 1; params.atk200 = 1; params.atk300 = 1;
 
     if (USE_ADOULIN_WEAPON_SKILL_CHANGES == true) then
         params.str_wsc = 0.6 params.vit_wsc = 0.6

--- a/scripts/globals/weaponskills/pyrrhic_kleos.lua
+++ b/scripts/globals/weaponskills/pyrrhic_kleos.lua
@@ -28,7 +28,7 @@ function onUseWeaponSkill(player, target, wsID, tp, primary, action, taChar)
     params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
     params.canCrit = false
     params.acc100 = 0.0 params.acc200 = 0.0 params.acc300 = 0.0
-    params.atkmulti = 1
+    params.atk100 = 1; params.atk200 = 1; params.atk300 = 1;
 
     if USE_ADOULIN_WEAPON_SKILL_CHANGES then
         params.ftp100 = 1.75 params.ftp200 = 1.75 params.ftp300 = 1.75

--- a/scripts/globals/weaponskills/quietus.lua
+++ b/scripts/globals/weaponskills/quietus.lua
@@ -25,7 +25,7 @@ function onUseWeaponSkill(player, target, wsID, tp, primary, action, taChar)
     params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
     params.canCrit = false
     params.acc100 = 0.0 params.acc200 = 0.0 params.acc300 = 0.0
-    params.atkmulti = 1
+    params.atk100 = 1; params.atk200 = 1; params.atk300 = 1;
     params.ignoresDef = true
     params.ignored100 = 0.1
     params.ignored200 = 0.3

--- a/scripts/globals/weaponskills/raging_axe.lua
+++ b/scripts/globals/weaponskills/raging_axe.lua
@@ -26,7 +26,7 @@ function onUseWeaponSkill(player, target, wsID, tp, primary, action, taChar)
     params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
     params.canCrit = false
     params.acc100 = 0.0 params.acc200= 0.0 params.acc300= 0.0
-    params.atkmulti = 1
+    params.atk100 = 1; params.atk200 = 1; params.atk300 = 1;
 
     if (USE_ADOULIN_WEAPON_SKILL_CHANGES == true) then
         params.str_wsc = 0.6

--- a/scripts/globals/weaponskills/raging_fists.lua
+++ b/scripts/globals/weaponskills/raging_fists.lua
@@ -25,7 +25,7 @@ function onUseWeaponSkill(player, target, wsID, tp, primary, action, taChar)
     params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
     params.canCrit = false
     params.acc100 = 0.0 params.acc200= 0.0 params.acc300= 0.0
-    params.atkmulti = 1
+    params.atk100 = 1; params.atk200 = 1; params.atk300 = 1;
 
     if (USE_ADOULIN_WEAPON_SKILL_CHANGES == true) then
         params.ftp200 = 4.6 params.ftp300 = 9

--- a/scripts/globals/weaponskills/raging_rush.lua
+++ b/scripts/globals/weaponskills/raging_rush.lua
@@ -25,7 +25,7 @@ function onUseWeaponSkill(player, target, wsID, tp, primary, action, taChar)
     params.crit100 = 0.1 params.crit200 = 0.3 params.crit300 = 0.5
     params.canCrit = true
     params.acc100 = 0.0 params.acc200= 0.0 params.acc300= 0.0
-    params.atkmulti = 1
+    params.atk100 = 1; params.atk200 = 1; params.atk300 = 1;
 
     if (USE_ADOULIN_WEAPON_SKILL_CHANGES == true) then
         params.crit100 = 0.15

--- a/scripts/globals/weaponskills/rampage.lua
+++ b/scripts/globals/weaponskills/rampage.lua
@@ -25,7 +25,7 @@ function onUseWeaponSkill(player, target, wsID, tp, primary, action, taChar)
     params.crit100 = 0.10 params.crit200 = 0.30 params.crit300 = 0.50
     params.canCrit = true
     params.acc100 = 0.0 params.acc200= 0.0 params.acc300= 0.0
-    params.atkmulti = 1
+    params.atk100 = 1; params.atk200 = 1; params.atk300 = 1;
 
     if (USE_ADOULIN_WEAPON_SKILL_CHANGES == true) then
         params.ftp100 = 1 params.ftp200 = 1 params.ftp300 = 1

--- a/scripts/globals/weaponskills/randgrith.lua
+++ b/scripts/globals/weaponskills/randgrith.lua
@@ -29,7 +29,7 @@ function onUseWeaponSkill(player, target, wsID, tp, primary, action, taChar)
     params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
     params.canCrit = false
     params.acc100 = 0.0 params.acc200 = 0.0 params.acc300 = 0.0
-    params.atkmulti = 1
+    params.atk100 = 1; params.atk200 = 1; params.atk300 = 1;
 
     local damage, criticalHit, tpHits, extraHits = doPhysicalWeaponskill(player, target, wsID, tp, primary, action, taChar, params)
 

--- a/scripts/globals/weaponskills/realmrazer.lua
+++ b/scripts/globals/weaponskills/realmrazer.lua
@@ -25,7 +25,7 @@ function onUseWeaponSkill(player, target, wsID, tp, primary, action, taChar)
     params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
     params.canCrit = false
     params.acc100 = 0.8 params.acc200= 0.9 params.acc300= 1
-    params.atkmulti = 1
+    params.atk100 = 1; params.atk200 = 1; params.atk300 = 1;
 
     if (USE_ADOULIN_WEAPON_SKILL_CHANGES == true) then
         params.mnd_wsc = 0.7 + (player:getMerit(dsp.merit.REALMRAZER) / 100)

--- a/scripts/globals/weaponskills/refulgent_arrow.lua
+++ b/scripts/globals/weaponskills/refulgent_arrow.lua
@@ -24,7 +24,7 @@ function onUseWeaponSkill(player, target, wsID, tp, primary, action, taChar)
     params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
     params.canCrit = false
     params.acc100 = 0.0 params.acc200= 0.0 params.acc300= 0.0
-    params.atkmulti = 1
+    params.atk100 = 1; params.atk200 = 1; params.atk300 = 1;
 
     if (USE_ADOULIN_WEAPON_SKILL_CHANGES == true) then
         params.ftp100 = 3 params.ftp200 = 4.25 params.ftp300 = 7

--- a/scripts/globals/weaponskills/requiescat.lua
+++ b/scripts/globals/weaponskills/requiescat.lua
@@ -22,7 +22,7 @@ function onUseWeaponSkill(player, target, wsID, tp, primary, action, taChar)
     params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
     params.canCrit = false
     params.acc100 = 0.0 params.acc200= 0.0 params.acc300= 0.0
-    params.atkmulti = 0.7 + tp/10000
+    params.atk100 = 0.7; params.atk200 = 0.7; params.atk300 = 0.7; + tp/10000
 
     if (USE_ADOULIN_WEAPON_SKILL_CHANGES == true) then
         params.mnd_wsc = 0.7 + (player:getMerit(dsp.merit.REQUIESCAT) / 100)

--- a/scripts/globals/weaponskills/requiescat.lua
+++ b/scripts/globals/weaponskills/requiescat.lua
@@ -22,7 +22,7 @@ function onUseWeaponSkill(player, target, wsID, tp, primary, action, taChar)
     params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
     params.canCrit = false
     params.acc100 = 0.0 params.acc200= 0.0 params.acc300= 0.0
-    params.atk100 = 0.7; params.atk200 = 0.7; params.atk300 = 0.7; + tp/10000
+    params.atk100 = 0.8; params.atk200 = 0.9; params.atk300 = 1.0;
 
     if (USE_ADOULIN_WEAPON_SKILL_CHANGES == true) then
         params.mnd_wsc = 0.7 + (player:getMerit(dsp.merit.REQUIESCAT) / 100)

--- a/scripts/globals/weaponskills/resolution.lua
+++ b/scripts/globals/weaponskills/resolution.lua
@@ -27,7 +27,7 @@ function onUseWeaponSkill(player, target, wsID, tp, primary, action, taChar)
     params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
     params.canCrit = false
     params.acc100 = 0.0 params.acc200= 0.0 params.acc300= 0.0
-    params.atkmulti = 0.85
+    params.atk100 = 0.85; params.atk200 = 0.85; params.atk300 = 0.85;
     params.multiHitfTP = true
 
     if (USE_ADOULIN_WEAPON_SKILL_CHANGES == true) then

--- a/scripts/globals/weaponskills/retribution.lua
+++ b/scripts/globals/weaponskills/retribution.lua
@@ -28,10 +28,10 @@ function onUseWeaponSkill(player, target, wsID, tp, primary, action, taChar)
     params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
     params.canCrit = false
     params.acc100 = 0.0 params.acc200= 0.0 params.acc300= 0.0
-    params.atkmulti = 1
+    params.atk100 = 1; params.atk200 = 1; params.atk300 = 1;
 
     if (USE_ADOULIN_WEAPON_SKILL_CHANGES == true) then
-        params.atkmulti = 1.5
+        params.atk100 = 1.5; params.atk200 = 1.5; params.atk300 = 1.5;
     end
 
     local damage, criticalHit, tpHits, extraHits = doPhysicalWeaponskill(player, target, wsID, tp, primary, action, taChar, params)

--- a/scripts/globals/weaponskills/rudras_storm.lua
+++ b/scripts/globals/weaponskills/rudras_storm.lua
@@ -24,7 +24,7 @@ function onUseWeaponSkill(player, target, wsID, tp, primary, action, taChar)
     params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
     params.canCrit = false
     params.acc100 = 0.0 params.acc200 = 0.0 params.acc300 = 0.0
-    params.atkmulti = 1
+    params.atk100 = 1; params.atk200 = 1; params.atk300 = 1;
 
     if USE_ADOULIN_WEAPON_SKILL_CHANGES then
         params.ftp100 = 5 params.ftp200 = 10.19 params.ftp300 = 13

--- a/scripts/globals/weaponskills/ruinator.lua
+++ b/scripts/globals/weaponskills/ruinator.lua
@@ -26,7 +26,7 @@ function onUseWeaponSkill(player, target, wsID, tp, primary, action, taChar)
     params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
     params.canCrit = false
     params.acc100 = 0.8 params.acc200= 0.9 params.acc300= 1.0
-    params.atkmulti = 1.1
+    params.atk100 = 1.1; params.atk200 = 1.1; params.atk300 = 1.1;
 
     if (USE_ADOULIN_WEAPON_SKILL_CHANGES == true) then
         params.str_wsc = 0.7 + (player:getMerit(dsp.merit.RUINATOR) / 100)

--- a/scripts/globals/weaponskills/savage_blade.lua
+++ b/scripts/globals/weaponskills/savage_blade.lua
@@ -26,7 +26,7 @@ function onUseWeaponSkill(player, target, wsID, tp, primary, action, taChar)
     params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
     params.canCrit = false
     params.acc100 = 0.0 params.acc200= 0.0 params.acc300= 0.0
-    params.atkmulti = 1
+    params.atk100 = 1; params.atk200 = 1; params.atk300 = 1;
 
     if (USE_ADOULIN_WEAPON_SKILL_CHANGES == true) then
         params.ftp100 = 4 params.ftp200 = 10.25 params.ftp300 = 13.75

--- a/scripts/globals/weaponskills/scourge.lua
+++ b/scripts/globals/weaponskills/scourge.lua
@@ -26,7 +26,7 @@ function onUseWeaponSkill(player, target, wsID, tp, primary, action, taChar)
     params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
     params.canCrit = false
     params.acc100 = 0.0 params.acc200 = 0.0 params.acc300 = 0.0
-    params.atkmulti = 1
+    params.atk100 = 1; params.atk200 = 1; params.atk300 = 1;
 
     if USE_ADOULIN_WEAPON_SKILL_CHANGES then
         params.str_wsc = 0.4 params.vit_wsc = 0.4 params.mnd_wsc = 0.0 params.chr_wsc = 0.0

--- a/scripts/globals/weaponskills/shadowstitch.lua
+++ b/scripts/globals/weaponskills/shadowstitch.lua
@@ -25,7 +25,7 @@ function onUseWeaponSkill(player, target, wsID, tp, primary, action, taChar)
     params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
     params.canCrit = false
     params.acc100 = 0.0 params.acc200= 0.0 params.acc300= 0.0
-    params.atkmulti = 1
+    params.atk100 = 1; params.atk200 = 1; params.atk300 = 1;
 
     if (USE_ADOULIN_WEAPON_SKILL_CHANGES == true) then
         params.chr_wsc = 1.0

--- a/scripts/globals/weaponskills/shark_bite.lua
+++ b/scripts/globals/weaponskills/shark_bite.lua
@@ -26,7 +26,7 @@ function onUseWeaponSkill(player, target, wsID, tp, primary, action, taChar)
     params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
     params.canCrit = false
     params.acc100 = 0.0 params.acc200= 0.0 params.acc300= 0.0
-    params.atkmulti = 1
+    params.atk100 = 1; params.atk200 = 1; params.atk300 = 1;
 
     if (USE_ADOULIN_WEAPON_SKILL_CHANGES == true) then
         params.ftp100 = 4.5 params.ftp200 = 6.8 params.ftp300 = 8.5

--- a/scripts/globals/weaponskills/shattersoul.lua
+++ b/scripts/globals/weaponskills/shattersoul.lua
@@ -30,7 +30,7 @@ function onUseWeaponSkill(player, target, wsID, tp, primary, action, taChar)
     params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
     params.canCrit = false
     params.acc100 = 0.0 params.acc200= 0.0 params.acc300= 0.0
-    params.atkmulti = 1
+    params.atk100 = 1; params.atk200 = 1; params.atk300 = 1;
 
     if (USE_ADOULIN_WEAPON_SKILL_CHANGES == true) then
         params.int_wsc = 0.7 + (player:getMerit(dsp.merit.SHATTERSOUL) / 100)

--- a/scripts/globals/weaponskills/shell_crusher.lua
+++ b/scripts/globals/weaponskills/shell_crusher.lua
@@ -26,7 +26,7 @@ function onUseWeaponSkill(player, target, wsID, tp, primary, action, taChar)
     params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
     params.canCrit = false
     params.acc100 = 0.0 params.acc200= 0.0 params.acc300= 0.0
-    params.atkmulti = 1
+    params.atk100 = 1; params.atk200 = 1; params.atk300 = 1;
 
     if (USE_ADOULIN_WEAPON_SKILL_CHANGES == true) then
         params.str_wsc = 1.0

--- a/scripts/globals/weaponskills/shield_break.lua
+++ b/scripts/globals/weaponskills/shield_break.lua
@@ -28,7 +28,7 @@ function onUseWeaponSkill(player, target, wsID, tp, primary, action, taChar)
     params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
     params.canCrit = false
     params.acc100 = 0.0 params.acc200= 0.0 params.acc300= 0.0
-    params.atkmulti = 1
+    params.atk100 = 1; params.atk200 = 1; params.atk300 = 1;
 
     if (USE_ADOULIN_WEAPON_SKILL_CHANGES == true) then
         params.str_wsc = 0.6 params.vit_wsc = 0.6

--- a/scripts/globals/weaponskills/shijin_spiral.lua
+++ b/scripts/globals/weaponskills/shijin_spiral.lua
@@ -25,7 +25,7 @@ function onUseWeaponSkill(player, target, wsID, tp, primary, action, taChar)
     params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
     params.canCrit = false
     params.acc100 = 0.0 params.acc200= 0.0 params.acc300= 0.0
-    params.atkmulti = 1.05
+    params.atk100 = 1.05; params.atk200 = 1.05; params.atk300 = 1.05;
     local damage, criticalHit, tpHits, extraHits = doPhysicalWeaponskill(player, target, wsID, tp, primary, action, taChar, params)
 
     if (USE_ADOULIN_WEAPON_SKILL_CHANGES == true) then

--- a/scripts/globals/weaponskills/shockwave.lua
+++ b/scripts/globals/weaponskills/shockwave.lua
@@ -24,7 +24,7 @@ function onUseWeaponSkill(player, target, wsID, tp, primary, action, taChar)
     params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
     params.canCrit = false
     params.acc100 = 0.0 params.acc200= 0.0 params.acc300= 0.0
-    params.atkmulti = 1
+    params.atk100 = 1; params.atk200 = 1; params.atk300 = 1;
     local damage, criticalHit, tpHits, extraHits = doPhysicalWeaponskill(player, target, wsID, tp, primary, action, taChar, params)
 
     if (damage > 0 and target:hasStatusEffect(dsp.effect.SLEEP_I) == false) then

--- a/scripts/globals/weaponskills/shoulder_tackle.lua
+++ b/scripts/globals/weaponskills/shoulder_tackle.lua
@@ -25,7 +25,7 @@ function onUseWeaponSkill(player, target, wsID, tp, primary, action, taChar)
     params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
     params.canCrit = false
     params.acc100 = 0.0 params.acc200= 0.0 params.acc300= 0.0
-    params.atkmulti = 1
+    params.atk100 = 1; params.atk200 = 1; params.atk300 = 1;
     local damage, criticalHit, tpHits, extraHits = doPhysicalWeaponskill(player, target, wsID, tp, primary, action, taChar, params)
 
     if (USE_ADOULIN_WEAPON_SKILL_CHANGES == true) then

--- a/scripts/globals/weaponskills/sickle_moon.lua
+++ b/scripts/globals/weaponskills/sickle_moon.lua
@@ -25,7 +25,7 @@ function onUseWeaponSkill(player, target, wsID, tp, primary, action, taChar)
     -- accuracy mods (ONLY USE FOR ACCURACY VARIES WITH TP) , should be the acc at those %s NOT the penalty values. Leave 0 if acc doesnt vary with tp.
     params.acc100 = 0 params.acc200=0 params.acc300=0
     -- attack multiplier (only some WSes use this, this varies the actual ratio value, see Tachi: Kasha) 1 is default.
-    params.atkmulti = 1
+    params.atk100 = 1; params.atk200 = 1; params.atk300 = 1;
 
     if (USE_ADOULIN_WEAPON_SKILL_CHANGES == true) then
         params.str_wsc = 0.4 params.agi_wsc = 0.4

--- a/scripts/globals/weaponskills/sidewinder.lua
+++ b/scripts/globals/weaponskills/sidewinder.lua
@@ -24,7 +24,7 @@ function onUseWeaponSkill(player, target, wsID, tp, primary, action, taChar)
     params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
     params.canCrit = false
     params.acc100 = 0.8 params.acc200= 0.9 params.acc300= 1
-    params.atkmulti = 1
+    params.atk100 = 1; params.atk200 = 1; params.atk300 = 1;
 
     if (USE_ADOULIN_WEAPON_SKILL_CHANGES == true) then
         params.str_wsc = 0.2 params.agi_wsc = 0.5

--- a/scripts/globals/weaponskills/skewer.lua
+++ b/scripts/globals/weaponskills/skewer.lua
@@ -25,7 +25,7 @@ function onUseWeaponSkill(player, target, wsID, tp, primary, action, taChar)
     params.crit100 = 0.1 params.crit200 = 0.3 params.crit300 = 0.5
     params.canCrit = true
     params.acc100 = 0.0 params.acc200= 0.0 params.acc300= 0.0
-    params.atkmulti = 1
+    params.atk100 = 1; params.atk200 = 1; params.atk300 = 1;
 
     if (USE_ADOULIN_WEAPON_SKILL_CHANGES == true) then
         params.str_wsc = 0.5

--- a/scripts/globals/weaponskills/skullbreaker.lua
+++ b/scripts/globals/weaponskills/skullbreaker.lua
@@ -25,7 +25,7 @@ function onUseWeaponSkill(player, target, wsID, tp, primary, action, taChar)
     params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
     params.canCrit = false
     params.acc100 = 0.0 params.acc200= 0.0 params.acc300= 0.0
-    params.atkmulti = 1
+    params.atk100 = 1; params.atk200 = 1; params.atk300 = 1;
     local damage, criticalHit, tpHits, extraHits = doPhysicalWeaponskill(player, target, wsID, tp, primary, action, taChar, params)
 
     if (USE_ADOULIN_WEAPON_SKILL_CHANGES == true) then

--- a/scripts/globals/weaponskills/slice.lua
+++ b/scripts/globals/weaponskills/slice.lua
@@ -26,7 +26,7 @@ function onUseWeaponSkill(player, target, wsID, tp, primary, action, taChar)
     -- accuracy mods (ONLY USE FOR ACCURACY VARIES WITH TP) , should be the acc at those %s NOT the penalty values. Leave 0 if acc doesnt vary with tp.
     params.acc100 = 0 params.acc200=0 params.acc300=0
     -- attack multiplier (only some WSes use this, this varies the actual ratio value, see Tachi: Kasha) 1 is default.
-    params.atkmulti = 1
+    params.atk100 = 1; params.atk200 = 1; params.atk300 = 1;
 
     if (USE_ADOULIN_WEAPON_SKILL_CHANGES == true) then
         params.str_wsc = 1.0

--- a/scripts/globals/weaponskills/slug_shot.lua
+++ b/scripts/globals/weaponskills/slug_shot.lua
@@ -25,7 +25,7 @@ function onUseWeaponSkill(player, target, wsID, tp, primary, action, taChar)
     params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
     params.canCrit = false
     params.acc100 = 0.8 params.acc200= 0.9 params.acc300= 1
-    params.atkmulti = 1
+    params.atk100 = 1; params.atk200 = 1; params.atk300 = 1;
 
     if (USE_ADOULIN_WEAPON_SKILL_CHANGES == true) then
         params.agi_wsc = 0.7

--- a/scripts/globals/weaponskills/smash_axe.lua
+++ b/scripts/globals/weaponskills/smash_axe.lua
@@ -25,7 +25,7 @@ function onUseWeaponSkill(player, target, wsID, tp, primary, action, taChar)
     params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
     params.canCrit = false
     params.acc100 = 0.0 params.acc200= 0.0 params.acc300= 0.0
-    params.atkmulti = 1
+    params.atk100 = 1; params.atk200 = 1; params.atk300 = 1;
 
     if (USE_ADOULIN_WEAPON_SKILL_CHANGES == true) then
         params.str_wsc = 1.0

--- a/scripts/globals/weaponskills/sniper_shot.lua
+++ b/scripts/globals/weaponskills/sniper_shot.lua
@@ -24,7 +24,7 @@ function onUseWeaponSkill(player, target, wsID, tp, primary, action, taChar)
     params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
     params.canCrit = false
     params.acc100 = 0.0 params.acc200= 0.0 params.acc300= 0.0
-    params.atkmulti = 1
+    params.atk100 = 1; params.atk200 = 1; params.atk300 = 1;
 
     if (USE_ADOULIN_WEAPON_SKILL_CHANGES == true) then
         params.agi_wsc = 0.7

--- a/scripts/globals/weaponskills/sonic_thrust.lua
+++ b/scripts/globals/weaponskills/sonic_thrust.lua
@@ -23,7 +23,7 @@ function onUseWeaponSkill(player, target, wsID, tp, primary, action, taChar)
     params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
     params.canCrit = false
     params.acc100 = 0.0 params.acc200= 0.0 params.acc300= 0.0
-    params.atkmulti = 1
+    params.atk100 = 1; params.atk200 = 1; params.atk300 = 1;
 
     if (USE_ADOULIN_WEAPON_SKILL_CHANGES == true) then
         params.ftp200 = 3.7 params.ftp300 = 4.5

--- a/scripts/globals/weaponskills/spinning_attack.lua
+++ b/scripts/globals/weaponskills/spinning_attack.lua
@@ -25,7 +25,7 @@ function onUseWeaponSkill(player, target, wsID, tp, primary, action, taChar)
     params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
     params.canCrit = false
     params.acc100 = 0.0 params.acc200= 0.0 params.acc300= 0.0
-    params.atkmulti = 1
+    params.atk100 = 1; params.atk200 = 1; params.atk300 = 1;
 
     if (USE_ADOULIN_WEAPON_SKILL_CHANGES == true) then
         params.str_wsc = 1.0

--- a/scripts/globals/weaponskills/spinning_axe.lua
+++ b/scripts/globals/weaponskills/spinning_axe.lua
@@ -25,7 +25,7 @@ function onUseWeaponSkill(player, target, wsID, tp, primary, action, taChar)
     params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
     params.canCrit = false
     params.acc100 = 0.0 params.acc200= 0.0 params.acc300= 0.0
-    params.atkmulti = 1
+    params.atk100 = 1; params.atk200 = 1; params.atk300 = 1;
 
     if (USE_ADOULIN_WEAPON_SKILL_CHANGES == true) then
         params.str_wsc = 0.6

--- a/scripts/globals/weaponskills/spinning_scythe.lua
+++ b/scripts/globals/weaponskills/spinning_scythe.lua
@@ -25,7 +25,7 @@ function onUseWeaponSkill(player, target, wsID, tp, primary, action, taChar)
     params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
     params.canCrit = false
     params.acc100 = 0.0 params.acc200= 0.0 params.acc300= 0.0
-    params.atkmulti = 1
+    params.atk100 = 1; params.atk200 = 1; params.atk300 = 1;
 
     if (USE_ADOULIN_WEAPON_SKILL_CHANGES == true) then
         params.str_wsc = 0.6 params.mnd_wsc = 0.6

--- a/scripts/globals/weaponskills/spinning_slash.lua
+++ b/scripts/globals/weaponskills/spinning_slash.lua
@@ -25,7 +25,7 @@ function onUseWeaponSkill(player, target, wsID, tp, primary, action, taChar)
     -- params.accuracy mods (ONLY USE FOR accURACY VARIES WITH TP) , should be the acc at those %s NOT the penalty values. Leave 0 if acc doesnt vary with tp.
     params.acc100 = 0 params.acc200=0 params.acc300=0
     -- attack multiplier (only some WSes use this, this varies the actual ratio value, see Tachi: Kasha) 1 is default.
-    params.atkmulti = 1.5
+    params.atk100 = 1.5; params.atk200 = 1.5; params.atk300 = 1.5;
 
     local damage, criticalHit, tpHits, extraHits = doPhysicalWeaponskill(player, target, wsID, tp, primary, action, taChar, params)
     return tpHits, extraHits, criticalHit, damage

--- a/scripts/globals/weaponskills/spiral_hell.lua
+++ b/scripts/globals/weaponskills/spiral_hell.lua
@@ -25,7 +25,7 @@ function onUseWeaponSkill(player, target, wsID, tp, primary, action, taChar)
     -- accuracy mods (ONLY USE FOR accURACY VARIES WITH TP) , should be the acc at those %s NOT the penalty values. Leave 0 if acc doesnt vary with tp.
     params.acc100 = 0 params.acc200=0 params.acc300=0
     -- attack multiplier (only some WSes use this, this varies the actual ratio value, see Tachi: Kasha) 1 is default.
-    params.atkmulti = 1
+    params.atk100 = 1; params.atk200 = 1; params.atk300 = 1;
 
     if (USE_ADOULIN_WEAPON_SKILL_CHANGES == true) then
         params.ftp200 = 2.75 params.ftp300 = 4.75

--- a/scripts/globals/weaponskills/spirit_taker.lua
+++ b/scripts/globals/weaponskills/spirit_taker.lua
@@ -25,7 +25,7 @@ function onUseWeaponSkill(player, target, wsID, tp, primary, action, taChar)
     params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
     params.canCrit = false
     params.acc100 = 0.0 params.acc200= 0.0 params.acc300= 0.0
-    params.atkmulti = 1
+    params.atk100 = 1; params.atk200 = 1; params.atk300 = 1;
     local damage, criticalHit, tpHits, extraHits = doPhysicalWeaponskill(player, target, wsID, tp, primary, action, taChar, params)
     player:addMP(damage)
     return tpHits, extraHits, criticalHit, damage

--- a/scripts/globals/weaponskills/split_shot.lua
+++ b/scripts/globals/weaponskills/split_shot.lua
@@ -25,7 +25,7 @@ function onUseWeaponSkill(player, target, wsID, tp, primary, action, taChar)
     params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
     params.canCrit = false
     params.acc100 = 0.0 params.acc200= 0.0 params.acc300= 0.0
-    params.atkmulti = 1
+    params.atk100 = 1; params.atk200 = 1; params.atk300 = 1;
 
     if (USE_ADOULIN_WEAPON_SKILL_CHANGES == true) then
         params.agi_wsc = 0.7

--- a/scripts/globals/weaponskills/stardiver.lua
+++ b/scripts/globals/weaponskills/stardiver.lua
@@ -23,7 +23,7 @@ function onUseWeaponSkill(player, target, wsID, tp, primary, action, taChar)
     params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
     params.canCrit = false
     params.acc100 = 0.0 params.acc200= 0.0 params.acc300= 0.0
-    params.atkmulti = 1
+    params.atk100 = 1; params.atk200 = 1; params.atk300 = 1;
 
     if (USE_ADOULIN_WEAPON_SKILL_CHANGES == true) then
         params.str_wsc = 0.7 + (player:getMerit(dsp.merit.STARDIVER) / 100)

--- a/scripts/globals/weaponskills/steel_cyclone.lua
+++ b/scripts/globals/weaponskills/steel_cyclone.lua
@@ -26,12 +26,12 @@ function onUseWeaponSkill(player, target, wsID, tp, primary, action, taChar)
     params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
     params.canCrit = false
     params.acc100 = 0.0 params.acc200= 0.0 params.acc300= 0.0
-    params.atkmulti = 1.66
+    params.atk100 = 1.66; params.atk200 = 1.66; params.atk300 = 1.66;
 
     if (USE_ADOULIN_WEAPON_SKILL_CHANGES == true) then
         params.ftp200 = 2.5 params.ftp300 = 4
         params.str_wsc = 0.6 params.vit_wsc = 0.6
-        params.atkmulti = 1.5
+        params.atk100 = 1.5; params.atk200 = 1.5; params.atk300 = 1.5;
     end
 
     local damage, criticalHit, tpHits, extraHits = doPhysicalWeaponskill(player, target, wsID, tp, primary, action, taChar, params)

--- a/scripts/globals/weaponskills/stringing_pummel.lua
+++ b/scripts/globals/weaponskills/stringing_pummel.lua
@@ -26,7 +26,7 @@ function onUseWeaponSkill(player, target, wsID, tp, primary, action, taChar)
     params.crit100 = 0.15 params.crit200 = 0.45 params.crit300 = 0.65
     params.canCrit = true
     params.acc100 = 0.0 params.acc200 = 0.0 params.acc300 = 0.0
-    params.atkmulti = 1
+    params.atk100 = 1; params.atk200 = 1; params.atk300 = 1;
 
     if USE_ADOULIN_WEAPON_SKILL_CHANGES then
         params.crit100 = 0.15 params.crit200 = 0.3 params.crit300 = 0.45

--- a/scripts/globals/weaponskills/sturmwind.lua
+++ b/scripts/globals/weaponskills/sturmwind.lua
@@ -25,7 +25,6 @@ function onUseWeaponSkill(player, target, wsID, tp, primary, action, taChar)
     params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
     params.canCrit = false
     params.acc100 = 0.0 params.acc200= 0.0 params.acc300= 0.0
-    -- params.atkmulti is supposed to vary with TP, however it is unknown what the multiplier is so I am going to leave it at 1. http://www.bg-wiki.com/bg/Sturmwind
     params.atk100 = 1; params.atk200 = 2; params.atk300 = 3.5;
 
     if (USE_ADOULIN_WEAPON_SKILL_CHANGES == true) then

--- a/scripts/globals/weaponskills/sturmwind.lua
+++ b/scripts/globals/weaponskills/sturmwind.lua
@@ -9,7 +9,7 @@
 -- Element: None
 -- Modifiers: STR:60%
 -- 100%TP    200%TP    300%TP
--- 1.00      1.00      1.00
+-- 1.0       2.0       3.5
 -----------------------------------
 require("scripts/globals/status")
 require("scripts/globals/settings")
@@ -26,7 +26,7 @@ function onUseWeaponSkill(player, target, wsID, tp, primary, action, taChar)
     params.canCrit = false
     params.acc100 = 0.0 params.acc200= 0.0 params.acc300= 0.0
     -- params.atkmulti is supposed to vary with TP, however it is unknown what the multiplier is so I am going to leave it at 1. http://www.bg-wiki.com/bg/Sturmwind
-    params.atkmulti = 1
+    params.atk100 = 1; params.atk200 = 2; params.atk300 = 3.5;
 
     if (USE_ADOULIN_WEAPON_SKILL_CHANGES == true) then
         params.str_wsc = 0.6

--- a/scripts/globals/weaponskills/swift_blade.lua
+++ b/scripts/globals/weaponskills/swift_blade.lua
@@ -25,7 +25,7 @@ function onUseWeaponSkill(player, target, wsID, tp, primary, action, taChar)
     params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
     params.canCrit = false
     params.acc100 = 0.8 params.acc200= 0.9 params.acc300= 1
-    params.atkmulti = 1
+    params.atk100 = 1; params.atk200 = 1; params.atk300 = 1;
 
     if (USE_ADOULIN_WEAPON_SKILL_CHANGES == true) then
         params.str_wsc = 0.5 params.mnd_wsc = 0.5

--- a/scripts/globals/weaponskills/tachi_ageha.lua
+++ b/scripts/globals/weaponskills/tachi_ageha.lua
@@ -27,7 +27,7 @@ function onUseWeaponSkill(player, target, wsID, tp, primary, action, taChar)
     params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
     params.canCrit = false
     params.acc100 = 0.0 params.acc200= 0.0 params.acc300= 0.0
-    params.atkmulti = 1
+    params.atk100 = 1; params.atk200 = 1; params.atk300 = 1;
 
     if (USE_ADOULIN_WEAPON_SKILL_CHANGES == true) then
         params.ftp100 = 2.625 params.ftp200 = 2.625 params.ftp300 = 2.625

--- a/scripts/globals/weaponskills/tachi_enpi.lua
+++ b/scripts/globals/weaponskills/tachi_enpi.lua
@@ -25,7 +25,7 @@ function onUseWeaponSkill(player, target, wsID, tp, primary, action, taChar)
     params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
     params.canCrit = false
     params.acc100 = 0.0 params.acc200= 0.0 params.acc300= 0.0
-    params.atkmulti = 1
+    params.atk100 = 1; params.atk200 = 1; params.atk300 = 1;
 
     if (USE_ADOULIN_WEAPON_SKILL_CHANGES == true) then
         params.str_wsc = 0.6

--- a/scripts/globals/weaponskills/tachi_fudo.lua
+++ b/scripts/globals/weaponskills/tachi_fudo.lua
@@ -25,12 +25,12 @@ function onUseWeaponSkill(player, target, wsID, tp, primary, action, taChar)
     params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
     params.canCrit = false
     params.acc100 = 0.0 params.acc200 = 0.0 params.acc300 = 0.0
-    params.atkmulti = 2
+    params.atk100 = 2; params.atk200 = 2; params.atk300 = 2;
 
     if USE_ADOULIN_WEAPON_SKILL_CHANGES then
         params.ftp100 = 3.75 params.ftp200 = 5.75 params.ftp300 = 8
         params.str_wsc = 0.8
-        params.atkmulti = 1
+        params.atk100 = 1; params.atk200 = 1; params.atk300 = 1;
     end
 
     local damage, criticalHit, tpHits, extraHits = doPhysicalWeaponskill(player, target, wsID, tp, primary, action, taChar, params)

--- a/scripts/globals/weaponskills/tachi_gekko.lua
+++ b/scripts/globals/weaponskills/tachi_gekko.lua
@@ -27,7 +27,7 @@ function onUseWeaponSkill(player, target, wsID, tp, primary, action, taChar)
     params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
     params.canCrit = false
     params.acc100 = 0.0 params.acc200= 0.0 params.acc300= 0.0
-    params.atkmulti = 2
+    params.atk100 = 2; params.atk200 = 2; params.atk300 = 2;
 
     if (USE_ADOULIN_WEAPON_SKILL_CHANGES == true) then
         params.ftp100 = 1.5625 params.ftp200 = 2.6875 params.ftp300 = 4.125

--- a/scripts/globals/weaponskills/tachi_goten.lua
+++ b/scripts/globals/weaponskills/tachi_goten.lua
@@ -25,7 +25,7 @@ function onUseWeaponSkill(player, target, wsID, tp, primary, action, taChar)
     params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
     params.canCrit = false
     params.acc100 = 0.0 params.acc200= 0.0 params.acc300= 0.0
-    params.atkmulti = 1
+    params.atk100 = 1; params.atk200 = 1; params.atk300 = 1;
 
     if (USE_ADOULIN_WEAPON_SKILL_CHANGES == true) then
         params.ftp100 = .5 params.ftp200 = .75 params.ftp300 = 1

--- a/scripts/globals/weaponskills/tachi_hobaku.lua
+++ b/scripts/globals/weaponskills/tachi_hobaku.lua
@@ -25,7 +25,7 @@ function onUseWeaponSkill(player, target, wsID, tp, primary, action, taChar)
     params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
     params.canCrit = false
     params.acc100 = 0.0 params.acc200= 0.0 params.acc300= 0.0
-    params.atkmulti = 1
+    params.atk100 = 1; params.atk200 = 1; params.atk300 = 1;
 
     if (USE_ADOULIN_WEAPON_SKILL_CHANGES == true) then
         params.str_wsc = 0.6

--- a/scripts/globals/weaponskills/tachi_kagero.lua
+++ b/scripts/globals/weaponskills/tachi_kagero.lua
@@ -25,7 +25,7 @@ function onUseWeaponSkill(player, target, wsID, tp, primary, action, taChar)
     params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
     params.canCrit = false
     params.acc100 = 0.0 params.acc200= 0.0 params.acc300= 0.0
-    params.atkmulti = 1
+    params.atk100 = 1; params.atk200 = 1; params.atk300 = 1;
 
     if (USE_ADOULIN_WEAPON_SKILL_CHANGES == true) then
         params.ftp100 = 0.5 params.ftp200 = 0.75 params.ftp300 = 1

--- a/scripts/globals/weaponskills/tachi_kaiten.lua
+++ b/scripts/globals/weaponskills/tachi_kaiten.lua
@@ -30,7 +30,7 @@ function onUseWeaponSkill(player, target, wsID, tp, primary, action, taChar)
     params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
     params.canCrit = false
     params.acc100 = 0.0 params.acc200 = 0.0 params.acc300 = 0.0
-    params.atkmulti = 1
+    params.atk100 = 1; params.atk200 = 1; params.atk300 = 1;
 
     if USE_ADOULIN_WEAPON_SKILL_CHANGES then
         params.str_wsc = 0.75

--- a/scripts/globals/weaponskills/tachi_kasha.lua
+++ b/scripts/globals/weaponskills/tachi_kasha.lua
@@ -28,12 +28,12 @@ function onUseWeaponSkill(player, target, wsID, tp, primary, action, taChar)
     params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
     params.canCrit = false
     params.acc100 = 0.0 params.acc200= 0.0 params.acc300= 0.0
-    params.atkmulti = 1.5
+    params.atk100 = 1.5; params.atk200 = 1.5; params.atk300 = 1.5;
 
     if (USE_ADOULIN_WEAPON_SKILL_CHANGES == true) then
         params.ftp100 = 1.5625 params.ftp200 = 2.6875 params.ftp300 = 4.125
         params.str_wsc = 0.75
-        params.atkmulti = 1.65
+        params.atk100 = 1.65; params.atk200 = 1.65; params.atk300 = 1.65;
     end
 
     local damage, criticalHit, tpHits, extraHits = doPhysicalWeaponskill(player, target, wsID, tp, primary, action, taChar, params)

--- a/scripts/globals/weaponskills/tachi_koki.lua
+++ b/scripts/globals/weaponskills/tachi_koki.lua
@@ -25,7 +25,7 @@ function onUseWeaponSkill(player, target, wsID, tp, primary, action, taChar)
     params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
     params.canCrit = false
     params.acc100 = 0.0 params.acc200= 0.0 params.acc300= 0.0
-    params.atkmulti = 1
+    params.atk100 = 1; params.atk200 = 1; params.atk300 = 1;
 
     if (USE_ADOULIN_WEAPON_SKILL_CHANGES == true) then
         params.str_wsc = 0.3 params.mnd_wsc = 0.5

--- a/scripts/globals/weaponskills/tachi_rana.lua
+++ b/scripts/globals/weaponskills/tachi_rana.lua
@@ -27,7 +27,7 @@ function onUseWeaponSkill(player, target, wsID, tp, primary, action, taChar)
     params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
     params.canCrit = false
     params.acc100 = 0.8 params.acc200 = 0.9 params.acc300 = 1
-    params.atkmulti = 1
+    params.atk100 = 1; params.atk200 = 1; params.atk300 = 1;
 
     if USE_ADOULIN_WEAPON_SKILL_CHANGES then
         params.str_wsc = 0.5

--- a/scripts/globals/weaponskills/tachi_shoha.lua
+++ b/scripts/globals/weaponskills/tachi_shoha.lua
@@ -26,7 +26,7 @@ function onUseWeaponSkill(player, target, wsID, tp, primary, action, taChar)
     params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
     params.canCrit = false
     params.acc100 = 0.0 params.acc200= 0.0 params.acc300= 0.0
-    params.atkmulti = 1.375
+    params.atk100 = 1.375; params.atk200 = 1.375; params.atk300 = 1.375;
 
     if (USE_ADOULIN_WEAPON_SKILL_CHANGES == true) then
         params.str_wsc = 0.7 + (player:getMerit(dsp.merit.TACHI_SHOHA) / 100)

--- a/scripts/globals/weaponskills/tachi_yukikaze.lua
+++ b/scripts/globals/weaponskills/tachi_yukikaze.lua
@@ -27,11 +27,11 @@ function onUseWeaponSkill(player, target, wsID, tp, primary, action, taChar)
     params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
     params.canCrit = false
     params.acc100 = 0.0 params.acc200= 0.0 params.acc300= 0.0
-    params.atkmulti = 1.33
+    params.atk100 = 1.33; params.atk200 = 1.33; params.atk300 = 1.33;
 
     if (USE_ADOULIN_WEAPON_SKILL_CHANGES == true) then
         params.ftp200 = 2.6875 params.ftp300 = 4.125
-        params.atkmulti = 1.5
+        params.atk100 = 1.5; params.atk200 = 1.5; params.atk300 = 1.5;
     end
 
     local damage, criticalHit, tpHits, extraHits = doPhysicalWeaponskill(player, target, wsID, tp, primary, action, taChar, params)

--- a/scripts/globals/weaponskills/torcleaver.lua
+++ b/scripts/globals/weaponskills/torcleaver.lua
@@ -26,7 +26,7 @@ function onUseWeaponSkill(player, target, wsID, tp, primary, action, taChar)
     params.crit100 = 0.00 params.crit200 = 0.00 params.crit300 = 0.00
     params.canCrit = false
     params.acc100 = 0.0 params.acc200 = 0.0 params.acc300 = 0.0
-    params.atkmulti = 1
+    params.atk100 = 1; params.atk200 = 1; params.atk300 = 1;
 
     if USE_ADOULIN_WEAPON_SKILL_CHANGES then
         params.ftp100 = 4.75 params.ftp200 = 7.5 params.ftp300 = 10

--- a/scripts/globals/weaponskills/tornado_kick.lua
+++ b/scripts/globals/weaponskills/tornado_kick.lua
@@ -35,13 +35,13 @@ function onUseWeaponSkill(player, target, wsID, tp, primary, action, taChar)
     params.acc100 = 0.0 params.acc200=0.0 params.acc300=0.0
 
     -- attack multiplier (only some WSes use this, this varies the actual ratio value, see Tachi: Kasha) 1 is default.
-    params.atkmulti = 1
+    params.atk100 = 1; params.atk200 = 1; params.atk300 = 1;
     params.kick = true -- https://www.bluegartr.com/threads/112776-Dev-Tracker-Findings-Posts-%28NO-DISCUSSION%29?p=6712150&viewfull=1#post6712150
 
     if (USE_ADOULIN_WEAPON_SKILL_CHANGES == true) then
         params.ftp100 = 2.25 params.ftp200 = 4.25 params.ftp300 = 7.5
         params.str_wsc = 0.4 params.dex_wsc = 0.4
-        params.atkmulti = 1.5
+        params.atk100 = 1.5; params.atk200 = 1.5; params.atk300 = 1.5;
     end
 
     local damage, criticalHit, tpHits, extraHits = doPhysicalWeaponskill(player, target, wsID, tp, primary, action, taChar, params)

--- a/scripts/globals/weaponskills/true_strike.lua
+++ b/scripts/globals/weaponskills/true_strike.lua
@@ -26,7 +26,7 @@ function onUseWeaponSkill(player, target, wsID, tp, primary, action, taChar)
     params.crit100 = 1.0 params.crit200 = 1.0 params.crit300 = 1.0
     params.canCrit = true
     params.acc100 = 0.5 params.acc200= 0.7 params.acc300= 1
-    params.atkmulti = 2
+    params.atk100 = 2; params.atk200 = 2; params.atk300 = 2;
 
     if (USE_ADOULIN_WEAPON_SKILL_CHANGES == true) then
         params.str_wsc = 1.0

--- a/scripts/globals/weaponskills/ukkos_fury.lua
+++ b/scripts/globals/weaponskills/ukkos_fury.lua
@@ -30,7 +30,7 @@ function onUseWeaponSkill(player, target, wsID, tp, primary, action, taChar)
     params.crit100 = 0.20 params.crit200 = 0.35 params.crit300 = 0.55
     params.canCrit = true
     params.acc100 = 0.0 params.acc200 = 0.0 params.acc300 = 0.0
-    params.atkmulti = 1
+    params.atk100 = 1; params.atk200 = 1; params.atk300 = 1;
 
     if USE_ADOULIN_WEAPON_SKILL_CHANGES then
         params.str_wsc = 0.8

--- a/scripts/globals/weaponskills/upheaval.lua
+++ b/scripts/globals/weaponskills/upheaval.lua
@@ -25,7 +25,7 @@ function onUseWeaponSkill(player, target, wsID, tp, primary, action, taChar)
     params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
     params.canCrit = true
     params.acc100 = 0.0 params.acc200= 0.0 params.acc300= 0.0
-    params.atkmulti = 1
+    params.atk100 = 1; params.atk200 = 1; params.atk300 = 1;
 
     if (USE_ADOULIN_WEAPON_SKILL_CHANGES == true) then
         params.vit_wsc = 0.7 + (player:getMerit(dsp.merit.UPHEAVAL) / 100)

--- a/scripts/globals/weaponskills/victory_smite.lua
+++ b/scripts/globals/weaponskills/victory_smite.lua
@@ -31,7 +31,7 @@ function onUseWeaponSkill(player, target, wsID, tp, primary, action, taChar)
     params.crit100 = 0.1 params.crit200 = 0.25 params.crit300 = 0.45
     params.canCrit = true
     params.acc100 = 0.0 params.acc200 = 0.0 params.acc300 = 0.0
-    params.atkmulti = 1
+    params.atk100 = 1; params.atk200 = 1; params.atk300 = 1;
 
     if USE_ADOULIN_WEAPON_SKILL_CHANGES then
         params.str_wsc = 0.8

--- a/scripts/globals/weaponskills/viper_bite.lua
+++ b/scripts/globals/weaponskills/viper_bite.lua
@@ -27,7 +27,7 @@ function onUseWeaponSkill(player, target, wsID, tp, primary, action, taChar)
     params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
     params.canCrit = false
     params.acc100 = 0.0 params.acc200= 0.0 params.acc300= 0.0
-    params.atkmulti = 2
+    params.atk100 = 2; params.atk200 = 2; params.atk300 = 2;
 
     if (USE_ADOULIN_WEAPON_SKILL_CHANGES == true) then
         params.dex_wsc = 1.0

--- a/scripts/globals/weaponskills/vorpal_blade.lua
+++ b/scripts/globals/weaponskills/vorpal_blade.lua
@@ -25,7 +25,7 @@ function onUseWeaponSkill(player, target, wsID, tp, primary, action, taChar)
     params.crit100 = 0.1 params.crit200 = 0.3 params.crit300 = 0.5
     params.canCrit = true
     params.acc100 = 0.0 params.acc200= 0.0 params.acc300= 0.0
-    params.atkmulti = 1
+    params.atk100 = 1; params.atk200 = 1; params.atk300 = 1;
 
     if (USE_ADOULIN_WEAPON_SKILL_CHANGES == true) then
         params.ftp100 = 1.375 params.ftp200 = 1.375 params.ftp300 = 1.375

--- a/scripts/globals/weaponskills/vorpal_scythe.lua
+++ b/scripts/globals/weaponskills/vorpal_scythe.lua
@@ -23,7 +23,7 @@ function onUseWeaponSkill(player, target, wsID, tp, primary, action, taChar)
     -- accuracy mods (ONLY USE FOR accURACY VARIES WITH TP) , should be the acc at those %s NOT the penalty values. Leave 0 if acc doesnt vary with tp.
     params.acc100 = 0 params.acc200=0 params.acc300=0
     -- attack multiplier (only some WSes use this, this varies the actual ratio value, see Tachi: Kasha) 1 is default.
-    params.atkmulti = 1
+    params.atk100 = 1; params.atk200 = 1; params.atk300 = 1;
 
     if (USE_ADOULIN_WEAPON_SKILL_CHANGES == true) then
         params.str_wsc = 1.0

--- a/scripts/globals/weaponskills/vorpal_thrust.lua
+++ b/scripts/globals/weaponskills/vorpal_thrust.lua
@@ -25,7 +25,7 @@ function onUseWeaponSkill(player, target, wsID, tp, primary, action, taChar)
     params.crit100 = 0.3 params.crit200 = 0.6 params.crit300 = 0.9
     params.canCrit = true
     params.acc100 = 0.0 params.acc200= 0.0 params.acc300= 0.0
-    params.atkmulti = 1
+    params.atk100 = 1; params.atk200 = 1; params.atk300 = 1;
 
     if (USE_ADOULIN_WEAPON_SKILL_CHANGES == true) then
         params.str_wsc = 0.5 params.agi_wsc = 0.5

--- a/scripts/globals/weaponskills/wasp_sting.lua
+++ b/scripts/globals/weaponskills/wasp_sting.lua
@@ -25,7 +25,7 @@ function onUseWeaponSkill(player, target, wsID, tp, primary, action, taChar)
     params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
     params.canCrit = false
     params.acc100 = 0.0 params.acc200= 0.0 params.acc300= 0.0
-    params.atkmulti = 1
+    params.atk100 = 1; params.atk200 = 1; params.atk300 = 1;
 
     if (USE_ADOULIN_WEAPON_SKILL_CHANGES == true) then
         params.dex_wsc = 1.0

--- a/scripts/globals/weaponskills/weapon_break.lua
+++ b/scripts/globals/weaponskills/weapon_break.lua
@@ -28,7 +28,7 @@ function onUseWeaponSkill(player, target, wsID, tp, primary, action, taChar)
     params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
     params.canCrit = false
     params.acc100 = 0.0 params.acc200= 0.0 params.acc300= 0.0
-    params.atkmulti = 1
+    params.atk100 = 1; params.atk200 = 1; params.atk300 = 1;
 
     if (USE_ADOULIN_WEAPON_SKILL_CHANGES == true) then
         params.str_wsc = 0.6 params.vit_wsc = 0.6

--- a/scripts/globals/weaponskills/wheeling_thrust.lua
+++ b/scripts/globals/weaponskills/wheeling_thrust.lua
@@ -25,7 +25,7 @@ function onUseWeaponSkill(player, target, wsID, tp, primary, action, taChar)
     params.crit100 = 0.0 params.crit200 = 0.0 params.crit300 = 0.0
     params.canCrit = false
     params.acc100 = 0.0 params.acc200= 0.0 params.acc300= 0.0
-    params.atkmulti = 1
+    params.atk100 = 1; params.atk200 = 1; params.atk300 = 1;
     -- Defense ignored is 50%, 75%, 100% (50% at 100 TP is accurate, other values are guesses)
     params.ignoresDef = true
     params.ignored100 = 0.5


### PR DESCRIPTION
Iron Tempest and Sturmwind both receive a varying attack modifier based on TP. This change renames params.atkmulti to params.atk100, params.atk200, params.atk300, consistent with other TP-varying parameters.

Iron Tempest and Sturmwind are given a 2.0 and 3.5 multipler at 2 and 3 tp respectively according to jp wiki figures.

Sturmwind: http://wiki.ffo.jp/html/860.html
Iron Tempest: http://wiki.ffo.jp/html/859.html