### PR TITLE
[Quest_Rewrite] Hopefully bring quest table system to near-completion

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -65,7 +65,7 @@ Clang-Format is also an option for C++
 ### Lua
 
 * Unix (LF) line ends
-* Curly braces go on a newline unless empty.
+* Curly braces go on a newline unless empty or encased in a function.
 * Our lua functions are typically lowerCamelCased, with few exceptions (just FYI).
 * No parentheses unless needed to clarify order of operations.
 * No semicolons unless multiple statements on a single line.

--- a/scripts/commands/checkquest.lua
+++ b/scripts/commands/checkquest.lua
@@ -75,14 +75,29 @@ function onTrigger(player,logId,questId,target)
 
     -- print any known quest vars
     if quest then
-        quest_status_string = quest_status_string .. string.format("\n%s is currently on stage: %i", targ:getName(), quest.getStage(targ))
-        local quest_vars_string = ''
-        for name, var in pairs(quest.vars.additional) do
-            quest_vars_string = string.format(quest_vars_string.. ", %s: %i", name, quest.getVar(targ, name))
+        quest_status_string = quest_status_string .. string.format("\nCurrently on stage: %i", quest.getStage(targ))
+        if quest.vars.additional then
+            local quest_vars_string = ''
+            for name, var in pairs(quest.vars.additional) do
+                quest_vars_string = string.format(quest_vars_string.. ", %s: %i", name, quest.getVar(targ, name))
+            end
+            if string.len(quest_vars_string) > 1 then
+                quest_vars_string = string.format("\n%s's additional quest vars are".. quest_vars_string, targ:getName())
+                quest_status_string = quest_status_string .. quest_vars_string
+            end
         end
-        if string.len(quest_vars_string) > 1 then
-            quest_vars_string = string.format("\n%s's additional quest vars are".. quest_vars_string, targ:getName())
-            quest_status_string = quest_status_string .. quest_vars_string
+
+        local held_items_string = '' -- See if the quest is holding any items for the player
+        local held_item = quest.holdingItem(player)
+        local stack = 1
+        while held_item and held_item > 0 do
+            held_items_string = held_items_string .. string.format(", %i", held_item)
+            stack = stack + 1
+            held_item = quest.holdingItem(player, stack)
+        end
+        if string.len(held_items_string) > 1 then
+            held_items_string = string.format("\nFollowing held for %s".. held_items_string, targ:getName())
+            quest_status_string = quest_status_string .. held_items_string
         end
     end
 

--- a/scripts/commands/checkquest.lua
+++ b/scripts/commands/checkquest.lua
@@ -62,23 +62,23 @@ function onTrigger(player,logId,questId,target)
     }
 
     -- fetch a quest table if there is one
-    local quest_table = dsp.quests.getQuestTable(logId, questId)
+    local quest = quests.getQuest(logId, questId)
 
     local quest_status_string = ''
 
     -- show quest status
-    if quest_table then
-        quest_status_string = quest_status_string .. string.format("%s's status for %s quest '%s' is: %s", targ:getName(), logName, quest_table.name, status)
+    if quest then
+        quest_status_string = quest_status_string .. string.format("%s's status for %s quest '%s' is: %s", targ:getName(), logName, quest.name, status)
     else
         quest_status_string = quest_status_string .. string.format("%s's status for %s quest ID %i is: %s", targ:getName(), logName, questId, status )
     end
 
     -- print any known quest vars
-    if quest_table then
-        quest_status_string = quest_status_string .. string.format("\n%s is currently on stage: %i", targ:getName(), dsp.quests.getStage(targ, quest_table))
+    if quest then
+        quest_status_string = quest_status_string .. string.format("\n%s is currently on stage: %i", targ:getName(), quest.getStage(targ))
         local quest_vars_string = ''
-        for name, var in pairs(quest_table.vars.additional) do
-            quest_vars_string = string.format(quest_vars_string.. ", %s: %i", name, dsp.quests.getVar(targ, quest_table, name))
+        for name, var in pairs(quest.vars.additional) do
+            quest_vars_string = string.format(quest_vars_string.. ", %s: %i", name, quest.getVar(targ, name))
         end
         if string.len(quest_vars_string) > 1 then
             quest_vars_string = string.format("\n%s's additional quest vars are".. quest_vars_string, targ:getName())

--- a/scripts/commands/checkquest.lua
+++ b/scripts/commands/checkquest.lua
@@ -62,7 +62,7 @@ function onTrigger(player,logId,questId,target)
     }
 
     -- fetch a quest table if there is one
-    local quest = quests.getQuest(logId, questId)
+    local quest = dsp.quest.getQuest(logId, questId)
 
     local quest_status_string = ''
 

--- a/scripts/commands/reloadquest.lua
+++ b/scripts/commands/reloadquest.lua
@@ -1,5 +1,5 @@
 ---------------------------------------------------------------------------------------------------
--- func: !reloadglobal <questLog> <questID>
+-- func: !reloadquest <questLog> <questID>
 -- desc: Attempt to reload specified quest without a restart.
 ---------------------------------------------------------------------------------------------------
 
@@ -12,8 +12,7 @@ cmdprops =
 }
 
 function error(player, msg)
-    player:PrintToPlayer(msg)
-    player:PrintToPlayer("!reloadquest <logID> <questID>")
+    player:PrintToPlayer(msg .. "\nUsage: !reloadquest <logID> <questID>")
 end
 
 function onTrigger(player, logId, quest_string)
@@ -26,9 +25,6 @@ function onTrigger(player, logId, quest_string)
         error(player, "Invalid logID.")
         return
     end
-    
-    local logName = questLog.full_name;
-    logId = questLog.quest_log;
 
     -- validate questId
     local areaQuestIds = dsp.quest.id[area]
@@ -60,9 +56,9 @@ function onTrigger(player, logId, quest_string)
     local quest_filename = quest_filename .. area_dirs[logId] .. '/' .. string.lower(quest_string)
 
     package.loaded[quest_filename] = nil
-    dsp.quest.object[logId][questId] = nil
+    dsp.quest.object[area][questId] = nil
     local quest = require(quest_filename)
-    dsp.quest.object[logId][questId] = quest
+    dsp.quest.object[area][questId] = quest
 
     player:PrintToPlayer(string.format("Quest '".. quest.name .. "' has been reloaded.",String))
 end

--- a/scripts/commands/reloadquest.lua
+++ b/scripts/commands/reloadquest.lua
@@ -1,0 +1,64 @@
+---------------------------------------------------------------------------------------------------
+-- func: !reloadglobal <logID> <questID>
+-- desc: Attempt to reload specified quest without a restart.
+---------------------------------------------------------------------------------------------------
+
+require("scripts/globals/quests");
+
+cmdprops =
+{
+    permission = 1,
+    parameters = "ss"
+};
+
+function error(player, msg)
+    player:PrintToPlayer(msg);
+    player:PrintToPlayer("!reloadquest <logID> <questID>");
+end;
+
+function onTrigger(player, logId, quest_string)
+    -- validate logId
+    local questLog = GetQuestLogInfo(logId);
+    if (questLog == nil) then
+        error(player, "Invalid logID.");
+        return;
+    end
+    local logName = questLog.full_name;
+    logId = questLog.quest_log;
+
+    -- validate questId
+    local areaQuestIds = dsp.quest.id[dsp.quest.area[logId]];
+    local questId = nil;
+    if (quest_string ~= nil) then
+        questId = areaQuestIds[string.upper(quest_string)];
+    end
+    if (questId == nil or questId < 0) then
+        error(player, "Invalid questID.");
+        return;
+    end
+
+    local quest_filename = 'scripts/quests/'
+    local area_dirs =
+    {
+        [dsp.quest.log_id.SANDORIA]    = 'sandoria',
+        [dsp.quest.log_id.BASTOK]      = 'bastok',
+        [dsp.quest.log_id.WINDURST]    = 'windurst',
+        [dsp.quest.log_id.JEUNO]       = 'jeuno',
+        [dsp.quest.log_id.OTHER_AREAS] = 'other_areas',
+        [dsp.quest.log_id.OUTLANDS]    = 'outlands',
+        [dsp.quest.log_id.AHT_URHGAN]  = 'aht_urhgan',
+        [dsp.quest.log_id.CRYSTAL_WAR] = 'crystal_war',
+        [dsp.quest.log_id.ABYSSEA]     = 'abyssea',
+        [dsp.quest.log_id.ADOULIN]     = 'adoulin',
+        [dsp.quest.log_id.COALITION]   = 'coalition'
+    }
+    local quest_file = dsp.quest.string[dsp.quest.area[logId]][questId]
+    if quest_file then
+        quest_filename = quest_filename .. area_dirs[logId] .. '/' .. string.lower(quest_file)
+        package.loaded[quest_filename] = nil;
+        local quest = require(quest_filename);
+        player:PrintToPlayer(string.format("Quest '".. quest.name .. "' has been reloaded.",String));
+    else
+        error(player, "Unable to find quest file for ".. quest_string)
+    end
+end;

--- a/scripts/commands/reloadquest.lua
+++ b/scripts/commands/reloadquest.lua
@@ -18,7 +18,7 @@ end
 function onTrigger(player, logId, quest_string)
     -- validate logId
     if type(logId) == "string" then
-        logId = dsp.quest.log_id[logId]
+        logId = dsp.quest.log_id[string.upper(logId)]
     end
     local area = dsp.quest.area[logId]
     if logId == nil or area == nil then

--- a/scripts/commands/resetquest.lua
+++ b/scripts/commands/resetquest.lua
@@ -28,8 +28,9 @@ function onTrigger(player,logId,questId,target)
     logId = questLog.quest_log;
 
     -- validate questId
+    local areaQuestIds = dsp.quest.id[dsp.quest.area[logId]];
     if (questId ~= nil) then
-        questId = tonumber(questId) or _G[string.upper(questId)];
+        questId = tonumber(questId) or areaQuestIds[string.upper(questId)];
     end
     if (questId == nil or questId < 0) then
         error(player, "Invalid questID.");

--- a/scripts/commands/resetquest.lua
+++ b/scripts/commands/resetquest.lua
@@ -59,11 +59,24 @@ function onTrigger(player,logId,questId,target)
         -- Begin resetting all quest progress to the best of our ability
         targ:delQuest(logId, questId) -- Delete quest status
         targ:setVar(quest.vars.stage, 0) -- Reset stage var
-        for name, var in pairs(quest.vars.additional) do -- Purge any additional quest vars
-            handleQuestVar(targ, quest, name, 0, "resetquest: ", nil)
+        if quest.vars.additional then -- Purge any additional quest vars
+            for name, var in pairs(quest.vars.additional) do 
+                handleQuestVar(targ, quest, name, 0, "resetquest: ", nil)
+            end
         end
-        for _, ki in pairs(quest.temporary.key_items) do -- Delete any temporary key items
-            player:delKeyItem(ki)
+        if quest.temporary and quest.temporary.key_items then -- Delete any temporary key items
+            for _, ki in pairs(quest.temporary.key_items) do
+                player:delKeyItem(ki)
+            end
+        end
+
+        -- Reset any held items being held by the quest for the player
+        local held_item = quest.holdingItem(player)
+        local stack = 1
+        while held_item and held_item > 0 do
+            player:setVar(quest.var_prefix .. "[I][".. stack .."]", 0)
+            stack = stack + 1
+            held_item = quest.holdingItem(player, stack)
         end
         player:PrintToPlayer( string.format("%s's progress for %s quest '%s' has been reset.", targ:getName(), logName, quest.name) )
     else

--- a/scripts/commands/resetquest.lua
+++ b/scripts/commands/resetquest.lua
@@ -53,7 +53,7 @@ function onTrigger(player,logId,questId,target)
     end
 
     -- fetch the quest table
-    local quest = quests.getQuest(logId, questId)
+    local quest = dsp.quest.getQuest(logId, questId)
 
     if quest then
         -- Begin resetting all quest progress to the best of our ability

--- a/scripts/commands/resetquest.lua
+++ b/scripts/commands/resetquest.lua
@@ -53,7 +53,7 @@ function onTrigger(player,logId,questId,target)
     end
 
     -- fetch the quest table
-    local quest = dsp.quests.getQuestTable(logId, questId)
+    local quest = dsp.quests.getQuest(logId, questId)
 
     if quest then
         -- Begin resetting all quest progress to the best of our ability

--- a/scripts/commands/resetquest.lua
+++ b/scripts/commands/resetquest.lua
@@ -53,7 +53,7 @@ function onTrigger(player,logId,questId,target)
     end
 
     -- fetch the quest table
-    local quest = dsp.quests.getQuest(logId, questId)
+    local quest = quests.getQuest(logId, questId)
 
     if quest then
         -- Begin resetting all quest progress to the best of our ability

--- a/scripts/commands/setquestvar.lua
+++ b/scripts/commands/setquestvar.lua
@@ -1,0 +1,84 @@
+---------------------------------------------------------------------------------------------------
+-- func: !setquestvar <logID> <questID> {player}
+-- desc: Sets a quest var for the provided quest for the target player
+---------------------------------------------------------------------------------------------------
+
+require("scripts/globals/quests")
+
+cmdprops =
+{
+    permission = 1,
+    parameters = "ssssi"
+}
+
+function error(player, msg)
+    player:PrintToPlayer(msg);
+    player:PrintToPlayer("!setquestvar <logID> <questID> <var> <value> {player}");
+end;
+
+function onTrigger(player, logId, questId, var, value, target)
+
+    -- validate logId
+    local questLog = GetQuestLogInfo(logId);
+    if (questLog == nil) then
+        error(player, "Invalid logID.");
+        return;
+    end
+    local logName = questLog.full_name;
+    logId = questLog.quest_log;
+
+    -- validate questId
+    local areaQuestIds = dsp.quest.id[dsp.quest.area[logId]];
+    if (questId ~= nil) then
+        questId = tonumber(questId) or areaQuestIds[string.upper(questId)];
+    end
+    if (questId == nil or questId < 0) then
+        error(player, "Invalid questID.");
+        return;
+    end
+
+    -- validate quest
+    local quest = quests.getQuest(logId, questId)
+    if not quest then
+        error(player, "Unable to load quest file!")
+        return
+    end
+
+    -- validate var
+    local db_name = false
+    if var == 'stage' then
+        db_name = quest.vars.stage
+    else
+        if quest.vars[var] then
+            db_name = quest.vars[var]['db_name']
+        end
+    end
+    if not db_name then
+        error(player, "Specified quest var not defined in quest file!")
+        return
+    end
+
+    -- validate target
+    local targ;
+    if (target == nil) then
+        targ = player:getCursorTarget()
+        if (targ == nil or not targ:isPC()) then
+            targ = player;
+        end
+    else
+        targ = GetPlayerByName(target)
+        if (targ == nil) then
+            error(player, string.format("Player named '%s' not found!", target))
+            return;
+        end
+    end
+    
+    -- validate value
+    if (value == nil) then
+        error(player, "You must provide a value.")
+        return
+    end
+
+    targ:setVar(db_name, value);
+    player:PrintToPlayer( string.format( "Set %s's quest variable '%s' for '%s' to %i.", targ:getName(), var, quest.name, value ) );
+end

--- a/scripts/commands/setquestvar.lua
+++ b/scripts/commands/setquestvar.lua
@@ -38,7 +38,7 @@ function onTrigger(player, logId, questId, var, value, target)
     end
 
     -- validate quest
-    local quest = quests.getQuest(logId, questId)
+    local quest = dsp.quest.getQuest(logId, questId)
     if not quest then
         error(player, "Unable to load quest file!")
         return

--- a/scripts/globals/npc_util.lua
+++ b/scripts/globals/npc_util.lua
@@ -303,7 +303,10 @@ function npcUtil.completeQuest(player, area, quest, params)
     if params["fame"] == nil then
         params["fame"] = 30
     end
-    if area["fame_area"] ~= nil and type(params["fame"]) == "number" then
+
+    if type(area) == "number" and params["fame_area"] then -- Quest object call
+        player:addFame(params["fame_area"], params["fame"])
+    elseif area["fame_area"] ~= nil and type(params["fame"]) == "number" then
         player:addFame(area, params["fame"])
     elseif params["fameArea"] ~= nil and params["fameArea"]["fame_area"] ~= nil and type(params["fame"]) == "number" then
         player:addFame(params["fameArea"], params["fame"])

--- a/scripts/globals/npc_util.lua
+++ b/scripts/globals/npc_util.lua
@@ -185,6 +185,7 @@ end
     Give item(s) to player.
     If player has inventory space, give items, display message, and return true.
     If not, do not give items, display a message to indicate this, and return false.
+    Optional silent_fail determines if a message should be displayed on failure.
 
     Examples of valid items parameter:
         640                 -- copper ore x1
@@ -192,7 +193,7 @@ end
         { {640,2} }         -- copper ore x2
         { {640,2}, 641 }    -- copper ore x2, tin ore x1
 ******************************************************************************* --]]
-function npcUtil.giveItem(player, items)
+function npcUtil.giveItem(player, items, silent_fail)
     local ID = zones[player:getZoneID()]
 
     -- create table of items, with key/val of itemId/itemQty
@@ -216,7 +217,9 @@ function npcUtil.giveItem(player, items)
 
     -- does player have enough inventory space?
     if player:getFreeSlotsCount() < #givenItems then
-        player:messageSpecial(ID.text.ITEM_CANNOT_BE_OBTAINED, givenItems[1][1])
+        if not silent_fail then
+            player:messageSpecial(ID.text.ITEM_CANNOT_BE_OBTAINED, givenItems[1][1])
+        end
         return false
     end
 
@@ -225,7 +228,9 @@ function npcUtil.giveItem(player, items)
         if player:addItem(v[1], v[2], true) then
             player:messageSpecial(ID.text.ITEM_OBTAINED, v[1])
         elseif #givenItems == 1 then
-            player:messageSpecial(ID.text.ITEM_CANNOT_BE_OBTAINED, givenItems[1][1])
+            if not silent_fail then
+                player:messageSpecial(ID.text.ITEM_CANNOT_BE_OBTAINED, givenItems[1][1])
+            end
             return false
         end
     end

--- a/scripts/globals/npc_util.lua
+++ b/scripts/globals/npc_util.lua
@@ -306,7 +306,7 @@ function npcUtil.completeQuest(player, area, quest, params)
 
     if type(area) == "number" and params["fame_area"] then -- Quest object call
         player:addFame(params["fame_area"], params["fame"])
-    elseif area["fame_area"] ~= nil and type(params["fame"]) == "number" then
+    elseif type(area) == "table" and area["fame_area"] ~= nil and type(params["fame"]) == "number" then
         player:addFame(area, params["fame"])
     elseif params["fameArea"] ~= nil and params["fameArea"]["fame_area"] ~= nil and type(params["fame"]) == "number" then
         player:addFame(params["fameArea"], params["fame"])

--- a/scripts/globals/quests.lua
+++ b/scripts/globals/quests.lua
@@ -1651,51 +1651,6 @@ dsp.quest.newQuest = function()
 end
 
 -----------------------------------
---  QUEST FUNCTIONS
------------------------------------
-
-dsp.quest.getQuest = function(area_log_id, quest_id)
-    local area = dsp.quest.area[area_log_id]
-    if area then
-        local quest_string = dsp.quest.string[area][quest_id]
-        if quest_string then -- Verify the quest ID is one we expect
-            if dsp.quest.object[area][quest_id] then
-                -- If we already have the quest loaded, just return it!
-                return dsp.quest.object[area][quest_id]
-            else
-                local quest_filename = 'scripts/quests/'
-                local area_dirs =
-                {
-                    [dsp.quest.log_id.SANDORIA]    = 'sandoria',
-                    [dsp.quest.log_id.BASTOK]      = 'bastok',
-                    [dsp.quest.log_id.WINDURST]    = 'windurst',
-                    [dsp.quest.log_id.JEUNO]       = 'jeuno',
-                    [dsp.quest.log_id.OTHER_AREAS] = 'other_areas',
-                    [dsp.quest.log_id.OUTLANDS]    = 'outlands',
-                    [dsp.quest.log_id.AHT_URHGAN]  = 'aht_urhgan',
-                    [dsp.quest.log_id.CRYSTAL_WAR] = 'crystal_war',
-                    [dsp.quest.log_id.ABYSSEA]     = 'abyssea',
-                    [dsp.quest.log_id.ADOULIN]     = 'adoulin',
-                    [dsp.quest.log_id.COALITION]   = 'coalition'
-                }
-                quest_filename = quest_filename .. area_dirs[area_log_id] .. '/' .. string.lower(quest_string)
-                local quest = require(quest_filename)
-                if (quest) then
-                    dsp.quest.object[area][quest_id] = quest -- Stash our quest away for others to use!
-                    return quest
-                else
-                    print("dsp.quest.getQuest: Unable to include designated file '".. quest_filename .."'")
-                end
-            end
-        else
-            print("dsp.quest.getQuest: Unknown quest ID: ".. quest_id.. " for area: ".. area_dirs[area_log_id])
-        end
-    else
-        print("dsp.quest.getQuest: Unknown area log ID: ".. area_log_id)
-    end
-end
-
------------------------------------
 --  INVOLVED QUESTS OBJECT
 -----------------------------------
 dsp.quest.involvedQuests = function(involvedQuests)
