### PR TITLE
One to be Feared: round two.

### DIFF
--- a/scripts/zones/Sealions_Den/bcnms/one_to_be_feared.lua
+++ b/scripts/zones/Sealions_Den/bcnms/one_to_be_feared.lua
@@ -3,62 +3,36 @@
 -- Name: one_to_be_feared
 -- bcnmID : 992
 -----------------------------------
-require("scripts/globals/missions");
+require("scripts/globals/missions")
 -----------------------------------
---instance 1   !pos -780 -103 -90
-          -- >     -231              = lieux de combat
---instance 2   !pos -140 -23 -450
-         --  >      -151             = lieux de combat
---instance 3   !pos 500  56  -810
-         --  >    640  -71   -206           = lieux de combat
 
+function onBcnmRegister(player, instance)
+end
 
-    --cs 0,instanceID= cs + teleportation     vers mamet
-    --cs 1,instanceID= cs + teleportation     vers ultima
-    --cs 2,instanceID= cs + teleportation     vers omega
-    --cs 7 leave l'insctance
-    -- cs 8 =>navire de guerre > retourner a tavnazia
+function onBcnmEnter(player, instance)
+end
 
-
--- After registering the BCNM via bcnmRegister(bcnmid)
-function onBcnmRegister(player,instance)
-end;
-
--- Physically entering the BCNM via bcnmEnter(bcnmid)
-function onBcnmEnter(player,instance)
-end;
-
--- Leaving the BCNM by every mean possible, given by the LeaveCode
--- 1=Select Exit on circle
--- 2=Winning the BC
--- 3=Disconnected or warped out
--- 4=Losing the BC
--- via bcnmLeave(1) or bcnmLeave(2). LeaveCodes 3 and 4 are called
--- from the core when a player disconnects or the time limit is up, etc
-
-function onBcnmLeave(player,instance,leavecode)
-
-    if (leavecode == 2) then -- play end CS. Need time and battle id for record keeping + storage
-        if (player:getCurrentMission(COP) == ONE_TO_BE_FEARED and player:getVar("PromathiaStatus")==2) then
-            player:startEvent(32001,1,1,1,instance:getTimeInside(),1,0,0);
-            player:setVar("PromathiaStatus",0);
-            player:completeMission(COP,ONE_TO_BE_FEARED);
-            player:addMission(COP,CHAINS_AND_BONDS);
+function onBcnmLeave(player, instance, leavecode)
+    if leavecode == 2 then
+        if player:getCurrentMission(COP) == ONE_TO_BE_FEARED and player:getVar("PromathiaStatus") == 2 then
+            player:startEvent(32001, 1, 1, 1, instance:getTimeInside(), 1, 0, 0)
+            player:setVar("PromathiaStatus", 0)
+            player:completeMission(COP, ONE_TO_BE_FEARED)
+            player:addMission(COP, CHAINS_AND_BONDS)
         else
-            player:startEvent(32001,1,1,1,instance:getTimeInside(),1,0,1);
+            player:startEvent(32001, 1, 1, 1, instance:getTimeInside(), 1, 0, 1)
         end
-    elseif (leavecode == 4) then
-        player:startEvent(32002);
+    elseif leavecode == 4 then
+        player:startEvent(32002)
     end
+end
 
-end;
+function onEventUpdate(player, csid, option)
+end
 
-function onEventUpdate(player,csid,option)
-end;
-
-function onEventFinish(player,csid,option)
-    if (csid == 32001) then
-        player:addExp(1500);
-        player:setPos(438 ,0 ,-18 ,11 ,24);-- tp lufease
+function onEventFinish(player, csid, option)
+    if csid == 32001 then
+        player:addExp(1500)
+        player:setPos(438, 0, -18, 11, 24) -- Lufaise
     end
-end;
+end

--- a/scripts/zones/Sealions_Den/bcnms/one_to_be_feared.lua
+++ b/scripts/zones/Sealions_Den/bcnms/one_to_be_feared.lua
@@ -38,7 +38,6 @@ end;
 
 function onBcnmLeave(player,instance,leavecode)
 
