### PR TITLE
Fix some values/logic in prelude songs

### DIFF
--- a/scripts/globals/spells/archers_prelude.lua
+++ b/scripts/globals/spells/archers_prelude.lua
@@ -1,6 +1,6 @@
 -----------------------------------------
 -- Spell: Archer's Prelude
--- Gives party members ranged attack accuracy
+-- Enhances ranged attack for party members within area of effect.
 -----------------------------------------
 require("scripts/globals/status")
 require("scripts/globals/msg")
@@ -14,37 +14,37 @@ function onSpellCast(caster,target,spell)
     local sLvl = caster:getSkillLevel(dsp.skill.SINGING) -- Gets skill level of Singing
     local iLvl = caster:getWeaponSkillLevel(dsp.slot.RANGED)
 
-    local power = 9
+    local power = 20
 
-    if (sLvl+iLvl > 130) then
-        power = power + math.floor((sLvl+iLvl-200) / 10)
+    if sLvl+iLvl > 130 then
+        power = power + math.floor((sLvl+iLvl - 130) / 18)
     end
 
-    if (power >= 40) then
-        power = 40
+    if power > 60 then
+        power = 60
     end
 
     local iBoost = caster:getMod(dsp.mod.PRELUDE_EFFECT) + caster:getMod(dsp.mod.ALL_SONGS_EFFECT)
-    if (iBoost > 0) then
-        power = power + 1 + (iBoost-1)*3
+    if iBoost > 0 then
+        power = power + 1 + (iBoost-1) * 3
     end
 
 
-    if (caster:hasStatusEffect(dsp.effect.SOUL_VOICE)) then
+    if caster:hasStatusEffect(dsp.effect.SOUL_VOICE) then
         power = power * 2
-    elseif (caster:hasStatusEffect(dsp.effect.MARCATO)) then
+    elseif caster:hasStatusEffect(dsp.effect.MARCATO) then
         power = power * 1.5
     end
     caster:delStatusEffect(dsp.effect.MARCATO)
 
     local duration = 120
-    duration = duration * ((iBoost * 0.1) + (caster:getMod(dsp.mod.SONG_DURATION_BONUS)/100) + 1)
+    duration = duration * ((iBoost * 0.1) + (caster:getMod(dsp.mod.SONG_DURATION_BONUS) / 100) + 1)
 
-    if (caster:hasStatusEffect(dsp.effect.TROUBADOUR)) then
+    if caster:hasStatusEffect(dsp.effect.TROUBADOUR) then
         duration = duration * 2
     end
 
-    if not (target:addBardSong(caster,dsp.effect.PRELUDE,power,0,duration,caster:getID(), 0, 2)) then
+    if not target:addBardSong(caster, dsp.effect.PRELUDE, power, 0, duration, caster:getID(), 0, 2) then
         spell:setMsg(dsp.msg.basic.MAGIC_NO_EFFECT)
     end
 

--- a/scripts/globals/spells/hunters_prelude.lua
+++ b/scripts/globals/spells/hunters_prelude.lua
@@ -1,6 +1,6 @@
 -----------------------------------------
 -- Spell: Hunter's Prelude
--- Gives party members ranged attack accuracy
+-- Enhances ranged attack for party members within area of effect.
 -----------------------------------------
 require("scripts/globals/status")
 require("scripts/globals/msg")
@@ -14,37 +14,37 @@ function onSpellCast(caster,target,spell)
     local sLvl = caster:getSkillLevel(dsp.skill.SINGING) -- Gets skill level of Singing
     local iLvl = caster:getWeaponSkillLevel(dsp.slot.RANGED)
 
-    local power = 5
+    local power = 10
 
-    if (sLvl+iLvl > 85) then
-        power = power + math.floor((sLvl+iLvl-300) / 10)
+    if sLvl+iLvl > 85 then
+        power = power + math.floor((sLvl+iLvl - 85) / 18)
     end
 
-    if (power >= 30) then
-        power = 30
+    if power > 45 then
+        power = 45
     end
 
     local iBoost = caster:getMod(dsp.mod.PRELUDE_EFFECT) + caster:getMod(dsp.mod.ALL_SONGS_EFFECT)
-    if (iBoost > 0) then
-        power = power + 1 + (iBoost-1)*3
+    if iBoost > 0 then
+        power = power + 1 + (iBoost-1) * 3
     end
 
 
-    if (caster:hasStatusEffect(dsp.effect.SOUL_VOICE)) then
+    if caster:hasStatusEffect(dsp.effect.SOUL_VOICE) then
         power = power * 2
-    elseif (caster:hasStatusEffect(dsp.effect.MARCATO)) then
+    elseif caster:hasStatusEffect(dsp.effect.MARCATO) then
         power = power * 1.5
     end
     caster:delStatusEffect(dsp.effect.MARCATO)
 
     local duration = 120
-    duration = duration * ((iBoost * 0.1) + (caster:getMod(dsp.mod.SONG_DURATION_BONUS)/100) + 1)
+    duration = duration * ((iBoost * 0.1) + (caster:getMod(dsp.mod.SONG_DURATION_BONUS) / 100) + 1)
 
-    if (caster:hasStatusEffect(dsp.effect.TROUBADOUR)) then
+    if caster:hasStatusEffect(dsp.effect.TROUBADOUR) then
         duration = duration * 2
     end
 
-    if not (target:addBardSong(caster,dsp.effect.PRELUDE,power,0,duration,caster:getID(), 0, 1)) then
+    if not target:addBardSong(caster, dsp.effect.PRELUDE, power, 0, duration, caster:getID(), 0, 1) then
         spell:setMsg(dsp.msg.basic.MAGIC_NO_EFFECT)
     end
 


### PR DESCRIPTION
1. Updated the minimum power based on retail testing. 
2. Up[dated potency caps per [BG Wiki](https://www.bg-wiki.com/bg/Prelude).
2. Fixed logic in the power adjustment - I don't know the formulae but surely whatever the inflection is it should be consistent within the formula? Currently a combined skill between 130-200 will result in a power below the base for Archer's Prelude.

The new params cap out at combined skill 320 for Hunter's Prelude (BRD54), and 815 for Archer's Prelude (BRD99 + extra gear/merits) and is consistent with the "Skill cap is < 900" claim on [BG Wiki](https://www.bg-wiki.com/bg/Archer%27s_Prelude).

**I can extend this PR (or make a new one) to cover other "buff" songs - just wanted to get a green light on the changes/ methodology first.**

-------

*1.* Sorry, I did this over Discord screen share for all songs with a friend on his newly-minted-99 BRD (power-leveled, 0 skill) and didn't think to take screenshots. The updated `local powers` were ascertained using /checkparam.