### PR TITLE
Fix automaton zero weaponskill damage

### DIFF
--- a/scripts/globals/automatonweaponskills.lua
+++ b/scripts/globals/automatonweaponskills.lua
@@ -8,212 +8,89 @@ require("scripts/globals/msg");
 
 
 -- params contains: ftp100, ftp200, ftp300, str_wsc, dex_wsc, vit_wsc, int_wsc, mnd_wsc, canCrit, crit100, crit200, crit300, acc100, acc200, acc300, ignoresDef, ignore100, ignore200, ignore300, atkmulti, kick, accBonus, weaponType, weaponDamage
-function doAutoPhysicalWeaponskill(attacker, target, wsID, tp, primary, action, taChar, params, skill, action)
+function doAutoPhysicalWeaponskill(attacker, target, wsID, tp, primaryMsg, action, taChar, wsParams, skill, action)
 
-    local criticalHit = false;
-    local bonusTP = params.bonusTP or 0
-    local multiHitfTP = params.multiHitfTP or false
-    local bonusacc = attacker:getMod(dsp.mod.WSACC) + (params.accBonus or 0);
+    -- Determine cratio and ccritratio
+    local ignoredDef = 0
+    if (wsParams.ignoresDef == not nil and wsParams.ignoresDef == true) then
+        ignoredDef = calculatedIgnoredDef(tp, target:getStat(dsp.mod.DEF), wsParams.ignored100, wsParams.ignored200, wsParams.ignored300)
+    end
+    local cratio, ccritratio = getAutocRatio(attacker, target, wsParams, ignoredDef, true)
 
-    local dstr = utils.clamp(attacker:getStat(dsp.mod.STR) - target:getStat(dsp.mod.VIT), -10, 10)
+    -- Set up conditions and wsParams used for calculating weaponskill damage
+    
+    -- Handle Flame Holder attachment.
+    -- DSP Mod usage, and values returned by Flame Holder script, might not be correct.
+    local flameHolderFTP = attacker:getMod(dsp.mod.WEAPONSKILL_DAMAGE_BASE) / 100
 
-    -- apply WSC
-    local weaponDamage = params.weaponDamage or attacker:getWeaponDmg();
-    local weaponType = params.weaponType or attacker:getWeaponSkillType(dsp.slot.MAIN);
-    local damageType = attacker:getWeaponDamageType(dsp.slot.MAIN)
+    local attack =
+    {
+        ['type'] = dsp.attackType.PHYSICAL,
+        ['slot'] = dsp.slot.MAIN,
+        ['weaponType'] = attacker:getWeaponSkillType(dsp.slot.MAIN),
+        ['damageType'] = attacker:getWeaponDamageType(dsp.slot.MAIN)
+    }
+ 
+    local calcParams = {}
+    calcParams.weaponDamage = getMeleeDmg(attacker, attack.weaponType, wsParams.kick)
+    
+    calcParams.fSTR = utils.clamp(attacker:getStat(dsp.mod.STR) - target:getStat(dsp.mod.VIT), -10, 10)
+    calcParams.cratio = cratio
+    calcParams.ccritratio = ccritratio
+    calcParams.accStat = attacker:getACC()
+    calcParams.melee = true
+    calcParams.mustMiss = target:hasStatusEffect(dsp.effect.PERFECT_DODGE) or
+                          (target:hasStatusEffect(dsp.effect.TOO_HIGH) and not wsParams.hitsHigh)
 
-    if (weaponType == dsp.skill.HAND_TO_HAND or weaponType == dsp.skill.NONE) then
-        local h2hSkill = ((attacker:getSkillLevel(1) * 0.11) + 3);
+    calcParams.sneakApplicable = false
+    calcParams.taChar = taChar
+    calcParams.trickApplicable = false
+    calcParams.assassinApplicable = false
+    calcParams.guaranteedHit = false
+    calcParams.mightyStrikesApplicable = attacker:hasStatusEffect(dsp.effect.MIGHTY_STRIKES)
+    calcParams.forcedFirstCrit = false
+    calcParams.extraOffhandHit = false
+    calcParams.hybridHit = false
+    calcParams.flourishEffect = false
+    calcParams.alpha = 1
+    calcParams.bonusWSmods = math.max(attacker:getMainLvl() - target:getMainLvl(), 0)
+    calcParams.bonusTP = wsParams.bonusTP or 0
+    calcParams.bonusfTP = flameHolderFTP or 0
+    calcParams.bonusAcc = 0 + attacker:getMod(dsp.mod.WSACC)
+    calcParams.hitRate = getAutoHitRate(attacker, target, false, calcParams.bonusAcc, calcParams.melee)
 
