### PR TITLE
Update Astral Flow Blood Pacts (damage-dealing types)

### DIFF
--- a/scripts/globals/mobskills/aerial_blast.lua
+++ b/scripts/globals/mobskills/aerial_blast.lua
@@ -2,11 +2,9 @@
 -- Aerial Blast
 -- Deals wind elemental damage to enemies within area of effect.
 ---------------------------------------------------
-
+require("scripts/globals/monstertpmoves")
 require("scripts/globals/settings")
 require("scripts/globals/status")
-require("scripts/globals/monstertpmoves")
-
 ---------------------------------------------------
 
 function onMobSkillCheck(target,mob,skill)
@@ -14,11 +12,9 @@ function onMobSkillCheck(target,mob,skill)
 end
 
 function onMobWeaponSkill(target, mob, skill)
-
     local dmgmod = 3
-    local info = MobMagicalMove(mob,target,skill,mob:getWeaponDmg() * 9,dsp.magic.ele.WIND,dmgmod,TP_NO_EFFECT,1)
-    local dmg = MobFinalAdjustments(info.dmg,mob,skill,target,dsp.attackType.MAGICAL,dsp.damageType.WIND,MOBPARAM_WIPE_SHADOWS)
+    local info = MobMagicalMove(mob, target, skill, mob:getWeaponDmg() * 9, dsp.magic.ele.WIND, dmgmod,TP_NO_EFFECT, 1)
+    local dmg = MobFinalAdjustments(info.dmg, mob, skill, target, dsp.attackType.MAGICAL, dsp.damageType.WIND,MOBPARAM_WIPE_SHADOWS)
     target:takeDamage(dmg, mob, dsp.attackType.MAGICAL, dsp.damageType.WIND)
     return dmg
-
 end

--- a/scripts/globals/mobskills/aerial_blast.lua
+++ b/scripts/globals/mobskills/aerial_blast.lua
@@ -16,9 +16,9 @@ end
 function onMobWeaponSkill(target, mob, skill)
 
     local dmgmod = 3
-    local info = MobMagicalMove(mob,target,skill,mob:getWeaponDmg() * 9,dsp.magic.ele.WIND,dmgmod,TP_MAB_BONUS,1)
-    local dmg = MobFinalAdjustments(info.dmg,mob,skill,target,dsp.attackType.MAGICAL,dsp.damageType.EARTH,MOBPARAM_WIPE_SHADOWS)
-    target:takeDamage(dmg, mob, dsp.attackType.MAGICAL, dsp.damageType.EARTH)
+    local info = MobMagicalMove(mob,target,skill,mob:getWeaponDmg() * 9,dsp.magic.ele.WIND,dmgmod,TP_NO_EFFECT,1)
+    local dmg = MobFinalAdjustments(info.dmg,mob,skill,target,dsp.attackType.MAGICAL,dsp.damageType.WIND,MOBPARAM_WIPE_SHADOWS)
+    target:takeDamage(dmg, mob, dsp.attackType.MAGICAL, dsp.damageType.WIND)
     return dmg
 
 end

--- a/scripts/globals/mobskills/diamond_dust.lua
+++ b/scripts/globals/mobskills/diamond_dust.lua
@@ -16,7 +16,7 @@ end
 function onMobWeaponSkill(target, mob, skill)
 
     local dmgmod = 3
-    local info = MobMagicalMove(mob,target,skill,mob:getWeaponDmg() * 9,dsp.magic.ele.ICE,dmgmod,TP_MAB_BONUS,1)
+    local info = MobMagicalMove(mob,target,skill,mob:getWeaponDmg() * 9,dsp.magic.ele.ICE,dmgmod,TP_NO_EFFECT,1)
     local dmg = MobFinalAdjustments(info.dmg,mob,skill,target,dsp.attackType.MAGICAL,dsp.damageType.ICE,MOBPARAM_WIPE_SHADOWS)
     target:takeDamage(dmg, mob, dsp.attackType.MAGICAL, dsp.damageType.ICE)
     return dmg

--- a/scripts/globals/mobskills/diamond_dust.lua
+++ b/scripts/globals/mobskills/diamond_dust.lua
@@ -2,11 +2,9 @@
 -- Diamond Dust
 -- Deals ice elemental damage to enemies within area of effect.
 ---------------------------------------------------
