### PR TITLE
[QUEST REWRITE] Reworking quest files to be stage-based + some GM commands

### DIFF
--- a/scripts/commands/checkquest.lua
+++ b/scripts/commands/checkquest.lua
@@ -60,7 +60,30 @@ function onTrigger(player,logId,questId,target)
         [2] = function (x) status = "COMPLETED"; end,
     }
 
-    -- show quest status
-    player:PrintToPlayer( string.format( "%s's status for %s quest ID %i is: %s", targ:getName(), logName, questId, status ) );
+    -- fetch a quest table if there is one
+    local quest_table = dsp.quests.getQuestTable(logId, questId)
 
+    local quest_status_string = ''
+
+    -- show quest status
+    if quest_table then
+        quest_status_string = quest_status_string .. string.format("%s's status for %s quest '%s' is: %s", targ:getName(), logName, quest_table.name, status)
+    else
+        quest_status_string = quest_status_string .. string.format("%s's status for %s quest ID %i is: %s", targ:getName(), logName, questId, status )
+    end
+
+    -- print any known quest vars
+    if quest_table then
+        quest_status_string = quest_status_string .. string.format("\n%s is currently on stage: %i", targ:getName(), dsp.quests.getStage(targ, quest_table))
+        local quest_vars_string = ''
+        for name, var in pairs(quest_table.vars.additional) do
+            quest_vars_string = string.format(quest_vars_string.. ", %s: %i", name, dsp.quests.getVar(targ, quest_table, name))
+        end
+        if string.len(quest_vars_string) > 1 then
+            quest_vars_string = string.format("\n%s's additional quest vars are".. quest_vars_string, targ:getName())
+            quest_status_string = quest_status_string .. quest_vars_string
+        end
+    end
+
+    player:PrintToPlayer(quest_status_string)
 end;

--- a/scripts/commands/resetquest.lua
+++ b/scripts/commands/resetquest.lua
@@ -1,0 +1,72 @@
+---------------------------------------------------------------------------------------------------
+-- func: !resetquest <logID> <questID> {player}
+-- desc: Resets the target's progress in a quest (log status, quest vars, and temporary key items)
+---------------------------------------------------------------------------------------------------
+
+require("scripts/globals/quests");
+
+cmdprops =
+{
+    permission = 1,
+    parameters = "sss"
+};
+
+function error(player, msg)
+    player:PrintToPlayer(msg);
+    player:PrintToPlayer("!resetquest <logID> <questID> {player}");
+end;
+
+function onTrigger(player,logId,questId,target)
+
+    -- validate logId
+    local questLog = GetQuestLogInfo(logId);
+    if (questLog == nil) then
+        error(player, "Invalid logID.");
+        return;
+    end
+    local logName = questLog.full_name;
+    logId = questLog.quest_log;
+
+    -- validate questId
+    if (questId ~= nil) then
+        questId = tonumber(questId) or _G[string.upper(questId)];
+    end
+    if (questId == nil or questId < 0) then
+        error(player, "Invalid questID.");
+        return;
+    end
+
+    -- validate target
+    local targ;
+    if (target == nil) then
+        targ = player:getCursorTarget();
+        if (targ == nil or not targ:isPC()) then
+            targ = player;
+        end
+    else
+        targ = GetPlayerByName(target);
+        if (targ == nil) then
+            error(player, string.format("Player named '%s' not found!", target));
+            return;
+        end
+    end
+
+    -- fetch the quest table
+    local quest = dsp.quests.getQuestTable(logId, questId)
+
+    if quest then
+        -- Begin resetting all quest progress to the best of our ability
+        targ:delQuest(logId, questId) -- Delete quest status
+        targ:setVar(quest.vars.stage, 0) -- Reset stage var
+        for name, var in pairs(quest.vars.additional) do -- Purge any additional quest vars
+            handleQuestVar(targ, quest, name, 0, "resetquest: ", nil)
+        end
+        for _, ki in pairs(quest.temporary.key_items) do -- Delete any temporary key items
+            player:delKeyItem(ki)
+        end
+        player:PrintToPlayer( string.format("%s's progress for %s quest '%s' has been reset.", targ:getName(), logName, quest.name) )
+    else
+        -- Quest table not defined for the given ID
+        player:PrintToPlayer( string.format("Unable to reset %s quest ID %i. No quest table found.", logName, questId) )
+    end
+end;

--- a/scripts/globals/quests.lua
+++ b/scripts/globals/quests.lua
@@ -9,10 +9,10 @@ dsp.quests.enums =
 {
     log_ids =
     {
-        SANDORIA  = 0, BASTOK      = 1,  WINDURST = 2,
-        JEUNO     = 3, OTHER_AREAS = 4,  OUTLANDS = 5,
-        AHT_URGAN = 6, CRYSTAL_WAR = 7,  ABYSSEA  = 8,
-        ADOULIN   = 9, COALITION   = 10
+        SANDORIA   = 0, BASTOK      = 1,  WINDURST = 2,
+        JEUNO      = 3, OTHER_AREAS = 4,  OUTLANDS = 5,
+        AHT_URHGAN = 6, CRYSTAL_WAR = 7,  ABYSSEA  = 8,
+        ADOULIN    = 9, COALITION   = 10
     },
 
     fame_areas =
@@ -40,6 +40,13 @@ dsp.quests.enums =
         QUEST_COMPLETED = 2,
     },
 