-
     if (leavecode == 2) then -- play end CS. Need time and battle id for record keeping + storage
         if (player:getCurrentMission(COP) == ONE_TO_BE_FEARED and player:getVar("PromathiaStatus")==2) then
             player:startEvent(32001,1,1,1,instance:getTimeInside(),1,0,0);
@@ -55,11 +54,9 @@ function onBcnmLeave(player,instance,leavecode)
 end;
 
 function onEventUpdate(player,csid,option)
-    -- print("bc update csid "..csid.." and option "..option);
 end;
 
 function onEventFinish(player,csid,option)
-    -- print("bc finish csid "..csid.." and option "..option);
     if (csid == 32001) then
         player:addExp(1500);
         player:setPos(438 ,0 ,-18 ,11 ,24);-- tp lufease

--- a/scripts/zones/Sealions_Den/mobs/Mammet-22_Zeta.lua
+++ b/scripts/zones/Sealions_Den/mobs/Mammet-22_Zeta.lua
@@ -10,7 +10,7 @@ function onMobDeath(mob, player, isKiller)
     -- find mob offset for given battlefield instance
     local inst = math.floor((mob:getID() - ID.mob.ONE_TO_BE_FEARED_OFFSET) / 7);
     local instOffset = ID.mob.ONE_TO_BE_FEARED_OFFSET + (7 * (inst));
-    
+
     -- if all five mammets in this instance are dead, start event
     local allMammetsDead = true;
     for i = instOffset + 0, instOffset + 4 do
@@ -34,12 +34,7 @@ function onEventFinish(player,csid,option)
             player:setHP(player:getMaxHP());
             player:setMP(player:getMaxMP());
             player:setTP(0);
-
-            -- spawn omega for given instance
-            local omegaId = ID.mob.ONE_TO_BE_FEARED_OFFSET + (7 * (inst - 1)) + 5;
-            if (omegaId ~= nil and not GetMobByID(omegaId):isSpawned()) then
-                SpawnMob(omegaId);
-            end
+            player:setLocalVar("[OTBF]cs", 1)
 
             -- move player to instance
             if (inst == 1) then

--- a/scripts/zones/Sealions_Den/mobs/Mammet-22_Zeta.lua
+++ b/scripts/zones/Sealions_Den/mobs/Mammet-22_Zeta.lua
@@ -2,48 +2,49 @@
 -- Area: Sealions Den
 --  Mob: Mammet-22_Zeta
 -----------------------------------
-local ID = require("scripts/zones/Sealions_Den/IDs");
-require("scripts/globals/titles");
+local ID = require("scripts/zones/Sealions_Den/IDs")
+require("scripts/globals/titles")
 -----------------------------------
 
 function onMobDeath(mob, player, isKiller)
     -- find mob offset for given battlefield instance
-    local inst = math.floor((mob:getID() - ID.mob.ONE_TO_BE_FEARED_OFFSET) / 7);
-    local instOffset = ID.mob.ONE_TO_BE_FEARED_OFFSET + (7 * (inst));
+    local inst = math.floor((mob:getID() - ID.mob.ONE_TO_BE_FEARED_OFFSET) / 7)
+    local instOffset = ID.mob.ONE_TO_BE_FEARED_OFFSET + (7 * (inst))
 
     -- if all five mammets in this instance are dead, start event
-    local allMammetsDead = true;
+    local allMammetsDead = true
     for i = instOffset + 0, instOffset + 4 do
-        if (not GetMobByID(i):isDead()) then
-            allMammetsDead = false;
-            break;
+        if not GetMobByID(i):isDead() then
+            allMammetsDead = false
+            break
         end
     end
-    if (allMammetsDead) then
-        player:release(); -- prevents event collision if player kills multiple remaining mammets with an AOE move/spell
-        player:startEvent(11);
+    if allMammetsDead then
+        player:release() -- prevents event collision if player kills multiple remaining mammets with an AOE move/spell
+        player:startEvent(11)
     end
-end;
+end
 
-function onEventFinish(player,csid,option)
-    if (csid == 11) then
-        local inst = player:getVar("bcnm_instanceid");
-        if (inst >= 1 and inst <= 3) then
+function onEventFinish(player, csid, option)
+    if csid == 11 then
+        local inst = player:getVar("bcnm_instanceid")
+
+        if inst >= 1 and inst <= 3 then
             -- players are healed in between fights, but their TP is set to 0