@@ -1798,4 +1753,49 @@ dsp.quest.involvedQuests = function(involvedQuests)
 
     this.involvedQuests = loadQuests(involvedQuests)
     return this
+end
+
+-----------------------------------
+--  OTHER QUEST FUNCTIONS
+-----------------------------------
+
+dsp.quest.getQuest = function(area_log_id, quest_id)
+    local area = dsp.quest.area[area_log_id]
+    if area then
+        local quest_string = dsp.quest.string[area][quest_id]
+        if quest_string then -- Verify the quest ID is one we expect
+            if dsp.quest.object[area][quest_id] then
+                -- If we already have the quest loaded, just return it!
+                return dsp.quest.object[area][quest_id]
+            else
+                local quest_filename = 'scripts/quests/'
+                local area_dirs =
+                {
+                    [dsp.quest.log_id.SANDORIA]    = 'sandoria',
+                    [dsp.quest.log_id.BASTOK]      = 'bastok',
+                    [dsp.quest.log_id.WINDURST]    = 'windurst',
+                    [dsp.quest.log_id.JEUNO]       = 'jeuno',
+                    [dsp.quest.log_id.OTHER_AREAS] = 'other_areas',
+                    [dsp.quest.log_id.OUTLANDS]    = 'outlands',
+                    [dsp.quest.log_id.AHT_URHGAN]  = 'aht_urhgan',
+                    [dsp.quest.log_id.CRYSTAL_WAR] = 'crystal_war',
+                    [dsp.quest.log_id.ABYSSEA]     = 'abyssea',
+                    [dsp.quest.log_id.ADOULIN]     = 'adoulin',
+                    [dsp.quest.log_id.COALITION]   = 'coalition'
+                }
+                quest_filename = quest_filename .. area_dirs[area_log_id] .. '/' .. string.lower(quest_string)
+                local quest = require(quest_filename)
+                if (quest) then
+                    dsp.quest.object[area][quest_id] = quest -- Stash our quest away for others to use!
+                    return quest
+                else
+                    print("dsp.quest.getQuest: Unable to include designated file '".. quest_filename .."'")
+                end
+            end
+        else
+            print("dsp.quest.getQuest: Unknown quest ID: ".. quest_id.. " for area: ".. area_dirs[area_log_id])
+        end
+    else
+        print("dsp.quest.getQuest: Unknown area log ID: ".. area_log_id)
+    end
 end

--- a/scripts/globals/quests.lua
+++ b/scripts/globals/quests.lua
@@ -5,7 +5,6 @@ require("scripts/globals/zone")
 
 dsp = dsp or {}
 dsp.quest = dsp.quest or {} -- "Solid" enum definitions which are currently in use by master
-quests = {}
 
 -- These should be tabled enums for rewritten quests, but
 -- these globals are kept so old-style quests will work
@@ -1554,8 +1553,10 @@ dsp.quest.newQuest = function()
 
     -- Begins an event for the player, with built-in return
     ---------------------------------------------------------------
-    this.startEvent = function(player, event)
-        player:startEvent(event)
+    this.startEvent = function(player, event, params)
+        if not params then params = {} end
+        player:startEvent(event, params[1], params[2], params[3], params[4],
+                                 params[5], params[6], params[7], params[8])
         return true
     end
 
@@ -1565,7 +1566,7 @@ dsp.quest.newQuest = function()
         return npcUtil.giveKeyItem(player, key_item)
     end
 
-    -- Give KI to player, while going through this quest's wrapper
+    -- Remove KI from player, while going through this quest's wrapper
     ---------------------------------------------------------------
     this.delKeyItem = function(player, key_item)
         for _, ki in pairs(this.temporary.key_items) do

--- a/scripts/quests/adoulin/a_certain_substitute_patrolman.lua
+++ b/scripts/quests/adoulin/a_certain_substitute_patrolman.lua
@@ -9,10 +9,10 @@ thisQuest.quest_id = dsp.quest.id.adoulin.A_CERTAIN_SUBSTITUTE_PATROLMAN
 thisQuest.string_key = dsp.quest.string.adoulin[thisQuest.quest_id]
 
 thisQuest.repeatable = false
