### PR TITLE
Outer Horutoto LUA cleanup + "Heart of the Matter" quest fixes

### DIFF
--- a/scripts/zones/Outer_Horutoto_Ruins/IDs.lua
+++ b/scripts/zones/Outer_Horutoto_Ruins/IDs.lua
@@ -11,16 +11,6 @@ zones[dsp.zone.OUTER_HORUTOTO_RUINS] =
     text =
     {
         ORB_ALREADY_PLACED             = 0, -- A dark Mana Orb is already placed here.
-        G_ORB_ALREADY_GOTTEN           = 3, -- You have already retrieved a glowing Mana Orb from here.
-        RETRIEVED_ALL_G_ORBS           = 4, -- You have retrieved all of the glowing Mana Orbs.
-        ALL_DARK_MANA_ORBS_SET         = 5, -- You have set all of the dark Mana Orbs in place.
-        FIRST_DARK_ORB_IN_PLACE        = 6, -- The first Mana Orb receptacle is ready for use.
-        SECOND_DARK_ORB_IN_PLACE       = 7, -- The second Mana Orb receptacle is ready for use.
-        THIRD_DARK_ORB_IN_PLACE        = 8, -- Third Mana Orb Receptacle is ready for use.
-        FOURTH_DARK_ORB_IN_PLACE       = 9, -- Forth Mana Orb Receptacle is ready for use.
-        FIFTH_DARK_ORB_IN_PLACE        = 10, -- Fifth Mana Orb Receptacle is ready for use.
-        SIXTH_DARK_ORB_IN_PLACE        = 11, -- Sixth Mana Orb Receptacle is ready for use.
-        DARK_MANA_ORB_RECHARGER        = 12, -- This appears to be a device that recharges Mana Orbs.
         CONQUEST_BASE                  = 15, -- Tallying conquest results...
         DEVICE_NOT_WORKING             = 188, -- The device is not working.
         SYS_OVERLOAD                   = 197, -- Warning! Sys...verload! Enterin...fety mode. ID eras...d.
@@ -57,7 +47,8 @@ zones[dsp.zone.OUTER_HORUTOTO_RUINS] =
     },
     npc =
     {
-        TREASURE_CHEST = 17572290,
+        GATE_MAGICAL_GIZMO = 17572248,
+        TREASURE_CHEST     = 17572290,
     },
 }
 

--- a/scripts/zones/Outer_Horutoto_Ruins/Zone.lua
+++ b/scripts/zones/Outer_Horutoto_Ruins/Zone.lua
@@ -3,32 +3,32 @@
 -- Zone: Outer_Horutoto_Ruins (194)
 --
 -----------------------------------
-local ID = require("scripts/zones/Outer_Horutoto_Ruins/IDs");
-require("scripts/globals/conquest");
+local ID = require("scripts/zones/Outer_Horutoto_Ruins/IDs")
+require("scripts/globals/conquest")
 require("scripts/globals/treasure")
 -----------------------------------
 
 function onInitialize(zone)
     dsp.treasure.initZone(zone)
-end;
+end
 
-function onZoneIn(player,prevZone)
-    local cs = -1;
-    if (player:getXPos() == 0 and player:getYPos() == 0 and player:getZPos() == 0) then
-        player:setPos(419.991,-9.637,716.991,190);
+function onZoneIn(player, prevZone)
+    local cs = -1
+    if player:getXPos() == 0 and player:getYPos() == 0 and player:getZPos() == 0 then
+        player:setPos(419.991, -9.637, 716.991, 190)
     end
-    return cs;
-end;
+    return cs
+end
 
 function onConquestUpdate(zone, updatetype)
     dsp.conq.onConquestUpdate(zone, updatetype)
-end;
+end
 
-function onRegionEnter(player,region)
-end;
+function onRegionEnter(player, region)
+end
 
-function onEventUpdate(player,csid,option)
-end;
+function onEventUpdate(player, csid, option)
+end
 
-function onEventFinish(player,csid,option)
-end;
+function onEventFinish(player, csid, option)
+end

--- a/scripts/zones/Outer_Horutoto_Ruins/globals.lua
+++ b/scripts/zones/Outer_Horutoto_Ruins/globals.lua
@@ -1,63 +1,182 @@
 -- Zone: Outer Horutoto Ruins (194)
 -- Desc: this file contains functions that are shared by multiple luas in this zone's directory
 -----------------------------------
-local ID = require("scripts/zones/Outer_Horutoto_Ruins/IDs");
+local ID = require("scripts/zones/Outer_Horutoto_Ruins/IDs")
+require("scripts/globals/keyitems")
+require("scripts/globals/missions")
 -----------------------------------
+
+-------------------------------------------------
+-- local functions
+-------------------------------------------------
+
+local function setTrioCooldown()
+    local pop = os.time() + math.random(2700, 3600) -- 45 to 60 minutes
+
+    for i = ID.mob.BALLOON_NM_OFFSET + 1, ID.mob.BALLOON_NM_OFFSET + 3 do
+        GetMobByID(i):setLocalVar("pop", pop)
+    end
+end
+
+local function trioPrimed()
+    for i = ID.mob.BALLOON_NM_OFFSET + 1, ID.mob.BALLOON_NM_OFFSET + 3 do
+        local nm = GetMobByID(i)
+        if nm ~= nil and (nm:isSpawned() or nm:getRespawnTime() ~= 0) then
+            return true
+        end
+    end
+
+    return false
+end
+
+local darkOrbKI =
+{
+    dsp.ki.FIRST_DARK_MANA_ORB,
+    dsp.ki.SECOND_DARK_MANA_ORB,
+    dsp.ki.THIRD_DARK_MANA_ORB,
+    dsp.ki.FOURTH_DARK_MANA_ORB,
+    dsp.ki.FIFTH_DARK_MANA_ORB,
+    dsp.ki.SIXTH_DARK_MANA_ORB,
+}
+
+local glowingOrbKI =
+{
+    dsp.ki.FIRST_GLOWING_MANA_ORB,
+    dsp.ki.SECOND_GLOWING_MANA_ORB,
+    dsp.ki.THIRD_GLOWING_MANA_ORB,
+    dsp.ki.FOURTH_GLOWING_MANA_ORB,
+    dsp.ki.FIFTH_GLOWING_MANA_ORB,
+    dsp.ki.SIXTH_GLOWING_MANA_ORB,
+}
+
+-------------------------------------------------
+-- public functions
+-------------------------------------------------
 
 OUTER_HORUTOTO_RUINS = {
     --[[..............................................................................................
-        set cooldown on trio NMs
-        ..............................................................................................]]
-    setTrioCooldown = function()
-        local pop = os.time() + math.random(2700,3600); -- 45 to 60 minutes
-        for i = ID.mob.BALLOON_NM_OFFSET + 1, ID.mob.BALLOON_NM_OFFSET + 3 do
-            GetMobByID(i):setLocalVar("pop", pop);
-        end
-    end,
-
-    --[[..............................................................................................
-        has a trio NM spawned or been selected to spawn?
-        ..............................................................................................]]
-    trioPrimed = function()
-        for i = ID.mob.BALLOON_NM_OFFSET + 1, ID.mob.BALLOON_NM_OFFSET + 3 do
-            local nm = GetMobByID(i);
-            if (nm ~= nil and (nm:isSpawned() or nm:getRespawnTime() ~= 0)) then
-                return true;
-            end
-        end
-        return false;
-    end,
-
-    --[[..............................................................................................
         check to spawn trio NM.
         ..............................................................................................]]
-    balloonDespawn = function(mob)
-        local phId = mob:getID();
-        local offset = phId - ID.mob.BALLOON_NM_OFFSET;
-        
-        if (offset >= 0 and offset <= 4 and not OUTER_HORUTOTO_RUINS.trioPrimed() and math.random(1,5) == 1) then
-            local nmId = ID.mob.BALLOON_NM_OFFSET + math.random(1,3);
-            local nm = GetMobByID(nmId);
-            local pop = nm:getLocalVar("pop");
-            
-            if (os.time() > pop) then
-                -- print(string.format("ph %i winner! nm %i will pop in place", phId, nmId));
-                DisallowRespawn(phId, true);
-                DisallowRespawn(nmId, false);
-                UpdateNMSpawnPoint(nmId);
-                nm:setRespawnTime(GetMobRespawnTime(phId));
+    balloonOnDespawn = function(mob)
+        local phId = mob:getID()
+        local offset = phId - ID.mob.BALLOON_NM_OFFSET
+
+        if offset >= 0 and offset <= 4 and not trioPrimed() and math.random(100) <= 20 then
+            local nmId = ID.mob.BALLOON_NM_OFFSET + math.random(1, 3)
+            local nm = GetMobByID(nmId)
+            local pop = nm:getLocalVar("pop")
+
+            if os.time() > pop then
+                -- print(string.format("ph %i winner! nm %i will pop in place", phId, nmId))
+                DisallowRespawn(phId, true)
+                DisallowRespawn(nmId, false)
+                UpdateNMSpawnPoint(nmId)
+                nm:setRespawnTime(GetMobRespawnTime(phId))
 
                 nm:addListener("DESPAWN", "DESPAWN_"..nmId, function(m)
-                    -- print(string.format("nm %i died. ph %i will pop in place", nmId, phId));
-                    DisallowRespawn(nmId, true);
-                    DisallowRespawn(phId, false);
-                    GetMobByID(phId):setRespawnTime(GetMobRespawnTime(phId));
-                    m:removeListener("DESPAWN_"..nmId);
-                    OUTER_HORUTOTO_RUINS.setTrioCooldown();
-                end);
+                    -- print(string.format("nm %i died. ph %i will pop in place", nmId, phId))
+                    DisallowRespawn(nmId, true)
+                    DisallowRespawn(phId, false)
+                    GetMobByID(phId):setRespawnTime(GetMobRespawnTime(phId))
+                    m:removeListener("DESPAWN_"..nmId)
+                    setTrioCooldown()
+                end)
+            end
+        end
+    end,
+
+    --[[..............................................................................................
+        player clicks on magical gizmo
+        ..............................................................................................]]
+    gizmoOnTrigger = function(player, npc)
+        local gizmoNum = npc:getID() - ID.npc.GATE_MAGICAL_GIZMO -- gizmoNum will be 1 through 6
+        local msgBase = ID.text.ORB_ALREADY_PLACED
+
+        if player:getCurrentMission(WINDURST) == THE_HEART_OF_THE_MATTER then
+            local missionStatus = player:getVar("MissionStatus")
+
+            -- placing dark mana orbs
+            if missionStatus == 2 then
+                if player:getVar("MissionStatus_orb" .. gizmoNum) == 1 then
+                    player:startEvent(57 + gizmoNum)
+                else
+                    player:messageSpecial(msgBase)
+                end
+
+            -- collecting energized mana orbs
+            elseif missionStatus == 4 then
+                if player:getVar("MissionStatus_orb" .. gizmoNum) == 2 then
+                    player:startEvent(45 + gizmoNum)
+                else
+                    player:messageSpecial(msgBase + 3)
+                end
+
+            else
+                player:messageSpecial(msgBase + 12)
+            end
+        else
+            player:messageSpecial(msgBase + 12)
+        end
+    end,
+
+    --[[..............................................................................................
+        magical gizmo event finish
+        ..............................................................................................]]
+    gizmoOnEventFinish = function(player, csid)
+        local npc = player:getEventTarget()
+
+        if npc then
+            local gizmoNum = npc:getID() - ID.npc.GATE_MAGICAL_GIZMO
+            local msgBase = ID.text.ORB_ALREADY_PLACED
+            local orbVal = player:getVar("MissionStatus_orb" .. gizmoNum)
+
+            -- placing dark mana orbs
+            if csid == (57 + gizmoNum) then
+                if orbVal == 1 then
+                    local ki = darkOrbKI[gizmoNum]
+
+                    player:setVar("MissionStatus_orb" .. gizmoNum, 2)
+                    player:messageSpecial(msgBase + 1, 0, 0, ki) -- "The <ki> has been placed into the receptacle."
+                    player:delKeyItem(ki)
+
+                    -- Check if all orbs have been placed or not
+                    if
+                        player:getVar("MissionStatus_orb1") == 2 and
+                        player:getVar("MissionStatus_orb2") == 2 and
+                        player:getVar("MissionStatus_orb3") == 2 and
+                        player:getVar("MissionStatus_orb4") == 2 and
+                        player:getVar("MissionStatus_orb5") == 2 and
+                        player:getVar("MissionStatus_orb6") == 2
+                    then
+                        player:messageSpecial(msgBase + 5) -- "You have set all of the Dark Mana Orbs in place."
+                        player:setVar("MissionStatus", 3)
+                    end
+                end
+
+            -- collecting energized mana orbs
+            elseif csid == (45 + gizmoNum) then
+                if orbVal == 2 then
+                    local ki = glowingOrbKI[gizmoNum]
+
+                    player:setVar("MissionStatus_orb" .. gizmoNum, 3)
+                    player:addKeyItem(ki)
+                    player:messageSpecial(ID.text.KEYITEM_OBTAINED, ki)
+
+                    if
+                        player:getVar("MissionStatus_orb1") == 3 and
+                        player:getVar("MissionStatus_orb2") == 3 and
+                        player:getVar("MissionStatus_orb3") == 3 and
+                        player:getVar("MissionStatus_orb4") == 3 and
+                        player:getVar("MissionStatus_orb5") == 3 and
+                        player:getVar("MissionStatus_orb6") == 3
+                    then
+                        player:messageSpecial(msgBase + 4)
+                        player:setVar("MissionStatus", 5)
+                    end
+                end
             end
         end
     end,
 }
 