-            player:addTitle(dsp.title.BRANDED_BY_LIGHTNING);
-            player:setHP(player:getMaxHP());
-            player:setMP(player:getMaxMP());
-            player:setTP(0);
+            player:addTitle(dsp.title.BRANDED_BY_LIGHTNING)
+            player:setHP(player:getMaxHP())
+            player:setMP(player:getMaxMP())
+            player:setTP(0)
             player:setLocalVar("[OTBF]cs", 1)
 
             -- move player to instance
-            if (inst == 1) then
-                player:setPos(-779, -103, -80);
-            elseif (inst == 2) then
-                player:setPos(-140, -23, -440);
-            elseif (inst == 3) then
-                player:setPos(499, 56, -802);
+            if inst == 1 then
+                player:setPos(-779, -103, -80)
+            elseif inst == 2 then
+                player:setPos(-140, -23, -440)
+            elseif inst == 3 then
+                player:setPos(499, 56, -802)
             end
         end
     end
-end;
+end

--- a/scripts/zones/Sealions_Den/mobs/Mammet-22_Zeta.lua
+++ b/scripts/zones/Sealions_Den/mobs/Mammet-22_Zeta.lua
@@ -6,6 +6,11 @@ local ID = require("scripts/zones/Sealions_Den/IDs")
 require("scripts/globals/titles")
 -----------------------------------
 
+function onMobInitialize(mob)
+    mob:setMobMod(dsp.mobMod.EXP_BONUS, -100)
+    mob:setMobMod(dsp.mobMod.GIL_MAX, -1)
+end
+
 function onMobDeath(mob, player, isKiller)
     -- find mob offset for given battlefield instance
     local inst = math.floor((mob:getID() - ID.mob.ONE_TO_BE_FEARED_OFFSET) / 7)

--- a/scripts/zones/Sealions_Den/mobs/Omega.lua
+++ b/scripts/zones/Sealions_Den/mobs/Omega.lua
@@ -36,12 +36,7 @@ function onEventFinish(player,csid,option)
             player:setHP(player:getMaxHP());
             player:setMP(player:getMaxMP());
             player:setTP(0);
-
-            -- spawn ultima for given instance
-            local ultimaId = ID.mob.ONE_TO_BE_FEARED_OFFSET + (7 * (inst - 1)) + 6;
-            if (ultimaId ~= nil and not GetMobByID(ultimaId):isSpawned()) then
-                SpawnMob(ultimaId);
-            end
+            player:setLocalVar("[OTBF]cs", 2)
 
             -- move player to instance
             if (inst == 1) then

--- a/scripts/zones/Sealions_Den/mobs/Omega.lua
+++ b/scripts/zones/Sealions_Den/mobs/Omega.lua
@@ -2,50 +2,51 @@
 -- Area: Sealions Den
 --  MOB: Omega
 -----------------------------------
-local ID = require("scripts/zones/Sealions_Den/IDs");
-require("scripts/globals/titles");
+local ID = require("scripts/zones/Sealions_Den/IDs")
+require("scripts/globals/titles")
 require("scripts/globals/mobs")
 -----------------------------------
 
 function onMobInitialize(mob)
-    mob:setMobMod(dsp.mobMod.ADD_EFFECT, 1);
-end;
+    mob:setMobMod(dsp.mobMod.ADD_EFFECT, 1)
+end
 
-function onMobFight(mob,target)
+function onMobFight(mob, target)
     -- Gains regain at under 25% HP
-    if (mob:getHPP() < 25 and not mob:hasStatusEffect(dsp.effect.REGAIN)) then
-        mob:addStatusEffect(dsp.effect.REGAIN,5,3,0);
-        mob:getStatusEffect(dsp.effect.REGAIN):setFlag(dsp.effectFlag.DEATH);
+    if mob:getHPP() < 25 and not mob:hasStatusEffect(dsp.effect.REGAIN) then
+        mob:addStatusEffect(dsp.effect.REGAIN, 5, 3, 0)
+        mob:getStatusEffect(dsp.effect.REGAIN):setFlag(dsp.effectFlag.DEATH)
     end
