### PR TITLE
[#5852] Fix H2H TP generation

### DIFF
--- a/src/map/utils/battleutils.cpp
+++ b/src/map/utils/battleutils.cpp
@@ -1983,7 +1983,7 @@ namespace battleutils
                 if (PAttacker->m_Weapons[slot]->getSkillType() == SKILL_HAND_TO_HAND)
                     ratio = 2.0f;
 
-                baseTp = (int16)(CalculateBaseTP((delay * 60) / 1000) / ratio);
+                baseTp = (int16)(CalculateBaseTP(((delay * 60) / 1000) / ratio));
             }
 
 


### PR DESCRIPTION
**Issue:**
https://github.com/DarkstarProject/darkstar/issues/5852

**Logging code:**
```
if (PAttacker->objtype == TYPE_PC)
{
    ShowDebug("delay: %d, ratio: %f, delay per fist: %f, baseTp: %d\n",
              delay,
              ratio,
              delayPerFist, *
              baseTp);
}
```
*: deplayPerFist being `(delay * 60) / 1000) / ratio` or `((delay * 60) / 1000) / ratio)` swapped in and out for both `CalculateBaseTP` and the logging 

**Before**
`delay: 5000, ratio: 2.000000, delay per fist: 150.000000, baseTp: 45`

**After**
`delay: 5000, ratio: 2.000000, delay per fist: 150.000000, baseTp: 55`

TLDR: Maths is sneaky