-        if (params.kick and attacker:hasStatusEffect(dsp.effect.FOOTWORK)) then
-            weaponDamage = attacker:getMod(dsp.mod.KICK_DMG) + 18; -- footwork formerly added 18 base dmg to all kicks, its effect on weaponskills was unchanged by update
+    -- Send our wsParams off to calculate our raw WS damage, hits landed, and shadows absorbed
+    calcParams = calculateRawWSDmg(attacker, target, wsID, tp, action, wsParams, calcParams)
+    local finaldmg = calcParams.finalDmg
+    
+    -- Delete statuses that may have been spent by the WS
+    attacker:delStatusEffectSilent(dsp.effect.BUILDING_FLOURISH)
+
+    -- Calculate reductions
+    if not wsParams.formless then
+        --finaldmg = target:physicalDmgTaken(finaldmg, attack.damageType)
+        if (attack.weaponType == dsp.skill.HAND_TO_HAND) then
+            finaldmg = finaldmg * target:getMod(dsp.mod.HTHRES) / 1000
+        elseif (attack.weaponType == dsp.skill.DAGGER or attack.weaponType == dsp.skill.POLEARM) then
+            finaldmg = finaldmg * target:getMod(dsp.mod.PIERCERES) / 1000
+        elseif (attack.weaponType == dsp.skill.CLUB or attack.weaponType == dsp.skill.STAFF) then
+            finaldmg = finaldmg * target:getMod(dsp.mod.IMPACTRES) / 1000
         else
