### PR TITLE
Fix real Padfoot loot

### DIFF
--- a/scripts/zones/Lufaise_Meadows/mobs/Padfoot.lua
+++ b/scripts/zones/Lufaise_Meadows/mobs/Padfoot.lua
@@ -1,37 +1,38 @@
 -----------------------------------
 -- Area: Lufaise Meadows
---  MOB: Padfoot
+--   NM: Padfoot
 -- !pos -43.689 0.487 -328.028 24
 -- !pos 260.445 -1.761 -27.862 24
 -- !pos 412.447 -0.057 -200.161 24
 -- !pos -378.950 -15.742 144.215 24
 -- !pos -141.523 -15.529 91.709 24
 -----------------------------------
-local ID = require("scripts/zones/Lufaise_Meadows/IDs");
+local ID = require("scripts/zones/Lufaise_Meadows/IDs")
 -----------------------------------
 
 function onMobSpawn(mob)
-    if (mob:getID() == ID.mob.PADFOOT[GetServerVariable("realPadfoot")]) then
-        mob:setDropID(4478);
+    if mob:getID() == ID.mob.PADFOOT[GetServerVariable("realPadfoot")] then
+        mob:setDropID(4478)
     else
-        mob:setDropID(2734);
+        mob:setDropID(2734)
     end
-end;
+end
 
 function onMobDeath(mob, player, isKiller)
-    if (isKiller) then
-        local mobId = mob:getID();
-        if (mobId == ID.mob.PADFOOT[GetServerVariable("realPadfoot")]) then
+    if isKiller then
+        local mobId = mob:getID()
 
-            local respawn = math.random(75600, 86400); -- 21-24 hours
+        if mobId == ID.mob.PADFOOT[GetServerVariable("realPadfoot")] then
+            local respawn = math.random(75600, 86400) -- 21-24 hours
+
             for _, v in pairs(ID.mob.PADFOOT) do
-                if (v ~= mobId and GetMobByID(v):isSpawned()) then
-                    DespawnMob(v);
+                if v ~= mobId and GetMobByID(v):isSpawned() then
+                    DespawnMob(v)
                 end
-                GetMobByID(v):setRespawnTime(respawn);
+                GetMobByID(v):setRespawnTime(respawn)
             end
 
-            SetServerVariable("realPadfoot",math.random(1,5));
+            SetServerVariable("realPadfoot", math.random(1,5))
         end
     end
-end;
+end

--- a/scripts/zones/Lufaise_Meadows/mobs/Padfoot.lua
+++ b/scripts/zones/Lufaise_Meadows/mobs/Padfoot.lua
@@ -19,20 +19,21 @@ function onMobSpawn(mob)
 end
 
 function onMobDeath(mob, player, isKiller)
-    if isKiller then
-        local mobId = mob:getID()
+end
 
-        if mobId == ID.mob.PADFOOT[GetServerVariable("realPadfoot")] then
-            local respawn = math.random(75600, 86400) -- 21-24 hours
+function onMobDespawn(mob)
+    local mobId = mob:getID()
 
-            for _, v in pairs(ID.mob.PADFOOT) do
-                if v ~= mobId and GetMobByID(v):isSpawned() then
-                    DespawnMob(v)
-                end
-                GetMobByID(v):setRespawnTime(respawn)
+    if mobId == ID.mob.PADFOOT[GetServerVariable("realPadfoot")] then
+        local respawn = math.random(75600, 86400) -- 21-24 hours
+
+        for _, v in pairs(ID.mob.PADFOOT) do
+            if v ~= mobId and GetMobByID(v):isSpawned() then
+                DespawnMob(v)
             end
-
-            SetServerVariable("realPadfoot", math.random(1,5))
+            GetMobByID(v):setRespawnTime(respawn)
         end
+
+        SetServerVariable("realPadfoot", math.random(1,5))
     end
 end

--- a/scripts/zones/Lufaise_Meadows/mobs/Padfoot.lua
+++ b/scripts/zones/Lufaise_Meadows/mobs/Padfoot.lua
@@ -13,6 +13,8 @@ local ID = require("scripts/zones/Lufaise_Meadows/IDs");
 function onMobSpawn(mob)
     if (mob:getID() == ID.mob.PADFOOT[GetServerVariable("realPadfoot")]) then
         mob:setDropID(4478);
+    else
+        mob:setDropID(2734);
     end
 end;
 
@@ -20,7 +22,7 @@ function onMobDeath(mob, player, isKiller)
     if (isKiller) then
         local mobId = mob:getID();
         if (mobId == ID.mob.PADFOOT[GetServerVariable("realPadfoot")]) then
-            
+
             local respawn = math.random(75600, 86400); -- 21-24 hours
             for _, v in pairs(ID.mob.PADFOOT) do
                 if (v ~= mobId and GetMobByID(v):isSpawned()) then
@@ -29,7 +31,6 @@ function onMobDeath(mob, player, isKiller)
                 GetMobByID(v):setRespawnTime(respawn);
             end
 
-            mob:setDropID(2734);
             SetServerVariable("realPadfoot",math.random(1,5));
         end
     end


### PR DESCRIPTION
setting its loot back to default dropid in onMobDeath is too early, so real padfoot would end up dropping same loot as the fake ones.