### PR TITLE
Implement tiered MB accuracy bonus

### DIFF
--- a/scripts/globals/magic.lua
+++ b/scripts/globals/magic.lua
@@ -581,7 +581,6 @@ function getSpellBonusAcc(caster, target, spell, params)
         else
             levelBonus = 128
         end
-
         magicAccBonus = magicAccBonus + levelBonus
         return magicAccBonus
     end
@@ -1039,6 +1038,8 @@ end;
 
 function getHelixDuration(caster)
     --Dark Arts will further increase Helix duration, but testing is ongoing.
+
+    local casterLevel = caster:getMainLvl();
     local duration = 30; --fallthrough
     if (casterLevel <= 39) then
         duration = 30;

--- a/scripts/globals/magic.lua
+++ b/scripts/globals/magic.lua
@@ -570,8 +570,18 @@ function getSpellBonusAcc(caster, target, spell, params)
     magicAccBonus = magicAccBonus + params.AMIIaccBonus;
 
     --add acc for skillchains
-    if (skillchainTier > 0) then
-        magicAccBonus = magicAccBonus + 25;
+    local casterLevel = caster:getMainLvl()
+    if skillchainTier > 0 then
+        local levelBonus = 0
+        if (casterLevel <= 25) then
+            levelBonus = 32;
+        elseif (casterLevel <= 50) then
+            levelBonus = 64;
+        else
+            levelBonus = 128;
+        end
+        return levelBonus
+        magicAccBonus = magicAccBonus + levelBonus
     end
 
     --Add acc for klimaform
@@ -1027,8 +1037,6 @@ end;
 
 function getHelixDuration(caster)
     --Dark Arts will further increase Helix duration, but testing is ongoing.
-
-    local casterLevel = caster:getMainLvl();
     local duration = 30; --fallthrough
     if (casterLevel <= 39) then
         duration = 30;

--- a/scripts/globals/magic.lua
+++ b/scripts/globals/magic.lua
@@ -583,7 +583,7 @@ function getSpellBonusAcc(caster, target, spell, params)
         end
 
         magicAccBonus = magicAccBonus + levelBonus
-        return levelBonus
+        return magicAccBonus
     end
 
     --Add acc for klimaform

--- a/scripts/globals/magic.lua
+++ b/scripts/globals/magic.lua
@@ -569,19 +569,21 @@ function getSpellBonusAcc(caster, target, spell, params)
     --add acc for BLM AMII spells
     magicAccBonus = magicAccBonus + params.AMIIaccBonus;
 
-    --add acc for skillchains
+    -- Add acc for skillchains
     local casterLevel = caster:getMainLvl()
+
     if skillchainTier > 0 then
         local levelBonus = 0
-        if (casterLevel <= 25) then
-            levelBonus = 32;
-        elseif (casterLevel <= 50) then
-            levelBonus = 64;
+        if casterLevel < 26 then
+            levelBonus = 32
+        elseif casterLevel < 51 then
+            levelBonus = 64
         else
-            levelBonus = 128;
+            levelBonus = 128
         end
-        return levelBonus
+
         magicAccBonus = magicAccBonus + levelBonus
+        return levelBonus
     end
 
     --Add acc for klimaform


### PR DESCRIPTION
Stole `local casterLevel` from Helix duration calc further down.

Selected tiers as 32/64/128, increasing at the level Black Mage acquires a higher tier nuke (Stone II at 26, Stone III at 51).

Not particularly married to any of it so wade in with your hot take <3