-thisQuest.varPrefix = "[Q]["..thisQuest.log_id.."]["..thisQuest.quest_id.."]"
+thisQuest.var_prefix = "[Q]["..thisQuest.log_id.."]["..thisQuest.quest_id.."]"
 thisQuest.vars =
 {
-    stage = thisQuest.varPrefix,
+    stage = thisQuest.var_prefix,
     additional =
     {
         --['name'] = { type = dsp.quest.var.CHAR, preserve = false, db_name = 'some_var' },
@@ -65,7 +65,7 @@ thisQuest.stages =
     {
         [dsp.zone.WESTERN_ADOULIN] =
         {
-            ['onTrigger'] =
+            onTrigger =
             {
                 ['Rising_Solstice'] = function(player, npc)
                     if thisQuest.checkRequirements(player) then
@@ -73,7 +73,7 @@ thisQuest.stages =
                     end
                 end
             },
-            ['onEventFinish'] =
+            onEventFinish =
             {
                 [2550] = function(player, option) -- Rising Solstice starting quest
                     if thisQuest.giveKeyItem(player, dsp.ki.WESTERN_ADOULIN_PATROL_ROUTE) then
@@ -88,14 +88,14 @@ thisQuest.stages =
     {
         [dsp.zone.WESTERN_ADOULIN] =
         {
-            ['onTrigger'] =
+            onTrigger =
             {
                 ['Rising_Solstice'] = thisQuest.GO_PATROL,
                 ['Zaoso'] = function(player, npc)
                     return thisQuest.startEvent(player, 2553) -- Reports to player, and advances quest
                 end
             },
-            ['onEventFinish'] =
+            onEventFinish =
             {
                 [2553] = function(player, option) -- Zaoso progressing quest
                     return thisQuest.advanceStage(player)
@@ -108,14 +108,14 @@ thisQuest.stages =
     {
         [dsp.zone.WESTERN_ADOULIN] =
         {
-            ['onTrigger'] =
+            onTrigger =
             {
                 ['Rising_Solstice'] = thisQuest.GO_PATROL,
                 ['Clemmar'] = function(player, npc)
                     return thisQuest.startEvent(player, 2554) -- Reports to player, and advances quest
                 end
             },
-            ['onEventFinish'] =
+            onEventFinish =
             {
                 [2554] = function(player, option) -- Clemmar progressing quest
                     return thisQuest.advanceStage(player)
@@ -128,14 +128,14 @@ thisQuest.stages =
     {
         [dsp.zone.WESTERN_ADOULIN] =
         {
-            ['onTrigger'] =
+            onTrigger =
             {
                 ['Rising_Solstice'] = thisQuest.GO_PATROL,
                 ['Kongramm'] = function(player, npc)
                     return thisQuest.startEvent(player, 2555) -- Reports to player, and advances quest
                 end
             },
-            ['onEventFinish'] =
+            onEventFinish =
             {
                 [2555] = function(player, option) -- Kongramm progressing quest
                     return thisQuest.advanceStage(player)
@@ -148,14 +148,14 @@ thisQuest.stages =
     {
         [dsp.zone.WESTERN_ADOULIN] =
         {
-            ['onTrigger'] =
+            onTrigger =
             {
                 ['Rising_Solstice'] = thisQuest.GO_PATROL,
                 ['Virsaint'] = function(player, npc)
                     return thisQuest.startEvent(player, 2556) -- Reports to player, and advances quest
                 end
             },
-            ['onEventFinish'] =
+            onEventFinish =
             {
                 [2556] = function(player, option) -- Virsaint progressing quest
                     return thisQuest.advanceStage(player)
@@ -168,14 +168,14 @@ thisQuest.stages =
     {
         [dsp.zone.WESTERN_ADOULIN] =
         {
-            ['onTrigger'] =
+            onTrigger =
             {
                 ['Rising_Solstice'] = thisQuest.GO_PATROL,
                 ['Shipilolo'] = function(player, npc)
                     return thisQuest.startEvent(player, 2557) -- Reports to player, and advances quest
                 end
             },
-            ['onEventFinish'] =
+            onEventFinish =
             {
                 [2557] = function(player, option) -- Shipilolo progressing quest
                     return thisQuest.advanceStage(player)
@@ -188,14 +188,14 @@ thisQuest.stages =
     {
         [dsp.zone.WESTERN_ADOULIN] =
         {
-            ['onTrigger'] =
+            onTrigger =
             {
                 ['Rising_Solstice'] = thisQuest.GO_PATROL,
                 ['Dangueubert'] = function(player, npc)
                     return thisQuest.startEvent(player, 2558) -- Reports to player, and advances quest
                 end
             },
-            ['onEventFinish'] =
+            onEventFinish =
             {
                 [2558] = function(player, option) -- Dangueubert progressing quest
                     return thisQuest.advanceStage(player)
@@ -208,14 +208,14 @@ thisQuest.stages =
     {
         [dsp.zone.WESTERN_ADOULIN] =
         {
-            ['onTrigger'] =
+            onTrigger =
             {
                 ['Rising_Solstice'] = thisQuest.GO_PATROL,
                 ['Nylene'] = function(player, npc)
                     return thisQuest.startEvent(player, 2559) -- Reports to player, and advances quest
                 end
             },
-            ['onEventFinish'] =
+            onEventFinish =
             {
                 [2559] = function(player, option) -- Nylene progressing quest
                     return thisQuest.advanceStage(player)
@@ -228,13 +228,13 @@ thisQuest.stages =
     {
         [dsp.zone.WESTERN_ADOULIN] =
         {
-            ['onTrigger'] =
+            onTrigger =
             {
                 ['Rising_Solstice'] = function(player, npc)
                     return thisQuest.startEvent(player, 2552) -- Finishes quest
                 end
             },
-            ['onEventFinish'] =
+            onEventFinish =
             {
                 [2552] = function(player, option) -- Rising Solstice finishing quest
                     if thisQuest.complete(player) then

--- a/scripts/quests/adoulin/a_certain_substitute_patrolman.lua
+++ b/scripts/quests/adoulin/a_certain_substitute_patrolman.lua
@@ -2,16 +2,25 @@ require("scripts/globals/missions")
 require("scripts/globals/quests")
 require("scripts/globals/zone")
 
-local this_quest = {}
+local thisQuest = quests.newQuest()
 
-this_quest.name = "A Certain Substitute Patrolman"
-this_quest.area = ADOULIN
-this_quest.log_id = dsp.quest.log_id.ADOULIN
-this_quest.quest_id = dsp.quest.id.adoulin.A_CERTAIN_SUBSTITUTE_PATROLMAN
+thisQuest.name = "A Certain Substitute Patrolman"
+thisQuest.log_id = dsp.quest.log_id.ADOULIN
+thisQuest.quest_id = dsp.quest.id.adoulin.A_CERTAIN_SUBSTITUTE_PATROLMAN
+thisQuest.string_key = dsp.quest.string.adoulin[thisQuest.quest_id]
 
-this_quest.repeatable = false
+thisQuest.repeatable = false
+thisQuest.varPrefix = "[Q]["..thisQuest.log_id.."]["..thisQuest.quest_id.."]"
+thisQuest.vars =
+{
+    stage = thisQuest.varPrefix,
+    additional =
+    {
+        --['name'] = { type = dsp.quest.var.CHAR, preserve = false, db_name = 'some_var' },
+    }
+}
 
-this_quest.requirements =
+thisQuest.requirements =
 {
     missions =
     {
@@ -22,12 +31,12 @@ this_quest.requirements =
     },
     fame =
     {
-        ['area'] = this_quest.area,
+        ['area'] = dsp.quest.fame.ADOULIN,
         ['level'] = 1
     }
 }
 
-this_quest.rewards =
+thisQuest.rewards =
 {
     sets =
     {
@@ -35,34 +44,29 @@ this_quest.rewards =
         {
             exp = 1000,
             bayld = 500,
-            fame_area = dsp.quests.enums.fame_areas.ADOULIN
+            fame_area = dsp.quest.fame.ADOULIN
         }
     }
 }
 
-this_quest.vars =
-{
-    stage = "[Q]["..this_quest.log_id.."]["..this_quest.quest_id.."]",
-    preserve_main_on_complete = false,
-    additional = {}
-}
-
-this_quest.temporary =
+thisQuest.temporary =
 {
     items = {},
     key_items = {dsp.ki.WESTERN_ADOULIN_PATROL_ROUTE}
 }
 
-this_quest.constants =
-{
-    ['GO_PATROL'] = function(player, npc)
-        -- Rising Solstice yelling at the player to go patrol
-        player:startEvent(2551)
-        return true
-    end
-}
+-- Additional quest functions
+-----------------------------------
+thisQuest.GO_PATROL = function(player, npc)
+    -- Rising Solstice yelling at the player to go patrol
+    player:startEvent(2551)
+    return true
+end
 
-this_quest.stages =
+-----------------------------------
+-- QUEST STAGES
+-----------------------------------
+thisQuest.stages =
 {
     -- Stage 0: Talk to Rising Solstice, Western Adoulin, to begin the quest
     [dsp.quest.stage.STAGE0] =
@@ -72,7 +76,7 @@ this_quest.stages =
             ['onTrigger'] =
             {
                 ['Rising_Solstice'] = function(player, npc)
-                    if dsp.quests.checkRequirements(player, this_quest) then
+                    if thisQuest.checkRequirements(player) then
                         player:startEvent(2550) -- Starts Quest: 'A Certain Substitute Patrolman'
                         return true
                     end
@@ -82,8 +86,7 @@ this_quest.stages =
             {
                 [2550] = function(player, option) -- Rising Solstice starting quest
                     if npcUtil.giveKeyItem(player, dsp.ki.WESTERN_ADOULIN_PATROL_ROUTE) then
-                        player:addQuest(this_quest.log_id, this_quest.quest_id)
-                        dsp.quests.advanceStage(player, this_quest)
+                        thisQuest.start(player)
                         return true
                     end
                 end
@@ -97,7 +100,7 @@ this_quest.stages =
         {
             ['onTrigger'] =
             {
-                ['Rising_Solstice'] = this_quest.constants['GO_PATROL'],
+                ['Rising_Solstice'] = thisQuest.GO_PATROL,
                 ['Zaoso'] = function(player, npc)
                     player:startEvent(2553) -- Reports to player, and advances quest
                     return true
@@ -106,7 +109,7 @@ this_quest.stages =
             ['onEventFinish'] =
             {
                 [2553] = function(player, option) -- Zaoso progressing quest
-                    dsp.quests.advanceStage(player, this_quest)
+                    thisQuest.advanceStage(player)
                     return true
                 end
             }
@@ -119,7 +122,7 @@ this_quest.stages =
         {
             ['onTrigger'] =
             {
-                ['Rising_Solstice'] = this_quest.constants['GO_PATROL'],
+                ['Rising_Solstice'] = thisQuest.GO_PATROL,
                 ['Clemmar'] = function(player, npc)
                     player:startEvent(2554) -- Reports to player, and advances quest
                     return true
@@ -128,7 +131,7 @@ this_quest.stages =
             ['onEventFinish'] =
             {
                 [2554] = function(player, option) -- Clemmar progressing quest
-                    dsp.quests.advanceStage(player, this_quest)
+                    thisQuest.advanceStage(player)
                     return true
                 end
             }
@@ -141,7 +144,7 @@ this_quest.stages =
         {
             ['onTrigger'] =
             {
-                ['Rising_Solstice'] = this_quest.constants['GO_PATROL'],
+                ['Rising_Solstice'] = thisQuest.GO_PATROL,
                 ['Kongramm'] = function(player, npc)
                     player:startEvent(2555) -- Reports to player, and advances quest
                     return true
@@ -150,7 +153,7 @@ this_quest.stages =
             ['onEventFinish'] =
             {
                 [2555] = function(player, option) -- Kongramm progressing quest
-                    dsp.quests.advanceStage(player, this_quest)
+                    thisQuest.advanceStage(player)
                     return true
                 end
             }
@@ -163,7 +166,7 @@ this_quest.stages =
         {
             ['onTrigger'] =
             {
-                ['Rising_Solstice'] = this_quest.constants['GO_PATROL'],
+                ['Rising_Solstice'] = thisQuest.GO_PATROL,
                 ['Virsaint'] = function(player, npc)
                     player:startEvent(2556) -- Reports to player, and advances quest
                     return true
@@ -172,7 +175,7 @@ this_quest.stages =
             ['onEventFinish'] =
             {
                 [2556] = function(player, option) -- Virsaint progressing quest
-                    dsp.quests.advanceStage(player, this_quest)
+                    thisQuest.advanceStage(player)
                     return true
                 end
             }
@@ -185,7 +188,7 @@ this_quest.stages =
         {
             ['onTrigger'] =
             {
-                ['Rising_Solstice'] = this_quest.constants['GO_PATROL'],
+                ['Rising_Solstice'] = thisQuest.GO_PATROL,
                 ['Shipilolo'] = function(player, npc)
                     player:startEvent(2557) -- Reports to player, and advances quest
                     return true
@@ -194,7 +197,7 @@ this_quest.stages =
             ['onEventFinish'] =
             {
                 [2557] = function(player, option) -- Shipilolo progressing quest
-                    dsp.quests.advanceStage(player, this_quest)
+                    thisQuest.advanceStage(player)
                     return true
                 end
             }
@@ -207,7 +210,7 @@ this_quest.stages =
         {
             ['onTrigger'] =
             {
-                ['Rising_Solstice'] = this_quest.constants['GO_PATROL'],
+                ['Rising_Solstice'] = thisQuest.GO_PATROL,
                 ['Dangueubert'] = function(player, npc)
                     player:startEvent(2558) -- Reports to player, and advances quest
                     return true
@@ -216,7 +219,7 @@ this_quest.stages =
             ['onEventFinish'] =
             {
                 [2558] = function(player, option) -- Dangueubert progressing quest
-                    dsp.quests.advanceStage(player, this_quest)
+                    thisQuest.advanceStage(player)
                     return true
                 end
             }
@@ -229,7 +232,7 @@ this_quest.stages =
         {
             ['onTrigger'] =
             {
-                ['Rising_Solstice'] = this_quest.constants['GO_PATROL'],
+                ['Rising_Solstice'] = thisQuest.GO_PATROL,
                 ['Nylene'] = function(player, npc)
                     player:startEvent(2559) -- Reports to player, and advances quest
                     return true
@@ -238,7 +241,7 @@ this_quest.stages =
             ['onEventFinish'] =
             {
                 [2559] = function(player, option) -- Nylene progressing quest
-                    dsp.quests.advanceStage(player, this_quest)
+                    thisQuest.advanceStage(player)
                     return true
                 end
             }
@@ -259,7 +262,7 @@ this_quest.stages =
             ['onEventFinish'] =
             {
                 [2552] = function(player, option) -- Rising Solstice finishing quest
-                    if dsp.quests.complete(player, this_quest) then
+                    if thisQuest.complete(player) then
                         player:delKeyItem(dsp.ki.WESTERN_ADOULIN_PATROL_ROUTE)
                         return true
                     end
@@ -269,4 +272,4 @@ this_quest.stages =
     }
 }
 
-return this_quest
+return thisQuest

--- a/scripts/quests/adoulin/a_certain_substitute_patrolman.lua
+++ b/scripts/quests/adoulin/a_certain_substitute_patrolman.lua
@@ -86,7 +86,7 @@ thisQuest.stages =
             {
                 [2550] = function(player, option) -- Rising Solstice starting quest
                     if npcUtil.giveKeyItem(player, dsp.ki.WESTERN_ADOULIN_PATROL_ROUTE) then
-                        thisQuest.start(player)
+                        thisQuest.begin(player)
                         return true
                     end
                 end

--- a/scripts/quests/adoulin/a_certain_substitute_patrolman.lua
+++ b/scripts/quests/adoulin/a_certain_substitute_patrolman.lua
@@ -1,6 +1,5 @@
 require("scripts/globals/missions")
 require("scripts/globals/quests")
-require("scripts/globals/zone")
 
 local thisQuest = quests.newQuest()
 
@@ -25,28 +24,22 @@ thisQuest.requirements =
     missions =
     {
         {
-            ['mission_log'] = ADOULIN,
-            ['mission_id'] = LIFE_ON_THE_FRONTIER
+            mission_log = ADOULIN,
+            mission_id = LIFE_ON_THE_FRONTIER
         }
     },
     fame =
     {
-        ['area'] = dsp.quest.fame.ADOULIN,
-        ['level'] = 1
+        area = dsp.quest.fame.ADOULIN,
+        level = 1
     }
 }
 
 thisQuest.rewards =
 {
-    sets =
-    {
-        [1] =
-        {
-            exp = 1000,
-            bayld = 500,
-            fame_area = dsp.quest.fame.ADOULIN
-        }
-    }
+    exp = 1000,
+    bayld = 500,
+    fame_area = dsp.quest.fame.ADOULIN
 }
 
 thisQuest.temporary =
@@ -83,7 +76,7 @@ thisQuest.stages =
             ['onEventFinish'] =
             {
                 [2550] = function(player, option) -- Rising Solstice starting quest
-                    if npcUtil.giveKeyItem(player, dsp.ki.WESTERN_ADOULIN_PATROL_ROUTE) then
+                    if thisQuest.giveKeyItem(player, dsp.ki.WESTERN_ADOULIN_PATROL_ROUTE) then
                         return thisQuest.begin(player)
                     end
                 end
@@ -245,8 +238,7 @@ thisQuest.stages =
             {
                 [2552] = function(player, option) -- Rising Solstice finishing quest
                     if thisQuest.complete(player) then
-                        player:delKeyItem(dsp.ki.WESTERN_ADOULIN_PATROL_ROUTE)
-                        return true
+                        return thisQuest.delKeyItem(dsp.ki.WESTERN_ADOULIN_PATROL_ROUTE)
                     end
                 end
             }

--- a/scripts/quests/adoulin/a_certain_substitute_patrolman.lua
+++ b/scripts/quests/adoulin/a_certain_substitute_patrolman.lua
@@ -1,7 +1,7 @@
 require("scripts/globals/missions")
 require("scripts/globals/quests")
 
-local thisQuest = quests.newQuest()
+local thisQuest = dsp.quest.newQuest()
 
 thisQuest.name = "A Certain Substitute Patrolman"
 thisQuest.log_id = dsp.quest.log_id.ADOULIN

--- a/scripts/quests/adoulin/a_certain_substitute_patrolman.lua
+++ b/scripts/quests/adoulin/a_certain_substitute_patrolman.lua
@@ -59,8 +59,7 @@ thisQuest.temporary =
 -----------------------------------
 thisQuest.GO_PATROL = function(player, npc)
     -- Rising Solstice yelling at the player to go patrol
-    player:startEvent(2551)
-    return true
+    return thisQuest.startEvent(player, 2551)
 end
 
 -----------------------------------
@@ -77,8 +76,7 @@ thisQuest.stages =
             {
                 ['Rising_Solstice'] = function(player, npc)
                     if thisQuest.checkRequirements(player) then
-                        player:startEvent(2550) -- Starts Quest: 'A Certain Substitute Patrolman'
-                        return true
+                        return thisQuest.startEvent(player, 2550) -- Starts Quest: 'A Certain Substitute Patrolman'
                     end
                 end
             },
@@ -86,8 +84,7 @@ thisQuest.stages =
             {
                 [2550] = function(player, option) -- Rising Solstice starting quest
                     if npcUtil.giveKeyItem(player, dsp.ki.WESTERN_ADOULIN_PATROL_ROUTE) then
-                        thisQuest.begin(player)
-                        return true
+                        return thisQuest.begin(player)
                     end
                 end
             }
@@ -102,15 +99,13 @@ thisQuest.stages =
             {
                 ['Rising_Solstice'] = thisQuest.GO_PATROL,
                 ['Zaoso'] = function(player, npc)
-                    player:startEvent(2553) -- Reports to player, and advances quest
-                    return true
+                    return thisQuest.startEvent(player, 2553) -- Reports to player, and advances quest
                 end
             },
             ['onEventFinish'] =
             {
                 [2553] = function(player, option) -- Zaoso progressing quest
-                    thisQuest.advanceStage(player)
-                    return true
+                    return thisQuest.advanceStage(player)
                 end
             }
         }
@@ -124,15 +119,13 @@ thisQuest.stages =
             {
                 ['Rising_Solstice'] = thisQuest.GO_PATROL,
                 ['Clemmar'] = function(player, npc)
-                    player:startEvent(2554) -- Reports to player, and advances quest
-                    return true
+                    return thisQuest.startEvent(player, 2554) -- Reports to player, and advances quest
                 end
             },
             ['onEventFinish'] =
             {
                 [2554] = function(player, option) -- Clemmar progressing quest
-                    thisQuest.advanceStage(player)
-                    return true
+                    return thisQuest.advanceStage(player)
                 end
             }
         }
@@ -146,15 +139,13 @@ thisQuest.stages =
             {
                 ['Rising_Solstice'] = thisQuest.GO_PATROL,
                 ['Kongramm'] = function(player, npc)
-                    player:startEvent(2555) -- Reports to player, and advances quest
-                    return true
+                    return thisQuest.startEvent(player, 2555) -- Reports to player, and advances quest
                 end
             },
             ['onEventFinish'] =
             {
                 [2555] = function(player, option) -- Kongramm progressing quest
-                    thisQuest.advanceStage(player)
-                    return true
+                    return thisQuest.advanceStage(player)
                 end
             }
         }
@@ -168,15 +159,13 @@ thisQuest.stages =
             {
                 ['Rising_Solstice'] = thisQuest.GO_PATROL,
                 ['Virsaint'] = function(player, npc)
-                    player:startEvent(2556) -- Reports to player, and advances quest
-                    return true
+                    return thisQuest.startEvent(player, 2556) -- Reports to player, and advances quest
                 end
             },
             ['onEventFinish'] =
             {
                 [2556] = function(player, option) -- Virsaint progressing quest
-                    thisQuest.advanceStage(player)
-                    return true
+                    return thisQuest.advanceStage(player)
                 end
             }
         }
@@ -190,15 +179,13 @@ thisQuest.stages =
             {
                 ['Rising_Solstice'] = thisQuest.GO_PATROL,
                 ['Shipilolo'] = function(player, npc)
-                    player:startEvent(2557) -- Reports to player, and advances quest
-                    return true
+                    return thisQuest.startEvent(player, 2557) -- Reports to player, and advances quest
                 end
             },
             ['onEventFinish'] =
             {
                 [2557] = function(player, option) -- Shipilolo progressing quest
-                    thisQuest.advanceStage(player)
-                    return true
+                    return thisQuest.advanceStage(player)
                 end
             }
         }
@@ -212,15 +199,13 @@ thisQuest.stages =
             {
                 ['Rising_Solstice'] = thisQuest.GO_PATROL,
                 ['Dangueubert'] = function(player, npc)
-                    player:startEvent(2558) -- Reports to player, and advances quest
-                    return true
+                    return thisQuest.startEvent(player, 2558) -- Reports to player, and advances quest
                 end
             },
             ['onEventFinish'] =
             {
                 [2558] = function(player, option) -- Dangueubert progressing quest
-                    thisQuest.advanceStage(player)
-                    return true
+                    return thisQuest.advanceStage(player)
                 end
             }
         }
@@ -234,15 +219,13 @@ thisQuest.stages =
             {
                 ['Rising_Solstice'] = thisQuest.GO_PATROL,
                 ['Nylene'] = function(player, npc)
-                    player:startEvent(2559) -- Reports to player, and advances quest
-                    return true
+                    return thisQuest.startEvent(player, 2559) -- Reports to player, and advances quest
                 end
             },
             ['onEventFinish'] =
             {
                 [2559] = function(player, option) -- Nylene progressing quest
-                    thisQuest.advanceStage(player)
-                    return true
+                    return thisQuest.advanceStage(player)
                 end
             }
         }
@@ -255,8 +238,7 @@ thisQuest.stages =
             ['onTrigger'] =
             {
                 ['Rising_Solstice'] = function(player, npc)
-                    player:startEvent(2552) -- Finishes quest
-                    return true
+                    return thisQuest.startEvent(player, 2552) -- Finishes quest
                 end
             },
             ['onEventFinish'] =

--- a/scripts/quests/adoulin/fertile_ground.lua
+++ b/scripts/quests/adoulin/fertile_ground.lua
@@ -55,14 +55,14 @@ thisQuest.stages =
     {
         [dsp.zone.RALA_WATERWAYS] =
         {
-            ['onTrigger'] =
+            onTrigger =
             {
                 ['Chalvava'] = function(player, npc)
                     -- TODO: Implement Chalvava's portions of the quest
                     return true
                 end
             },
-            ['onEventFinish'] =
+            onEventFinish =
             {
                 -- TODO: Implement Chalvava's portions of the quest
             }
@@ -73,13 +73,13 @@ thisQuest.stages =
     {
         [dsp.zone.WESTERN_ADOULIN] =
         {
-            ['onTrigger'] =
+            onTrigger =
             {
                 ['Shipilolo'] = function(player, npc)
                     return thisQuest.startEvent(player, 2850) -- Gives Bottle of Fertilizer X to player
                 end
             },
-            ['onEventFinish'] =
+            onEventFinish =
             {
                 [2850] = function(player, option)
                     -- Shipilolo, giving Bottle of Fertilizer X
@@ -91,7 +91,7 @@ thisQuest.stages =
         },
         [dsp.zone.RALA_WATERWAYS] =
         {
-            ['onTrigger'] =
+            onTrigger =
             {
                 ['Chalvava'] = function(player, npc)
                     -- TODO: Implement Chalvava's portions of the quest
@@ -105,14 +105,14 @@ thisQuest.stages =
     {
         [dsp.zone.RALA_WATERWAYS] =
         {
-            ['onTrigger'] =
+            onTrigger =
             {
                 ['Chalvava'] = function(player, npc)
                     -- TODO: Implement Chalvava's portions of the quest
                     return true
                 end
             },
-            ['onEventFinish'] =
+            onEventFinish =
             {
                 -- TODO: Implement Chalvava's portions of the quest
             }

--- a/scripts/quests/adoulin/fertile_ground.lua
+++ b/scripts/quests/adoulin/fertile_ground.lua
@@ -1,7 +1,7 @@
 require("scripts/globals/missions")
 require("scripts/globals/quests")
 
-local thisQuest = quests.newQuest()
+local thisQuest = dsp.quest.newQuest()
 
 thisQuest.name = "Fertile Ground"
 thisQuest.log_id = dsp.quest.log_id.ADOULIN

--- a/scripts/quests/adoulin/fertile_ground.lua
+++ b/scripts/quests/adoulin/fertile_ground.lua
@@ -1,6 +1,5 @@
 require("scripts/globals/missions")
 require("scripts/globals/quests")
-require("scripts/globals/zone")
 
 local thisQuest = quests.newQuest()
 
@@ -10,10 +9,10 @@ thisQuest.quest_id = dsp.quest.id.adoulin.FERTILE_GROUND
 thisQuest.string_key = dsp.quest.string.adoulin[thisQuest.quest_id]
 
 thisQuest.repeatable = false
-thisQuest.varPrefix = "[Q]["..thisQuest.log_id.."]["..thisQuest.quest_id.."]"
+thisQuest.var_prefix = "[Q]["..thisQuest.log_id.."]["..thisQuest.quest_id.."]"
 thisQuest.vars =
 {
-    stage = thisQuest.varPrefix,
+    stage = thisQuest.var_prefix,
     additional = {}
 }
 
@@ -22,28 +21,22 @@ thisQuest.requirements =
     quests =
     {
         {
-            ['area'] = ADOULIN,
-            ['quest_id'] = dsp.quest.id.adoulin.THE_OLD_MAN_AND_THE_HARPOON
+            log_id = dsp.quest.log_id.ADOULIN,
+            quest_id = dsp.quest.id.adoulin.THE_OLD_MAN_AND_THE_HARPOON
         }
     },
     fame =
     {
-        ['area'] = dsp.quest.fame.ADOULIN,
-        ['level'] = 2
+        area = dsp.quest.fame.ADOULIN,
+        level = 2
     }
 }
 
 thisQuest.rewards =
 {
-    sets =
-    {
-        [1] =
-        {
-            exp = 500,
-            bayld = 300,
-            fame_area = dsp.quest.fame.ADOULIN
-        }
-    }
+    exp = 500,
+    bayld = 300,
+    fame_area = dsp.quest.fame.ADOULIN
 }
 
 thisQuest.temporary =
@@ -90,7 +83,7 @@ thisQuest.stages =
             {
                 [2850] = function(player, option)
                     -- Shipilolo, giving Bottle of Fertilizer X
-                    if npcUtil.giveKeyItem(player, dsp.ki.BOTTLE_OF_FERTILIZER_X) then
+                    if thisQuest.giveKeyItem(player, dsp.ki.BOTTLE_OF_FERTILIZER_X) then
                         return thisQuest.advanceStage(player)
                     end
                 end

--- a/scripts/quests/adoulin/fertile_ground.lua
+++ b/scripts/quests/adoulin/fertile_ground.lua
@@ -83,8 +83,7 @@ thisQuest.stages =
             ['onTrigger'] =
             {
                 ['Shipilolo'] = function(player, npc)
-                    player:startEvent(2850) -- Gives Bottle of Fertilizer X to player
-                    return true
+                    return thisQuest.startEvent(player, 2850) -- Gives Bottle of Fertilizer X to player
                 end
             },
             ['onEventFinish'] =
@@ -92,8 +91,7 @@ thisQuest.stages =
                 [2850] = function(player, option)
                     -- Shipilolo, giving Bottle of Fertilizer X
                     if npcUtil.giveKeyItem(player, dsp.ki.BOTTLE_OF_FERTILIZER_X) then
-                        dsp.quests.advanceStage(player, thisQuest)
-                        return true
+                        return thisQuest.advanceStage(player)
                     end
                 end
             }

--- a/scripts/quests/adoulin/fertile_ground.lua
+++ b/scripts/quests/adoulin/fertile_ground.lua
@@ -2,16 +2,22 @@ require("scripts/globals/missions")
 require("scripts/globals/quests")
 require("scripts/globals/zone")
 
-local this_quest = {}
+local thisQuest = quests.newQuest()
 
-this_quest.name = "Fertile Ground"
-this_quest.area = ADOULIN
-this_quest.log_id = dsp.quest.log_id.ADOULIN
-this_quest.quest_id = dsp.quest.id.adoulin.FERTILE_GROUND
+thisQuest.name = "Fertile Ground"
+thisQuest.log_id = dsp.quest.log_id.ADOULIN
+thisQuest.quest_id = dsp.quest.id.adoulin.FERTILE_GROUND
+thisQuest.string_key = dsp.quest.string.adoulin[thisQuest.quest_id]
 
-this_quest.repeatable = false
+thisQuest.repeatable = false
+thisQuest.varPrefix = "[Q]["..thisQuest.log_id.."]["..thisQuest.quest_id.."]"
+thisQuest.vars =
+{
+    stage = thisQuest.varPrefix,
+    additional = {}
+}
 
-this_quest.requirements =
+thisQuest.requirements =
 {
     quests =
     {
@@ -22,12 +28,12 @@ this_quest.requirements =
     },
     fame =
     {
-        ['area'] = this_quest.area,
+        ['area'] = dsp.quest.fame.ADOULIN,
         ['level'] = 2
     }
 }
 
-this_quest.rewards =
+thisQuest.rewards =
 {
     sets =
     {
@@ -35,25 +41,21 @@ this_quest.rewards =
         {
             exp = 500,
             bayld = 300,
-            fame_area = dsp.quests.enums.fame_areas.ADOULIN
+            fame_area = dsp.quest.fame.ADOULIN
         }
     }
 }
 
-this_quest.temporary =
+thisQuest.temporary =
 {
     items = {},
     key_items = {dsp.ki.BOTTLE_OF_FERTILIZER_X}
 }
 
-this_quest.vars =
-{
-    stage = "[Q]["..this_quest.log_id.."]["..this_quest.quest_id.."]",
-    preserve_main_on_complete = false,
-    additional = {}
-}
-
-this_quest.stages =
+-----------------------------------
+-- QUEST STAGES
+-----------------------------------
+thisQuest.stages =
 {
     -- [TODO] Stage 0: Talk to Chalvava, Rala Waterways, to begin the quest
     [dsp.quest.stage.STAGE0] =
@@ -90,7 +92,7 @@ this_quest.stages =
                 [2850] = function(player, option)
                     -- Shipilolo, giving Bottle of Fertilizer X
                     if npcUtil.giveKeyItem(player, dsp.ki.BOTTLE_OF_FERTILIZER_X) then
-                        dsp.quests.advanceStage(player, this_quest)
+                        dsp.quests.advanceStage(player, thisQuest)
                         return true
                     end
                 end
@@ -127,4 +129,4 @@ this_quest.stages =
     }
 }
 
-return this_quest
+return thisQuest

--- a/scripts/quests/adoulin/the_old_man_and_the_harpoon.lua
+++ b/scripts/quests/adoulin/the_old_man_and_the_harpoon.lua
@@ -82,7 +82,7 @@ thisQuest.stages =
                 [2540] = function(player, option)
                     -- Jorin, starting quest
                     if npcUtil.giveKeyItem(player, dsp.ki.BROKEN_HARPOON) then
-                        thisQuest.start(player)
+                        thisQuest.begin(player)
                         return true
                     end
                 end

--- a/scripts/quests/adoulin/the_old_man_and_the_harpoon.lua
+++ b/scripts/quests/adoulin/the_old_man_and_the_harpoon.lua
@@ -72,8 +72,8 @@ thisQuest.stages =
             {
                 ['Jorin'] = function(player, npc)
                     if thisQuest.checkRequirements(player) then
-                        player:startEvent(2540) -- Starting quest, his harpoon is broken
-                        return true
+                        -- Starting quest, his harpoon is broken
+                        return thisQuest.startEvent(player, 2540) 
                     end
                 end
             },
@@ -82,8 +82,7 @@ thisQuest.stages =
                 [2540] = function(player, option)
                     -- Jorin, starting quest
                     if npcUtil.giveKeyItem(player, dsp.ki.BROKEN_HARPOON) then
-                        thisQuest.begin(player)
-                        return true
+                        return thisQuest.begin(player)
                     end
                 end
             }
@@ -97,12 +96,12 @@ thisQuest.stages =
             ['onTrigger'] =
             {
                 ['Jorin'] = function(player, npc)
-                    player:startEvent(2541) -- Begs player to hurry up
-                    return true
+                    -- Begs player to hurry up
+                    return thisQuest.startEvent(player, 2541) 
                 end,
                 ['Shipilolo'] = function(player, npc)
-                    player:startEvent(2543) -- Upgrading Broken Harpoon to Extravagant Harpoon
-                    return true
+                    -- Upgrading Broken Harpoon to Extravagant Harpoon
+                    return thisQuest.startEvent(player, 2543) 
                 end
             },
             ['onEventFinish'] =
@@ -111,8 +110,7 @@ thisQuest.stages =
                     -- Shipilolo, fixes Broken Harpoon and advances quest
                     if npcUtil.giveKeyItem(player, dsp.ki.EXTRAVAGANT_HARPOON) then
                         player:delKeyItem(dsp.ki.BROKEN_HARPOON)
-                        thisQuest.advanceStage(player)
-                        return true
+                        return thisQuest.advanceStage(player)
                     end
                 end
             }
@@ -126,8 +124,8 @@ thisQuest.stages =
             ['onTrigger'] =
             {
                 ['Jorin'] = function(player, npc)
-                    player:startEvent(2542) -- Giving Jorin the Extravagant Harpoon
-                    return true
+                    -- Giving Jorin the Extravagant Harpoon
+                    return thisQuest.startEvent(player, 2542) 
                 end
             },
             ['onEventFinish'] =

--- a/scripts/quests/adoulin/the_old_man_and_the_harpoon.lua
+++ b/scripts/quests/adoulin/the_old_man_and_the_harpoon.lua
@@ -9,10 +9,10 @@ thisQuest.quest_id = dsp.quest.id.adoulin.THE_OLD_MAN_AND_THE_HARPOON
 thisQuest.string_key = dsp.quest.string.adoulin[thisQuest.quest_id]
 
 thisQuest.repeatable = false
-thisQuest.varPrefix = "[Q]["..thisQuest.log_id.."]["..thisQuest.quest_id.."]"
+thisQuest.var_prefix = "[Q]["..thisQuest.log_id.."]["..thisQuest.quest_id.."]"
 thisQuest.vars =
 {
-    stage = thisQuest.varPrefix,
+    stage = thisQuest.var_prefix,
     additional =
     {
         --['name'] = { type = dsp.quest.var.CHAR, preserve = false, db_name = 'some_var' },
@@ -24,32 +24,22 @@ thisQuest.requirements =
     missions =
     {
         {
-            ['mission_log'] = ADOULIN,
-            ['mission_id'] = LIFE_ON_THE_FRONTIER
+            mission_log = ADOULIN,
+            mission_id = LIFE_ON_THE_FRONTIER
         }
-        -- [1] = { ['quest'] = require("scripts/globals/missions/adoulin/life_on_the_frontier"), ['stage'] = x }
     },
     fame =
     {
-        ['area'] = dsp.quest.fame.ADOULIN,
-        ['level'] = 1
+        area = dsp.quest.fame.ADOULIN,
+        level = 1
     }
-    -- trade = { {item, qty} },
-    -- key_items = {...},
-    -- etc..
 }
 
 thisQuest.rewards =
 {
-    sets =
-    {
-        [1] =
-        {
-            exp = 500,
-            bayld = 300,
-            fame_area = dsp.quest.fame.ADOULIN
-        }
-    }
+    exp = 500,
+    bayld = 300,
+    fame_area = dsp.quest.fame.ADOULIN
 }
 
 thisQuest.temporary =
@@ -81,7 +71,7 @@ thisQuest.stages =
             {
                 [2540] = function(player, option)
                     -- Jorin, starting quest
-                    if npcUtil.giveKeyItem(player, dsp.ki.BROKEN_HARPOON) then
+                    if thisQuest.giveKeyItem(player, dsp.ki.BROKEN_HARPOON) then
                         return thisQuest.begin(player)
                     end
                 end
@@ -109,7 +99,7 @@ thisQuest.stages =
                 [2543] = function(player, option)
                     -- Shipilolo, fixes Broken Harpoon and advances quest
                     if npcUtil.giveKeyItem(player, dsp.ki.EXTRAVAGANT_HARPOON) then
-                        player:delKeyItem(dsp.ki.BROKEN_HARPOON)
+                        thisQuest.delKeyItem(player, dsp.ki.BROKEN_HARPOON)
                         return thisQuest.advanceStage(player)
                     end
                 end
@@ -133,7 +123,7 @@ thisQuest.stages =
                 [2542] = function(player, option)
                     -- Jorin, finishing quest
                     if thisQuest.complete(player, thisQuest) then
-                        player:delKeyItem(dsp.ki.EXTRAVAGANT_HARPOON)
+                        thisQuest.delKeyItem(player, dsp.ki.EXTRAVAGANT_HARPOON)
                         return true
                     end
                 end

--- a/scripts/quests/adoulin/the_old_man_and_the_harpoon.lua
+++ b/scripts/quests/adoulin/the_old_man_and_the_harpoon.lua
@@ -98,7 +98,7 @@ thisQuest.stages =
             {
                 [2543] = function(player, option)
                     -- Shipilolo, fixes Broken Harpoon and advances quest
-                    if npcUtil.giveKeyItem(player, dsp.ki.EXTRAVAGANT_HARPOON) then
+                    if thisQuest.giveKeyItem(player, dsp.ki.EXTRAVAGANT_HARPOON) then
                         thisQuest.delKeyItem(player, dsp.ki.BROKEN_HARPOON)
                         return thisQuest.advanceStage(player)
                     end

--- a/scripts/quests/adoulin/the_old_man_and_the_harpoon.lua
+++ b/scripts/quests/adoulin/the_old_man_and_the_harpoon.lua
@@ -58,7 +58,7 @@ thisQuest.stages =
     {
         [dsp.zone.WESTERN_ADOULIN] =
         {
-            ['onTrigger'] =
+            onTrigger =
             {
                 ['Jorin'] = function(player, npc)
                     if thisQuest.checkRequirements(player) then
@@ -67,7 +67,7 @@ thisQuest.stages =
                     end
                 end
             },
-            ['onEventFinish'] =
+            onEventFinish =
             {
                 [2540] = function(player, option)
                     -- Jorin, starting quest
@@ -83,7 +83,7 @@ thisQuest.stages =
     {
         [dsp.zone.WESTERN_ADOULIN] =
         {
-            ['onTrigger'] =
+            onTrigger =
             {
                 ['Jorin'] = function(player, npc)
                     -- Begs player to hurry up
@@ -94,7 +94,7 @@ thisQuest.stages =
                     return thisQuest.startEvent(player, 2543) 
                 end
             },
-            ['onEventFinish'] =
+            onEventFinish =
             {
                 [2543] = function(player, option)
                     -- Shipilolo, fixes Broken Harpoon and advances quest
@@ -111,18 +111,18 @@ thisQuest.stages =
     {
         [dsp.zone.WESTERN_ADOULIN] =
         {
-            ['onTrigger'] =
+            onTrigger =
             {
                 ['Jorin'] = function(player, npc)
                     -- Giving Jorin the Extravagant Harpoon
                     return thisQuest.startEvent(player, 2542) 
                 end
             },
-            ['onEventFinish'] =
+            onEventFinish =
             {
                 [2542] = function(player, option)
                     -- Jorin, finishing quest
-                    if thisQuest.complete(player, thisQuest) then
+                    if thisQuest.complete(player) then
                         thisQuest.delKeyItem(player, dsp.ki.EXTRAVAGANT_HARPOON)
                         return true
                     end

--- a/scripts/quests/adoulin/the_old_man_and_the_harpoon.lua
+++ b/scripts/quests/adoulin/the_old_man_and_the_harpoon.lua
@@ -1,7 +1,7 @@
 require("scripts/globals/missions")
 require("scripts/globals/quests")
 
-local thisQuest = quests.newQuest()
+local thisQuest = dsp.quest.newQuest()
 
 thisQuest.name = "The Old Man and the Harpoon"
 thisQuest.log_id = dsp.quest.log_id.ADOULIN

--- a/scripts/quests/adoulin/the_old_man_and_the_harpoon.lua
+++ b/scripts/quests/adoulin/the_old_man_and_the_harpoon.lua
@@ -1,26 +1,25 @@
 require("scripts/globals/missions")
 require("scripts/globals/quests")
-require("scripts/globals/zone")
 
-local this_quest = {}
+local thisQuest = quests.newQuest()
 
-this_quest.name = "The Old Man and the Harpoon"
-this_quest.area = ADOULIN
-this_quest.log_id = dsp.quest.log_id.ADOULIN
-this_quest.quest_id = dsp.quest.id.adoulin.THE_OLD_MAN_AND_THE_HARPOON
+thisQuest.name = "The Old Man and the Harpoon"
+thisQuest.log_id = dsp.quest.log_id.ADOULIN
+thisQuest.quest_id = dsp.quest.id.adoulin.THE_OLD_MAN_AND_THE_HARPOON
+thisQuest.string_key = dsp.quest.string.adoulin[thisQuest.quest_id]
 
-this_quest.repeatable = false
-this_quest.vars =
+thisQuest.repeatable = false
+thisQuest.varPrefix = "[Q]["..thisQuest.log_id.."]["..thisQuest.quest_id.."]"
+thisQuest.vars =
 {
-    stage = "[Q]["..this_quest.log_id.."]["..this_quest.quest_id.."]",
-    preserve_main_on_complete = false, -- do we keep main var on quest completion
+    stage = thisQuest.varPrefix,
     additional =
     {
-        --['name'] = { id = 1, type = dsp.quests.enums.var_types.LOCAL_VAR, repeatable = false, preserve_on_complete = false },
+        --['name'] = { type = dsp.quest.var.CHAR, preserve = false, db_name = 'some_var' },
     }
 }
 
-this_quest.requirements =
+thisQuest.requirements =
 {
     missions =
     {
@@ -32,15 +31,15 @@ this_quest.requirements =
     },
     fame =
     {
-        ['area'] = this_quest.area,
+        ['area'] = dsp.quest.fame.ADOULIN,
         ['level'] = 1
     }
     -- trade = { {item, qty} },
-    -- keyitems = {...},
+    -- key_items = {...},
     -- etc..
 }
 
-this_quest.rewards =
+thisQuest.rewards =
 {
     sets =
     {
@@ -48,18 +47,21 @@ this_quest.rewards =
         {
             exp = 500,
             bayld = 300,
-            fame_area = dsp.quests.enums.fame_areas.ADOULIN
+            fame_area = dsp.quest.fame.ADOULIN
         }
     }
 }
 
-this_quest.temporary =
+thisQuest.temporary =
 {
     items = {},
     key_items = {dsp.ki.BROKEN_HARPOON, dsp.ki.EXTRAVAGANT_HARPOON}
 }
 
-this_quest.stages =
+-----------------------------------
+-- QUEST STAGES
+-----------------------------------
+thisQuest.stages =
 {
     -- Stage 0: Talk to Jorin, Western Adoulin, to get Broken Harpoon KI and start quest
     [dsp.quest.stage.STAGE0] =
@@ -69,8 +71,8 @@ this_quest.stages =
             ['onTrigger'] =
             {
                 ['Jorin'] = function(player, npc)
-                    if dsp.quests.checkRequirements(player, this_quest) then
-                        player:startEvent(2540) -- Starting quest
+                    if thisQuest.checkRequirements(player) then
+                        player:startEvent(2540) -- Starting quest, his harpoon is broken
                         return true
                     end
                 end
@@ -80,8 +82,7 @@ this_quest.stages =
                 [2540] = function(player, option)
                     -- Jorin, starting quest
                     if npcUtil.giveKeyItem(player, dsp.ki.BROKEN_HARPOON) then
-                        player:addQuest(this_quest.log_id, this_quest.quest_id)
-                        dsp.quests.advanceStage(player, this_quest)
+                        thisQuest.start(player)
                         return true
                     end
                 end
@@ -100,7 +101,7 @@ this_quest.stages =
                     return true
                 end,
                 ['Shipilolo'] = function(player, npc)
-                    player:startEvent(2543) -- Upgrading Broken Hapoon to Extravagant Harpoon
+                    player:startEvent(2543) -- Upgrading Broken Harpoon to Extravagant Harpoon
                     return true
                 end
             },
@@ -110,14 +111,14 @@ this_quest.stages =
                     -- Shipilolo, fixes Broken Harpoon and advances quest
                     if npcUtil.giveKeyItem(player, dsp.ki.EXTRAVAGANT_HARPOON) then
                         player:delKeyItem(dsp.ki.BROKEN_HARPOON)
-                        dsp.quests.advanceStage(player, this_quest)
+                        thisQuest.advanceStage(player)
                         return true
                     end
                 end
             }
         }
     },
-    -- Stage 2: Talk to Jorin, quest complete
+    -- Stage 2: Talk to Jorin, to give him Extravagant Harpoon and finish quest
     [dsp.quest.stage.STAGE2] =
     {
         [dsp.zone.WESTERN_ADOULIN] =
@@ -125,7 +126,7 @@ this_quest.stages =
             ['onTrigger'] =
             {
                 ['Jorin'] = function(player, npc)
-                    player:startEvent(2542) -- Finishes quest
+                    player:startEvent(2542) -- Giving Jorin the Extravagant Harpoon
                     return true
                 end
             },
@@ -133,7 +134,7 @@ this_quest.stages =
             {
                 [2542] = function(player, option)
                     -- Jorin, finishing quest
-                    if dsp.quests.complete(player, this_quest) then
+                    if thisQuest.complete(player, thisQuest) then
                         player:delKeyItem(dsp.ki.EXTRAVAGANT_HARPOON)
                         return true
                     end
@@ -143,4 +144,4 @@ this_quest.stages =
     }
 }
 
-return this_quest
+return thisQuest

--- a/scripts/quests/adoulin/wayward_waypoints.lua
+++ b/scripts/quests/adoulin/wayward_waypoints.lua
@@ -1,6 +1,5 @@
 require("scripts/globals/missions")
 require("scripts/globals/quests")
-require("scripts/globals/zone")
 
 local thisQuest = quests.newQuest()
 
@@ -10,14 +9,14 @@ thisQuest.quest_id = dsp.quest.id.adoulin.WAYWARD_WAYPOINTS
 thisQuest.string_key = dsp.quest.string.adoulin[thisQuest.quest_id]
 
 thisQuest.repeatable = false
-thisQuest.varPrefix = "[Q]["..thisQuest.log_id.."]["..thisQuest.quest_id.."]"
+thisQuest.var_prefix = "[Q]["..thisQuest.log_id.."]["..thisQuest.quest_id.."]"
 thisQuest.vars =
 {
-    stage = thisQuest.varPrefix,
+    stage = thisQuest.var_prefix,
     additional =
     {
         -- Bitmask of waypoints calibrated during the second stage.
-        ["waypoints"] = {  type = dsp.quest.var.CHAR, preserve = false, db_name = 'waypoints' },
+        ["waypoints"] = { type = dsp.quest.var.CHAR, preserve = false, db_name = 'waypoints' },
     }
 }
 
@@ -26,29 +25,23 @@ thisQuest.requirements =
     quests =
     { 
         {
-            ['area'] = ADOULIN,
-            ['quest_id'] = dsp.quest.id.adoulin.MEGALOMANIAC
+            log_id = dsp.quest.log_id.ADOULIN,
+            quest_id = dsp.quest.id.adoulin.MEGALOMANIAC
         } 
     },
     fame =
     {
-        ['area'] = dsp.quest.fame.ADOULIN,
-        ['level'] = 4
+        area = dsp.quest.fame.ADOULIN,
+        level = 4
     }
 }
 
 thisQuest.rewards =
 {
-    sets =
-    {
-        [1] =
-        {
-            exp = 1000,
-            bayld = 500,
-            -- TODO: kinetic_units = 3000, -- Kinetic units need to be implemented before we reward them.
-            fame_area = dsp.quest.fame.ADOULIN
-        }
-    }
+    exp = 1000,
+    bayld = 500,
+    -- TODO: kinetic_units = 3000, -- Kinetic units need to be implemented before we reward them.
+    fame_area = dsp.quest.fame.ADOULIN
 }
 
 thisQuest.temporary =
@@ -135,8 +128,8 @@ thisQuest.stages =
             ['onEventFinish'] =
             {
                 [79] = function(player, option) -- Shipilolo upgrading waypoint kit
-                    if npcUtil.giveKeyItem(player, dsp.ki.WAYPOINT_RECALIBRATION_KIT) then
-                        player:delKeyItem(dsp.ki.WAYPOINT_SCANNER_KIT)
+                    if thisQuest.giveKeyItem(player, dsp.ki.WAYPOINT_RECALIBRATION_KIT) then
+                        thisQuest.delKeyItem(dsp.ki.WAYPOINT_SCANNER_KIT)
                         return thisQuest.advanceStage(player)
                     end
                 end

--- a/scripts/quests/adoulin/wayward_waypoints.lua
+++ b/scripts/quests/adoulin/wayward_waypoints.lua
@@ -73,13 +73,13 @@ thisQuest.stages =
     {
         [dsp.zone.EASTERN_ADOULIN] =
         {
-            ['onTrigger'] =
+            onTrigger =
             {
                 ['Sharuru'] = function(player, npc)
                     -- TODO: Implement Sharuru's portions of the quest
                 end
             },
-            ['onEventFinish'] =
+            onEventFinish =
             {
                 -- TODO: find Sharuru's events and implement their onFinishes
             }
@@ -102,13 +102,13 @@ thisQuest.stages =
     {
         [dsp.zone.EASTERN_ADOULIN] =
         {
-            ['onTrigger'] =
+            onTrigger =
             {
                 ['Sharuru'] = function(player, npc)
                     -- TODO: Implement Sharuru's portions of the quest
                 end
             },
-            ['onEventFinish'] =
+            onEventFinish =
             {
                 -- TODO: find Sharuru's events and implement their onFinishes
             }
@@ -119,13 +119,13 @@ thisQuest.stages =
     {
         [dsp.zone.WESTERN_ADOULIN] =
         {
-            ['onTrigger'] =
+            onTrigger =
             {
                 ['Shipilolo'] = function(player, npc)
                     return thisQuest.startEvent(player, 79) -- Gives player Waypoint Recalibration Kit
                 end
             },
-            ['onEventFinish'] =
+            onEventFinish =
             {
                 [79] = function(player, option) -- Shipilolo upgrading waypoint kit
                     if thisQuest.giveKeyItem(player, dsp.ki.WAYPOINT_RECALIBRATION_KIT) then
@@ -147,13 +147,13 @@ thisQuest.stages =
     {
         [dsp.zone.EASTERN_ADOULIN] =
         {
-            ['onTrigger'] =
+            onTrigger =
             {
                 ['Sharuru'] = function(player, npc)
                     -- TODO: Implement Sharuru's portions of the quest
                 end
             },
-            ['onEventFinish'] =
+            onEventFinish =
             {
                 -- TODO: find Sharuru's events and implement their onFinishes
             }

--- a/scripts/quests/adoulin/wayward_waypoints.lua
+++ b/scripts/quests/adoulin/wayward_waypoints.lua
@@ -129,8 +129,7 @@ thisQuest.stages =
             ['onTrigger'] =
             {
                 ['Shipilolo'] = function(player, npc)
-                    player:startEvent(79) -- Gives player Waypoint Recalibration Kit
-                    return true
+                    return thisQuest.startEvent(player, 79) -- Gives player Waypoint Recalibration Kit
                 end
             },
             ['onEventFinish'] =
@@ -138,8 +137,7 @@ thisQuest.stages =
                 [79] = function(player, option) -- Shipilolo upgrading waypoint kit
                     if npcUtil.giveKeyItem(player, dsp.ki.WAYPOINT_RECALIBRATION_KIT) then
                         player:delKeyItem(dsp.ki.WAYPOINT_SCANNER_KIT)
-                        thisQuest.advanceStage(player)
-                        return true
+                        return thisQuest.advanceStage(player)
                     end
                 end
             }

--- a/scripts/quests/adoulin/wayward_waypoints.lua
+++ b/scripts/quests/adoulin/wayward_waypoints.lua
@@ -1,7 +1,7 @@
 require("scripts/globals/missions")
 require("scripts/globals/quests")
 
-local thisQuest = quests.newQuest()
+local thisQuest = dsp.quest.newQuest()
 
 thisQuest.name = "Wayward Waypoints"
 thisQuest.log_id = dsp.quest.log_id.ADOULIN

--- a/scripts/quests/adoulin/wayward_waypoints.lua
+++ b/scripts/quests/adoulin/wayward_waypoints.lua
@@ -2,23 +2,26 @@ require("scripts/globals/missions")
 require("scripts/globals/quests")
 require("scripts/globals/zone")
 
-local waypointEventFinish = function(player, waypoint)
-    -- Make sure player is working on stage 1
-    -- Bitmask the bit in the waypoints var for the given waypoint
-    -- Check value of the waypoint var, if all are set, advance to stage 2
-    -- Return true if we did something
-end
+local thisQuest = quests.newQuest()
 
-local this_quest = {}
+thisQuest.name = "Wayward Waypoints"
+thisQuest.log_id = dsp.quest.log_id.ADOULIN
+thisQuest.quest_id = dsp.quest.id.adoulin.WAYWARD_WAYPOINTS
+thisQuest.string_key = dsp.quest.string.adoulin[thisQuest.quest_id]
 
-this_quest.name = "Wayward Waypoints"
-this_quest.area = ADOULIN
-this_quest.log_id = dsp.quest.log_id.ADOULIN
-this_quest.quest_id = dsp.quest.id.adoulin.WAYWARD_WAYPOINTS
+thisQuest.repeatable = false
+thisQuest.varPrefix = "[Q]["..thisQuest.log_id.."]["..thisQuest.quest_id.."]"
+thisQuest.vars =
+{
+    stage = thisQuest.varPrefix,
+    additional =
+    {
+        -- Bitmask of waypoints calibrated during the second stage.
+        ["waypoints"] = {  type = dsp.quest.var.CHAR, preserve = false, db_name = 'waypoints' },
+    }
+}
 
-this_quest.repeatable = false
-
-this_quest.requirements =
+thisQuest.requirements =
 {
     quests =
     { 
@@ -29,12 +32,12 @@ this_quest.requirements =
     },
     fame =
     {
-        ['area'] = this_quest.area,
+        ['area'] = dsp.quest.fame.ADOULIN,
         ['level'] = 4
     }
 }
 
-this_quest.rewards =
+thisQuest.rewards =
 {
     sets =
     {
@@ -43,12 +46,12 @@ this_quest.rewards =
             exp = 1000,
             bayld = 500,
             -- TODO: kinetic_units = 3000, -- Kinetic units need to be implemented before we reward them.
-            fame_area = dsp.quests.enums.fame_areas.ADOULIN
+            fame_area = dsp.quest.fame.ADOULIN
         }
     }
 }
 
-this_quest.temporary =
+thisQuest.temporary =
 {
     items = {},
     key_items =
@@ -58,18 +61,19 @@ this_quest.temporary =
     }
 }
 
-this_quest.vars =
-{
-    stage = "[Q]["..this_quest.log_id.."]["..this_quest.quest_id.."]",
-    preserve_main_on_complete = false, -- do we keep main var on quest completion
-    additional =
-    {
-        -- Bitmask of waypoints calibrated during the second stage.
-        ["waypoints"] = { id = 1, type = dsp.quests.enums.var_types.LOCAL_VAR, repeatable = false, preserve_on_complete = false }, 
-    }
-}
+-- Additional quest functions
+-----------------------------------
+thisQuest.CHECK_WAYPOINT = function(player, waypoint)
+    -- Make sure player is working on stage 1
+    -- Bitmask the bit in the waypoints var for the given waypoint
+    -- Check value of the waypoint var, if all are set, advance to stage 2
+    -- Return true if we did something
+end
 
-this_quest.stages =
+-----------------------------------
+-- QUEST STAGES
+-----------------------------------
+thisQuest.stages =
 {
     -- [TODO] Stage 0: Speak to Sharuru in Eastern Adoulin to start the quest and receive a Waypoint Scanner Kit KI
     [dsp.quest.stage.STAGE0] =
@@ -134,7 +138,7 @@ this_quest.stages =
                 [79] = function(player, option) -- Shipilolo upgrading waypoint kit
                     if npcUtil.giveKeyItem(player, dsp.ki.WAYPOINT_RECALIBRATION_KIT) then
                         player:delKeyItem(dsp.ki.WAYPOINT_SCANNER_KIT)
-                        dsp.quests.advanceStage(player, this_quest)
+                        thisQuest.advanceStage(player)
                         return true
                     end
                 end
@@ -166,4 +170,4 @@ this_quest.stages =
     }
 }
 
-return this_quest
+return thisQuest

--- a/scripts/quests/sandoria/the_brugaire_consortium.lua
+++ b/scripts/quests/sandoria/the_brugaire_consortium.lua
@@ -1,0 +1,269 @@
+require("scripts/globals/quests")
+
+local thisQuest = dsp.quest.newQuest()
+
+thisQuest.name = "The Brugaire Consortium"
+thisQuest.log_id = dsp.quest.log_id.SANDORIA
+thisQuest.quest_id = dsp.quest.id.sandoria.THE_BRUGAIRE_CONSORTIUM
+thisQuest.string_key = dsp.quest.string.sandoria[thisQuest.quest_id]
+
+thisQuest.repeatable = false
+thisQuest.var_prefix = "[Q]["..thisQuest.log_id.."]["..thisQuest.quest_id.."]"
+thisQuest.vars =
+{
+    stage = thisQuest.var_prefix,
+    additional = {}
+}
+
+thisQuest.requirements =
+{
+    fame =
+    {
+        area = dsp.quest.fame.SANDORIA,
+        level = 1
+    }
+}
+
+thisQuest.rewards =
+{
+    items = 12289, -- Lauan Shield
+    title = dsp.title.COURIER_EXTRAORDINAIRE,
+    fame_area = dsp.quest.fame.SANDORIA
+}
+
+thisQuest.temporary =
+{
+    items = {593, 594, 595} -- Magic Shop Parcel, Port Parcel, Pub Parcel
+}
+
+-- Additional quest functions
+-----------------------------------
+thisQuest.PAY_REPLACE_PARCEL = function(player, npc, trade)
+    -- Player repaying to replace a parcel they have lost
+    local parcel_lost = math.floor(thisQuest.getStage(player) / 2) + 1
+    local parcel_item_id = 592 + parcel_lost
+    if thisQuest.tradeHas(player, trade, {{"gil", 100}}) and not player:hasItem(parcel_item_id) then
+        return thisQuest.startEvent(player, 607 + parcel_lost)
+    end
+end
+
+thisQuest.PARCEL_REPLACED = function(player, csid)
+    -- Player being given a replacement parcel
+    local parcel_lost = math.floor(thisQuest.getStage(player) / 2) + 1
+    local parcel_item_id = 592 + parcel_lost
+
+    thisQuest.completeTrade(player)
+    if not thisQuest.giveItem(player, parcel_item_id, true) then 
+        return thisQuest.startEvent(player, 537) -- Says player can't carry item
+    end
+    return true
+end
+
+thisQuest.DELIVER_FIRST = function(player, npc)
+    if not thisQuest.holdingItem(player) then -- Are we holding a parcel for player?
+        -- Tells the player to finish delivering the current parcel before taking another
+        return thisQuest.startEvent(player, 560)
+    else
+        -- Try to give the player the parcel again
+        if thisQuest.returnItem(player, true) then
+            return true
+        else
+            return thisQuest.startEvent(player, 537) -- Says player can't carry item
+        end
+    end
+end
+
+-----------------------------------
+-- QUEST STAGES
+-----------------------------------
+thisQuest.stages =
+{
+    -- Stage 0: Talk to Fontoumant, Port San d'Oria, to receive the first parcel and begin the quest
+    [dsp.quest.stage.STAGE0] =
+    {
+        [dsp.zone.PORT_SAN_DORIA] =
+        {
+            onTrigger =
+            {
+                ['Fontoumant'] = function(player, npc)
+                    if thisQuest.holdingItem(player) then
+                        -- Try giving the player their rewards for completing the quest
+                        thisQuest.returnItem(player)
+                        return true
+                    elseif thisQuest.checkRequirements(player) then
+                        -- Asks player if they want to work, and if so, gives them first parcel
+                        return thisQuest.startEvent(player, 509)
+                    end
+                end
+            },
+            onEventFinish =
+            {
+                [509] = function(player, option) -- Fontoumant starting quest
+                    if option == 0 then
+                        thisQuest.begin(player) -- Goes ahead and starts the quest
+                        if thisQuest.giveItem(player, 593, true) then -- Attempts to give Magic Shop Parcel
+                            return true
+                        else
+                            return thisQuest.startEvent(player, 537) -- Says player can't carry item
+                        end
+                    end
+                end
+            }
+        }
+    },
+    -- Stage 1: Deliver the first parcel to Regine, Port San d'Oria
+    [dsp.quest.stage.STAGE1] =
+    {
+        [dsp.zone.PORT_SAN_DORIA] =
+        {
+            onTrade =
+            {
+                ['Fontoumant'] = thisQuest.PAY_REPLACE_PARCEL, -- Player compensating for lost parcel
+                ['Regine'] = function(player, npc, trade)
+                    if thisQuest.tradeHas(player, trade, 593) then
+                        return thisQuest.startEvent(player, 535) -- Player delivering the Magic Shop Parcel
+                    else
+                        return thisQuest.startEvent(player, 536) -- Player attempted to deliver wrong item
+                    end
+                end
+            },
+            onTrigger =
+            {
+                ['Fontoumant'] = thisQuest.DELIVER_FIRST
+            },
+            onEventFinish =
+            {
+                [535] = function(player, option) -- Player delivered Magic Shop Parcel
+                    thisQuest.completeTrade(player)
+                    return thisQuest.advanceStage(player)
+                end,
+                [608] = thisQuest.PARCEL_REPLACED -- Player paid to replace Magic Shop Parcel
+            }
+        }
+    },
+    -- Stage 2: Return to Fontoumant to receive the next parcel
+    [dsp.quest.stage.STAGE2] =
+    {
+        [dsp.zone.PORT_SAN_DORIA] =
+        {
+            onTrigger =
+            {
+                ['Fontoumant'] = function(player, npc)
+                    return thisQuest.startEvent(player, 511)
+                end
+            },
+            onEventFinish =
+            {
+                [511] = function(player, option) -- Fontoumant giving player the next parcel
+                    thisQuest.advanceStage(player)
+                    if not thisQuest.giveItem(player, 594, true) then -- Attempts to give Port Parcel
+                        return thisQuest.startEvent(player, 537) -- Says player can't carry item
+                    end
+                end
+            }
+        }
+    },
+    -- Stage 3: Deliver the second parcel to Apstaule, Port San d'Oria
+    [dsp.quest.stage.STAGE3] =
+    {
+        [dsp.zone.PORT_SAN_DORIA] =
+        {
+            onTrade =
+            {
+                ['Fontoumant'] = thisQuest.PAY_REPLACE_PARCEL, -- Player compensating for lost parcel
+                ['Apstaule'] = function(player, npc, trade)
+                    if thisQuest.tradeHas(player, trade, 594) then
+                        return thisQuest.startEvent(player, 540) -- Player delivering the Auction Parcel
+                    else
+                        return thisQuest.startEvent(player, 541) -- Player attempted to deliver wrong item
+                    end
+                end
+            },
+            onTrigger =
+            {
+                ['Fontoumant'] = thisQuest.DELIVER_FIRST
+            },
+            onEventFinish =
+            {
+                [540] = function(player, option) -- Player delivered Auction Parcel
+                    thisQuest.completeTrade(player)
+                    return thisQuest.advanceStage(player)
+                end,
+                [609] = thisQuest.PARCEL_REPLACED -- Player paid to replace Port Parcel
+            }
+        }
+    },
+    -- Stage 4: Return to Fontoumant to receive the next parcel
+    [dsp.quest.stage.STAGE4] =
+    {
+        [dsp.zone.PORT_SAN_DORIA] =
+        {
+            onTrigger =
+            {
+                ['Fontoumant'] = function(player, npc)
+                    return thisQuest.startEvent(player, 512)
+                end
+            },
+            onEventFinish =
+            {
+                [512] = function(player, option) -- Fontoumant giving player the next parcel
+                    thisQuest.advanceStage(player)
+                    if not thisQuest.giveItem(player, 595, true) then -- Attempts to give Pub Parcel
+                        return thisQuest.startEvent(player, 537) -- Says player can't carry item
+                    end
+                end
+            }
+        }
+    },
+    -- Stage 5: Deliver the third parcel to Thierride, Port San d'Oria
+    [dsp.quest.stage.STAGE5] =
+    {
+        [dsp.zone.PORT_SAN_DORIA] =
+        {
+            onTrade =
+            {
+                ['Fontoumant'] = thisQuest.PAY_REPLACE_PARCEL, -- Player compensating for lost parcel
+                ['Thierride'] = function(player, npc, trade)
+                    if thisQuest.tradeHas(player, trade, 595) then
+                        return thisQuest.startEvent(player, 539) -- Player delivering the Pub Parcel
+                    else
+                        return thisQuest.startEvent(player, 529) -- Player attempted to deliver wrong item
+                    end
+                end
+            },
+            onTrigger =
+            {
+                ['Fontoumant'] = thisQuest.DELIVER_FIRST
+            },
+            onEventFinish =
+            {
+                [539] = function(player, option) -- Player delivered Pub Parcel
+                    thisQuest.completeTrade(player)
+                    return thisQuest.advanceStage(player)
+                end,
+                [610] = thisQuest.PARCEL_REPLACED -- Player paid to replace Pub Parcel
+            }
+        }
+    },
+    -- Stage 6: Speak to Fontoumant to finish quest and receive reward
+    [dsp.quest.stage.STAGE6] =
+    {
+        [dsp.zone.PORT_SAN_DORIA] =
+        {
+            onTrigger =
+            {
+                ['Fontoumant'] = function(player, npc)
+                    return thisQuest.startEvent(player, 515)
+                end
+            },
+            onEventFinish =
+            {
+                [515] = function(player, option) -- Fontoumant giving player their reward
+                    return thisQuest.complete(player)
+                end
+            }
+        }
+    }
+}
+
+return thisQuest

--- a/scripts/zones/Port_San_dOria/npcs/Apstaule.lua
+++ b/scripts/zones/Port_San_dOria/npcs/Apstaule.lua
@@ -7,11 +7,9 @@ local ID = require("scripts/zones/Port_San_dOria/IDs");
 require("scripts/globals/quests");
 require("scripts/globals/shop");
 
-local quests =
-{
+local quests = dsp.quest.involvedQuests({
     require("scripts/quests/sandoria/the_brugaire_consortium")
-}
-quests = dsp.quest.involvedQuests(quests)
+})
 -----------------------------------
 
 function onTrade(player,npc,trade)

--- a/scripts/zones/Port_San_dOria/npcs/Apstaule.lua
+++ b/scripts/zones/Port_San_dOria/npcs/Apstaule.lua
@@ -6,36 +6,37 @@
 local ID = require("scripts/zones/Port_San_dOria/IDs");
 require("scripts/globals/quests");
 require("scripts/globals/shop");
+
+local quests =
+{
+    require("scripts/quests/sandoria/the_brugaire_consortium")
+}
+quests = dsp.quest.involvedQuests(quests)
 -----------------------------------
 
 function onTrade(player,npc,trade)
     -- "Flyers for Regine" conditional script
     local count = trade:getItemCount();
     local MagicFlyer    = trade:hasItemQty(532,1);
-    local AuctionParcel = trade:hasItemQty(594,1);
 
     if (MagicFlyer == true and count == 1) then
         local FlyerForRegine = player:getQuestStatus(SANDORIA,dsp.quest.id.sandoria.FLYERS_FOR_REGINE);
         if (FlyerForRegine == 1) then
             player:messageSpecial(ID.text.FLYER_REFUSED);
         end
-    elseif (AuctionParcel == true and count == 1) then
-        local TheBrugaireConsortium = player:getQuestStatus(SANDORIA,dsp.quest.id.sandoria.THE_BRUGAIRE_CONSORTIUM);
-        if (TheBrugaireConsortium == 1) then
-            player:tradeComplete();
-            player:startEvent(540);
-            player:setVar("TheBrugaireConsortium-Parcels", 21);
-        end
+    else
+        quests.onTrade(player, npc, trade)
     end
 
 end;
 
 function onTrigger(player,npc)
-    player:startEvent(542);
+    player:startEvent(542) -- Standard dialogue
 end;
 
 function onEventUpdate(player,csid,option)
 end;
 
 function onEventFinish(player,csid,option)
+    quests.onEventFinish(player, csid, option)
 end;

--- a/scripts/zones/Port_San_dOria/npcs/Fontoumant.lua
+++ b/scripts/zones/Port_San_dOria/npcs/Fontoumant.lua
@@ -1,117 +1,53 @@
 -----------------------------------
 -- Area: Port San d'Oria
---  NPC: Fontoumant
--- Starts Quest: The Brugaire Consortium
+-- NPC: Fontoumant
 -- Involved in Quests: Riding on the Clouds
 -- !pos -10 -10 -122 232
 -----------------------------------
 local ID = require("scripts/zones/Port_San_dOria/IDs");
 require("scripts/globals/settings");
 require("scripts/globals/keyitems");
-require("scripts/globals/titles");
 require("scripts/globals/quests");
+
+local quests =
+{
+    require("scripts/quests/sandoria/the_brugaire_consortium")
+}
+quests = dsp.quest.involvedQuests(quests)
 -----------------------------------
 
 function onTrade(player,npc,trade)
     local count = trade:getItemCount();
-    if (player:getQuestStatus(SANDORIA,dsp.quest.id.sandoria.THE_BRUGAIRE_CONSORTIUM) == QUEST_ACCEPTED) then
-        if (count == 1 and trade:getGil() == 100) then  -- pay to replace package
-            local prog = player:getVar("TheBrugaireConsortium-Parcels");
-            if (prog == 10 and player:hasItem(593) == false) then
-                player:startEvent(608);
-                player:setVar("TheBrugaireConsortium-Parcels",11)
-            elseif (prog == 20 and player:hasItem(594) == false) then
-                player:startEvent(609);
-                player:setVar("TheBrugaireConsortium-Parcels",21)
-            elseif (prog == 30 and player:hasItem(595) == false) then
-                player:startEvent(610);
-                player:setVar("TheBrugaireConsortium-Parcels",31)
+
+    if not quests.onTrade(player, npc, trade) then
+        if (player:getQuestStatus(SANDORIA,dsp.quest.id.sandoria.FLYERS_FOR_REGINE) == QUEST_ACCEPTED) then
+            if (trade:hasItemQty(532,1) and count == 1) then -- Trade Magicmart Flyer
+                player:messageSpecial(ID.text.FLYER_REFUSED);
             end
         end
-    end
 
-    if (player:getQuestStatus(SANDORIA,dsp.quest.id.sandoria.FLYERS_FOR_REGINE) == QUEST_ACCEPTED) then
-        if (trade:hasItemQty(532,1) and count == 1) then -- Trade Magicmart Flyer
-            player:messageSpecial(ID.text.FLYER_REFUSED);
-        end
-    end
-
-    if (player:getQuestStatus(JEUNO,dsp.quest.id.jeuno.RIDING_ON_THE_CLOUDS) == QUEST_ACCEPTED and player:getVar("ridingOnTheClouds_1") == 6) then
-        if (trade:hasItemQty(1127,1) and count == 1) then -- Trade Kindred seal
-            player:setVar("ridingOnTheClouds_1",0);
-            player:tradeComplete();
-            player:addKeyItem(dsp.ki.SCOWLING_STONE);
-            player:messageSpecial(ID.text.KEYITEM_OBTAINED,dsp.ki.SCOWLING_STONE);
+        if (player:getQuestStatus(JEUNO,dsp.quest.id.jeuno.RIDING_ON_THE_CLOUDS) == QUEST_ACCEPTED and player:getVar("ridingOnTheClouds_1") == 6) then
+            if (trade:hasItemQty(1127,1) and count == 1) then -- Trade Kindred seal
+                player:setVar("ridingOnTheClouds_1",0);
+                player:tradeComplete();
+                player:addKeyItem(dsp.ki.SCOWLING_STONE);
+                player:messageSpecial(ID.text.KEYITEM_OBTAINED,dsp.ki.SCOWLING_STONE);
+            end
         end
     end
 
 end;
 
 function onTrigger(player,npc)
-
-    local TheBrugaireConsortium = player:getQuestStatus(SANDORIA,dsp.quest.id.sandoria.THE_BRUGAIRE_CONSORTIUM);
-
-    if (TheBrugaireConsortium == QUEST_AVAILABLE) then
-        player:startEvent(509);
-    elseif (TheBrugaireConsortium == QUEST_ACCEPTED) then
-
-        local prog = player:getVar("TheBrugaireConsortium-Parcels");
-        if (prog == 11) then
-            player:startEvent(511);
-        elseif (prog == 21) then
-            player:startEvent(512);
-        elseif (prog == 31) then
-            player:startEvent(515);
-        else
-            player:startEvent(560);
-        end
+    if not quests.onTrigger(player, npc) then
+        -- Standard dialogue, after completing quest: 'The Brugaire Consortium''
+        player:startEvent(561)
     end
-
 end;
 
 function onEventUpdate(player,csid,option)
 end;
 
 function onEventFinish(player,csid,option)
-    local freeSlots = player:getFreeSlotsCount();
-    if (csid == 509 and option == 0) then
-        if (freeSlots ~= 0) then
-            player:addItem(593);
-            player:messageSpecial(ID.text.ITEM_OBTAINED,593);
-            player:addQuest(SANDORIA,dsp.quest.id.sandoria.THE_BRUGAIRE_CONSORTIUM)
-            player:setVar("TheBrugaireConsortium-Parcels",10)
-        else
-            player:startEvent(537);
-        end
-    elseif (csid == 511) then
-        if (freeSlots ~= 0) then
-            player:addItem(594);
-            player:messageSpecial(ID.text.ITEM_OBTAINED,594);
-            player:setVar("TheBrugaireConsortium-Parcels",20);
-        else
-            player:startEvent(537);
-        end
-    elseif (csid == 512) then
-        if (freeSlots ~= 0) then
-            player:addItem(595);
-            player:messageSpecial(ID.text.ITEM_OBTAINED,595);
-            player:setVar("TheBrugaireConsortium-Parcels",30);
-        else
-            player:startEvent(537);
-        end
-    elseif (csid == 608 or csid == 609 or csid == 610) then
-        player:tradeComplete()
-    elseif (csid == 515) then
-        if (freeSlots ~= 0) then
-            player:addItem(12289);
-            player:messageSpecial(ID.text.ITEM_OBTAINED,12289);
-            player:addTitle(dsp.title.COURIER_EXTRAORDINAIRE);
-            player:completeQuest(SANDORIA,dsp.quest.id.sandoria.THE_BRUGAIRE_CONSORTIUM);
-            player:addFame(SANDORIA,30);
-            player:setVar("TheBrugaireConsortium-Parcels",0);
-        else
-            player:startEvent(537);
-        end
-    end
-
+    quests.onEventFinish(player, csid, option)
 end;

--- a/scripts/zones/Port_San_dOria/npcs/Fontoumant.lua
+++ b/scripts/zones/Port_San_dOria/npcs/Fontoumant.lua
@@ -9,11 +9,9 @@ require("scripts/globals/settings");
 require("scripts/globals/keyitems");
 require("scripts/globals/quests");
 
-local quests =
-{
+local quests = dsp.quest.involvedQuests({
     require("scripts/quests/sandoria/the_brugaire_consortium")
-}
-quests = dsp.quest.involvedQuests(quests)
+})
 -----------------------------------
 
 function onTrade(player,npc,trade)

--- a/scripts/zones/Port_San_dOria/npcs/Regine.lua
+++ b/scripts/zones/Port_San_dOria/npcs/Regine.lua
@@ -9,9 +9,15 @@ require("scripts/globals/npc_util");
 require("scripts/globals/quests");
 require("scripts/globals/shop");
 
+local quests =
+{
+    require("scripts/quests/sandoria/the_brugaire_consortium")
+}
+quests = dsp.quest.involvedQuests(quests)
+-----------------------------------
+
 function onTrade(player,npc,trade)
     local flyersForRegine = player:getQuestStatus(SANDORIA,dsp.quest.id.sandoria.FLYERS_FOR_REGINE);
-    local theBrugaireConsortium = player:getQuestStatus(SANDORIA,dsp.quest.id.sandoria.THE_BRUGAIRE_CONSORTIUM);
 
     -- FLYERS FOR REGINE
     if (flyersForRegine == QUEST_ACCEPTED and npcUtil.tradeHas( trade, {{"gil",10}} )) then
@@ -20,10 +26,8 @@ function onTrade(player,npc,trade)
         end
     elseif (flyersForRegine == QUEST_ACCEPTED and npcUtil.tradeHas(trade, 532)) then
         player:messageSpecial(ID.text.FLYER_REFUSED);
-
-    -- THE BRUGAIRE CONSORTIUM
-    elseif (theBrugaireConsortium == QUEST_ACCEPTED and npcUtil.tradeHas(trade, 593)) then
-        player:startEvent(535);
+    else
+        quests.onTrade(player, npc, trade)
     end
 end;
 
@@ -77,59 +81,56 @@ function onEventFinish(player,csid,option)
             player:setVar("tradeRosel",0);
             player:setVar("FFR",0);
         end
+    end
 
-    -- THE BRUGAIRE CONSORTIUM
-    elseif (csid == 535) then
-        player:confirmTrade();
-        player:setVar("TheBrugaireConsortium-Parcels", 11);
-        
-    -- WHITE MAGIC SHOP
-    elseif (csid == 510 and option == 0) then
-        local stockA =
-        {
-            4641,1165,1, -- Scroll of Diaga
-            4664,837,1,  -- Scroll of Slow
-            4662,7025,1, -- Scroll of Stoneskin
+    if not quests.onEventFinish(player, csid, option) then
+        -- WHITE MAGIC SHOP
+        if (csid == 510 and option == 0) then
+            local stockA =
+            {
+                4641,1165,1, -- Scroll of Diaga
+                4664,837,1,  -- Scroll of Slow
+                4662,7025,1, -- Scroll of Stoneskin
 
-            4636,140,2,  -- Scroll of Banish
-            4646,1165,2, -- Scroll of Banishga
-            4661,2097,2, -- Scroll of Blink
-            4610,585,2,  -- Scroll of Cure II
+                4636,140,2,  -- Scroll of Banish
+                4646,1165,2, -- Scroll of Banishga
+                4661,2097,2, -- Scroll of Blink
+                4610,585,2,  -- Scroll of Cure II
 
-            4663,360,3,  -- Scroll of Aquaveil
-            4624,990,3,  -- Scroll of Blindna
-            4615,1363,3, -- Scroll of Curaga
-            4609,61,3,   -- Scroll of Cure
-            4631,82,3,   -- Scroll of Dia
-            4623,324,3,  -- Scroll of Paralyna
-            4622,180,3,  -- Scroll of Poisona
-            4651,219,3,  -- Scroll of Protect
-            4656,1584,3  -- Scroll of Shell
-        }
-        dsp.shop.nation(player, stockA, dsp.nation.SANDORIA);
+                4663,360,3,  -- Scroll of Aquaveil
+                4624,990,3,  -- Scroll of Blindna
+                4615,1363,3, -- Scroll of Curaga
+                4609,61,3,   -- Scroll of Cure
+                4631,82,3,   -- Scroll of Dia
+                4623,324,3,  -- Scroll of Paralyna
+                4622,180,3,  -- Scroll of Poisona
+                4651,219,3,  -- Scroll of Protect
+                4656,1584,3  -- Scroll of Shell
+            }
+            dsp.shop.nation(player, stockA, dsp.nation.SANDORIA);
+        -- BLACK MAGIC SHOP
+        elseif (csid == 510 and option == 1) then
+            local stockB =
+            {
+                4862,111,1,  -- Scroll of Blind
+                4838,360,2,  -- Scroll of Bio
+                4828,82,2,   -- Scroll of Poison
+                4861,2250,2, -- Scroll of Sleep
 
-    -- BLACK MAGIC SHOP
-    elseif (csid == 510 and option == 1) then
-        local stockB =
-        {
-            4862,111,1,  -- Scroll of Blind
-            4838,360,2,  -- Scroll of Bio
-            4828,82,2,   -- Scroll of Poison
-            4861,2250,2, -- Scroll of Sleep
-
-            4762,324,3,  -- Scroll of Aero
-            4757,1584,3, -- Scroll of Blizzard
-            4843,4644,3, -- Scroll of Burn
-            4845,2250,3, -- Scroll of Choke
-            4848,6366,3, -- Scroll of Drown
-            4752,837,3,  -- Scroll of Fire
-            4844,3688,3, -- Scroll of Frost
-            4846,1827,3, -- Scroll of Rasp
-            4847,1363,3, -- Scroll of Shock
-            4767,61,3,   -- Scroll of Stone
-            4772,3261,3, -- Scroll of Thunder
-            4777,140,3   -- Scroll of Water
-        }
-        dsp.shop.nation(player, stockB, dsp.nation.SANDORIA);
+                4762,324,3,  -- Scroll of Aero
+                4757,1584,3, -- Scroll of Blizzard
+                4843,4644,3, -- Scroll of Burn
+                4845,2250,3, -- Scroll of Choke
+                4848,6366,3, -- Scroll of Drown
+                4752,837,3,  -- Scroll of Fire
+                4844,3688,3, -- Scroll of Frost
+                4846,1827,3, -- Scroll of Rasp
+                4847,1363,3, -- Scroll of Shock
+                4767,61,3,   -- Scroll of Stone
+                4772,3261,3, -- Scroll of Thunder
+                4777,140,3   -- Scroll of Water
+            }
+            dsp.shop.nation(player, stockB, dsp.nation.SANDORIA);
+        end
     end
 end;

--- a/scripts/zones/Port_San_dOria/npcs/Regine.lua
+++ b/scripts/zones/Port_San_dOria/npcs/Regine.lua
@@ -9,11 +9,9 @@ require("scripts/globals/npc_util");
 require("scripts/globals/quests");
 require("scripts/globals/shop");
 
-local quests =
-{
+local quests = dsp.quest.involvedQuests({
     require("scripts/quests/sandoria/the_brugaire_consortium")
-}
-quests = dsp.quest.involvedQuests(quests)
+})
 -----------------------------------
 
 function onTrade(player,npc,trade)

--- a/scripts/zones/Port_San_dOria/npcs/Thierride.lua
+++ b/scripts/zones/Port_San_dOria/npcs/Thierride.lua
@@ -11,11 +11,9 @@ require("scripts/globals/quests");
 require("scripts/globals/titles");
 local ID = require("scripts/zones/Port_San_dOria/IDs");
 
-local quests =
-{
+local quests = dsp.quest.involvedQuests({
     require("scripts/quests/sandoria/the_brugaire_consortium")
-}
-quests = dsp.quest.involvedQuests(quests)
+})
 -----------------------------------
 
 function onTrade(player,npc,trade)

--- a/scripts/zones/Port_San_dOria/npcs/Thierride.lua
+++ b/scripts/zones/Port_San_dOria/npcs/Thierride.lua
@@ -1,6 +1,6 @@
 -----------------------------------
 -- Area: Port San d'Oria
---   NPC: Thierride
+-- NPC: Thierride
 -- Type: Quest Giver
 -- !pos -67 -5 -28 232
 --
@@ -10,6 +10,12 @@ require("scripts/globals/settings");
 require("scripts/globals/quests");
 require("scripts/globals/titles");
 local ID = require("scripts/zones/Port_San_dOria/IDs");
+
+local quests =
+{
+    require("scripts/quests/sandoria/the_brugaire_consortium")
+}
+quests = dsp.quest.involvedQuests(quests)
 -----------------------------------
 
 function onTrade(player,npc,trade)
@@ -21,14 +27,9 @@ function onTrade(player,npc,trade)
         else
             player:startEvent(526);
         end
-    elseif (player:getQuestStatus(SANDORIA,dsp.quest.id.sandoria.THE_BRUGAIRE_CONSORTIUM) == QUEST_ACCEPTED and trade:hasItemQty(595,1) == true and count == 1) then
-        player:tradeComplete();
-        player:startEvent(539);
-        player:setVar("TheBrugaireConsortium-Parcels", 31);
-    else
+    elseif not quests.onTrade(player, npc, trade) then
         player:startEvent(529);
     end
-
 end;
 
 function onTrigger(player,npc)
@@ -62,4 +63,5 @@ function onEventFinish(player,csid,option)
         player:addTitle(dsp.title.RABBITER);
     end;
 
+    quests.onEventFinish(player, csid, option)
 end;

--- a/scripts/zones/Western_Adoulin/npcs/Clemmar.lua
+++ b/scripts/zones/Western_Adoulin/npcs/Clemmar.lua
@@ -7,11 +7,9 @@
 require("scripts/globals/missions");
 require("scripts/globals/quests");
 
-local quests =
-{
+local quests = dsp.quest.involvedQuests({
     require("scripts/quests/adoulin/a_certain_substitute_patrolman")
-}
-quests = dsp.quest.involvedQuests(quests)
+})
 -----------------------------------
 
 function onTrade(player,npc,trade)

--- a/scripts/zones/Western_Adoulin/npcs/Clemmar.lua
+++ b/scripts/zones/Western_Adoulin/npcs/Clemmar.lua
@@ -9,7 +9,7 @@ require("scripts/globals/quests");
 
 local quests =
 {
-    {dsp.quest.log_id.ADOULIN, dsp.quest.id.adoulin.A_CERTAIN_SUBSTITUTE_PATROLMAN}
+    require("scripts/quests/adoulin/a_certain_substitute_patrolman")
 }
 quests = dsp.quest.involvedQuests(quests)
 -----------------------------------

--- a/scripts/zones/Western_Adoulin/npcs/Clemmar.lua
+++ b/scripts/zones/Western_Adoulin/npcs/Clemmar.lua
@@ -1,24 +1,24 @@
 -----------------------------------
 -- Area: Western Adoulin
---  NPC: Clemmar
+-- NPC: Clemmar
 -- Type: Standard NPC and Quest NPC
---  Involved with Quest: 'A Certain Substitute Patrolman'
 -- !pos -12 0 12 256
 -----------------------------------
 require("scripts/globals/missions");
 require("scripts/globals/quests");
 
-local quest_table =
+local involvedQuests =
 {
-    require("scripts/quests/adoulin/a_certain_substitute_patrolman")
+    {dsp.quest.log_id.ADOULIN, dsp.quest.id.adoulin.A_CERTAIN_SUBSTITUTE_PATROLMAN}
 }
+involvedQuests = quests.loadQuests(involvedQuests)
 -----------------------------------
 
 function onTrade(player,npc,trade)
 end;
 
 function onTrigger(player,npc)
-    if not dsp.quests.onTrigger(player, npc, quest_table) then
+    if not quests.onTrigger(player, npc, involvedQuests) then
         if player:getCurrentMission(SOA) >= LIFE_ON_THE_FRONTIER then
             -- Standard dialogue
             player:startEvent(570)
@@ -33,5 +33,5 @@ function onEventUpdate(player,csid,option)
 end;
 
 function onEventFinish(player,csid,option)
-    dsp.quests.onEventFinish(player, csid, option, quest_table)
+    quests.onEventFinish(player, csid, option, involvedQuests)
 end;

--- a/scripts/zones/Western_Adoulin/npcs/Clemmar.lua
+++ b/scripts/zones/Western_Adoulin/npcs/Clemmar.lua
@@ -7,18 +7,18 @@
 require("scripts/globals/missions");
 require("scripts/globals/quests");
 
-local involvedQuests =
+local quests =
 {
     {dsp.quest.log_id.ADOULIN, dsp.quest.id.adoulin.A_CERTAIN_SUBSTITUTE_PATROLMAN}
 }
-involvedQuests = quests.loadQuests(involvedQuests)
+quests = dsp.quest.involvedQuests(quests)
 -----------------------------------
 
 function onTrade(player,npc,trade)
-end;
+end
 
 function onTrigger(player,npc)
-    if not quests.onTrigger(player, npc, involvedQuests) then
+    if not quests.onTrigger(player, npc) then
         if player:getCurrentMission(SOA) >= LIFE_ON_THE_FRONTIER then
             -- Standard dialogue
             player:startEvent(570)
@@ -27,11 +27,11 @@ function onTrigger(player,npc)
             player:startEvent(519)
         end
     end
-end;
+end
 
 function onEventUpdate(player,csid,option)
-end;
+end
 
 function onEventFinish(player,csid,option)
-    quests.onEventFinish(player, csid, option, involvedQuests)
-end;
+    quests.onEventFinish(player, csid, option)
+end

--- a/scripts/zones/Western_Adoulin/npcs/Dangueubert.lua
+++ b/scripts/zones/Western_Adoulin/npcs/Dangueubert.lua
@@ -7,11 +7,9 @@
 require("scripts/globals/missions")
 require("scripts/globals/quests")
 
-local quests =
-{
+local quests = dsp.quest.involvedQuests({
     require("scripts/quests/adoulin/a_certain_substitute_patrolman")
-}
-quests = dsp.quest.involvedQuests(quests)
+})
 -----------------------------------
 
 function onTrade(player,npc,trade)

--- a/scripts/zones/Western_Adoulin/npcs/Dangueubert.lua
+++ b/scripts/zones/Western_Adoulin/npcs/Dangueubert.lua
@@ -9,7 +9,7 @@ require("scripts/globals/quests")
 
 local quests =
 {
-    {dsp.quest.log_id.ADOULIN, dsp.quest.id.adoulin.A_CERTAIN_SUBSTITUTE_PATROLMAN}
+    require("scripts/quests/adoulin/a_certain_substitute_patrolman")
 }
 quests = dsp.quest.involvedQuests(quests)
 -----------------------------------

--- a/scripts/zones/Western_Adoulin/npcs/Dangueubert.lua
+++ b/scripts/zones/Western_Adoulin/npcs/Dangueubert.lua
@@ -7,18 +7,18 @@
 require("scripts/globals/missions")
 require("scripts/globals/quests")
 
-local involvedQuests =
+local quests =
 {
     {dsp.quest.log_id.ADOULIN, dsp.quest.id.adoulin.A_CERTAIN_SUBSTITUTE_PATROLMAN}
 }
-involvedQuests = quests.loadQuests(involvedQuests)
+quests = dsp.quest.involvedQuests(quests)
 -----------------------------------
 
 function onTrade(player,npc,trade)
-end;
+end
 
 function onTrigger(player,npc)
-    if not quests.onTrigger(player, npc, involvedQuests) then
+    if not quests.onTrigger(player, npc) then
         if player:getCurrentMission(SOA) >= LIFE_ON_THE_FRONTIER then
             -- Standard dialogue
             player:startEvent(546, 0, 1)
@@ -27,13 +27,13 @@ function onTrigger(player,npc)
             player:startEvent(546)
         end
     end
-end;
+end
 
 function onEventUpdate(player,csid,option)
-end;
+end
 
 function onEventFinish(player,csid,option)
-    if not quests.onEventFinish(player, csid, option, involvedQuests) then
+    if not quests.onEventFinish(player, csid, option) then
         if (csid == 546) then
             if (option == 1) then
                 -- Warps player to Mog Garden
@@ -41,4 +41,4 @@ function onEventFinish(player,csid,option)
             end
         end
     end
-end;
+end

--- a/scripts/zones/Western_Adoulin/npcs/Dangueubert.lua
+++ b/scripts/zones/Western_Adoulin/npcs/Dangueubert.lua
@@ -1,24 +1,24 @@
 -----------------------------------
 -- Area: Western Adoulin
---  NPC: Dangueubert
+-- NPC: Dangueubert
 -- Type: Standard NPC and Quest NPC
--- Involved with Quest: 'A Certain Substitute Patrolman'
 -- !pos 5 0 -136 256
 -----------------------------------
-require("scripts/globals/missions");
-require("scripts/globals/quests");
+require("scripts/globals/missions")
+require("scripts/globals/quests")
 
-local quest_table =
+local involvedQuests =
 {
-    require("scripts/quests/adoulin/a_certain_substitute_patrolman")
+    {dsp.quest.log_id.ADOULIN, dsp.quest.id.adoulin.A_CERTAIN_SUBSTITUTE_PATROLMAN}
 }
+involvedQuests = quests.loadQuests(involvedQuests)
 -----------------------------------
 
 function onTrade(player,npc,trade)
 end;
 
 function onTrigger(player,npc)
-    if not dsp.quests.onTrigger(player, npc, quest_table) then
+    if not quests.onTrigger(player, npc, involvedQuests) then
         if player:getCurrentMission(SOA) >= LIFE_ON_THE_FRONTIER then
             -- Standard dialogue
             player:startEvent(546, 0, 1)
@@ -33,11 +33,11 @@ function onEventUpdate(player,csid,option)
 end;
 
 function onEventFinish(player,csid,option)
-    if not dsp.quests.onEventFinish(player, csid, option, quest_table) then
+    if not quests.onEventFinish(player, csid, option, involvedQuests) then
         if (csid == 546) then
             if (option == 1) then
                 -- Warps player to Mog Garden
-                player:setPos(0, 0, 0, 0, 280);
+                player:setPos(0, 0, 0, 0, 280)
             end
         end
     end

--- a/scripts/zones/Western_Adoulin/npcs/Jorin.lua
+++ b/scripts/zones/Western_Adoulin/npcs/Jorin.lua
@@ -8,7 +8,7 @@ require("scripts/globals/quests")
 
 local quests =
 {
-    {dsp.quest.log_id.ADOULIN, dsp.quest.id.adoulin.THE_OLD_MAN_AND_THE_HARPOON}
+    require("scripts/quests/adoulin/the_old_man_and_the_harpoon")
 }
 quests = dsp.quest.involvedQuests(quests)
 -----------------------------------

--- a/scripts/zones/Western_Adoulin/npcs/Jorin.lua
+++ b/scripts/zones/Western_Adoulin/npcs/Jorin.lua
@@ -6,25 +6,25 @@
 -----------------------------------
 require("scripts/globals/quests")
 
-local involvedQuests =
+local quests =
 {
     {dsp.quest.log_id.ADOULIN, dsp.quest.id.adoulin.THE_OLD_MAN_AND_THE_HARPOON}
 }
-involvedQuests = quests.loadQuests(involvedQuests)
+quests = dsp.quest.involvedQuests(quests)
 -----------------------------------
 
 function onTrade(player,npc,trade)
-end;
+end
 
 function onTrigger(player,npc)
-    if not quests.onTrigger(player, npc, involvedQuests) then
+    if not quests.onTrigger(player, npc) then
         player:startEvent(560) -- Standard dialogue
     end
 end
 
 function onEventUpdate(player,csid,option)
-end;
+end
 
 function onEventFinish(player,csid,option)
-    quests.onEventFinish(player, csid, option, involvedQuests)
+    quests.onEventFinish(player, csid, option)
 end

--- a/scripts/zones/Western_Adoulin/npcs/Jorin.lua
+++ b/scripts/zones/Western_Adoulin/npcs/Jorin.lua
@@ -1,23 +1,23 @@
 -----------------------------------
 -- Area: Western Adoulin
---  NPC: Jorin
+-- NPC: Jorin
 -- Type: Standard NPC and Quest Giver
--- Starts, Involved with, and Finishes Quest: 'The Old Man and the Harpoon'
 -- !pos 92 32 152 256
 -----------------------------------
 require("scripts/globals/quests")
 
-local quest_table =
+local involvedQuests =
 {
-    require("scripts/quests/adoulin/the_old_man_and_the_harpoon"),
+    {dsp.quest.log_id.ADOULIN, dsp.quest.id.adoulin.THE_OLD_MAN_AND_THE_HARPOON}
 }
+involvedQuests = quests.loadQuests(involvedQuests)
 -----------------------------------
 
 function onTrade(player,npc,trade)
 end;
 
 function onTrigger(player,npc)
-    if not dsp.quests.onTrigger(player, npc, quest_table) then
+    if not quests.onTrigger(player, npc, involvedQuests) then
         player:startEvent(560) -- Standard dialogue
     end
 end
@@ -26,5 +26,5 @@ function onEventUpdate(player,csid,option)
 end;
 
 function onEventFinish(player,csid,option)
-    dsp.quests.onEventFinish(player, csid, option, quest_table)
+    quests.onEventFinish(player, csid, option, involvedQuests)
 end

--- a/scripts/zones/Western_Adoulin/npcs/Jorin.lua
+++ b/scripts/zones/Western_Adoulin/npcs/Jorin.lua
@@ -6,11 +6,9 @@
 -----------------------------------
 require("scripts/globals/quests")
 
-local quests =
-{
+local quests = dsp.quest.involvedQuests({
     require("scripts/quests/adoulin/the_old_man_and_the_harpoon")
-}
-quests = dsp.quest.involvedQuests(quests)
+})
 -----------------------------------
 
 function onTrade(player,npc,trade)

--- a/scripts/zones/Western_Adoulin/npcs/Kongramm.lua
+++ b/scripts/zones/Western_Adoulin/npcs/Kongramm.lua
@@ -11,7 +11,7 @@ require("scripts/globals/quests")
 
 local quests =
 {
-    {dsp.quest.log_id.ADOULIN, dsp.quest.id.adoulin.A_CERTAIN_SUBSTITUTE_PATROLMAN}
+    require("scripts/quests/adoulin/a_certain_substitute_patrolman")
 }
 quests = dsp.quest.involvedQuests(quests)
 -----------------------------------

--- a/scripts/zones/Western_Adoulin/npcs/Kongramm.lua
+++ b/scripts/zones/Western_Adoulin/npcs/Kongramm.lua
@@ -1,19 +1,19 @@
 -----------------------------------
 -- Area: Western Adoulin
---  NPC: Kongramm
+-- NPC: Kongramm
 -- Type: Standard NPC, Mission NPC, and Quest NPC
---  Involved with Mission: 'A Curse From The Past'
---  Involved with Quests: 'A Certain Substitute Patrolman' and 'Transporting'
+-- Involved with Mission: 'A Curse From The Past'
+-- Involved with Quests: 'Transporting'
 -- !pos 61 32 138 256
 -----------------------------------
-require("scripts/globals/missions");
-require("scripts/globals/quests");
-require("scripts/globals/keyitems");
+require("scripts/globals/missions")
+require("scripts/globals/quests")
 
-local quest_table =
+local involvedQuests =
 {
-    require("scripts/quests/adoulin/a_certain_substitute_patrolman")
+    {dsp.quest.log_id.ADOULIN, dsp.quest.id.adoulin.A_CERTAIN_SUBSTITUTE_PATROLMAN}
 }
+involvedQuests = quests.loadQuests(involvedQuests)
 -----------------------------------
 
 function onTrade(player,npc,trade)
@@ -32,7 +32,7 @@ function onTrigger(player,npc)
             player:startEvent(149);
         end
     else
-        if not dsp.quests.onTrigger(player, npc, quest_table) then
+        if not quests.onTrigger(player, npc, involvedQuests) then
             if ((Transporting == QUEST_ACCEPTED) and (player:getVar("Transporting_Status") < 1)) then
                 -- Progresses Quest: 'Transporting'
                 player:startEvent(2592);
@@ -48,7 +48,7 @@ function onEventUpdate(player,csid,option)
 end;
 
 function onEventFinish(player,csid,option)
-    if not dsp.quests.onEventFinish(player, csid, option, quest_table) then
+    if not quests.onEventFinish(player, csid, option, involvedQuests) then
         if (csid == 148) then
             -- Gave hint for SOA Mission: 'A Curse From the Past'
             player:setVar("SOA_ACFTP_Kongramm", 1);

--- a/scripts/zones/Western_Adoulin/npcs/Kongramm.lua
+++ b/scripts/zones/Western_Adoulin/npcs/Kongramm.lua
@@ -9,11 +9,9 @@
 require("scripts/globals/missions")
 require("scripts/globals/quests")
 
-local quests =
-{
+local quests = dsp.quest.involvedQuests({
     require("scripts/quests/adoulin/a_certain_substitute_patrolman")
-}
-quests = dsp.quest.involvedQuests(quests)
+})
 -----------------------------------
 
 function onTrade(player,npc,trade)

--- a/scripts/zones/Western_Adoulin/npcs/Kongramm.lua
+++ b/scripts/zones/Western_Adoulin/npcs/Kongramm.lua
@@ -9,52 +9,52 @@
 require("scripts/globals/missions")
 require("scripts/globals/quests")
 
-local involvedQuests =
+local quests =
 {
     {dsp.quest.log_id.ADOULIN, dsp.quest.id.adoulin.A_CERTAIN_SUBSTITUTE_PATROLMAN}
 }
-involvedQuests = quests.loadQuests(involvedQuests)
+quests = dsp.quest.involvedQuests(quests)
 -----------------------------------
 
 function onTrade(player,npc,trade)
-end;
+end
 
 function onTrigger(player,npc)
-    local SOA_Mission = player:getCurrentMission(SOA);
-    local Transporting = player:getQuestStatus(ADOULIN, dsp.quest.id.adoulin.TRANSPORTING);
+    local SOA_Mission = player:getCurrentMission(SOA)
+    local Transporting = player:getQuestStatus(ADOULIN, dsp.quest.id.adoulin.TRANSPORTING)
 
     if ((SOA_Mission == A_CURSE_FROM_THE_PAST) and (not player:hasKeyItem(dsp.ki.PIECE_OF_A_STONE_WALL))) then
         if (player:getVar("SOA_ACFTP_Kongramm") < 1) then
             -- Gives hint for SOA Mission: 'A Curse From the Past'
-            player:startEvent(148);
+            player:startEvent(148)
         else
             -- Reminds player of hint for SOA Mission: 'A Curse From the Past'
-            player:startEvent(149);
+            player:startEvent(149)
         end
     else
-        if not quests.onTrigger(player, npc, involvedQuests) then
+        if not quests.onTrigger(player, npc) then
             if ((Transporting == QUEST_ACCEPTED) and (player:getVar("Transporting_Status") < 1)) then
                 -- Progresses Quest: 'Transporting'
-                player:startEvent(2592);
+                player:startEvent(2592)
             else
                 -- Standard dialogue
-                player:startEvent(558);
+                player:startEvent(558)
             end
         end
     end
-end;
+end
 
 function onEventUpdate(player,csid,option)
-end;
+end
 
 function onEventFinish(player,csid,option)
-    if not quests.onEventFinish(player, csid, option, involvedQuests) then
+    if not quests.onEventFinish(player, csid, option) then
         if (csid == 148) then
             -- Gave hint for SOA Mission: 'A Curse From the Past'
-            player:setVar("SOA_ACFTP_Kongramm", 1);
+            player:setVar("SOA_ACFTP_Kongramm", 1)
         elseif (csid == 2592) then
             -- Progresses Quest: 'Transporting'
-            player:setVar("Transporting_Status", 1);
+            player:setVar("Transporting_Status", 1)
         end
     end
-end;
+end

--- a/scripts/zones/Western_Adoulin/npcs/Nylene.lua
+++ b/scripts/zones/Western_Adoulin/npcs/Nylene.lua
@@ -7,11 +7,9 @@
 require("scripts/globals/missions")
 require("scripts/globals/quests")
 
-local quests =
-{
+local quests = dsp.quest.involvedQuests({
     require("scripts/quests/adoulin/a_certain_substitute_patrolman")
-}
-quests = dsp.quest.involvedQuests(quests)
+})
 -----------------------------------
 
 function onTrade(player,npc,trade)

--- a/scripts/zones/Western_Adoulin/npcs/Nylene.lua
+++ b/scripts/zones/Western_Adoulin/npcs/Nylene.lua
@@ -1,24 +1,24 @@
 -----------------------------------
 -- Area: Western Adoulin
---  NPC: Nylene
+-- NPC: Nylene
 -- Type: Standard NPC and Quest NPC
---  Involved with Quest: 'A Certain Substitute Patrolman'
 -- !pos 12 0 -82 256
 -----------------------------------
-require("scripts/globals/missions");
-require("scripts/globals/quests");
+require("scripts/globals/missions")
+require("scripts/globals/quests")
 
-local quest_table =
+local involvedQuests =
 {
-    require("scripts/quests/adoulin/a_certain_substitute_patrolman")
+    {dsp.quest.log_id.ADOULIN, dsp.quest.id.adoulin.A_CERTAIN_SUBSTITUTE_PATROLMAN}
 }
+involvedQuests = quests.loadQuests(involvedQuests)
 -----------------------------------
 
 function onTrade(player,npc,trade)
 end;
 
 function onTrigger(player,npc)
-    if not dsp.quests.onTrigger(player, npc, quest_table) then
+    if not quests.onTrigger(player, npc, involvedQuests) then
         if player:getCurrentMission(SOA) >= LIFE_ON_THE_FRONTIER then
             -- Standard dialogue
             player:startEvent(562)
@@ -33,5 +33,5 @@ function onEventUpdate(player,csid,option)
 end;
 
 function onEventFinish(player,csid,option)
-    dsp.quests.onEventFinish(player, csid, option, quest_table)
+    quests.onEventFinish(player, csid, option, involvedQuests)
 end;

--- a/scripts/zones/Western_Adoulin/npcs/Nylene.lua
+++ b/scripts/zones/Western_Adoulin/npcs/Nylene.lua
@@ -9,7 +9,7 @@ require("scripts/globals/quests")
 
 local quests =
 {
-    {dsp.quest.log_id.ADOULIN, dsp.quest.id.adoulin.A_CERTAIN_SUBSTITUTE_PATROLMAN}
+    require("scripts/quests/adoulin/a_certain_substitute_patrolman")
 }
 quests = dsp.quest.involvedQuests(quests)
 -----------------------------------

--- a/scripts/zones/Western_Adoulin/npcs/Nylene.lua
+++ b/scripts/zones/Western_Adoulin/npcs/Nylene.lua
@@ -7,18 +7,18 @@
 require("scripts/globals/missions")
 require("scripts/globals/quests")
 
-local involvedQuests =
+local quests =
 {
     {dsp.quest.log_id.ADOULIN, dsp.quest.id.adoulin.A_CERTAIN_SUBSTITUTE_PATROLMAN}
 }
-involvedQuests = quests.loadQuests(involvedQuests)
+quests = dsp.quest.involvedQuests(quests)
 -----------------------------------
 
 function onTrade(player,npc,trade)
-end;
+end
 
 function onTrigger(player,npc)
-    if not quests.onTrigger(player, npc, involvedQuests) then
+    if not quests.onTrigger(player, npc) then
         if player:getCurrentMission(SOA) >= LIFE_ON_THE_FRONTIER then
             -- Standard dialogue
             player:startEvent(562)
@@ -27,11 +27,11 @@ function onTrigger(player,npc)
             player:startEvent(533)
         end
     end
-end;
+end
 
 function onEventUpdate(player,csid,option)
-end;
+end
 
 function onEventFinish(player,csid,option)
-    quests.onEventFinish(player, csid, option, involvedQuests)
-end;
+    quests.onEventFinish(player, csid, option)
+end

--- a/scripts/zones/Western_Adoulin/npcs/Rising_Solstice.lua
+++ b/scripts/zones/Western_Adoulin/npcs/Rising_Solstice.lua
@@ -7,38 +7,38 @@
 require("scripts/globals/missions")
 require("scripts/globals/quests")
 
-local involvedQuests =
+local quests =
 {
     {dsp.quest.log_id.ADOULIN, dsp.quest.id.adoulin.A_CERTAIN_SUBSTITUTE_PATROLMAN}
 }
-involvedQuests = quests.loadQuests(involvedQuests)
+quests = dsp.quest.involvedQuests(quests)
 -----------------------------------
 
 function onTrade(player,npc,trade)
-end;
+end
 
 function onTrigger(player,npc)
-    local SOA_Mission = player:getCurrentMission(SOA);
+    local SOA_Mission = player:getCurrentMission(SOA)
 
     if SOA_Mission >= LIFE_ON_THE_FRONTIER then
         if (SOA_Mission >= BEAUTY_AND_THE_BEAST) and (SOA_Mission <= SALVATION) then
             -- Speech while Arciela is 'kidnapped'
-            player:startEvent(150);
+            player:startEvent(150)
         else
-            if not quests.onTrigger(player, npc, involvedQuests) then
+            if not quests.onTrigger(player, npc) then
                 -- Standard dialogue, after joining colonization effort
-                player:startEvent(580);
+                player:startEvent(580)
             end
         end
     else
         -- Dialogue prior to joining colonization effort
-        player:startEvent(502);
+        player:startEvent(502)
     end
 end;
 
 function onEventUpdate(player,csid,option)
-end;
+end
 
 function onEventFinish(player,csid,option)
-    quests.onEventFinish(player, csid, option, involvedQuests)
-end;
+    quests.onEventFinish(player, csid, option)
+end

--- a/scripts/zones/Western_Adoulin/npcs/Rising_Solstice.lua
+++ b/scripts/zones/Western_Adoulin/npcs/Rising_Solstice.lua
@@ -7,11 +7,9 @@
 require("scripts/globals/missions")
 require("scripts/globals/quests")
 
-local quests =
-{
+local quests = dsp.quest.involvedQuests({
     require("scripts/quests/adoulin/a_certain_substitute_patrolman")
-}
-quests = dsp.quest.involvedQuests(quests)
+})
 -----------------------------------
 
 function onTrade(player,npc,trade)

--- a/scripts/zones/Western_Adoulin/npcs/Rising_Solstice.lua
+++ b/scripts/zones/Western_Adoulin/npcs/Rising_Solstice.lua
@@ -9,7 +9,7 @@ require("scripts/globals/quests")
 
 local quests =
 {
-    {dsp.quest.log_id.ADOULIN, dsp.quest.id.adoulin.A_CERTAIN_SUBSTITUTE_PATROLMAN}
+    require("scripts/quests/adoulin/a_certain_substitute_patrolman")
 }
 quests = dsp.quest.involvedQuests(quests)
 -----------------------------------

--- a/scripts/zones/Western_Adoulin/npcs/Rising_Solstice.lua
+++ b/scripts/zones/Western_Adoulin/npcs/Rising_Solstice.lua
@@ -1,18 +1,17 @@
 -----------------------------------
 -- Area: Western Adoulin
---  NPC: Rising Solstice
+-- NPC: Rising Solstice
 -- Type: Standard NPC and Quest Giver
--- Starts, Involved With, and Finishes Quest: 'A Certain Substitute Patrolman'
 -- !pos -154 4 -29 256
 -----------------------------------
-require("scripts/globals/missions");
-require("scripts/globals/quests");
-require("scripts/globals/keyitems");
+require("scripts/globals/missions")
+require("scripts/globals/quests")
 
-local quest_table =
+local involvedQuests =
 {
-    require("scripts/quests/adoulin/a_certain_substitute_patrolman")
+    {dsp.quest.log_id.ADOULIN, dsp.quest.id.adoulin.A_CERTAIN_SUBSTITUTE_PATROLMAN}
 }
+involvedQuests = quests.loadQuests(involvedQuests)
 -----------------------------------
 
 function onTrade(player,npc,trade)
@@ -26,7 +25,7 @@ function onTrigger(player,npc)
             -- Speech while Arciela is 'kidnapped'
             player:startEvent(150);
         else
-            if not dsp.quests.onTrigger(player, npc, quest_table) then
+            if not quests.onTrigger(player, npc, involvedQuests) then
                 -- Standard dialogue, after joining colonization effort
                 player:startEvent(580);
             end
@@ -41,5 +40,5 @@ function onEventUpdate(player,csid,option)
 end;
 
 function onEventFinish(player,csid,option)
-    dsp.quests.onEventFinish(player, csid, option, quest_table)
+    quests.onEventFinish(player, csid, option, involvedQuests)
 end;

--- a/scripts/zones/Western_Adoulin/npcs/Shipilolo.lua
+++ b/scripts/zones/Western_Adoulin/npcs/Shipilolo.lua
@@ -1,31 +1,27 @@
 -----------------------------------
 -- Area: Western Adoulin
---  NPC: Shipilolo
+-- NPC: Shipilolo
 -- Type: Standard NPC and Quest NPC
---  Involved with Quests: 'A Certain Substitute Patrolman'
---                        'Fertile Ground'
---                        'The Old Man and the Harpoon'
---                        'Wayward Waypoints'
 -- !pos 84 0 -60 256
 -----------------------------------
 require("scripts/globals/missions")
 require("scripts/globals/quests")
-require("scripts/globals/keyitems")
 
-local quest_table =
+local involvedQuests =
 {
-    require("scripts/quests/adoulin/a_certain_substitute_patrolman"),
-    require("scripts/quests/adoulin/the_old_man_and_the_harpoon"),
-    require("scripts/quests/adoulin/fertile_ground"),
-    require("scripts/quests/adoulin/wayward_waypoints")
+    {dsp.quest.log_id.ADOULIN, dsp.quest.id.adoulin.A_CERTAIN_SUBSTITUTE_PATROLMAN},
+    {dsp.quest.log_id.ADOULIN, dsp.quest.id.adoulin.THE_OLD_MAN_AND_THE_HARPOON},
+    {dsp.quest.log_id.ADOULIN, dsp.quest.id.adoulin.FERTILE_GROUND},
+    {dsp.quest.log_id.ADOULIN, dsp.quest.id.adoulin.WAYWARD_WAYPOINTS}
 }
+involvedQuests = quests.loadQuests(involvedQuests)
 -----------------------------------
 
 function onTrade(player,npc,trade)
 end;
 
 function onTrigger(player,npc)
-    if not dsp.quests.onTrigger(player, npc, quest_table) then
+    if not quests.onTrigger(player, npc, involvedQuests) then
         if player:getCurrentMission(SOA) >= LIFE_ON_THE_FRONTIER then
             -- Standard dialogue
             player:startEvent(535);
@@ -40,5 +36,5 @@ function onEventUpdate(player,csid,option)
 end;
 
 function onEventFinish(player,csid,option)
-    dsp.quests.onEventFinish(player, csid, option, quest_table)
+    quests.onEventFinish(player, csid, option, involvedQuests)
 end

--- a/scripts/zones/Western_Adoulin/npcs/Shipilolo.lua
+++ b/scripts/zones/Western_Adoulin/npcs/Shipilolo.lua
@@ -7,34 +7,34 @@
 require("scripts/globals/missions")
 require("scripts/globals/quests")
 
-local involvedQuests =
+local quests =
 {
     {dsp.quest.log_id.ADOULIN, dsp.quest.id.adoulin.A_CERTAIN_SUBSTITUTE_PATROLMAN},
     {dsp.quest.log_id.ADOULIN, dsp.quest.id.adoulin.THE_OLD_MAN_AND_THE_HARPOON},
     {dsp.quest.log_id.ADOULIN, dsp.quest.id.adoulin.FERTILE_GROUND},
     {dsp.quest.log_id.ADOULIN, dsp.quest.id.adoulin.WAYWARD_WAYPOINTS}
 }
-involvedQuests = quests.loadQuests(involvedQuests)
+quests = dsp.quest.involvedQuests(quests)
 -----------------------------------
 
 function onTrade(player,npc,trade)
-end;
+end
 
 function onTrigger(player,npc)
-    if not quests.onTrigger(player, npc, involvedQuests) then
+    if not quests.onTrigger(player, npc) then
         if player:getCurrentMission(SOA) >= LIFE_ON_THE_FRONTIER then
             -- Standard dialogue
-            player:startEvent(535);
+            player:startEvent(535)
         else
             -- Dialogue prior to joining colonization effort
-            player:startEvent(526);
+            player:startEvent(526)
         end
     end
-end;
+end
 
 function onEventUpdate(player,csid,option)
-end;
+end
 
 function onEventFinish(player,csid,option)
-    quests.onEventFinish(player, csid, option, involvedQuests)
+    quests.onEventFinish(player, csid, option)
 end

--- a/scripts/zones/Western_Adoulin/npcs/Shipilolo.lua
+++ b/scripts/zones/Western_Adoulin/npcs/Shipilolo.lua
@@ -7,14 +7,12 @@
 require("scripts/globals/missions")
 require("scripts/globals/quests")
 
-local quests =
-{
+local quests = dsp.quest.involvedQuests({
     require("scripts/quests/adoulin/a_certain_substitute_patrolman"),
     require("scripts/quests/adoulin/the_old_man_and_the_harpoon"),
     require("scripts/quests/adoulin/fertile_ground"),
     require("scripts/quests/adoulin/wayward_waypoints")
-}
-quests = dsp.quest.involvedQuests(quests)
+})
 -----------------------------------
 
 function onTrade(player,npc,trade)

--- a/scripts/zones/Western_Adoulin/npcs/Shipilolo.lua
+++ b/scripts/zones/Western_Adoulin/npcs/Shipilolo.lua
@@ -9,10 +9,10 @@ require("scripts/globals/quests")
 
 local quests =
 {
-    {dsp.quest.log_id.ADOULIN, dsp.quest.id.adoulin.A_CERTAIN_SUBSTITUTE_PATROLMAN},
-    {dsp.quest.log_id.ADOULIN, dsp.quest.id.adoulin.THE_OLD_MAN_AND_THE_HARPOON},
-    {dsp.quest.log_id.ADOULIN, dsp.quest.id.adoulin.FERTILE_GROUND},
-    {dsp.quest.log_id.ADOULIN, dsp.quest.id.adoulin.WAYWARD_WAYPOINTS}
+    require("scripts/quests/adoulin/a_certain_substitute_patrolman"),
+    require("scripts/quests/adoulin/the_old_man_and_the_harpoon"),
+    require("scripts/quests/adoulin/fertile_ground"),
+    require("scripts/quests/adoulin/wayward_waypoints")
 }
 quests = dsp.quest.involvedQuests(quests)
 -----------------------------------

--- a/scripts/zones/Western_Adoulin/npcs/Virsaint.lua
+++ b/scripts/zones/Western_Adoulin/npcs/Virsaint.lua
@@ -6,11 +6,9 @@
 -----------------------------------
 require("scripts/globals/quests")
 
-local quests =
-{
+local quests = dsp.quest.involvedQuests({
     require("scripts/quests/adoulin/a_certain_substitute_patrolman")
-}
-quests = dsp.quest.involvedQuests(quests)
+})
 -----------------------------------
 
 function onTrade(player,npc,trade)

--- a/scripts/zones/Western_Adoulin/npcs/Virsaint.lua
+++ b/scripts/zones/Western_Adoulin/npcs/Virsaint.lua
@@ -1,23 +1,23 @@
 -----------------------------------
 -- Area: Western Adoulin
---  NPC: Virsaint
+-- NPC: Virsaint
 -- Type: Standard NPC and Quest NPC
---  Involved with Quests: 'A Certain Substitute Patrolman'
 -- !pos 32 0 -5 256
 -----------------------------------
-require("scripts/globals/quests");
+require("scripts/globals/quests")
 
-local quest_table =
+local involvedQuests =
 {
-    require("scripts/quests/adoulin/a_certain_substitute_patrolman")
+    {dsp.quest.log_id.ADOULIN, dsp.quest.id.adoulin.A_CERTAIN_SUBSTITUTE_PATROLMAN}
 }
+involvedQuests = quests.loadQuests(involvedQuests)
 -----------------------------------
 
 function onTrade(player,npc,trade)
 end;
 
 function onTrigger(player,npc)
-    if not dsp.quests.onTrigger(player, npc, quest_table) then
+    if not quests.onTrigger(player, npc, involvedQuests) then
         -- Standard dialogue
         player:startEvent(540)
     end
@@ -27,5 +27,5 @@ function onEventUpdate(player,csid,option)
 end;
 
 function onEventFinish(player,csid,option)
-    dsp.quests.onEventFinish(player, csid, option, quest_table)
+    quests.onEventFinish(player, csid, option, involvedQuests)
 end;

--- a/scripts/zones/Western_Adoulin/npcs/Virsaint.lua
+++ b/scripts/zones/Western_Adoulin/npcs/Virsaint.lua
@@ -8,7 +8,7 @@ require("scripts/globals/quests")
 
 local quests =
 {
-    {dsp.quest.log_id.ADOULIN, dsp.quest.id.adoulin.A_CERTAIN_SUBSTITUTE_PATROLMAN}
+    require("scripts/quests/adoulin/a_certain_substitute_patrolman")
 }
 quests = dsp.quest.involvedQuests(quests)
 -----------------------------------

--- a/scripts/zones/Western_Adoulin/npcs/Virsaint.lua
+++ b/scripts/zones/Western_Adoulin/npcs/Virsaint.lua
@@ -6,26 +6,26 @@
 -----------------------------------
 require("scripts/globals/quests")
 
-local involvedQuests =
+local quests =
 {
     {dsp.quest.log_id.ADOULIN, dsp.quest.id.adoulin.A_CERTAIN_SUBSTITUTE_PATROLMAN}
 }
-involvedQuests = quests.loadQuests(involvedQuests)
+quests = dsp.quest.involvedQuests(quests)
 -----------------------------------
 
 function onTrade(player,npc,trade)
-end;
+end
 
 function onTrigger(player,npc)
-    if not quests.onTrigger(player, npc, involvedQuests) then
+    if not quests.onTrigger(player, npc) then
         -- Standard dialogue
         player:startEvent(540)
     end
-end;
+end
 
 function onEventUpdate(player,csid,option)
-end;
+end
 
 function onEventFinish(player,csid,option)
-    quests.onEventFinish(player, csid, option, involvedQuests)
-end;
+    quests.onEventFinish(player, csid, option)
+end

--- a/scripts/zones/Western_Adoulin/npcs/Zaoso.lua
+++ b/scripts/zones/Western_Adoulin/npcs/Zaoso.lua
@@ -7,18 +7,18 @@
 require("scripts/globals/missions")
 require("scripts/globals/quests")
 
-local involvedQuests =
+local quests =
 {
     {dsp.quest.log_id.ADOULIN, dsp.quest.id.adoulin.A_CERTAIN_SUBSTITUTE_PATROLMAN}
 }
-involvedQuests = quests.loadQuests(involvedQuests)
+quests = dsp.quest.involvedQuests(quests)
 -----------------------------------
 
 function onTrade(player,npc,trade)
-end;
+end
 
 function onTrigger(player,npc)
-    if not quests.onTrigger(player, npc, involvedQuests) then
+    if not quests.onTrigger(player, npc) then
         if player:getCurrentMission(SOA) >= LIFE_ON_THE_FRONTIER then
             -- Standard dialogue
             player:startEvent(574)
@@ -27,11 +27,11 @@ function onTrigger(player,npc)
             player:startEvent(506)
         end
     end
-end;
+end
 
 function onEventUpdate(player,csid,option)
-end;
+end
 
 function onEventFinish(player,csid,option)
-    quests.onEventFinish(player, csid, option, involvedQuests)
-end;
+    quests.onEventFinish(player, csid, option)
+end

--- a/scripts/zones/Western_Adoulin/npcs/Zaoso.lua
+++ b/scripts/zones/Western_Adoulin/npcs/Zaoso.lua
@@ -7,11 +7,9 @@
 require("scripts/globals/missions")
 require("scripts/globals/quests")
 
-local quests =
-{
+local quests = dsp.quest.involvedQuests({
     require("scripts/quests/adoulin/a_certain_substitute_patrolman")
-}
-quests = dsp.quest.involvedQuests(quests)
+})
 -----------------------------------
 
 function onTrade(player,npc,trade)

--- a/scripts/zones/Western_Adoulin/npcs/Zaoso.lua
+++ b/scripts/zones/Western_Adoulin/npcs/Zaoso.lua
@@ -9,7 +9,7 @@ require("scripts/globals/quests")
 
 local quests =
 {
-    {dsp.quest.log_id.ADOULIN, dsp.quest.id.adoulin.A_CERTAIN_SUBSTITUTE_PATROLMAN}
+    require("scripts/quests/adoulin/a_certain_substitute_patrolman")
 }
 quests = dsp.quest.involvedQuests(quests)
 -----------------------------------

--- a/scripts/zones/Western_Adoulin/npcs/Zaoso.lua
+++ b/scripts/zones/Western_Adoulin/npcs/Zaoso.lua
@@ -1,24 +1,24 @@
 -----------------------------------
 -- Area: Western Adoulin
---  NPC: Zaoso
+-- NPC: Zaoso
 -- Type: Standard NPC and Quest NPC
---  Involved with Quest: 'A Certain Substitute Patrolman'
 -- !pos -94 3 -11 256
 -----------------------------------
-require("scripts/globals/missions");
-require("scripts/globals/quests");
+require("scripts/globals/missions")
+require("scripts/globals/quests")
 
-local quest_table =
+local involvedQuests =
 {
-    require("scripts/quests/adoulin/a_certain_substitute_patrolman")
+    {dsp.quest.log_id.ADOULIN, dsp.quest.id.adoulin.A_CERTAIN_SUBSTITUTE_PATROLMAN}
 }
+involvedQuests = quests.loadQuests(involvedQuests)
 -----------------------------------
 
 function onTrade(player,npc,trade)
 end;
 
 function onTrigger(player,npc)
-    if not dsp.quests.onTrigger(player, npc, quest_table) then
+    if not quests.onTrigger(player, npc, involvedQuests) then
         if player:getCurrentMission(SOA) >= LIFE_ON_THE_FRONTIER then
             -- Standard dialogue
             player:startEvent(574)
@@ -33,5 +33,5 @@ function onEventUpdate(player,csid,option)
 end;
 
 function onEventFinish(player,csid,option)
-    dsp.quests.onEventFinish(player, csid, option, quest_table)
+    quests.onEventFinish(player, csid, option, involvedQuests)
 end;


### PR DESCRIPTION
**I _intend_ for this to be my last PR to this branch, in hopes that my next PR will be merging quest_rewrite into master.** (After which this branch can be closed.) If you think there's a course correction to be made, or the brakes need to be tapped, now is the time to say so! (Now is also the time to give thumbs up in approval too!)

At the moment, this new system is serviceable enough to start actively using and benefiting from. I foresee no major changes to the _underlying system_, and any deficiencies or new features can be added later as needed (ex: BCNM-related functions and hooks).

**"Why master after this PR? Quests aren't actually rewritten yet!"**
Trying to rewrite all our quests - and keep quests rewritten - while people are actively adding to and modifying master would just be a conflict nightmare, slow down progress, and make would-be contributors wary/unsure about adding new stuff (in the current style) due to the "threat" of some imposing new system that'll arrive in an unspecified future. The sooner the new system is in place and can be used from master, the quicker people can start using it when implementing new quest stuff! (Also the sooner I can begin making those long references I introduced in #5758 start vanishing so people don't complain about them.)

To assuage fears: **this new system does not break any quests currently in master. It has been explicitly designed such that quests can be rewritten in a new style, and exist alongside quests still in the older style.** (And it also shouldn't break any custom content, since you have to proactively set out to use these new functions for them to be applicable.) I'm not like, deleting `player:completeQuest()` or anything.

**"Give me the tl;dr on changes to quest_rewrite in this PR."**
One thing led to another and I ended up going full object on quests. Quests have methods now. I included a bunch of wrappers for quest-related functions so people don't have to worry about what function is in what "namespace". Other changes resulted in reducing the number of typed characters required to do stuff. It's real neato.

**"You [said something before about player var SQL changes](https://github.com/DarkstarProject/darkstar/pull/5824)?"**
The DB doesn't understand or care about what we tag values as. It doesn't care if a SQL player var is called "WaywardWaypoints", "WW_progress" or "waypoints_calibrated". But once _one_ person decides to refer to something by a certain player var name, we're stuck with it, as we can't go willy-nilly modifying player var names without potentially screwing with player progress on live servers.

So with the new system, player vars for quests are intended to be _unique_ and mostly _anonymous_. In that the scripter can use _whatever_ name they want for referencing a variable _in the script_, but the new quest var wrappers will handle storing/fetching the value _in the DB_. Stored player vars are guaranteed to be unique to the quest (via the quest's prefix, example: "[Q][2][26]"), and capable of being "renamed" later (a key such as "[1]" to be added after the quest prefix). This results in DB player vars of "[Q][2][26][1]", "[Q][2][26][2]", etc.

This is done through the `db_name` field for a quest var, defined at the top of the quest file. So long as these db_names follow a mandated style for their creation (`thisQuest.varPrefix .. "[1]"`), we can freely rename our references to that variable inside a script later, as no matter what we call it _in code_, it'll still resolve to the _same DB var_.

This also gives us the added benefits of letting us be as verbose as we want in what references we use for variables (as player var names in the DB _are_ character limited, while they are not in scripts), but more importantly, _eliminates any concern over collisions_. One quest can refer to a variable about waypoints as, well, "waypoints", and another quest also dealing with waypoints can _also_ call a variable "waypoints" inside its script. The scripter doesn't need to fret over prepending an acronym for the quest, as the new quest system abstracts all that away for you.

**"But our current player vars _don't_ function that way. Do you have a migration plan?"**
By using the quest var's db_name field, of course!

It'd suck to have to run SQL queries to migrate player vars every single PR that rewrites a quest. So while quests are slowly being rewritten and converted to the new system, simply have the db_name for the appropriate var be what is _currently_ the SQL var name (`"WW_waypoints_calibrated"`). Then, once all existing quests are rewritten, compile a list of mappings of old player var -> new player var, put them in a migration script, and _then_ push the single commit that changes all the db_names in quest files to reflect more anonymous names (`"[Q][9][25][1]"`).

Server operators only need to run the migration once, and then not have to worry about people wanting to change (quest-related) SQL player var names again, as they're now mapped to generic vars that can be "renamed" (inside the script) later.

**"Hold up, I don't know what [Q][9][25][1] refers to. What if I want to look up a player's quest vars to fix something?"**
Hey, _I_ don't know what it refers to either, but I can run `!checkquest AREA QUEST_NAME` and it'll tell me what all the player's vars associated with that quest are, with the variable's "human friendly" scripter-defined names! Then if I need to change it for a player, I can do a `!setquestvar AREA QUEST_NAME FRIENDLY_NAME VALUE` and the command will make sure the right SQL entry gets updated.

So now in this scenario, you no longer have to find the right NPC file and then search it for the correct `player:setVar()` definition. New GM commands will tell you upfront with no files opened!

(Also, if you ever _actually_ need to do this, someone really screwed up, as with this new system, quests should be harder to break.)

**"Okay, but how do I write quests with this new system?"**
I will have documentation and How-Tos ready before attempting a merge of quest_rewrite into master. It'll take me a bit, because as you all have no doubt seen, I can tend to be... verbose.

But for now, the eager can check out `quests/adoulin/the_old_man_and_the_harpoon` and `zones/western_adoulin/npcs/jorin`. The Old Man and the Harpoon is probably one of the most basic of quests, and can make for a good study.

**"Why do some of your quest methods just call methods we already have?"**
Consistency! All quest-related actions a scripter would want to perform are in the form of `thisQuest.doFoo`. The scripter doesn't need to remind themselves that `npcUtil.giveKeyItem` is the one that includes the message, while `player:giveKeyItem` doesn't, or that calls to lua-exposed core functions use `:` while our lua helper library functions use `.` The first argument is also always `player` for more consistency. The coding instinct becomes "I want to do bar, I will type `thisQuest.bar(player,`"

And by always going through a `thisQuest` wrapper, we can:
1) Enforce certain conventions, like not allowing a scripter to delete a key item from the player if it's not in the quest's temporary key items table (which avoids mistakes, _and_ makes people clearly define what they intend to delete later in the file)
2) Help the scripter out a little with returns, to shorten the number of lines required. Since the new quest system requires a return of `true` to indicate to the calling NPC that control should be diverted away from the rest of its script, we can write `return thisQuest.startEvent(player, csid)` which gives us a free `true`, instead of having to:
`player:startEvent(csid)`
`return true`
The fewer lines we have, the closer we are to Altana!
3) If we ever need/want to change an underlying function we're using later (like changes to how trades work), we just need to update the code in the method for the base quest object, and not have to worry about mass-find-and-replaces later!

**"Who is getting tagged?"**
- @takhlaq so he can say if this branch is everything he envisioned
- @TeoTwawki because I'd _like_ for this to meet his definition of easy-enough-to-use-while-adding-needed-functionality
- @teschnei because while I don't need to since he already got a notification, I didn't want him to feel left out, and I'm totally not doing a little brown-nosing because he's the most likely candidate to hit the merge button
- @zynjec to hedge my bets
- @whasf because he was the one to hit the merge button on my last PR, so apparently he's a merge-candidate as well, and I gotta cover as many bases as I can
- @wrenffxi because I care about his input in particular (even if just a silent emoji), because he's one of the more likely candidates to immediately start using this system other than me
- @KnowOne134 because I know he's already looked this system over and may/may not have an opinion
- @Bizzle-Dapp , @helixhamin , and @isotor because they're easy "thumbs up emoji" candidates, and seeing the emoji makes me puff out my chest in pride