-return OUTER_HORUTOTO_RUINS;
+return OUTER_HORUTOTO_RUINS

--- a/scripts/zones/Outer_Horutoto_Ruins/mobs/Ah_Puch.lua
+++ b/scripts/zones/Outer_Horutoto_Ruins/mobs/Ah_Puch.lua
@@ -4,4 +4,4 @@
 -----------------------------------
 
 function onMobDeath(mob, player, isKiller)
-end;
+end

--- a/scripts/zones/Outer_Horutoto_Ruins/mobs/Balloon.lua
+++ b/scripts/zones/Outer_Horutoto_Ruins/mobs/Balloon.lua
@@ -3,12 +3,12 @@
 --  MOB: Balloon
 -- Note: PH for Bomb King, Doppelganger Dio, and Doppelganger Gog
 -----------------------------------
-require("scripts/zones/Outer_Horutoto_Ruins/globals");
+local func = require("scripts/zones/Outer_Horutoto_Ruins/globals")
 -----------------------------------
 
 function onMobDeath(mob, player, isKiller)
-end;
+end
 
 function onMobDespawn(mob)
-    OUTER_HORUTOTO_RUINS.balloonDespawn(mob);
-end;
+    func.balloonOnDespawn(mob)
+end

--- a/scripts/zones/Outer_Horutoto_Ruins/mobs/Bomb_King.lua
+++ b/scripts/zones/Outer_Horutoto_Ruins/mobs/Bomb_King.lua
@@ -4,4 +4,4 @@
 -----------------------------------
 
 function onMobDeath(mob, player, isKiller)
-end;
+end

--- a/scripts/zones/Outer_Horutoto_Ruins/mobs/Doppelganger_Dio.lua
+++ b/scripts/zones/Outer_Horutoto_Ruins/mobs/Doppelganger_Dio.lua
@@ -4,4 +4,4 @@
 -----------------------------------
 
 function onMobDeath(mob, player, isKiller)
-end;
+end

--- a/scripts/zones/Outer_Horutoto_Ruins/mobs/Doppelganger_Gog.lua
+++ b/scripts/zones/Outer_Horutoto_Ruins/mobs/Doppelganger_Gog.lua
@@ -4,4 +4,4 @@
 -----------------------------------
 
 function onMobDeath(mob, player, isKiller)
-end;
+end

--- a/scripts/zones/Outer_Horutoto_Ruins/mobs/Eight_of_Batons.lua
+++ b/scripts/zones/Outer_Horutoto_Ruins/mobs/Eight_of_Batons.lua
@@ -7,4 +7,4 @@ require("scripts/globals/regimes")
 
 function onMobDeath(mob, player, isKiller)
     dsp.regime.checkRegime(player, mob, 667, 2, dsp.regime.type.GROUNDS)
-end;
+end

--- a/scripts/zones/Outer_Horutoto_Ruins/mobs/Eight_of_Coins.lua
+++ b/scripts/zones/Outer_Horutoto_Ruins/mobs/Eight_of_Coins.lua
@@ -7,4 +7,4 @@ require("scripts/globals/regimes")
 
 function onMobDeath(mob, player, isKiller)
     dsp.regime.checkRegime(player, mob, 667, 4, dsp.regime.type.GROUNDS)
-end;
+end

--- a/scripts/zones/Outer_Horutoto_Ruins/mobs/Eight_of_Cups.lua
+++ b/scripts/zones/Outer_Horutoto_Ruins/mobs/Eight_of_Cups.lua
@@ -7,4 +7,4 @@ require("scripts/globals/regimes")
 
 function onMobDeath(mob, player, isKiller)
     dsp.regime.checkRegime(player, mob, 667, 1, dsp.regime.type.GROUNDS)
-end;
+end

--- a/scripts/zones/Outer_Horutoto_Ruins/mobs/Eight_of_Swords.lua
+++ b/scripts/zones/Outer_Horutoto_Ruins/mobs/Eight_of_Swords.lua
@@ -7,4 +7,4 @@ require("scripts/globals/regimes")
 
 function onMobDeath(mob, player, isKiller)
     dsp.regime.checkRegime(player, mob, 667, 3, dsp.regime.type.GROUNDS)
-end;
+end

--- a/scripts/zones/Outer_Horutoto_Ruins/mobs/Fetor_Bats.lua
+++ b/scripts/zones/Outer_Horutoto_Ruins/mobs/Fetor_Bats.lua
@@ -7,4 +7,4 @@ require("scripts/globals/regimes")
 
 function onMobDeath(mob, player, isKiller)
     dsp.regime.checkRegime(player, mob, 669, 1, dsp.regime.type.GROUNDS)
-end;
+end

--- a/scripts/zones/Outer_Horutoto_Ruins/mobs/Five_of_Batons.lua
+++ b/scripts/zones/Outer_Horutoto_Ruins/mobs/Five_of_Batons.lua
@@ -7,4 +7,4 @@ require("scripts/globals/regimes")
 
 function onMobDeath(mob, player, isKiller)
     dsp.regime.checkRegime(player, mob, 664, 2, dsp.regime.type.GROUNDS)
-end;
+end