+    stages =
+    {
+        STAGE0   =  0, STAGE1  =  1, STAGE2  =  2, STAGE3   =  3, STAGE4   =  4,
+        STAGE5   =  5, STAGE6  =  6, STAGE7  =  7, STAGE8   =  8, STAGE9   =  9,
+        STAGE10  = 10, STAGE11 = 11, STAGE12 = 12, STAGE13  = 13, STAGE14  = 14,
+    },
+
     quest_ids =
     {
         sandoria =
@@ -57,23 +64,17 @@ dsp.quests.enums =
             A_SQUIRE_S_TEST                 = 10, -- + --
             GRAVE_CONCERNS                  = 11, -- ± --
             THE_BRUGAIRE_CONSORTIUM         = 12, -- + --
-
             LIZARD_SKINS                    = 15, -- + --
             FLYERS_FOR_REGINE               = 16, -- + --
-
             GATES_TO_PARADISE               = 18, -- + --
             A_SQUIRE_S_TEST_II              = 19, -- + --
             TO_CURE_A_COUGH                 = 20, -- + --
-
             TIGER_S_TEETH                   = 23, -- ± --
-
             UNDYING_FLAMES                  = 26, -- + --
             A_PURCHASE_OF_ARMS              = 27, -- + --
-
             A_KNIGHT_S_TEST                 = 29, -- + --
             THE_MEDICINE_WOMAN              = 30, -- + --
             BLACK_TIGER_SKINS               = 31, -- + --
-
             GROWING_FLOWERS                 = 58, -- ± --
             TRIAL_BY_ICE                    = 59, -- + --
             THE_GENERAL_S_SECRET            = 60, -- ± --
@@ -89,7 +90,6 @@ dsp.quests.enums =
             UNEXPECTED_TREASURE             = 70,
             BLACKMAIL                       = 71, -- + --
             THE_SETTING_SUN                 = 72, -- + --
-
             DISTANT_LOYALTIES               = 74,
             THE_RIVALRY                     = 75, -- ± --
             THE_COMPETITION                 = 76, -- ± --
@@ -127,11 +127,9 @@ dsp.quests.enums =
             SIGNED_IN_BLOOD                 = 108, -- + --
             TEA_WITH_A_TONBERRY             = 109,
             SPICE_GALS                      = 110,
-
-            OVER_THE_HILLS_AND_FAR_AWAY     = 112,
+            OVER_THE_HILLS_AND_FAR_AWAY     = 112, -- + --
             LURE_OF_THE_WILDCAT_SAN_D_ORIA  = 113, -- ± --
             ATELLOUNE_S_LAMENT              = 114,
-
             THICK_SHELLS                    = 117, -- ± --
             FOREST_FOR_THE_TREES            = 118,
         },
@@ -256,7 +254,6 @@ dsp.quests.enums =
             THE_POSTMAN_ALWAYS_KO_S_TWICE   = 19, -- + --
             EARLY_BIRD_CATCHES_THE_BOOKWORM = 20, -- + --
             CATCH_IT_IF_YOU_CAN             = 21, -- + --
-
             ALL_AT_SEA                      = 23,
             THE_ALL_NEW_C_2000              = 24, -- ± --
             MIHGO_S_AMIGO                   = 25, -- + --
@@ -288,7 +285,6 @@ dsp.quests.enums =
             HOIST_THE_JELLY_ROGER           = 51, -- + --
             SOMETHING_FISHY                 = 52, -- + --
             TO_CATCH_A_FALLIHG_STAR         = 53, -- + --
-
             PAYING_LIP_SERVICE              = 60, -- + --
             THE_AMAZIN_SCORPIO              = 61, -- + --
             TWINSTONE_BONDING               = 62, -- + --
@@ -327,7 +323,8 @@ dsp.quests.enums =
             BABBAN_NY_MHEILLEA              = 95,
         },
 
-        adoulin = {
+        adoulin =
+        {
         -- These also do not match the DAT file order, had
         -- discrepencies and swapped orders from the start.
             TWITHERYM_DUST                  = 0,
@@ -431,7 +428,16 @@ dsp.quests.enums =
     },
 }
 