-
+require("scripts/globals/monstertpmoves")
 require("scripts/globals/settings")
 require("scripts/globals/status")
-require("scripts/globals/monstertpmoves")
-
 ---------------------------------------------------
 
 function onMobSkillCheck(target,mob,skill)
@@ -14,11 +12,9 @@ function onMobSkillCheck(target,mob,skill)
 end
 
 function onMobWeaponSkill(target, mob, skill)
-
     local dmgmod = 3
-    local info = MobMagicalMove(mob,target,skill,mob:getWeaponDmg() * 9,dsp.magic.ele.ICE,dmgmod,TP_NO_EFFECT,1)
-    local dmg = MobFinalAdjustments(info.dmg,mob,skill,target,dsp.attackType.MAGICAL,dsp.damageType.ICE,MOBPARAM_WIPE_SHADOWS)
+    local info = MobMagicalMove(mob, target, skill, mob:getWeaponDmg() * 9, dsp.magic.ele.ICE, dmgmod,TP_NO_EFFECT, 1)
+    local dmg = MobFinalAdjustments(info.dmg, mob, skill, target, dsp.attackType.MAGICAL, dsp.damageType.ICE, MOBPARAM_WIPE_SHADOWS)
     target:takeDamage(dmg, mob, dsp.attackType.MAGICAL, dsp.damageType.ICE)
     return dmg
-
 end

--- a/scripts/globals/mobskills/earthen_fury.lua
+++ b/scripts/globals/mobskills/earthen_fury.lua
@@ -13,9 +13,8 @@ end
 
 function onMobWeaponSkill(target, mob, skill)
     local dmgmod = 3
-    local info = MobMagicalMove(mob,target,skill,mob:getWeaponDmg() * 9,dsp.magic.ele.EARTH,dmgmod,TP_NO_EFFECT,1)
-    local dmg = MobFinalAdjustments(info.dmg,mob,skill,target,dsp.attackType.MAGICAL,dsp.damageType.EARTH,MOBPARAM_WIPE_SHADOWS)
-
+    local info = MobMagicalMove(mob, target, skill, mob:getWeaponDmg() * 9, dsp.magic.ele.EARTH, dmgmod,TP_NO_EFFECT, 1)
+    local dmg = MobFinalAdjustments(info.dmg, mob, skill, target, dsp.attackType.MAGICAL, dsp.damageType.EARTH, MOBPARAM_WIPE_SHADOWS)
     target:takeDamage(dmg, mob, dsp.attackType.MAGICAL, dsp.damageType.EARTH)
     return dmg
 end

--- a/scripts/globals/mobskills/earthen_fury.lua
+++ b/scripts/globals/mobskills/earthen_fury.lua
@@ -13,7 +13,7 @@ end
 
 function onMobWeaponSkill(target, mob, skill)
     local dmgmod = 3
-    local info = MobMagicalMove(mob,target,skill,mob:getWeaponDmg() * 9,dsp.magic.ele.EARTH,dmgmod,TP_MAB_BONUS,1)
+    local info = MobMagicalMove(mob,target,skill,mob:getWeaponDmg() * 9,dsp.magic.ele.EARTH,dmgmod,TP_NO_EFFECT,1)
     local dmg = MobFinalAdjustments(info.dmg,mob,skill,target,dsp.attackType.MAGICAL,dsp.damageType.EARTH,MOBPARAM_WIPE_SHADOWS)
 
     target:takeDamage(dmg, mob, dsp.attackType.MAGICAL, dsp.damageType.EARTH)

--- a/scripts/globals/mobskills/howling_moon.lua
+++ b/scripts/globals/mobskills/howling_moon.lua
@@ -1,12 +1,10 @@
 ---------------------------------------------------
 -- Howling Moon
--- Deals dark elemental damage to enemies within area of effect. (2H)
+-- Deals dark elemental damage to enemies within area of effect.
 ---------------------------------------------------
-
+require("scripts/globals/monstertpmoves")
 require("scripts/globals/settings")
 require("scripts/globals/status")
-require("scripts/globals/monstertpmoves")
-
 ---------------------------------------------------
 
 function onMobSkillCheck(target,mob,skill)