--- a/scripts/zones/Outer_Horutoto_Ruins/mobs/Five_of_Coins.lua
+++ b/scripts/zones/Outer_Horutoto_Ruins/mobs/Five_of_Coins.lua
@@ -7,4 +7,4 @@ require("scripts/globals/regimes")
 
 function onMobDeath(mob, player, isKiller)
     dsp.regime.checkRegime(player, mob, 664, 4, dsp.regime.type.GROUNDS)
-end;
+end

--- a/scripts/zones/Outer_Horutoto_Ruins/mobs/Five_of_Cups.lua
+++ b/scripts/zones/Outer_Horutoto_Ruins/mobs/Five_of_Cups.lua
@@ -7,4 +7,4 @@ require("scripts/globals/regimes")
 
 function onMobDeath(mob, player, isKiller)
     dsp.regime.checkRegime(player, mob, 664, 1, dsp.regime.type.GROUNDS)
-end;
+end

--- a/scripts/zones/Outer_Horutoto_Ruins/mobs/Five_of_Swords.lua
+++ b/scripts/zones/Outer_Horutoto_Ruins/mobs/Five_of_Swords.lua
@@ -7,4 +7,4 @@ require("scripts/globals/regimes")
 
 function onMobDeath(mob, player, isKiller)
     dsp.regime.checkRegime(player, mob, 664, 3, dsp.regime.type.GROUNDS)
-end;
+end

--- a/scripts/zones/Outer_Horutoto_Ruins/mobs/Four_of_Batons.lua
+++ b/scripts/zones/Outer_Horutoto_Ruins/mobs/Four_of_Batons.lua
@@ -7,4 +7,4 @@ require("scripts/globals/regimes")
 
 function onMobDeath(mob, player, isKiller)
     dsp.regime.checkRegime(player, mob, 663, 2, dsp.regime.type.GROUNDS)
-end;
+end

--- a/scripts/zones/Outer_Horutoto_Ruins/mobs/Four_of_Coins.lua
+++ b/scripts/zones/Outer_Horutoto_Ruins/mobs/Four_of_Coins.lua
@@ -7,4 +7,4 @@ require("scripts/globals/regimes")
 
 function onMobDeath(mob, player, isKiller)
     dsp.regime.checkRegime(player, mob, 663, 4, dsp.regime.type.GROUNDS)
-end;
+end

--- a/scripts/zones/Outer_Horutoto_Ruins/mobs/Four_of_Cups.lua
+++ b/scripts/zones/Outer_Horutoto_Ruins/mobs/Four_of_Cups.lua
@@ -7,4 +7,4 @@ require("scripts/globals/regimes")
 
 function onMobDeath(mob, player, isKiller)
     dsp.regime.checkRegime(player, mob, 663, 1, dsp.regime.type.GROUNDS)
-end;
+end

--- a/scripts/zones/Outer_Horutoto_Ruins/mobs/Four_of_Swords.lua
+++ b/scripts/zones/Outer_Horutoto_Ruins/mobs/Four_of_Swords.lua
@@ -7,4 +7,4 @@ require("scripts/globals/regimes")
 
 function onMobDeath(mob, player, isKiller)
     dsp.regime.checkRegime(player, mob, 663, 3, dsp.regime.type.GROUNDS)
-end;
+end

--- a/scripts/zones/Outer_Horutoto_Ruins/mobs/Fuligo.lua
+++ b/scripts/zones/Outer_Horutoto_Ruins/mobs/Fuligo.lua
@@ -8,4 +8,4 @@ require("scripts/globals/regimes")
 function onMobDeath(mob, player, isKiller)
     dsp.regime.checkRegime(player, mob, 669, 2, dsp.regime.type.GROUNDS)
     dsp.regime.checkRegime(player, mob, 670, 2, dsp.regime.type.GROUNDS)
-end;
+end

--- a/scripts/zones/Outer_Horutoto_Ruins/mobs/Ghoul.lua
+++ b/scripts/zones/Outer_Horutoto_Ruins/mobs/Ghoul.lua
@@ -3,12 +3,13 @@
 --  MOB: Ghoul
 -- Note: Place holder for Ah Puch
 -----------------------------------
-local ID = require("scripts/zones/Outer_Horutoto_Ruins/IDs");
-require("scripts/globals/mobs");
+local ID = require("scripts/zones/Outer_Horutoto_Ruins/IDs")
+require("scripts/globals/mobs")
+-----------------------------------
 
 function onMobDeath(mob, player, isKiller)
-end;
+end
 
 function onMobDespawn(mob)
-    dsp.mob.phOnDespawn(mob,ID.mob.AH_PUCH_PH,20,math.random(3600,10800)); -- 1 to 3 hours
-end;
+    dsp.mob.phOnDespawn(mob, ID.mob.AH_PUCH_PH, 20, math.random(3600, 10800)) -- 1 to 3 hours
+end

--- a/scripts/zones/Outer_Horutoto_Ruins/mobs/Jack_of_Batons.lua
+++ b/scripts/zones/Outer_Horutoto_Ruins/mobs/Jack_of_Batons.lua
@@ -1,29 +1,23 @@
 -----------------------------------
 -- Area: Outer Horutoto Ruins
---  MOB: Jack of Batons
+--   NM: Jack of Batons
 -----------------------------------
-mixins = {require("scripts/mixins/job_special")};
-require("scripts/globals/missions");
+mixins = {require("scripts/mixins/job_special")}
+require("scripts/globals/missions")
 -----------------------------------
 
 function onMobSpawn(mob)
     mob:setLocalVar("popTime", os.time())
-end;
+end
 
 function onMobRoam(mob)
-    local spawnTime = mob:getLocalVar("popTime");
-
-    if (os.time() - spawnTime > 180) then
-        DespawnMob(mob:getID());
+    if os.time() - mob:getLocalVar("popTime") > 180 then
+        DespawnMob(mob:getID())
     end
-
-end;
+end
 
 function onMobDeath(mob, player, isKiller)
-    local CurrentMission = player:getCurrentMission(WINDURST);
-    local MissionStatus = player:getVar("MissionStatus");
-
-    if (CurrentMission == FULL_MOON_FOUNTAIN and MissionStatus == 1) then
-        player:setVar("MissionStatus",2);
+    if player:getCurrentMission(WINDURST) == FULL_MOON_FOUNTAIN and player:getVar("MissionStatus") == 1 then
+        player:setVar("MissionStatus", 2)
     end
-end;
+end

--- a/scripts/zones/Outer_Horutoto_Ruins/mobs/Jack_of_Coins.lua
+++ b/scripts/zones/Outer_Horutoto_Ruins/mobs/Jack_of_Coins.lua
@@ -1,29 +1,23 @@
 -----------------------------------
 -- Area: Outer Horutoto Ruins
---  MOB: Jack of Coins
+--   NM: Jack of Coins
 -----------------------------------
-mixins = {require("scripts/mixins/job_special")};
-require("scripts/globals/missions");
+mixins = {require("scripts/mixins/job_special")}
+require("scripts/globals/missions")
 -----------------------------------
 
 function onMobSpawn(mob)
     mob:setLocalVar("popTime", os.time())
-end;
+end
 
 function onMobRoam(mob)
-    local spawnTime = mob:getLocalVar("popTime");
-
-    if (os.time() - spawnTime > 180) then
-        DespawnMob(mob:getID());
+    if os.time() - mob:getLocalVar("popTime") > 180 then
+        DespawnMob(mob:getID())
     end
-
-end;
+end
 
 function onMobDeath(mob, player, isKiller)
-    local CurrentMission = player:getCurrentMission(WINDURST);
-    local MissionStatus = player:getVar("MissionStatus");
-
-    if (CurrentMission == FULL_MOON_FOUNTAIN and MissionStatus == 1) then
-        player:setVar("MissionStatus",2);
+    if player:getCurrentMission(WINDURST) == FULL_MOON_FOUNTAIN and player:getVar("MissionStatus") == 1 then
+        player:setVar("MissionStatus", 2)
     end
-end;
+end

--- a/scripts/zones/Outer_Horutoto_Ruins/mobs/Jack_of_Cups.lua
+++ b/scripts/zones/Outer_Horutoto_Ruins/mobs/Jack_of_Cups.lua
@@ -1,29 +1,23 @@
 -----------------------------------
 -- Area: Outer Horutoto Ruins
---  MOB: Jack of Cups
+--   NM: Jack of Cups
 -----------------------------------
-mixins = {require("scripts/mixins/job_special")};
-require("scripts/globals/missions");
+mixins = {require("scripts/mixins/job_special")}
+require("scripts/globals/missions")
 -----------------------------------
 
 function onMobSpawn(mob)
     mob:setLocalVar("popTime", os.time())
-end;
+end
 
 function onMobRoam(mob)
-    local spawnTime = mob:getLocalVar("popTime");
-
-    if (os.time() - spawnTime > 180) then
-        DespawnMob(mob:getID());
+    if os.time() - mob:getLocalVar("popTime") > 180 then
+        DespawnMob(mob:getID())
     end
-
-end;
+end
 
 function onMobDeath(mob, player, isKiller)
-    local CurrentMission = player:getCurrentMission(WINDURST);
-    local MissionStatus = player:getVar("MissionStatus");
-
-    if (CurrentMission == FULL_MOON_FOUNTAIN and MissionStatus == 1) then
-        player:setVar("MissionStatus",2);
+    if player:getCurrentMission(WINDURST) == FULL_MOON_FOUNTAIN and player:getVar("MissionStatus") == 1 then
+        player:setVar("MissionStatus", 2)
     end
-end;
+end

