### PR TITLE
Fix VS warning

### DIFF
--- a/src/map/utils/battleutils.cpp
+++ b/src/map/utils/battleutils.cpp
@@ -1983,7 +1983,7 @@ namespace battleutils
                 if (PAttacker->m_Weapons[slot]->getSkillType() == SKILL_HAND_TO_HAND)
                     ratio = 2.0f;
 
-                baseTp = (int16)(CalculateBaseTP(((delay * 60) / 1000) / ratio));
+                baseTp = CalculateBaseTP((int16)(delay * 60.0f / 1000.0f / ratio));
             }
 
 


### PR DESCRIPTION
I introduced a warning-as-error with my H2H TP fix. 

Built with VS, warning is gone, TP fix still works