### PR TITLE
Set flag on Death spell to ignore shadows and added isUndead check

### DIFF
--- a/scripts/globals/spells/death.lua
+++ b/scripts/globals/spells/death.lua
@@ -1,6 +1,7 @@
 -----------------------------------------
 -- Spell: Death
--- Instant K.O.
+-- Consumes all MP. Has a chance to knock out the target. If Death fails to knock out the target, it 
+-- will instead deal darkness damage. Ineffective against undead.
 -----------------------------------------
 require("scripts/globals/magic")
 require("scripts/globals/status")
@@ -8,16 +9,16 @@ require("scripts/globals/msg")
 -----------------------------------------
 
 function onMagicCastingCheck(caster,target,spell)
+    spell:setFlag(dsp.magic.spellFlag.IGNORE_SHADOWS)
     return 0
 end
 
 function onSpellCast(caster,target,spell)
-    if (target:hasStatusEffect(dsp.effect.MAGIC_SHIELD) or math.random(0,99) < target:getMod(dsp.mod.DEATHRES)) then
+    if target(isUndead) or target:hasStatusEffect(dsp.effect.MAGIC_SHIELD) or math.random(0,99) < target:getMod(dsp.mod.DEATHRES) then
         spell:setMsg(dsp.msg.basic.MAGIC_NO_EFFECT)
         return 0
     end
 
     target:setHP(0)
-
     return 0
 end


### PR DESCRIPTION
https://ffxiclopedia.fandom.com/wiki/Death

There is some fancier stuff in the above, but mostly I just wanted to get the `ignore_shadows` flag set.