-
+dsp.quests.quest_filenames =
+{
+    [dsp.quests.enums.log_ids.ADOULIN] =
+    {
+        [dsp.quests.enums.quest_ids.adoulin.WAYWARD_WAYPOINTS] = 'wayward_waypoints',
+        [dsp.quests.enums.quest_ids.adoulin.A_CERTAIN_SUBSTITUTE_PATROLMAN] = 'a_certain_substitute_patrolman',
+        [dsp.quests.enums.quest_ids.adoulin.THE_OLD_MAN_AND_THE_HARPOON] = 'the_old_man_and_the_harpoon',
+        [dsp.quests.enums.quest_ids.adoulin.FERTILE_GROUND] = 'fertile_ground',
+    }
+}
 
 local check_enum =
 {
@@ -513,7 +519,7 @@ dsp.quests.setVar = function(entity, quest, varname, val)
     local message = "dsp.quests.setVar "
     local ret = handleQuestVar(entity, quest, varname, val, false)
     if ret.message then
-        error(message..ret.message)
+        error(entity, message..ret.message)
     end
 end
 
@@ -521,7 +527,7 @@ dsp.quests.getVar = function(entity, quest, varname, val)
     local message = "dsp.quests.getVar "
     local ret = handleQuestVar(entity, quest, varname, val, true)
     if ret.message then
-        error(message..ret.message)
+        error(entity, message..ret.message)
     else
         return ret.val
     end
@@ -537,30 +543,54 @@ dsp.quests.getStage = function(entity, quest)
     return dsp.quests.getVar(entity, quest, quest.vars.stage)
 end
 
-dsp.quests.complete = function(player, quest, reward_set)
-    local message = "dsp.quests.complete "
-    if quest then
-        if reward_set == nil then
-            reward_set = quest.rewards.sets[1]
-        end
-        if quest.rewards and reward_set then
-            -- todo: check inventory (including stack space), award items, return false if cant complete
-            local rewards_given = npcUtil.completeQuest(player, quest.area, quest.quest_id, reward_set)
-            if rewards_given then
-                -- clear stage CHAR_VAR if shouldnt be preserved
-                if not quest.vars.preserve_main_on_complete then
-                    player:setVar(quest.vars.stage, 0)
-                end
-                for name, var in pairs(quest.vars.additional) do
-                    if not var.preserve_on_complete then
-                        handleQuestVar(player, quest, name, 0, "dsp.quests.complete ", nil)
-                    end
-                end
+dsp.quests.advanceStage = function(entity, quest)
+    local message = "dsp.quests.advanceStage "
+    local current_stage = dsp.quests.getStage(entity, quest)
+    return dsp.quests.setVar(entity, quest, quest.vars.stage, current_stage + 1)
+end
 
-                return true
-            else
-                error(message.. "Unable to give quest rewards.")
+dsp.quests.complete = function(player, quest, reward_set)
+    local message = "dsp.quests.complete: "
+    if quest then
+        local rewards_given = false
+        if quest.rewards then
+            if reward_set == nil then
+                if quest.rewards.sets and quest.rewards.sets[1] then
+                    reward_set = quest.rewards.sets[1]
+                else
+                    reward_set = quest.rewards
+                end
             end
+            if reward_set then
+                -- todo: check inventory (including stack space), award items, return false if cant complete
+                rewards_given = npcUtil.completeQuest(player, quest.area, quest.quest_id, reward_set)
+                if not rewards_given then
+                    error(player, message.. "Unable to give quest rewards.")
+                end
+            else
+                error(player, message.. "Rewards table defined, but unable to get rewards set")
+            end
+        else
+            error(player, message.. "No quest rewards defined!")
+        end
+
+        if rewards_given then
+            -- clear stage CHAR_VAR if shouldnt be preserved
+            if not quest.vars.preserve_main_on_complete then
+                player:setVar(quest.vars.stage, 0)
+            end
+            for name, var in pairs(quest.vars.additional) do
+                if not var.preserve_on_complete then
+                    handleQuestVar(player, quest, name, 0, "dsp.quests.complete: ", nil)
+                end
+            end
+
+            -- make certain any forgotten temporary key items have been removed
+            for _, ki in pairs(quest.temporary.key_items) do
+                player:delKeyItem(ki)
+            end
+
+            return true
         end
     end
 end
@@ -585,24 +615,47 @@ dsp.quests.check = function(player, params)
             local quest = quest_table[i]
             if quest then
                 local exitLoop
+                local stage_zone_table
+                local player_current_stage = dsp.quests.getStage(player, quest)
+                if quest.stages[player_current_stage] then
+                    stage_zone_table = quest.stages[player_current_stage][zoneid]
+                end
                 local checks =
                 {
-                    [check_enum.onTrade] = function(player, params) return quest.npcs[zoneid][targetName].onTrade(player, params.target, params.trade) end,
-                    [check_enum.onTrigger] = function(player, params) return quest.npcs[zoneid][targetName].onTrigger(player, params.target) end,
+                    [check_enum.onTrade] = function(player, params)
+                        if stage_zone_table['onTrade'] and stage_zone_table['onTrade'][targetName] then
+                            return stage_zone_table['onTrade'][targetName](player, params.target, params.trade)
+                        end
+                    end,
+                    [check_enum.onTrigger] = function(player, params)
+                        if stage_zone_table['onTrigger'] and stage_zone_table['onTrigger'][targetName] then
+                            return stage_zone_table['onTrigger'][targetName](player, params.target)
+                        end
+                    end,
                     [check_enum.onEventUpdate] = function(player, params)
-                        if quest.events[zoneid][params.csid] then
-                            return quest.events[zoneid][params.csid].onEventUpdate(player, params.option)
+                        if stage_zone_table['onEventUpdate'] and stage_zone_table['onEventUpdate'][params.csid] then
+                            return stage_zone_table['onEventUpdate'][params.csid](player, params.option)
                         end
                     end,
                     [check_enum.onEventFinish] = function(player, params)
-                        if quest.events[zoneid][params.csid] then
-                            return quest.events[zoneid][params.csid].onEventFinish(player, params.option)
+                        if stage_zone_table['onEventFinish'] and stage_zone_table['onEventFinish'][params.csid] then
+                            return stage_zone_table['onEventFinish'][params.csid](player, params.option)
                         end
                     end,
-                    [check_enum.onZoneIn] = function(player, params) return quest.onZoneIn(player, params.zone) end,
-                    [check_enum.onMobDeath] = function(player, params) return quest.mobs[zoneid][targetName].onMobDeath(params.target, player, params.isKiller, params.isWeaponSkillKill) end,
+                    [check_enum.onZoneIn] = function(player, params)
+                        if stage_zone_table['onZoneIn'] then
+                            return stage_zone_table['onZoneIn'](player, params)
+                        end
+                    end,
+                    [check_enum.onMobDeath] = function(player, params)
+                        if stage_zone_table['onMobDeath'] and stage_zone_table['onMobDeath'][targetName] then
+                            return stage_zone_table['onMobDeath'][targetName](params.target, player, params.isKiller, params.isWeaponSkillKill)
+                        end
+                    end,
                 }
-                exitLoop = checks[params.check_type](player, params)
+                if stage_zone_table then
+                    exitLoop = checks[params.check_type](player, params)
+                end
                 player:setLocalVar("[quests]cycle", i)
                 --print("Player: "..player:getName()..(targetName and " Npc: "..targetName or " Event: "..params.csid).. " \tCycle: "..i.." Quest: "..quest.name)
                 if exitLoop then
@@ -668,6 +721,36 @@ dsp.quests.checkRequirements = function(player, quest)
         return true
     else
         return false
+    end
+end
+
+dsp.quests.getQuestTable = function(area_log_id, quest_id)
+    local quest_filename = 'scripts/quests/'
+    local area_dirs =
+    {
+        [dsp.quests.enums.log_ids.SANDORIA]    = 'sandoria',
+        [dsp.quests.enums.log_ids.BASTOK]      = 'bastok',
+        [dsp.quests.enums.log_ids.WINDURST]    = 'windurst',
+        [dsp.quests.enums.log_ids.JEUNO]       = 'jeuno',
+        [dsp.quests.enums.log_ids.OTHER_AREAS] = 'other_areas',
+        [dsp.quests.enums.log_ids.OUTLANDS]    = 'outlands',
+        [dsp.quests.enums.log_ids.AHT_URHGAN]  = 'aht_urhgan',
+        [dsp.quests.enums.log_ids.CRYSTAL_WAR] = 'crystal_war',
+        [dsp.quests.enums.log_ids.ABYSSEA]     = 'abyssea',
+        [dsp.quests.enums.log_ids.ADOULIN]     = 'adoulin',
+        [dsp.quests.enums.log_ids.COALITION]   = 'coalition'
+    }
+    local quest_file = dsp.quests.quest_filenames[area_log_id][quest_id]
+    if quest_file then
+        quest_filename = quest_filename .. area_dirs[area_log_id] .. '/' .. quest_file
+        local quest_table = require(quest_filename)
+        if (quest_table) then
+            return quest_table
+        else
+            print("dsp.quests.getQuestTable: Unable to include designated file '".. quest_filename .."'")
+        end
+    else
+        print("dsp.quests.getQuestTable: No quest file defined for quest ID: ".. quest_id.. " for area: ".. area_dirs[area_log_id])
     end
 end
 

--- a/scripts/quests/adoulin/a_certain_substitute_patrolman.lua
+++ b/scripts/quests/adoulin/a_certain_substitute_patrolman.lua
@@ -2,16 +2,6 @@ require("scripts/globals/missions")
 require("scripts/globals/quests")
 require("scripts/globals/zone")
 
--- Stage 0: Talk to Rising Solstice, Western, to begin the quest
--- Stage 1: Talk to Zaoso, Western Adoulin
--- Stage 2: Talk to Clemmar, Western Adoulin
--- Stage 3: Talk to Kongramm, Western Adoulin
--- Stage 4: Talk to Virsaint, Western Adoulin
--- Stage 5: Talk to Shipilolo, Western Adoulin
--- Stage 6: Talk to Dangueubert, Western Adoulin
--- Stage 7: Talk to Nylene, Western Adoulin
--- Stage 8: Talk to Rising Solstice again, quest complete
-
 local this_quest = {}
 
 this_quest.name = "A Certain Substitute Patrolman"
@@ -20,12 +10,6 @@ this_quest.log_id = dsp.quests.enums.log_ids.ADOULIN
 this_quest.quest_id = dsp.quests.enums.quest_ids.adoulin.A_CERTAIN_SUBSTITUTE_PATROLMAN
 
 this_quest.repeatable = false
-this_quest.vars =
-{
-    stage = "[Q]".."["..this_quest.log_id.."]".."["..this_quest.quest_id.."]",
-    preserve_main_on_complete = false,
-    additional = {}
-}
 
 this_quest.requirements =
 {
@@ -56,178 +40,231 @@ this_quest.rewards =
     }
 }
 
