### PR TITLE
OSX Build Support

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -41,6 +41,10 @@ if DARKSTAR_ARCH_WIN32
 CPPFLAGS_ALL            += -DFD_SETSIZE=4096 -DCYGWIN
 endif
 
+if DARKSTAR_ARCH_OSX
+LDFLAGS_ALL             += -pagezero_size=10000 -image_base=100000000 ##-image_base=7fff04c4a000
+endif
+
 ## Targets
 bin_PROGRAMS          = dsgame dsconnect dssearch
 

--- a/Makefile.am
+++ b/Makefile.am
@@ -42,7 +42,7 @@ CPPFLAGS_ALL            += -DFD_SETSIZE=4096 -DCYGWIN
 endif
 
 if DARKSTAR_ARCH_OSX
-LDFLAGS_ALL             += -pagezero_size=10000 -image_base=100000000 ##-image_base=7fff04c4a000
+LDFLAGS_ALL             += -pagezero_size 10000 -image_base 100000000
 endif
 
 ## Targets

--- a/configure.ac
+++ b/configure.ac
@@ -51,6 +51,9 @@ case "$host" in
         *-*-cygwin* | *-*-mingw32*)
                 darkstar_arch_win32=true
                 ;;
+        *-*-darwin*)
+                darkstar_arch_osx=true
+                ;;
         *)
                 AC_MSG_ERROR([*** Invalid host])
                 ;;
@@ -254,6 +257,13 @@ then
         AC_MSG_RESULT(Building Win32 targets)
         AC_DEFINE(DARKSTAR_ARCH_WIN32,1,Compile code for a windows target)
         DLLEXT=".dll"
+fi
+
+### OSX Specifics
+if test "$darkstar_arch_osx"
+then
+        AC_MSG_RESULT(Building OSX targets)
+        AC_DEFINE(DARKSTAR_ARCH_OSX,1,Compile code for an OSX target)
 fi
 
 AC_SUBST([DLLEXT])

--- a/configure.ac
+++ b/configure.ac
@@ -273,6 +273,7 @@ AM_CONDITIONAL(DARKSTAR_ARCH_SOLARIS,test "$darkstar_arch_solaris")
 AM_CONDITIONAL(DARKSTAR_ARCH_FREEBSD,test "$darkstar_arch_freebsd")
 AM_CONDITIONAL(DARKSTAR_ARCH_NETBSD,test "$darkstar_arch_netbsd")
 AM_CONDITIONAL(DARKSTAR_ARCH_WIN32,test "$darkstar_arch_win32")
+AM_CONDITIONAL(DARKSTAR_ARCH_OSX,test "$darkstar_arch_osx")
 
 AC_CONFIG_HEADER([src/common/config.h])
 AC_CONFIG_FILES([Makefile])

--- a/src/common/socket.h
+++ b/src/common/socket.h
@@ -7,6 +7,7 @@
 	#include "../common/cbasetypes.h"
 #endif
 
+#include <CoreFoundation/CoreFoundation.h>
 
 #ifdef WIN32
     #define FD_SETSIZE 1000

--- a/src/common/socket.h
+++ b/src/common/socket.h
@@ -7,7 +7,9 @@
 	#include "../common/cbasetypes.h"
 #endif
 
-#include <CoreFoundation/CoreFoundation.h>
+#ifdef __APPLE__
+	#include <CoreFoundation/CoreFoundation.h>
+#endif
 
 #ifdef WIN32
     #define FD_SETSIZE 1000

--- a/src/map/guild.h
+++ b/src/map/guild.h
@@ -27,6 +27,7 @@ This file is part of DarkStar-server source code.
 #include "../common/cbasetypes.h"
 #include <array>
 #include <vector>
+#include <string>
 
 #define GP_ITEM_RANKS 7
 


### PR DESCRIPTION
Nobody asked, but here is build support for OSX. Obviously reliant on having your `include` and `lib` paths set up correctly.

**Setup (To be added to the wiki)**
`brew install git pkg-config autoconf make gcc@7 openssl mysql@5.7 mysql-client lua@5.1 luajit zeromq zmqpp`

**Build Instructions**
Otherwise the same as the Linux instructions:
https://wiki.dspt.info/index.php/Building_the_Server

