### PR TITLE
Add Latents for Berserk for Conqueror 75 -> 119v3

### DIFF
--- a/scripts/globals/abilities/berserk.lua
+++ b/scripts/globals/abilities/berserk.lua
@@ -14,7 +14,7 @@ function onAbilityCheck(player,target,ability)
 end
 
 function onUseAbility(player,target,ability)
-    player:addStatusEffect(dsp.effect.BERSERK,1,0,180)
+    player:addStatusEffect(dsp.effect.BERSERK,player:getMod(dsp.mod.BERSERK_EFFECT),0,180)
 
     return dsp.effect.BERSERK
 end

--- a/scripts/globals/abilities/berserk.lua
+++ b/scripts/globals/abilities/berserk.lua
@@ -14,7 +14,7 @@ function onAbilityCheck(player,target,ability)
 end
 
 function onUseAbility(player,target,ability)
-    player:addStatusEffect(dsp.effect.BERSERK,player:getMod(dsp.mod.BERSERK_EFFECT),0,180)
+    player:addStatusEffect(dsp.effect.BERSERK,25 + player:getMod(dsp.mod.BERSERK_EFFECT),0,180)
 
     return dsp.effect.BERSERK
 end

--- a/scripts/globals/effects/berserk.lua
+++ b/scripts/globals/effects/berserk.lua
@@ -7,16 +7,16 @@ require("scripts/globals/status")
 -----------------------------------
 
 function onEffectGain(target,effect)
-    target:addMod(dsp.mod.ATTP, 25 + effect:getPower())
-    target:addMod(dsp.mod.RATTP, 25 + effect:getPower())
-    target:addMod(dsp.mod.DEFP, -25 - effect:getPower())
+    target:addMod(dsp.mod.ATTP, effect:getPower())
+    target:addMod(dsp.mod.RATTP, effect:getPower())
+    target:addMod(dsp.mod.DEFP, - effect:getPower())
 end
 
 function onEffectTick(target,effect)
 end
 
 function onEffectLose(target,effect)
-    target:delMod(dsp.mod.ATTP, 25 + effect:getPower())
-    target:delMod(dsp.mod.RATTP, 25 + effect:getPower())
-    target:delMod(dsp.mod.DEFP, -25 - effect:getPower())
+    target:delMod(dsp.mod.ATTP, effect:getPower())
+    target:delMod(dsp.mod.RATTP, effect:getPower())
+    target:delMod(dsp.mod.DEFP, - effect:getPower())
 end

--- a/scripts/globals/effects/berserk.lua
+++ b/scripts/globals/effects/berserk.lua
@@ -7,16 +7,18 @@ require("scripts/globals/status")
 -----------------------------------
 
 function onEffectGain(target,effect)
-    target:addMod(dsp.mod.ATTP, effect:getPower())
-    target:addMod(dsp.mod.RATTP, effect:getPower())
-    target:addMod(dsp.mod.DEFP, - effect:getPower())
+    local power = effect:getPower()
+    target:addMod(dsp.mod.ATTP, power)
+    target:addMod(dsp.mod.RATTP, power)
+    target:addMod(dsp.mod.DEFP, -power)
 end
 
 function onEffectTick(target,effect)
 end
 
 function onEffectLose(target,effect)
-    target:delMod(dsp.mod.ATTP, effect:getPower())
-    target:delMod(dsp.mod.RATTP, effect:getPower())
-    target:delMod(dsp.mod.DEFP, - effect:getPower())
+    local power = effect:getPower()
+    target:delMod(dsp.mod.ATTP, power)
+    target:delMod(dsp.mod.RATTP, power)
+    target:delMod(dsp.mod.DEFP, -power)
 end

--- a/scripts/globals/effects/berserk.lua
+++ b/scripts/globals/effects/berserk.lua
@@ -7,16 +7,16 @@ require("scripts/globals/status")
 -----------------------------------
 
 function onEffectGain(target,effect)