+this_quest.vars =
+{
+    stage = "[Q]["..this_quest.log_id.."]["..this_quest.quest_id.."]",
+    preserve_main_on_complete = false,
+    additional = {}
+}
+
 this_quest.temporary =
 {
     items = {},
     key_items = {dsp.ki.WESTERN_ADOULIN_PATROL_ROUTE}
 }
 
-this_quest.npcs =
+this_quest.constants =
 {
-    [dsp.zone.WESTERN_ADOULIN] =
-    {
-        ["Rising_Solstice"] =
-        {
-            onTrigger = function(player, npc)
-                if dsp.quests.getStage(player, this_quest) >= 1 then
-                    if dsp.quests.getStage(player, this_quest) == 8 then
-                        player:startEvent(2552) -- Finishes Quest: 'A Certain Substitute Patrolman'
-                    else
-                        player:startEvent(2551) -- Dialogue during Quest: 'A Certain Substitute Patrolman'
-                    end
-                    return true
-                elseif dsp.quests.checkRequirements(player, this_quest) then
-                    player:startEvent(2550) -- Starts Quest: 'A Certain Substitute Patrolman'
-                    return true
-                end
-            end
-        },
-        ["Zaoso"] =
-        {
-            onTrigger = function(player, npc)
-                if dsp.quests.getStage(player, this_quest) == 1 then
-                    player:startEvent(2553) -- Progresses Quest: 'A Certain Substitute Patrolman'
-                    return true
-                end
-            end
-        },
-        ["Clemmar"] =
-        {
-            onTrigger = function(player, npc)
-                if dsp.quests.getStage(player, this_quest) == 2 then
-                    player:startEvent(2554) -- Progresses Quest: 'A Certain Substitute Patrolman'
-                    return true
-                end
-            end
-        },
-        ["Kongramm"] =
-        {
-            onTrigger = function(player, npc)
-                if dsp.quests.getStage(player, this_quest) == 3 then
-                    player:startEvent(2555) -- Progresses Quest: 'A Certain Substitute Patrolman'
-                    return true
-                end
-            end
-        },
-        ["Virsaint"] =
-        {
-            onTrigger = function(player, npc)
-                if dsp.quests.getStage(player, this_quest) == 4 then
-                    player:startEvent(2556) -- Progresses Quest: 'A Certain Substitute Patrolman'
-                    return true
-                end
-            end
-        },
-        ["Shipilolo"] =
-        {
-            onTrigger = function(player, npc)
-                if dsp.quests.getStage(player, this_quest) == 5 then
-                    player:startEvent(2557) -- Progresses Quest: 'A Certain Substitute Patrolman'
-                    return true
-                end
-            end
-        },
-        ["Dangueubert"] =
-        {
-            onTrigger = function(player, npc)
-                if dsp.quests.getStage(player, this_quest) == 6 then
-                    player:startEvent(2558) -- Progresses Quest: 'A Certain Substitute Patrolman'
-                    return true
-                end
-            end
-        },
-        ["Nylene"] =
-        {
-            onTrigger = function(player, npc)
-                if dsp.quests.getStage(player, this_quest) == 7 then
-                    player:startEvent(2559) -- Progresses Quest: 'A Certain Substitute Patrolman'
-                    return true
-                end
-            end
-        }
-    }
+    ['GO_PATROL'] = function(player, npc)
+        -- Rising Solstice yelling at the player to go patrol
+        player:startEvent(2551)
+        return true
+    end
 }
 
