### PR TITLE
Fix minor issue with Making the Grade quest

### DIFF
--- a/scripts/zones/Windurst_Waters/npcs/Fuepepe.lua
+++ b/scripts/zones/Windurst_Waters/npcs/Fuepepe.lua
@@ -61,6 +61,7 @@ function onEventFinish(player,csid,option)
         if (player:getFreeSlotsCount() == 0) then
             player:messageSpecial(ID.text.ITEM_CANNOT_BE_OBTAINED,4855);
         else
+            player:tradeComplete();
             player:completeQuest(WINDURST,dsp.quest.id.windurst.MAKING_THE_GRADE);
             player:addFame(WINDURST,75);
             player:addItem(4855);


### PR DESCRIPTION
add tradeComplete() to remove test answers from player inventory on completion

https://ffxiclopedia.fandom.com/wiki/Making_the_Grade