### PR TITLE
Fix synth support to remove existing support from other guild

### DIFF
--- a/scripts/zones/Bastok_Markets/npcs/Fatimah.lua
+++ b/scripts/zones/Bastok_Markets/npcs/Fatimah.lua
@@ -4,43 +4,44 @@
 -- Type: Goldsmithing Adv. Synthesis Image Support
 -- !pos -193.849 -7.824 -56.372 235
 -----------------------------------
-require("scripts/globals/status");
-require("scripts/globals/crafting");
-local ID = require("scripts/zones/Bastok_Markets/IDs");
+local ID = require("scripts/zones/Bastok_Markets/IDs")
+require("scripts/globals/status")
+require("scripts/globals/crafting")
 -----------------------------------
 
 function onTrade(player,npc,trade)
-end;
+end
 
 function onTrigger(player,npc)
-    local guildMember = isGuildMember(player,6);
-    local SkillLevel = player:getSkillLevel(dsp.skill.GOLDSMITHING);
-    local Cost = getAdvImageSupportCost(player, dsp.skill.GOLDSMITHING);
+    local guildMember = isGuildMember(player, 6)
+    local SkillLevel = player:getSkillLevel(dsp.skill.GOLDSMITHING)
+    local Cost = getAdvImageSupportCost(player, dsp.skill.GOLDSMITHING)
 
-    if (guildMember == 1) then
-        if (player:hasStatusEffect(dsp.effect.GOLDSMITHING_IMAGERY) == false) then
-            player:startEvent(302,Cost,SkillLevel,0,0xB0001AF,player:getGil(),0,0,0); -- Event doesn't work
+    if guildMember == 1 then
+        if player:hasStatusEffect(dsp.effect.GOLDSMITHING_IMAGERY) == false then
+            player:startEvent(302, Cost, SkillLevel, 0, 0xB0001AF, player:getGil(), 0, 0, 0) -- Event doesn't work
         else
-            player:startEvent(302,Cost,SkillLevel,0,0xB0001AF,player:getGil(),28674,0,0);
+            player:startEvent(302, Cost, SkillLevel, 0, 0xB0001AF, player:getGil(), 28674, 0, 0)
         end
     else
-        player:startEvent(302);
+        player:startEvent(302)
     end
-end;
+end
 
 function onEventUpdate(player,csid,option)
-end;
+end
 
 function onEventFinish(player,csid,option)
-    local Cost = getAdvImageSupportCost(player, dsp.skill.GOLDSMITHING);
+    local Cost = getAdvImageSupportCost(player, dsp.skill.GOLDSMITHING)
 
-    if (csid == 302 and option == 1) then
-        if (player:getGil() >= Cost) then
-            player:messageSpecial(ID.text.GOLDSMITHING_SUPPORT,0,3,0);
-            player:addStatusEffect(dsp.effect.GOLDSMITHING_IMAGERY,3,0,480);
-            player:delGil(Cost);
+    if csid == 302 and option == 1 then
+        if player:getGil() >= Cost then
+            player:delGil(Cost)
+            player:delStatusEffectsByFlag(dsp.effectFlag.SYNTH_SUPPORT, true)
+            player:addStatusEffect(dsp.effect.GOLDSMITHING_IMAGERY, 3, 0, 480)
+            player:messageSpecial(ID.text.GOLDSMITHING_SUPPORT, 0, 3, 0)
         else
-            player:messageSpecial(ID.text.NOT_HAVE_ENOUGH_GIL);
+            player:messageSpecial(ID.text.NOT_HAVE_ENOUGH_GIL)
         end
     end
-end;
+end

--- a/scripts/zones/Bastok_Markets/npcs/Ulrike.lua
+++ b/scripts/zones/Bastok_Markets/npcs/Ulrike.lua
@@ -4,36 +4,37 @@
 -- Type: Goldsmithing Synthesis Image Support
 -- !pos -218.399 -7.824 -56.203 235
 -----------------------------------
-require("scripts/globals/status");
-require("scripts/globals/crafting");
-local ID = require("scripts/zones/Bastok_Markets/IDs");
+local ID = require("scripts/zones/Bastok_Markets/IDs")
+require("scripts/globals/status")
+require("scripts/globals/crafting")
 -----------------------------------
 
 function onTrade(player,npc,trade)
-end;
+end
 
 function onTrigger(player,npc)
-    local guildMember = isGuildMember(player,6);
-    local SkillCap = getCraftSkillCap(player, dsp.skill.GOLDSMITHING);
-    local SkillLevel = player:getSkillLevel(dsp.skill.GOLDSMITHING);
+    local guildMember = isGuildMember(player, 6)
+    local SkillCap = getCraftSkillCap(player, dsp.skill.GOLDSMITHING)
+    local SkillLevel = player:getSkillLevel(dsp.skill.GOLDSMITHING)
 