-    target:addMod(dsp.mod.ATTP,25)
-    target:addMod(dsp.mod.RATTP, 25)
-    target:addMod(dsp.mod.DEFP,-25)
+    target:addMod(dsp.mod.ATTP, 25 + effect:getPower())
+    target:addMod(dsp.mod.RATTP, 25 + effect:getPower())
+    target:addMod(dsp.mod.DEFP, -25 - effect:getPower())
 end
 
 function onEffectTick(target,effect)
 end
 
 function onEffectLose(target,effect)
-    target:delMod(dsp.mod.ATTP,25)
-    target:delMod(dsp.mod.DEFP,-25)
-    target:delMod(dsp.mod.RATTP, 25)
+    target:delMod(dsp.mod.ATTP, 25 + effect:getPower())
+    target:delMod(dsp.mod.RATTP, 25 + effect:getPower())
+    target:delMod(dsp.mod.DEFP, -25 - effect:getPower())
 end

--- a/scripts/globals/status.lua
+++ b/scripts/globals/status.lua
@@ -1525,12 +1525,13 @@ dsp.mod =
     SHIELD_DEF_BONUS                = 905, -- Shield Defense Bonus
     SNEAK_DURATION                  = 946, -- Additional duration in seconds 
     INVISIBLE_DURATION              = 947, -- Additional duration in seconds
+    BERSERK_EFFECT                  = 948, -- Conqueror Berserk Effect
 
     -- The spares take care of finding the next ID to use so long as we don't forget to list IDs that have been freed up by refactoring.
     -- 570 - 825 used by WS DMG mods these are not spares.
-    -- SPARE = 948, -- stuff
     -- SPARE = 949, -- stuff
     -- SPARE = 950, -- stuff
+    -- SPARE = 951, -- stuff
 };
 
 dsp.latent =

--- a/sql/item_latents.sql
+++ b/sql/item_latents.sql
@@ -3235,3 +3235,56 @@ INSERT INTO `item_latents` VALUES(21661, 405, 3, 10, 0);      -- Rune Algol: Dra
 -- INSERT INTO `item_latents` VALUES(21667, 30, 10, ??, 0); -- Futhark Claymore: (D): Magic Accuracy+10
 -- INSERT INTO `item_latents` VALUES(21668, 25, 10, ??, 0); -- Peord Claymore: (D): Accuracy+10
 -- INSERT INTO `item_latents` VALUES(21668, 30, 10, ??, 0); -- Peord Claymore: (D): Magic Accuracy+10
