### PR TITLE
Updated Citipati respawn timers

### DIFF
--- a/scripts/zones/Attohwa_Chasm/mobs/Corse.lua
+++ b/scripts/zones/Attohwa_Chasm/mobs/Corse.lua
@@ -10,5 +10,5 @@ function onMobDeath(mob, player, isKiller)
 end;
 
 function onMobDespawn(mob)
-    dsp.mob.phOnDespawn(mob,ID.mob.CITIPATI_PH,20,math.random(10800,21600)); -- 3 to 6 hours
+    dsp.mob.phOnDespawn(mob,ID.mob.CITIPATI_PH,20,math.random(9216,19584)); -- 3 to 6 game nights
 end;


### PR DESCRIPTION
In advance, please forgive me for this "well actually herpderp" correction.

Citi repops every 3-6 game nights, rather than a fixed timer on Earth hours. This means he can be killed as late at 04:00 on Night 1, and respawn as early as 20:00 on Night 4 (assuming no PHs for this math). One Vana day is exactly 57m 36s so the minimum respawn is ((57*60)+36)*(2+(16/24)), or 9,216 seconds. Add three full Vana days for the minimum time on the longest window.