### PR TITLE
Fix an exploit with limbus and a memory corruption vuln

### DIFF
--- a/scripts/zones/Port_Jeuno/npcs/Sagheera.lua
+++ b/scripts/zones/Port_Jeuno/npcs/Sagheera.lua
@@ -350,11 +350,13 @@ function onTrigger(player,npc)
         end
 
         -- calculate cosmocleanse parameters
+        local cosmoTime = 0
+
         if player:hasKeyItem(dsp.ki.COSMOCLEANSE) then
             hasCosmoCleanse = 1
+        else
+            cosmoTime = getCosmoCleanseTime(player)
         end
-
-        local cosmoTime = getCosmoCleanseTime(player)
 
         player:startEvent(310, 3, arg3, arg4, gil, cosmoTime, 1, hasCosmoCleanse, storedABCs)
     end

--- a/scripts/zones/Port_Jeuno/npcs/Sagheera.lua
+++ b/scripts/zones/Port_Jeuno/npcs/Sagheera.lua
@@ -253,7 +253,9 @@ local abcShop =
 
 -----------------------------------
 
-function getCosmoCleanseTime(player)
+local COSMO_READY = 2147483649 -- BITMASK for the purchase
+
+local function getCosmoCleanseTime(player)
     local cosmoWaitTime = BETWEEN_2COSMOCLEANSE_WAIT_TIME * 60 * 60
     local lastCosmoTime = player:getVar("Cosmo_Cleanse_TIME")
 
@@ -262,7 +264,7 @@ function getCosmoCleanseTime(player)
     end
 
     if lastCosmoTime <= os.time() then
-        return 2147483649 -- BITMASK for the purchase
+        return COSMO_READY
     end
 
     return (lastCosmoTime - 1009843200) - 39600 -- (os.time number - BITMASK for the event) - 11 hours in seconds. Only works in this format (strangely).
@@ -385,7 +387,7 @@ function onEventFinish(player,csid,option)
     -- purchase cosmocleanse
     elseif csid == 310 and option == 3 then
         local cosmoTime = getCosmoCleanseTime(player)
-        if cosmoTime == 2147483649 and player:delGil(15000) then
+        if cosmoTime == COSMO_READY and player:delGil(15000) then
             npcUtil.giveKeyItem(player, dsp.ki.COSMOCLEANSE)
             player:setVar("Cosmo_Cleanse_TIME", os.time())
         end

--- a/src/map/packet_system.cpp
+++ b/src/map/packet_system.cpp
@@ -2583,6 +2583,9 @@ void SmallPacket0x053(map_session_data_t* session, CCharEntity* PChar, CBasicPac
             // uint8 locationId = data.ref<uint8>(i + 0x02);
             uint16 itemId = data.ref<uint16>(i + 0x04);
 
+            if (equipSlotId > SLOT_BACK)
+                continue;
+
             auto PItem = itemutils::GetItem(itemId);
             if (PItem == nullptr || !(PItem->isType(ITEM_WEAPON) || PItem->isType(ITEM_ARMOR)))
                 itemId = 0;


### PR DESCRIPTION
The limbus exploit can be done by spoofing the bitmask via packet injection or modding the client. They can effectively bypass the timer allowing them to buy cosmo-cleanse KI's as much as they want.

The memory corruption vuln isn't too bad because it will only null the memory values rather than write the custom itemID supplied due to the conditions. It's relative distance is short due to it being an 8 bit value for the equipSlotId too so people can't go giving themselves a high gmLevel :)



