### PR TITLE
Fix BLU trait calculation

### DIFF
--- a/src/map/utils/blueutils.cpp
+++ b/src/map/utils/blueutils.cpp
@@ -416,7 +416,7 @@ void CalculateTraits(CCharEntity* PChar)
 
                 if (iter != points.end())
                 {
-                    iter->second += iter->second + weight;
+                    iter->second += weight;
                 }
                 else
                 {


### PR DESCRIPTION
It was rewarding traits without the required points.

Example: Auto-Refresh was being rewarded from
    Cold Wave, Self-Destruct and Frightful Roar 

 ...which is only 5 points towards the trait