### PR TITLE
Remove erroneous command to set respawntime

### DIFF
--- a/scripts/zones/Batallia_Downs/mobs/Weeping_Willow.lua
+++ b/scripts/zones/Batallia_Downs/mobs/Weeping_Willow.lua
@@ -21,6 +21,4 @@ function onMobDespawn(mob)
     -- Retail behavior is for it to walk back to where willow died if unclaimed *unless* willow was pulled down the cliff
     -- In that case, it will walk back near where Willow was spawned at.
     GetMobByID(mob:getID() + 6):setSpawn(mob:getXPos(), mob:getYPos(), mob:getZPos())
-
-    mob:setRespawnTime(math.random(75600, 86400)) -- 21 to 24 hours
 end


### PR DESCRIPTION
https://github.com/DarkstarProject/darkstar/blob/a293999536fdc8eb3a106b0514ef421b2d21d2c6/scripts/zones/Batallia_Downs/mobs/Lumber_Jack.lua#L27

Willows repop time is without exception always set by Lumber Jacks despawn. You should not be able to see Willow ever repop if Jack did not despawn, which he will always do if killed or was left idle until depop. Therefor there was no reason to be setting this line in willow's onMobDespawn only to have it overwritten by Lumber Jack's onMobDespawn