### PR TITLE
BCNM content for Boneyard Gully

### DIFF
--- a/scripts/globals/bcnm.lua
+++ b/scripts/globals/bcnm.lua
@@ -28,7 +28,7 @@ local battlefields = {
 
     [8] = {                 -- BONEYARD GULLY
         { 0,  672,    0},   -- Head Wind (PM5-3 U2)
-        { 1,  673,    0},   -- Like the Wind (ENM)
+     -- { 1,  673,    0},   -- Like the Wind (ENM) -- TODO: mob constantly runs during battle
      -- { 2,  674,    0},   -- Sheep in Antlion's Clothing (ENM)
      -- { 3,  675,    0},   -- Shell We Dance? (ENM)
      -- { 4,  676,    0},   -- Totentanz (ENM)

--- a/scripts/zones/Boneyard_Gully/mobs/Race_Runner.lua
+++ b/scripts/zones/Boneyard_Gully/mobs/Race_Runner.lua
@@ -1,10 +1,11 @@
 -----------------------------------
--- Area: Boneyard_Gully
+-- Area: Boneyard Gully
 --  Mob: Race Runner
+--  ENM: Like the Wind
 -----------------------------------
-require("scripts/globals/pathfind");
-require("scripts/globals/titles");
-require("scripts/globals/status");
+require("scripts/globals/pathfind")
+require("scripts/globals/status")
+require("scripts/globals/titles")
 -----------------------------------
 
 local path =
@@ -16,24 +17,21 @@ local path =
     -572, 2, -433,
     -545, 1, -440,
     -532, 0, -466
-};
+}
 
 function onMobSpawn(mob)
-    onMobRoam(mob);
-end;
+    onMobRoam(mob)
+end
 
 function onMobRoamAction(mob)
-
-    dsp.path.patrol(mob, path, dsp.path.flag.REVERSE);
-
-end;
+    dsp.path.patrol(mob, path, dsp.path.flag.REVERSE)
+end
 
 function onMobRoam(mob)
-    -- move to start position if not moving
-    if (mob:isFollowingPath() == false) then
-        mob:pathThrough(dsp.path.first(path));
+    if not mob:isFollowingPath() then
+        mob:pathThrough(dsp.path.first(path))
     end
-end;
+end
 
 function onMobDeath(mob, player, isKiller)
-end;
+end

--- a/scripts/zones/Boneyard_Gully/npcs/Armoury_Crate.lua
+++ b/scripts/zones/Boneyard_Gully/npcs/Armoury_Crate.lua
@@ -8,31 +8,35 @@ require("scripts/globals/quests");
 
 local loot =
 {
-    -- ENM: Like the Wind (Wiki showed ???% for droprate, these are guesses based on other ENMs)
+    -- ENM: Like the Wind
     [673] =
     {
         {
-            {itemid = 1763, droprate = 342},  -- Viridian Urushi
-            {itemid = 1769, droprate = 268},  -- Square of Galateia (26.8% Drop Rate)
-            {itemid = 1764, droprate = 266},  -- Kejusu Satin
+            {itemid =     0, droprate =  140}, -- nothing
+            {itemid =  1763, droprate =  310}, -- Viridian Urushi
+            {itemid =  1769, droprate =  241}, -- Square of Galateia
+            {itemid =  1764, droprate =  310}, -- Kejusu Satin
         },
         {
-            {itemid = 1842, droprate = 56},   -- Cloud Evoker (5.6% Drop Rate)
+            {itemid =     0, droprate =  862}, -- nothing
+            {itemid =  1842, droprate =  138}, -- Cloud Evoker
         },
         {
-            {itemid = 17946, droprate = 92},  -- Maneater
-            {itemid = 18358, droprate = 63},  -- Wagh Baghnakhs
-            {itemid = 16976, droprate = 82},  -- Onimaru
-            {itemid = 4990, droprate = 121},  -- Army's Paeon V
+            {itemid =     0, droprate =  380}, -- nothing
+            {itemid = 17946, droprate =  138}, -- Maneater
+            {itemid = 18358, droprate =  172}, -- Wagh Baghnakhs
+            {itemid = 16976, droprate =  138}, -- Onimaru
+            {itemid =  4990, droprate =  172}, -- Army's Paeon V
         },
         {
-            {itemid = 17946, droprate = 92},  -- Maneater
-            {itemid = 18358, droprate = 63},  -- Wagh Baghnakhs
-            {itemid = 16976, droprate = 82},  -- Onimaru
-            {itemid = 4990, droprate = 121},  -- Army's Paeon V
+            {itemid =     0, droprate =  380}, -- nothing
+            {itemid = 17946, droprate =  138}, -- Maneater
+            {itemid = 18358, droprate =  172}, -- Wagh Baghnakhs
+            {itemid = 16976, droprate =  138}, -- Onimaru
+            {itemid =  4990, droprate =  172}, -- Army's Paeon V
         },
     },
-			
+
     -- ENM: Sheep in Antlion's Clothing
     [674] =
     {
@@ -52,7 +56,7 @@ local loot =
             {itemid = 13109, droprate = 121}, -- Harmonia's Torque
         },
     },
-		
+
     -- ENM: Shell We Dance?
     [675] =
     {
@@ -77,7 +81,7 @@ local loot =
             {itemid = 4990, droprate = 238},  -- Scroll of Army's Paeon V
         },
     },
-	
+
     -- ENM: Totentanz (Wiki did not have groupings or droprates, these values are guesses based on other ENMs)
     [676] =
     {


### PR DESCRIPTION
Closing ENM "Like the Wind", as the main mechanic does not work.  Mob should run around constantly, stopping only if it get near the target atop its hate list.  Then it will attack with very short delay between swings until it uses a TP move, at which point it will start running again.

Otherwise the fight works, so server admins can toggle the ENM on in scripts/globals/bcnm.lua if they want to enable easy mode victories.