-            weaponDamage = utils.clamp(weaponDamage-3, 0);
-        end
-
-        weaponDamage = weaponDamage + h2hSkill;
-    end
-
-    local base = math.max(weaponDamage + dstr +
-        (attacker:getStat(dsp.mod.STR) * params.str_wsc + attacker:getStat(dsp.mod.DEX) * params.dex_wsc +
-         attacker:getStat(dsp.mod.VIT) * params.vit_wsc + attacker:getStat(dsp.mod.AGI) * params.agi_wsc +
-         attacker:getStat(dsp.mod.INT) * params.int_wsc + attacker:getStat(dsp.mod.MND) * params.mnd_wsc +
-         attacker:getStat(dsp.mod.CHR) * params.chr_wsc) + math.max(attacker:getMainLvl() - target:getMainLvl(), 0), 1)
-
-    -- Applying fTP multiplier
-    local ftpdmgbonus = attacker:getMod(dsp.mod.WEAPONSKILL_DAMAGE_BASE)/100;
-    local ftp = fTP(tp,params.ftp100,params.ftp200,params.ftp300) + ftpdmgbonus;
-
-    local ignoredDef = 0;
-    if (params.ignoresDef == not nil and params.ignoresDef == true) then
-        ignoredDef = calculatedIgnoredDef(tp, target:getStat(dsp.mod.DEF), params.ignored100, params.ignored200, params.ignored300);
-    end
-
-    -- get cratio min and max
-    local cratio, ccritratio = getAutocRatio(attacker, target, params, ignoredDef, true);
-    local ccmin = 0;
-    local ccmax = 0;
-    local hasMightyStrikes = attacker:hasStatusEffect(dsp.effect.MIGHTY_STRIKES);
-    local isSneakValid = attacker:hasStatusEffect(dsp.effect.SNEAK_ATTACK);
-    if (isSneakValid and not (attacker:isBehind(target) or attacker:hasStatusEffect(dsp.effect.HIDE) or target:hasStatusEffect(dsp.effect.DOUBT))) then
-        isSneakValid = false;
-    end
-    attacker:delStatusEffectsByFlag(dsp.effectFlag.DETECTABLE);
-    attacker:delStatusEffect(dsp.effect.SNEAK_ATTACK);
-    local isTrickValid = taChar ~= nil
-
-    local isAssassinValid = isTrickValid;
-    if (isAssassinValid and not attacker:hasTrait(68)) then
-        isAssassinValid = false;
-    end
-
-    local critrate = 0;
-    local nativecrit = 0;
-
-    if (params.canCrit) then -- work out critical hit ratios, by +1ing
-        critrate = fTP(tp,params.crit100,params.crit200,params.crit300);
-        -- add on native crit hit rate (guesstimated, it actually follows an exponential curve)
-        local flourisheffect = attacker:getStatusEffect(dsp.effect.BUILDING_FLOURISH);
-        if flourisheffect ~= nil and flourisheffect:getPower() > 1 then
-            critrate = critrate + (10 + flourisheffect:getSubPower()/2)/100;
-        end
-        nativecrit = (attacker:getStat(dsp.mod.DEX) - target:getStat(dsp.mod.AGI))*0.005; -- assumes +0.5% crit rate per 1 dDEX
-        nativecrit = nativecrit + (attacker:getMod(dsp.mod.CRITHITRATE)/100) + attacker:getMerit(dsp.merit.CRIT_HIT_RATE)/100 - target:getMerit(dsp.merit.ENEMY_CRIT_RATE)/100;
-        if (attacker:hasStatusEffect(dsp.effect.INNIN) and attacker:isBehind(target, 23)) then -- Innin acc boost attacker is behind target
-            nativecrit = nativecrit + attacker:getStatusEffect(dsp.effect.INNIN):getPower();
-        end
-
-        if (nativecrit > 0.2) then -- caps!
-            nativecrit = 0.2;
-        elseif (nativecrit < 0.05) then
-            nativecrit = 0.05;
-        end
-        critrate = critrate + nativecrit;
-    end
-
-    -- Applying pDIF
-    local pdif = generatePdif(cratio[1], cratio[2], true);
-
-    local missChance = math.random();
-    local finaldmg = 0;
-    local hitrate = getAutoHitRate(attacker,target,true,bonusacc,true);
-    if (params.acc100~=0) then
-        -- ACCURACY VARIES WITH TP, APPLIED TO ALL HITS.
-        -- print("Accuracy varies with TP.");
-        hr = accVariesWithTP(getAutoHitRate(attacker,target,false,bonusacc,true),attacker:getACC(),tp,params.acc100,params.acc200,params.acc300);
-        hitrate = hr;
-    end
-
-    local dmg = base * ftp;
-    local tpHitsLanded = 0;
-    local shadowsAbsorbed = 0;
-    if ((missChance <= hitrate or isSneakValid or isAssassinValid or math.random() < attacker:getMod(dsp.mod.ZANSHIN)/100) and
-            not target:hasStatusEffect(dsp.effect.PERFECT_DODGE) and not target:hasStatusEffect(dsp.effect.TOO_HIGH) ) then
-        if not shadowAbsorb(target) then
-            if (params.canCrit or isSneakValid or isAssassinValid) then
-                local critchance = math.random();
-                if (critchance <= critrate or hasMightyStrikes or isSneakValid or isAssassinValid) then -- crit hit!
-                    local cpdif = generatePdif(ccritratio[1], ccritratio[2], true);
-                    finaldmg = dmg * cpdif;
-                    if (isSneakValid and attacker:getMainJob() == dsp.job.THF) then -- have to add on DEX bonus if on THF main
-                        finaldmg = finaldmg + (attacker:getStat(dsp.mod.DEX) * ftp * cpdif) * ((100+(attacker:getMod(dsp.mod.AUGMENTS_SA)))/100);
-                    end
-                    if (isTrickValid and attacker:getMainJob() == dsp.job.THF) then
-                        finaldmg = finaldmg + (attacker:getStat(dsp.mod.AGI) * (1 + attacker:getMod(dsp.mod.TRICK_ATK_AGI)/100) * ftp * cpdif) * ((100+(attacker:getMod(dsp.mod.AUGMENTS_TA)))/100);
-                    end
-                else
-                    finaldmg = dmg * pdif;
-                    if (isTrickValid and attacker:getMainJob() == dsp.job.THF) then
-                        finaldmg = finaldmg + (attacker:getStat(dsp.mod.AGI) * (1 + attacker:getMod(dsp.mod.TRICK_ATK_AGI)/100) * ftp * pdif) * ((100+(attacker:getMod(dsp.mod.AUGMENTS_TA)))/100);
-                    end
-                end
-            else
-                finaldmg = dmg * pdif;
-                if (isTrickValid and attacker:getMainJob() == dsp.job.THF) then
-                    finaldmg = finaldmg + (attacker:getStat(dsp.mod.AGI) * (1 + attacker:getMod(dsp.mod.TRICK_ATK_AGI)/100) * ftp * pdif) * ((100+(attacker:getMod(dsp.mod.AUGMENTS_TA)))/100);
-                end
-            end
-            tpHitsLanded = 1;
-        else
-            shadowsAbsorbed = shadowsAbsorbed + 1
+            finaldmg = finaldmg * target:getMod(dsp.mod.SLASHRES) / 1000
         end
     end
 
-    if not multiHitfTP then dmg = base end
+    finaldmg = finaldmg * WEAPON_SKILL_POWER -- Add server bonus
+    calcParams.finalDmg = finaldmg
 
