### PR TITLE
Remove incorrect requirements to open Brass Door in Castle O.

### DIFF
--- a/scripts/zones/Castle_Oztroja/npcs/_479.lua
+++ b/scripts/zones/Castle_Oztroja/npcs/_479.lua
@@ -16,7 +16,6 @@ function onTrade(player,npc,trade)
 
     if
         npcUtil.tradeHas(trade, 1142) and
-        player:getCurrentMission(WINDURST) == dsp.mission.id.windurst.SAINTLY_INVITATION and
         player:hasKeyItem(dsp.ki.BALGA_CHAMPION_CERTIFICATE) and
         Z >= 80 and Z < 86
     then


### PR DESCRIPTION
The door is used in the mission; but the mission isn't a requirement to open the door itself.

https://ffxiclopedia.fandom.com/wiki/Judgment_Key