### PR TITLE
Update Opo-opo Necklace latent to trigger on Lullaby sleep

### DIFF
--- a/sql/item_latents.sql
+++ b/sql/item_latents.sql
@@ -709,6 +709,7 @@ INSERT INTO `item_latents` VALUES(14946, 346, 1, 13, 19);
 
 INSERT INTO `item_latents` VALUES(13143, 368, 25, 13, 2);
 INSERT INTO `item_latents` VALUES(13143, 368, 25, 13, 19);
+INSERT INTO `item_latents` VALUES(13143, 368, 25, 13, 193);
 
 INSERT INTO `item_latents` VALUES(15328, 370, 2, 13, 11);
 


### PR DESCRIPTION
Currently only triggers on `SLEEP_I` (2) and `SLEEP_II` (19)

https://ffxiclopedia.fandom.com/wiki/Opo-opo_Necklace