### PR TITLE
[#5850] Change guard skill proc rate to check jobs, rather than equipped weapon

### DIFF
--- a/src/map/utils/battleutils.cpp
+++ b/src/map/utils/battleutils.cpp
@@ -1726,6 +1726,10 @@ namespace battleutils
         // Defender must have no weapon equipped, or a hand to hand weapon equipped to guard
         bool validWeapon = (PWeapon == nullptr || PWeapon->getSkillType() == SKILL_HAND_TO_HAND);
 
+        if (PDefender->objtype == TYPE_MOB || PDefender->objtype == TYPE_PET) {
+            validWeapon = PDefender->GetMJob() == JOB_MNK || PDefender->GetMJob() == JOB_PUP;
+        }
+
         auto hasH2HSkill = PDefender->GetSkill(SKILL_HAND_TO_HAND);
 
         if (validWeapon && hasH2HSkill && PDefender->PAI->IsEngaged())

--- a/src/map/utils/battleutils.cpp
+++ b/src/map/utils/battleutils.cpp
@@ -1730,7 +1730,7 @@ namespace battleutils
             validWeapon = PDefender->GetMJob() == JOB_MNK || PDefender->GetMJob() == JOB_PUP;
         }
 
-        auto hasH2HSkill = PDefender->GetSkill(SKILL_HAND_TO_HAND);
+        bool hasH2HSkill = PDefender->GetSkill(SKILL_HAND_TO_HAND) > 0;
 
         if (validWeapon && hasH2HSkill && PDefender->PAI->IsEngaged())
         {

--- a/src/map/utils/battleutils.cpp
+++ b/src/map/utils/battleutils.cpp
@@ -1730,7 +1730,7 @@ namespace battleutils
             validWeapon = PDefender->GetMJob() == JOB_MNK || PDefender->GetMJob() == JOB_PUP;
         }
 