-this_quest.events =
+this_quest.stages =
 {
-    [dsp.zone.WESTERN_ADOULIN] =
+    -- Stage 0: Talk to Rising Solstice, Western Adoulin, to begin the quest
+    [dsp.quests.enums.stages.STAGE0] =
     {
-        [2550] =
+        [dsp.zone.WESTERN_ADOULIN] =
         {
-            onEventFinish = function(player, option)
-                -- Rising Solstice, starts Quest: 'A Certain Substitute Patrolman'
-                if npcUtil.giveKeyItem(player, dsp.ki.WESTERN_ADOULIN_PATROL_ROUTE) then
-                    player:addQuest(this_quest.log_id, this_quest.quest_id)
-                    dsp.quests.setStage(player, this_quest, 1)
+            ['onTrigger'] =
+            {
+                ['Rising_Solstice'] = function(player, npc)
+                    if dsp.quests.checkRequirements(player, this_quest) then
+                        player:startEvent(2550) -- Starts Quest: 'A Certain Substitute Patrolman'
+                        return true
+                    end
+                end
+            },
+            ['onEventFinish'] =
+            {
+                [2550] = function(player, option) -- Rising Solstice starting quest
+                    if npcUtil.giveKeyItem(player, dsp.ki.WESTERN_ADOULIN_PATROL_ROUTE) then
+                        player:addQuest(this_quest.log_id, this_quest.quest_id)
+                        dsp.quests.advanceStage(player, this_quest)
+                        return true
+                    end
+                end
+            }
+        }
+    },
+    -- Stage 1: Talk to Zaoso, Western Adoulin
+    [dsp.quests.enums.stages.STAGE1] =
+    {
+        [dsp.zone.WESTERN_ADOULIN] =
+        {
+            ['onTrigger'] =
+            {
+                ['Rising_Solstice'] = this_quest.constants['GO_PATROL'],
+                ['Zaoso'] = function(player, npc)
+                    player:startEvent(2553) -- Reports to player, and advances quest
                     return true
                 end
-            end
-        },
-        [2552] =
-        {
-            onEventFinish = function(player, option)
-                -- Rising Solstice, finishes Quest: 'A Certain Substitute Patrolman'
-                if dsp.quests.complete(player, this_quest) then
-                    player:delKeyItem(dsp.ki.WESTERN_ADOULIN_PATROL_ROUTE)
+            },
+            ['onEventFinish'] =
+            {
+                [2553] = function(player, option) -- Zaoso progressing quest
+                    dsp.quests.advanceStage(player, this_quest)
                     return true
                 end
-            end
-        },
-        [2553] =
+            }
+        }
+    },
+    -- Stage 2: Talk to Clemmar, Western Adoulin
+    [dsp.quests.enums.stages.STAGE2] =
+    {
+        [dsp.zone.WESTERN_ADOULIN] =
         {
-            onEventFinish = function(player, option)
-                -- Zaoso, progresses Quest: 'A Certain Substitute Patrolman'
-                dsp.quests.setStage(player, this_quest, 2)
-                return true
-            end
-        },
-        [2554] =
+            ['onTrigger'] =
+            {
+                ['Rising_Solstice'] = this_quest.constants['GO_PATROL'],
+                ['Clemmar'] = function(player, npc)
+                    player:startEvent(2554) -- Reports to player, and advances quest
+                    return true
+                end
+            },
+            ['onEventFinish'] =
+            {
+                [2554] = function(player, option) -- Clemmar progressing quest
+                    dsp.quests.advanceStage(player, this_quest)
+                    return true
+                end
+            }
+        }
+    },
+    -- Stage 3: Talk to Kongramm, Western Adoulin
+    [dsp.quests.enums.stages.STAGE3] =
+    {
+        [dsp.zone.WESTERN_ADOULIN] =
         {
-            onEventFinish = function(player, option)
-                -- Clemmar, progresses Quest: 'A Certain Substitute Patrolman'
-                dsp.quests.setStage(player, this_quest, 3)
-                return true
-            end
-        },
-        [2555] =
+            ['onTrigger'] =
+            {
+                ['Rising_Solstice'] = this_quest.constants['GO_PATROL'],
+                ['Kongramm'] = function(player, npc)
+                    player:startEvent(2555) -- Reports to player, and advances quest
+                    return true
+                end
+            },
+            ['onEventFinish'] =
+            {
+                [2555] = function(player, option) -- Kongramm progressing quest
+                    dsp.quests.advanceStage(player, this_quest)
+                    return true
+                end
+            }
+        }
+    },
+    -- Stage 4: Talk to Virsaint, Western Adoulin
+    [dsp.quests.enums.stages.STAGE4] =
+    {
+        [dsp.zone.WESTERN_ADOULIN] =
         {
-            onEventFinish = function(player, option)
-                -- Kongramm, progresses Quest: 'A Certain Substitute Patrolman'
-                dsp.quests.setStage(player, this_quest, 4)
-                return true
-            end
-        },
-        [2556] =
+            ['onTrigger'] =
+            {
+                ['Rising_Solstice'] = this_quest.constants['GO_PATROL'],
+                ['Virsaint'] = function(player, npc)
+                    player:startEvent(2556) -- Reports to player, and advances quest
+                    return true
+                end
+            },
+            ['onEventFinish'] =
+            {
+                [2556] = function(player, option) -- Virsaint progressing quest
+                    dsp.quests.advanceStage(player, this_quest)
+                    return true
+                end
+            }
+        }
+    },
+    -- Stage 5: Talk to Shipilolo, Western Adoulin
+    [dsp.quests.enums.stages.STAGE5] =
+    {
+        [dsp.zone.WESTERN_ADOULIN] =
         {
-            onEventFinish = function(player, option)
-                -- Virsaint, progresses Quest: 'A Certain Substitute Patrolman'
-                dsp.quests.setStage(player, this_quest, 5)
-                return true
-            end
-        },
-        [2557] =
+            ['onTrigger'] =
+            {
+                ['Rising_Solstice'] = this_quest.constants['GO_PATROL'],
+                ['Shipilolo'] = function(player, npc)
+                    player:startEvent(2557) -- Reports to player, and advances quest
+                    return true
+                end
+            },
+            ['onEventFinish'] =
+            {
+                [2557] = function(player, option) -- Shipilolo progressing quest
+                    dsp.quests.advanceStage(player, this_quest)
+                    return true
+                end
+            }
+        }
+    },
+    -- Stage 6: Talk to Dangueubert, Western Adoulin
+    [dsp.quests.enums.stages.STAGE6] =
+    {
+        [dsp.zone.WESTERN_ADOULIN] =
         {
-            onEventFinish = function(player, option)
-                -- Shipilolo, progresses Quest: 'A Certain Substitute Patrolman'
-                dsp.quests.setStage(player, this_quest, 6)
-                return true
-            end
-        },
-        [2558] =
+            ['onTrigger'] =
+            {
+                ['Rising_Solstice'] = this_quest.constants['GO_PATROL'],
+                ['Dangueubert'] = function(player, npc)
+                    player:startEvent(2558) -- Reports to player, and advances quest
+                    return true
+                end
+            },
+            ['onEventFinish'] =
+            {
+                [2558] = function(player, option) -- Dangueubert progressing quest
+                    dsp.quests.advanceStage(player, this_quest)
+                    return true
+                end
+            }
+        }
+    },
+    -- Stage 7: Talk to Nylene, Western Adoulin
+    [dsp.quests.enums.stages.STAGE7] =
+    {
+        [dsp.zone.WESTERN_ADOULIN] =
         {
-            onEventFinish = function(player, option)
-                -- Dangueubert, progresses Quest: 'A Certain Substitute Patrolman'
-                dsp.quests.setStage(player, this_quest, 7)
-                return true
-            end
-        },
-        [2559] =
+            ['onTrigger'] =
+            {
+                ['Rising_Solstice'] = this_quest.constants['GO_PATROL'],
+                ['Nylene'] = function(player, npc)
+                    player:startEvent(2559) -- Reports to player, and advances quest
+                    return true
+                end
+            },
+            ['onEventFinish'] =
+            {
+                [2559] = function(player, option) -- Nylene progressing quest
+                    dsp.quests.advanceStage(player, this_quest)
+                    return true
+                end
+            }
+        }
+    },
+    -- Stage 8: Talk to Rising Solstice again, quest complete
+    [dsp.quests.enums.stages.STAGE8] =
+    {
+        [dsp.zone.WESTERN_ADOULIN] =
         {
-            onEventFinish = function(player, option)
-                -- Nylene, progresses Quest: 'A Certain Substitute Patrolman'
-                dsp.quests.setStage(player, this_quest, 8)
-                return true
-            end
+            ['onTrigger'] =
+            {
+                ['Rising_Solstice'] = function(player, npc)
+                    player:startEvent(2552) -- Finishes quest
+                    return true
+                end
+            },
+            ['onEventFinish'] =
+            {
+                [2552] = function(player, option) -- Rising Solstice finishing quest
+                    if dsp.quests.complete(player, this_quest) then
+                        player:delKeyItem(dsp.ki.WESTERN_ADOULIN_PATROL_ROUTE)
+                        return true
+                    end
+                end
+            }
         }
     }
 }