--- a/scripts/zones/Outer_Horutoto_Ruins/mobs/Jack_of_Swords.lua
+++ b/scripts/zones/Outer_Horutoto_Ruins/mobs/Jack_of_Swords.lua
@@ -1,29 +1,23 @@
 -----------------------------------
 -- Area: Outer Horutoto Ruins
---  MOB: Jack of Swords
+--   NM: Jack of Swords
 -----------------------------------
-mixins = {require("scripts/mixins/job_special")};
-require("scripts/globals/missions");
+mixins = {require("scripts/mixins/job_special")}
+require("scripts/globals/missions")
 -----------------------------------
 
 function onMobSpawn(mob)
     mob:setLocalVar("popTime", os.time())
-end;
+end
 
 function onMobRoam(mob)
-    local spawnTime = mob:getLocalVar("popTime");
-
-    if (os.time() - spawnTime > 180) then
-        DespawnMob(mob:getID());
+    if os.time() - mob:getLocalVar("popTime") > 180 then
+        DespawnMob(mob:getID())
     end
-
-end;
+end
 
 function onMobDeath(mob, player, isKiller)
-    local CurrentMission = player:getCurrentMission(WINDURST);
-    local MissionStatus = player:getVar("MissionStatus");
-
-    if (CurrentMission == FULL_MOON_FOUNTAIN and MissionStatus == 1) then
-        player:setVar("MissionStatus",2);
+    if player:getCurrentMission(WINDURST) == FULL_MOON_FOUNTAIN and player:getVar("MissionStatus") == 1 then
+        player:setVar("MissionStatus", 2)
     end
-end;
+end

--- a/scripts/zones/Outer_Horutoto_Ruins/mobs/Nine_of_Batons.lua
+++ b/scripts/zones/Outer_Horutoto_Ruins/mobs/Nine_of_Batons.lua
@@ -7,4 +7,4 @@ require("scripts/globals/regimes")
 
 function onMobDeath(mob, player, isKiller)
     dsp.regime.checkRegime(player, mob, 668, 2, dsp.regime.type.GROUNDS)
-end;
+end

--- a/scripts/zones/Outer_Horutoto_Ruins/mobs/Nine_of_Coins.lua
+++ b/scripts/zones/Outer_Horutoto_Ruins/mobs/Nine_of_Coins.lua
@@ -7,4 +7,4 @@ require("scripts/globals/regimes")
 
 function onMobDeath(mob, player, isKiller)
     dsp.regime.checkRegime(player, mob, 668, 4, dsp.regime.type.GROUNDS)
-end;
+end

--- a/scripts/zones/Outer_Horutoto_Ruins/mobs/Nine_of_Cups.lua
+++ b/scripts/zones/Outer_Horutoto_Ruins/mobs/Nine_of_Cups.lua
@@ -7,4 +7,4 @@ require("scripts/globals/regimes")
 
 function onMobDeath(mob, player, isKiller)
     dsp.regime.checkRegime(player, mob, 668, 1, dsp.regime.type.GROUNDS)
-end;
+end

--- a/scripts/zones/Outer_Horutoto_Ruins/mobs/Nine_of_Swords.lua
+++ b/scripts/zones/Outer_Horutoto_Ruins/mobs/Nine_of_Swords.lua
@@ -7,4 +7,4 @@ require("scripts/globals/regimes")
 
 function onMobDeath(mob, player, isKiller)
     dsp.regime.checkRegime(player, mob, 668, 3, dsp.regime.type.GROUNDS)
-end;
+end

--- a/scripts/zones/Outer_Horutoto_Ruins/mobs/Queen_of_Coins.lua
+++ b/scripts/zones/Outer_Horutoto_Ruins/mobs/Queen_of_Coins.lua
@@ -1,13 +1,13 @@
 -----------------------------------
 -- Area: Outer Horutoto Ruins
---  MOB: Queen of Coins
+--   NM: Queen of Coins
 -----------------------------------
-mixins = {require("scripts/mixins/job_special")};
-require("scripts/globals/missions");
+mixins = {require("scripts/mixins/job_special")}
+require("scripts/globals/missions")
 -----------------------------------
 
 function onMobDeath(mob, player, isKiller)
-    if (player:getCurrentMission(WINDURST) == THE_JESTER_WHO_D_BE_KING and player:getVar("MissionStatus") == 4 and GetMobByID(mob:getID() - 1):isDead()) then
-        player:setVar("MissionStatus",5)
+    if player:getCurrentMission(WINDURST) == THE_JESTER_WHO_D_BE_KING and player:getVar("MissionStatus") == 4 and GetMobByID(mob:getID() - 1):isDead() then
+        player:setVar("MissionStatus", 5)
     end
-end;
+end

--- a/scripts/zones/Outer_Horutoto_Ruins/mobs/Queen_of_Swords.lua
+++ b/scripts/zones/Outer_Horutoto_Ruins/mobs/Queen_of_Swords.lua
@@ -1,13 +1,13 @@
 -----------------------------------
 -- Area: Outer Horutoto Ruins
---  MOB: Queen of Swords
+--   NM: Queen of Swords
 -----------------------------------
-mixins = {require("scripts/mixins/job_special")};
-require("scripts/globals/missions");
+mixins = {require("scripts/mixins/job_special")}
+require("scripts/globals/missions")
 -----------------------------------
 
 function onMobDeath(mob, player, isKiller)
-    if (player:getCurrentMission(WINDURST) == THE_JESTER_WHO_D_BE_KING and player:getVar("MissionStatus") == 4 and GetMobByID(mob:getID() + 1):isDead()) then
-        player:setVar("MissionStatus",5)
+    if player:getCurrentMission(WINDURST) == THE_JESTER_WHO_D_BE_KING and player:getVar("MissionStatus") == 4 and GetMobByID(mob:getID() + 1):isDead() then
+        player:setVar("MissionStatus", 5)
     end
-end;
+end

--- a/scripts/zones/Outer_Horutoto_Ruins/mobs/Seven_of_Batons.lua
+++ b/scripts/zones/Outer_Horutoto_Ruins/mobs/Seven_of_Batons.lua
@@ -7,4 +7,4 @@ require("scripts/globals/regimes")
 
 function onMobDeath(mob, player, isKiller)
     dsp.regime.checkRegime(player, mob, 666, 2, dsp.regime.type.GROUNDS)
-end;
+end

--- a/scripts/zones/Outer_Horutoto_Ruins/mobs/Seven_of_Coins.lua
+++ b/scripts/zones/Outer_Horutoto_Ruins/mobs/Seven_of_Coins.lua
@@ -7,4 +7,4 @@ require("scripts/globals/regimes")
 
 function onMobDeath(mob, player, isKiller)
     dsp.regime.checkRegime(player, mob, 666, 4, dsp.regime.type.GROUNDS)
-end;
+end

--- a/scripts/zones/Outer_Horutoto_Ruins/mobs/Seven_of_Cups.lua
+++ b/scripts/zones/Outer_Horutoto_Ruins/mobs/Seven_of_Cups.lua
@@ -7,4 +7,4 @@ require("scripts/globals/regimes")
 
 function onMobDeath(mob, player, isKiller)
     dsp.regime.checkRegime(player, mob, 666, 1, dsp.regime.type.GROUNDS)
-end;
+end

--- a/scripts/zones/Outer_Horutoto_Ruins/mobs/Seven_of_Swords.lua
+++ b/scripts/zones/Outer_Horutoto_Ruins/mobs/Seven_of_Swords.lua
@@ -7,4 +7,4 @@ require("scripts/globals/regimes")
 
 function onMobDeath(mob, player, isKiller)
     dsp.regime.checkRegime(player, mob, 666, 3, dsp.regime.type.GROUNDS)
-end;
+end

--- a/scripts/zones/Outer_Horutoto_Ruins/mobs/Six_of_Batons.lua
+++ b/scripts/zones/Outer_Horutoto_Ruins/mobs/Six_of_Batons.lua
@@ -7,4 +7,4 @@ require("scripts/globals/regimes")
 
 function onMobDeath(mob, player, isKiller)
     dsp.regime.checkRegime(player, mob, 665, 2, dsp.regime.type.GROUNDS)
-end;
+end

--- a/scripts/zones/Outer_Horutoto_Ruins/mobs/Six_of_Coins.lua
+++ b/scripts/zones/Outer_Horutoto_Ruins/mobs/Six_of_Coins.lua
@@ -7,4 +7,4 @@ require("scripts/globals/regimes")
 
 function onMobDeath(mob, player, isKiller)
     dsp.regime.checkRegime(player, mob, 665, 4, dsp.regime.type.GROUNDS)
-end;
+end

--- a/scripts/zones/Outer_Horutoto_Ruins/mobs/Six_of_Cups.lua
+++ b/scripts/zones/Outer_Horutoto_Ruins/mobs/Six_of_Cups.lua
@@ -7,4 +7,4 @@ require("scripts/globals/regimes")
 
 function onMobDeath(mob, player, isKiller)
     dsp.regime.checkRegime(player, mob, 665, 1, dsp.regime.type.GROUNDS)
-end;
+end

--- a/scripts/zones/Outer_Horutoto_Ruins/mobs/Six_of_Swords.lua
+++ b/scripts/zones/Outer_Horutoto_Ruins/mobs/Six_of_Swords.lua
@@ -7,4 +7,4 @@ require("scripts/globals/regimes")
 
 function onMobDeath(mob, player, isKiller)
     dsp.regime.checkRegime(player, mob, 665, 3, dsp.regime.type.GROUNDS)
-end;
+end