-    -- Store first hit bonus for use after other calcs are done..
-    local firstHitBonus = ((finaldmg * attacker:getMod(dsp.mod.ALL_WSDMG_FIRST_HIT))/100);
-
-    local numHits = getMultiAttacks(attacker, target, params.numHits);
-    local extraHitsLanded = 0;
-
-    if (numHits > 1) then
-
-        local hitsdone = 1;
-        while (hitsdone < numHits) do
-            local chance = math.random();
-            local targetHP = target:getHP();
-            if ((chance<=hitrate or math.random() < attacker:getMod(dsp.mod.ZANSHIN)/100) and
-                    not target:hasStatusEffect(dsp.effect.PERFECT_DODGE) and not target:hasStatusEffect(dsp.effect.TOO_HIGH) ) then  -- it hit
-                if not shadowAbsorb(target) then
-                    pdif = generatePdif(cratio[1], cratio[2], true);
-                    if (params.canCrit) then
-                        critchance = math.random();
-                        if (critchance <= nativecrit or hasMightyStrikes) then -- crit hit!
-                            criticalHit = true;
-                            cpdif = generatePdif(ccritratio[1], ccritratio[2], true);
-                            finaldmg = finaldmg + dmg * cpdif;
-                        else
-                            finaldmg = finaldmg + dmg * pdif;
-                        end
-                    else
-                        finaldmg = finaldmg + dmg * pdif;
-                    end
-                    extraHitsLanded = extraHitsLanded + 1;
-                else
-                    shadowsAbsorbed = shadowsAbsorbed + 1
-                end
-            end
-            hitsdone = hitsdone + 1;
-            if (finaldmg > targetHP) then
-                break;
-            end
-        end
-    end
-    -- print("Landed " .. hitslanded .. "/" .. numHits .. " hits with hitrate " .. hitrate .. "!");
-
-
-    -- DMG Bonus for any WS
-    local bonusdmg = attacker:getMod(dsp.mod.ALL_WSDMG_ALL_HITS);
-
-    -- Add in bonusdmg
-    finaldmg = finaldmg * ((100 + bonusdmg)/100);
-    finaldmg = finaldmg + firstHitBonus;
-
-    -- Check for reductions from PDT
-    finaldmg = target:physicalDmgTaken(finaldmg, damageType);
-
-    -- Check for reductions from phys resistances
-    if (weaponType == dsp.skill.HAND_TO_HAND) then
-        finaldmg = finaldmg * target:getMod(dsp.mod.HTHRES) / 1000;
-    elseif (weaponType == dsp.skill.DAGGER or weaponType == dsp.skill.POLEARM) then
-        finaldmg = finaldmg * target:getMod(dsp.mod.PIERCERES) / 1000;
-    elseif (weaponType == dsp.skill.CLUB or weaponType == dsp.skill.STAFF) then
-        finaldmg = finaldmg * target:getMod(dsp.mod.IMPACTRES) / 1000;
-    else
-        finaldmg = finaldmg * target:getMod(dsp.mod.SLASHRES) / 1000;
-    end
-
-    attacker:delStatusEffectSilent(dsp.effect.BUILDING_FLOURISH);
-    finaldmg = finaldmg * WEAPON_SKILL_POWER
-    if tpHitsLanded + extraHitsLanded > 0 then
-        finaldmg = takeWeaponskillDamage(target, attacker, params, primary, finaldmg, dsp.attackType.PHYSICAL, damageType, dsp.slot.MAIN, tpHitsLanded, extraHitsLanded, shadowsAbsorbed, bonusTP, action, taChar)
+    if calcParams.tpHitsLanded + calcParams.extraHitsLanded > 0 then
+        finaldmg = takeWeaponskillDamage(target, attacker, wsParams, primaryMsg, attack, calcParams, action)
     else
         skill:setMsg(dsp.msg.basic.SKILL_MISS)
     end
-
-    return finaldmg, criticalHit, tpHitsLanded, extraHitsLanded;
-end;
+    
+    return finaldmg, calcParams.criticalHit, calcParams.tpHitsLanded, calcParams.extraHitsLanded, calcParams.shadowsAbsorbed
+end
 
 function getAutoHitRate(attacker,defender,capHitRate,bonus,melee)
     local acc = (melee and attacker:getACC() or attacker:getRACC()) + (bonus or 0);
@@ -358,150 +235,68 @@ function getAutocRatio(attacker, defender, params, ignoredDef, melee)
     return pdif, pdifcrit
 end
 
