### PR TITLE
[#5843] Add checking for level difference in exp chain calcs

### DIFF
--- a/src/map/utils/charutils.cpp
+++ b/src/map/utils/charutils.cpp
@@ -3205,7 +3205,7 @@ namespace charutils
             auto PMember = static_cast<CCharEntity*>(PPartyMember);
             uint32 baseexp = 0;
             auto exp = 0.f;
-            int8 levelDifference = PPartyMember->GetMLevel() - PMob->GetMLevel();
+            int8 levelDifference = PMob->GetMLevel() - PPartyMember->GetMLevel();
             bool evenMatchOrHigher = levelDifference >= 0;
             float permonstercap, monsterbonus = 1.0f;
             bool chainactive = false;

--- a/src/map/utils/charutils.cpp
+++ b/src/map/utils/charutils.cpp
@@ -3205,6 +3205,8 @@ namespace charutils
             auto PMember = static_cast<CCharEntity*>(PPartyMember);
             uint32 baseexp = 0;
             auto exp = 0.f;
+            int8 levelDifference = PPartyMember->GetMLevel() - PMob->GetMLevel();
+            bool evenMatchOrHigher = levelDifference >= 0;
             float permonstercap, monsterbonus = 1.0f;
             bool chainactive = false;
             if (PMob->m_HiPCLvl > maxlevel) maxlevel = PMob->m_HiPCLvl;
@@ -3291,7 +3293,7 @@ namespace charutils
                         exp = 300 * permonstercap;
                     }
 
-                    if (PMember->expChain.chainTime > gettick() || PMember->expChain.chainTime == 0)
+                    if ((PMember->expChain.chainTime > gettick() || PMember->expChain.chainTime == 0) && evenMatchOrHigher)
                     {
                         chainactive = true;
                         switch (PMember->expChain.chainNumber)


### PR DESCRIPTION
Potential fix for:https://github.com/DarkstarProject/darkstar/issues/5843

Used this for EM calculation:
https://ffxiclopedia.fandom.com/wiki/Check
```
Even Match
Abbreviation: EM

An Even Match enemy is the same level you are.
```

Not had time to test, but will do in the next few days 🙏 

EDIT: EM logic can also be worked out with:
`charutils::GetRealExp(PPartyMember->GetMLevel(), PMob->GetMLevel()) >= 100; // EM or Higher`
But its less clear?