--- a/scripts/zones/Outer_Horutoto_Ruins/mobs/Thorn_Bat.lua
+++ b/scripts/zones/Outer_Horutoto_Ruins/mobs/Thorn_Bat.lua
@@ -7,4 +7,4 @@ require("scripts/globals/regimes")
 
 function onMobDeath(mob, player, isKiller)
     dsp.regime.checkRegime(player, mob, 670, 1, dsp.regime.type.GROUNDS)
-end;
+end

--- a/scripts/zones/Outer_Horutoto_Ruins/npcs/Grounds_Tome.lua
+++ b/scripts/zones/Outer_Horutoto_Ruins/npcs/Grounds_Tome.lua
@@ -5,17 +5,17 @@
 require("scripts/globals/regimes")
 -----------------------------------
 
-function onTrade(player,npc,trade)
+function onTrade(player, npc, trade)
 end
 
-function onTrigger(player,npc)
+function onTrigger(player, npc)
     dsp.regime.bookOnTrigger(player, dsp.regime.type.GROUNDS)
 end
 
-function onEventUpdate(player,csid,option)
+function onEventUpdate(player, csid, option)
     dsp.regime.bookOnEventUpdate(player, option, dsp.regime.type.GROUNDS)
-end;
+end
 
-function onEventFinish(player,csid,option)
+function onEventFinish(player, csid, option)
     dsp.regime.bookOnEventFinish(player, option, dsp.regime.type.GROUNDS)
 end

--- a/scripts/zones/Outer_Horutoto_Ruins/npcs/Treasure_Chest.lua
+++ b/scripts/zones/Outer_Horutoto_Ruins/npcs/Treasure_Chest.lua
@@ -6,16 +6,16 @@
 require("scripts/globals/treasure")
 -----------------------------------
 
-function onTrade(player,npc,trade)
+function onTrade(player, npc, trade)
     dsp.treasure.onTrade(player, npc, trade, dsp.treasure.type.CHEST)
 end
 
-function onTrigger(player,npc)
+function onTrigger(player, npc)
     dsp.treasure.onTrigger(player, dsp.treasure.type.CHEST)
 end
 
-function onEventUpdate(player,csid,option)
+function onEventUpdate(player, csid, option)
 end
 
-function onEventFinish(player,csid,option)
+function onEventFinish(player, csid, option)
 end

--- a/scripts/zones/Outer_Horutoto_Ruins/npcs/_5e5.lua
+++ b/scripts/zones/Outer_Horutoto_Ruins/npcs/_5e5.lua
@@ -4,36 +4,36 @@
 -- Involved In Mission: The Jester Who'd Be King
 -- !pos -424.255 -1.909 619.995
 -----------------------------------
-local ID = require("scripts/zones/Outer_Horutoto_Ruins/IDs");
-require("scripts/globals/keyitems");
-require("scripts/globals/missions");
+local ID = require("scripts/zones/Outer_Horutoto_Ruins/IDs")
+require("scripts/globals/keyitems")
+require("scripts/globals/missions")
 -----------------------------------
 
-function onTrade(player,npc,trade)
-end;
+function onTrade(player, npc, trade)
+end
 
-function onTrigger(player,npc)
-    if (
+function onTrigger(player, npc)
+    if
         player:getCurrentMission(WINDURST) == THE_JESTER_WHO_D_BE_KING and
         player:getVar("MissionStatus") == 4 and
         not GetMobByID(ID.mob.JESTER_WHO_D_BE_KING_OFFSET + 0):isSpawned() and
         not GetMobByID(ID.mob.JESTER_WHO_D_BE_KING_OFFSET + 1):isSpawned()
-    ) then
-        SpawnMob(ID.mob.JESTER_WHO_D_BE_KING_OFFSET + 0):updateEnmity(player);
-        SpawnMob(ID.mob.JESTER_WHO_D_BE_KING_OFFSET + 1):updateEnmity(player);
+    then
+        SpawnMob(ID.mob.JESTER_WHO_D_BE_KING_OFFSET + 0):updateEnmity(player)
+        SpawnMob(ID.mob.JESTER_WHO_D_BE_KING_OFFSET + 1):updateEnmity(player)
 
     elseif (player:getCurrentMission(WINDURST) == THE_JESTER_WHO_D_BE_KING and player:getVar("MissionStatus") == 5) then
-        player:startEvent(71);
+        player:startEvent(71)
     end
-end;
+end
 
-function onEventUpdate(player,csid,option)
-end;
+function onEventUpdate(player, csid, option)
+end
 
-function onEventFinish(player,csid,option)
-    if (csid == 71) then
-        player:addKeyItem(dsp.ki.ORASTERY_RING);
-        player:messageSpecial(ID.text.KEYITEM_OBTAINED,dsp.ki.ORASTERY_RING);
-        player:setVar("MissionStatus",6)
+function onEventFinish(player, csid, option)
+    if csid == 71 then
+        player:addKeyItem(dsp.ki.ORASTERY_RING)
+        player:messageSpecial(ID.text.KEYITEM_OBTAINED, dsp.ki.ORASTERY_RING)
+        player:setVar("MissionStatus", 6)
     end
-end;
+end

--- a/scripts/zones/Outer_Horutoto_Ruins/npcs/_5e9.lua
+++ b/scripts/zones/Outer_Horutoto_Ruins/npcs/_5e9.lua
@@ -4,39 +4,35 @@
 -- Involved In Mission: The Heart of the Matter
 -- !pos 584 0 -660 194
 -----------------------------------
-require("scripts/globals/keyitems");
-require("scripts/globals/missions");
-local ID = require("scripts/zones/Outer_Horutoto_Ruins/IDs");
+local ID = require("scripts/zones/Outer_Horutoto_Ruins/IDs")
+require("scripts/globals/keyitems")
+require("scripts/globals/missions")
 -----------------------------------
 
-function onTrade(player,npc,trade)
-end;
+function onTrade(player, npc, trade)
+end
 
-function onTrigger(player,npc)
-
-    -- Check if we are on Windurst Mission 1-2
-    if (player:getCurrentMission(WINDURST) == THE_HEART_OF_THE_MATTER and
-       player:getVar("MissionStatus") == 3 and player:hasKeyItem(dsp.ki.SOUTHEASTERN_STAR_CHARM)) then
-        player:startEvent(44);
+function onTrigger(player, npc)
+    if
+        player:getCurrentMission(WINDURST) == THE_HEART_OF_THE_MATTER and
+        player:getVar("MissionStatus") == 3 and
+        player:hasKeyItem(dsp.ki.SOUTHEASTERN_STAR_CHARM)
+    then
+        player:startEvent(44)
     else
-        player:messageSpecial(ID.text.DOOR_FIRMLY_SHUT);
+        player:messageSpecial(ID.text.DOOR_FIRMLY_SHUT)
     end
 
-    return 1;
+    return 1
+end
 
-end;
+function onEventUpdate(player, csid, option)
+end
 
-function onEventUpdate(player,csid,option)
-end;
-
-function onEventFinish(player,csid,option)
-
-    -- If we just finished the cutscene for Windurst Mission 1-2
-    if (csid == 44) then
-        player:setVar("MissionStatus",4);
-        player:messageSpecial(ID.text.ALL_G_ORBS_ENERGIZED);
-        -- Remove the charm that opens this door
-        player:delKeyItem(dsp.ki.SOUTHEASTERN_STAR_CHARM);
+function onEventFinish(player, csid, option)
+    if csid == 44 then
+        player:setVar("MissionStatus", 4)
+        player:messageSpecial(ID.text.ALL_G_ORBS_ENERGIZED)
+        player:delKeyItem(dsp.ki.SOUTHEASTERN_STAR_CHARM)
     end
-
-end;
+end

--- a/scripts/zones/Outer_Horutoto_Ruins/npcs/_5eb.lua
+++ b/scripts/zones/Outer_Horutoto_Ruins/npcs/_5eb.lua
@@ -4,54 +4,54 @@
 -- Involved In Mission: Full Moon Fountain
 -- !pos -291 0 -659 194
 -----------------------------------
-local ID = require("scripts/zones/Outer_Horutoto_Ruins/IDs");
-require("scripts/globals/keyitems");
-require("scripts/globals/missions");
+local ID = require("scripts/zones/Outer_Horutoto_Ruins/IDs")
+require("scripts/globals/keyitems")
+require("scripts/globals/missions")
 -----------------------------------
 
-function onTrade(player,npc,trade)
-end;
+function onTrade(player, npc, trade)
+end
 
-function onTrigger(player,npc)
-    local CurrentMission = player:getCurrentMission(WINDURST);
-    local MissionStatus = player:getVar("MissionStatus");
+function onTrigger(player, npc)
+    local currentMission = player:getCurrentMission(WINDURST)
+    local missionStatus = player:getVar("MissionStatus")
 
-    if (
-        CurrentMission == FULL_MOON_FOUNTAIN and
-        MissionStatus == 1 and
+    if
+        currentMission == FULL_MOON_FOUNTAIN and
+        missionStatus == 1 and
         player:hasKeyItem(dsp.ki.SOUTHWESTERN_STAR_CHARM) and
         not GetMobByID(ID.mob.FULL_MOON_FOUNTAIN_OFFSET + 0):isSpawned() and
         not GetMobByID(ID.mob.FULL_MOON_FOUNTAIN_OFFSET + 1):isSpawned() and
         not GetMobByID(ID.mob.FULL_MOON_FOUNTAIN_OFFSET + 2):isSpawned() and
         not GetMobByID(ID.mob.FULL_MOON_FOUNTAIN_OFFSET + 3):isSpawned()
-    ) then
+    then
         for i = ID.mob.FULL_MOON_FOUNTAIN_OFFSET, ID.mob.FULL_MOON_FOUNTAIN_OFFSET + 3 do