@@ -14,11 +12,9 @@ function onMobSkillCheck(target,mob,skill)
 end
 
 function onMobWeaponSkill(target, mob, skill)
-
     local dmgmod = 3
-    local info = MobMagicalMove(mob,target,skill,mob:getWeaponDmg() * 9,dsp.magic.ele.DARK,dmgmod,TP_NO_EFFECT,1)
-    local dmg = MobFinalAdjustments(info.dmg,mob,skill,target,dsp.attackType.MAGICAL,dsp.damageType.DARK,MOBPARAM_WIPE_SHADOWS)
+    local info = MobMagicalMove(mob, target, skill, mob:getWeaponDmg() * 9, dsp.magic.ele.DARK, dmgmod,TP_NO_EFFECT, 1)
+    local dmg = MobFinalAdjustments(info.dmg, mob, skill, target, dsp.attackType.MAGICAL, dsp.damageType.DARK, MOBPARAM_WIPE_SHADOWS)
     target:takeDamage(dmg, mob, dsp.attackType.MAGICAL, dsp.damageType.DARK)
     return dmg
-
 end

--- a/scripts/globals/mobskills/howling_moon.lua
+++ b/scripts/globals/mobskills/howling_moon.lua
@@ -16,7 +16,7 @@ end
 function onMobWeaponSkill(target, mob, skill)
 
     local dmgmod = 3
-    local info = MobMagicalMove(mob,target,skill,mob:getWeaponDmg() * 9,dsp.magic.ele.DARK,dmgmod,TP_MAB_BONUS,1)
+    local info = MobMagicalMove(mob,target,skill,mob:getWeaponDmg() * 9,dsp.magic.ele.DARK,dmgmod,TP_NO_EFFECT,1)
     local dmg = MobFinalAdjustments(info.dmg,mob,skill,target,dsp.attackType.MAGICAL,dsp.damageType.DARK,MOBPARAM_WIPE_SHADOWS)
     target:takeDamage(dmg, mob, dsp.attackType.MAGICAL, dsp.damageType.DARK)
     return dmg

--- a/scripts/globals/mobskills/inferno.lua
+++ b/scripts/globals/mobskills/inferno.lua
@@ -2,11 +2,9 @@
 -- Inferno
 -- Deals fire elemental damage to enemies within area of effect.
 ---------------------------------------------------
-
+require("scripts/globals/monstertpmoves")
 require("scripts/globals/settings")
 require("scripts/globals/status")
-require("scripts/globals/monstertpmoves")
-
 ---------------------------------------------------
 
 function onMobSkillCheck(target,mob,skill)
@@ -14,11 +12,9 @@ function onMobSkillCheck(target,mob,skill)
 end
 
 function onMobWeaponSkill(target, mob, skill)
-
     local dmgmod = 3
-    local info = MobMagicalMove(mob,target,skill,mob:getWeaponDmg() * 9,dsp.magic.ele.FIRE,dmgmod,TP_NO_EFFECT,1)
-    local dmg = MobFinalAdjustments(info.dmg,mob,skill,target,dsp.attackType.MAGICAL,dsp.damageType.FIRE,MOBPARAM_WIPE_SHADOWS)
+    local info = MobMagicalMove(mob, target, skill, mob:getWeaponDmg() * 9, dsp.magic.ele.FIRE, dmgmod,TP_NO_EFFECT, 1)
+    local dmg = MobFinalAdjustments(info.dmg, mob, skill, target, dsp.attackType.MAGICAL, dsp.damageType.FIRE, MOBPARAM_WIPE_SHADOWS)
     target:takeDamage(dmg, mob, dsp.attackType.MAGICAL, dsp.damageType.FIRE)
     return dmg
-
 end

--- a/scripts/globals/mobskills/inferno.lua
+++ b/scripts/globals/mobskills/inferno.lua
@@ -16,7 +16,7 @@ end
 function onMobWeaponSkill(target, mob, skill)
 
     local dmgmod = 3
