### PR TITLE
Update Skulker's Cape bonus effect

### DIFF
--- a/scripts/globals/spells/invisible.lua
+++ b/scripts/globals/spells/invisible.lua
@@ -16,9 +16,11 @@ end
 function onSpellCast(caster, target, spell)
     if not target:hasStatusEffect(dsp.effect.INVISIBLE) then
 
-        local duration = calculateDuration(math.random(42, 54) * 10, spell:getSkillType(), spell:getSpellGroup(), caster, target)
+        local duration = calculateDuration(math.random(420, 540), spell:getSkillType(), spell:getSpellGroup(), caster, target)
 
-        duration = calculateDurationForLvl(duration, 25, target:getMainLvl()) + player:getMod(dsp.mod.INVISIBLE_DURATION)
+		duration = duration + target:getMod(dsp.mod.INVISIBLE_DURATION)
+		
+        duration = calculateDurationForLvl(duration, 20, target:getMainLvl())
 
         spell:setMsg(dsp.msg.basic.MAGIC_GAIN_EFFECT)
         target:addStatusEffect(dsp.effect.INVISIBLE, 0, 10, math.floor(duration * SNEAK_INVIS_DURATION_MULTIPLIER))

--- a/scripts/globals/spells/invisible.lua
+++ b/scripts/globals/spells/invisible.lua
@@ -18,8 +18,8 @@ function onSpellCast(caster, target, spell)
 
         local duration = calculateDuration(math.random(420, 540), spell:getSkillType(), spell:getSpellGroup(), caster, target)
 
-		duration = duration + target:getMod(dsp.mod.INVISIBLE_DURATION)
-		
+        duration = duration + target:getMod(dsp.mod.INVISIBLE_DURATION)
+	
         duration = calculateDurationForLvl(duration, 20, target:getMainLvl())
 
         spell:setMsg(dsp.msg.basic.MAGIC_GAIN_EFFECT)

--- a/scripts/globals/spells/invisible.lua
+++ b/scripts/globals/spells/invisible.lua
@@ -21,7 +21,7 @@ function onSpellCast(caster, target, spell)
 
         -- FIXME: Create mod and use that instead of an itemID check
         if (target:getEquipID(dsp.slot.BACK) == 13692) then -- skulker's cape
-            duration = duration * 1.5
+            duration = duration + 30
         end
 
         spell:setMsg(dsp.msg.basic.MAGIC_GAIN_EFFECT)

--- a/scripts/globals/spells/invisible.lua
+++ b/scripts/globals/spells/invisible.lua
@@ -1,12 +1,13 @@
 -----------------------------------------
 -- Spell: Invisible
 -- Lessens chance of being detected by sight.
--- Duration is random number between 30 seconds and 5 minutes
+-- Duration is random number between 30 seconds and 5 minutes.
 -----------------------------------------
 require("scripts/globals/magic")
 require("scripts/globals/msg")
 require("scripts/globals/settings")
 require("scripts/globals/status")
+-----------------------------------------
 
 function onMagicCastingCheck(caster, target, spell)
     return 0
@@ -15,19 +16,14 @@ end
 function onSpellCast(caster, target, spell)
     if not target:hasStatusEffect(dsp.effect.INVISIBLE) then
 
-        -- last 7-9 minutes
-        local duration = calculateDuration(math.random(420, 540), spell:getSkillType(), spell:getSpellGroup(), caster, target)
-        duration = calculateDurationForLvl(duration, 25, target:getMainLvl())
+        local duration = calculateDuration(math.random(42, 54) * 10, spell:getSkillType(), spell:getSpellGroup(), caster, target)
 
-        -- FIXME: Create mod and use that instead of an itemID check
-        if (target:getEquipID(dsp.slot.BACK) == 13692) then -- skulker's cape
-            duration = duration + 30
-        end
+        duration = calculateDurationForLvl(duration, 25, target:getMainLvl()) + player:getMod(dsp.mod.INVISIBLE_DURATION)
 
         spell:setMsg(dsp.msg.basic.MAGIC_GAIN_EFFECT)
         target:addStatusEffect(dsp.effect.INVISIBLE, 0, 10, math.floor(duration * SNEAK_INVIS_DURATION_MULTIPLIER))
     else