- -- params contains: ftp100, ftp200, ftp300, str_wsc, dex_wsc, vit_wsc, int_wsc, mnd_wsc, canCrit, crit100, crit200, crit300, acc100, acc200, acc300, ignoresDef, ignore100, ignore200, ignore300, atkmulti, accBonus, weaponDamage
- function doAutoRangedWeaponskill(attacker, target, wsID, params, tp, primary, skill, action)
-
-    local bonusTP = params.bonusTP or 0
-    local multiHitfTP = params.multiHitfTP or false
-    local bonusacc = attacker:getMod(dsp.mod.WSACC) + (params.accBonus or 0);
-
-    local dstr = utils.clamp(attacker:getStat(dsp.mod.STR) - target:getStat(dsp.mod.VIT), -10, 10)
-
-    -- apply WSC
-    local base = math.max((params.weaponDamage or attacker:getRangedDmg()) + dstr +
-        (attacker:getStat(dsp.mod.STR) * params.str_wsc + attacker:getStat(dsp.mod.DEX) * params.dex_wsc +
-         attacker:getStat(dsp.mod.VIT) * params.vit_wsc + attacker:getStat(dsp.mod.AGI) * params.agi_wsc +
-         attacker:getStat(dsp.mod.INT) * params.int_wsc + attacker:getStat(dsp.mod.MND) * params.mnd_wsc +
-         attacker:getStat(dsp.mod.CHR) * params.chr_wsc) + math.max(attacker:getMainLvl() - target:getMainLvl(), 0), 1)
-
-    -- Applying fTP multiplier
-    local ftpdmgbonus = attacker:getMod(dsp.mod.WEAPONSKILL_DAMAGE_BASE)/100;
-    local ftp = fTP(tp,params.ftp100,params.ftp200,params.ftp300) + ftpdmgbonus;
-    local crit = false
-
-    local ignoredDef = 0;
-    if (params.ignoresDef == not nil and params.ignoresDef == true) then
-        ignoredDef = calculatedIgnoredDef(tp, target:getStat(dsp.mod.DEF), params.ignored100, params.ignored200, params.ignored300);
+-- params contains: ftp100, ftp200, ftp300, str_wsc, dex_wsc, vit_wsc, int_wsc, mnd_wsc, canCrit, crit100, crit200, crit300, acc100, acc200, acc300, ignoresDef, ignore100, ignore200, ignore300, atkmulti, accBonus, weaponDamage
+function doAutoRangedWeaponskill(attacker, target, wsID, wsParams, tp, primaryMsg, skill, action)
+    -- Determine cratio and ccritratio
+    local ignoredDef = 0
+    if (wsParams.ignoresDef == not nil and wsParams.ignoresDef == true) then
+        ignoredDef = calculatedIgnoredDef(tp, target:getStat(dsp.mod.DEF), wsParams.ignored100, wsParams.ignored200, wsParams.ignored300)
     end
+    local cratio, ccritratio = getAutocRatio(attacker, target, wsParams, ignoredDef, false)
 
-    -- get cratio min and max
-    local cratio, ccritratio = getAutocRatio(attacker, target, params, ignoredDef, false);
-    local ccmin = 0;
-    local ccmax = 0;
-    local hasMightyStrikes = attacker:hasStatusEffect(dsp.effect.MIGHTY_STRIKES);
-    local critrate = 0;
-    if (params.canCrit) then -- work out critical hit ratios, by +1ing
-        critrate = fTP(tp,params.crit100,params.crit200,params.crit300);
-        -- add on native crit hit rate (guesstimated, it actually follows an exponential curve)
-        local nativecrit = (attacker:getStat(dsp.mod.DEX) - target:getStat(dsp.mod.AGI))*0.005; -- assumes +0.5% crit rate per 1 dDEX
-        nativecrit = nativecrit + (attacker:getMod(dsp.mod.CRITHITRATE)/100) + attacker:getMerit(dsp.merit.CRIT_HIT_RATE)/100 - target:getMerit(dsp.merit.ENEMY_CRIT_RATE)/100;
-        if (attacker:hasStatusEffect(dsp.effect.INNIN) and attacker:isBehind(target, 23)) then -- Innin crit boost if attacker is behind target
-            nativecrit = nativecrit + attacker:getStatusEffect(dsp.effect.INNIN):getPower();
-        end
+    -- Set up conditions and wsParams used for calculating weaponskill damage
 
-        if (nativecrit > 0.2) then -- caps!
-            nativecrit = 0.2;
-        elseif (nativecrit < 0.05) then
-            nativecrit = 0.05;
-        end
-        critrate = critrate + nativecrit;
-    end
+    -- Handle Flame Holder attachment.
+    -- DSP Mod usage, and values returned by Flame Holder script, might not be correct.
+    local flameHolderFTP = attacker:getMod(dsp.mod.WEAPONSKILL_DAMAGE_BASE) / 100
 