-end;
+end
 
 function onAdditionalEffect(mob, target, damage)
     return dsp.mob.onAddEffect(mob, target, damage, dsp.mob.ae.STUN)
 end
 
 function onMobDeath(mob, player, isKiller)
-    player:addTitle(dsp.title.OMEGA_OSTRACIZER);
-    player:startEvent(11);
-end;
+    player:addTitle(dsp.title.OMEGA_OSTRACIZER)
+    player:startEvent(11)
+end
 
-function onEventFinish(player,csid,option)
-    if (csid == 11) then
-        local inst = player:getVar("bcnm_instanceid");
-        if (inst >= 1 and inst <= 3) then
+function onEventFinish(player, csid, option)
+    if csid == 11 then
+        local inst = player:getVar("bcnm_instanceid")
+
+        if inst >= 1 and inst <= 3 then
             -- players are healed in between fights, but their TP is set to 0
-            player:setHP(player:getMaxHP());
-            player:setMP(player:getMaxMP());
-            player:setTP(0);
+            player:setHP(player:getMaxHP())
+            player:setMP(player:getMaxMP())
+            player:setTP(0)
             player:setLocalVar("[OTBF]cs", 2)
 
             -- move player to instance
-            if (inst == 1) then
-                player:setPos(-779, -103, -80);
-            elseif (inst == 2) then
-                player:setPos(-140, -23, -440);
-            elseif (inst == 3) then
-                player:setPos(499, 56, -802);
+            if inst == 1 then
+                player:setPos(-779, -103, -80)
+            elseif inst == 2 then
+                player:setPos(-140, -23, -440)
+            elseif inst == 3 then
+                player:setPos(499, 56, -802)
             end
         end
     end
-end;
+end

--- a/scripts/zones/Sealions_Den/mobs/Omega.lua
+++ b/scripts/zones/Sealions_Den/mobs/Omega.lua
@@ -8,7 +8,9 @@ require("scripts/globals/mobs")
 -----------------------------------
 
 function onMobInitialize(mob)
+    mob:setMobMod(dsp.mobMod.EXP_BONUS, -100)
     mob:setMobMod(dsp.mobMod.ADD_EFFECT, 1)
+    mob:setMobMod(dsp.mobMod.GIL_MAX, -1)
 end
 
 function onMobFight(mob, target)

--- a/scripts/zones/Sealions_Den/mobs/Ultima.lua
+++ b/scripts/zones/Sealions_Den/mobs/Ultima.lua
@@ -24,4 +24,5 @@ end
 
 function onMobDeath(mob, player, isKiller)
     player:addTitle(dsp.title.ULTIMA_UNDERTAKER);
+    player:setLocalVar("[OTBF]cs", 0)
 end;

--- a/scripts/zones/Sealions_Den/mobs/Ultima.lua
+++ b/scripts/zones/Sealions_Den/mobs/Ultima.lua
@@ -2,27 +2,27 @@
 -- Area: Sealions Den
 --   NM: Ultima
 -----------------------------------
-require("scripts/globals/titles");
+require("scripts/globals/titles")
 require("scripts/globals/mobs")
 -----------------------------------
 
 function onMobInitialize(mob)
-    mob:setMobMod(dsp.mobMod.ADD_EFFECT, 1);
-end;
+    mob:setMobMod(dsp.mobMod.ADD_EFFECT, 1)
+end
 
-function onMobFight(mob,target)
+function onMobFight(mob, target)
     -- Gains regain at under 25% HP
-    if (mob:getHPP() < 25 and not mob:hasStatusEffect(dsp.effect.REGAIN)) then
-        mob:addStatusEffect(dsp.effect.REGAIN,5,3,0);
-        mob:getStatusEffect(dsp.effect.REGAIN):setFlag(dsp.effectFlag.DEATH);
+    if mob:getHPP() < 25 and not mob:hasStatusEffect(dsp.effect.REGAIN) then
+        mob:addStatusEffect(dsp.effect.REGAIN, 5, 3, 0)
+        mob:getStatusEffect(dsp.effect.REGAIN):setFlag(dsp.effectFlag.DEATH)
     end
-end;
+end
 
 function onAdditionalEffect(mob, target, damage)
     return dsp.mob.onAddEffect(mob, target, damage, dsp.mob.ae.PARALYZE, {duration = 60})
 end
 
 function onMobDeath(mob, player, isKiller)