-            SpawnMob(i);
+            SpawnMob(i)
         end
-        
-    elseif (
-        CurrentMission == FULL_MOON_FOUNTAIN and
-        MissionStatus == 2 and
+
+    elseif
+        currentMission == FULL_MOON_FOUNTAIN and
+        missionStatus == 2 and
         GetMobByID(ID.mob.FULL_MOON_FOUNTAIN_OFFSET + 0):isDead() and
         GetMobByID(ID.mob.FULL_MOON_FOUNTAIN_OFFSET + 1):isDead() and
         GetMobByID(ID.mob.FULL_MOON_FOUNTAIN_OFFSET + 2):isDead() and
         GetMobByID(ID.mob.FULL_MOON_FOUNTAIN_OFFSET + 3):isDead()
-    ) then
-        player:startEvent(68);
-        
+    then
+        player:startEvent(68)
+
     else
-        player:messageSpecial(ID.text.DOOR_FIRMLY_SHUT);
+        player:messageSpecial(ID.text.DOOR_FIRMLY_SHUT)
     end
 
-    return 1;
-end;
+    return 1
+end
 
-function onEventUpdate(player,csid,option)
-end;
+function onEventUpdate(player, csid, option)
+end
 
-function onEventFinish(player,csid,option)
-    if (csid == 68) then
-        player:setVar("MissionStatus",3);
-        player:delKeyItem(dsp.ki.SOUTHWESTERN_STAR_CHARM);
+function onEventFinish(player, csid, option)
+    if csid == 68 then
+        player:setVar("MissionStatus", 3)
+        player:delKeyItem(dsp.ki.SOUTHWESTERN_STAR_CHARM)
     end
-end;
+end

--- a/scripts/zones/Outer_Horutoto_Ruins/npcs/_5ee.lua
+++ b/scripts/zones/Outer_Horutoto_Ruins/npcs/_5ee.lua
@@ -1,87 +1,23 @@
 -----------------------------------
 -- Area: Outer Horutoto Ruins
 --  NPC: Ancient Magical Gizmo #1 (E out of E, F, G, H, I, J)
---  Involved In Mission: The Heart of the Matter
+-- Involved In Mission: The Heart of the Matter
 -----------------------------------
-require("scripts/globals/keyitems");
-require("scripts/globals/missions");
-local ID = require("scripts/zones/Outer_Horutoto_Ruins/IDs");
+local func = require("scripts/zones/Outer_Horutoto_Ruins/globals")
 -----------------------------------
 
-function onTrade(player,npc,trade)
-end;
+function onTrade(player, npc, trade)
+end
 
-function onTrigger(player,npc)
+function onTrigger(player, npc)
+    func.gizmoOnTrigger(player, npc)
 
-    -- Check if we are on Windurst Mission 1-2
-    if (player:getCurrentMission(WINDURST) == THE_HEART_OF_THE_MATTER) then
-        local MissionStatus = player:getVar("MissionStatus");
+    return 1
+end
 
-        if (MissionStatus == 2) then
-            -- Entered a Dark Orb
-            if (player:getVar("MissionStatus_orb1") == 1) then
-                player:startEvent(46);
-            else
-                player:messageSpecial(ID.text.ORB_ALREADY_PLACED);
-            end
-        elseif (MissionStatus == 4) then
-            -- Took out a Glowing Orb
-            if (player:getVar("MissionStatus_orb1") == 2) then
-                player:startEvent(46);
-            else
-                player:messageSpecial(ID.text.G_ORB_ALREADY_GOTTEN);
-            end
-        else
-            player:messageSpecial(ID.text.DARK_MANA_ORB_RECHARGER);
-        end
-    else
-        player:messageSpecial(ID.text.DARK_MANA_ORB_RECHARGER);
-    end
+function onEventUpdate(player, csid, option)
+end
 
-    return 1;
-
-end;
-
-function onEventUpdate(player,csid,option)
-end;
-
-function onEventFinish(player,csid,option)
-
-    if (csid == 46) then
-        local orb_value = player:getVar("MissionStatus_orb1");
-
-        if (orb_value == 1) then
-            player:setVar("MissionStatus_orb1",2);
-            -- Push the text that the player has placed the orb
-            player:messageSpecial(ID.text.FIRST_DARK_ORB_IN_PLACE);
-            --Delete the key item
-            player:delKeyItem(dsp.ki.FIRST_DARK_MANA_ORB);
-
-            -- Check if all orbs have been placed or not
-            if (player:getVar("MissionStatus_orb2") == 2 and
-               player:getVar("MissionStatus_orb3") == 2 and
-               player:getVar("MissionStatus_orb4") == 2 and
-               player:getVar("MissionStatus_orb5") == 2 and
-               player:getVar("MissionStatus_orb6") == 2) then
-                player:messageSpecial(ID.text.ALL_DARK_MANA_ORBS_SET);
-                player:setVar("MissionStatus",3);
-            end
-        elseif (orb_value == 2) then
-            player:setVar("MissionStatus_orb1",3);
-            -- Time to get the glowing orb out
-            player:addKeyItem(dsp.ki.FIRST_GLOWING_MANA_ORB);
-            player:messageSpecial(ID.text.KEYITEM_OBTAINED,dsp.ki.FIRST_GLOWING_MANA_ORB);
-
-            -- Check if all orbs have been placed or not
-            if (player:getVar("MissionStatus_orb2") == 3 and
-               player:getVar("MissionStatus_orb3") == 3 and
-               player:getVar("MissionStatus_orb4") == 3 and
-               player:getVar("MissionStatus_orb5") == 3 and
-               player:getVar("MissionStatus_orb6") == 3) then
-                player:messageSpecial(ID.text.RETRIEVED_ALL_G_ORBS);
-                player:setVar("MissionStatus",5);
-            end
-        end
-    end
-
-end;
+function onEventFinish(player, csid, option)
+    func.gizmoOnEventFinish(player, csid)
+end

--- a/scripts/zones/Outer_Horutoto_Ruins/npcs/_5ef.lua
+++ b/scripts/zones/Outer_Horutoto_Ruins/npcs/_5ef.lua
@@ -1,85 +1,23 @@
 -----------------------------------
 -- Area: Outer Horutoto Ruins
 --  NPC: Ancient Magical Gizmo #2 (F out of E, F, G, H, I, J)
---  Involved In Mission: The Heart of the Matter
+-- Involved In Mission: The Heart of the Matter
 -----------------------------------
-require("scripts/globals/keyitems");
-require("scripts/globals/missions");
-local ID = require("scripts/zones/Outer_Horutoto_Ruins/IDs");
+local func = require("scripts/zones/Outer_Horutoto_Ruins/globals")
 -----------------------------------
 
-function onTrade(player,npc,trade)
-end;
+function onTrade(player, npc, trade)
+end
 
-function onTrigger(player,npc)
+function onTrigger(player, npc)
+    func.gizmoOnTrigger(player, npc)
 
-    -- Check if we are on Windurst Mission 1-2
-    if (player:getCurrentMission(WINDURST) == THE_HEART_OF_THE_MATTER) then
-        local MissionStatus = player:getVar("MissionStatus");
+    return 1
+end
 
-        if (MissionStatus == 2) then
-            -- Entered a Dark Orb
-            if (player:getVar("MissionStatus_orb2") == 1) then
-                player:startEvent(47);
-            else
-                player:messageSpecial(ID.text.ORB_ALREADY_PLACED);
-            end
-        elseif (MissionStatus == 4) then
-            -- Took out a Glowing Orb
-            if (player:getVar("MissionStatus_orb2") == 2) then
-                player:startEvent(47);
-            else
-                player:messageSpecial(ID.text.G_ORB_ALREADY_GOTTEN);
-            end
-        else
-            player:messageSpecial(ID.text.DARK_MANA_ORB_RECHARGER);
-        end
-    else
-        player:messageSpecial(ID.text.DARK_MANA_ORB_RECHARGER);
-    end
-    return 1;
-end;
+function onEventUpdate(player, csid, option)
+end
 
-function onEventUpdate(player,csid,option)
-end;
-
-function onEventFinish(player,csid,option)
-
-    if (csid == 47) then
-        local orb_value = player:getVar("MissionStatus_orb2");
-
-        if (orb_value == 1) then
-            player:setVar("MissionStatus_orb2",2);
-            -- Push the text that the player has placed the orb
-            player:messageSpecial(ID.text.SECOND_DARK_ORB_IN_PLACE);
-            --Delete the key item
-            player:delKeyItem(dsp.ki.SECOND_DARK_MANA_ORB);
-
-            -- Check if all orbs have been placed or not
-            if (player:getVar("MissionStatus_orb1") == 2 and
-               player:getVar("MissionStatus_orb3") == 2 and
-               player:getVar("MissionStatus_orb4") == 2 and
-               player:getVar("MissionStatus_orb5") == 2 and
-               player:getVar("MissionStatus_orb6") == 2) then
-                player:messageSpecial(ID.text.ALL_DARK_MANA_ORBS_SET);
-                player:setVar("MissionStatus",3);
-            end
-        elseif (orb_value == 2) then
-            player:setVar("MissionStatus_orb2",3);
-            -- Time to get the glowing orb out
-            player:addKeyItem(dsp.ki.SECOND_GLOWING_MANA_ORB);
-            player:messageSpecial(ID.text.KEYITEM_OBTAINED,dsp.ki.SECOND_GLOWING_MANA_ORB);
-
-            -- Check if all orbs have been placed or not
-            if (player:getVar("MissionStatus_orb1") == 3 and
-               player:getVar("MissionStatus_orb3") == 3 and
-               player:getVar("MissionStatus_orb4") == 3 and
-               player:getVar("MissionStatus_orb5") == 3 and
-               player:getVar("MissionStatus_orb6") == 3) then
-                player:messageSpecial(ID.text.RETRIEVED_ALL_G_ORBS);
-                player:setVar("MissionStatus",5);
-            end
-        end
-    end
-
-end;
+function onEventFinish(player, csid, option)
+    func.gizmoOnEventFinish(player, csid)
+end