-    local dmg = base * ftp;
+    local attack =
+    {
+        ['type'] = dsp.attackType.RANGED,
+        ['slot'] = dsp.slot.RANGED,
+        ['weaponType'] = attacker:getWeaponSkillType(dsp.slot.RANGED),
+        ['damageType'] = attacker:getWeaponDamageType(dsp.slot.RANGED)
+    }
+    local calcParams =
+    {
+        weaponDamage = {wsParams.weaponDamage or attacker:getRangedDmg()},
+        fSTR = utils.clamp(attacker:getStat(dsp.mod.STR) - target:getStat(dsp.mod.VIT), -10, 10),
+        cratio = cratio,
+        ccritratio = ccritratio,
+        accStat = attacker:getRACC(),
+        melee = false,
+        mustMiss = false,
+        sneakApplicable = false,
+        trickApplicable = false,
+        assassinApplicable = false,
+        mightyStrikesApplicable = false,
+        forcedFirstCrit = false,
+        extraOffhandHit = false,
+        flourishEffect = false,
+        alpha = 1,
+        bonusWSmods = math.max(attacker:getMainLvl() - target:getMainLvl(), 0),
+        bonusTP = wsParams.bonusTP or 0,
+        bonusfTP = flameHolderFTP or 0,
+        bonusAcc = 0 + attacker:getMod(dsp.mod.WSACC)
+    }
+    calcParams.hitRate = getAutoHitRate(attacker, target, false, calcParams.bonusAcc, calcParams.melee)
 
-    -- Applying pDIF
-    local pdif = generatePdif(cratio[1],cratio[2], false);
+    -- Send our params off to calculate our raw WS damage, hits landed, and shadows absorbed
+    calcParams = calculateRawWSDmg(attacker, target, wsID, tp, action, wsParams, calcParams)
+    local finaldmg = calcParams.finalDmg
 
-    -- First hit has 95% acc always. Second hit + affected by hit rate.
-    local missChance = math.random();
-    local finaldmg = 0;
-    local hitrate = getAutoHitRate(attacker,target,true,bonusacc,false);
-    if (params.acc100~=0) then
-        -- ACCURACY VARIES WITH TP, APPLIED TO ALL HITS.
-        -- print("Accuracy varies with TP.");
-        hr = accVariesWithTP(getAutoHitRate(attacker,target,false,bonusacc,false),attacker:getRACC(),tp,params.acc100,params.acc200,params.acc300);
-        hitrate = hr;
-    end
+    -- Calculate reductions
+    finaldmg = target:rangedDmgTaken(finaldmg)
+    finaldmg = finaldmg * target:getMod(dsp.mod.PIERCERES) / 1000
 
-    local tpHitsLanded = 0;
-    local shadowsAbsorbed = 0
-    if (missChance <= hitrate) then
-        if not shadowAbsorb(target) then
-            if (params.canCrit) then
-                local critchance = math.random();
-                if (critchance <= critrate or hasMightyStrikes) then -- crit hit!
-                    crit = true
-                    local cpdif = generatePdif(ccritratio[1], ccritratio[2], false);
-                    finaldmg = dmg * cpdif;
-                else
-                    finaldmg = dmg * pdif;
-                end
-            else
-                finaldmg = dmg * pdif;
-            end
-            tpHitsLanded = 1;
-        else
-            shadowsAbsorbed = shadowsAbsorbed + 1
-        end
-    end
+    finaldmg = finaldmg * WEAPON_SKILL_POWER -- Add server bonus
+    calcParams.finalDmg = finaldmg
 
