### PR TITLE
String tables for quests + simplify stage constants

### DIFF
--- a/scripts/globals/quests.lua
+++ b/scripts/globals/quests.lua
@@ -1207,6 +1207,38 @@ dsp.quest.id =
     }
 }
 
+-----------------------------------
+--  QUEST STRING KEYS
+-----------------------------------
+
+-- These are the string key counterparts for a quest, and can be used to find the string
+-- key/path that DSP uses for a given quest when all you have is the quest's ID and its area.
+-- Filepaths can be built using "(AREA_FOLDER)/".. dsp.quest.string.(AREA)[(QUEST_ID)],
+-- Where (AREA) is dsp.quest.area[AREAS_LOG_ID] (a string), _not_ the default integer log ID
+local function buildQuestStringTable(dspQuestIDtable)
+    local questStringTable = {}
+    for areaKey, areaQuestTable in pairs(dspQuestIDtable) do
+        local areaQuestStringTable = {}
+        for questStringKey, questID in pairs(areaQuestTable) do
+            areaQuestStringTable[questID] = questStringKey
+        end
+        questStringTable[areaKey] = areaQuestStringTable
+    end
+    return questStringTable
+end
+
+dsp.quest.string = buildQuestStringTable(dsp.quest.id)
+
+-----------------------------------
+--  DSP QUEST SYSTEM CONSTANTS
+-----------------------------------
+
+dsp.quest.stage =
+{
+    STAGE0   =  0, STAGE1  =  1, STAGE2  =  2, STAGE3   =  3, STAGE4   =  4,
+    STAGE5   =  5, STAGE6  =  6, STAGE7  =  7, STAGE8   =  8, STAGE9   =  9,
+    STAGE10  = 10, STAGE11 = 11, STAGE12 = 12, STAGE13  = 13, STAGE14  = 14,
+}
 
 -----------------------------------
 --  QUEST_REWRITE ENUMS
@@ -1242,27 +1274,6 @@ dsp.quests.enums =
         QUEST_ACCEPTED  = 1,
         QUEST_COMPLETED = 2,
     },
-
-    stages =
-    {
-        STAGE0   =  0, STAGE1  =  1, STAGE2  =  2, STAGE3   =  3, STAGE4   =  4,
-        STAGE5   =  5, STAGE6  =  6, STAGE7  =  7, STAGE8   =  8, STAGE9   =  9,
-        STAGE10  = 10, STAGE11 = 11, STAGE12 = 12, STAGE13  = 13, STAGE14  = 14,
-    },
-}
-
--- After writing a "first require" function which builds a reverse
--- 'quest ID' -> 'quest string' lookup table, this table should be removed.
--- Filepaths can then be built using "area_folder/".. dsp.quest.name.area[quest_id]
-dsp.quests.quest_filenames =
-{
-    [dsp.quest.log_id.ADOULIN] =
-    {
-        [dsp.quest.id.adoulin.WAYWARD_WAYPOINTS] = 'wayward_waypoints',
-        [dsp.quest.id.adoulin.A_CERTAIN_SUBSTITUTE_PATROLMAN] = 'a_certain_substitute_patrolman',
-        [dsp.quest.id.adoulin.THE_OLD_MAN_AND_THE_HARPOON] = 'the_old_man_and_the_harpoon',
-        [dsp.quest.id.adoulin.FERTILE_GROUND] = 'fertile_ground',
-    }
 }
 
 -----------------------------------
