### PR TITLE
Prevent multiple completions during the same conquest tally

### DIFF
--- a/scripts/globals/items/mahogany_bed.lua
+++ b/scripts/globals/items/mahogany_bed.lua
@@ -7,8 +7,9 @@ require("scripts/globals/quests");
 -----------------------------------------
 
 function onFurniturePlaced(player)
-    if player:getQuestStatus(OTHER_AREAS_LOG, dsp.quest.id.otherAreas.THE_MOOGLE_PICNIC) == QUEST_AVAILABLE then
-        player:setVar("[MS2]NextTally", getConquestTally())
+    if player:getQuestStatus(OTHER_AREAS_LOG, dsp.quest.id.otherAreas.THE_MOOGLE_PICNIC) == QUEST_AVAILABLE and
+       player:getQuestStatus(OTHER_AREAS_LOG, dsp.quest.id.otherAreas.GIVE_A_MOOGLE_A_BREAK) == QUEST_COMPLETED then
+            player:setVar("[MS2]NextTally", getConquestTally())
     end
 end
 

--- a/scripts/globals/items/nobles_bed.lua
+++ b/scripts/globals/items/nobles_bed.lua
@@ -7,8 +7,9 @@ require("scripts/globals/quests");
 -----------------------------------------
 
 function onFurniturePlaced(player)
-    if player:getQuestStatus(OTHER_AREAS_LOG, dsp.quest.id.otherAreas.MOOGLES_IN_THE_WILD) == QUEST_AVAILABLE then
-        player:setVar("[MS3]NextTally", getConquestTally())
+    if player:getQuestStatus(OTHER_AREAS_LOG, dsp.quest.id.otherAreas.MOOGLES_IN_THE_WILD) == QUEST_AVAILABLE and
+       player:getQuestStatus(OTHER_AREAS_LOG, dsp.quest.id.otherAreas.THE_MOOGLE_PICNIC) == QUEST_COMPLETED then
+            player:setVar("[MS3]NextTally", getConquestTally())
     end
 end
 


### PR DESCRIPTION
I don't remember if multiple quests can be completed in the same conquest tally, but if not, here you go!