-    -- Store first hit bonus for use after other calcs are done..
-    local firstHitBonus = ((finaldmg * attacker:getMod(dsp.mod.ALL_WSDMG_FIRST_HIT))/100);
-
-    local numHits = params.numHits;
-
-    if not multiHitfTP then dmg = base end
-    local extraHitsLanded = 0;
-    if (numHits>1) then
-        if (params.acc100==0) then
-            -- work out acc since we actually need it now
-            hitrate = getAutoHitRate(attacker,target,true,bonusacc,false);
-        end
-
-        hitsdone = 1;
-        while (hitsdone < numHits) do
-            chance = math.random();
-            if (chance<=hitrate) then -- it hit
-                if not shadowAbsorb(target) then
-                    pdif = generatePdif(cratio[1],cratio[2], false);
-                    if (canCrit) then
-                        critchance = math.random();
-                        if (critchance <= critrate or hasMightyStrikes) then -- crit hit!
-                            cpdif = generatePdif(ccritratio[1], ccritratio[2], false);
-                            finaldmg = finaldmg + dmg * cpdif;
-                        else
-                            finaldmg = finaldmg + dmg * pdif;
-                        end
-                    else
-                        finaldmg = finaldmg + dmg * pdif; -- NOTE: not using 'dmg' since fTP is 1.0 for subsequent hits!!
-                    end
-                    extraHitsLanded = extraHitsLanded + 1;
-                else
-                    shadowsAbsorbed = shadowsAbsorbed + 1
-                end
-            end
-            hitsdone = hitsdone + 1;
-        end
-    end
-    -- print("Landed " .. hitslanded .. "/" .. numHits .. " hits with hitrate " .. hitrate .. "!");
-
-    -- DMG Bonus for any WS
-    local bonusdmg = attacker:getMod(dsp.mod.ALL_WSDMG_ALL_HITS);
-
-    -- Add in bonusdmg
-    finaldmg = finaldmg * ((100 + bonusdmg)/100);
-    finaldmg = finaldmg + firstHitBonus;
-
-    -- Check for reductions
-    finaldmg = target:rangedDmgTaken(finaldmg);
-    finaldmg = finaldmg * target:getMod(dsp.mod.PIERCERES) / 1000;
-
-    finaldmg = finaldmg * WEAPON_SKILL_POWER
-    if tpHitsLanded + extraHitsLanded > 0 then
-        finaldmg = takeWeaponskillDamage(target, attacker, params, primary, finaldmg, dsp.attackType.RANGED, attacker:getWeaponDamageType(dsp.slot.RANGED), dsp.slot.RANGED, tpHitsLanded, extraHitsLanded, shadowsAbsorbed, bonusTP, action, nil)
+    if calcParams.tpHitsLanded + calcParams.extraHitsLanded > 0 then
+        finaldmg = takeWeaponskillDamage(target, attacker, wsParams, primaryMsg, attack, calcParams, action)
     else
         skill:setMsg(dsp.msg.basic.SKILL_MISS)
     end
 
-    return finaldmg, crit, tpHitsLanded, extraHitsLanded;
-end;
+    return finaldmg, calcParams.criticalHit, calcParams.tpHitsLanded, calcParams.extraHitsLanded, calcParams.shadowsAbsorbed
+end

--- a/src/map/lua/lua_baseentity.cpp
+++ b/src/map/lua/lua_baseentity.cpp
@@ -11799,7 +11799,7 @@ inline int32 CLuaBaseEntity::getWeaponDmgRank(lua_State *L)
     DSP_DEBUG_BREAK_IF(m_PBaseEntity == nullptr);
     DSP_DEBUG_BREAK_IF(m_PBaseEntity->objtype == TYPE_NPC);
 
-    uint16 weapondam = ((CBattleEntity*)m_PBaseEntity)->GetMainWeaponRank() * 9;
+    uint16 weapondam = ((CBattleEntity*)m_PBaseEntity)->GetMainWeaponRank();
 
     lua_pushinteger(L, weapondam);
     return 1;
@@ -11836,7 +11836,7 @@ inline int32 CLuaBaseEntity::getOffhandDmgRank(lua_State *L)
     DSP_DEBUG_BREAK_IF(m_PBaseEntity == nullptr);
     DSP_DEBUG_BREAK_IF(m_PBaseEntity->objtype == TYPE_NPC);
 
-    uint16 weapondam = ((CBattleEntity*)m_PBaseEntity)->GetSubWeaponRank() * 9;
+    uint16 weapondam = ((CBattleEntity*)m_PBaseEntity)->GetSubWeaponRank();
 
     lua_pushinteger(L, weapondam);
     return 1;
@@ -11861,18 +11861,18 @@ inline int32 CLuaBaseEntity::getRangedDmg(lua_State *L)
 }
 
 /************************************************************************
-*  Function: getRangedDmgForRank()
+*  Function: getRangedDmgRank()
 *  Purpose : Used in determining fSTR caculcation in weaponskills.lua
-*  Example : attacker:getRangedDmgForRank()
-*  Notes   :   To Do: Rename to getRangedDmgRank to match convention
+*  Example : attacker:getRangedDmgRank()
+*  Notes   :
 ************************************************************************/
 