@@ -1558,21 +1569,21 @@ dsp.quests.getQuestTable = function(area_log_id, quest_id)
     local quest_filename = 'scripts/quests/'
     local area_dirs =
     {
-        [dsp.quests.enums.log_ids.SANDORIA]    = 'sandoria',
-        [dsp.quests.enums.log_ids.BASTOK]      = 'bastok',
-        [dsp.quests.enums.log_ids.WINDURST]    = 'windurst',
-        [dsp.quests.enums.log_ids.JEUNO]       = 'jeuno',
-        [dsp.quests.enums.log_ids.OTHER_AREAS] = 'other_areas',
-        [dsp.quests.enums.log_ids.OUTLANDS]    = 'outlands',
-        [dsp.quests.enums.log_ids.AHT_URHGAN]  = 'aht_urhgan',
-        [dsp.quests.enums.log_ids.CRYSTAL_WAR] = 'crystal_war',
-        [dsp.quests.enums.log_ids.ABYSSEA]     = 'abyssea',
-        [dsp.quests.enums.log_ids.ADOULIN]     = 'adoulin',
-        [dsp.quests.enums.log_ids.COALITION]   = 'coalition'
+        [dsp.quest.log_id.SANDORIA]    = 'sandoria',
+        [dsp.quest.log_id.BASTOK]      = 'bastok',
+        [dsp.quest.log_id.WINDURST]    = 'windurst',
+        [dsp.quest.log_id.JEUNO]       = 'jeuno',
+        [dsp.quest.log_id.OTHER_AREAS] = 'other_areas',
+        [dsp.quest.log_id.OUTLANDS]    = 'outlands',
+        [dsp.quest.log_id.AHT_URHGAN]  = 'aht_urhgan',
+        [dsp.quest.log_id.CRYSTAL_WAR] = 'crystal_war',
+        [dsp.quest.log_id.ABYSSEA]     = 'abyssea',
+        [dsp.quest.log_id.ADOULIN]     = 'adoulin',
+        [dsp.quest.log_id.COALITION]   = 'coalition'
     }
-    local quest_file = dsp.quests.quest_filenames[area_log_id][quest_id]
+    local quest_file = dsp.quest.string[dsp.quest.area[area_log_id]][quest_id]
     if quest_file then
-        quest_filename = quest_filename .. area_dirs[area_log_id] .. '/' .. quest_file
+        quest_filename = quest_filename .. area_dirs[area_log_id] .. '/' .. string.lower(quest_file)
         local quest_table = require(quest_filename)
         if (quest_table) then
             return quest_table