-        spell:setMsg(dsp.msg.basic.MAGIC_NO_EFFECT) -- no dsp.effect.
+        spell:setMsg(dsp.msg.basic.MAGIC_NO_EFFECT)
     end
 
     return dsp.effect.INVISIBLE

--- a/scripts/globals/spells/sneak.lua
+++ b/scripts/globals/spells/sneak.lua
@@ -1,33 +1,29 @@
 -----------------------------------------
 -- Spell: Sneak
--- Lessens chance of being detected by sound
--- Duration is random number between 30 seconds and 5 minutes
+-- Lessens chance of being detected by sound.
+-- Duration is random number between 30 seconds and 5 minutes.
 -----------------------------------------
 require("scripts/globals/magic")
 require("scripts/globals/msg")
 require("scripts/globals/settings")
 require("scripts/globals/status")
+-----------------------------------------
 
-function onMagicCastingCheck(caster,target,spell)
+function onMagicCastingCheck(caster, target, spell)
     return 0
 end
 
-function onSpellCast(caster,target,spell)
-    if (not target:hasStatusEffect(dsp.effect.SNEAK)) then
+function onSpellCast(caster, target, spell)
+    if not target:hasStatusEffect(dsp.effect.SNEAK) then
 
-        -- last 7-9 minutes
-        local duration = calculateDuration(math.random(420, 540), spell:getSkillType(), spell:getSpellGroup(), caster, target)
-        duration = calculateDurationForLvl(duration, 20, target:getMainLvl())
+        local duration = calculateDuration(math.random(42, 54) * 10, spell:getSkillType(), spell:getSpellGroup(), caster, target)
 
-        -- FIXME: Create mod and use that instead of an itemID check
-        if (target:getEquipID(dsp.slot.BACK) == 13692) then -- skulker's cape
-            duration = duration + 30
-        end
+        duration = calculateDurationForLvl(duration, 20, target:getMainLvl()) + player:getMod(dsp.mod.SNEAK_DURATION)
         
         spell:setMsg(dsp.msg.basic.MAGIC_GAIN_EFFECT)
         target:addStatusEffect(dsp.effect.SNEAK, 0, 10, math.floor(duration * SNEAK_INVIS_DURATION_MULTIPLIER))
     else
-        spell:setMsg(dsp.msg.basic.MAGIC_NO_EFFECT) -- no dsp.effect.
+        spell:setMsg(dsp.msg.basic.MAGIC_NO_EFFECT)
     end
 
     return dsp.effect.SNEAK

--- a/scripts/globals/spells/sneak.lua
+++ b/scripts/globals/spells/sneak.lua
@@ -16,9 +16,11 @@ end
 function onSpellCast(caster, target, spell)
     if not target:hasStatusEffect(dsp.effect.SNEAK) then
 
-        local duration = calculateDuration(math.random(42, 54) * 10, spell:getSkillType(), spell:getSpellGroup(), caster, target)
+        local duration = calculateDuration(math.random(420, 540), spell:getSkillType(), spell:getSpellGroup(), caster, target)
 
-        duration = calculateDurationForLvl(duration, 20, target:getMainLvl()) + player:getMod(dsp.mod.SNEAK_DURATION)
+        duration = duration + target:getMod(dsp.mod.SNEAK_DURATION)
+		
+        duration = calculateDurationForLvl(duration, 20, target:getMainLvl())
         
         spell:setMsg(dsp.msg.basic.MAGIC_GAIN_EFFECT)
         target:addStatusEffect(dsp.effect.SNEAK, 0, 10, math.floor(duration * SNEAK_INVIS_DURATION_MULTIPLIER))

--- a/scripts/globals/spells/sneak.lua
+++ b/scripts/globals/spells/sneak.lua
@@ -21,7 +21,7 @@ function onSpellCast(caster,target,spell)
 
         -- FIXME: Create mod and use that instead of an itemID check
         if (target:getEquipID(dsp.slot.BACK) == 13692) then -- skulker's cape
