### PR TITLE
[WIP] Set cap on CP awarded for rank bar overspill on trade

### DIFF
--- a/scripts/globals/conquest.lua
+++ b/scripts/globals/conquest.lua
@@ -939,7 +939,7 @@ dsp.conquest.overseerOnTrade = function(player, npc, trade, guardNation, guardTy
                         break
                     else
                         trade:confirmItem(crystalId, count)
-                        addPoints = addPoints + count * math.floor(4000 / (player:getRank() * 12 - crystalWorth))
+                        addPoints = addPoints + count * math.floor(400 / (player:getRank() * 12 - crystalWorth))
                     end
                 end
             end
@@ -947,7 +947,7 @@ dsp.conquest.overseerOnTrade = function(player, npc, trade, guardNation, guardTy
             if addPoints > 0 and pRank ~= 1 and pRankPoints < 4000 then
                 if pRankPoints + addPoints >= 4000 then
                     player:setRankPoints(4000)
-                    player:addCP(math.min(pRankPoints + addPoints - 4000, 1000))
+                    player:addCP(pRankPoints + addPoints - 4000)
                     player:showText(npc, mOffset + 44) -- "Your rank points are full. We've added the excess to your conquest points."
                 else
                     player:addRankPoints(addPoints)

--- a/scripts/globals/conquest.lua
+++ b/scripts/globals/conquest.lua
@@ -947,7 +947,7 @@ dsp.conquest.overseerOnTrade = function(player, npc, trade, guardNation, guardTy
             if addPoints > 0 and pRank ~= 1 and pRankPoints < 4000 then
                 if pRankPoints + addPoints >= 4000 then
                     player:setRankPoints(4000)
-                    player:addCP(pRankPoints + addPoints - 4000)
+                    player:addCP(math.min(pRankPoints + addPoints - 4000, 1000))
                     player:showText(npc, mOffset + 44) -- "Your rank points are full. We've added the excess to your conquest points."
                 else
                     player:addRankPoints(addPoints)


### PR DESCRIPTION
__Closing an exploit with arbitrary limit.__

Just tried this on local master build at Rank 2 - traded a stack of Earth crystals to set me very close to the rank cap, then traded 8 full stacks of Dark crystals and was awarded a pretty hilarious 48,000 CP. I don't believe this is an intended use of this feature so propose setting an arbitrary cap of 1k CP for any amount of excess crystals above filling the rank bar. 

I have absolutely no support for the 1k cap, and the correct fix is probably an hefty reduction on CP-per-crystal, but this PR is just an option for consideration/discussion.