-    if (guildMember == 1) then
-        if (player:hasStatusEffect(dsp.effect.GOLDSMITHING_IMAGERY) == false) then
-            player:startEvent(304,SkillCap,SkillLevel,2,201,player:getGil(),0,9,0);
+    if guildMember == 1 then
+        if player:hasStatusEffect(dsp.effect.GOLDSMITHING_IMAGERY) == false then
+            player:startEvent(304, SkillCap, SkillLevel, 2, 201, player:getGil(), 0, 9, 0)
         else
-            player:startEvent(304,SkillCap,SkillLevel,2,201,player:getGil(),6975,9,0);
+            player:startEvent(304, SkillCap, SkillLevel, 2, 201, player:getGil(), 6975, 9, 0)
         end
     else
-        player:startEvent(304);
+        player:startEvent(304)
     end
-end;
+end
 
 function onEventUpdate(player,csid,option)
-end;
+end
 
 function onEventFinish(player,csid,option)
-    if (csid == 304 and option == 1) then
-        player:messageSpecial(ID.text.GOLDSMITHING_SUPPORT,0,3,2);
-        player:addStatusEffect(dsp.effect.GOLDSMITHING_IMAGERY,1,0,120);
+    if csid == 304 and option == 1 then
+        player:delStatusEffectsByFlag(dsp.effectFlag.SYNTH_SUPPORT, true)
+        player:addStatusEffect(dsp.effect.GOLDSMITHING_IMAGERY, 1, 0, 120)
+        player:messageSpecial(ID.text.GOLDSMITHING_SUPPORT, 0, 3, 2)
     end
-end;
+end

--- a/scripts/zones/Bastok_Markets/npcs/Wulfnoth.lua
+++ b/scripts/zones/Bastok_Markets/npcs/Wulfnoth.lua
@@ -4,36 +4,37 @@
 -- Type: Goldsmithing Synthesis Image Support
 -- !pos -211.937 -7.814 -56.292 235
 -----------------------------------
-require("scripts/globals/status");
-require("scripts/globals/crafting");
-local ID = require("scripts/zones/Bastok_Markets/IDs");
+local ID = require("scripts/zones/Bastok_Markets/IDs")
+require("scripts/globals/status")
+require("scripts/globals/crafting")
 -----------------------------------
 
 function onTrade(player,npc,trade)
-end;
+end
 
 function onTrigger(player,npc)
-    local guildMember = isGuildMember(player,6);
-    local SkillCap = getCraftSkillCap(player, dsp.skill.GOLDSMITHING);
-    local SkillLevel = player:getSkillLevel(dsp.skill.GOLDSMITHING);
+    local guildMember = isGuildMember(player, 6)
+    local SkillCap = getCraftSkillCap(player, dsp.skill.GOLDSMITHING)
+    local SkillLevel = player:getSkillLevel(dsp.skill.GOLDSMITHING)
 
-    if (guildMember == 1) then
+    if guildMember == 1 then
         if (player:hasStatusEffect(dsp.effect.GOLDSMITHING_IMAGERY) == false) then
-            player:startEvent(303,SkillCap,SkillLevel,1,201,player:getGil(),0,3,0);
+            player:startEvent(303, SkillCap, SkillLevel, 1, 201, player:getGil(), 0, 3, 0)
         else
-            player:startEvent(303,SkillCap,SkillLevel,1,201,player:getGil(),7054,3,0);
+            player:startEvent(303, SkillCap, SkillLevel, 1, 201, player:getGil(), 7054, 3, 0)
         end
     else
-        player:startEvent(303);
+        player:startEvent(303)
     end
-end;
+end
 
 function onEventUpdate(player,csid,option)
-end;
+end
 
 function onEventFinish(player,csid,option)
-    if (csid == 303 and option == 1) then
-        player:messageSpecial(ID.text.GOLDSMITHING_SUPPORT,0,3,1);
-        player:addStatusEffect(dsp.effect.GOLDSMITHING_IMAGERY,1,0,120);
+    if csid == 303 and option == 1 then
+        player:delStatusEffectsByFlag(dsp.effectFlag.SYNTH_SUPPORT, true)
+        player:addStatusEffect(dsp.effect.GOLDSMITHING_IMAGERY, 1, 0, 120)
+        player:messageSpecial(ID.text.GOLDSMITHING_SUPPORT, 0, 3, 1)
     end
-end;
+end

