### PR TITLE
Sync conquest buy and recharge Vars

### DIFF
--- a/scripts/globals/conquest.lua
+++ b/scripts/globals/conquest.lua
@@ -828,7 +828,7 @@ local function canBuyExpRing(player, item)
     end
 
     -- one exp ring per conquest tally
-    if BYPASS_EXP_RING_ONE_PER_WEEK ~= 1 and player:getVar("CONQUEST_RING_TIMER") > os.time() then
+    if BYPASS_EXP_RING_ONE_PER_WEEK ~= 1 and player:getVar("CONQUEST_RING_RECHARGE") > os.time() then
         player:messageSpecial(text.CONQUEST + 60, 0, 0, item)
         return false
     end
@@ -1157,7 +1157,7 @@ dsp.conquest.overseerOnEventFinish = function(player, csid, option, guardNation,
         if npcUtil.giveItem(player, stock.item) then
             player:delCP(price)
             if option >= 32933 and option <= 32935 then
-                player:setVar("CONQUEST_RING_TIMER", getConquestTally())
+                player:setVar("CONQUEST_RING_RECHARGE", getConquestTally())
             end
         end
     end


### PR DESCRIPTION
Presently you can buy and recharge a ring once per week, should be either/or

source: https://ffxiclopedia.fandom.com/wiki/Empress_Band

> You may only purchase *or* recharge one Chariot Band, Empress Band, or Emperor Band once each week (the end/beginning of the week is marked by the conquest tally). 