### PR TITLE
Fix a missed mission ID for San d'Oria

### DIFF
--- a/scripts/globals/missions.lua
+++ b/scripts/globals/missions.lua
@@ -897,7 +897,7 @@ function getMissionMask(player)
             if (player:hasCompletedMission(SANDORIA,dsp.mission.id.sandoria.THE_RUINS_OF_FEI_YIN) == false and player:hasKeyItem(dsp.ki.MESSAGE_TO_JEUNO_SANDORIA) == false) then
                 first_mission = first_mission + 16384;
             end
-            if (player:hasCompletedMission(SANDORIA,dsp.mission.id.sandoria.THE_SHADOW_LORD) == false and player:hasCompletedMission(SANDORIA,THE_RUINS_OF_FEI_YIN) and getMissionRankPoints(player,15) == 1) then
+            if (player:hasCompletedMission(SANDORIA,dsp.mission.id.sandoria.THE_SHADOW_LORD) == false and player:hasCompletedMission(SANDORIA,dsp.mission.id.sandoria.THE_RUINS_OF_FEI_YIN) and getMissionRankPoints(player,15) == 1) then
                 -- 5-2
                 first_mission = first_mission + 32768;
             end


### PR DESCRIPTION
```
DanteMccloud: Side note... is anyone aware of an R0 issue when trying to pick up 
mission 5-2 in sandy from Endracion? I’m on the most recent master build for 
DSP and most recent game client but we all R0 trying to pickup that quest from him.
ibm2431: Is DSP Game saying anything?
ibm2431: (I have rechecked him, and do not believe table is at fault.)
ibm2431: Hold
ibm2431: Sorry for crashing your server.
```