### PR TITLE
Fix typo in Evasion Down effect script

### DIFF
--- a/scripts/globals/effects/evasion_down.lua
+++ b/scripts/globals/effects/evasion_down.lua
@@ -7,24 +7,24 @@ require("scripts/globals/status")
 -----------------------------------
 
 function onEffectGain(target,effect)
-    if (target:getMod(dsp.mod.EVA) - effect:getPower() < 0) then
+    if target:getStat(dsp.mod.EVA) - effect:getPower() < 0 then
         effect:setPower(target:getStat(dsp.mod.EVA))
     end
-    target:addMod(dsp.mod.EVA,-effect:getPower())
+    target:addMod(dsp.mod.EVA, -effect:getPower())
 end
 
 function onEffectTick(target,effect)
     -- Only Feint uses the tick, restore 10 evasion every tick
     local evaDownAmt = effect:getPower()
-    if (evaDownAmt > 0) then
-        effect:setPower(evaDownAmt - 10)
-        target:delMod(dsp.mod.EVA, -10)
+    if evaDownAmt > 0 then
+        effect:setPower(math.max(evaDownAmt - 10, 0))
+        target:delMod(dsp.mod.EVA, 10)
     end
 end
 
 function onEffectLose(target,effect)
     local evaDownAmt = effect:getPower()
-    if (evaDownAmt > 0) then
-        target:delMod(dsp.mod.EVA,-effect:getPower())
+    if evaDownAmt > 0 then
+        target:delMod(dsp.mod.EVA, effect:getPower())
     end
 end


### PR DESCRIPTION
Fixes #5701.

------

Edit: I figure this just wasn't explained very well. My reading of the code suggests the following situation:

- Target natural evasion: 240
- Target evasion mod total: 10 *(say from gear)*
- Effect power: 40

Check currently calculates that 40 (**Effect**) is bigger than 10 (**Mod**), and so sets the effect power to 240 (**Stat**)

Correct check is whether the effect power exceeds the target's natural evasion - not sure if maybe this should also include gear from mods but then there's the issue of what happens if you're set to 0 then take off your +eva gear?

https://github.com/DarkstarProject/darkstar/blob/1a6eaa31d76bf449b91b972142cf815ddda97bfb/scripts/globals/status.lua#L884-L885