### PR TITLE
Reworked m_weapons to not accidentally use non-weapons

### DIFF
--- a/src/map/ai/controllers/player_controller.cpp
+++ b/src/map/ai/controllers/player_controller.cpp
@@ -168,13 +168,14 @@ bool CPlayerController::WeaponSkill(uint16 targid, uint16 wsid)
         }
         if (PWeaponSkill->getType() == SKILL_ARCHERY || PWeaponSkill->getType() == SKILL_MARKSMANSHIP)
         {
-            CItemWeapon* PItem = (CItemWeapon*)PChar->getEquip(SLOT_AMMO);
+            auto PItem = dynamic_cast<CItemWeapon*>(PChar->getEquip(SLOT_AMMO));
+            auto weapon = dynamic_cast<CItemWeapon*>(PChar->m_Weapons[SLOT_RANGED]);
+            auto ammo = dynamic_cast<CItemWeapon*>(PChar->m_Weapons[SLOT_AMMO]);
 
             // before allowing ranged weapon skill...
             if (PItem == nullptr ||
-                !(PItem->isType(ITEM_WEAPON)) ||
-                !PChar->m_Weapons[SLOT_AMMO]->isRanged() ||
-                !PChar->m_Weapons[SLOT_RANGED]->isRanged() ||
+                !weapon || !weapon->isRanged() ||
+                !ammo || !ammo->isRanged() ||
                 PChar->equip[SLOT_AMMO] == 0)
             {
                 PChar->pushPacket(new CMessageBasicPacket(PChar, PChar, 0, 0, MSGBASIC_NO_RANGED_WEAPON));

--- a/src/map/attack.cpp
+++ b/src/map/attack.cpp
@@ -521,7 +521,7 @@ void CAttack::ProcessDamage()
     }
 
     // Get damage multipliers.
-    m_damage = attackutils::CheckForDamageMultiplier((CCharEntity*)m_attacker, m_attacker->m_Weapons[slot], m_damage, m_attackType, slot);
+    m_damage = attackutils::CheckForDamageMultiplier((CCharEntity*)m_attacker, dynamic_cast<CItemWeapon*>(m_attacker->m_Weapons[slot]), m_damage, m_attackType, slot);
 
     // Get critical bonus mods.
     if (m_isCritical)
@@ -544,7 +544,10 @@ void CAttack::ProcessDamage()
     // Try skill up.
     if (m_damage > 0)
     {
-        charutils::TrySkillUP((CCharEntity*)m_attacker, (SKILLTYPE)m_attacker->m_Weapons[slot]->getSkillType(), m_victim->GetMLevel());
+        if (auto weapon = dynamic_cast<CItemWeapon*>(m_attacker->m_Weapons[slot]))
+        {
+            charutils::TrySkillUP((CCharEntity*)m_attacker, (SKILLTYPE)weapon->getSkillType(), m_victim->GetMLevel());
+        }
 
         if (m_attacker->objtype == TYPE_PET && m_attacker->PMaster && m_attacker->PMaster->objtype == TYPE_PC &&
             static_cast<CPetEntity*>(m_attacker)->getPetType() == PETTYPE_AUTOMATON)

--- a/src/map/attackround.cpp
+++ b/src/map/attackround.cpp
@@ -41,22 +41,22 @@ CAttackRound::CAttackRound(CBattleEntity* attacker, CBattleEntity* defender)
     m_sataOccured = false;
     m_subWeaponType = 0;
 
-    if (attacker->m_Weapons[SLOT_SUB]->isType(ITEM_WEAPON))
+    if (auto weapon = dynamic_cast<CItemWeapon*>(attacker->m_Weapons[SLOT_SUB]))
     {
-        m_subWeaponType = attacker->m_Weapons[SLOT_SUB]->getDmgType();
+        m_subWeaponType = weapon->getDmgType();
     }
 
     // Grab a trick attack assistant.
     m_taEntity = battleutils::getAvailableTrickAttackChar(attacker, attacker->GetBattleTarget());
 
     // Build main weapon attacks.
-    CreateAttacks(attacker->m_Weapons[SLOT_MAIN], RIGHTATTACK);
+    CreateAttacks(dynamic_cast<CItemWeapon*>(attacker->m_Weapons[SLOT_MAIN]), RIGHTATTACK);
 
     // Build dual wield off hand weapon attacks.
     if (IsH2H())
     {
         // Build left hand H2H attacks.
-        CreateAttacks(attacker->m_Weapons[SLOT_MAIN], LEFTATTACK);
+        CreateAttacks(dynamic_cast<CItemWeapon*>(attacker->m_Weapons[SLOT_MAIN]), LEFTATTACK);
 
         // Build kick attacks.
         CreateKickAttacks();
@@ -65,7 +65,7 @@ CAttackRound::CAttackRound(CBattleEntity* attacker, CBattleEntity* defender)
     else if ((m_subWeaponType > 0 && m_subWeaponType < 4) ||
         (attacker->objtype == TYPE_MOB && static_cast<CMobEntity*>(attacker)->getMobMod(MOBMOD_DUAL_WIELD)))
     {
-        CreateAttacks(attacker->m_Weapons[SLOT_SUB], LEFTATTACK);
+        CreateAttacks(dynamic_cast<CItemWeapon*>(attacker->m_Weapons[SLOT_SUB]), LEFTATTACK);
     }
 
     // Build Daken throw
@@ -158,7 +158,9 @@ CBattleEntity*	CAttackRound::GetTAEntity()
 ************************************************************************/
 bool CAttackRound::IsH2H()
 {
-    return m_attacker->m_Weapons[SLOT_MAIN]->getSkillType() == SKILL_HAND_TO_HAND ? true : false;
+    if (auto weapon = dynamic_cast<CItemWeapon*>(m_attacker->m_Weapons[SLOT_MAIN]))
+        return weapon->getSkillType() == SKILL_HAND_TO_HAND;
+    return false;
 }
 
 /************************************************************************
@@ -200,6 +202,9 @@ void CAttackRound::DeleteAttackSwing()
 ************************************************************************/
 void CAttackRound::CreateAttacks(CItemWeapon* PWeapon, PHYSICAL_ATTACK_DIRECTION direction)
 {
+    if (!PWeapon)
+        return;
+
     uint8 num = 1;
 
     bool isPC = m_attacker->objtype == TYPE_PC;
@@ -377,7 +382,7 @@ void CAttackRound::CreateDakenAttack()
 {
     if (m_attacker->objtype == TYPE_PC)
     {
-        CItemWeapon* PAmmo = m_attacker->m_Weapons[SLOT_AMMO];
+        auto PAmmo = dynamic_cast<CItemWeapon*>(m_attacker->m_Weapons[SLOT_AMMO]);
         if (PAmmo && PAmmo->isShuriken())
         {
             uint16 daken = m_attacker->getMod(Mod::DAKEN);

--- a/src/map/entities/battleentity.cpp
+++ b/src/map/entities/battleentity.cpp
@@ -246,39 +246,43 @@ int16 CBattleEntity::GetWeaponDelay(bool tp)
     {
         return 1700;
     }
-    uint16 MinimumDelay = m_Weapons[SLOT_MAIN]->getDelay(); // Track base delay.  We will need this later.  Mod::DELAY is ignored for now.
-    uint16 WeaponDelay = m_Weapons[SLOT_MAIN]->getDelay() - getMod(Mod::DELAY);
-    if (m_Weapons[SLOT_MAIN]->isHandToHand())
+    uint16 WeaponDelay = 9999;
+    if (auto weapon = dynamic_cast<CItemWeapon*>(m_Weapons[SLOT_MAIN]))
     {
-        WeaponDelay -= getMod(Mod::MARTIAL_ARTS) * 1000 / 60;
-    }
-    else if (m_Weapons[SLOT_SUB]->getDmgType() > 0 &&
-             m_Weapons[SLOT_SUB]->getDmgType() < 4)
-    {
-        MinimumDelay += m_Weapons[SLOT_SUB]->getDelay();
-        WeaponDelay += m_Weapons[SLOT_SUB]->getDelay();
-        //apply dual wield delay reduction
-        WeaponDelay = (uint16)(WeaponDelay * ((100.0f - getMod(Mod::DUAL_WIELD)) / 100.0f));
-    }
+        uint16 MinimumDelay = weapon->getDelay(); // Track base delay.  We will need this later.  Mod::DELAY is ignored for now.
+        WeaponDelay = weapon->getDelay() - getMod(Mod::DELAY);
+        if (weapon->isHandToHand())
+        {
+            WeaponDelay -= getMod(Mod::MARTIAL_ARTS) * 1000 / 60;
+        }
+        else if (auto subweapon = dynamic_cast<CItemWeapon*>(m_Weapons[SLOT_SUB]); subweapon && subweapon->getDmgType() > 0 &&
+            subweapon->getDmgType() < 4)
+        {
+            MinimumDelay += subweapon->getDelay();
+            WeaponDelay += subweapon->getDelay();
+            //apply dual wield delay reduction
+            WeaponDelay = (uint16)(WeaponDelay * ((100.0f - getMod(Mod::DUAL_WIELD)) / 100.0f));
+        }
 
-    //apply haste and delay reductions that don't affect tp
-    if (!tp)
-    {
-        // Cap haste at appropriate levels.
-        int16 hasteMagic = std::clamp<int16>(getMod(Mod::HASTE_MAGIC), -10000, 4375); // 43.75% cap -- handle 100% slow for weakness
-        int16 hasteAbility = std::clamp<int16>(getMod(Mod::HASTE_ABILITY), -2500, 2500); // 25% cap
-        int16 hasteGear = std::clamp<int16>(getMod(Mod::HASTE_GEAR), -2500, 2500); // 25%
+        //apply haste and delay reductions that don't affect tp
+        if (!tp)
+        {
+            // Cap haste at appropriate levels.
+            int16 hasteMagic = std::clamp<int16>(getMod(Mod::HASTE_MAGIC), -10000, 4375); // 43.75% cap -- handle 100% slow for weakness
+            int16 hasteAbility = std::clamp<int16>(getMod(Mod::HASTE_ABILITY), -2500, 2500); // 25% cap
+            int16 hasteGear = std::clamp<int16>(getMod(Mod::HASTE_GEAR), -2500, 2500); // 25%
 
-        // Divide by float to get a more accurate reduction, then use int16 cast to truncate
-        WeaponDelay -= (int16)(WeaponDelay * (hasteMagic + hasteAbility + hasteGear) / 10000.f);
+            // Divide by float to get a more accurate reduction, then use int16 cast to truncate
+            WeaponDelay -= (int16)(WeaponDelay * (hasteMagic + hasteAbility + hasteGear) / 10000.f);
+        }
+        WeaponDelay = (uint16)(WeaponDelay * ((100.0f + getMod(Mod::DELAYP)) / 100.0f));
+
+        // Global delay reduction cap of "about 80%" being enforced.
+        // This should be enforced on -delay equipment, martial arts, dual wield, and haste, hence MinimumDelay * 0.2.
+        // TODO: Could be converted to value/1024 if the exact cap is ever determined.
+        MinimumDelay -= (uint16)(MinimumDelay * 0.8);
+        WeaponDelay = (WeaponDelay < MinimumDelay) ? MinimumDelay : WeaponDelay;
     }
-    WeaponDelay = (uint16)(WeaponDelay * ((100.0f + getMod(Mod::DELAYP)) / 100.0f));
-
-    // Global delay reduction cap of "about 80%" being enforced.
-    // This should be enforced on -delay equipment, martial arts, dual wield, and haste, hence MinimumDelay * 0.2.
-    // TODO: Could be converted to value/1024 if the exact cap is ever determined.
-    MinimumDelay -= (uint16)(MinimumDelay * 0.8);
-    WeaponDelay = (WeaponDelay < MinimumDelay) ? MinimumDelay : WeaponDelay;
     return WeaponDelay;
 }
 
@@ -327,106 +331,96 @@ int16 CBattleEntity::GetAmmoDelay()
 
 uint16 CBattleEntity::GetMainWeaponDmg()
 {
-    if (m_Weapons[SLOT_MAIN])
+    if (auto weapon = dynamic_cast<CItemWeapon*>(m_Weapons[SLOT_MAIN]))
     {
-        if ((m_Weapons[SLOT_MAIN]->getReqLvl() > GetMLevel()) && objtype == TYPE_PC)
+        if ((weapon->getReqLvl() > GetMLevel()) && objtype == TYPE_PC)
         {
-            uint16 dmg = m_Weapons[SLOT_MAIN]->getDamage();
+            uint16 dmg = weapon->getDamage();
             dmg *= GetMLevel() * 3;
             dmg /= 4;
-            dmg /= m_Weapons[SLOT_MAIN]->getReqLvl();
+            dmg /= weapon->getReqLvl();
             return dmg + getMod(Mod::MAIN_DMG_RATING);
         }
         else
-            return m_Weapons[SLOT_MAIN]->getDamage() + getMod(Mod::MAIN_DMG_RATING);
+            return weapon->getDamage() + getMod(Mod::MAIN_DMG_RATING);
     }
-    //Unhandled Scenario
-    DSP_DEBUG_BREAK_IF(true);
     return 0;
 }
 
 uint16 CBattleEntity::GetSubWeaponDmg()
 {
-    if (m_Weapons[SLOT_SUB])
+    if (auto weapon = dynamic_cast<CItemWeapon*>(m_Weapons[SLOT_SUB]))
     {
-        if ((m_Weapons[SLOT_SUB]->getReqLvl() > GetMLevel()) && objtype == TYPE_PC)
+        if ((weapon->getReqLvl() > GetMLevel()) && objtype == TYPE_PC)
         {
-            uint16 dmg = m_Weapons[SLOT_SUB]->getDamage();
+            uint16 dmg = weapon->getDamage();
             dmg *= GetMLevel() * 3;
             dmg /= 4;
-            dmg /= m_Weapons[SLOT_SUB]->getReqLvl();
+            dmg /= weapon->getReqLvl();
             return dmg + getMod(Mod::SUB_DMG_RATING);
         }
         else
-            return m_Weapons[SLOT_SUB]->getDamage() + getMod(Mod::SUB_DMG_RATING);
+            return weapon->getDamage() + getMod(Mod::SUB_DMG_RATING);
     }
-    //Unhandled Scenario
-    DSP_DEBUG_BREAK_IF(true);
     return 0;
 }
 
 uint16 CBattleEntity::GetRangedWeaponDmg()
 {
     uint16 dmg = 0;
-    if (m_Weapons[SLOT_RANGED])
+    if (auto weapon = dynamic_cast<CItemWeapon*>(m_Weapons[SLOT_RANGED]))
     {
-        if ((m_Weapons[SLOT_RANGED]->getReqLvl() > GetMLevel()) && objtype == TYPE_PC)
+        if ((weapon->getReqLvl() > GetMLevel()) && objtype == TYPE_PC)
         {
-            uint16 scaleddmg = m_Weapons[SLOT_RANGED]->getDamage();
+            uint16 scaleddmg = weapon->getDamage();
             scaleddmg *= GetMLevel() * 3;
             scaleddmg /= 4;
-            scaleddmg /= m_Weapons[SLOT_RANGED]->getReqLvl();
+            scaleddmg /= weapon->getReqLvl();
             dmg += scaleddmg;
         }
         else
-            dmg += m_Weapons[SLOT_RANGED]->getDamage();
+            dmg += weapon->getDamage();
     }
-    if (m_Weapons[SLOT_AMMO])
+    if (auto ammo = dynamic_cast<CItemWeapon*>(m_Weapons[SLOT_AMMO]))
     {
-        if ((m_Weapons[SLOT_AMMO]->getReqLvl() > GetMLevel()) && objtype == TYPE_PC)
+        if ((ammo->getReqLvl() > GetMLevel()) && objtype == TYPE_PC)
         {
-            uint16 scaleddmg = m_Weapons[SLOT_AMMO]->getDamage();
+            uint16 scaleddmg = ammo->getDamage();
             scaleddmg *= GetMLevel() * 3;
             scaleddmg /= 4;
-            scaleddmg /= m_Weapons[SLOT_AMMO]->getReqLvl();
+            scaleddmg /= ammo->getReqLvl();
             dmg += scaleddmg;
         }
         else
-            dmg += m_Weapons[SLOT_AMMO]->getDamage();
+            dmg += ammo->getDamage();
     }
     return dmg + getMod(Mod::RANGED_DMG_RATING);
 }
 
 uint16 CBattleEntity::GetMainWeaponRank()
 {
-    if (m_Weapons[SLOT_MAIN])
+    if (auto weapon = dynamic_cast<CItemWeapon*>(m_Weapons[SLOT_MAIN]))
     {
-        return (m_Weapons[SLOT_MAIN]->getDamage() + getMod(Mod::MAIN_DMG_RANK)) / 9;
+        return (weapon->getDamage() + getMod(Mod::MAIN_DMG_RANK)) / 9;
     }
-    //Unhandled Scenario
-    DSP_DEBUG_BREAK_IF(true);
     return 0;
 }
 
 uint16 CBattleEntity::GetSubWeaponRank()
 {
-    if (m_Weapons[SLOT_SUB])
+    if (auto weapon = dynamic_cast<CItemWeapon*>(m_Weapons[SLOT_SUB]))
     {
-        return (m_Weapons[SLOT_SUB]->getDamage() + getMod(Mod::SUB_DMG_RANK)) / 9;
+        return (weapon->getDamage() + getMod(Mod::SUB_DMG_RANK)) / 9;
     }
-    //Unhandled Scenario
-    DSP_DEBUG_BREAK_IF(true);
     return 0;
 }
 
 uint16 CBattleEntity::GetRangedWeaponRank()
 {
-    if (m_Weapons[SLOT_RANGED])
+    if (auto weapon = dynamic_cast<CItemWeapon*>(m_Weapons[SLOT_RANGED]))
     {
-        return (m_Weapons[SLOT_RANGED]->getDamage() + getMod(Mod::RANGED_DMG_RANK)) / 9;
+        return (weapon->getDamage() + getMod(Mod::RANGED_DMG_RANK)) / 9;
     }
-    //Unhandled Scenario
-    DSP_DEBUG_BREAK_IF(true);
     return 0;
 }
 
@@ -574,7 +568,8 @@ uint16 CBattleEntity::ATT()
 {
     //TODO: consider which weapon!
     int32 ATT = 8 + m_modStat[Mod::ATT];
-    if (m_Weapons[SLOT_MAIN]->isTwoHanded())
+    auto weapon = dynamic_cast<CItemWeapon*>(m_Weapons[SLOT_MAIN]);
+    if (weapon && weapon->isTwoHanded())
     {
         ATT += (STR() * 3) / 4;
     }
@@ -588,12 +583,15 @@ uint16 CBattleEntity::ATT()
 
     if (this->objtype & TYPE_PC)
     {
-        ATT += GetSkill(m_Weapons[SLOT_MAIN]->getSkillType()) + m_Weapons[SLOT_MAIN]->getILvlSkill();
-
-        // Smite applies when using 2H or H2H weapons
-        if (m_Weapons[SLOT_MAIN]->isTwoHanded() || m_Weapons[SLOT_MAIN]->isHandToHand())
+        if (weapon)
         {
-            ATT += static_cast<int32>(ATT * this->getMod(Mod::SMITE) / 256.f); // Divide smite value by 256
+            ATT += GetSkill(weapon->getSkillType()) + weapon->getILvlSkill();
+
+            // Smite applies when using 2H or H2H weapons
+            if (weapon->isTwoHanded() || weapon->isHandToHand())
+            {
+                ATT += static_cast<int32>(ATT * this->getMod(Mod::SMITE) / 256.f); // Divide smite value by 256
+            }
         }
     }
     else if (this->objtype == TYPE_PET && ((CPetEntity*)this)->getPetType() == PETTYPE_AUTOMATON)
@@ -642,27 +640,39 @@ uint16 CBattleEntity::ACC(uint8 attackNumber, uint8 offsetAccuracy)
         uint16 iLvlSkill = 0;
         if (attackNumber == 0)
         {
-            skill = m_Weapons[SLOT_MAIN]->getSkillType();
-            iLvlSkill = m_Weapons[SLOT_MAIN]->getILvlSkill();
-            if (skill == SKILL_NONE && GetSkill(SKILL_HAND_TO_HAND) > 0)
-                skill = SKILL_HAND_TO_HAND;
+            if (auto weapon = dynamic_cast<CItemWeapon*>(m_Weapons[SLOT_MAIN]))
+            {
+                skill = weapon->getSkillType();
+                iLvlSkill = weapon->getILvlSkill();
+                if (skill == SKILL_NONE && GetSkill(SKILL_HAND_TO_HAND) > 0)
+                    skill = SKILL_HAND_TO_HAND;
+            }
         }
         else if (attackNumber == 1)
         {
-            skill = m_Weapons[SLOT_SUB]->getSkillType();
-            iLvlSkill = m_Weapons[SLOT_SUB]->getILvlSkill();
-            if (skill == SKILL_NONE && GetSkill(SKILL_HAND_TO_HAND) > 0 &&
-                (m_Weapons[SLOT_MAIN]->getSkillType() == SKILL_NONE || m_Weapons[SLOT_MAIN]->getSkillType() == SKILL_HAND_TO_HAND))
-                skill = SKILL_HAND_TO_HAND;
+            if (auto weapon = dynamic_cast<CItemWeapon*>(m_Weapons[SLOT_SUB]))
+            {
+                skill = weapon->getSkillType();
+                iLvlSkill = weapon->getILvlSkill();
+                if (skill == SKILL_NONE && GetSkill(SKILL_HAND_TO_HAND) > 0)
+                    if (auto main_weapon = dynamic_cast<CItemWeapon*>(m_Weapons[SLOT_MAIN]);
+                        main_weapon && main_weapon->getSkillType() == SKILL_NONE || main_weapon->getSkillType() == SKILL_HAND_TO_HAND)
+                    {
+                        skill = SKILL_HAND_TO_HAND;
+                    }
+            }
         }
         else if (attackNumber == 2)
         {
-            iLvlSkill = m_Weapons[SLOT_MAIN]->getILvlSkill();
+            if (auto weapon = dynamic_cast<CItemWeapon*>(m_Weapons[SLOT_MAIN]))
+            {
+                iLvlSkill = weapon->getILvlSkill();
+            }
             skill = SKILL_HAND_TO_HAND;
         }
         int16 ACC = GetSkill(skill) + iLvlSkill;
         ACC = (ACC > 200 ? (int16)(((ACC - 200) * 0.9) + 200) : ACC);
-        if (m_Weapons[SLOT_MAIN]->isTwoHanded() == true)
+        if (auto weapon = dynamic_cast<CItemWeapon*>(m_Weapons[SLOT_MAIN]); weapon && weapon->isTwoHanded() == true)
         {
             ACC += (int16)(DEX() * 0.75);
         }
@@ -1482,7 +1492,7 @@ bool CBattleEntity::OnAttack(CAttackState& state, action_t& action)
                     else
                     {
                         int16 naturalh2hDMG = 0;
-                        if (PTarget->m_Weapons[SLOT_MAIN]->getSkillType() == SKILL_HAND_TO_HAND || (PTarget->objtype == TYPE_MOB && PTarget->GetMJob() == JOB_MNK))
+                        if (auto targ_weapon = dynamic_cast<CItemWeapon*>(PTarget->m_Weapons[SLOT_MAIN]); targ_weapon && targ_weapon->getSkillType() == SKILL_HAND_TO_HAND || (PTarget->objtype == TYPE_MOB && PTarget->GetMJob() == JOB_MNK))
                         {
                             naturalh2hDMG = (int16)((PTarget->GetSkill(SKILL_HAND_TO_HAND) * 0.11f) + 3);
                         }
@@ -1493,7 +1503,8 @@ bool CBattleEntity::OnAttack(CAttackState& state, action_t& action)
                         actionTarget.spikesMessage = 33;
                         if (PTarget->objtype == TYPE_PC)
                         {
-                            uint8 skilltype = (PTarget->m_Weapons[SLOT_MAIN] == nullptr ? SKILL_HAND_TO_HAND : PTarget->m_Weapons[SLOT_MAIN]->getSkillType());
+                            auto targ_weapon = dynamic_cast<CItemWeapon*>(PTarget->m_Weapons[SLOT_MAIN]);
+                            uint8 skilltype = (targ_weapon == nullptr ? SKILL_HAND_TO_HAND : targ_weapon->getSkillType());
                             charutils::TrySkillUP((CCharEntity*)PTarget, (SKILLTYPE)skilltype, GetMLevel());
                         } // In case the Automaton can counter
                         else if (PTarget->objtype == TYPE_PET && PTarget->PMaster && PTarget->PMaster->objtype == TYPE_PC &&

--- a/src/map/entities/battleentity.h
+++ b/src/map/entities/battleentity.h
@@ -468,7 +468,7 @@ class CParty;
 class CStatusEffectContainer;
 class CPetEntity;
 class CSpell;
-class CItemWeapon;
+class CItemArmor;
 class CAbilityState;
 class CAttackState;
 class CWeaponSkillState;
@@ -654,7 +654,7 @@ public:
 
     uint8			m_ModelSize;			    // размер модели сущности, для расчета дальности физической атаки
     ECOSYSTEM		m_EcoSystem;			    // эко-система сущности
-    CItemWeapon*	m_Weapons[4];			    // четыре основных ячейки, используемыж для хранения оружия (только оружия)
+    CItemArmor*	    m_Weapons[4];			    // четыре основных ячейки, используемыж для хранения оружия (только оружия)
 
     TraitList_t     TraitList;                  // список постянно активных способностей в виде указателей
 

--- a/src/map/entities/charentity.h
+++ b/src/map/entities/charentity.h
@@ -40,6 +40,7 @@ This file is part of DarkStar-server source code.
 #define MAX_MISSIONAREA	 15
 #define MAX_MISSIONID    226
 
+class CItemWeapon;
 class CTrustEntity;
 
 struct jobs_t

--- a/src/map/instance_loader.cpp
+++ b/src/map/instance_loader.cpp
@@ -151,11 +151,11 @@ CInstance* CInstanceLoader::LoadInstance(CInstance* instance)
             PMob->SetMJob(Sql_GetIntData(SqlInstanceHandle, 14));
             PMob->SetSJob(Sql_GetIntData(SqlInstanceHandle, 15));
 
-            PMob->m_Weapons[SLOT_MAIN]->setMaxHit(1);
-            PMob->m_Weapons[SLOT_MAIN]->setSkillType(Sql_GetIntData(SqlInstanceHandle, 16));
+            ((CItemWeapon*)PMob->m_Weapons[SLOT_MAIN])->setMaxHit(1);
+            ((CItemWeapon*)PMob->m_Weapons[SLOT_MAIN])->setSkillType(Sql_GetIntData(SqlInstanceHandle, 16));
             PMob->m_dmgMult = Sql_GetUIntData(SqlInstanceHandle, 17);
-            PMob->m_Weapons[SLOT_MAIN]->setDelay((Sql_GetIntData(SqlInstanceHandle, 18) * 1000) / 60);
-            PMob->m_Weapons[SLOT_MAIN]->setBaseDelay((Sql_GetIntData(SqlInstanceHandle, 18) * 1000) / 60);
+            ((CItemWeapon*)PMob->m_Weapons[SLOT_MAIN])->setDelay((Sql_GetIntData(SqlInstanceHandle, 18) * 1000) / 60);
+            ((CItemWeapon*)PMob->m_Weapons[SLOT_MAIN])->setBaseDelay((Sql_GetIntData(SqlInstanceHandle, 18) * 1000) / 60);
 
             PMob->m_Behaviour = (uint16)Sql_GetIntData(SqlInstanceHandle, 19);
             PMob->m_Link = (uint8)Sql_GetIntData(SqlInstanceHandle, 20);

--- a/src/map/lua/lua_baseentity.cpp
+++ b/src/map/lua/lua_baseentity.cpp
@@ -11517,7 +11517,7 @@ inline int32 CLuaBaseEntity::getRACC(lua_State *L)
 {
     DSP_DEBUG_BREAK_IF(m_PBaseEntity == nullptr);
 
-    CItemWeapon* weapon = ((CBattleEntity*)m_PBaseEntity)->m_Weapons[SLOT_RANGED];
+    auto weapon = dynamic_cast<CItemWeapon*>(((CBattleEntity*)m_PBaseEntity)->m_Weapons[SLOT_RANGED]);
 
     if (weapon == nullptr)
     {
@@ -11551,7 +11551,7 @@ inline int32 CLuaBaseEntity::getRATT(lua_State *L)
     DSP_DEBUG_BREAK_IF(m_PBaseEntity == nullptr);
     DSP_DEBUG_BREAK_IF(m_PBaseEntity->objtype == TYPE_NPC);
 
-    CItemWeapon* weapon = ((CBattleEntity*)m_PBaseEntity)->m_Weapons[SLOT_RANGED];
+    auto weapon = dynamic_cast<CItemWeapon*>(((CBattleEntity*)m_PBaseEntity)->m_Weapons[SLOT_RANGED]);
 
     if (weapon == nullptr)
     {
@@ -11574,7 +11574,10 @@ inline int32 CLuaBaseEntity::getILvlMacc(lua_State *L)
 {
     DSP_DEBUG_BREAK_IF(m_PBaseEntity == nullptr);
 
-    lua_pushinteger(L, ((CBattleEntity*)m_PBaseEntity)->m_Weapons[SLOT_MAIN]->getILvlMacc());
+    if (auto weapon = dynamic_cast<CItemWeapon*>(((CBattleEntity*)m_PBaseEntity)->m_Weapons[SLOT_MAIN]))
+        lua_pushinteger(L, weapon->getILvlMacc());
+    else
+        lua_pushinteger(L, 0);
 
     return 1;
 }
@@ -11719,7 +11722,7 @@ inline int32 CLuaBaseEntity::isWeaponTwoHanded(lua_State *L)
     DSP_DEBUG_BREAK_IF(m_PBaseEntity == nullptr);
     DSP_DEBUG_BREAK_IF(m_PBaseEntity->objtype == TYPE_NPC);
 
-    CItemWeapon* weapon = ((CBattleEntity*)m_PBaseEntity)->m_Weapons[SLOT_MAIN];
+    auto weapon = dynamic_cast<CItemWeapon*>(((CBattleEntity*)m_PBaseEntity)->m_Weapons[SLOT_MAIN]);
 
     if (weapon == nullptr)
     {
@@ -11887,7 +11890,7 @@ inline int32 CLuaBaseEntity::getAmmoDmg(lua_State *L)
     DSP_DEBUG_BREAK_IF(m_PBaseEntity == nullptr);
     DSP_DEBUG_BREAK_IF(m_PBaseEntity->objtype == TYPE_NPC);
 
-    CItemWeapon* weapon = ((CBattleEntity*)m_PBaseEntity)->m_Weapons[SLOT_AMMO];
+    auto weapon = dynamic_cast<CItemWeapon*>(((CBattleEntity*)m_PBaseEntity)->m_Weapons[SLOT_AMMO]);
 
     if (weapon == nullptr)
     {
@@ -11936,7 +11939,7 @@ inline int32 CLuaBaseEntity::getWeaponSkillLevel(lua_State *L)
 
         CCharEntity* PChar = (CCharEntity*)m_PBaseEntity;
 
-        CItemWeapon* PWeapon = PChar->m_Weapons[SLOT];
+        auto PWeapon = dynamic_cast<CItemWeapon*>(PChar->m_Weapons[SLOT]);
 
         if ((PWeapon != nullptr) && PWeapon->isType(ITEM_WEAPON))
         {
@@ -11968,7 +11971,7 @@ inline int32 CLuaBaseEntity::getWeaponDamageType(lua_State *L)
             lua_pushinteger(L, 0);
             return 1;
         }
-        CItemWeapon* weapon = ((CBattleEntity*)m_PBaseEntity)->m_Weapons[SLOT];
+        auto weapon = dynamic_cast<CItemWeapon*>(((CBattleEntity*)m_PBaseEntity)->m_Weapons[SLOT]);
         if (weapon == nullptr)
         {
             lua_pushinteger(L, 0);
@@ -12001,7 +12004,7 @@ inline int32 CLuaBaseEntity::getWeaponSkillType(lua_State *L)
             lua_pushinteger(L, 0);
             return 1;
         }
-        CItemWeapon* weapon = ((CBattleEntity*)m_PBaseEntity)->m_Weapons[SLOT];
+        auto weapon = dynamic_cast<CItemWeapon*>(((CBattleEntity*)m_PBaseEntity)->m_Weapons[SLOT]);
         if (weapon == nullptr)
         {
             lua_pushinteger(L, 0);
@@ -13397,7 +13400,7 @@ inline int32 CLuaBaseEntity::setDelay(lua_State* L)
 
     DSP_DEBUG_BREAK_IF(lua_isnil(L, 1) || !lua_isnumber(L, 1));
 
-    ((CMobEntity*)m_PBaseEntity)->m_Weapons[SLOT_MAIN]->setDelay((uint16)lua_tonumber(L, 1));
+    ((CItemWeapon*)((CMobEntity*)m_PBaseEntity)->m_Weapons[SLOT_MAIN])->setDelay((uint16)lua_tonumber(L, 1));
     return 0;
 }
 
@@ -13415,7 +13418,7 @@ inline int32 CLuaBaseEntity::setDamage(lua_State* L)
 
     DSP_DEBUG_BREAK_IF(lua_isnil(L, 1) || !lua_isnumber(L, 1));
 
-    ((CMobEntity*)m_PBaseEntity)->m_Weapons[SLOT_MAIN]->setDamage((uint16)lua_tonumber(L, 1));
+    ((CItemWeapon*)((CMobEntity*)m_PBaseEntity)->m_Weapons[SLOT_MAIN])->setDamage((uint16)lua_tonumber(L, 1));
     return 0;
 }
 

--- a/src/map/packet_system.cpp
+++ b/src/map/packet_system.cpp
@@ -5489,7 +5489,11 @@ void SmallPacket0x100(map_session_data_t* session, CCharEntity* PChar, CBasicPac
             else if (prevsjob == JOB_BLU)
                 blueutils::UnequipAllBlueSpells(PChar);
 
-            uint16 subType = PChar->m_Weapons[SLOT_SUB]->getDmgType();
+            uint16 subType = 0;
+            if (auto weapon = dynamic_cast<CItemWeapon*>(PChar->m_Weapons[SLOT_SUB]))
+            {
+                subType = weapon->getDmgType();
+            }
 
             if (subType > 0 && subType < 4)
             {

--- a/src/map/utils/battleutils.cpp
+++ b/src/map/utils/battleutils.cpp
@@ -587,7 +587,11 @@ namespace battleutils
                 if (PDefender->objtype == TYPE_PC)
                 {
                     // Check for skillup
-                    uint8 skilltype = PDefender->m_Weapons[SLOT_MAIN]->getSkillType();
+                    uint8 skilltype = 0;
+                    if (auto weapon = dynamic_cast<CItemWeapon*>(PDefender->m_Weapons[SLOT_MAIN]))
+                    {
+                        skilltype = weapon->getSkillType();
+                    }
                     charutils::TrySkillUP((CCharEntity*)PDefender, (SKILLTYPE)skilltype, PAttacker->GetMLevel());
                 }
 
@@ -597,7 +601,7 @@ namespace battleutils
                 // Dmg math.
                 float DamageRatio = GetDamageRatio(PDefender, PAttacker, crit, 0.f);
                 uint16 dmg = (uint32)((PDefender->GetMainWeaponDmg() + battleutils::GetFSTR(PDefender, PAttacker, SLOT_MAIN)) * DamageRatio);
-                dmg = attackutils::CheckForDamageMultiplier(((CCharEntity*)PDefender), PDefender->m_Weapons[SLOT_MAIN], dmg, PHYSICAL_ATTACK_TYPE::NORMAL, SLOT_MAIN);
+                dmg = attackutils::CheckForDamageMultiplier(((CCharEntity*)PDefender), dynamic_cast<CItemWeapon*>(PDefender->m_Weapons[SLOT_MAIN]), dmg, PHYSICAL_ATTACK_TYPE::NORMAL, SLOT_MAIN);
                 uint16 bonus = dmg * (PDefender->getMod(Mod::RETALIATION) / 100);
                 dmg = dmg + bonus;
 
@@ -1611,7 +1615,8 @@ namespace battleutils
         int8 shieldSize = 3;
         int32 base = 0;
         float blockRateMod = (100.0f + PDefender->getMod(Mod::SHIELDBLOCKRATE)) / 100.0f;
-        uint16 attackskill = PAttacker->GetSkill((SKILLTYPE)(PAttacker->m_Weapons[SLOT_MAIN]->getSkillType()));
+        auto weapon = dynamic_cast<CItemWeapon*>(PAttacker->m_Weapons[SLOT_MAIN]);
+        uint16 attackskill = PAttacker->GetSkill((SKILLTYPE)(weapon ? weapon->getSkillType() : 0));
         uint16 blockskill = PDefender->GetSkill(SKILL_SHIELD);
 
         if (PDefender->objtype == TYPE_PC)
@@ -1762,6 +1767,7 @@ namespace battleutils
 
     int32 TakePhysicalDamage(CBattleEntity* PAttacker, CBattleEntity* PDefender, PHYSICAL_ATTACK_TYPE physicalAttackType, int32 damage, bool isBlocked, uint8 slot, uint16 tpMultiplier, CBattleEntity* taChar, bool giveTPtoVictim, bool giveTPtoAttacker, bool isCounter)
     {
+        auto weapon = GetEntityWeapon(PAttacker, (SLOTTYPE)slot);
         giveTPtoAttacker = giveTPtoAttacker && !PAttacker->StatusEffectContainer->HasStatusEffect(EFFECT_MEIKYO_SHISUI);
         giveTPtoVictim = giveTPtoVictim && physicalAttackType != PHYSICAL_ATTACK_TYPE::DAKEN;
         bool isRanged = (slot == SLOT_AMMO || slot == SLOT_RANGED);
@@ -1784,7 +1790,7 @@ namespace battleutils
         }
         else
         {
-            damageType = (DAMAGETYPE)PAttacker->m_Weapons[slot]->getDmgType();
+            damageType = (DAMAGETYPE)(weapon ? weapon->getDmgType() : 0);
 
             if (isRanged)
             {
@@ -1972,17 +1978,18 @@ namespace battleutils
             else
             {
                 int16 delay = PAttacker->GetWeaponDelay(true);
+                auto sub_weapon = dynamic_cast<CItemWeapon*>(PAttacker->m_Weapons[SLOT_SUB]);
 
-                if (PAttacker->m_Weapons[SLOT_SUB]->getDmgType() > 0 &&
-                    PAttacker->m_Weapons[SLOT_SUB]->getDmgType() < 4 &&
-                    PAttacker->m_Weapons[slot]->getSkillType() != SKILL_HAND_TO_HAND)
+                if (sub_weapon && sub_weapon->getDmgType() > 0 &&
+                    sub_weapon->getDmgType() < 4 &&
+                    weapon->getSkillType() != SKILL_HAND_TO_HAND)
                 {
                     delay = delay / 2;
                 }
 
                 float ratio = 1.0f;
 
-                if (PAttacker->m_Weapons[slot]->getSkillType() == SKILL_HAND_TO_HAND)
+                if (weapon->getSkillType() == SKILL_HAND_TO_HAND)
                     ratio = 2.0f;
 
                 baseTp = CalculateBaseTP((int16)(delay * 60.0f / 1000.0f / ratio));
@@ -2030,6 +2037,7 @@ namespace battleutils
 
     int32 TakeWeaponskillDamage(CCharEntity* PAttacker, CBattleEntity* PDefender, int32 damage, ATTACKTYPE attackType, DAMAGETYPE damageType, uint8 slot, bool primary, float tpMultiplier, uint16 bonusTP, float targetTPMultiplier)
     {
+        auto weapon = GetEntityWeapon(PAttacker, (SLOTTYPE)slot);
         bool isRanged = (slot == SLOT_AMMO || slot == SLOT_RANGED);
 
         if (damage > 0)
@@ -2118,16 +2126,18 @@ namespace battleutils
             {
                 int16 delay = PAttacker->GetWeaponDelay(true);
 
-                if (PAttacker->m_Weapons[SLOT_SUB]->getDmgType() > 0 &&
-                    PAttacker->m_Weapons[SLOT_SUB]->getDmgType() < 4 &&
-                    PAttacker->m_Weapons[slot]->getSkillType() != SKILL_HAND_TO_HAND)
+                auto sub_weapon = dynamic_cast<CItemWeapon*>(PAttacker->m_Weapons[SLOT_SUB]);
+
+                if (sub_weapon && sub_weapon->getDmgType() > 0 &&
+                    sub_weapon->getDmgType() < 4 &&
+                    weapon->getSkillType() != SKILL_HAND_TO_HAND)
                 {
                     delay /= 2;
                 }
 
                 float ratio = 1.0f;
 
-                if (PAttacker->m_Weapons[slot]->getSkillType() == SKILL_HAND_TO_HAND)
+                if (weapon && weapon->getSkillType() == SKILL_HAND_TO_HAND)
                     ratio = 2.0f;
 
                 baseTp = (int16)(CalculateBaseTP((delay * 60) / 1000) / ratio);
@@ -2274,10 +2284,10 @@ namespace battleutils
                 crithitrate += PCharAttacker->PMeritPoints->GetMeritValue(MERIT_CRIT_HIT_RATE, PCharAttacker);
 
                 // Add Fencer crit hit rate
-                CItemWeapon* PMain = PCharAttacker->m_Weapons[SLOT_MAIN];
-                CItemWeapon* PSub = PCharAttacker->m_Weapons[SLOT_SUB];
-                if (!PMain->isTwoHanded() && !PMain->isHandToHand() &&
-                    (PSub->getSkillType() == SKILL_NONE || PSub->IsShield()))
+                CItemWeapon* PMain = dynamic_cast<CItemWeapon*>(PCharAttacker->m_Weapons[SLOT_MAIN]);
+                CItemWeapon* PSub = dynamic_cast<CItemWeapon*>(PCharAttacker->m_Weapons[SLOT_SUB]);
+                if (PMain && !PMain->isTwoHanded() && !PMain->isHandToHand() &&
+                    (!PSub || PSub->getSkillType() == SKILL_NONE || PCharAttacker->m_Weapons[SLOT_SUB]->IsShield()))
                 {
                     crithitrate += PCharAttacker->getMod(Mod::FENCER_CRITHITRATE);
                 }
@@ -2555,6 +2565,9 @@ namespace battleutils
 
     uint8 CheckMultiHits(CBattleEntity* PEntity, CItemWeapon* PWeapon)
     {
+        if (!PWeapon)
+            return 0;
+
         //checking players weapon hit count
         uint8 num = PWeapon->getHitCount();
 
@@ -3143,28 +3156,13 @@ namespace battleutils
         {
             return (((CCharEntity*)PEntity)->getEquip(Slot));
         }
-        else if (PEntity->objtype == TYPE_NPC)
-        {
-            return nullptr;
-        }
-
         return nullptr;
     }
 
     CItemWeapon* GetEntityWeapon(CBattleEntity* PEntity, SLOTTYPE Slot)
     {
         DSP_DEBUG_BREAK_IF(Slot < SLOT_MAIN || Slot > SLOT_AMMO);
-
-        if (PEntity->objtype == TYPE_PC)
-        {
-            return (CItemWeapon*)(((CCharEntity*)PEntity)->getEquip(Slot));
-        }
-        else if (PEntity->objtype == TYPE_NPC)
-        {
-            return (CItemWeapon*)(((CMobEntity*)PEntity)->m_Weapons[Slot]);
-        }
-
-        return nullptr;
+        return dynamic_cast<CItemWeapon*>(((CMobEntity*)PEntity)->m_Weapons[Slot]);
     }
 
     void MakeEntityStandUp(CBattleEntity* PEntity)
@@ -3636,9 +3634,6 @@ namespace battleutils
         return shotCount;
     }
 
-
-
-
     /************************************************************************
     *                                                                       *
     *   Jump DRG Job ability                                                *
@@ -3665,22 +3660,23 @@ namespace battleutils
 
 
         // multihit's just multiply jump damage
-        uint16 subType = PAttacker->m_Weapons[SLOT_SUB]->getDmgType();
+        auto sub = dynamic_cast<CItemWeapon*>(PAttacker->m_Weapons[SLOT_SUB]);
         uint8 numattacksLeftHand = 0;
 
         //sub weapon is equipped
-        if ((subType > 0 && subType < 4))
-            numattacksLeftHand = battleutils::CheckMultiHits(PAttacker, PAttacker->m_Weapons[SLOT_SUB]);
+        if (sub && sub->getDmgType() > 0 && sub->getDmgType() < 4)
+            numattacksLeftHand = battleutils::CheckMultiHits(PAttacker, sub);
+
+        auto PWeapon = dynamic_cast<CItemWeapon*>(PAttacker->m_Weapons[SLOT_MAIN]);
 
         //h2h equipped
-        if (PAttacker->m_Weapons[SLOT_MAIN]->getSkillType() == SKILL_HAND_TO_HAND)
-            numattacksLeftHand = battleutils::CheckMultiHits(PAttacker, PAttacker->m_Weapons[SLOT_MAIN]);
+        if (PWeapon && PWeapon->getSkillType() == SKILL_HAND_TO_HAND)
+            numattacksLeftHand = battleutils::CheckMultiHits(PAttacker, PWeapon);
 
         // normal multi hit from left hand
-        uint8 numattacksRightHand = battleutils::CheckMultiHits(PAttacker, PAttacker->m_Weapons[SLOT_MAIN]);
+        uint8 numattacksRightHand = battleutils::CheckMultiHits(PAttacker, PWeapon);
 
 
-        CItemWeapon* PWeapon = PAttacker->m_Weapons[SLOT_MAIN];
         uint8 fstrslot = SLOT_MAIN;
 
         uint8 hitrate = battleutils::GetHitRate(PAttacker, PVictim);
@@ -3697,9 +3693,9 @@ namespace battleutils
                 if (PVictim->isDead())
                     break;
 
-                if (PAttacker->m_Weapons[SLOT_MAIN]->getSkillType() != SKILL_HAND_TO_HAND && i >= numattacksRightHand)
+                if (PWeapon && PWeapon->getSkillType() != SKILL_HAND_TO_HAND && i >= numattacksRightHand)
                 {
-                    PWeapon = PAttacker->m_Weapons[SLOT_SUB];
+                    PWeapon = dynamic_cast<CItemWeapon*>(PAttacker->m_Weapons[SLOT_SUB]);
                     fstrslot = SLOT_SUB;
                 }
             }
@@ -5397,10 +5393,10 @@ namespace battleutils
                 }
 
                 // Add Fencer TP Bonus
-                CItemWeapon* PMain = PChar->m_Weapons[SLOT_MAIN];
-                CItemWeapon* PSub = PChar->m_Weapons[SLOT_SUB];
-                if (!PMain->isTwoHanded() && !PMain->isHandToHand() &&
-                    (PSub->getSkillType() == SKILL_NONE || PSub->IsShield()))
+                CItemWeapon* PMain = dynamic_cast<CItemWeapon*>(PEntity->m_Weapons[SLOT_MAIN]);
+                CItemWeapon* PSub = dynamic_cast<CItemWeapon*>(PEntity->m_Weapons[SLOT_SUB]);
+                if (PMain && !PMain->isTwoHanded() && !PMain->isHandToHand() &&
+                    (!PSub || PSub->getSkillType() == SKILL_NONE || PEntity->m_Weapons[SLOT_SUB]->IsShield()))
                 {
                     tp += PEntity->getMod(Mod::FENCER_TP_BONUS);
                 }

--- a/src/map/utils/charutils.cpp
+++ b/src/map/utils/charutils.cpp
@@ -1802,9 +1802,9 @@ namespace charutils
                             auto state = dynamic_cast<CAttackState*>(PChar->PAI->GetCurrentState());
                             if (state) state->ResetAttackTimer();
                         }
-                        PChar->m_Weapons[SLOT_MAIN] = (CItemWeapon*)PItem;
+                        PChar->m_Weapons[SLOT_MAIN] = PItem;
 
-                        if (!PChar->m_Weapons[SLOT_MAIN]->isTwoHanded())
+                        if (!((CItemWeapon*)PChar->m_Weapons[SLOT_MAIN])->isTwoHanded())
                         {
                             PChar->StatusEffectContainer->DelStatusEffect(EFFECT_HASSO);
                             PChar->StatusEffectContainer->DelStatusEffect(EFFECT_SEIGAN);
@@ -2299,7 +2299,7 @@ namespace charutils
         {
             if (PChar->m_Weapons[std::get<0>(slot)])
             {
-                PItem = PChar->m_Weapons[std::get<0>(slot)];
+                PItem = dynamic_cast<CItemWeapon*>(PChar->m_Weapons[std::get<0>(slot)]);
 
                 std::get<1>(slot) = battleutils::GetScaledItemModifier(PChar, PItem, Mod::ADDS_WEAPONSKILL);
                 std::get<2>(slot) = battleutils::GetScaledItemModifier(PChar, PItem, Mod::ADDS_WEAPONSKILL_DYN);
@@ -2307,7 +2307,8 @@ namespace charutils
         }
 
         //add in melee ws
-        uint8 skill = PChar->m_Weapons[SLOT_MAIN]->getSkillType();
+        PItem = dynamic_cast<CItemWeapon*>(PChar->getEquip(SLOT_MAIN));
+        uint8 skill = PItem ? PItem->getSkillType() : 0;
         auto& WeaponSkillList = battleutils::GetWeaponSkills(skill);
         for (auto&& PSkill : WeaponSkillList)
         {
@@ -2320,10 +2321,10 @@ namespace charutils
         }
 
         //add in ranged ws
-        PItem = (CItemWeapon*)PChar->getEquip(SLOT_RANGED);
+        PItem = dynamic_cast<CItemWeapon*>(PChar->getEquip(SLOT_RANGED));
         if (PItem != nullptr && PItem->isType(ITEM_WEAPON) && PItem->getSkillType() != SKILL_THROWING)
         {
-            skill = PChar->m_Weapons[SLOT_RANGED]->getSkillType();
+            skill = PItem ? PItem->getSkillType() : 0;
             auto& WeaponSkillList = battleutils::GetWeaponSkills(skill);
             for (auto&& PSkill : WeaponSkillList)
             {
@@ -2768,7 +2769,8 @@ namespace charutils
 
     void CheckWeaponSkill(CCharEntity* PChar, uint8 skill)
     {
-        if (PChar->m_Weapons[SLOT_MAIN]->getSkillType() != skill)
+        auto weapon = dynamic_cast<CItemWeapon*>(PChar->m_Weapons[SLOT_MAIN]);
+        if (!weapon || weapon->getSkillType() != skill)
         {
             return;
         }

--- a/src/map/utils/mobutils.cpp
+++ b/src/map/utils/mobutils.cpp
@@ -383,11 +383,11 @@ void CalculateStats(CMobEntity * PMob)
     PMob->health.hp = PMob->GetMaxHP();
     PMob->health.mp = PMob->GetMaxMP();
 
-    PMob->m_Weapons[SLOT_MAIN]->setDamage(GetWeaponDamage(PMob));
+    ((CItemWeapon*)PMob->m_Weapons[SLOT_MAIN])->setDamage(GetWeaponDamage(PMob));
 
     //reduce weapon delay of MNK
     if(PMob->GetMJob()==JOB_MNK){
-        PMob->m_Weapons[SLOT_MAIN]->resetDelay();
+        ((CItemWeapon*)PMob->m_Weapons[SLOT_MAIN])->resetDelay();
     }
 
     uint16 fSTR = GetBaseToRank(PMob->strRank, mLvl);
@@ -808,7 +808,7 @@ void SetupDynamisMob(CMobEntity* PMob)
 
     // boost dynamis mobs weapon damage
     PMob->setMobMod(MOBMOD_WEAPON_BONUS, 135);
-    PMob->m_Weapons[SLOT_MAIN]->setDamage(GetWeaponDamage(PMob));
+    ((CItemWeapon*)PMob->m_Weapons[SLOT_MAIN])->setDamage(GetWeaponDamage(PMob));
 
     // never despawn
     PMob->SetDespawnTime(0s);
@@ -1251,11 +1251,11 @@ CMobEntity* InstantiateAlly(uint32 groupid, uint16 zoneID, CInstance* instance)
             PMob->SetMJob(Sql_GetIntData(SqlHandle, 10));
             PMob->SetSJob(Sql_GetIntData(SqlHandle, 11));
 
-            PMob->m_Weapons[SLOT_MAIN]->setMaxHit(1);
-            PMob->m_Weapons[SLOT_MAIN]->setSkillType(Sql_GetIntData(SqlHandle, 12));
+            ((CItemWeapon*)PMob->m_Weapons[SLOT_MAIN])->setMaxHit(1);
+            ((CItemWeapon*)PMob->m_Weapons[SLOT_MAIN])->setSkillType(Sql_GetIntData(SqlHandle, 12));
             PMob->m_dmgMult = Sql_GetUIntData(SqlHandle, 13);
-            PMob->m_Weapons[SLOT_MAIN]->setDelay((Sql_GetIntData(SqlHandle, 14) * 1000) / 60);
-            PMob->m_Weapons[SLOT_MAIN]->setBaseDelay((Sql_GetIntData(SqlHandle, 14) * 1000) / 60);
+            ((CItemWeapon*)PMob->m_Weapons[SLOT_MAIN])->setDelay((Sql_GetIntData(SqlHandle, 14) * 1000) / 60);
+            ((CItemWeapon*)PMob->m_Weapons[SLOT_MAIN])->setBaseDelay((Sql_GetIntData(SqlHandle, 14) * 1000) / 60);
 
             PMob->m_Behaviour = (uint16)Sql_GetIntData(SqlHandle, 15);
             PMob->m_Link = (uint8)Sql_GetIntData(SqlHandle, 16);

--- a/src/map/utils/petutils.cpp
+++ b/src/map/utils/petutils.cpp
@@ -419,12 +419,12 @@ namespace petutils
         PMob->setModifier(Mod::ATT, GetJugBase(PMob, petStats->attRank));
         PMob->setModifier(Mod::ACC, GetJugBase(PMob, petStats->accRank));
 
-        PMob->m_Weapons[SLOT_MAIN]->setDamage(GetJugWeaponDamage(PMob));
+        ((CItemWeapon*)PMob->m_Weapons[SLOT_MAIN])->setDamage(GetJugWeaponDamage(PMob));
 
         //reduce weapon delay of MNK
         if (PMob->GetMJob() == JOB_MNK)
         {
-            PMob->m_Weapons[SLOT_MAIN]->resetDelay();
+            ((CItemWeapon*)PMob->m_Weapons[SLOT_MAIN])->resetDelay();
         }
 
         uint16 fSTR = GetBaseToRank(petStats->strRank, PMob->GetMLevel());
@@ -602,12 +602,12 @@ namespace petutils
         PPet->stats.MND = fMND + mMND + sMND;
         PPet->stats.CHR = fCHR + mCHR + sCHR;
 
-        PPet->m_Weapons[SLOT_MAIN]->setSkillType(SKILL_AUTOMATON_MELEE);
-        PPet->m_Weapons[SLOT_MAIN]->setDelay((uint16)(floor(1000.0f * (petStats->cmbDelay / 60.0f)))); //every pet should use this eventually
-        PPet->m_Weapons[SLOT_MAIN]->setDamage((PPet->GetSkill(SKILL_AUTOMATON_MELEE) / 9) * 2 + 3);
+        ((CItemWeapon*)PPet->m_Weapons[SLOT_MAIN])->setSkillType(SKILL_AUTOMATON_MELEE);
+        ((CItemWeapon*)PPet->m_Weapons[SLOT_MAIN])->setDelay((uint16)(floor(1000.0f * (petStats->cmbDelay / 60.0f)))); //every pet should use this eventually
+        ((CItemWeapon*)PPet->m_Weapons[SLOT_MAIN])->setDamage((PPet->GetSkill(SKILL_AUTOMATON_MELEE) / 9) * 2 + 3);
 
-        PPet->m_Weapons[SLOT_RANGED]->setSkillType(SKILL_AUTOMATON_RANGED);
-        PPet->m_Weapons[SLOT_RANGED]->setDamage((PPet->GetSkill(SKILL_AUTOMATON_RANGED) / 9) * 2 + 3);
+        ((CItemWeapon*)PPet->m_Weapons[SLOT_RANGED])->setSkillType(SKILL_AUTOMATON_RANGED);
+        ((CItemWeapon*)PPet->m_Weapons[SLOT_RANGED])->setDamage((PPet->GetSkill(SKILL_AUTOMATON_RANGED) / 9) * 2 + 3);
 
         CAutomatonEntity* PAutomaton = (CAutomatonEntity*)PPet;
 
@@ -1583,17 +1583,17 @@ namespace petutils
             {
                 PPet->setModifier(Mod::MATT, 20);
             }
-            PPet->m_Weapons[SLOT_MAIN]->setDelay((uint16)(floor(1000.0f * (320.0f / 60.0f))));
+            ((CItemWeapon*)PPet->m_Weapons[SLOT_MAIN])->setDelay((uint16)(floor(1000.0f * (320.0f / 60.0f))));
 
             if (PetID == PETID_FENRIR)
             {
-                PPet->m_Weapons[SLOT_MAIN]->setDelay((uint16)(floor(1000.0 * (280.0f / 60.0f))));
+                ((CItemWeapon*)PPet->m_Weapons[SLOT_MAIN])->setDelay((uint16)(floor(1000.0 * (280.0f / 60.0f))));
             }
-            PPet->m_Weapons[SLOT_MAIN]->setDamage((uint16)(floor(PPet->GetMLevel() * 0.74f)));
+            ((CItemWeapon*)PPet->m_Weapons[SLOT_MAIN])->setDamage((uint16)(floor(PPet->GetMLevel() * 0.74f)));
 
             if (PetID == PETID_CARBUNCLE)
             {
-                PPet->m_Weapons[SLOT_MAIN]->setDamage((uint16)(floor(PPet->GetMLevel() * 0.67f)));
+                ((CItemWeapon*)PPet->m_Weapons[SLOT_MAIN])->setDamage((uint16)(floor(PPet->GetMLevel() * 0.67f)));
             }
 
             //Set B+ weapon skill (assumed capped for level derp)
@@ -1637,7 +1637,7 @@ namespace petutils
         }
         else if (PPet->getPetType() == PETTYPE_JUG_PET)
         {
-            PPet->m_Weapons[SLOT_MAIN]->setDelay((uint16)(floor(1000.0f*(240.0f / 60.0f))));
+            ((CItemWeapon*)PPet->m_Weapons[SLOT_MAIN])->setDelay((uint16)(floor(1000.0f*(240.0f / 60.0f))));
 
             //Get the Jug pet cap level
             uint8 highestLvl = PPetData->maxLevel;
@@ -1774,8 +1774,8 @@ namespace petutils
         PPet->SetMLevel(PMaster->GetMLevel());
 
         LoadAvatarStats(PPet); //follows PC calcs (w/o SJ)
-        PPet->m_Weapons[SLOT_MAIN]->setDelay((uint16)(floor(1000.0f * (320.0f / 60.0f)))); //320 delay
-        PPet->m_Weapons[SLOT_MAIN]->setDamage((uint16)(1 + floor(PPet->GetMLevel() * 0.9f)));
+        ((CItemWeapon*)PPet->m_Weapons[SLOT_MAIN])->setDelay((uint16)(floor(1000.0f * (320.0f / 60.0f)))); //320 delay
+        ((CItemWeapon*)PPet->m_Weapons[SLOT_MAIN])->setDamage((uint16)(1 + floor(PPet->GetMLevel() * 0.9f)));
         //Set A+ weapon skill
         PPet->setModifier(Mod::ATT, battleutils::GetMaxSkill(SKILL_GREAT_AXE, JOB_WAR, PPet->GetMLevel()));
         PPet->setModifier(Mod::ACC, battleutils::GetMaxSkill(SKILL_GREAT_AXE, JOB_WAR, PPet->GetMLevel()));

--- a/src/map/utils/zoneutils.cpp
+++ b/src/map/utils/zoneutils.cpp
@@ -399,11 +399,11 @@ void LoadMOBList()
                 PMob->SetMJob(Sql_GetIntData(SqlHandle, 15));
                 PMob->SetSJob(Sql_GetIntData(SqlHandle, 16));
 
-                PMob->m_Weapons[SLOT_MAIN]->setMaxHit(1);
-                PMob->m_Weapons[SLOT_MAIN]->setSkillType(Sql_GetIntData(SqlHandle, 17));
+                ((CItemWeapon*)PMob->m_Weapons[SLOT_MAIN])->setMaxHit(1);
+                ((CItemWeapon*)PMob->m_Weapons[SLOT_MAIN])->setSkillType(Sql_GetIntData(SqlHandle, 17));
                 PMob->m_dmgMult = Sql_GetUIntData(SqlHandle, 18);
-                PMob->m_Weapons[SLOT_MAIN]->setDelay((Sql_GetIntData(SqlHandle, 19) * 1000) / 60);
-                PMob->m_Weapons[SLOT_MAIN]->setBaseDelay((Sql_GetIntData(SqlHandle, 19) * 1000) / 60);
+                ((CItemWeapon*)PMob->m_Weapons[SLOT_MAIN])->setDelay((Sql_GetIntData(SqlHandle, 19) * 1000) / 60);
+                ((CItemWeapon*)PMob->m_Weapons[SLOT_MAIN])->setBaseDelay((Sql_GetIntData(SqlHandle, 19) * 1000) / 60);
 
                 PMob->m_Behaviour = (uint16)Sql_GetIntData(SqlHandle, 20);
                 PMob->m_Link = (uint8)Sql_GetIntData(SqlHandle, 21);


### PR DESCRIPTION
Fixes #6023

I'm not able to test everything with this, and it touched a lot of stuff.  Any weird new bugs will probably be due to this, but they're fairly easy to diagnose (usually a null pointer for a weapon that needs to be checked)