-        bool hasGuardSkillRank = GetSkillRank(SKILL_GUARD, PDefender->GetMJob() > 0 || GetSkillRank(SKILL_GUARD, PDefender->GetSJob() > 0;
+        bool hasGuardSkillRank = (GetSkillRank(SKILL_GUARD, PDefender->GetMJob()) > 0 || GetSkillRank(SKILL_GUARD, PDefender->GetSJob()) > 0);
 
         if (validWeapon && hasGuardSkillRank && PDefender->PAI->IsEngaged())
         {

--- a/src/map/utils/battleutils.cpp
+++ b/src/map/utils/battleutils.cpp
@@ -1730,9 +1730,10 @@ namespace battleutils
             validWeapon = PDefender->GetMJob() == JOB_MNK || PDefender->GetMJob() == JOB_PUP;
         }
 
-        bool hasH2HSkill = PDefender->GetSkill(SKILL_HAND_TO_HAND) > 0;
+        auto combinedGuardSkillCap = battleutils::GetMaxSkill(SKILL_GUARD, PDefender->GetMJob(), PDefender->GetMLevel()) +
+                                     battleutils::GetMaxSkill(SKILL_GUARD, PDefender->GetSJob(), PDefender->GetSLevel());
 
-        if (validWeapon && hasH2HSkill && PDefender->PAI->IsEngaged())
+        if (validWeapon && (combinedGuardSkillCap > 0) && PDefender->PAI->IsEngaged())
         {
             // assuming this is like parry
             float skill = (float)PDefender->GetSkill(SKILL_GUARD) + PDefender->getMod(Mod::GUARD);

--- a/src/map/utils/battleutils.cpp
+++ b/src/map/utils/battleutils.cpp
@@ -1730,10 +1730,9 @@ namespace battleutils
             validWeapon = PDefender->GetMJob() == JOB_MNK || PDefender->GetMJob() == JOB_PUP;
         }
 
-        auto combinedGuardSkillCap = battleutils::GetMaxSkill(SKILL_GUARD, PDefender->GetMJob(), PDefender->GetMLevel()) +
-                                     battleutils::GetMaxSkill(SKILL_GUARD, PDefender->GetSJob(), PDefender->GetSLevel());
+        bool hasGuardSkillRank = GetSkillRank(SKILL_GUARD, PDefender->GetMJob() > 0 || GetSkillRank(SKILL_GUARD, PDefender->GetSJob() > 0;
 
-        if (validWeapon && (combinedGuardSkillCap > 0) && PDefender->PAI->IsEngaged())
+        if (validWeapon && hasGuardSkillRank && PDefender->PAI->IsEngaged())
         {
             // assuming this is like parry
             float skill = (float)PDefender->GetSkill(SKILL_GUARD) + PDefender->getMod(Mod::GUARD);

--- a/src/map/utils/battleutils.cpp
+++ b/src/map/utils/battleutils.cpp
@@ -1723,10 +1723,12 @@ namespace battleutils
     {
         CItemWeapon* PWeapon = GetEntityWeapon(PDefender, SLOT_MAIN);
 
-        bool hasGuardSkill = (PDefender->GetMJob() == JOB_MNK || PDefender->GetSJob() == JOB_MNK ||
-                              PDefender->GetMJob() == JOB_PUP || PDefender->GetSJob() == JOB_PUP);
+        // Defender must have no weapon equipped, or a hand to hand weapon equipped to guard
+        bool validWeapon = (PWeapon == nullptr || PWeapon->getSkillType() == SKILL_HAND_TO_HAND);
 
-        if (hasGuardSkill && PDefender->PAI->IsEngaged())
+        auto hasH2HSkill = PDefender->GetSkill(SKILL_HAND_TO_HAND);
+
+        if (validWeapon && hasH2HSkill && PDefender->PAI->IsEngaged())
         {
             // assuming this is like parry
             float skill = (float)PDefender->GetSkill(SKILL_GUARD) + PDefender->getMod(Mod::GUARD);

--- a/src/map/utils/battleutils.cpp
+++ b/src/map/utils/battleutils.cpp
@@ -1723,14 +1723,10 @@ namespace battleutils
     {
         CItemWeapon* PWeapon = GetEntityWeapon(PDefender, SLOT_MAIN);
 
-        // Defender must have no weapon equipped, or a hand to hand weapon equipped to guard
-        bool validWeapon = (PWeapon == nullptr || PWeapon->getSkillType() == SKILL_HAND_TO_HAND);
+        bool hasGuardSkill = (PDefender->GetMJob() == JOB_MNK || PDefender->GetSJob() == JOB_MNK ||
+                              PDefender->GetMJob() == JOB_PUP || PDefender->GetSJob() == JOB_PUP);
 
-        if (PDefender->objtype == TYPE_MOB || PDefender->objtype == TYPE_PET) {
-            validWeapon = PDefender->GetMJob() == JOB_MNK || PDefender->GetMJob() == JOB_PUP;
-        }
-
-        if (validWeapon && PDefender->PAI->IsEngaged())
+        if (hasGuardSkill && PDefender->PAI->IsEngaged())
         {
             // assuming this is like parry
             float skill = (float)PDefender->GetSkill(SKILL_GUARD) + PDefender->getMod(Mod::GUARD);


### PR DESCRIPTION
Issue: https://github.com/DarkstarProject/darkstar/issues/5850

```
Guard can proc on jobs without native hand-to-hand skill (any job attacking without a weapon). It should only be possible to guard with MNK or PUP set as main or sub job. Unsure how this interacts with skill gained from guard merits when otherwise the skill wouldn't exist.
```

As far as I can see, there is a hidden "weapon" that is inserted behind the scenes when you don't have a weapon equipped. This would allow `PWeapon->getSkillType() == SKILL_HAND_TO_HAND` to pass and allow any class without a weapon to guard. So checking instead for MNK or PUP being main/sub job will fix this.

**Not yet tested, will test all my things at the weekend :)**