### PR TITLE
Update Cure V enmity cap

### DIFF
--- a/scripts/globals/spells/cure_v.lua
+++ b/scripts/globals/spells/cure_v.lua
@@ -97,7 +97,7 @@ function onSpellCast(caster,target,spell)
         target:addHP(final)
 
         target:wakeUp()
-        caster:updateEnmityFromCure(target,final)
+        caster:updateEnmityFromCure(target, 180)
     else
         if (target:isUndead()) then -- e.g. PCs healing skeles for damage (?)
             spell:setMsg(dsp.msg.basic.MAGIC_DMG)

--- a/scripts/globals/spells/cure_v.lua
+++ b/scripts/globals/spells/cure_v.lua
@@ -97,7 +97,7 @@ function onSpellCast(caster,target,spell)
         target:addHP(final)
 
         target:wakeUp()
-        caster:updateEnmityFromCure(target, 180)
+        caster:updateEnmityFromCure(target, 65535)
     else
         if (target:isUndead()) then -- e.g. PCs healing skeles for damage (?)
             spell:setMsg(dsp.msg.basic.MAGIC_DMG)


### PR DESCRIPTION
Cure V currently giving full cure enmity on DSP but should give about the same enmity as Cure III (see: https://ffxiclopedia.fandom.com/wiki/Cure_V).

Updated the enmity to the Cure III cap of ~180 (see: https://ffxiclopedia.fandom.com/wiki/Cure_III)