--- a/scripts/zones/Outer_Horutoto_Ruins/npcs/_5eg.lua
+++ b/scripts/zones/Outer_Horutoto_Ruins/npcs/_5eg.lua
@@ -1,85 +1,23 @@
 -----------------------------------
 -- Area: Outer Horutoto Ruins
 --  NPC: Ancient Magical Gizmo #3 (G out of E, F, G, H, I, J)
---  Involved In Mission: The Heart of the Matter
+-- Involved In Mission: The Heart of the Matter
 -----------------------------------
-require("scripts/globals/keyitems");
-require("scripts/globals/missions");
-local ID = require("scripts/zones/Outer_Horutoto_Ruins/IDs");
+local func = require("scripts/zones/Outer_Horutoto_Ruins/globals")
 -----------------------------------
 
-function onTrade(player,npc,trade)
-end;
+function onTrade(player, npc, trade)
+end
 
-function onTrigger(player,npc)
+function onTrigger(player, npc)
+    func.gizmoOnTrigger(player, npc)
 
-    -- Check if we are on Windurst Mission 1-2
-    if (player:getCurrentMission(WINDURST) == THE_HEART_OF_THE_MATTER) then
-        local MissionStatus = player:getVar("MissionStatus");
+    return 1
+end
 
-        if (MissionStatus == 2) then
-            -- Entered a Dark Orb
-            if (player:getVar("MissionStatus_orb3") == 1) then
-                player:startEvent(48);
-            else
-                player:messageSpecial(ID.text.ORB_ALREADY_PLACED);
-            end
-        elseif (MissionStatus == 4) then
-            -- Took out a Glowing Orb
-            if (player:getVar("MissionStatus_orb3") == 2) then
-                player:startEvent(48);
-            else
-                player:messageSpecial(ID.text.G_ORB_ALREADY_GOTTEN);
-            end
-        else
-            player:messageSpecial(ID.text.DARK_MANA_ORB_RECHARGER);
-        end
-    else
-        player:messageSpecial(ID.text.DARK_MANA_ORB_RECHARGER);
-    end
-    return 1;
-end;
+function onEventUpdate(player, csid, option)
+end
 
-function onEventUpdate(player,csid,option)
-end;
-
-function onEventFinish(player,csid,option)
-
-    if (csid == 48) then
-        local orb_value = player:getVar("MissionStatus_orb3");
-
-        if (orb_value == 1) then
-            player:setVar("MissionStatus_orb3",2);
-            -- Push the text that the player has placed the orb
-            player:messageSpecial(ID.text.THIRD_DARK_ORB_IN_PLACE);
-            --Delete the key item
-            player:delKeyItem(dsp.ki.THIRD_DARK_MANA_ORB);
-
-            -- Check if all orbs have been placed or not
-            if (player:getVar("MissionStatus_orb1") == 2 and
-               player:getVar("MissionStatus_orb2") == 2 and
-               player:getVar("MissionStatus_orb4") == 2 and
-               player:getVar("MissionStatus_orb5") == 2 and
-               player:getVar("MissionStatus_orb6") == 2) then
-                player:messageSpecial(ID.text.ALL_DARK_MANA_ORBS_SET);
-                player:setVar("MissionStatus",3);
-            end
-        elseif (orb_value == 2) then
-            player:setVar("MissionStatus_orb3",3);
-            -- Time to get the glowing orb out
-            player:addKeyItem(dsp.ki.THIRD_GLOWING_MANA_ORB);
-            player:messageSpecial(ID.text.KEYITEM_OBTAINED,dsp.ki.THIRD_GLOWING_MANA_ORB);
-
-            -- Check if all orbs have been placed or not
-            if (player:getVar("MissionStatus_orb1") == 3 and
-               player:getVar("MissionStatus_orb2") == 3 and
-               player:getVar("MissionStatus_orb4") == 3 and
-               player:getVar("MissionStatus_orb5") == 3 and
-               player:getVar("MissionStatus_orb6") == 3) then
-                player:messageSpecial(ID.text.RETRIEVED_ALL_G_ORBS);
-                player:setVar("MissionStatus",5);
-            end
-        end
-    end
-
-end;
+function onEventFinish(player, csid, option)
+    func.gizmoOnEventFinish(player, csid)
+end

--- a/scripts/zones/Outer_Horutoto_Ruins/npcs/_5eh.lua
+++ b/scripts/zones/Outer_Horutoto_Ruins/npcs/_5eh.lua
@@ -1,85 +1,23 @@
 -----------------------------------
 -- Area: Outer Horutoto Ruins
 --  NPC: Ancient Magical Gizmo #4 (H out of E, F, G, H, I, J)
---  Involved In Mission: The Heart of the Matter
+-- Involved In Mission: The Heart of the Matter
 -----------------------------------
-require("scripts/globals/keyitems");
-require("scripts/globals/missions");
-local ID = require("scripts/zones/Outer_Horutoto_Ruins/IDs");
+local func = require("scripts/zones/Outer_Horutoto_Ruins/globals")
 -----------------------------------
 
-function onTrade(player,npc,trade)
-end;
+function onTrade(player, npc, trade)
+end
 
-function onTrigger(player,npc)
+function onTrigger(player, npc)
+    func.gizmoOnTrigger(player, npc)
 
-    -- Check if we are on Windurst Mission 1-2
-    if (player:getCurrentMission(WINDURST) == THE_HEART_OF_THE_MATTER) then
-        local MissionStatus = player:getVar("MissionStatus");
+    return 1
+end
 
-        if (MissionStatus == 2) then
-            -- Entered a Dark Orb
-            if (player:getVar("MissionStatus_orb4") == 1) then
-                player:startEvent(49);
-            else
-                player:messageSpecial(ID.text.ORB_ALREADY_PLACED);
-            end
-        elseif (MissionStatus == 4) then
-            -- Took out a Glowing Orb
-            if (player:getVar("MissionStatus_orb4") == 2) then
-                player:startEvent(49);
-            else
-                player:messageSpecial(ID.text.G_ORB_ALREADY_GOTTEN);
-            end
-        else
-            player:messageSpecial(ID.text.DARK_MANA_ORB_RECHARGER);
-        end
-    else
-        player:messageSpecial(ID.text.DARK_MANA_ORB_RECHARGER);
-    end
-    return 1;
-end;
+function onEventUpdate(player, csid, option)
+end
 
-function onEventUpdate(player,csid,option)
-end;
-
-function onEventFinish(player,csid,option)
-
-    if (csid == 49) then
-        local orb_value = player:getVar("MissionStatus_orb4");
-
-        if (orb_value == 1) then
-            player:setVar("MissionStatus_orb4",2);
-            -- Push the text that the player has placed the orb
-            player:messageSpecial(ID.text.FOURTH_DARK_ORB_IN_PLACE);
-            --Delete the key item
-            player:delKeyItem(dsp.ki.FOURTH_DARK_MANA_ORB);
-
-            -- Check if all orbs have been placed or not
-            if (player:getVar("MissionStatus_orb1") == 2 and
-               player:getVar("MissionStatus_orb2") == 2 and
-               player:getVar("MissionStatus_orb3") == 2 and
-               player:getVar("MissionStatus_orb5") == 2 and
-               player:getVar("MissionStatus_orb6") == 2) then
-                player:messageSpecial(ID.text.ALL_DARK_MANA_ORBS_SET);
-                player:setVar("MissionStatus",3);
-            end
-        elseif (orb_value == 2) then
-            player:setVar("MissionStatus_orb4",3);
-            -- Time to get the glowing orb out
-            player:addKeyItem(dsp.ki.FOURTH_GLOWING_MANA_ORB);
-            player:messageSpecial(ID.text.KEYITEM_OBTAINED,dsp.ki.FOURTH_GLOWING_MANA_ORB);
-
-            -- Check if all orbs have been placed or not
-            if (player:getVar("MissionStatus_orb1") == 3 and
-               player:getVar("MissionStatus_orb2") == 3 and
-               player:getVar("MissionStatus_orb3") == 3 and
-               player:getVar("MissionStatus_orb5") == 3 and
-               player:getVar("MissionStatus_orb6") == 3) then
-                player:messageSpecial(ID.text.RETRIEVED_ALL_G_ORBS);
-                player:setVar("MissionStatus",5);
-            end
-        end
-    end
-
-end;
+function onEventFinish(player, csid, option)
+    func.gizmoOnEventFinish(player, csid)
+end

--- a/scripts/zones/Outer_Horutoto_Ruins/npcs/_5ei.lua
+++ b/scripts/zones/Outer_Horutoto_Ruins/npcs/_5ei.lua
@@ -1,85 +1,23 @@
 -----------------------------------
 -- Area: Outer Horutoto Ruins
 --  NPC: Ancient Magical Gizmo #5 (I out of E, F, G, H, I, J)
