### PR TITLE
Update first hHP/hMP recovery to occur at second healing tic

### DIFF
--- a/scripts/globals/effects/healing.lua
+++ b/scripts/globals/effects/healing.lua
@@ -1,12 +1,12 @@
 -----------------------------------
 --
 -- dsp.effect.HEALING
+-- Activated through the /heal command
 --
---    Activated through the /heal command
 -----------------------------------
-
 require("scripts/globals/status")
 require("scripts/globals/settings")
+-----------------------------------
 
 function onEffectGain(target,effect)
     target:setAnimation(33)
@@ -16,27 +16,25 @@ function onEffectTick(target,effect)
 
     local healtime = effect:getTickCount()
 
-    if (healtime > 1) then
+    if healtime > 1 then
         -- curse II also known as "zombie"
-        if (not(target:hasStatusEffect(dsp.effect.DISEASE)) and target:hasStatusEffect(dsp.effect.PLAGUE) == false and target:hasStatusEffect(dsp.effect.CURSE_II) == false) then
+        if not(target:hasStatusEffect(dsp.effect.DISEASE)) and target:hasStatusEffect(dsp.effect.PLAGUE) == false and target:hasStatusEffect(dsp.effect.CURSE_II) == false then
             local healHP = 0
-            if (target:getContinentID() == 1 and target:hasStatusEffect(dsp.effect.SIGNET)) then
-                healHP = 10+(3*math.floor(target:getMainLvl()/10))+(healtime-2)*(1+math.floor(target:getMaxHP()/300))+(target:getMod(dsp.mod.HPHEAL))
+            if target:getContinentID() == 1 and target:hasStatusEffect(dsp.effect.SIGNET) then
+                healHP = 10 + (3 * math.floor(target:getMainLvl() / 10)) + (healtime - 2) * (1 + math.floor(target:getMaxHP() / 300)) + target:getMod(dsp.mod.HPHEAL)
             else
                 target:addTP(HEALING_TP_CHANGE)
-                healHP = 10+(healtime-2)+(target:getMod(dsp.mod.HPHEAL))
+                healHP = 10 + (healtime - 2) + target:getMod(dsp.mod.HPHEAL)
             end
 
             target:addHP(healHP)
             target:updateEnmityFromCure(target, healHP)
-
-         -- Each rank of Clear Mind provides +3 hMP (via dsp.mod.MPHEAL)
-         -- Each tic of healing should be +1mp more than the last
-         -- Clear Mind III increases this to +2, and Clear Mind V to +3 (via dsp.mod.CLEAR_MIND)
-            target:addMP(12+((healtime-2) * (1+target:getMod(dsp.mod.CLEAR_MIND)))+(target:getMod(dsp.mod.MPHEAL)))
         end
     end
 
+    if healtime > 2 then
+        target:addMP(12 + ((healtime - 2) * (1 + target:getMod(dsp.mod.CLEAR_MIND))) + target:getMod(dsp.mod.MPHEAL))
+    end
 end
 
 function onEffectLose(target,effect)

--- a/scripts/globals/effects/healing.lua
+++ b/scripts/globals/effects/healing.lua
@@ -16,7 +16,7 @@ function onEffectTick(target,effect)
 
     local healtime = effect:getTickCount()
 
-    if healtime > 1 then
+    if healtime > 2 then
         -- curse II also known as "zombie"
         if not(target:hasStatusEffect(dsp.effect.DISEASE)) and target:hasStatusEffect(dsp.effect.PLAGUE) == false and target:hasStatusEffect(dsp.effect.CURSE_II) == false then
             local healHP = 0
@@ -29,11 +29,8 @@ function onEffectTick(target,effect)
 
             target:addHP(healHP)
             target:updateEnmityFromCure(target, healHP)
+            target:addMP(12 + ((healtime - 2) * (1 + target:getMod(dsp.mod.CLEAR_MIND))) + target:getMod(dsp.mod.MPHEAL))
         end
-    end
-
-    if healtime > 2 then
-        target:addMP(12 + ((healtime - 2) * (1 + target:getMod(dsp.mod.CLEAR_MIND))) + target:getMod(dsp.mod.MPHEAL))
     end
 end
 


### PR DESCRIPTION
https://ffxiclopedia.fandom.com/wiki/MP_Recovered_While_Healing

> The first recovery tick requires 20 seconds of rest and each subsequent recovery tick occurs every 10 seconds. 

Rest is just formatting.