### PR TITLE
Fixing gcc compile warnings

### DIFF
--- a/src/map/message.cpp
+++ b/src/map/message.cpp
@@ -473,8 +473,7 @@ namespace message
 						{
                             // If entity not spawned, go to default location as listed in database
                             const char* query = "SELECT pos_x, pos_y, pos_z FROM mob_spawn_points WHERE mobid = %u;";
-                            uint32 fetch = Sql_Query(SqlHandle, query, Entity->id);
-                            uint64 list  = Sql_NumRows(SqlHandle);
+                            auto fetch = Sql_Query(SqlHandle, query, Entity->id);
 
                             if (fetch != SQL_ERROR && Sql_NumRows(SqlHandle) != 0)
                             {

--- a/src/map/utils/battleutils.cpp
+++ b/src/map/utils/battleutils.cpp
@@ -1807,6 +1807,8 @@ namespace battleutils
                     case DAMAGE_SLASHING: damage = (damage * (PDefender->getMod(Mod::SLASHRES))) / 1000; break;
                     case DAMAGE_IMPACT:   damage = (damage * (PDefender->getMod(Mod::IMPACTRES))) / 1000; break;
                     case DAMAGE_HTH:      damage = (damage * (PDefender->getMod(Mod::HTHRES))) / 1000; break;
+                    default:
+                        break;
                 }
             }
             else
@@ -4231,7 +4233,7 @@ namespace battleutils
 
     int32 HandleSteamJacket(CBattleEntity* PDefender, int32 damage, int16 damageType)
     {
-        uint32 steamJacketType = PDefender->GetLocalVar("steam_jacket_type");
+        auto steamJacketType = (int16)PDefender->GetLocalVar("steam_jacket_type");
         int16 steamJacketHits = (int16)PDefender->GetLocalVar("steam_jacket_hits");
 
         if (steamJacketType != damageType)

--- a/src/map/utils/charutils.cpp
+++ b/src/map/utils/charutils.cpp
@@ -2286,9 +2286,6 @@ namespace charutils
     {
         memset(&PChar->m_WeaponSkills, 0, sizeof(PChar->m_WeaponSkills));
 
-        JOBTYPE curMainJob = PChar->GetMJob();
-        JOBTYPE curSubJob = PChar->GetSJob();
-
         CItemWeapon* PItem;
         int main_ws = 0;
         int range_ws = 0;

--- a/src/map/utils/itemutils.h
+++ b/src/map/utils/itemutils.h
@@ -53,9 +53,9 @@ enum DROP_TYPE
 struct DropItem_t
 {
     DropItem_t(uint8 DropType, uint16 ItemID, uint16 DropRate);
+    uint8 DropType;
     uint16 ItemID;
     uint16 DropRate;
-    uint8 DropType;
 };
 
 struct DropGroup_t

--- a/src/map/utils/petutils.cpp
+++ b/src/map/utils/petutils.cpp
@@ -1720,7 +1720,6 @@ namespace petutils
     CTrustEntity* LoadTrust(CCharEntity* PMaster, uint32 TrustID)
     {
         DSP_DEBUG_BREAK_IF(TrustID >= g_PPetList.size());
-        Pet_t* PPetData = g_PPetList.at(TrustID);
         CTrustEntity* PTrust = new CTrustEntity(PMaster);
         PTrust->loc = PMaster->loc;
         PTrust->m_OwnerID.id = PMaster->id;


### PR DESCRIPTION
- issues with unused parameters
- issue with sign to unsigned comparison
- issue with order of object construction
- issue with no default switch option