-    player:addTitle(dsp.title.ULTIMA_UNDERTAKER);
+    player:addTitle(dsp.title.ULTIMA_UNDERTAKER)
     player:setLocalVar("[OTBF]cs", 0)
-end;
+end

--- a/scripts/zones/Sealions_Den/mobs/Ultima.lua
+++ b/scripts/zones/Sealions_Den/mobs/Ultima.lua
@@ -7,7 +7,9 @@ require("scripts/globals/mobs")
 -----------------------------------
 
 function onMobInitialize(mob)
+    mob:setMobMod(dsp.mobMod.EXP_BONUS, -100)
     mob:setMobMod(dsp.mobMod.ADD_EFFECT, 1)
+    mob:setMobMod(dsp.mobMod.GIL_MAX, -1)
 end
 
 function onMobFight(mob, target)

--- a/scripts/zones/Sealions_Den/npcs/Airship_Door.lua
+++ b/scripts/zones/Sealions_Den/npcs/Airship_Door.lua
@@ -14,29 +14,27 @@ function onTrigger(player,npc)
 end;
 
 function onEventUpdate(player,csid,option)
+    local inst = player:getVar("bcnm_instanceid")
+
+    -- spawn omega for given instance
+    if csid == 1 and option == 0 then
+        local omegaId = ID.mob.ONE_TO_BE_FEARED_OFFSET + (7 * (inst - 1)) + 5
+        if omegaId and not GetMobByID(omegaId):isSpawned() then
+            SpawnMob(omegaId)
+        end
+
+    -- spawn ultima for given instance
+    elseif csid == 2 and option == 0 then
+        local ultimaId = ID.mob.ONE_TO_BE_FEARED_OFFSET + (7 * (inst - 1)) + 6
+        if ultimaId and not GetMobByID(ultimaId):isSpawned() then
+            SpawnMob(ultimaId)
+        end
+    end
 end;
 
 function onEventFinish(player,csid,option)
     if (csid == 32003 and (option >= 100 and option <= 102)) then
         local inst = option - 99;
-        local instOffset = ID.mob.ONE_TO_BE_FEARED_OFFSET + (7 * (inst - 1));
-
-        local stillAlive = nil;
-        for i = 0, 6 do
-            if (GetMobByID(instOffset + i):isAlive()) then
-                stillAlive = i;
-                break;
-            end
-        end
-        
-        if (stillAlive ~= nil) then
-            if (stillAlive <= 4) then
-                player:startEvent(0, inst); -- send to mammet arena
-            elseif (stillAlive == 5) then
-                player:startEvent(1, inst); -- send to omega arena
-            elseif (stillAlive == 6) then
-                player:startEvent(2, inst); -- send to ultima arena
-            end
-        end
+        player:startEvent(player:getLocalVar("[OTBF]cs"), inst)
     end
 end;

--- a/scripts/zones/Sealions_Den/npcs/Airship_Door.lua
+++ b/scripts/zones/Sealions_Den/npcs/Airship_Door.lua
@@ -2,18 +2,18 @@
 -- Area: Sealion's Den
 --  NPC: Airship_Door
 -----------------------------------
-local ID = require("scripts/zones/Sealions_Den/IDs");
+local ID = require("scripts/zones/Sealions_Den/IDs")
 -----------------------------------
 
-function onTrade(player,npc,trade)
-end;
+function onTrade(player, npc, trade)
+end
 
-function onTrigger(player,npc)
-    local offset = npc:getID() - ID.npc.AIRSHIP_DOOR_OFFSET;
-    player:startEvent(32003, offset + 1);
-end;
+function onTrigger(player, npc)
+    local offset = npc:getID() - ID.npc.AIRSHIP_DOOR_OFFSET
+    player:startEvent(32003, offset + 1)
+end
 
-function onEventUpdate(player,csid,option)
+function onEventUpdate(player, csid, option)
     local inst = player:getVar("bcnm_instanceid")
 
     -- spawn omega for given instance
@@ -30,11 +30,11 @@ function onEventUpdate(player,csid,option)
             SpawnMob(ultimaId)
         end
     end