+
+-- -------------------------------------------------------
+-- Conqueror Enhances Berserk I - V
+-- -------------------------------------------------------
+INSERT INTO `item_latents` VALUES(18991,62,5,13,56);   -- Conqueror 75 Attack +5% if Berserk Active
+INSERT INTO `item_latents` VALUES(18991,63,-5,13,56);  -- DEF -5% if Berserk Active
+INSERT INTO `item_latents` VALUES(18991,165,5,13,56);  -- Crit Rate +5% if Berserk Active
+INSERT INTO `item_latents` VALUES(18991,288,5,13,56);  -- Double Attack +5% if Berserk Active
+
+INSERT INTO `item_latents` VALUES(19060,62,6,13,56);   -- Conqueror 80 Attack +6% if Berserk Active
+INSERT INTO `item_latents` VALUES(19060,63,-6,13,56);  -- DEF -6% if Berserk Active
+INSERT INTO `item_latents` VALUES(19060,165,7,13,56);  -- Crit Rate +7% if Berserk Active
+INSERT INTO `item_latents` VALUES(19060,288,5,13,56);  -- Double Attack +5% if Berserk Active
+
+INSERT INTO `item_latents` VALUES(19080,62,7,13,56);   -- Conqueror 85 Attack +7% if Berserk Active
+INSERT INTO `item_latents` VALUES(19080,63,-7,13,56);  -- DEF -7% if Berserk Active
+INSERT INTO `item_latents` VALUES(19080,165,9,13,56);  -- Crit Rate +9% if Berserk Active
+INSERT INTO `item_latents` VALUES(19080,288,5,13,56);  -- Double Attack +5% if Berserk Active
+
+INSERT INTO `item_latents` VALUES(19612,62,8,13,56);   -- Conqueror 90 Attack +8% if Berserk Active
+INSERT INTO `item_latents` VALUES(19612,63,-8,13,56);  -- DEF -8% if Berserk Active
+INSERT INTO `item_latents` VALUES(19612,165,11,13,56); -- Crit Rate +11% if Berserk Active
+INSERT INTO `item_latents` VALUES(19612,288,5,13,56);  -- Double Attack +5% if Berserk Active
+
+INSERT INTO `item_latents` VALUES(19710,62,8,13,56);   -- Conqueror 95 Attack +8% if Berserk Active
+INSERT INTO `item_latents` VALUES(19710,63,-8,13,56);  -- DEF -8% if Berserk Active
+INSERT INTO `item_latents` VALUES(19710,165,11,13,56); -- Crit Rate +11% if Berserk Active
+INSERT INTO `item_latents` VALUES(19710,288,5,13,56);  -- Double Attack +5% if Berserk Active
+
+INSERT INTO `item_latents` VALUES(19819,62,8,13,56);   -- Conqueror 99 Attack +8% if Berserk Active
+INSERT INTO `item_latents` VALUES(19819,63,-8,13,56);  -- DEF -8% if Berserk Active
+INSERT INTO `item_latents` VALUES(19819,165,14,13,56); -- Crit Rate +14% if Berserk Active
+INSERT INTO `item_latents` VALUES(19819,288,5,13,56);  -- Double Attack +5% if Berserk Active
+
+INSERT INTO `item_latents` VALUES(19948,62,8,13,56);   -- Conqueror AG 99 Attack +8% if Berserk Active
+INSERT INTO `item_latents` VALUES(19948,63,-8,13,56);  -- DEF -8% if Berserk Active
+INSERT INTO `item_latents` VALUES(19948,165,14,13,56); -- Crit Rate +14% if Berserk Active
+INSERT INTO `item_latents` VALUES(19948,288,5,13,56);  -- Double Attack +5% if Berserk Active
+
+INSERT INTO `item_latents` VALUES(20837,62,8,13,56);   -- Conqueror 119 Attack +8% if Berserk Active
+INSERT INTO `item_latents` VALUES(20837,63,-8,13,56);  -- DEF -8% if Berserk Active
+INSERT INTO `item_latents` VALUES(20837,165,14,13,56); -- Crit Rate +14% if Berserk Active
+INSERT INTO `item_latents` VALUES(20837,288,5,13,56);  -- Double Attack +5% if Berserk Active
+
+INSERT INTO `item_latents` VALUES(20838,62,8,13,56);   -- Conqueror AG 119 v2 Attack +8% if Berserk Active
+INSERT INTO `item_latents` VALUES(20838,63,-8,13,56);  -- DEF -8% if Berserk Active
+INSERT INTO `item_latents` VALUES(20838,165,14,13,56); -- Crit Rate +14% if Berserk Active
+INSERT INTO `item_latents` VALUES(20838,288,5,13,56);  -- Double Attack +5% if Berserk Active
+
+INSERT INTO `item_latents` VALUES(21757,62,8,13,56);   -- Conqueror AG 119 v3 Attack +8% if Berserk Active
+INSERT INTO `item_latents` VALUES(21757,63,-8,13,56);  -- DEF -8% if Berserk Active
+INSERT INTO `item_latents` VALUES(21757,165,14,13,56); -- Crit Rate +14% if Berserk Active
+INSERT INTO `item_latents` VALUES(21757,288,5,13,56);  -- Double Attack +5% if Berserk Active

--- a/sql/item_latents.sql
+++ b/sql/item_latents.sql
@@ -3239,52 +3239,42 @@ INSERT INTO `item_latents` VALUES(21661, 405, 3, 10, 0);      -- Rune Algol: Dra
 -- -------------------------------------------------------
 -- Conqueror Enhances Berserk I - V
 -- -------------------------------------------------------
