### PR TITLE
Check for infinite loop that is causing stack overflow when releasing…

### DIFF
--- a/src/map/entities/baseentity.cpp
+++ b/src/map/entities/baseentity.cpp
@@ -53,6 +53,11 @@ CBaseEntity::CBaseEntity()
 
 CBaseEntity::~CBaseEntity()
 {
+    if (destructing)
+        return;
+
+    destructing = true;
+
     if (PBattlefield)
         PBattlefield->RemoveEntity(this, BATTLEFIELD_LEAVE_CODE_WARPDC);
 }

--- a/src/map/entities/baseentity.h
+++ b/src/map/entities/baseentity.h
@@ -245,6 +245,8 @@ public:
     std::unique_ptr<CAIContainer> PAI;       // AI container
     CBattlefield* PBattlefield;            // pointer to battlefield (if in one)
     CInstance*		PInstance;
+
+    bool            destructing;        // dtor called
 protected:
     std::map<std::string, uint32> m_localVars;
 };


### PR DESCRIPTION
… a pet in a battlefield.

Resolves issue #6115.

I did not see a particular code pattern in dsp for addressing an infinite loop in a dtor, so looked online for existing C++ patterns and went with this one.