--- a/scripts/zones/Metalworks/npcs/Hugues.lua
+++ b/scripts/zones/Metalworks/npcs/Hugues.lua
@@ -4,36 +4,37 @@
 -- Type: Smithing Synthesis Image Support
 -- !pos -106.336 2.000 26.117 237
 -----------------------------------
-require("scripts/globals/status");
-require("scripts/globals/crafting");
-local ID = require("scripts/zones/Metalworks/IDs");
+local ID = require("scripts/zones/Metalworks/IDs")
+require("scripts/globals/status")
+require("scripts/globals/crafting")
 -----------------------------------
 
 function onTrade(player,npc,trade)
-end;
+end
 
 function onTrigger(player,npc)
-    local guildMember = isGuildMember(player,8);
-    local SkillCap = getCraftSkillCap(player,dsp.skill.SMITHING);
-    local SkillLevel = player:getSkillLevel(dsp.skill.SMITHING);
+    local guildMember = isGuildMember(player, 8)
+    local SkillCap = getCraftSkillCap(player, dsp.skill.SMITHING)
+    local SkillLevel = player:getSkillLevel(dsp.skill.SMITHING)
 
-    if (guildMember == 1) then
-        if (player:hasStatusEffect(dsp.effect.SMITHING_IMAGERY) == false) then
-            player:startEvent(104,SkillCap,SkillLevel,1,207,player:getGil(),0,4095,0);
+    if guildMember == 1 then
+        if player:hasStatusEffect(dsp.effect.SMITHING_IMAGERY) == false then
+            player:startEvent(104, SkillCap, SkillLevel, 1, 207, player:getGil(), 0, 4095, 0)
         else
-            player:startEvent(104,SkillCap,SkillLevel,1,207,player:getGil(),7101,4095,0);
+            player:startEvent(104, SkillCap, SkillLevel, 1, 207, player:getGil(), 7101, 4095, 0)
         end
     else
-        player:startEvent(104); -- Standard Dialogue
+        player:startEvent(104)
     end
-end;
+end
 
 function onEventUpdate(player,csid,option)
-end;
+end
 
 function onEventFinish(player,csid,option)
-    if (csid == 104 and option == 1) then
-        player:messageSpecial(ID.text.SMITHING_SUPPORT,0,2,1);
-        player:addStatusEffect(dsp.effect.SMITHING_IMAGERY,1,0,120);
+    if csid == 104 and option == 1 then
+        target:delStatusEffectsByFlag(dsp.effectFlag.SYNTH_SUPPORT, true)
+        player:addStatusEffect(dsp.effect.SMITHING_IMAGERY, 1, 0, 120)
+        player:messageSpecial(ID.text.SMITHING_SUPPORT, 0, 2, 1)
     end
-end;
+end

--- a/scripts/zones/Metalworks/npcs/Romero.lua
+++ b/scripts/zones/Metalworks/npcs/Romero.lua
@@ -4,36 +4,37 @@
 -- Type: Smithing Synthesis Image Support
 -- !pos -106.336 2.000 26.117 237
 -----------------------------------
-require("scripts/globals/status");
-require("scripts/globals/crafting");
-local ID = require("scripts/zones/Metalworks/IDs");
+local ID = require("scripts/zones/Metalworks/IDs")
+require("scripts/globals/status")
+require("scripts/globals/crafting")
 -----------------------------------
 
 function onTrade(player,npc,trade)
-end;
+end
 
 function onTrigger(player,npc)
-    local guildMember = isGuildMember(player,8);
-    local SkillCap = getCraftSkillCap(player,dsp.skill.SMITHING);
-    local SkillLevel = player:getSkillLevel(dsp.skill.SMITHING);
+    local guildMember = isGuildMember(player, 8)
+    local SkillCap = getCraftSkillCap(player, dsp.skill.SMITHING)
+    local SkillLevel = player:getSkillLevel(dsp.skill.SMITHING)
 
-    if (guildMember == 1) then
-        if (player:hasStatusEffect(dsp.effect.SMITHING_IMAGERY) == false) then
-            player:startEvent(105,SkillCap,SkillLevel,2,207,player:getGil(),0,0,0);
+    if guildMember == 1 then
+        if player:hasStatusEffect(dsp.effect.SMITHING_IMAGERY) == false then
+            player:startEvent(105, SkillCap, SkillLevel, 2, 207, player:getGil(), 0, 0, 0)
         else
-            player:startEvent(105,SkillCap,SkillLevel,2,207,player:getGil(),7127,0,0);
+            player:startEvent(105, SkillCap, SkillLevel, 2, 207, player:getGil(), 7127, 0, 0)
         end
     else
-        player:startEvent(105); -- Standard Dialogue
+        player:startEvent(105)
     end
-end;
+end
 
 function onEventUpdate(player,csid,option)
