### PR TITLE
Fix for relic scythe aftermath effect.

### DIFF
--- a/scripts/globals/aftermath.lua
+++ b/scripts/globals/aftermath.lua
@@ -38,7 +38,7 @@ dsp.aftermath.effects =
     [4]  = { mods = { dsp.mod.CRITHITRATE, 5 }, duration = getTier1RelicDuration }, -- Ragnarok
     [5]  = { mods = { dsp.mod.ATTP, 10 }, duration = getTier1RelicDuration }, -- Guttler
     [6]  = { mods = { dsp.mod.DMG, -20 }, duration = getTier1RelicDuration }, -- Bravura
-    [7]  = { mods = { dsp.mod.HASTE, 1000 }, duration = getTier1RelicDuration }, -- Apocalypse
+    [7]  = { mods = { dsp.mod.HASTE_GEAR, 1000 }, duration = getTier1RelicDuration }, -- Apocalypse
     [8]  = { mods = { dsp.mod.SPIKES, dsp.subEffect.SHOCK_SPIKES, dsp.mod.SPIKES_DMG, 10 }, duration = getTier1RelicDuration }, -- Gungnir
     [9]  = { mods = { dsp.mod.SUBTLE_BLOW, 10 }, duration = getTier1RelicDuration }, -- Kikoku
     [10] = { mods = { dsp.mod.STORETP, 7 }, duration = getTier1RelicDuration }, -- Amanomurakumo
@@ -56,7 +56,7 @@ dsp.aftermath.effects =
     [18] = { mods = { dsp.mod.CRITHITRATE, 10, dsp.mod.ACC, 15 }, duration = getTier2RelicDuration }, -- Ragnarok
     [19] = { mods = { dsp.mod.ATTP, 10 }, duration = getTier2RelicDuration, includePets = true }, -- Guttler
     [20] = { mods = { dsp.mod.DMG, -20, dsp.mod.REGEN, 15 }, duration = getTier2RelicDuration }, -- Bravura
-    [21] = { mods = { dsp.mod.HASTE, 1000, dsp.mod.ACC, 15 }, duration = getTier2RelicDuration }, -- Apocalypse
+    [21] = { mods = { dsp.mod.HASTE_ABILITY, 1000, dsp.mod.ACC, 15 }, duration = getTier2RelicDuration }, -- Apocalypse
     [22] = { mods = { dsp.mod.SPIKES, dsp.subEffect.SHOCK_SPIKES, dsp.mod.SPIKES_DMG, 10, dsp.mod.ATTP, 5, dsp.mod.DOUBLE_ATTACK, 5 }, duration = getTier2RelicDuration }, -- Gungir
     [23] = { mods = { dsp.mod.SUBTLE_BLOW, 10, dsp.mod.ATTP, 10 }, duration = getTier2RelicDuration }, -- Kikoku
     [24] = { mods = { dsp.mod.STORETP, 10, dsp.mod.ZANSHIN, 10 }, duration = getTier2RelicDuration }, -- Amanomurakumo


### PR DESCRIPTION
dsp.mod variable HASTE no longer exists.
Tier I set to HASTE_GEAR and Tier II set to HASTE_ABILITY per the BG Wiki.