### PR TITLE
Update HQ rates for various tiers

### DIFF
--- a/src/map/utils/synthutils.cpp
+++ b/src/map/utils/synthutils.cpp
@@ -390,10 +390,10 @@ uint8 calcSynthResult(CCharEntity* PChar)
 
                     switch(hqtier)
                     {
-                        case 4:  chance = 0.500; break;
-                        case 3:  chance = 0.300; break;
-                        case 2:  chance = 0.100; break;
-                        case 1:  chance = 0.015; break;
+                        case 4:  chance = (1/2); break;
+                        case 3:  chance = (1/4); break;
+                        case 2:  chance = (1/16); break;
+                        case 1:  chance = (1/64); break;
                         default: chance = 0.000; break;
                     }
 


### PR DESCRIPTION
Updating HQ tier success chances to the values [literally referenced just a few lines below](https://github.com/DarkstarProject/darkstar/blob/7eeef20eb4f9bd01a8f7948336a59a203fe3cb77/src/map/utils/synthutils.cpp#L403). Quick search finds this adjustment was also suggested previously within #2440.

Are fractions valid here? I *think* so but not 100%.