### PR TITLE
Fix for the optional dialog chain not being optional.

### DIFF
--- a/scripts/zones/Ordelles_Caves/npcs/Ruillont.lua
+++ b/scripts/zones/Ordelles_Caves/npcs/Ruillont.lua
@@ -23,7 +23,7 @@ function onTrigger(player, npc)
     if player:getCurrentMission(SANDORIA) == THE_RESCUE_DRILL then
         local missionStatus = player:getVar("MissionStatus")
 
-        if (missionStatus >= 2 && missionStatus <= 7) then
+        if (missionStatus >= 2 and missionStatus <= 7) then
             player:startEvent(1)
         elseif missionStatus >= 10 or player:hasCompletedMission(SANDORIA, THE_RESCUE_DRILL) then
             player:showText(npc, ID.text.RUILLONT_INITIAL_DIALOG + 9)

--- a/scripts/zones/Ordelles_Caves/npcs/Ruillont.lua
+++ b/scripts/zones/Ordelles_Caves/npcs/Ruillont.lua
@@ -23,7 +23,7 @@ function onTrigger(player, npc)
     if player:getCurrentMission(SANDORIA) == THE_RESCUE_DRILL then
         local missionStatus = player:getVar("MissionStatus")
 
-        if missionStatus == 7 then
+        if missionStatus <= 7 then
             player:startEvent(1)
         elseif missionStatus >= 10 or player:hasCompletedMission(SANDORIA, THE_RESCUE_DRILL) then
             player:showText(npc, ID.text.RUILLONT_INITIAL_DIALOG + 9)

--- a/scripts/zones/Ordelles_Caves/npcs/Ruillont.lua
+++ b/scripts/zones/Ordelles_Caves/npcs/Ruillont.lua
@@ -23,7 +23,7 @@ function onTrigger(player, npc)
     if player:getCurrentMission(SANDORIA) == THE_RESCUE_DRILL then
         local missionStatus = player:getVar("MissionStatus")
 
-        if (missionStatus >= 2 and missionStatus <= 7) then
+        if missionStatus >= 2 and missionStatus <= 7 then
             player:startEvent(1)
         elseif missionStatus >= 10 or player:hasCompletedMission(SANDORIA, THE_RESCUE_DRILL) then
             player:showText(npc, ID.text.RUILLONT_INITIAL_DIALOG + 9)

--- a/scripts/zones/Ordelles_Caves/npcs/Ruillont.lua
+++ b/scripts/zones/Ordelles_Caves/npcs/Ruillont.lua
@@ -23,7 +23,7 @@ function onTrigger(player, npc)
     if player:getCurrentMission(SANDORIA) == THE_RESCUE_DRILL then
         local missionStatus = player:getVar("MissionStatus")
 
-        if missionStatus <= 7 then
+        if (missionStatus >= 2 && missionStatus <= 7) then
             player:startEvent(1)
         elseif missionStatus >= 10 or player:hasCompletedMission(SANDORIA, THE_RESCUE_DRILL) then
             player:showText(npc, ID.text.RUILLONT_INITIAL_DIALOG + 9)


### PR DESCRIPTION
Sources suggest no action other than mission active is required for Ruillont to request you to go get his Bronze Sword.
https://www.bg-wiki.com/bg/San_d%27Oria_Mission_2-1

[My first commit - be gentle...]