-INSERT INTO `item_latents` VALUES(18991,62,5,13,56);   -- Conqueror 75 Attack +5% if Berserk Active
-INSERT INTO `item_latents` VALUES(18991,63,-5,13,56);  -- DEF -5% if Berserk Active
+-- Conqueror 75 
 INSERT INTO `item_latents` VALUES(18991,165,5,13,56);  -- Crit Rate +5% if Berserk Active
-INSERT INTO `item_latents` VALUES(18991,288,5,13,56);  -- Double Attack +5% if Berserk Active
+INSERT INTO `item_latents` VALUES(18991,288,3,13,56);  -- Double Attack +3% if Berserk Active
 
-INSERT INTO `item_latents` VALUES(19060,62,6,13,56);   -- Conqueror 80 Attack +6% if Berserk Active
-INSERT INTO `item_latents` VALUES(19060,63,-6,13,56);  -- DEF -6% if Berserk Active
+-- Conqueror 80
 INSERT INTO `item_latents` VALUES(19060,165,7,13,56);  -- Crit Rate +7% if Berserk Active
-INSERT INTO `item_latents` VALUES(19060,288,5,13,56);  -- Double Attack +5% if Berserk Active
+INSERT INTO `item_latents` VALUES(19060,288,3,13,56);  -- Double Attack +3% if Berserk Active
 
-INSERT INTO `item_latents` VALUES(19080,62,7,13,56);   -- Conqueror 85 Attack +7% if Berserk Active
-INSERT INTO `item_latents` VALUES(19080,63,-7,13,56);  -- DEF -7% if Berserk Active
+-- Conqueror 85
 INSERT INTO `item_latents` VALUES(19080,165,9,13,56);  -- Crit Rate +9% if Berserk Active
-INSERT INTO `item_latents` VALUES(19080,288,5,13,56);  -- Double Attack +5% if Berserk Active
+INSERT INTO `item_latents` VALUES(19080,288,3,13,56);  -- Double Attack +3% if Berserk Active
 
-INSERT INTO `item_latents` VALUES(19612,62,8,13,56);   -- Conqueror 90 Attack +8% if Berserk Active
-INSERT INTO `item_latents` VALUES(19612,63,-8,13,56);  -- DEF -8% if Berserk Active
+-- Conqueror 90
 INSERT INTO `item_latents` VALUES(19612,165,11,13,56); -- Crit Rate +11% if Berserk Active
-INSERT INTO `item_latents` VALUES(19612,288,5,13,56);  -- Double Attack +5% if Berserk Active
+INSERT INTO `item_latents` VALUES(19612,288,3,13,56);  -- Double Attack +3% if Berserk Active
 
-INSERT INTO `item_latents` VALUES(19710,62,8,13,56);   -- Conqueror 95 Attack +8% if Berserk Active
-INSERT INTO `item_latents` VALUES(19710,63,-8,13,56);  -- DEF -8% if Berserk Active
+-- Conqueror 95
 INSERT INTO `item_latents` VALUES(19710,165,11,13,56); -- Crit Rate +11% if Berserk Active
-INSERT INTO `item_latents` VALUES(19710,288,5,13,56);  -- Double Attack +5% if Berserk Active
+INSERT INTO `item_latents` VALUES(19710,288,3,13,56);  -- Double Attack +3% if Berserk Active
 
-INSERT INTO `item_latents` VALUES(19819,62,8,13,56);   -- Conqueror 99 Attack +8% if Berserk Active
-INSERT INTO `item_latents` VALUES(19819,63,-8,13,56);  -- DEF -8% if Berserk Active
+-- Conqueror 99
 INSERT INTO `item_latents` VALUES(19819,165,14,13,56); -- Crit Rate +14% if Berserk Active
-INSERT INTO `item_latents` VALUES(19819,288,5,13,56);  -- Double Attack +5% if Berserk Active
+INSERT INTO `item_latents` VALUES(19819,288,3,13,56);  -- Double Attack +3% if Berserk Active
 