-    local info = MobMagicalMove(mob,target,skill,mob:getWeaponDmg() * 9,dsp.magic.ele.FIRE,dmgmod,TP_MAB_BONUS,1)
+    local info = MobMagicalMove(mob,target,skill,mob:getWeaponDmg() * 9,dsp.magic.ele.FIRE,dmgmod,TP_NO_EFFECT,1)
     local dmg = MobFinalAdjustments(info.dmg,mob,skill,target,dsp.attackType.MAGICAL,dsp.damageType.FIRE,MOBPARAM_WIPE_SHADOWS)
     target:takeDamage(dmg, mob, dsp.attackType.MAGICAL, dsp.damageType.FIRE)
     return dmg

--- a/scripts/globals/mobskills/judgment_bolt.lua
+++ b/scripts/globals/mobskills/judgment_bolt.lua
@@ -16,7 +16,7 @@ end
 function onMobWeaponSkill(target, mob, skill)
 
     local dmgmod = 3
-    local info = MobMagicalMove(mob,target,skill,mob:getWeaponDmg() * 9,dsp.magic.ele.THUNDER,dmgmod,TP_MAB_BONUS,1)
+    local info = MobMagicalMove(mob,target,skill,mob:getWeaponDmg() * 9,dsp.magic.ele.THUNDER,dmgmod,TP_NO_EFFECT,1)
     local dmg = MobFinalAdjustments(info.dmg,mob,skill,target,dsp.attackType.MAGICAL,dsp.damageType.LIGHTNING,MOBPARAM_WIPE_SHADOWS)
     target:takeDamage(dmg, mob, dsp.attackType.MAGICAL, dsp.damageType.LIGHTNING)
     return dmg

--- a/scripts/globals/mobskills/judgment_bolt.lua
+++ b/scripts/globals/mobskills/judgment_bolt.lua
@@ -2,11 +2,9 @@
 -- Judgment Bolt
 -- Deals lightning elemental damage to enemies within area of effect.
 ---------------------------------------------------
-
+require("scripts/globals/monstertpmoves")
 require("scripts/globals/settings")
 require("scripts/globals/status")
-require("scripts/globals/monstertpmoves")
-
 ---------------------------------------------------
 
 function onMobSkillCheck(target,mob,skill)
@@ -14,11 +12,9 @@ function onMobSkillCheck(target,mob,skill)
 end
 
 function onMobWeaponSkill(target, mob, skill)
-
     local dmgmod = 3
-    local info = MobMagicalMove(mob,target,skill,mob:getWeaponDmg() * 9,dsp.magic.ele.THUNDER,dmgmod,TP_NO_EFFECT,1)
-    local dmg = MobFinalAdjustments(info.dmg,mob,skill,target,dsp.attackType.MAGICAL,dsp.damageType.LIGHTNING,MOBPARAM_WIPE_SHADOWS)
+    local info = MobMagicalMove(mob, target, skill, mob:getWeaponDmg() * 9, dsp.magic.ele.THUNDER, dmgmod,TP_NO_EFFECT, 1)
+    local dmg = MobFinalAdjustments(info.dmg, mob, skill, target, dsp.attackType.MAGICAL, dsp.damageType.LIGHTNING, MOBPARAM_WIPE_SHADOWS)
     target:takeDamage(dmg, mob, dsp.attackType.MAGICAL, dsp.damageType.LIGHTNING)
     return dmg
-
 end

--- a/scripts/globals/mobskills/searing_light.lua
+++ b/scripts/globals/mobskills/searing_light.lua
@@ -14,7 +14,7 @@ end
 function onMobWeaponSkill(target, mob, skill)
     local dmgmod = 3
     local info = MobMagicalMove(mob,target,skill,mob:getWeaponDmg() * 9,dsp.magic.ele.LIGHT,dmgmod,TP_NO_EFFECT,1)
-    local dmg = MobFinalAdjustments(info.dmg,mob,skill,target,dsp.attackType.MAGICAL,dsp.damageType.LIGHT,MOBPARAM_IGNORE_SHADOWS)
+    local dmg = MobFinalAdjustments(info.dmg,mob,skill,target,dsp.attackType.MAGICAL,dsp.damageType.LIGHT,MOBPARAM_WIPE_SHADOWS)
     target:takeDamage(dmg, mob, dsp.attackType.MAGICAL, dsp.damageType.LIGHT)
     return dmg
 end

