### PR TITLE
Prevent exp status buff deduction in invalid situations

### DIFF
--- a/src/map/utils/charutils.cpp
+++ b/src/map/utils/charutils.cpp
@@ -3203,6 +3203,7 @@ namespace charutils
 
         PChar->ForAlliance([&PMob, &region, &minlevel, &maxlevel, &pcinzone](CBattleEntity* PPartyMember) {
             auto PMember = static_cast<CCharEntity*>(PPartyMember);
+            if (PMember->isDead()) { return; }
             uint32 baseexp = 0;
             auto exp = 0.f;
             float monsterbonus = 1.0f;
@@ -3407,7 +3408,6 @@ namespace charutils
                             default: PMember->expChain.chainTime = gettick() + 60000; break;
                         }
                     }
-                    exp = charutils::AddExpBonus(PMember, exp);
 
                     // pet or companion exp penalty needs to be added here
 
@@ -3416,6 +3416,7 @@ namespace charutils
                         PMember->pushPacket(new CMessageBasicPacket(PMember, PMember, 0, 0, 37));
                         return;
                     }
+                    exp = charutils::AddExpBonus(PMember, exp);
                     charutils::AddExperiencePoints(false, PMember, PMob, (uint32)exp, baseexp, chainactive);
                 }
             }


### PR DESCRIPTION
Prevents exp being deducted from bonus exp status effect if you do not meet the requirements to receive experience from mobs killed i.e. (1) you are dead, or (2) you are too far from the battle.