--- a/scripts/quests/adoulin/fertile_ground.lua
+++ b/scripts/quests/adoulin/fertile_ground.lua
@@ -2,10 +2,6 @@ require("scripts/globals/missions")
 require("scripts/globals/quests")
 require("scripts/globals/zone")
 
--- [TODO] Stage 0: Talk to Chalvava, Rala Waterways, to begin the quest
--- Stage 1: Talk to Shipilolo, Western Adoulin, to get Bottle of Fertilizer X KI
--- [TODO] Stage 2: Talk to Chalvava again, quest complete
-
 local this_quest = {}
 
 this_quest.name = "Fertile Ground"
@@ -14,12 +10,6 @@ this_quest.log_id = dsp.quests.enums.log_ids.ADOULIN
 this_quest.quest_id = dsp.quests.enums.quest_ids.adoulin.FERTILE_GROUND
 
 this_quest.repeatable = false
-this_quest.vars =
-{
-    stage = "[Q]".."["..this_quest.log_id.."]".."["..this_quest.quest_id.."]",
-    preserve_main_on_complete = false,
-    additional = {}
-}
 
 this_quest.requirements =
 {
@@ -29,7 +19,6 @@ this_quest.requirements =
             ['area'] = ADOULIN,
             ['quest_id'] = dsp.quests.enums.quest_ids.adoulin.THE_OLD_MAN_AND_THE_HARPOON
         }
-        -- [1] = { ['quest'] = require("scripts/globals/quests/adoulin/the_old_man_and_the_harpoon") }
     },
     fame =
     {
@@ -57,49 +46,84 @@ this_quest.temporary =
     key_items = {dsp.ki.BOTTLE_OF_FERTILIZER_X}
 }
 
-this_quest.npcs =
+this_quest.vars =
 {
-    [dsp.zone.WESTERN_ADOULIN] =
-    {
-        ["Shipilolo"] =
-        {
-            onTrigger = function(player, npc)
-                if dsp.quests.getStage(player, this_quest) == 1 then
-                    player:startEvent(2850) -- Progresses Quest: 'Fertile Ground'
-                    return true
-                end
-            end
-        }
-    },
-    [dsp.zone.RALA_WATERWAYS] =
-    {
-        ["Chalvava"] =
-        {
-            onTrigger = function(player, npc)
-                -- TODO: Implement Chalvava's portions of the quest
-            end
-        }
-    }
+    stage = "[Q]["..this_quest.log_id.."]["..this_quest.quest_id.."]",
+    preserve_main_on_complete = false,
+    additional = {}
 }
 