-            duration = duration * 1.5
+            duration = duration + 30
         end
         
         spell:setMsg(dsp.msg.basic.MAGIC_GAIN_EFFECT)

--- a/scripts/globals/status.lua
+++ b/scripts/globals/status.lua
@@ -1523,12 +1523,14 @@ dsp.mod =
     FENCER_TP_BONUS                 = 903, -- TP Bonus to weapon skills from Fencer Trait
     FENCER_CRITHITRATE              = 904, -- Increased Crit chance from Fencer Trait
     SHIELD_DEF_BONUS                = 905, -- Shield Defense Bonus
+    SNEAK_DURATION                  = 946, -- Additional duration in seconds 
+    INVISIBLE_DURATION              = 947, -- Additional duration in seconds
 
     -- The spares take care of finding the next ID to use so long as we don't forget to list IDs that have been freed up by refactoring.
     -- 570 - 825 used by WS DMG mods these are not spares.
-    -- SPARE = 944, -- stuff
-    -- SPARE = 945, -- stuff
-    -- SPARE = 946, -- stuff
+    -- SPARE = 948, -- stuff
+    -- SPARE = 949, -- stuff
+    -- SPARE = 950, -- stuff
 };
 
 dsp.latent =

--- a/sql/item_mods.sql
+++ b/sql/item_mods.sql
@@ -11118,7 +11118,9 @@ INSERT INTO `item_mods` VALUES (13690,8,3);
 INSERT INTO `item_mods` VALUES (13690,23,15);
 INSERT INTO `item_mods` VALUES (13691,1,12);
 INSERT INTO `item_mods` VALUES (13691,10,4);
-INSERT INTO `item_mods` VALUES (13692,1,4);
+INSERT INTO `item_mods` VALUES (13692,1,4);       -- Skulker's Cape: DEF 4
+INSERT INTO `item_mods` VALUES (13692,946,30);    -- Sneak duration +30
+INSERT INTO `item_mods` VALUES (13692,947,30);    -- Invisible duration +30 
 INSERT INTO `item_mods` VALUES (13693,1,6);
 INSERT INTO `item_mods` VALUES (13694,1,6);
 INSERT INTO `item_mods` VALUES (13694,23,12);

--- a/src/map/modifier.h
+++ b/src/map/modifier.h
@@ -578,6 +578,8 @@ enum class Mod
     ADDS_WEAPONSKILL_DYN      = 356, // In Dynamis
 
     STEALTH                   = 358, //
+    SNEAK_DURATION            = 946, // Additional duration in seconds 
+    INVISIBLE_DURATION        = 947, // Additional duration in seconds
 
     MAIN_DMG_RATING           = 366, // adds damage rating to main hand weapon (maneater/blau dolch etc hidden effects)
     SUB_DMG_RATING            = 367, // adds damage rating to off hand weapon
@@ -772,9 +774,9 @@ enum class Mod
 
     // The spares take care of finding the next ID to use so long as we don't forget to list IDs that have been freed up by refactoring.
     // 570 through 825 used by WS DMG mods these are not spares.
-    // SPARE = 946, // stuff
-    // SPARE = 947, // stuff
     // SPARE = 948, // stuff
+    // SPARE = 949, // stuff
+    // SPARE = 950, // stuff
 };
 
 //temporary workaround for using enum class as unordered_map key until compilers support it


### PR DESCRIPTION
Previously estimated as 1.5x from BGwiki. This was also the case on wiki *(with a verification needed tag)* until [27 March 2018](https://ffxiclopedia.fandom.com/wiki/Skulker%27s_Cape?oldid=1651833) when it was updated to +30 seconds and the tag removed. The entry on BG wiki [hasn't been updated since 2016](https://www.bg-wiki.com/index.php?title=Skulker%27s_Cape&action=history) so I suspect is using the old estimate from wiki.

Also: yes I saw the comment on making a mod, will look into that once the bonus is agreed on 👍 