---  Involved In Mission: The Heart of the Matter
+-- Involved In Mission: The Heart of the Matter
 -----------------------------------
-require("scripts/globals/keyitems");
-require("scripts/globals/missions");
-local ID = require("scripts/zones/Outer_Horutoto_Ruins/IDs");
+local func = require("scripts/zones/Outer_Horutoto_Ruins/globals")
 -----------------------------------
 
-function onTrade(player,npc,trade)
-end;
+function onTrade(player, npc, trade)
+end
 
-function onTrigger(player,npc)
+function onTrigger(player, npc)
+    func.gizmoOnTrigger(player, npc)
 
-    -- Check if we are on Windurst Mission 1-2
-    if (player:getCurrentMission(WINDURST) == THE_HEART_OF_THE_MATTER) then
-        local MissionStatus = player:getVar("MissionStatus");
+    return 1
+end
 
-        if (MissionStatus == 2) then
-            -- Entered a Dark Orb
-            if (player:getVar("MissionStatus_orb5") == 1) then
-                player:startEvent(50);
-            else
-                player:messageSpecial(ID.text.ORB_ALREADY_PLACED);
-            end
-        elseif (MissionStatus == 4) then
-            -- Took out a Glowing Orb
-            if (player:getVar("MissionStatus_orb5") == 2) then
-                player:startEvent(50);
-            else
-                player:messageSpecial(ID.text.G_ORB_ALREADY_GOTTEN);
-            end
-        else
-            player:messageSpecial(ID.text.DARK_MANA_ORB_RECHARGER);
-        end
-    else
-        player:messageSpecial(ID.text.DARK_MANA_ORB_RECHARGER);
-    end
-    return 1;
-end;
+function onEventUpdate(player, csid, option)
+end
 
-function onEventUpdate(player,csid,option)
-end;
-
-function onEventFinish(player,csid,option)
-
-    if (csid == 50) then
-        local orb_value = player:getVar("MissionStatus_orb5");
-
-        if (orb_value == 1) then
-            player:setVar("MissionStatus_orb5",2);
-            -- Push the text that the player has placed the orb
-            player:messageSpecial(ID.text.FIFTH_DARK_ORB_IN_PLACE);
-            --Delete the key item
-            player:delKeyItem(dsp.ki.FIFTH_DARK_MANA_ORB);
-
-            -- Check if all orbs have been placed or not
-            if (player:getVar("MissionStatus_orb1") == 2 and
-               player:getVar("MissionStatus_orb2") == 2 and
-               player:getVar("MissionStatus_orb3") == 2 and
-               player:getVar("MissionStatus_orb4") == 2 and
-               player:getVar("MissionStatus_orb6") == 2) then
-                player:messageSpecial(ID.text.ALL_DARK_MANA_ORBS_SET);
-                player:setVar("MissionStatus",3);
-            end
-        elseif (orb_value == 2) then
-            player:setVar("MissionStatus_orb5",3);
-            -- Time to get the glowing orb out
-            player:addKeyItem(dsp.ki.FIFTH_GLOWING_MANA_ORB);
-            player:messageSpecial(ID.text.KEYITEM_OBTAINED,dsp.ki.FIFTH_GLOWING_MANA_ORB);
-
-            -- Check if all orbs have been placed or not
-            if (player:getVar("MissionStatus_orb1") == 3 and
-               player:getVar("MissionStatus_orb2") == 3 and
-               player:getVar("MissionStatus_orb3") == 3 and
-               player:getVar("MissionStatus_orb4") == 3 and
-               player:getVar("MissionStatus_orb6") == 3) then
-                player:messageSpecial(ID.text.RETRIEVED_ALL_G_ORBS);
-                player:setVar("MissionStatus",5);
-            end
-        end
-    end
-
-end;
+function onEventFinish(player, csid, option)
+    func.gizmoOnEventFinish(player, csid)
+end

--- a/scripts/zones/Outer_Horutoto_Ruins/npcs/_5ej.lua
+++ b/scripts/zones/Outer_Horutoto_Ruins/npcs/_5ej.lua
@@ -1,85 +1,23 @@
 -----------------------------------
 -- Area: Outer Horutoto Ruins
 --  NPC: Ancient Magical Gizmo #6 (J out of E, F, G, H, I, J)
---  Involved In Mission: The Heart of the Matter
+-- Involved In Mission: The Heart of the Matter
 -----------------------------------
-require("scripts/globals/keyitems");
-require("scripts/globals/missions");
-local ID = require("scripts/zones/Outer_Horutoto_Ruins/IDs");
+local func = require("scripts/zones/Outer_Horutoto_Ruins/globals")
 -----------------------------------
 
-function onTrade(player,npc,trade)
-end;
+function onTrade(player, npc, trade)
+end
 
-function onTrigger(player,npc)
+function onTrigger(player, npc)
+    func.gizmoOnTrigger(player, npc)
 
-    -- Check if we are on Windurst Mission 1-2
-    if (player:getCurrentMission(WINDURST) == THE_HEART_OF_THE_MATTER) then
-        local MissionStatus = player:getVar("MissionStatus");
+    return 1
+end
 
-        if (MissionStatus == 2) then
-            -- Entered a Dark Orb
-            if (player:getVar("MissionStatus_orb6") == 1) then
-                player:startEvent(51);
-            else
-                player:messageSpecial(ID.text.ORB_ALREADY_PLACED);
-            end
-        elseif (MissionStatus == 4) then
-            -- Took out a Glowing Orb
-            if (player:getVar("MissionStatus_orb6") == 2) then
-                player:startEvent(51);
-            else
-                player:messageSpecial(ID.text.G_ORB_ALREADY_GOTTEN);
-            end
-        else
-            player:messageSpecial(ID.text.DARK_MANA_ORB_RECHARGER);
-        end
-    else
-        player:messageSpecial(ID.text.DARK_MANA_ORB_RECHARGER);
-    end
-    return 1;
-end;
+function onEventUpdate(player, csid, option)
+end
 
-function onEventUpdate(player,csid,option)
-end;
-
-function onEventFinish(player,csid,option)
-
-    if (csid == 51) then
-        local orb_value = player:getVar("MissionStatus_orb6");
-
-        if (orb_value == 1) then
-            player:setVar("MissionStatus_orb6",2);
-            -- Push the text that the player has placed the orb
-            player:messageSpecial(ID.text.SIXTH_DARK_ORB_IN_PLACE);
-            --Delete the key item
-            player:delKeyItem(dsp.ki.SIXTH_DARK_MANA_ORB);
-
-            -- Check if all orbs have been placed or not
-            if (player:getVar("MissionStatus_orb1") == 2 and
-               player:getVar("MissionStatus_orb2") == 2 and
-               player:getVar("MissionStatus_orb3") == 2 and
-               player:getVar("MissionStatus_orb4") == 2 and
-               player:getVar("MissionStatus_orb5") == 2) then
-                player:messageSpecial(ID.text.ALL_DARK_MANA_ORBS_SET);
-                player:setVar("MissionStatus",3);
-            end
-        elseif (orb_value == 2) then
-            player:setVar("MissionStatus_orb6",3);
-            -- Time to get the glowing orb out
-            player:addKeyItem(dsp.ki.SIXTH_GLOWING_MANA_ORB);
-            player:messageSpecial(ID.text.KEYITEM_OBTAINED,dsp.ki.SIXTH_GLOWING_MANA_ORB);
-
-            -- Check if all orbs have been placed or not
-            if (player:getVar("MissionStatus_orb1") == 3 and
-               player:getVar("MissionStatus_orb2") == 3 and
-               player:getVar("MissionStatus_orb3") == 3 and
-               player:getVar("MissionStatus_orb4") == 3 and
-               player:getVar("MissionStatus_orb5") == 3) then
-                player:messageSpecial(ID.text.RETRIEVED_ALL_G_ORBS);
-                player:setVar("MissionStatus",5);
-            end
-        end
-    end
-
-end;
+function onEventFinish(player, csid, option)
+    func.gizmoOnEventFinish(player, csid)
+end

--- a/scripts/zones/Outer_Horutoto_Ruins/npcs/_ne4.lua
+++ b/scripts/zones/Outer_Horutoto_Ruins/npcs/_ne4.lua
@@ -6,21 +6,21 @@
 require("scripts/globals/strangeapparatus")
 -----------------------------------
 
-function onTrade(player,npc,trade)
+function onTrade(player, npc, trade)
     dsp.strangeApparatus.onTrade(player, trade, 66)
 end
 
-function onTrigger(player,npc)
+function onTrigger(player, npc)
     dsp.strangeApparatus.onTrigger(player, 64)
 end
 
-function onEventUpdate(player,csid,option)
+function onEventUpdate(player, csid, option)
     if csid == 64 then
         dsp.strangeApparatus.onEventUpdate(player, option)
     end
 end
 
-function onEventFinish(player,csid,option)
+function onEventFinish(player, csid, option)
     if csid == 66 then
         dsp.strangeApparatus.onEventFinish(player)
     end


### PR DESCRIPTION
Outer Horutoto zone globals / magical gizmo luas (_5ee through _5ej):
* made local two functions that didn't need to be on the global table.
* renamed function balloonDespawn -> balloonOnDespawn
* stole all the magical gizmo logic for "Heart of the Matter" from the six gizmo luas.
* fixed a bunch of incorrect events and messages in this quest logic.
* used this [video](https://www.youtube.com/watch?v=Vuib11LApEc) as reference for quest.

All other files:
* style guided. no logic changes.