-this_quest.events =
+this_quest.stages =
 {
-    [dsp.zone.WESTERN_ADOULIN] =
+    -- [TODO] Stage 0: Talk to Chalvava, Rala Waterways, to begin the quest
+    [dsp.quests.enums.stages.STAGE0] =
     {
-        [2850] =
+        [dsp.zone.RALA_WATERWAYS] =
         {
-            onEventFinish = function(player, option)
-                -- Shipilolo, progresses Quest: 'Fertile Ground'
-                if npcUtil.giveKeyItem(player, dsp.ki.BOTTLE_OF_FERTILIZER_X) then
-                    dsp.quests.setStage(player, this_quest, 2)
+            ['onTrigger'] =
+            {
+                ['Chalvava'] = function(player, npc)
+                    -- TODO: Implement Chalvava's portions of the quest
                     return true
                 end
-            end
+            },
+            ['onEventFinish'] =
+            {
+                -- TODO: Implement Chalvava's portions of the quest
+            }
         }
     },
-    [dsp.zone.RALA_WATERWAYS] =
+    -- Stage 1: Talk to Shipilolo, Western Adoulin, to get Bottle of Fertilizer X KI
+    [dsp.quests.enums.stages.STAGE1] =
     {
-        -- TODO: find Chalvava's eventses and implement their onFinishes
+        [dsp.zone.WESTERN_ADOULIN] =
+        {
+            ['onTrigger'] =
+            {
+                ['Shipilolo'] = function(player, npc)
+                    player:startEvent(2850) -- Gives Bottle of Fertilizer X to player
+                    return true
+                end
+            },
+            ['onEventFinish'] =
+            {
+                [2850] = function(player, option)
+                    -- Shipilolo, giving Bottle of Fertilizer X
+                    if npcUtil.giveKeyItem(player, dsp.ki.BOTTLE_OF_FERTILIZER_X) then
+                        dsp.quests.advanceStage(player, this_quest)
+                        return true
+                    end
+                end
+            }
+        },
+        [dsp.zone.RALA_WATERWAYS] =
+        {
+            ['onTrigger'] =
+            {
+                ['Chalvava'] = function(player, npc)
+                    -- TODO: Implement Chalvava's portions of the quest
+                    return true
+                end
+            }
+        }
+    },
+    -- [TODO] Stage 2: Talk to Chalvava again, quest complete
+    [dsp.quests.enums.stages.STAGE2] =
+    {
+        [dsp.zone.RALA_WATERWAYS] =
+        {
+            ['onTrigger'] =
+            {
+                ['Chalvava'] = function(player, npc)
+                    -- TODO: Implement Chalvava's portions of the quest
+                    return true
+                end
+            },
+            ['onEventFinish'] =
+            {
+                -- TODO: Implement Chalvava's portions of the quest
+            }
+        }
     }
 }
 

--- a/scripts/quests/adoulin/wayward_waypoints.lua
+++ b/scripts/quests/adoulin/wayward_waypoints.lua
@@ -2,14 +2,6 @@ require("scripts/globals/missions")
 require("scripts/globals/quests")
 require("scripts/globals/zone")
 
--- [TODO] Stage 0: Speak to Sharuru in Eastern Adoulin to start the quest and receive a Waypoint Scanner Kit KI
--- [TODO] Stage 1: Adjust waypoints at Frontier Stations in Ceizak, Yahse, Foret, Morimar, Yorcia, Marjami, and Kamihr
--- [TODO] Stage 2: Try adjusting waypoint in Lower Jeuno
--- [TODO] Stage 3: Talk to Sharuru again.
--- Stage 4: Talk to Shipilolo in Western Adoulin and get Waypoint Recalibration Kit KI
--- [TODO] Stage 5: Try Lower Jeuno waypoint again
--- [TODO] Stage 6: Return to Sharuru, quest complete
-
 local waypointEventFinish = function(player, waypoint)
     -- Make sure player is working on stage 1
     -- Bitmask the bit in the waypoints var for the given waypoint
@@ -25,16 +17,6 @@ this_quest.log_id = dsp.quests.enums.log_ids.ADOULIN
 this_quest.quest_id = dsp.quests.enums.quest_ids.adoulin.WAYWARD_WAYPOINTS
 
 this_quest.repeatable = false
-this_quest.vars =
-{
-    stage = "[Q]".."["..this_quest.log_id.."]".."["..this_quest.quest_id.."]",
-    preserve_main_on_complete = false, -- do we keep main var on quest completion
-    additional =
-    {
-        -- Bitmask of waypoints calibrated during the second stage.
-        ["waypoints"] = { id = 1, type = dsp.quests.enums.var_types.LOCAL_VAR, repeatable = false, preserve_on_complete = false }, 
-    }
-}
 
 this_quest.requirements =
 {
@@ -76,55 +58,112 @@ this_quest.temporary =
     }
 }
 
-this_quest.npcs =
+this_quest.vars =
 {
-    [dsp.zone.WESTERN_ADOULIN] =
+    stage = "[Q]["..this_quest.log_id.."]["..this_quest.quest_id.."]",
+    preserve_main_on_complete = false, -- do we keep main var on quest completion
+    additional =
     {
-        ["Shipilolo"] =
-        {
-            onTrigger = function(player, npc)
-                if dsp.quests.getStage(player, this_quest) == 4 then
-                    player:startEvent(79) -- Progresses Quest: 'Wayward Waypoints'
-                    return true
-                end
-            end
-        }
-    },
-    [dsp.zone.EASTERN_ADOULIN] =
-    {
-        ["Sharuru"] =
-        {
-            onTrigger = function(player, npc)
-                -- TODO: Implement Sharuru's portions of the quest
-            end
-        }
+        -- Bitmask of waypoints calibrated during the second stage.
+        ["waypoints"] = { id = 1, type = dsp.quests.enums.var_types.LOCAL_VAR, repeatable = false, preserve_on_complete = false }, 
     }
-    -- TODO: Find/implement the onTriggers for the Adoulin waypoints
-    -- TODO: Find/implement the onTrigger for the Lower Jeuno waypoint
 }
 