--- a/scripts/quests/adoulin/a_certain_substitute_patrolman.lua
+++ b/scripts/quests/adoulin/a_certain_substitute_patrolman.lua
@@ -65,7 +65,7 @@ this_quest.constants =
 this_quest.stages =
 {
     -- Stage 0: Talk to Rising Solstice, Western Adoulin, to begin the quest
-    [dsp.quests.enums.stages.STAGE0] =
+    [dsp.quest.stage.STAGE0] =
     {
         [dsp.zone.WESTERN_ADOULIN] =
         {
@@ -91,7 +91,7 @@ this_quest.stages =
         }
     },
     -- Stage 1: Talk to Zaoso, Western Adoulin
-    [dsp.quests.enums.stages.STAGE1] =
+    [dsp.quest.stage.STAGE1] =
     {
         [dsp.zone.WESTERN_ADOULIN] =
         {
@@ -113,7 +113,7 @@ this_quest.stages =
         }
     },
     -- Stage 2: Talk to Clemmar, Western Adoulin
-    [dsp.quests.enums.stages.STAGE2] =
+    [dsp.quest.stage.STAGE2] =
     {
         [dsp.zone.WESTERN_ADOULIN] =
         {
@@ -135,7 +135,7 @@ this_quest.stages =
         }
     },
     -- Stage 3: Talk to Kongramm, Western Adoulin
-    [dsp.quests.enums.stages.STAGE3] =
+    [dsp.quest.stage.STAGE3] =
     {
         [dsp.zone.WESTERN_ADOULIN] =
         {
@@ -157,7 +157,7 @@ this_quest.stages =
         }
     },
     -- Stage 4: Talk to Virsaint, Western Adoulin
-    [dsp.quests.enums.stages.STAGE4] =
+    [dsp.quest.stage.STAGE4] =
     {
         [dsp.zone.WESTERN_ADOULIN] =
         {
@@ -179,7 +179,7 @@ this_quest.stages =
         }
     },
     -- Stage 5: Talk to Shipilolo, Western Adoulin
-    [dsp.quests.enums.stages.STAGE5] =
+    [dsp.quest.stage.STAGE5] =
     {
         [dsp.zone.WESTERN_ADOULIN] =
         {
@@ -201,7 +201,7 @@ this_quest.stages =
         }
     },
     -- Stage 6: Talk to Dangueubert, Western Adoulin
-    [dsp.quests.enums.stages.STAGE6] =
+    [dsp.quest.stage.STAGE6] =
     {
         [dsp.zone.WESTERN_ADOULIN] =
         {
@@ -223,7 +223,7 @@ this_quest.stages =
         }
     },
     -- Stage 7: Talk to Nylene, Western Adoulin
-    [dsp.quests.enums.stages.STAGE7] =
+    [dsp.quest.stage.STAGE7] =
     {
         [dsp.zone.WESTERN_ADOULIN] =
         {
@@ -245,7 +245,7 @@ this_quest.stages =
         }
     },
     -- Stage 8: Talk to Rising Solstice again, quest complete
-    [dsp.quests.enums.stages.STAGE8] =
+    [dsp.quest.stage.STAGE8] =
     {
         [dsp.zone.WESTERN_ADOULIN] =
         {

--- a/scripts/quests/adoulin/fertile_ground.lua
+++ b/scripts/quests/adoulin/fertile_ground.lua
@@ -56,7 +56,7 @@ this_quest.vars =
 this_quest.stages =
 {
     -- [TODO] Stage 0: Talk to Chalvava, Rala Waterways, to begin the quest
-    [dsp.quests.enums.stages.STAGE0] =
+    [dsp.quest.stage.STAGE0] =
     {
         [dsp.zone.RALA_WATERWAYS] =
         {
@@ -74,7 +74,7 @@ this_quest.stages =
         }
     },
     -- Stage 1: Talk to Shipilolo, Western Adoulin, to get Bottle of Fertilizer X KI
-    [dsp.quests.enums.stages.STAGE1] =
+    [dsp.quest.stage.STAGE1] =
     {
         [dsp.zone.WESTERN_ADOULIN] =
         {
@@ -108,7 +108,7 @@ this_quest.stages =
         }
     },
     -- [TODO] Stage 2: Talk to Chalvava again, quest complete
-    [dsp.quests.enums.stages.STAGE2] =
+    [dsp.quest.stage.STAGE2] =
     {
         [dsp.zone.RALA_WATERWAYS] =
         {

--- a/scripts/quests/adoulin/the_old_man_and_the_harpoon.lua
+++ b/scripts/quests/adoulin/the_old_man_and_the_harpoon.lua
@@ -62,7 +62,7 @@ this_quest.temporary =
 this_quest.stages =
 {
     -- Stage 0: Talk to Jorin, Western Adoulin, to get Broken Harpoon KI and start quest
-    [dsp.quests.enums.stages.STAGE0] =
+    [dsp.quest.stage.STAGE0] =
     {
         [dsp.zone.WESTERN_ADOULIN] =
         {
@@ -89,7 +89,7 @@ this_quest.stages =
         }
     },
     -- Stage 1: Talk to Shipilolo, Western Adoulin, to exchange Broken Harpoon KI for Extravagant Harpoon KI
-    [dsp.quests.enums.stages.STAGE1] =
+    [dsp.quest.stage.STAGE1] =
     {
         [dsp.zone.WESTERN_ADOULIN] =
         {
@@ -118,7 +118,7 @@ this_quest.stages =
         }
     },
     -- Stage 2: Talk to Jorin, quest complete
-    [dsp.quests.enums.stages.STAGE2] =
+    [dsp.quest.stage.STAGE2] =
     {
         [dsp.zone.WESTERN_ADOULIN] =
         {

--- a/scripts/quests/adoulin/wayward_waypoints.lua
+++ b/scripts/quests/adoulin/wayward_waypoints.lua
@@ -72,7 +72,7 @@ this_quest.vars =
 this_quest.stages =
 {
     -- [TODO] Stage 0: Speak to Sharuru in Eastern Adoulin to start the quest and receive a Waypoint Scanner Kit KI
-    [dsp.quests.enums.stages.STAGE0] =
+    [dsp.quest.stage.STAGE0] =
     {
         [dsp.zone.EASTERN_ADOULIN] =
         {
@@ -89,19 +89,19 @@ this_quest.stages =
         }
     },
     -- [TODO] Stage 1: Adjust waypoints at Frontier Stations in Ceizak, Yahse, Foret, Morimar, Yorcia, Marjami, and Kamihr
-    [dsp.quests.enums.stages.STAGE1] =
+    [dsp.quest.stage.STAGE1] =
     {
         -- TODO: Find/implement the onTriggers for the Adoulin waypoints
         -- TODO: Implement the event onFinishes for the Adoulin waypoints, just call waypointEventFinish() with their number
     },
     -- [TODO] Stage 2: Try adjusting waypoint in Lower Jeuno
-    [dsp.quests.enums.stages.STAGE2] =
+    [dsp.quest.stage.STAGE2] =
     {
         -- TODO: Find/implement the onTriggers for the Lower Jeuno waypoint
         -- TODO: Implement the Lower Jeuno waypoint onFinish events
     },
     -- [TODO] Stage 3: Talk to Sharuru again.
-    [dsp.quests.enums.stages.STAGE3] =
+    [dsp.quest.stage.STAGE3] =
     {
         [dsp.zone.EASTERN_ADOULIN] =
         {
@@ -118,7 +118,7 @@ this_quest.stages =
         }
     },
     -- Stage 4: Talk to Shipilolo in Western Adoulin and get Waypoint Recalibration Kit KI
-    [dsp.quests.enums.stages.STAGE4] =
+    [dsp.quest.stage.STAGE4] =
     {
         [dsp.zone.WESTERN_ADOULIN] =
         {
@@ -142,13 +142,13 @@ this_quest.stages =
         }
     },
     -- [TODO] Stage 5: Try Lower Jeuno waypoint again
-    [dsp.quests.enums.stages.STAGE5] =
+    [dsp.quest.stage.STAGE5] =
     {
         -- TODO: Find/implement the onTriggers for the Lower Jeuno waypoint
         -- TODO: Implement the Lower Jeuno waypoint onFinish events
     },
     -- [TODO] Stage 6: Return to Sharuru, quest complete
-    [dsp.quests.enums.stages.STAGE6] =
+    [dsp.quest.stage.STAGE6] =
     {
         [dsp.zone.EASTERN_ADOULIN] =
         {


### PR DESCRIPTION
**Adds the previously mentioned quest string key tables**, which are built from our defined quest ID tables. This presents a unified string reference for quests, which can (and now are) be used to build a filepath to a quest's file. **The short-lived `quest.filenames` has been removed**. `quests.getQuest()` can now fully pull a quest table from just an ID, provided that the file exists. Of course, this means that the filename for a quest must be the same as its string key representation.

Also **simplified stage constants** a little.

**Like with last PR, I'll try to lay out (my) future plans:**
1. **Sneak more enum tables into master, like `dsp.fame.JEUNO`, and phase the would-be-duplicate definitions out of the current quest_rewrite enums** table.
2. Revisit requirements, using quest tables being pulled from just an ID, to **be able to check if a player is on/past a given stage** for a required quest/mission
3. Tweak how quest rewards are defined, and what the default behavior is for a call to `quests.complete()` when a reward set isn't passed to it. It'd be nice to be able to **simplify the process of defining rewards** for the vast majority of quests that only have a single reward set.
4. **Reconsider how quest vars should be _stored_ in the DB**, in that maybe instead of using prefix+scripter_var_name, if they should be stored as simple prefix+integer_indexes, with the quest functions abstracting away the conversion from scripter_varname to DB_definition. This is also a concern for being able to **simplify DB migration when the entire current quest player var system is radically upended** later.
5. I'm **waffling on the best order for subtables inside a stage**. [At the moment they're stage->zone->action->NPC or event](https://github.com/ibm2431/darkstar/blob/bf5b78527879e2652da5468fa3c2ecc63182c877/scripts/quests/adoulin/a_certain_substitute_patrolman.lua#L67). I can't decide which order is the most logical for scripting, compared against ease/speed for the quest functions to access them.
If we were being as true as possible to our _current_ quest implementation (in master), it'd be stage->zone->NPC->action, and have event CS IDs be "owned" by the NPC and checked in an `onFinish` subtable inside that NPC, as opposed to the way the stage table currently considers events to be a _separate entity_ from the NPC. I want to make it as easy as possible for people to adjust to the new quest layout, but also don't want to keep a convention  _just_ for the sake of keeping the convention (events as _part_ of an NPC), if another might be better (events are simply events, not NPCs).
**How DSP handles events currently (from an NPC script), versus how it _could_ in the _future_**, might play a factor in this decision.