-end;
+end
 
-function onEventFinish(player,csid,option)
-    if (csid == 32003 and (option >= 100 and option <= 102)) then
-        local inst = option - 99;
+function onEventFinish(player, csid, option)
+    if csid == 32003 and option >= 100 and option <= 102 then
+        local inst = option - 99
         player:startEvent(player:getLocalVar("[OTBF]cs"), inst)
     end
-end;
+end

--- a/scripts/zones/Sealions_Den/npcs/_0w0.lua
+++ b/scripts/zones/Sealions_Den/npcs/_0w0.lua
@@ -24,15 +24,10 @@ function onTrigger(player,npc)
 end;
 
 function onEventUpdate(player,csid,option)
-    -- printf("onUpdate CSID: %u",csid);
-    -- printf("onUpdate RESULT: %u",option);
     EventUpdateBCNM(player,csid,option)
 end;
 
 function onEventFinish(player,csid,option)
-    -- printf("onFinish CSID: %u",csid);
-    -- printf("onFinish RESULT: %u",option);
-
     if (EventFinishBCNM(player,csid,option)) then
         return;
     end

--- a/scripts/zones/Sealions_Den/npcs/_0w0.lua
+++ b/scripts/zones/Sealions_Den/npcs/_0w0.lua
@@ -3,39 +3,39 @@
 --  NPC: Iron Gate
 -- !pos 612 132 774 32
 -----------------------------------
-require("scripts/globals/teleports");
-require("scripts/globals/missions");
-require("scripts/globals/titles");
-require("scripts/globals/bcnm");
+require("scripts/globals/teleports")
+require("scripts/globals/missions")
+require("scripts/globals/titles")
+require("scripts/globals/bcnm")
 -----------------------------------
 
-function onTrade(player,npc,trade)
-    if (TradeBCNM(player,player:getZoneID(),trade,npc)) then
-        return;
+function onTrade(player, npc, trade)
+    if TradeBCNM(player, player:getZoneID(), trade, npc) then
+        return
     end
-end;
+end
 
-function onTrigger(player,npc)
-    if (player:getCurrentMission(COP) == SLANDEROUS_UTTERINGS and player:getVar("PromathiaStatus") == 1) then
-        player:startEvent(13);
-    elseif (EventTriggerBCNM(player,npc)) then
-        return;
+function onTrigger(player, npc)
+    if player:getCurrentMission(COP) == SLANDEROUS_UTTERINGS and player:getVar("PromathiaStatus") == 1 then
+        player:startEvent(13)
+    elseif EventTriggerBCNM(player, npc) then
+        return
     end
-end;
+end
 
-function onEventUpdate(player,csid,option)
-    EventUpdateBCNM(player,csid,option)
-end;
+function onEventUpdate(player, csid, option)
+    EventUpdateBCNM(player, csid, option)
+end
 
-function onEventFinish(player,csid,option)
-    if (EventFinishBCNM(player,csid,option)) then
-        return;
+function onEventFinish(player, csid, option)
+    if EventFinishBCNM(player, csid, option) then
+        return
     end
 
-    if (csid == 13) then
-        player:setVar("PromathiaStatus",0);
-        player:completeMission(COP,SLANDEROUS_UTTERINGS);
-        player:addMission(COP,THE_ENDURING_TUMULT_OF_WAR);
-        player:addTitle(dsp.title.THE_LOST_ONE);
+    if csid == 13 then
+        player:setVar("PromathiaStatus", 0)
+        player:completeMission(COP, SLANDEROUS_UTTERINGS)
+        player:addMission(COP, THE_ENDURING_TUMULT_OF_WAR)
+        player:addTitle(dsp.title.THE_LOST_ONE)
     end
-end;
+end


### PR DESCRIPTION
What used to happen:

When players would kill the final mammet, or omega, the next stage's mob would spawn right away, before all the players had been warped back to the "hub" airship.  The mob would aggro a player, then -- when they were warped to the hub -- it would tear off after them, right into open space.

When the players hopped back through the door to the next stage of the fight, the mob would be in some random location, usually floating out in the sky out of reach, or sometimes not visible at all.

What happens now:

The mobs for next stage of battle are spawned only when players begin to go back through the airship door.