-this_quest.events =
+this_quest.stages =
 {
-    [dsp.zone.WESTERN_ADOULIN] =
+    -- [TODO] Stage 0: Speak to Sharuru in Eastern Adoulin to start the quest and receive a Waypoint Scanner Kit KI
+    [dsp.quests.enums.stages.STAGE0] =
     {
-        [79] =
+        [dsp.zone.EASTERN_ADOULIN] =
         {
-            onEventFinish = function(player, option)
-                -- Shipilolo, progresses Quest: 'Wayward Waypoints'
-                if npcUtil.giveKeyItem(player, dsp.ki.WAYPOINT_RECALIBRATION_KIT) then
-                    player:delKeyItem(dsp.ki.WAYPOINT_SCANNER_KIT)
-                    dsp.quests.setStage(player, this_quest, 5)
-                    return true
+            ['onTrigger'] =
+            {
+                ['Sharuru'] = function(player, npc)
+                    -- TODO: Implement Sharuru's portions of the quest
                 end
-            end
+            },
+            ['onEventFinish'] =
+            {
+                -- TODO: find Sharuru's events and implement their onFinishes
+            }
         }
     },
-    [dsp.zone.EASTERN_ADOULIN] =
+    -- [TODO] Stage 1: Adjust waypoints at Frontier Stations in Ceizak, Yahse, Foret, Morimar, Yorcia, Marjami, and Kamihr
+    [dsp.quests.enums.stages.STAGE1] =
     {
-        -- TODO: find Sharuru's events and implement their onFinishes
+        -- TODO: Find/implement the onTriggers for the Adoulin waypoints
+        -- TODO: Implement the event onFinishes for the Adoulin waypoints, just call waypointEventFinish() with their number
+    },
+    -- [TODO] Stage 2: Try adjusting waypoint in Lower Jeuno
+    [dsp.quests.enums.stages.STAGE2] =
+    {
+        -- TODO: Find/implement the onTriggers for the Lower Jeuno waypoint
+        -- TODO: Implement the Lower Jeuno waypoint onFinish events
+    },
+    -- [TODO] Stage 3: Talk to Sharuru again.
+    [dsp.quests.enums.stages.STAGE3] =
+    {
+        [dsp.zone.EASTERN_ADOULIN] =
+        {
+            ['onTrigger'] =
+            {
+                ['Sharuru'] = function(player, npc)
+                    -- TODO: Implement Sharuru's portions of the quest
+                end
+            },
+            ['onEventFinish'] =
+            {
+                -- TODO: find Sharuru's events and implement their onFinishes
+            }
+        }
+    },
+    -- Stage 4: Talk to Shipilolo in Western Adoulin and get Waypoint Recalibration Kit KI
+    [dsp.quests.enums.stages.STAGE4] =
+    {
+        [dsp.zone.WESTERN_ADOULIN] =
+        {
+            ['onTrigger'] =
+            {
+                ['Shipilolo'] = function(player, npc)
+                    player:startEvent(79) -- Gives player Waypoint Recalibration Kit
+                    return true
+                end
+            },
+            ['onEventFinish'] =
+            {
+                [79] = function(player, option) -- Shipilolo upgrading waypoint kit
+                    if npcUtil.giveKeyItem(player, dsp.ki.WAYPOINT_RECALIBRATION_KIT) then
+                        player:delKeyItem(dsp.ki.WAYPOINT_SCANNER_KIT)
+                        dsp.quests.advanceStage(player, this_quest)
+                        return true
+                    end
+                end
+            }
+        }
+    },
+    -- [TODO] Stage 5: Try Lower Jeuno waypoint again
+    [dsp.quests.enums.stages.STAGE5] =
+    {
+        -- TODO: Find/implement the onTriggers for the Lower Jeuno waypoint
+        -- TODO: Implement the Lower Jeuno waypoint onFinish events
+    },
+    -- [TODO] Stage 6: Return to Sharuru, quest complete
+    [dsp.quests.enums.stages.STAGE6] =
+    {
+        [dsp.zone.EASTERN_ADOULIN] =
+        {
+            ['onTrigger'] =
+            {
+                ['Sharuru'] = function(player, npc)
+                    -- TODO: Implement Sharuru's portions of the quest
+                end
+            },
+            ['onEventFinish'] =
+            {
+                -- TODO: find Sharuru's events and implement their onFinishes
+            }
+        }
     }
-    -- TODO: Implement the event onFinishes for the Adoulin waypoints, just call waypointEventFinish() with their number
-    -- TODO: Implement the Lower Jeuno onFinish events
 }
 
 return this_quest


### PR DESCRIPTION
Mainly @takhlaq , but I'd be happy for a few thumbs-up-or-down from others on this quest format, as _I_ personally don't have major changes to the format planned after this, and am concerned about people feeling it was suddenly sprung on them one day upon being merged into master.

Even if you don't have any _words_ to say, just a :+1: would show this branch is on the right track!

Anyway, I **reworked quest tables to have stage enums as their top-level** for NPC checks, resulting in being able to read the quest file from top-to-bottom and **see the steps/stages in chronological order**. ([Link to non-diff Old Man and The Harpoon for example](https://github.com/ibm2431/darkstar/blob/c3d5f4d3b8082d08167b4bdcb9c319a58cb69cfa/scripts/quests/adoulin/the_old_man_and_the_harpoon.lua#L62))

All previous occurrences of **magic numbers in scripts changed to straight enums. Added `dsp.quests.advanceStage(player, quest)`**, so a scripter will probably never need to get or set a player's stage variable.

I've been thinking about how to fetch a quest table from just an ID for a while, and still have concerns about colossal require tables being needed/loaded at the top of the global quest script (mainly rewrite/migration). Instead, I wrote a **`dsp.quests.getQuestTable(area_id, quest_id)` method that can fetch/require a quest table from just an ID** when it's called, instead of loading all quests, all the time. This still requires a table of script name strings, but at least the table isn't actively requiring _every_ quest file in the game at _all_ times.

I'm open to ideas on any better ways of solving the questID -> quest file problem.

With the ability to fetch quest tables from just an ID, I **added a GM command, `resetquest`**, which will (try to) **reset the player's progress of a quest back to zero**. It only resets quest log status, the player's stage var for the quest, any additional quest vars (as listed in the quest file), and any temporary key items used only for that quest (again as listed in the quest file). This doesn't guarantee completely resetting a quest, as things like physical items aren't touched (intentionally), and it doesn't reset any rewards for a quest either. But as it's meant primarily for debugging purposes, it should be sufficient for testing/debugging _most_ things.

I also **made an addition to the GM command `checkquest`**, in that if a quest table exists for the quest ID (as fetched by `dsp.quests.getQuestTable`), it'll **print the player's current stage and any additional quest vars**. So if a player is complaining about something not working as expected, you can check their relevant vars without having to look in the DB!

![quest_stuff](https://user-images.githubusercontent.com/13112942/52545188-7eb69d80-2dad-11e9-9cae-f42fe79e3e6b.jpg)

But _more_ importantly, the message now displays the quest's _name_ instead of just an ID! Truly vital stuff.

And I apparently made a few changes to `dsp.quests.completeQuest` to better handle giving rewards.