### PR TITLE
stringing pummel fTP/crit rate. drakesbane attack penalty.

### DIFF
--- a/scripts/globals/weaponskills/drakesbane.lua
+++ b/scripts/globals/weaponskills/drakesbane.lua
@@ -26,10 +26,9 @@ function onUseWeaponSkill(player, target, wsID, tp, primary, action, taChar)
     params.crit100 = 0.1 params.crit200 = 0.3 params.crit300 = 0.5
     params.canCrit = true
     params.acc100 = 0.0 params.acc200 = 0.0 params.acc300 = 0.0
-    params.atk100 = 1; params.atk200 = 1; params.atk300 = 1;
+    params.atk100 = 0.8125 params.atk200 = 0.8125 params.atk300 = 0.8125
 
     if USE_ADOULIN_WEAPON_SKILL_CHANGES then
-        params.atk100 = 0.8125; params.atk200 = 0.8125; params.atk300 = 0.8125;
         params.crit100 = 0.1 params.crit200 = 0.25 params.crit300 = 0.4
     end
 

--- a/scripts/globals/weaponskills/stringing_pummel.lua
+++ b/scripts/globals/weaponskills/stringing_pummel.lua
@@ -9,7 +9,7 @@
 -- Element: Darkness
 -- Modifiers: STR:32% VIT:32%
 -- 100%TP    200%TP    300%TP
---   1         1         1
+-- 0.75      0.75      0.75
 -----------------------------------
 require("scripts/globals/aftermath")
 require("scripts/globals/settings")
@@ -20,13 +20,13 @@ require("scripts/globals/weaponskills")
 function onUseWeaponSkill(player, target, wsID, tp, primary, action, taChar)
     local params = {}
     params.numHits = 6
-    params.ftp100 = 1 params.ftp200 = 1 params.ftp300 = 1
+    params.ftp100 = 0.75 params.ftp200 = 0.75 params.ftp300 = 0.75
     params.str_wsc = 0.32 params.dex_wsc = 0.0 params.vit_wsc = 0.32 params.agi_wsc = 0.0 params.int_wsc = 0.0
     params.mnd_wsc = 0.0 params.chr_wsc = 0.0
-    params.crit100 = 0.15 params.crit200 = 0.45 params.crit300 = 0.65
+    params.crit100 = 0.15 params.crit200 = 0.30 params.crit300 = 0.45
     params.canCrit = true
     params.acc100 = 0.0 params.acc200 = 0.0 params.acc300 = 0.0
-    params.atk100 = 1; params.atk200 = 1; params.atk300 = 1;
+    params.atk100 = 1 params.atk200 = 1 params.atk300 = 1
 
     if USE_ADOULIN_WEAPON_SKILL_CHANGES then
         params.crit100 = 0.15 params.crit200 = 0.3 params.crit300 = 0.45


### PR DESCRIPTION
**Stringing Pummel**

Can find no reference for those high crit rates, looking back at history of any wiki.  Assume they were always ~15/30/45.

fTP is 0.75.  See discussion [here](https://ffxiclopedia.fandom.com/wiki/Talk:Stringing_Pummel).  This WS is currently doing way more damage than expected.

**Drakesbane**

This WS had an attack penalty [from its](https://www.bluegartr.com/threads/104123-Weapon-Skills?p=4931325&viewfull=1#post4931325) [introduction](https://www32.atwiki.jp/studiogobli/pages/93.html).