-end;
+end
 
 function onEventFinish(player,csid,option)
-    if (csid == 105 and option == 1) then
-        player:messageSpecial(ID.text.SMITHING_SUPPORT,0,2,2);
-        player:addStatusEffect(dsp.effect.SMITHING_IMAGERY,1,0,120);
+    if csid == 105 and option == 1 then
+        player:delStatusEffectsByFlag(dsp.effectFlag.SYNTH_SUPPORT, true)
+        player:addStatusEffect(dsp.effect.SMITHING_IMAGERY, 1, 0, 120)
+        player:messageSpecial(ID.text.SMITHING_SUPPORT, 0, 2, 2)
     end
-end;
+end

--- a/scripts/zones/Metalworks/npcs/Wise_Owl.lua
+++ b/scripts/zones/Metalworks/npcs/Wise_Owl.lua
@@ -4,39 +4,44 @@
 -- Type: Smithing Adv. Image Support
 -- !pos -106.336 2.000 26.117 237
 -----------------------------------
-require("scripts/globals/status");
-require("scripts/globals/crafting");
-local ID = require("scripts/zones/Metalworks/IDs");
+local ID = require("scripts/zones/Metalworks/IDs")
+require("scripts/globals/status")
+require("scripts/globals/crafting")
 -----------------------------------
 
 function onTrade(player,npc,trade)
-end;
+end
 
 function onTrigger(player,npc)
-    local guildMember = isGuildMember(player,8);
-    local SkillLevel = player:getSkillLevel(dsp.skill.SMITHING);
-    local Cost = getAdvImageSupportCost(player,dsp.skill.SMITHING);
+    local guildMember = isGuildMember(player, 8)
+    local SkillLevel = player:getSkillLevel(dsp.skill.SMITHING)
+    local Cost = getAdvImageSupportCost(player, dsp.skill.SMITHING)
 
-    if (guildMember == 1) then
-        if (player:hasStatusEffect(dsp.effect.SMITHING_IMAGERY) == false) then
-            player:startEvent(103,Cost,SkillLevel,0,207,player:getGil(),0,4095,0);
+    if guildMember == 1 then
+        if player:hasStatusEffect(dsp.effect.SMITHING_IMAGERY) == false then
+            player:startEvent(103, Cost, SkillLevel, 0, 207, player:getGil(), 0, 4095, 0)
         else
-            player:startEvent(103,Cost,SkillLevel,0,207,player:getGil(),28721,4095,0);
+            player:startEvent(103, Cost, SkillLevel, 0, 207, player:getGil(), 28721, 4095, 0)
         end
     else
-        player:startEvent(103); -- Standard Dialogue
+        player:startEvent(103)
     end
-end;
+end
 
 function onEventUpdate(player,csid,option)
-end;
+end
 
 function onEventFinish(player,csid,option)
-    local Cost = getAdvImageSupportCost(player,dsp.skill.SMITHING);
+    local Cost = getAdvImageSupportCost(player,dsp.skill.SMITHING)
 
-    if (csid == 103 and option == 1) then
-        player:delGil(Cost);
-        player:messageSpecial(ID.text.SMITHING_SUPPORT,0,2,0);
-        player:addStatusEffect(dsp.effect.SMITHING_IMAGERY,3,0,480);
+    if csid == 103 and option == 1 then
+        if player:getGil() >= Cost then
+            player:delGil(Cost)
+            player:delStatusEffectsByFlag(dsp.effectFlag.SYNTH_SUPPORT, true)
+            player:addStatusEffect(dsp.effect.SMITHING_IMAGERY, 3, 0, 480)
+            player:messageSpecial(ID.text.SMITHING_SUPPORT, 0, 2, 0)
+        else
+            player:messageSpecial(ID.text.NOT_HAVE_ENOUGH_GIL)
+        end
     end
-end;
+end


### PR DESCRIPTION
First pass just with the Bastok Goldsmith and Smith NPCs for feedback. Includes various bits of formatting *(ordering, semicolons, spaces, parens)* but the only logic change is `player:delStatusEffectsByFlag(dsp.effectFlag.SYNTH_SUPPORT, true)` onEventFinish to strip existing support which is [how it works on retail](https://ffxiclopedia.fandom.com/wiki/Synthesis_Image_Support)

> This effect will be replaced by synthesis image support for any craftskill except the craftskill currently supported by the existing effect.

__Other issues:__

1. `if player:hasStatusEffect(dsp.effect.SMITHING_IMAGERY) == false then` is probably not the correct check for the advanced support NPCs since they blow you off if you have basic support. I need to confirm this on retail but I strongly suspect this check should only catch existing *advanced* image support.
2. Fatimah still has `0xB0001AF`