### PR TITLE
Fix broken getTHlevel() function

### DIFF
--- a/src/map/lua/lua_baseentity.cpp
+++ b/src/map/lua/lua_baseentity.cpp
@@ -8927,13 +8927,13 @@ inline int32 CLuaBaseEntity::getBattlefield(lua_State* L)
 *  Function: getBattlefieldID()
 *  Purpose : Returns the integer ID for the battlefield, -1 if not found
 *  Example : local battlefieldId = player:getBattlefieldID()
-*  Notes   : 
+*  Notes   :
 ************************************************************************/
 
 inline int32 CLuaBaseEntity::getBattlefieldID(lua_State *L)
 {
     DSP_DEBUG_BREAK_IF(m_PBaseEntity == nullptr);
-    
+
     lua_pushinteger(L, m_PBaseEntity->PBattlefield ? m_PBaseEntity->PBattlefield->GetID() : -1);
     return 1;
 }
@@ -8990,7 +8990,7 @@ inline int32 CLuaBaseEntity::battlefieldAtCapacity(lua_State *L)
 *  Function: enterBattlefield(area)
 *  Purpose : Places an entity into a battlefield they are registered for (or tries enter a specific area if not full)
 *  Example : player:enterBattlefield(area)
-*  Notes   : 
+*  Notes   :
 ************************************************************************/
 
 inline int32 CLuaBaseEntity::enterBattlefield(lua_State* L)
@@ -13706,7 +13706,7 @@ inline int32 CLuaBaseEntity::getTHlevel(lua_State* L)
     DSP_DEBUG_BREAK_IF(m_PBaseEntity->objtype != TYPE_MOB);
 
     CMobEntity* PMob = (CMobEntity*)m_PBaseEntity;
-    lua_pushinteger(L, PMob->m_THLvl);
+    lua_pushinteger(L, PMob->PEnmityContainer->GetHighestTH());
     return 1;
 }
 


### PR DESCRIPTION
This change fetches it from the enmitycontainer's value of the highest TH currently applied, rather than the mobs TH value which is now only being set on death. This means after this merged you can see the Mob's TH go up/down in realtime via script. I'm 99% sure this _was_ how it worked original before some changes to mobentity.cpp moved things around a bit. Currently in master without this change you can only see the real TH value when a mob dies, making this function less useful.