-INSERT INTO `item_latents` VALUES(19948,62,8,13,56);   -- Conqueror AG 99 Attack +8% if Berserk Active
-INSERT INTO `item_latents` VALUES(19948,63,-8,13,56);  -- DEF -8% if Berserk Active
+-- Conqueror 99 AG
 INSERT INTO `item_latents` VALUES(19948,165,14,13,56); -- Crit Rate +14% if Berserk Active
-INSERT INTO `item_latents` VALUES(19948,288,5,13,56);  -- Double Attack +5% if Berserk Active
+INSERT INTO `item_latents` VALUES(19948,288,3,13,56);  -- Double Attack +3% if Berserk Active
 
-INSERT INTO `item_latents` VALUES(20837,62,8,13,56);   -- Conqueror 119 Attack +8% if Berserk Active
-INSERT INTO `item_latents` VALUES(20837,63,-8,13,56);  -- DEF -8% if Berserk Active
+-- Conqueror 119
 INSERT INTO `item_latents` VALUES(20837,165,14,13,56); -- Crit Rate +14% if Berserk Active
-INSERT INTO `item_latents` VALUES(20837,288,5,13,56);  -- Double Attack +5% if Berserk Active
+INSERT INTO `item_latents` VALUES(20837,288,3,13,56);  -- Double Attack +3% if Berserk Active
 
-INSERT INTO `item_latents` VALUES(20838,62,8,13,56);   -- Conqueror AG 119 v2 Attack +8% if Berserk Active
-INSERT INTO `item_latents` VALUES(20838,63,-8,13,56);  -- DEF -8% if Berserk Active
+-- Conqueror 119 AG
 INSERT INTO `item_latents` VALUES(20838,165,14,13,56); -- Crit Rate +14% if Berserk Active
-INSERT INTO `item_latents` VALUES(20838,288,5,13,56);  -- Double Attack +5% if Berserk Active
+INSERT INTO `item_latents` VALUES(20838,288,3,13,56);  -- Double Attack +3% if Berserk Active
 
-INSERT INTO `item_latents` VALUES(21757,62,8,13,56);   -- Conqueror AG 119 v3 Attack +8% if Berserk Active
-INSERT INTO `item_latents` VALUES(21757,63,-8,13,56);  -- DEF -8% if Berserk Active
+-- Conqueror 119 AG v3
 INSERT INTO `item_latents` VALUES(21757,165,14,13,56); -- Crit Rate +14% if Berserk Active
-INSERT INTO `item_latents` VALUES(21757,288,5,13,56);  -- Double Attack +5% if Berserk Active
+INSERT INTO `item_latents` VALUES(21757,288,3,13,56);  -- Double Attack +3% if Berserk Active

--- a/sql/item_mods.sql
+++ b/sql/item_mods.sql
@@ -23377,6 +23377,7 @@ INSERT INTO `item_mods` VALUES (18990,256,31);  -- Aftermath
 INSERT INTO `item_mods` VALUES (18990,355,188); -- Omniscience
 INSERT INTO `item_mods` VALUES (18991,256,29); -- Conqueror 75 - Aftermath
 INSERT INTO `item_mods` VALUES (18991,355,90); -- King's Justice
+INSERT INTO `item_mods` VALUES (18991,948,5);  -- Enhances Berserk I (5%)
 INSERT INTO `item_mods` VALUES (18992,256,29); -- Glanzfaust 75 - Aftermath
 INSERT INTO `item_mods` VALUES (18992,355,11); -- Ascetic's Fury
 INSERT INTO `item_mods` VALUES (18993,30,10);   -- Yagrush 75 - Magic Accuracy+10
@@ -23527,6 +23528,7 @@ INSERT INTO `item_mods` VALUES (19058,117,3);
 INSERT INTO `item_mods` VALUES (19059,119,3);
 INSERT INTO `item_mods` VALUES (19060,256,34); -- Conqueror 80 - Aftermath
 INSERT INTO `item_mods` VALUES (19060,355,90); -- King's Justice
