### PR TITLE
Increase critical damage cap

### DIFF
--- a/src/map/utils/battleutils.cpp
+++ b/src/map/utils/battleutils.cpp
@@ -2329,7 +2329,7 @@ namespace battleutils
 
         if (PAttacker->objtype == TYPE_PC)
         {
-            ratioCap = 2.25f;
+            ratioCap = isCritical ? 3 : 2.25f;
         }
         if (PAttacker->objtype == TYPE_MOB)
         {


### PR DESCRIPTION
The cap for critical damage is currently the same as the cap for normal damage - for critical hits the cap for the multiplier should be 3 (see: https://ffxiclopedia.fandom.com/wiki/Level_Correction_Function_and_pDIF)