### PR TITLE
Bandaid fix on purchasing HQ crystals with GP

### DIFF
--- a/scripts/globals/crafting.lua
+++ b/scripts/globals/crafting.lua
@@ -254,7 +254,7 @@ function unionRepresentativeTriggerFinish(player, option, target, guildID, curre
     elseif (category == 2 or category == 1) then -- item
         local idx = bit.band(option, 3);
         local i = items[(category - 1) * 4 + idx];
-        local quantity = bit.rshift(option, 9);
+        local quantity = math.min(bit.rshift(option, 9), 12);
         local cost = quantity * i.cost;
         if (i and rank >= i.rank) then
             if (player:getCurrency(currency) >= cost) then
@@ -280,7 +280,7 @@ function unionRepresentativeTriggerFinish(player, option, target, guildID, curre
         if (i and rank >= 3) then
             if (player:getCurrency(currency) >= cost) then
                 if (player:addItem(i.id, quantity)) then
-                    player:delCurrency(currency, math.min(cost, 2400));
+                    player:delCurrency(currency, cost);
                     player:messageSpecial(text.ITEM_OBTAINED, i.id);
                 else
                     player:messageSpecial(text.ITEM_CANNOT_BE_OBTAINED, i.id);

--- a/scripts/globals/crafting.lua
+++ b/scripts/globals/crafting.lua
@@ -280,7 +280,7 @@ function unionRepresentativeTriggerFinish(player, option, target, guildID, curre
         if (i and rank >= 3) then
             if (player:getCurrency(currency) >= cost) then
                 if (player:addItem(i.id, quantity)) then
-                    player:delCurrency(currency, cost);
+                    player:delCurrency(currency, math.min(cost, 2400));
                     player:messageSpecial(text.ITEM_OBTAINED, i.id);
                 else
                     player:messageSpecial(text.ITEM_CANNOT_BE_OBTAINED, i.id);


### PR DESCRIPTION
Okay so there's undoubtedly a better fix for this but here's my offer for a temporary/bandaid solution. Right now the client let's you order as many HQ crystals as you like but only gives you a max of 12 (one stack). This is a quick fix to limit the ~~amount of GP paid to the same maximum (12 x 200 GP each = 2400)~~ number of crystals you can request in one trade to 12 *(tho the client will still let you input however many you want)*.