+INSERT INTO `item_mods` VALUES (19060,948,6);  -- Enhances Berserk II (6%)
 INSERT INTO `item_mods` VALUES (19061,256,34); -- Glanzfaust 80 - Aftermath
 INSERT INTO `item_mods` VALUES (19061,355,11); -- Ascetic's Fury
 INSERT INTO `item_mods` VALUES (19061,30,10);   -- Yagrush 80 - Magic Accuracy+10
@@ -23605,6 +23607,7 @@ INSERT INTO `item_mods` VALUES (19079,256,36);  -- Aftermath
 INSERT INTO `item_mods` VALUES (19079,355,188); -- Omniscience
 INSERT INTO `item_mods` VALUES (19080,256,34); -- Conqueror 85 - Aftermath
 INSERT INTO `item_mods` VALUES (19080,355,90); -- King's Justice
+INSERT INTO `item_mods` VALUES (19080,948,7);  -- Enhances Berserk III (7%)
 INSERT INTO `item_mods` VALUES (19081,256,34); -- Glanzfaust 85 - Aftermath
 INSERT INTO `item_mods` VALUES (19081,355,11); -- Ascetic's Fury
 INSERT INTO `item_mods` VALUES (19082,30,15);   -- Yagrush 85 - Magic Accuracy +15
@@ -24055,6 +24058,7 @@ INSERT INTO `item_mods` VALUES (19547,355,220); -- Wildfire
 INSERT INTO `item_mods` VALUES (19612,256,34); -- Conqueror 90 - Aftermath
 INSERT INTO `item_mods` VALUES (19612,355,90); -- King's Justice
 INSERT INTO `item_mods` VALUES (19612,660,15); -- King's Justice WS DMG +15%
+INSERT INTO `item_mods` VALUES (19612,948,8);  -- Enhances Berserk IV (8%)
 INSERT INTO `item_mods` VALUES (19613,256,34); -- Glanzfaust 90 - Aftermath
 INSERT INTO `item_mods` VALUES (19613,355,11); -- Ascetic's Fury
 INSERT INTO `item_mods` VALUES (19613,581,15); -- Ascetic's Fury WS DMG +15%
@@ -24197,6 +24201,7 @@ INSERT INTO `item_mods` VALUES (19645,355,220); -- Wildfire
 INSERT INTO `item_mods` VALUES (19710,256,39); -- Conqueror 95 - Aftermath
 INSERT INTO `item_mods` VALUES (19710,355,90); -- King's Justice
 INSERT INTO `item_mods` VALUES (19710,660,15); -- King's Justice WS DMG +15%
+INSERT INTO `item_mods` VALUES (19710,948,8);  -- Enhances Berserk IV (8%)
 INSERT INTO `item_mods` VALUES (19711,256,39); -- Glanzfaust 95 - Aftermath
 INSERT INTO `item_mods` VALUES (19711,355,11); -- Ascetic's Fury
 INSERT INTO `item_mods` VALUES (19711,581,15); -- Ascetic's Fury WS DMG +15%
@@ -24515,6 +24520,7 @@ INSERT INTO `item_mods` VALUES (19818,355,220); -- Wildfire
 INSERT INTO `item_mods` VALUES (19819,256,39); -- Conqueror 99 - Aftermath
 INSERT INTO `item_mods` VALUES (19819,355,90); -- King's Justice
 INSERT INTO `item_mods` VALUES (19819,660,30); -- King's Justice WS DMG +30%
+INSERT INTO `item_mods` VALUES (19819,948,8);  -- Enhances Berserk V (8%)
 INSERT INTO `item_mods` VALUES (19820,256,39); -- Glanzfaust 99 - Aftermath
 INSERT INTO `item_mods` VALUES (19820,355,11); -- Ascetic's Fury
 INSERT INTO `item_mods` VALUES (19820,581,30); -- Ascetic's Fury WS DMG +30%
@@ -24756,6 +24762,7 @@ INSERT INTO `item_mods` VALUES (19936,288,30);
 INSERT INTO `item_mods` VALUES (19948,256,39); -- Conqueror 99 AG - Aftermath
 INSERT INTO `item_mods` VALUES (19948,355,90); -- King's Justice
 INSERT INTO `item_mods` VALUES (19948,660,30); -- King's Justice WS DMG +30%