--- a/scripts/globals/mobskills/searing_light.lua
+++ b/scripts/globals/mobskills/searing_light.lua
@@ -13,8 +13,8 @@ end
 
 function onMobWeaponSkill(target, mob, skill)
     local dmgmod = 3
-    local info = MobMagicalMove(mob,target,skill,mob:getWeaponDmg() * 9,dsp.magic.ele.LIGHT,dmgmod,TP_NO_EFFECT,1)
-    local dmg = MobFinalAdjustments(info.dmg,mob,skill,target,dsp.attackType.MAGICAL,dsp.damageType.LIGHT,MOBPARAM_WIPE_SHADOWS)
+    local info = MobMagicalMove(mob, target, skill, mob:getWeaponDmg() * 9, dsp.magic.ele.LIGHT, dmgmod,TP_NO_EFFECT, 1)
+    local dmg = MobFinalAdjustments(info.dmg, mob, skill, target, dsp.attackType.MAGICAL, dsp.damageType.LIGHT, MOBPARAM_WIPE_SHADOWS)
     target:takeDamage(dmg, mob, dsp.attackType.MAGICAL, dsp.damageType.LIGHT)
     return dmg
 end

--- a/scripts/globals/mobskills/tidal_wave.lua
+++ b/scripts/globals/mobskills/tidal_wave.lua
@@ -2,11 +2,9 @@
 -- Tidal Wave
 -- Deals water elemental damage to enemies within area of effect.
 ---------------------------------------------------
-
+require("scripts/globals/monstertpmoves")
 require("scripts/globals/settings")
 require("scripts/globals/status")
-require("scripts/globals/monstertpmoves")
-
 ---------------------------------------------------
 
 function onMobSkillCheck(target,mob,skill)
@@ -14,11 +12,9 @@ function onMobSkillCheck(target,mob,skill)
 end
 
 function onMobWeaponSkill(target, mob, skill)
-
     dmgmod = 3
-    info = MobMagicalMove(mob,target,skill,mob:getWeaponDmg() * 9,dsp.magic.ele.WATER,dmgmod,TP_NO_EFFECT,1)
-    dmg = MobFinalAdjustments(info.dmg,mob,skill,target,dsp.attackType.MAGICAL,dsp.damageType.WATER,MOBPARAM_WIPE_SHADOWS)
+    info = MobMagicalMove(mob, target, skill, mob:getWeaponDmg() * 9, dsp.magic.ele.WATER, dmgmod,TP_NO_EFFECT, 1)
+    dmg = MobFinalAdjustments(info.dmg, mob, skill, target, dsp.attackType.MAGICAL, dsp.damageType.WATER, MOBPARAM_WIPE_SHADOWS)
     target:takeDamage(dmg, mob, dsp.attackType.MAGICAL, dsp.damageType.WATER)
     return dmg
-
 end

--- a/scripts/globals/mobskills/tidal_wave.lua
+++ b/scripts/globals/mobskills/tidal_wave.lua
@@ -17,7 +17,7 @@ function onMobWeaponSkill(target, mob, skill)
 
     dmgmod = 3
     info = MobMagicalMove(mob,target,skill,mob:getWeaponDmg() * 9,dsp.magic.ele.WATER,dmgmod,TP_NO_EFFECT,1)
-    dmg = MobFinalAdjustments(info.dmg,mob,skill,target,dsp.attackType.MAGICAL,dsp.damageType.WATER,MOBPARAM_IGNORE_SHADOWS)
+    dmg = MobFinalAdjustments(info.dmg,mob,skill,target,dsp.attackType.MAGICAL,dsp.damageType.WATER,MOBPARAM_WIPE_SHADOWS)
     target:takeDamage(dmg, mob, dsp.attackType.MAGICAL, dsp.damageType.WATER)
     return dmg
 


### PR DESCRIPTION
1. Set consistent `TP_NO_EFFECT`.
2. Set consistent `MOBPARAM_WIPE_SHADOWS`.
3. Fix Garuda Element from `EARTH` to `WIND`.
4. General formatting fix for style guide and consistency.

For TP effect see https://ffxiclopedia.fandom.com/wiki/Astral_Flow. Wipe shadows is same as all AOE magical moves.