-inline int32 CLuaBaseEntity::getRangedDmgForRank(lua_State *L)
+inline int32 CLuaBaseEntity::getRangedDmgRank(lua_State *L)
 {
     DSP_DEBUG_BREAK_IF(m_PBaseEntity == nullptr);
     DSP_DEBUG_BREAK_IF(m_PBaseEntity->objtype == TYPE_NPC);
 
-    uint16 weaponrank = ((CBattleEntity*)m_PBaseEntity)->GetRangedWeaponRank() * 9;
+    uint16 weaponrank = ((CBattleEntity*)m_PBaseEntity)->GetRangedWeaponRank();
 
     lua_pushinteger(L, weaponrank);
     return 1;
@@ -14795,7 +14795,7 @@ Lunar<CLuaBaseEntity>::Register_t CLuaBaseEntity::methods[] =
     LUNAR_DECLARE_METHOD(CLuaBaseEntity,getOffhandDmg),
     LUNAR_DECLARE_METHOD(CLuaBaseEntity,getOffhandDmgRank),
     LUNAR_DECLARE_METHOD(CLuaBaseEntity,getRangedDmg),
-    LUNAR_DECLARE_METHOD(CLuaBaseEntity,getRangedDmgForRank),
+    LUNAR_DECLARE_METHOD(CLuaBaseEntity,getRangedDmgRank),
     LUNAR_DECLARE_METHOD(CLuaBaseEntity,getAmmoDmg),
 
     LUNAR_DECLARE_METHOD(CLuaBaseEntity,removeAmmo),

--- a/src/map/lua/lua_baseentity.h
+++ b/src/map/lua/lua_baseentity.h
@@ -575,7 +575,7 @@ public:
     int32 getOffhandDmg(lua_State*);            // gets the current equipped offhand's DMG rating (used in WS calcs)
     int32 getOffhandDmgRank(lua_State*);        // gets the current equipped offhand's DMG rating for Rank calc
     int32 getRangedDmg(lua_State*);             // Get ranged weapon DMG rating
-    int32 getRangedDmgForRank(lua_State*);      // Get ranged weapond DMG rating used for calculating rank
+    int32 getRangedDmgRank(lua_State*);         // Get ranged weapond DMG rating used for calculating rank
     int32 getAmmoDmg(lua_State*);               // Get ammo DMG rating
 
     int32 removeAmmo(lua_State* L);


### PR DESCRIPTION
This partially address #6035 

The "quick fix" would have been to touch the automaton functions as little as possible and just fiddle their output into what takeWeaponskillDamage expects. But that's boring, and why write a `calculateRawWeaponskillDmg` function if you're not going to use it?

Notes:
- This naturally fixes an issue where automaton crit rates were being capped by "natural" crit rates. I don't know if their are any non-natural critical mods for automatons, but they can go past cap now.
- Renamed `getRangedDmgForRank` to `getRangedDmgRank` per convention, as requested by the comment in core
- Removed the dmgRank multiplication by 9 in `lua_baseentity` that was only getting divided by 9 in the lua weaponskill script. Weaponskill script now simply uses the divided-by-9 value originally given by `battleEntity->Get[Melee/Ranged]WeaponRank`.
- Renamed base_dmg in fSTR to weapon_rank; the variable was probably the actual damage before (hence the division mentioned above), but wasn't renamed when it was changed to use weaponRank from lua_baseentity. (That's my guess anyway.)
- For players, corrected both melee and ranged WS using a weird combination of fSTR (melee) and fSTR2 (ranged). The approximations in the original function were for fSTR2, but it was using fSTR caps. Melee/Ranged WSes now use separate functions for their appropriate values, and `do[Physical/Ranged]Weaponskill` were changed to calculate their fSTR upfront before passing it in to `calculateRawWSDmg`. This also lets automatons precalculate their clamped dSTR value, allowing them to use `calculateRawWSDmg` as well. See [bgwiki's fSTR page](https://www.bg-wiki.com/bg/FSTR) for player fSTR/fSTR2 formulae and caps.
- Removed weaponDmgRank from calcParams because it's no longer used by calculateRawWSDmg (it's only used to calculate fSTR)
- Tweaked how calculateRawWSDmg sets/uses alpha, to let an alpha be passed in (to overwrite calculateRaw default behavior if desired), and added a `calcParams.bonusWSmods`. These are mainly for automatons right now, but could potentially be hooked into by other things in the future.
- Had to move hitRate calculations back into their original `do[Physical/Ranged]Weaponskill` functions, but are still put into `calcParams`.
- Fencer bonus calculated upfront by player `doPhysical/Ranged` , outside `calculateRawWeaponskillDmg`, because automatons don't have inventories.
- Bonus fTP and accuracy from Elemental Gorgets and Belts are now also pre-calculated before going into `calculateRaw`. The calcParams passed in for these in `calculateRaw` can also be used for generic bonus fTP, such as being used for an automaton's Flame Holder

Speaking of Flame Holder, I'm fairly certain that [the values it uses](https://github.com/DarkstarProject/darkstar/blob/master/scripts/globals/abilities/pets/attachments/flame_holder.lua#L28-L40) aren't [in line with retail](https://www.bg-wiki.com/bg/Flame_Holder). But that was outside of "get automaton WS working again", and I didn't want fixing it to delay getting a PR in.

The non-working player WSes mentioned in #6035 are still on my docket, but again, I wanted to get an automaton fix PR in relatively swiftly.

(And for once, my attempts at simplifying something actually resulted in net deletions! :tada: )