+INSERT INTO `item_mods` VALUES (19948,948,8);  -- Enhances Berserk V (8%)
 INSERT INTO `item_mods` VALUES (19949,256,39); -- Glanzfaust 99 AG - Aftermath
 INSERT INTO `item_mods` VALUES (19949,355,11); -- Ascetic's Fury
 INSERT INTO `item_mods` VALUES (19949,581,30); -- Ascetic's Fury WS DMG +30%
@@ -25367,9 +25374,11 @@ INSERT INTO `item_mods` VALUES (20836,659,40); -- Metatron Torment DMG +40%
 INSERT INTO `item_mods` VALUES (20837,256,39); -- Conqueror iLvL 119 - Aftermath
 INSERT INTO `item_mods` VALUES (20837,355,90); -- King's Justice
 INSERT INTO `item_mods` VALUES (20837,660,30); -- King's Justice WS DMG +30%
+INSERT INTO `item_mods` VALUES (20837,948,8);  -- Enhances Berserk V (8%)
 INSERT INTO `item_mods` VALUES (20838,256,39); -- Conqueror iLvL 119 AG - King's Justice
 INSERT INTO `item_mods` VALUES (20838,355,90); -- King's Justice
 INSERT INTO `item_mods` VALUES (20838,660,30); -- King's Justice WS DMG +30%
+INSERT INTO `item_mods` VALUES (20838,948,8);  -- Enhances Berserk V (8%)
 INSERT INTO `item_mods` VALUES (20839,8,20);   -- Ukonvasara 119 - STR+20
 INSERT INTO `item_mods` VALUES (20839,256,44); -- Aftermath
 INSERT INTO `item_mods` VALUES (20839,355,92); -- Ukko's Fury
@@ -26625,6 +26634,7 @@ INSERT INTO `item_mods` VALUES (21756,659,40); -- Metatron Torment DMG +40%
 INSERT INTO `item_mods` VALUES (21757,256,39); -- Conqueror 119 III - Aftermath
 INSERT INTO `item_mods` VALUES (21757,355,90); -- King's Justice
 INSERT INTO `item_mods` VALUES (21757,660,30); -- King's Justice WS DMG +30%
+INSERT INTO `item_mods` VALUES (21757,948,8);  -- Enhances Berserk V (8%)
 INSERT INTO `item_mods` VALUES (21758,8,50);   -- Ukonvasara 119 III - STR+50
 INSERT INTO `item_mods` VALUES (21758,256,45); -- Aftermath
 INSERT INTO `item_mods` VALUES (21758,355,92); -- Ukko's Fury

--- a/src/map/modifier.h
+++ b/src/map/modifier.h
@@ -295,6 +295,7 @@ enum class Mod
     // Warrior
     DOUBLE_ATTACK             = 288, // Percent chance to proc
     WARCRY_DURATION           = 483, // Warcy duration bonus from gear
+    BERSERK_EFFECT            = 948, // Conqueror Berserk Effect
 
     // Monk
     BOOST_EFFECT              = 97,  // Boost power in tenths
@@ -774,9 +775,9 @@ enum class Mod
 
     // The spares take care of finding the next ID to use so long as we don't forget to list IDs that have been freed up by refactoring.
     // 570 through 825 used by WS DMG mods these are not spares.
-    // SPARE = 948, // stuff
     // SPARE = 949, // stuff
     // SPARE = 950, // stuff
+    // SPARE = 951, // stuff
 };
 
 //temporary workaround for using enum class as unordered_map key until compilers support it


### PR DESCRIPTION
Adds Conqueror's Latent Berserk Buffs. Stats based on data from BGWiki: https://www.bg-wiki.com/bg/Conqueror

ATTP +x% (varies by tier see SQL Comments)
DEFP -x% (varies by tier see SQL Comments)
Crit Rate +x% (varies by tier see SQL Comments)
DA +5%