### PR TITLE
clean up mission/quest battlefield scripts

### DIFF
--- a/scripts/zones/Balgas_Dais/bcnms/shattering_stars.lua
+++ b/scripts/zones/Balgas_Dais/bcnms/shattering_stars.lua
@@ -3,65 +3,46 @@
 -- Name: Shattering stars - Maat Fight
 -- !pos 299 -123 345 146
 -----------------------------------
-
-require("scripts/globals/titles");
-require("scripts/globals/quests");
-local ID =require("scripts/zones/Balgas_Dais/IDs");
+local ID = require("scripts/zones/Balgas_Dais/IDs")
 require("scripts/globals/battlefield")
-
+require("scripts/globals/quests")
+require("scripts/globals/titles")
 -----------------------------------
 
 function onBattlefieldTick(battlefield, tick)
     dsp.battlefield.onBattlefieldTick(battlefield, tick)
 end
 
--- After registering the BCNM via bcnmRegister(bcnmid)
-function onBattlefieldRegister(player,battlefield)
-end;
+function onBattlefieldRegister(player, battlefield)
+end
 
--- Physically entering the BCNM via bcnmEnter(bcnmid)
-function onBattlefieldEnter(player,battlefield)
-end;
+function onBattlefieldEnter(player, battlefield)
+end
 
--- Leaving the BCNM by every mean possible, given by the LeaveCode
--- 1=Select Exit on circle
--- 2=Winning the BC
--- 3=Disconnected or warped out
--- 4=Losing the BC
--- via bcnmLeave(1) or bcnmLeave(2). LeaveCodes 3 and 4 are called
--- from the core when a player disconnects or the time limit is up, etc
-
-function onBattlefieldLeave(player,battlefield,leavecode)
--- print("leave code "..leavecode);
-
-    if leavecode == dsp.battlefield.leaveCode.WON then -- play end CS. Need time and battle id for record keeping + storage
+function onBattlefieldLeave(player, battlefield, leavecode)
+    if leavecode == dsp.battlefield.leaveCode.WON then
         local name, clearTime, partySize = battlefield:getRecord()
         player:startEvent(32001, battlefield:getArea(), clearTime, partySize, battlefield:getTimeInside(), 1, battlefield:getLocalVar("[cs]bit"), 0)
     elseif leavecode == dsp.battlefield.leaveCode.LOST then
-        player:startEvent(32002);
+        player:startEvent(32002)
     end
+end
 
-end;
+function onEventUpdate(player, csid, option)
+end
 
-function onEventUpdate(player,csid,option)
--- print("bc update csid "..csid.." and option "..option);
-end;
-
-function onEventFinish(player,csid,option)
--- print("bc finish csid "..csid.." and option "..option);
-
-    if (csid == 32001) then
-        if (player:getQuestStatus(JEUNO,dsp.quest.id.jeuno.SHATTERING_STARS) == QUEST_ACCEPTED and player:getFreeSlotsCount() > 0) then
-            player:addItem(4181);
-            player:messageSpecial(ID.text.ITEM_OBTAINED,4181);
+function onEventFinish(player, csid, option)
+    if csid == 32001 then
+        if player:getQuestStatus(JEUNO, dsp.quest.id.jeuno.SHATTERING_STARS) == QUEST_ACCEPTED and player:getFreeSlotsCount() > 0 then
+            player:addItem(4181)
+            player:messageSpecial(ID.text.ITEM_OBTAINED, 4181)
         end
-        local pjob = player:getMainJob();
-        player:setVar("maatDefeated",pjob);
+        local pjob = player:getMainJob()
+        player:setVar("maatDefeated", pjob)
         local maatsCap = player:getVar("maatsCap")
-        if (bit.band(maatsCap, bit.lshift(1, (pjob -1))) ~= 1) then
-            player:setVar("maatsCap",bit.bor(maatsCap, bit.lshift(1, (pjob -1))))
+        if bit.band(maatsCap, bit.lshift(1, pjob - 1)) ~= 1 then
+            player:setVar("maatsCap", bit.bor(maatsCap, bit.lshift(1, pjob - 1)))
         end
-        player:addTitle(dsp.title.MAAT_MASHER);
+        player:addTitle(dsp.title.MAAT_MASHER)
     end
-
-end;
+end

--- a/scripts/zones/Chamber_of_Oracles/bcnms/shattering_stars.lua
+++ b/scripts/zones/Chamber_of_Oracles/bcnms/shattering_stars.lua
@@ -13,38 +13,25 @@ function onBattlefieldTick(battlefield, tick)
     dsp.battlefield.onBattlefieldTick(battlefield, tick)
 end
 
--- After registering the BCNM via bcnmRegister(bcnmid)
-function onBattlefieldRegister(player,battlefield)
-end;
+function onBattlefieldRegister(player, battlefield)
+end
 
--- Physically entering the BCNM via bcnmEnter(bcnmid)
-function onBattlefieldEnter(player,battlefield)
-    -- player:messageSpecial(107);
-end;
+function onBattlefieldEnter(player, battlefield)
+end
 
--- Leaving the BCNM by every mean possible, given by the LeaveCode
--- 1=Select Exit on circle
--- 2=Winning the BC
--- 3=Disconnected or warped out
--- 4=Losing the BC
--- via bcnmLeave(1) or bcnmLeave(2). LeaveCodes 3 and 4 are called
--- from the core when a player disconnects or the time limit is up, etc
-
-function onBattlefieldLeave(player,battlefield,leavecode)
-    -- print("leave code "..leavecode);
-
-    if leavecode == dsp.battlefield.leaveCode.WON then -- play end CS. Need time and battle id for record keeping + storage
+function onBattlefieldLeave(player, battlefield, leavecode)
+    if leavecode == dsp.battlefield.leaveCode.WON then
         local name, clearTime, partySize = battlefield:getRecord()
         player:startEvent(32001, battlefield:getArea(), clearTime, partySize, battlefield:getTimeInside(), 1, battlefield:getLocalVar("[cs]bit"), 0)
     elseif leavecode == dsp.battlefield.leaveCode.LOST then
-        player:startEvent(32002);
+        player:startEvent(32002)
     end
 end
 
-function onEventUpdate(player,csid,option)
+function onEventUpdate(player, csid, option)
 end
 
-function onEventFinish(player,csid,option)
+function onEventFinish(player, csid, option)
     if csid == 32001 then
         if player:getQuestStatus(JEUNO, dsp.quest.id.jeuno.SHATTERING_STARS) == QUEST_ACCEPTED and player:getFreeSlotsCount() > 0 then
             player:addItem(4181)
@@ -53,8 +40,8 @@ function onEventFinish(player,csid,option)
         local pjob = player:getMainJob()
         player:setVar("maatDefeated", pjob)
         local maatsCap = player:getVar("maatsCap")
-        if bit.band(maatsCap, bit.lshift(1, (pjob - 1))) ~= 1 then
-            player:setVar("maatsCap", bit.bor(maatsCap, bit.lshift(1, (pjob - 1))))
+        if bit.band(maatsCap, bit.lshift(1, pjob - 1)) ~= 1 then
+            player:setVar("maatsCap", bit.bor(maatsCap, bit.lshift(1, pjob - 1)))
         end
         player:addTitle(dsp.title.MAAT_MASHER)
     end

--- a/scripts/zones/Chamber_of_Oracles/bcnms/through_the_quicksand_caves.lua
+++ b/scripts/zones/Chamber_of_Oracles/bcnms/through_the_quicksand_caves.lua
@@ -4,53 +4,35 @@
 -- !pos -221 -24 19 206
 -----------------------------------
 require("scripts/globals/battlefield")
-require("scripts/globals/keyitems");
-require("scripts/globals/missions");
-require("scripts/globals/titles");
+require("scripts/globals/missions")
 -----------------------------------
 
 function onBattlefieldTick(battlefield, tick)
     dsp.battlefield.onBattlefieldTick(battlefield, tick)
 end
 
--- After registering the BCNM via bcnmRegister(bcnmid)
-function onBcnmRegister(player,instance)
+function onBcnmRegister(player, instance)
 end
 
-function onBcnmEnter(player,instance)
+function onBcnmEnter(player, instance)
 end
 
--- Leaving the BCNM by every mean possible, given by the LeaveCode
--- 1=Select Exit on circle
--- 2=Winning the BC
--- 3=Disconnected or warped out
--- 4=Losing the BC
--- via bcnmLeave(1) or bcnmLeave(2). LeaveCodes 3 and 4 are called
--- from the core when a player disconnects or the time limit is up, etc
-
-function onBattlefieldLeave(player,battlefield,leavecode)
-    -- print("leave code "..leavecode);
-
-    if leavecode == dsp.battlefield.leaveCode.WON then -- play end CS. Need time and battle id for record keeping + storage
+function onBattlefieldLeave(player, battlefield, leavecode)
+    if leavecode == dsp.battlefield.leaveCode.WON then
         local name, clearTime, partySize = battlefield:getRecord()
-        if (player:getCurrentMission(ZILART) == dsp.mission.id.zilart.THROUGH_THE_QUICKSAND_CAVES) then
-            player:startEvent(32001, battlefield:getArea(), clearTime, partySize, battlefield:getTimeInside(), 1, battlefield:getLocalVar("[cs]bit"), 0)
-        else
-            player:startEvent(32001, battlefield:getArea(), clearTime, partySize, battlefield:getTimeInside(), 1, battlefield:getLocalVar("[cs]bit"), 1)
-        end
+        local arg8 = (player:getCurrentMission(ZILART) ~= dsp.mission.id.zilart.THROUGH_THE_QUICKSAND_CAVES) and 1 or 0
+        player:startEvent(32001, battlefield:getArea(), clearTime, partySize, battlefield:getTimeInside(), 1, battlefield:getLocalVar("[cs]bit"), arg8)
     elseif leavecode == dsp.battlefield.leaveCode.LOST then
-        player:startEvent(32002);
+        player:startEvent(32002)
     end
 end
 
-function onEventUpdate(player,csid,option)
+function onEventUpdate(player, csid, option)
 end
 
-function onEventFinish(player,csid,option)
-    if csid == 32001 then
-        if player:getCurrentMission(ZILART) == dsp.mission.id.zilart.THROUGH_THE_QUICKSAND_CAVES then
-            player:completeMission(ZILART, dsp.mission.id.zilart.THROUGH_THE_QUICKSAND_CAVES)
-            player:addMission(ZILART, dsp.mission.id.zilart.THE_CHAMBER_OF_ORACLES)
-        end
+function onEventFinish(player, csid, option)
+    if csid == 32001 and player:getCurrentMission(ZILART) == dsp.mission.id.zilart.THROUGH_THE_QUICKSAND_CAVES then
+        player:completeMission(ZILART, dsp.mission.id.zilart.THROUGH_THE_QUICKSAND_CAVES)
+        player:addMission(ZILART, dsp.mission.id.zilart.THE_CHAMBER_OF_ORACLES)
     end
 end

--- a/scripts/zones/Cloister_of_Flames/bcnms/sugar-coated_directive.lua
+++ b/scripts/zones/Cloister_of_Flames/bcnms/sugar-coated_directive.lua
@@ -1,58 +1,37 @@
 ----------------------------------------
 -- Area: Cloister of Flames
 -- BCNM: Sugar Coated Directive (ASA-4)
--- !pos -721 0 -598 207
 ----------------------------------------
-require("scripts/globals/keyitems");
 require("scripts/globals/battlefield")
-require("scripts/globals/missions");
+require("scripts/globals/missions")
 ----------------------------------------
 
--- After registering the BCNM via bcnmRegister(bcnmid)
-function onBattlefieldRegister(player,battlefield)
-end;
 function onBattlefieldTick(battlefield, tick)
     dsp.battlefield.onBattlefieldTick(battlefield, tick)
 end
 
--- Physically entering the BCNM via bcnmEnter(bcnmid)
-function onBattlefieldEnter(player,battlefield)
-end;
+function onBattlefieldRegister(player, battlefield)
+end
 
--- Leaving the BCNM by every mean possible, given by the LeaveCode
--- 1=Select Exit on circle
--- 2=Winning the BC
--- 3=Disconnected or warped out
--- 4=Losing the BC
--- via bcnmLeave(1) or bcnmLeave(2). LeaveCodes 3 and 4 are called
--- from the core when a player disconnects or the time limit is up, etc
+function onBattlefieldEnter(player, battlefield)
+end
 
-function onBattlefieldLeave(player,battlefield,leavecode)
-    -- print("leave code "..leavecode);
-
-    if leavecode == dsp.battlefield.leaveCode.WON then -- play end CS. Need time and battle id for record keeping + storage
+function onBattlefieldLeave(player, battlefield, leavecode)
+    if leavecode == dsp.battlefield.leaveCode.WON then
         local name, clearTime, partySize = battlefield:getRecord()
-        if (player:hasCompletedMission(ASA,dsp.mission.id.asa.SUGAR_COATED_DIRECTIVE)) then
-            player:startEvent(32001, battlefield:getArea(), clearTime, partySize, battlefield:getTimeInside(), 1, battlefield:getLocalVar("[cs]bit"), 1)
-        else
-            player:startEvent(32001, battlefield:getArea(), clearTime, partySize, battlefield:getTimeInside(), 1, battlefield:getLocalVar("[cs]bit"), 0)
-        end
+        local arg8 = (player:hasCompletedMission(ASA, dsp.mission.id.asa.SUGAR_COATED_DIRECTIVE)) and 1 or 0
+        player:startEvent(32001, battlefield:getArea(), clearTime, partySize, battlefield:getTimeInside(), 1, battlefield:getLocalVar("[cs]bit"), arg8)
     elseif leavecode == dsp.battlefield.leaveCode.LOST then
-        player:startEvent(32002);
+        player:startEvent(32002)
     end
+end
 
-end;
+function onEventUpdate(player, csid, option)
+end
 
-function onEventUpdate(player,csid,option)
-    -- print("bc update csid "..csid.." and option "..option);
-end;
-
-function onEventFinish(player,csid,option)
-    -- print("bc finish csid "..csid.." and option "..option);
-
-    if (csid == 32001) then
-        player:addExp(400);
-        player:setVar("ASA4_Scarlet","1");
+function onEventFinish(player, csid, option)
+    if csid == 32001 then
+        player:addExp(400)
+        player:setVar("ASA4_Scarlet", "1")
     end
-
-end;
+end

--- a/scripts/zones/Cloister_of_Flames/bcnms/trial-size_trial_by_fire.lua
+++ b/scripts/zones/Cloister_of_Flames/bcnms/trial-size_trial_by_fire.lua
@@ -1,69 +1,48 @@
 -----------------------------------
 -- Area: Cloister of Flames
 -- BCNM: Trial-size Trial by Fire
--- !pos -721 0 -598 207
 -----------------------------------
-
-require("scripts/globals/keyitems");
-require("scripts/globals/shop");
-require("scripts/globals/quests");
-local ID = require("scripts/zones/Cloister_of_Flames/IDs");
+local ID = require("scripts/zones/Cloister_of_Flames/IDs")
 require("scripts/globals/battlefield")
-
+require("scripts/globals/quests")
 -----------------------------------
 
 function onBattlefieldTick(battlefield, tick)
     dsp.battlefield.onBattlefieldTick(battlefield, tick)
 end
 
--- After registering the BCNM via bcnmRegister(bcnmid)
-function onBattlefieldRegister(player,battlefield)
-end;
+function onBattlefieldRegister(player, battlefield)
+end
 
--- Physically entering the BCNM via bcnmEnter(bcnmid)
-function onBattlefieldEnter(player,battlefield)
-end;
+function onBattlefieldEnter(player, battlefield)
+end
 
--- Leaving the BCNM by every mean possible, given by the LeaveCode
--- 1=Select Exit on circle
--- 2=Winning the BC
--- 3=Disconnected or warped out
--- 4=Losing the BC
--- via bcnmLeave(1) or bcnmLeave(2). LeaveCodes 3 and 4 are called
--- from the core when a player disconnects or the time limit is up, etc
-
-function onBattlefieldLeave(player,battlefield,leavecode)
--- print("leave code "..leavecode);
-
-    if leavecode == dsp.battlefield.leaveCode.WON then -- play end CS. Need time and battle id for record keeping + storage
+function onBattlefieldLeave(player, battlefield, leavecode)
+    if leavecode == dsp.battlefield.leaveCode.WON then
         local name, clearTime, partySize = battlefield:getRecord()
-        player:startEvent(32001, battlefield:getArea(), clearTime, partySize, battlefield:getTimeInside(), 1, battlefield:getLocalVar("[cs]bit"), 0)
+        local arg8 = (player:getQuestStatus(OUTLANDS, dsp.quest.id.otherAreas.TRIAL_SIZE_TRIAL_BY_FIRE) == QUEST_COMPLETED) and 1 or 0
+        player:startEvent(32001, battlefield:getArea(), clearTime, partySize, battlefield:getTimeInside(), 1, battlefield:getLocalVar("[cs]bit"), arg8)
     elseif leavecode == dsp.battlefield.leaveCode.LOST then
-        player:setVar("TrialSizeFire_date",tonumber(os.date("%j"))); -- If you loose, you need to wait 1 real day
-        player:startEvent(32002);
+        player:setVar("TrialSizeFire_date", tonumber(os.date("%j"))) -- If you lose, you need to wait 1 real day
+        player:startEvent(32002)
     end
+end
 
-end;
+function onEventUpdate(player, csid, option)
+end
 
-function onEventUpdate(player,csid,option)
--- print("bc update csid "..csid.." and option "..option);
-end;
-
-function onEventFinish(player,csid,option)
--- print("bc finish csid "..csid.." and option "..option);
-
-    if (csid == 32001) then
-        if (player:hasSpell(298) == false) then
-        player:addSpell(298); -- Ifrit
-        player:messageSpecial(ID.text.IFRIT_UNLOCKED,0,0,0);
+function onEventFinish(player, csid, option)
+    if csid == 32001 then
+        if not player:hasSpell(298) then
+            player:addSpell(298)
+            player:messageSpecial(ID.text.IFRIT_UNLOCKED, 0, 0, 0)
         end
-        if (player:hasItem(4181) == false) then
-            player:addItem(4181);
-            player:messageSpecial(ID.text.ITEM_OBTAINED,4181); -- Scroll of instant warp
+        if not player:hasItem(4181) then
+            player:addItem(4181) -- Scroll of instant warp
+            player:messageSpecial(ID.text.ITEM_OBTAINED, 4181)
         end
-        player:setVar("TrialSizeFire_date", 0);
-        player:addFame(KAZHAM,30);
-        player:completeQuest(OUTLANDS,dsp.quest.id.outlands.TRIAL_SIZE_TRIAL_BY_FIRE);
+        player:setVar("TrialSizeFire_date", 0)
+        player:addFame(KAZHAM, 30)
+        player:completeQuest(OUTLANDS, dsp.quest.id.outlands.TRIAL_SIZE_TRIAL_BY_FIRE)
     end
-
-end;
+end

--- a/scripts/zones/Cloister_of_Flames/bcnms/trial_by_fire.lua
+++ b/scripts/zones/Cloister_of_Flames/bcnms/trial_by_fire.lua
@@ -1,63 +1,42 @@
 -----------------------------------
 -- Area: Cloister of Flames
 -- BCNM: Trial by Fire
--- !pos -721 0 -598 207
 -----------------------------------
-
-require("scripts/globals/keyitems");
-require("scripts/globals/quests");
-local ID = require("scripts/zones/Cloister_of_Flames/IDs");
+local ID = require("scripts/zones/Cloister_of_Flames/IDs")
 require("scripts/globals/battlefield")
-
+require("scripts/globals/keyitems")
+require("scripts/globals/quests")
+require("scripts/globals/titles")
 -----------------------------------
 
 function onBattlefieldTick(battlefield, tick)
     dsp.battlefield.onBattlefieldTick(battlefield, tick)
 end
 
--- After registering the BCNM via bcnmRegister(bcnmid)
-function onBattlefieldRegister(player,battlefield)
-end;
+function onBattlefieldRegister(player, battlefield)
+end
 
--- Physically entering the BCNM via bcnmEnter(bcnmid)
-function onBattlefieldEnter(player,battlefield)
-end;
+function onBattlefieldEnter(player, battlefield)
+end
 
--- Leaving the BCNM by every mean possible, given by the LeaveCode
--- 1=Select Exit on circle
--- 2=Winning the BC
--- 3=Disconnected or warped out
--- 4=Losing the BC
--- via bcnmLeave(1) or bcnmLeave(2). LeaveCodes 3 and 4 are called
--- from the core when a player disconnects or the time limit is up, etc
-
-function onBattlefieldLeave(player,battlefield,leavecode)
--- print("leave code "..leavecode);
-
-    if leavecode == dsp.battlefield.leaveCode.WON then -- play end CS. Need time and battle id for record keeping + storage
+function onBattlefieldLeave(player, battlefield, leavecode)
+    if leavecode == dsp.battlefield.leaveCode.WON then
         local name, clearTime, partySize = battlefield:getRecord()
-        if (player:hasCompletedQuest(OUTLANDS,dsp.quest.id.outlands.TRIAL_BY_FIRE)) then
-            player:startEvent(32001, battlefield:getArea(), clearTime, partySize, battlefield:getTimeInside(), 1, battlefield:getLocalVar("[cs]bit"), 1)
-        else
-            player:startEvent(32001, battlefield:getArea(), clearTime, partySize, battlefield:getTimeInside(), 1, battlefield:getLocalVar("[cs]bit"), 0)
-        end
+        local arg8 = (player:hasCompletedQuest(OUTLANDS, dsp.quest.id.outlands.TRIAL_BY_FIRE)) and 1 or 0
+        player:startEvent(32001, battlefield:getArea(), clearTime, partySize, battlefield:getTimeInside(), 1, battlefield:getLocalVar("[cs]bit"), arg8)
     elseif leavecode == dsp.battlefield.leaveCode.LOST then
-        player:startEvent(32002);
+        player:startEvent(32002)
     end
+end
 
-end;
+function onEventUpdate(player, csid, option)
+end
 
-function onEventUpdate(player,csid,option)
--- print("bc update csid "..csid.." and option "..option);
-end;
-
-function onEventFinish(player,csid,option)
--- print("bc finish csid "..csid.." and option "..option);
-
-    if (csid == 32001) then
-        player:delKeyItem(dsp.ki.TUNING_FORK_OF_FIRE);
-        player:addKeyItem(dsp.ki.WHISPER_OF_FLAMES);
-        player:messageSpecial(ID.text.KEYITEM_OBTAINED,dsp.ki.WHISPER_OF_FLAMES);
+function onEventFinish(player, csid, option)
+    if csid == 32001 then
+        player:delKeyItem(dsp.ki.TUNING_FORK_OF_FIRE)
+        player:addKeyItem(dsp.ki.WHISPER_OF_FLAMES)
+        player:addTitle(dsp.title.HEIR_OF_THE_GREAT_FIRE)
+        player:messageSpecial(ID.text.KEYITEM_OBTAINED, dsp.ki.WHISPER_OF_FLAMES)
     end
-
-end;
+end

--- a/scripts/zones/Cloister_of_Frost/bcnms/class_reunion.lua
+++ b/scripts/zones/Cloister_of_Frost/bcnms/class_reunion.lua
@@ -2,51 +2,33 @@
 -- Area: Cloister of Tremors
 -- BCNM: Class Reunion
 -----------------------------------
-
 require("scripts/globals/battlefield")
-
 -----------------------------------
 
 function onBattlefieldTick(battlefield, tick)
     dsp.battlefield.onBattlefieldTick(battlefield, tick)
 end
 
--- After registering the BCNM via bcnmRegister(bcnmid)
-function onBattlefieldRegister(player,battlefield)
-end;
+function onBattlefieldRegister(player, battlefield)
+end
 
--- Physically entering the BCNM via bcnmEnter(bcnmid)
-function onBattlefieldEnter(player,battlefield)
-end;
+function onBattlefieldEnter(player, battlefield)
+end
 
--- Leaving the BCNM by every mean possible, given by the LeaveCode
--- 1=Select Exit on circle
--- 2=Winning the BC
--- 3=Disconnected or warped out
--- 4=Losing the BC
--- via bcnmLeave(1) or bcnmLeave(2). LeaveCodes 3 and 4 are called
--- from the core when a player disconnects or the time limit is up, etc
-
-function onBattlefieldLeave(player,battlefield,leavecode)
--- print("leave code "..leavecode);
-
-    if leavecode == dsp.battlefield.leaveCode.WON then -- play end CS. Need time and battle id for record keeping + storage
+function onBattlefieldLeave(player, battlefield, leavecode)
+    if leavecode == dsp.battlefield.leaveCode.WON then
         local name, clearTime, partySize = battlefield:getRecord()
         player:startEvent(32001, battlefield:getArea(), clearTime, partySize, battlefield:getTimeInside(), 1, battlefield:getLocalVar("[cs]bit"), 2)
     elseif leavecode == dsp.battlefield.leaveCode.LOST then
-        player:startEvent(32002);
+        player:startEvent(32002)
     end
+end
 
-end;
+function onEventUpdate(player, csid, option)
+end
 
-function onEventUpdate(player,csid,option)
--- print("bc update csid "..csid.." and option "..option);
-end;
-
-function onEventFinish(player,csid,option)
--- print("bc finish csid "..csid.." and option "..option);
-
-    if (csid == 32001 and player:getVar("ClassReunionProgress") == 5) then
-        player:setVar("ClassReunionProgress",6);
-    end;
-end;
+function onEventFinish(player, csid, option)
+    if csid == 32001 and player:getVar("ClassReunionProgress") == 5 then
+        player:setVar("ClassReunionProgress", 6)
+    end
+end

--- a/scripts/zones/Cloister_of_Frost/bcnms/sugar-coated_directive.lua
+++ b/scripts/zones/Cloister_of_Frost/bcnms/sugar-coated_directive.lua
@@ -1,58 +1,37 @@
 ----------------------------------------
 -- Area: Cloister of Frost
 -- BCNM: Sugar Coated Directive (ASA-4)
--- !pos -721 0 -598 207
 ----------------------------------------
-require("scripts/globals/keyitems");
 require("scripts/globals/battlefield")
-require("scripts/globals/missions");
+require("scripts/globals/missions")
 ----------------------------------------
 
--- After registering the BCNM via bcnmRegister(bcnmid)
-function onBattlefieldRegister(player,battlefield)
-end;
 function onBattlefieldTick(battlefield, tick)
     dsp.battlefield.onBattlefieldTick(battlefield, tick)
 end
 
--- Physically entering the BCNM via bcnmEnter(bcnmid)
-function onBattlefieldEnter(player,battlefield)
-end;
+function onBattlefieldRegister(player, battlefield)
+end
 
--- Leaving the BCNM by every mean possible, given by the LeaveCode
--- 1=Select Exit on circle
--- 2=Winning the BC
--- 3=Disconnected or warped out
--- 4=Losing the BC
--- via bcnmLeave(1) or bcnmLeave(2). LeaveCodes 3 and 4 are called
--- from the core when a player disconnects or the time limit is up, etc
+function onBattlefieldEnter(player, battlefield)
+end
 
-function onBattlefieldLeave(player,battlefield,leavecode)
-    -- print("leave code "..leavecode);
-
-    if leavecode == dsp.battlefield.leaveCode.WON then -- play end CS. Need time and battle id for record keeping + storage
+function onBattlefieldLeave(player, battlefield, leavecode)
+    if leavecode == dsp.battlefield.leaveCode.WON then
         local name, clearTime, partySize = battlefield:getRecord()
-        if (player:hasCompletedMission(ASA,dsp.mission.id.asa.SUGAR_COATED_DIRECTIVE)) then
-            player:startEvent(32001, battlefield:getArea(), clearTime, partySize, battlefield:getTimeInside(), 1, battlefield:getLocalVar("[cs]bit"), 1)
-        else
-            player:startEvent(32001, battlefield:getArea(), clearTime, partySize, battlefield:getTimeInside(), 1, battlefield:getLocalVar("[cs]bit"), 0)
-        end
+        local arg8 = (player:hasCompletedMission(ASA, dsp.mission.id.asa.SUGAR_COATED_DIRECTIVE)) and 1 or 0
+        player:startEvent(32001, battlefield:getArea(), clearTime, partySize, battlefield:getTimeInside(), 1, battlefield:getLocalVar("[cs]bit"), arg8)
     elseif leavecode == dsp.battlefield.leaveCode.LOST then
-        player:startEvent(32002);
+        player:startEvent(32002)
     end
+end
 
-end;
+function onEventUpdate(player, csid, option)
+end
 
-function onEventUpdate(player,csid,option)
-    -- print("bc update csid "..csid.." and option "..option);
-end;
-
-function onEventFinish(player,csid,option)
-    -- print("bc finish csid "..csid.." and option "..option);
-
-    if (csid == 32001) then
-        player:addExp(400);
-        player:setVar("ASA4_Azure","1");
+function onEventFinish(player, csid, option)
+    if csid == 32001 then
+        player:addExp(400)
+        player:setVar("ASA4_Azure", "1")
     end
-
-end;
+end

--- a/scripts/zones/Cloister_of_Frost/bcnms/trial-size_trial_by_ice.lua
+++ b/scripts/zones/Cloister_of_Frost/bcnms/trial-size_trial_by_ice.lua
@@ -1,68 +1,48 @@
 -----------------------------------
 -- Area: Cloister of Frost
 -- BCNM: Trial-size Trial by Ice
--- !pos 558 0.1 596 203
 -----------------------------------
-
-require("scripts/globals/keyitems");
-require("scripts/globals/quests");
-local ID = require("scripts/zones/Cloister_of_Frost/IDs");
+local ID = require("scripts/zones/Cloister_of_Frost/IDs")
 require("scripts/globals/battlefield")
-
+require("scripts/globals/quests")
 -----------------------------------
 
 function onBattlefieldTick(battlefield, tick)
     dsp.battlefield.onBattlefieldTick(battlefield, tick)
 end
 
--- After registering the BCNM via bcnmRegister(bcnmid)
-function onBattlefieldRegister(player,battlefield)
-end;
+function onBattlefieldRegister(player, battlefield)
+end
 
--- Physically entering the BCNM via bcnmEnter(bcnmid)
-function onBattlefieldEnter(player,battlefield)
-end;
+function onBattlefieldEnter(player, battlefield)
+end
 
--- Leaving the BCNM by every mean possible, given by the LeaveCode
--- 1=Select Exit on circle
--- 2=Winning the BC
--- 3=Disconnected or warped out
--- 4=Losing the BC
--- via bcnmLeave(1) or bcnmLeave(2). LeaveCodes 3 and 4 are called
--- from the core when a player disconnects or the time limit is up, etc
-
-function onBattlefieldLeave(player,battlefield,leavecode)
--- print("leave code "..leavecode);
-
-    if leavecode == dsp.battlefield.leaveCode.WON then -- play end CS. Need time and battle id for record keeping + storage
+function onBattlefieldLeave(player, battlefield, leavecode)
+    if leavecode == dsp.battlefield.leaveCode.WON then
         local name, clearTime, partySize = battlefield:getRecord()
-        player:startEvent(32001, battlefield:getArea(), clearTime, partySize, battlefield:getTimeInside(), 1, battlefield:getLocalVar("[cs]bit"), 0)
+        local arg8 = (player:getQuestStatus(SANDORIA, dsp.quest.id.otherAreas.TRIAL_SIZE_TRIAL_BY_ICE) == QUEST_COMPLETED) and 1 or 0
+        player:startEvent(32001, battlefield:getArea(), clearTime, partySize, battlefield:getTimeInside(), 1, battlefield:getLocalVar("[cs]bit"), arg8)
     elseif leavecode == dsp.battlefield.leaveCode.LOST then
-        player:setVar("TrialSizeIce_date",tonumber(os.date("%j"))); -- If you loose, you need to wait 1 real day
-        player:startEvent(32002);
+        player:setVar("TrialSizeIce_date", tonumber(os.date("%j"))) -- If you lose, you need to wait 1 real day
+        player:startEvent(32002)
     end
+end
 
-end;
+function onEventUpdate(player, csid, option)
+end
 
-function onEventUpdate(player,csid,option)
--- print("bc update csid "..csid.." and option "..option);
-end;
-
-function onEventFinish(player,csid,option)
--- print("bc finish csid "..csid.." and option "..option);
-
-    if (csid == 32001) then
-        if (player:hasSpell(302) == false) then
-            player:addSpell(302); -- Shiva
-            player:messageSpecial(ID.text.SHIVA_UNLOCKED,0,0,4);
+function onEventFinish(player, csid, option)
+    if csid == 32001 then
+        if not player:hasSpell(302) then
+            player:addSpell(302)
+            player:messageSpecial(ID.text.SHIVA_UNLOCKED, 0, 0, 4)
         end
-        if (player:hasItem(4181) == false) then
-            player:addItem(4181);
-            player:messageSpecial(ID.text.ITEM_OBTAINED,4181); -- Scroll of instant warp
+        if not player:hasItem(4181) then
+            player:addItem(4181) -- Scroll of instant warp
+            player:messageSpecial(ID.text.ITEM_OBTAINED, 4181)
         end
-        player:setVar("TrialSizeIce_date", 0);
-        player:addFame(SANDORIA,30);
-        player:completeQuest(SANDORIA,dsp.quest.id.sandoria.TRIAL_SIZE_TRIAL_BY_ICE);
+        player:setVar("TrialSizeIce_date", 0)
+        player:addFame(SANDORIA, 30)
+        player:completeQuest(SANDORIA, dsp.quest.id.sandoria.TRIAL_SIZE_TRIAL_BY_ICE)
     end
-
-end;
+end

--- a/scripts/zones/Cloister_of_Frost/bcnms/trial_by_ice.lua
+++ b/scripts/zones/Cloister_of_Frost/bcnms/trial_by_ice.lua
@@ -1,65 +1,42 @@
 -----------------------------------
 -- Area: Cloister of Frost
 -- BCNM: Trial by Ice
--- !pos 558 0.1 596 203
 -----------------------------------
-
-require("scripts/globals/keyitems");
-require("scripts/globals/quests");
-require("scripts/globals/titles");
-local ID = require("scripts/zones/Cloister_of_Frost/IDs");
+local ID = require("scripts/zones/Cloister_of_Frost/IDs")
 require("scripts/globals/battlefield")
-
+require("scripts/globals/keyitems")
+require("scripts/globals/quests")
+require("scripts/globals/titles")
 -----------------------------------
 
 function onBattlefieldTick(battlefield, tick)
     dsp.battlefield.onBattlefieldTick(battlefield, tick)
 end
 
--- After registering the BCNM via bcnmRegister(bcnmid)
-function onBattlefieldRegister(player,battlefield)
-end;
+function onBattlefieldRegister(player, battlefield)
+end
 
--- Physically entering the BCNM via bcnmEnter(bcnmid)
-function onBattlefieldEnter(player,battlefield)
-end;
+function onBattlefieldEnter(player, battlefield)
+end
 
--- Leaving the BCNM by every mean possible, given by the LeaveCode
--- 1=Select Exit on circle
--- 2=Winning the BC
--- 3=Disconnected or warped out
--- 4=Losing the BC
--- via bcnmLeave(1) or bcnmLeave(2). LeaveCodes 3 and 4 are called
--- from the core when a player disconnects or the time limit is up, etc
-
-function onBattlefieldLeave(player,battlefield,leavecode)
--- print("leave code "..leavecode);
-
-    if leavecode == dsp.battlefield.leaveCode.WON then -- play end CS. Need time and battle id for record keeping + storage
+function onBattlefieldLeave(player, battlefield, leavecode)
+    if leavecode == dsp.battlefield.leaveCode.WON then
         local name, clearTime, partySize = battlefield:getRecord()
-        if (player:hasCompletedQuest(SANDORIA,dsp.quest.id.sandoria.TRIAL_BY_ICE)) then
-            player:startEvent(32001, battlefield:getArea(), clearTime, partySize, battlefield:getTimeInside(), 1, battlefield:getLocalVar("[cs]bit"), 1)
-        else
-            player:startEvent(32001, battlefield:getArea(), clearTime, partySize, battlefield:getTimeInside(), 1, battlefield:getLocalVar("[cs]bit"), 0)
-        end
+        local arg8 = (player:hasCompletedQuest(SANDORIA, dsp.quest.id.sandoria.TRIAL_BY_ICE)) and 1 or 0
+        player:startEvent(32001, battlefield:getArea(), clearTime, partySize, battlefield:getTimeInside(), 1, battlefield:getLocalVar("[cs]bit"), arg8)
     elseif leavecode == dsp.battlefield.leaveCode.LOST then
-        player:startEvent(32002);
+        player:startEvent(32002)
     end
+end
 
-end;
+function onEventUpdate(player, csid, option)
+end
 
-function onEventUpdate(player,csid,option)
--- print("bc update csid "..csid.." and option "..option);
-end;
-
-function onEventFinish(player,csid,option)
--- print("bc finish csid "..csid.." and option "..option);
-
-    if (csid == 32001) then
-        player:delKeyItem(dsp.ki.TUNING_FORK_OF_ICE);
-        player:addKeyItem(dsp.ki.WHISPER_OF_FROST);
-        player:addTitle(dsp.title.HEIR_OF_THE_GREAT_ICE);
-        player:messageSpecial(ID.text.KEYITEM_OBTAINED,dsp.ki.WHISPER_OF_FROST);
+function onEventFinish(player, csid, option)
+    if csid == 32001 then
+        player:delKeyItem(dsp.ki.TUNING_FORK_OF_ICE)
+        player:addKeyItem(dsp.ki.WHISPER_OF_FROST)
+        player:addTitle(dsp.title.HEIR_OF_THE_GREAT_ICE)
+        player:messageSpecial(ID.text.KEYITEM_OBTAINED, dsp.ki.WHISPER_OF_FROST)
     end
-
-end;
+end

--- a/scripts/zones/Cloister_of_Gales/bcnms/carbuncle_debacle.lua
+++ b/scripts/zones/Cloister_of_Gales/bcnms/carbuncle_debacle.lua
@@ -2,54 +2,35 @@
 -- Area: Cloister of Gales
 -- BCNM: Carbuncle Debacle
 -----------------------------------
-
-require("scripts/globals/settings");
-require("scripts/globals/keyitems");
 require("scripts/globals/battlefield")
-
+require("scripts/globals/keyitems")
 -----------------------------------
 
 function onBattlefieldTick(battlefield, tick)
     dsp.battlefield.onBattlefieldTick(battlefield, tick)
 end
 
--- After registering the BCNM via bcnmRegister(bcnmid)
-function onBattlefieldRegister(player,battlefield)
-end;
+function onBattlefieldRegister(player, battlefield)
+end
 
--- Physically entering the BCNM via bcnmEnter(bcnmid)
-function onBattlefieldEnter(player,battlefield)
-end;
+function onBattlefieldEnter(player, battlefield)
+end
 
--- Leaving the BCNM by every mean possible, given by the LeaveCode
--- 1=Select Exit on circle
--- 2=Winning the BC
--- 3=Disconnected or warped out
--- 4=Losing the BC
--- via bcnmLeave(1) or bcnmLeave(2). LeaveCodes 3 and 4 are called
--- from the core when a player disconnects or the time limit is up, etc
-
-function onBattlefieldLeave(player,battlefield,leavecode)
--- print("leave code "..leavecode);
-
-    if leavecode == dsp.battlefield.leaveCode.WON then -- play end CS. Need time and battle id for record keeping + storage
+function onBattlefieldLeave(player, battlefield, leavecode)
+    if leavecode == dsp.battlefield.leaveCode.WON then
         local name, clearTime, partySize = battlefield:getRecord()
         player:startEvent(32001, battlefield:getArea(), clearTime, partySize, battlefield:getTimeInside(), 1, battlefield:getLocalVar("[cs]bit"), 0)
     elseif leavecode == dsp.battlefield.leaveCode.LOST then
-        player:startEvent(32002);
+        player:startEvent(32002)
     end
+end
 
-end;
+function onEventUpdate(player, csid, option)
+end
 
-function onEventUpdate(player,csid,option)
--- print("bc update csid "..csid.." and option "..option);
-end;
-
-function onEventFinish(player,csid,option)
--- print("bc finish csid "..csid.." and option "..option);
-
-    if (csid == 32001) then
-        player:setVar("CarbuncleDebacleProgress",7);
-        player:delKeyItem(dsp.ki.DAZEBREAKER_CHARM);
-    end;
-end;
+function onEventFinish(player, csid, option)
+    if csid == 32001 then
+        player:setVar("CarbuncleDebacleProgress", 7)
+        player:delKeyItem(dsp.ki.DAZEBREAKER_CHARM)
+    end
+end

--- a/scripts/zones/Cloister_of_Gales/bcnms/sugar-coated_directive.lua
+++ b/scripts/zones/Cloister_of_Gales/bcnms/sugar-coated_directive.lua
@@ -3,56 +3,35 @@
 -- BCNM: Sugar Coated Directive (ASA-4)
 ----------------------------------------
 require("scripts/globals/battlefield")
-require("scripts/globals/keyitems");
-require("scripts/globals/missions");
+require("scripts/globals/missions")
 ----------------------------------------
 
--- After registering the BCNM via bcnmRegister(bcnmid)
-function onBattlefieldRegister(player,battlefield)
-end;
 function onBattlefieldTick(battlefield, tick)
     dsp.battlefield.onBattlefieldTick(battlefield, tick)
 end
 
--- Physically entering the BCNM via bcnmEnter(bcnmid)
-function onBattlefieldEnter(player,battlefield)
-end;
+function onBattlefieldRegister(player, battlefield)
+end
 
--- Leaving the BCNM by every mean possible, given by the LeaveCode
--- 1=Select Exit on circle
--- 2=Winning the BC
--- 3=Disconnected or warped out
--- 4=Losing the BC
--- via bcnmLeave(1) or bcnmLeave(2). LeaveCodes 3 and 4 are called
--- from the core when a player disconnects or the time limit is up, etc
+function onBattlefieldEnter(player, battlefield)
+end
 
-function onBattlefieldLeave(player,battlefield,leavecode)
-    -- print("leave code "..leavecode);
-
-    if leavecode == dsp.battlefield.leaveCode.WON then -- play end CS. Need time and battle id for record keeping + storage
-
+function onBattlefieldLeave(player, battlefield, leavecode)
+    if leavecode == dsp.battlefield.leaveCode.WON then
         local name, clearTime, partySize = battlefield:getRecord()
-        if (player:hasCompletedMission(ASA,dsp.mission.id.asa.SUGAR_COATED_DIRECTIVE)) then
-            player:startEvent(32001, battlefield:getArea(), clearTime, partySize, battlefield:getTimeInside(), 1, battlefield:getLocalVar("[cs]bit"), 1)
-        else
-            player:startEvent(32001, battlefield:getArea(), clearTime, partySize, battlefield:getTimeInside(), 1, battlefield:getLocalVar("[cs]bit"), 0)
-        end
+        local arg8 = (player:hasCompletedMission(ASA, dsp.mission.id.asa.SUGAR_COATED_DIRECTIVE)) and 1 or 0
+        player:startEvent(32001, battlefield:getArea(), clearTime, partySize, battlefield:getTimeInside(), 1, battlefield:getLocalVar("[cs]bit"), arg8)
     elseif leavecode == dsp.battlefield.leaveCode.LOST then
-        player:startEvent(32002);
+        player:startEvent(32002)
     end
+end
 
-end;
+function onEventUpdate(player, csid, option)
+end
 
-function onEventUpdate(player,csid,option)
-    -- print("bc update csid "..csid.." and option "..option);
-end;
-
-function onEventFinish(player,csid,option)
-    -- print("bc finish csid "..csid.." and option "..option);
-
-    if (csid == 32001) then
-        player:addExp(400);
-        player:setVar("ASA4_Emerald","1");
+function onEventFinish(player, csid, option)
+    if csid == 32001 then
+        player:addExp(400)
+        player:setVar("ASA4_Emerald", "1")
     end
-
-end;
+end

--- a/scripts/zones/Cloister_of_Gales/bcnms/trial-size_trial_by_wind.lua
+++ b/scripts/zones/Cloister_of_Gales/bcnms/trial-size_trial_by_wind.lua
@@ -1,69 +1,48 @@
 -----------------------------------
 -- Area: Cloister of Gales
 -- BCNM: Trial-size Trial by Wind
--- !pos -361 1 -381 201
 -----------------------------------
-
-require("scripts/globals/shop");
-require("scripts/globals/quests");
-local ID = require("scripts/zones/Cloister_of_Gales/IDs");
+local ID = require("scripts/zones/Cloister_of_Gales/IDs")
 require("scripts/globals/battlefield")
-
+require("scripts/globals/quests")
 -----------------------------------
 
 function onBattlefieldTick(battlefield, tick)
     dsp.battlefield.onBattlefieldTick(battlefield, tick)
 end
 
--- After registering the BCNM via bcnmRegister(bcnmid)
-function onBattlefieldRegister(player,battlefield)
-end;
+function onBattlefieldRegister(player, battlefield)
+end
 
--- Physically entering the BCNM via bcnmEnter(bcnmid)
-function onBattlefieldEnter(player,battlefield)
-end;
+function onBattlefieldEnter(player, battlefield)
+end
 
--- Leaving the BCNM by every mean possible, given by the LeaveCode
--- 1=Select Exit on circle
--- 2=Winning the BC
--- 3=Disconnected or warped out
--- 4=Losing the BC
--- via bcnmLeave(1) or bcnmLeave(2). LeaveCodes 3 and 4 are called
--- from the core when a player disconnects or the time limit is up, etc
-
-function onBattlefieldLeave(player,battlefield,leavecode)
--- print("leave code "..leavecode);
-
-    if leavecode == dsp.battlefield.leaveCode.WON then -- play end CS. Need time and battle id for record keeping + storage
-
+function onBattlefieldLeave(player, battlefield, leavecode)
+    if leavecode == dsp.battlefield.leaveCode.WON then
         local name, clearTime, partySize = battlefield:getRecord()
-        player:startEvent(32001, battlefield:getArea(), clearTime, partySize, battlefield:getTimeInside(), 1, battlefield:getLocalVar("[cs]bit"), 0)
+        local arg8 = (player:getQuestStatus(OUTLANDS, dsp.quest.id.otherAreas.TRIAL_SIZE_TRIAL_BY_WIND) == QUEST_COMPLETED) and 1 or 0
+        player:startEvent(32001, battlefield:getArea(), clearTime, partySize, battlefield:getTimeInside(), 1, battlefield:getLocalVar("[cs]bit"), arg8)
     elseif leavecode == dsp.battlefield.leaveCode.LOST then
-        player:setVar("TrialSizeWind_date",tonumber(os.date("%j"))); -- If you loose, you need to wait 1 real day
-        player:startEvent(32002);
+        player:setVar("TrialSizeWind_date", tonumber(os.date("%j"))) -- If you lose, you need to wait 1 real day
+        player:startEvent(32002)
     end
+end
 
-end;
+function onEventUpdate(player, csid, option)
+end
 
-function onEventUpdate(player,csid,option)
--- print("bc update csid "..csid.." and option "..option);
-end;
-
-function onEventFinish(player,csid,option)
--- print("bc finish csid "..csid.." and option "..option);
-
-    if (csid == 32001) then
-        if (player:hasSpell(301) == false) then
-        player:addSpell(301); -- Garuda
-        player:messageSpecial(ID.text.GARUDA_UNLOCKED,0,0,3);
+function onEventFinish(player, csid, option)
+    if csid == 32001 then
+        if not player:hasSpell(301) then
+            player:addSpell(301)
+            player:messageSpecial(ID.text.GARUDA_UNLOCKED, 0, 0, 3)
         end
-        if (player:hasItem(4181) == false) then
-            player:addItem(4181);
-            player:messageSpecial(ID.text.ITEM_OBTAINED,4181); -- Scroll of instant warp
+        if not player:hasItem(4181) then
+            player:addItem(4181) -- Scroll of instant warp
+            player:messageSpecial(ID.text.ITEM_OBTAINED, 4181)
         end
-        player:setVar("TrialSizeWind_date", 0);
-        player:addFame(RABAO,30);
-        player:completeQuest(OUTLANDS,dsp.quest.id.outlands.TRIAL_SIZE_TRIAL_BY_WIND);
+        player:setVar("TrialSizeWind_date", 0)
+        player:addFame(RABAO, 30)
+        player:completeQuest(OUTLANDS, dsp.quest.id.outlands.TRIAL_SIZE_TRIAL_BY_WIND)
     end
-
-end;
+end

--- a/scripts/zones/Cloister_of_Gales/bcnms/trial_by_wind.lua
+++ b/scripts/zones/Cloister_of_Gales/bcnms/trial_by_wind.lua
@@ -1,64 +1,42 @@
 -----------------------------------
 -- Area: Cloister of Gales
 -- BCNM: Trial by Wind
--- !pos -361 1 -381 201
 -----------------------------------
-
-require("scripts/globals/keyitems");
-require("scripts/globals/quests");
-local ID = require("scripts/zones/Cloister_of_Gales/IDs");
+local ID = require("scripts/zones/Cloister_of_Gales/IDs")
 require("scripts/globals/battlefield")
-
+require("scripts/globals/keyitems")
+require("scripts/globals/quests")
+require("scripts/globals/titles")
 -----------------------------------
 
 function onBattlefieldTick(battlefield, tick)
     dsp.battlefield.onBattlefieldTick(battlefield, tick)
 end
 
--- After registering the BCNM via bcnmRegister(bcnmid)
-function onBattlefieldRegister(player,battlefield)
-end;
+function onBattlefieldRegister(player, battlefield)
+end
 
--- Physically entering the BCNM via bcnmEnter(bcnmid)
-function onBattlefieldEnter(player,battlefield)
-end;
+function onBattlefieldEnter(player, battlefield)
+end
 
--- Leaving the BCNM by every mean possible, given by the LeaveCode
--- 1=Select Exit on circle
--- 2=Winning the BC
--- 3=Disconnected or warped out
--- 4=Losing the BC
--- via bcnmLeave(1) or bcnmLeave(2). LeaveCodes 3 and 4 are called
--- from the core when a player disconnects or the time limit is up, etc
-
-function onBattlefieldLeave(player,battlefield,leavecode)
--- print("leave code "..leavecode);
-
-    if leavecode == dsp.battlefield.leaveCode.WON then -- play end CS. Need time and battle id for record keeping + storage
-
+function onBattlefieldLeave(player, battlefield, leavecode)
+    if leavecode == dsp.battlefield.leaveCode.WON then
         local name, clearTime, partySize = battlefield:getRecord()
-        if (player:hasCompletedQuest(OUTLANDS,dsp.quest.id.outlands.TRIAL_BY_WIND)) then
-            player:startEvent(32001, battlefield:getArea(), clearTime, partySize, battlefield:getTimeInside(), 1, battlefield:getLocalVar("[cs]bit"), 1)
-        else
-            player:startEvent(32001, battlefield:getArea(), clearTime, partySize, battlefield:getTimeInside(), 1, battlefield:getLocalVar("[cs]bit"), 0)
-        end
+        local arg8 = (player:hasCompletedQuest(OUTLANDS, dsp.quest.id.outlands.TRIAL_BY_WIND)) and 1 or 0
+        player:startEvent(32001, battlefield:getArea(), clearTime, partySize, battlefield:getTimeInside(), 1, battlefield:getLocalVar("[cs]bit"), arg8)
     elseif leavecode == dsp.battlefield.leaveCode.LOST then
-        player:startEvent(32002);
+        player:startEvent(32002)
     end
+end
 
-end;
+function onEventUpdate(player, csid, option)
+end
 
-function onEventUpdate(player,csid,option)
--- print("bc update csid "..csid.." and option "..option);
-end;
-
-function onEventFinish(player,csid,option)
--- print("bc finish csid "..csid.." and option "..option);
-
-    if (csid == 32001) then
-        player:delKeyItem(dsp.ki.TUNING_FORK_OF_WIND);
-        player:addKeyItem(dsp.ki.WHISPER_OF_GALES);
-        player:messageSpecial(ID.text.KEYITEM_OBTAINED,dsp.ki.WHISPER_OF_GALES);
+function onEventFinish(player, csid, option)
+    if csid == 32001 then
+        player:delKeyItem(dsp.ki.TUNING_FORK_OF_WIND)
+        player:addKeyItem(dsp.ki.WHISPER_OF_GALES)
+        player:addTitle(dsp.title.HEIR_OF_THE_GREAT_WIND)
+        player:messageSpecial(ID.text.KEYITEM_OBTAINED, dsp.ki.WHISPER_OF_GALES)
     end
-
-end;
+end

--- a/scripts/zones/Cloister_of_Storms/bcnms/carbuncle_debacle.lua
+++ b/scripts/zones/Cloister_of_Storms/bcnms/carbuncle_debacle.lua
@@ -2,52 +2,33 @@
 -- Area: Cloister of Storms
 -- BCNM: Carbuncle Debacle
 -----------------------------------
-
-require("scripts/globals/settings");
 require("scripts/globals/battlefield")
-
 -----------------------------------
 
 function onBattlefieldTick(battlefield, tick)
     dsp.battlefield.onBattlefieldTick(battlefield, tick)
 end
 
--- After registering the BCNM via bcnmRegister(bcnmid)
-function onBattlefieldRegister(player,battlefield)
-end;
+function onBattlefieldRegister(player, battlefield)
+end
 
--- Physically entering the BCNM via bcnmEnter(bcnmid)
-function onBattlefieldEnter(player,battlefield)
-end;
+function onBattlefieldEnter(player, battlefield)
+end
 
--- Leaving the BCNM by every mean possible, given by the LeaveCode
--- 1=Select Exit on circle
--- 2=Winning the BC
--- 3=Disconnected or warped out
--- 4=Losing the BC
--- via bcnmLeave(1) or bcnmLeave(2). LeaveCodes 3 and 4 are called
--- from the core when a player disconnects or the time limit is up, etc
-
-function onBattlefieldLeave(player,battlefield,leavecode)
--- print("leave code "..leavecode);
-
-    if leavecode == dsp.battlefield.leaveCode.WON then -- play end CS. Need time and battle id for record keeping + storage
+function onBattlefieldLeave(player, battlefield, leavecode)
+    if leavecode == dsp.battlefield.leaveCode.WON then
         local name, clearTime, partySize = battlefield:getRecord()
         player:startEvent(32001, battlefield:getArea(), clearTime, partySize, battlefield:getTimeInside(), 1, battlefield:getLocalVar("[cs]bit"), 0)
     elseif leavecode == dsp.battlefield.leaveCode.LOST then
-        player:startEvent(32002);
+        player:startEvent(32002)
     end
+end
 
-end;
+function onEventUpdate(player, csid, option)
+end
 
-function onEventUpdate(player,csid,option)
--- print("bc update csid "..csid.." and option "..option);
-end;
-
-function onEventFinish(player,csid,option)
--- print("bc finish csid "..csid.." and option "..option);
-
-    if (csid == 32001) then
-        player:setVar("CarbuncleDebacleProgress",4);
-    end;
-end;
+function onEventFinish(player, csid, option)
+    if csid == 32001 then
+        player:setVar("CarbuncleDebacleProgress", 4)
+    end
+end

--- a/scripts/zones/Cloister_of_Storms/bcnms/sugar-coated_directive.lua
+++ b/scripts/zones/Cloister_of_Storms/bcnms/sugar-coated_directive.lua
@@ -3,56 +3,35 @@
 -- BCNM: Sugar Coated Directive (ASA-4)
 ----------------------------------------
 require("scripts/globals/battlefield")
-require("scripts/globals/keyitems");
-require("scripts/globals/missions");
+require("scripts/globals/missions")
 ----------------------------------------
 
--- After registering the BCNM via bcnmRegister(bcnmid)
-function onBattlefieldRegister(player,battlefield)
-end;
 function onBattlefieldTick(battlefield, tick)
     dsp.battlefield.onBattlefieldTick(battlefield, tick)
 end
 
--- Physically entering the BCNM via bcnmEnter(bcnmid)
-function onBattlefieldEnter(player,battlefield)
-end;
+function onBattlefieldRegister(player, battlefield)
+end
 
--- Leaving the BCNM by every mean possible, given by the LeaveCode
--- 1=Select Exit on circle
--- 2=Winning the BC
--- 3=Disconnected or warped out
--- 4=Losing the BC
--- via bcnmLeave(1) or bcnmLeave(2). LeaveCodes 3 and 4 are called
--- from the core when a player disconnects or the time limit is up, etc
+function onBattlefieldEnter(player, battlefield)
+end
 
-function onBattlefieldLeave(player,battlefield,leavecode)
-    -- print("leave code "..leavecode);
-
-    if leavecode == dsp.battlefield.leaveCode.WON then -- play end CS. Need time and battle id for record keeping + storage
-
+function onBattlefieldLeave(player, battlefield, leavecode)
+    if leavecode == dsp.battlefield.leaveCode.WON then
         local name, clearTime, partySize = battlefield:getRecord()
-        if (player:hasCompletedMission(ASA,dsp.mission.id.asa.SUGAR_COATED_DIRECTIVE)) then
-            player:startEvent(32001, battlefield:getArea(), clearTime, partySize, battlefield:getTimeInside(), 1, battlefield:getLocalVar("[cs]bit"), 1)
-        else
-            player:startEvent(32001, battlefield:getArea(), clearTime, partySize, battlefield:getTimeInside(), 1, battlefield:getLocalVar("[cs]bit"), 0)
-        end
+        local arg8 = (player:hasCompletedMission(ASA, dsp.mission.id.asa.SUGAR_COATED_DIRECTIVE)) and 1 or 0
+        player:startEvent(32001, battlefield:getArea(), clearTime, partySize, battlefield:getTimeInside(), 1, battlefield:getLocalVar("[cs]bit"), arg8)
     elseif leavecode == dsp.battlefield.leaveCode.LOST then
-        player:startEvent(32002);
+        player:startEvent(32002)
     end
+end
 
-end;
+function onEventUpdate(player, csid, option)
+end
 
-function onEventUpdate(player,csid,option)
-    -- print("bc update csid "..csid.." and option "..option);
-end;
-
-function onEventFinish(player,csid,option)
-    -- print("bc finish csid "..csid.." and option "..option);
-
-    if (csid == 32001) then
-        player:addExp(400);
-        player:setVar("ASA4_Violet","1");
+function onEventFinish(player, csid, option)
+    if csid == 32001 then
+        player:addExp(400)
+        player:setVar("ASA4_Violet", "1")
     end
-
-end;
+end

--- a/scripts/zones/Cloister_of_Storms/bcnms/trial-size_trial_by_lightning.lua
+++ b/scripts/zones/Cloister_of_Storms/bcnms/trial-size_trial_by_lightning.lua
@@ -1,80 +1,48 @@
 -----------------------------------
 -- Area: Cloister of Storms
--- BCNM: Trial by Lightning
+-- BCNM: Trial-size Trial by Lightning
 -----------------------------------
-require("scripts/globals/keyitems");
+local ID = require("scripts/zones/Cloister_of_Storms/IDs")
 require("scripts/globals/battlefield")
-require("scripts/globals/missions");
-local ID = require("scripts/zones/Cloister_of_Storms/IDs");
-
+require("scripts/globals/quests")
 -----------------------------------
 
--- What should go here:
--- giving key items, playing ENDING cutscenes
---
--- What should NOT go here:
--- Handling of "battlefield" status, spawning of monsters,
--- putting loot into treasure pool,
--- enforcing ANY rules (SJ/number of people/etc), moving
--- chars around, playing entrance CSes (entrance CSes go in bcnm.lua)
-
--- After registering the BCNM via bcnmRegister(bcnmid)
 function onBattlefieldTick(battlefield, tick)
     dsp.battlefield.onBattlefieldTick(battlefield, tick)
 end
 
+function onBattlefieldRegister(player, battlefield)
+end
 
-function onBattlefieldRegister(player,battlefield)
-end;
+function onBattlefieldEnter(player, battlefield)
+end
 
--- Physically entering the BCNM via bcnmEnter(bcnmid)
-function onBattlefieldEnter(player,battlefield)
-end;
-
--- Leaving the BCNM by every mean possible, given by the LeaveCode
--- 1=Select Exit on circle
--- 2=Winning the BC
--- 3=Disconnected or warped out
--- 4=Losing the BC
--- via bcnmLeave(1) or bcnmLeave(2). LeaveCodes 3 and 4 are called
--- from the core when a player disconnects or the time limit is up, etc
-
-function onBattlefieldLeave(player,battlefield,leavecode)
--- print("leave code "..leavecode);
-    trialLightning = player:getQuestStatus(OTHER_AREAS_LOG,dsp.quest.id.otherAreas.TRIAL_SIZE_TRIAL_BY_LIGHTNING)
-
-    if leavecode == dsp.battlefield.leaveCode.WON then -- play end CS. Need time and battle id for record keeping + storage
-
+function onBattlefieldLeave(player, battlefield, leavecode)
+    if leavecode == dsp.battlefield.leaveCode.WON then
         local name, clearTime, partySize = battlefield:getRecord()
-        if (trialLightning == QUEST_COMPLETED) then
-            player:startEvent(32001, battlefield:getArea(), clearTime, partySize, battlefield:getTimeInside(), 1, battlefield:getLocalVar("[cs]bit"), 1)
-        else
-            player:startEvent(32001, battlefield:getArea(), clearTime, partySize, battlefield:getTimeInside(), 1, battlefield:getLocalVar("[cs]bit"), 0)
-        end
+        local arg8 = (player:getQuestStatus(OTHER_AREAS_LOG, dsp.quest.id.otherAreas.TRIAL_SIZE_TRIAL_BY_LIGHTNING) == QUEST_COMPLETED) and 1 or 0
+        player:startEvent(32001, battlefield:getArea(), clearTime, partySize, battlefield:getTimeInside(), 1, battlefield:getLocalVar("[cs]bit"), arg8)
     elseif leavecode == dsp.battlefield.leaveCode.LOST then
-        player:startEvent(32002);
+        player:setVar("TrialSizeLightning_date", tonumber(os.date("%j"))) -- If you lose, you need to wait 1 real day
+        player:startEvent(32002)
     end
-end;
+end
 
-function onEventUpdate(player,csid,option)
--- print("bc update csid "..csid.." and option "..option);
-end;
+function onEventUpdate(player, csid, option)
+end
 
-function onEventFinish(player,csid,option)
--- print("bc finish csid "..csid.." and option "..option);
-
-    if (csid == 32001) then
-        if (player:hasSpell(303) == false) then
-            player:addSpell(303) -- Ramuh
-            player:messageSpecial(ID.text.RAMUH_UNLOCKED,0,0,5);
+function onEventFinish(player, csid, option)
+    if csid == 32001 then
+        if not player:hasSpell(303) then
+            player:addSpell(303)
+            player:messageSpecial(ID.text.RAMUH_UNLOCKED, 0, 0, 5)
         end
-        if (player:hasItem(4181) == false) then
-            player:addItem(4181);
-            player:messageSpecial(ID.text.ITEM_OBTAINED,4181); -- Scroll of instant warp
+        if not player:hasItem(4181) then
+            player:addItem(4181) -- Scroll of instant warp
+            player:messageSpecial(ID.text.ITEM_OBTAINED, 4181)
         end
-        player:setVar("TrialSizeLightning_date", 0);
-        player:addFame(WINDURST,30);
-        player:completeQuest(OTHER_AREAS_LOG,dsp.quest.id.otherAreas.TRIAL_SIZE_TRIAL_BY_LIGHTNING);
+        player:setVar("TrialSizeLightning_date", 0)
+        player:addFame(WINDURST, 30)
+        player:completeQuest(OTHER_AREAS_LOG, dsp.quest.id.otherAreas.TRIAL_SIZE_TRIAL_BY_LIGHTNING)
     end
-
-end;
+end

--- a/scripts/zones/Cloister_of_Storms/bcnms/trial_by_lightning.lua
+++ b/scripts/zones/Cloister_of_Storms/bcnms/trial_by_lightning.lua
@@ -2,69 +2,41 @@
 -- Area: Cloister of Storms
 -- BCNM: Trial by Lightning
 -----------------------------------
-
-require("scripts/globals/keyitems");
+local ID = require("scripts/zones/Cloister_of_Storms/IDs")
 require("scripts/globals/battlefield")
-require("scripts/globals/missions");
-local ID = require("scripts/zones/Cloister_of_Storms/IDs");
-
+require("scripts/globals/keyitems")
+require("scripts/globals/quests")
+require("scripts/globals/titles")
 -----------------------------------
 
--- What should go here:
--- giving key items, playing ENDING cutscenes
---
--- What should NOT go here:
--- Handling of "battlefield" status, spawning of monsters,
--- putting loot into treasure pool,
--- enforcing ANY rules (SJ/number of people/etc), moving
--- chars around, playing entrance CSes (entrance CSes go in bcnm.lua)
-
--- After registering the BCNM via bcnmRegister(bcnmid)
-function onBattlefieldRegister(player,battlefield)
-end;
 function onBattlefieldTick(battlefield, tick)
     dsp.battlefield.onBattlefieldTick(battlefield, tick)
 end
 
--- Physically entering the BCNM via bcnmEnter(bcnmid)
-function onBattlefieldEnter(player,battlefield)
-end;
+function onBattlefieldRegister(player, battlefield)
+end
 
--- Leaving the BCNM by every mean possible, given by the LeaveCode
--- 1=Select Exit on circle
--- 2=Winning the BC
--- 3=Disconnected or warped out
--- 4=Losing the BC
--- via bcnmLeave(1) or bcnmLeave(2). LeaveCodes 3 and 4 are called
--- from the core when a player disconnects or the time limit is up, etc
+function onBattlefieldEnter(player, battlefield)
+end
 
-function onBattlefieldLeave(player,battlefield,leavecode)
--- print("leave code "..leavecode);
-    trialLightning = player:getQuestStatus(OTHER_AREAS_LOG,dsp.quest.id.otherAreas.TRIAL_BY_LIGHTNING)
-
-    if leavecode == dsp.battlefield.leaveCode.WON then -- play end CS. Need time and battle id for record keeping + storage
-
+function onBattlefieldLeave(player, battlefield, leavecode)
+    if leavecode == dsp.battlefield.leaveCode.WON then
         local name, clearTime, partySize = battlefield:getRecord()
-        if (trialLightning == QUEST_COMPLETED) then
-            player:startEvent(32001, battlefield:getArea(), clearTime, partySize, battlefield:getTimeInside(), 1, battlefield:getLocalVar("[cs]bit"), 1)
-        else
-            player:startEvent(32001, battlefield:getArea(), clearTime, partySize, battlefield:getTimeInside(), 1, battlefield:getLocalVar("[cs]bit"), 0)
-        end
+        local arg8 = (player:hasCompletedQuest(OTHER_AREAS_LOG, dsp.quest.id.outlands.TRIAL_BY_LIGHTNING)) and 1 or 0
+        player:startEvent(32001, battlefield:getArea(), clearTime, partySize, battlefield:getTimeInside(), 1, battlefield:getLocalVar("[cs]bit"), arg8)
     elseif leavecode == dsp.battlefield.leaveCode.LOST then
-        player:startEvent(32002);
+        player:startEvent(32002)
     end
-end;
+end
 
-function onEventUpdate(player,csid,option)
--- print("bc update csid "..csid.." and option "..option);
-end;
+function onEventUpdate(player, csid, option)
+end
 
-function onEventFinish(player,csid,option)
--- print("bc finish csid "..csid.." and option "..option);
-
-    if (csid == 32001) then
-        player:delKeyItem(dsp.ki.TUNING_FORK_OF_LIGHTNING);
-        player:addKeyItem(dsp.ki.WHISPER_OF_STORMS);
-        player:messageSpecial(ID.text.KEYITEM_OBTAINED,dsp.ki.WHISPER_OF_STORMS);
+function onEventFinish(player, csid, option)
+    if csid == 32001 then
+        player:delKeyItem(dsp.ki.TUNING_FORK_OF_LIGHTNING)
+        player:addKeyItem(dsp.ki.WHISPER_OF_STORMS)
+        player:addTitle(dsp.title.HEIR_OF_THE_GREAT_LIGHTNING)
+        player:messageSpecial(ID.text.KEYITEM_OBTAINED, dsp.ki.WHISPER_OF_STORMS)
     end
-end;
+end

--- a/scripts/zones/Cloister_of_Tides/bcnms/sugar-coated_directive.lua
+++ b/scripts/zones/Cloister_of_Tides/bcnms/sugar-coated_directive.lua
@@ -2,59 +2,36 @@
 -- Area: Cloister of Tides
 -- BCNM: Sugar Coated Directive (ASA-4)
 ----------------------------------------
-
-require("scripts/globals/keyitems");
 require("scripts/globals/battlefield")
-require("scripts/globals/missions");
-
+require("scripts/globals/missions")
 ----------------------------------------
 
--- After registering the BCNM via bcnmRegister(bcnmid)
-function onBattlefieldRegister(player,battlefield)
-end;
 function onBattlefieldTick(battlefield, tick)
     dsp.battlefield.onBattlefieldTick(battlefield, tick)
 end
 
--- Physically entering the BCNM via bcnmEnter(bcnmid)
-function onBattlefieldEnter(player,battlefield)
-end;
+function onBattlefieldRegister(player, battlefield)
+end
 
--- Leaving the BCNM by every mean possible, given by the LeaveCode
--- 1=Select Exit on circle
--- 2=Winning the BC
--- 3=Disconnected or warped out
--- 4=Losing the BC
--- via bcnmLeave(1) or bcnmLeave(2). LeaveCodes 3 and 4 are called
--- from the core when a player disconnects or the time limit is up, etc
+function onBattlefieldEnter(player, battlefield)
+end
 
-function onBattlefieldLeave(player,battlefield,leavecode)
-    -- print("leave code "..leavecode);
-
-    if leavecode == dsp.battlefield.leaveCode.WON then -- play end CS. Need time and battle id for record keeping + storage
-
+function onBattlefieldLeave(player, battlefield, leavecode)
+    if leavecode == dsp.battlefield.leaveCode.WON then
         local name, clearTime, partySize = battlefield:getRecord()
-        if (player:hasCompletedMission(ASA,dsp.mission.id.asa.SUGAR_COATED_DIRECTIVE)) then
-            player:startEvent(32001, battlefield:getArea(), clearTime, partySize, battlefield:getTimeInside(), 1, battlefield:getLocalVar("[cs]bit"), 1)
-        else
-            player:startEvent(32001, battlefield:getArea(), clearTime, partySize, battlefield:getTimeInside(), 1, battlefield:getLocalVar("[cs]bit"), 0)
-        end
+        local arg8 = (player:hasCompletedMission(ASA, dsp.mission.id.asa.SUGAR_COATED_DIRECTIVE)) and 1 or 0
+        player:startEvent(32001, battlefield:getArea(), clearTime, partySize, battlefield:getTimeInside(), 1, battlefield:getLocalVar("[cs]bit"), arg8)
     elseif leavecode == dsp.battlefield.leaveCode.LOST then
-        player:startEvent(32002);
+        player:startEvent(32002)
     end
+end
 
-end;
+function onEventUpdate(player, csid, option)
+end
 
-function onEventUpdate(player,csid,option)
-    -- print("bc update csid "..csid.." and option "..option);
-end;
-
-function onEventFinish(player,csid,option)
-    -- print("bc finish csid "..csid.." and option "..option);
-
-    if (csid == 32001) then
-        player:addExp(400);
-        player:setVar("ASA4_Cerulean","1");
+function onEventFinish(player, csid, option)
+    if csid == 32001 then
+        player:addExp(400)
+        player:setVar("ASA4_Cerulean", "1")
     end
-
-end;
+end

--- a/scripts/zones/Cloister_of_Tides/bcnms/trial-size_trial_by_water.lua
+++ b/scripts/zones/Cloister_of_Tides/bcnms/trial-size_trial_by_water.lua
@@ -1,67 +1,48 @@
 -----------------------------------
 -- Area: Cloister of Tides
--- BCNM: Trial by Water
+-- BCNM: Trial-size Trial by Water
 -----------------------------------
-require("scripts/globals/keyitems");
-require("scripts/globals/shop");
-require("scripts/globals/quests");
-local ID = require("scripts/zones/Cloister_of_Tides/IDs");
+local ID = require("scripts/zones/Cloister_of_Tides/IDs")
 require("scripts/globals/battlefield")
-
+require("scripts/globals/quests")
 -----------------------------------
 
 function onBattlefieldTick(battlefield, tick)
     dsp.battlefield.onBattlefieldTick(battlefield, tick)
 end
 
--- After registering the BCNM via bcnmRegister(bcnmid)
-function onBattlefieldRegister(player,battlefield)
-end;
+function onBattlefieldRegister(player, battlefield)
+end
 
--- Physically entering the BCNM via bcnmEnter(bcnmid)
-function onBattlefieldEnter(player,battlefield)
-end;
+function onBattlefieldEnter(player, battlefield)
+end
 
--- Leaving the BCNM by every mean possible, given by the LeaveCode
--- 1=Select Exit on circle
--- 2=Winning the BC
--- 3=Disconnected or warped out
--- 4=Losing the BC
--- via bcnmLeave(1) or bcnmLeave(2). LeaveCodes 3 and 4 are called
--- from the core when a player disconnects or the time limit is up, etc
-
-function onBattlefieldLeave(player,battlefield,leavecode)
--- print("leave code "..leavecode);
-    trialLightning = player:getQuestStatus(OUTLANDS,dsp.quest.id.outlands.TRIAL_SIZE_TRIAL_BY_WATER)
-
-    if leavecode == dsp.battlefield.leaveCode.WON then -- play end CS. Need time and battle id for record keeping + storage
-
+function onBattlefieldLeave(player, battlefield, leavecode)
+    if leavecode == dsp.battlefield.leaveCode.WON then
         local name, clearTime, partySize = battlefield:getRecord()
-        player:startEvent(32001, battlefield:getArea(), clearTime, partySize, battlefield:getTimeInside(), 1, battlefield:getLocalVar("[cs]bit"), 0)
+        local arg8 = (player:getQuestStatus(OUTLANDS, dsp.quest.id.otherAreas.TRIAL_SIZE_TRIAL_BY_WATER) == QUEST_COMPLETED) and 1 or 0
+        player:startEvent(32001, battlefield:getArea(), clearTime, partySize, battlefield:getTimeInside(), 1, battlefield:getLocalVar("[cs]bit"), arg8)
     elseif leavecode == dsp.battlefield.leaveCode.LOST then
-        player:setVar("TrialSizeWater_date",tonumber(os.date("%j"))); -- If you loose, you need to wait 1 real day
-        player:startEvent(32002);
+        player:setVar("TrialSizeWater_date", tonumber(os.date("%j"))) -- If you lose, you need to wait 1 real day
+        player:startEvent(32002)
     end
-end;
+end
 
-function onEventUpdate(player,csid,option)
--- print("bc update csid "..csid.." and option "..option);
-end;
+function onEventUpdate(player, csid, option)
+end
 
-function onEventFinish(player,csid,option)
--- print("bc finish csid "..csid.." and option "..option);
-
-    if (csid == 32001) then
-        if (player:hasSpell(300) == false) then
-        player:addSpell(300); -- Leviathan
-        player:messageSpecial(ID.text.LEVIATHAN_UNLOCKED,0,0,2);
+function onEventFinish(player, csid, option)
+    if csid == 32001 then
+        if not player:hasSpell(300) then
+            player:addSpell(300)
+            player:messageSpecial(ID.text.LEVIATHAN_UNLOCKED, 0, 0, 2)
         end
-        if (player:hasItem(4181) == false) then
-            player:addItem(4181);
-            player:messageSpecial(ID.text.ITEM_OBTAINED,4181); -- Scroll of instant warp
+        if not player:hasItem(4181) then
+            player:addItem(4181) -- Scroll of instant warp
+            player:messageSpecial(ID.text.ITEM_OBTAINED, 4181)
         end
-        player:setVar("TrialSizeWater_date", 0);
-        player:addFame(NORG,30);
-        player:completeQuest(OUTLANDS,dsp.quest.id.outlands.TRIAL_SIZE_TRIAL_BY_WATER);
+        player:setVar("TrialSizeWater_date", 0)
+        player:addFame(NORG, 30)
+        player:completeQuest(OUTLANDS, dsp.quest.id.outlands.TRIAL_SIZE_TRIAL_BY_WATER)
     end
-end;
+end

--- a/scripts/zones/Cloister_of_Tides/bcnms/trial_by_water.lua
+++ b/scripts/zones/Cloister_of_Tides/bcnms/trial_by_water.lua
@@ -2,59 +2,41 @@
 -- Area: Cloister of Tides
 -- BCNM: Trial by Water
 -----------------------------------
-local ID = require("scripts/zones/Cloister_of_Tides/IDs");
+local ID = require("scripts/zones/Cloister_of_Tides/IDs")
 require("scripts/globals/battlefield")
-require("scripts/globals/keyitems");
-require("scripts/globals/quests");
+require("scripts/globals/keyitems")
+require("scripts/globals/quests")
+require("scripts/globals/titles")
+-----------------------------------
 
 function onBattlefieldTick(battlefield, tick)
     dsp.battlefield.onBattlefieldTick(battlefield, tick)
 end
 
--- After registering the BCNM via bcnmRegister(bcnmid)
-function onBattlefieldRegister(player,battlefield)
-end;
+function onBattlefieldRegister(player, battlefield)
+end
 
--- Physically entering the BCNM via bcnmEnter(bcnmid)
-function onBattlefieldEnter(player,battlefield)
-end;
+function onBattlefieldEnter(player, battlefield)
+end
 
--- Leaving the BCNM by every mean possible, given by the LeaveCode
--- 1=Select Exit on circle
--- 2=Winning the BC
--- 3=Disconnected or warped out
--- 4=Losing the BC
--- via bcnmLeave(1) or bcnmLeave(2). LeaveCodes 3 and 4 are called
--- from the core when a player disconnects or the time limit is up, etc
-
-function onBattlefieldLeave(player,battlefield,leavecode)
--- print("leave code "..leavecode);
-
-    if leavecode == dsp.battlefield.leaveCode.WON then -- play end CS. Need time and battle id for record keeping + storage
-
+function onBattlefieldLeave(player, battlefield, leavecode)
+    if leavecode == dsp.battlefield.leaveCode.WON then
         local name, clearTime, partySize = battlefield:getRecord()
-        if (player:getQuestStatus(OUTLANDS,dsp.quest.id.outlands.TRIAL_BY_WATER) == QUEST_COMPLETED) then
-            player:startEvent(32001, battlefield:getArea(), clearTime, partySize, battlefield:getTimeInside(), 1, battlefield:getLocalVar("[cs]bit"), 1)
-        else
-            player:startEvent(32001, battlefield:getArea(), clearTime, partySize, battlefield:getTimeInside(), 1, battlefield:getLocalVar("[cs]bit"), 0)
-        end
+        local arg8 = (player:hasCompletedQuest(OUTLANDS, dsp.quest.id.outlands.TRIAL_BY_WATER)) and 1 or 0
+        player:startEvent(32001, battlefield:getArea(), clearTime, partySize, battlefield:getTimeInside(), 1, battlefield:getLocalVar("[cs]bit"), arg8)
     elseif leavecode == dsp.battlefield.leaveCode.LOST then
-        player:startEvent(32002);
+        player:startEvent(32002)
     end
+end
 
-end;
+function onEventUpdate(player, csid, option)
+end
 
-function onEventUpdate(player,csid,option)
--- print("bc update csid "..csid.." and option "..option);
-end;
-
-function onEventFinish(player,csid,option)
-    -- print("bc finish csid "..csid.." and option "..option);
-
-    if (csid == 32001) then
-        player:delKeyItem(dsp.ki.TUNING_FORK_OF_WATER);
-        player:addKeyItem(dsp.ki.WHISPER_OF_TIDES);
-        player:messageSpecial(ID.text.KEYITEM_OBTAINED,dsp.ki.WHISPER_OF_TIDES);
+function onEventFinish(player, csid, option)
+    if csid == 32001 then
+        player:delKeyItem(dsp.ki.TUNING_FORK_OF_WATER)
+        player:addKeyItem(dsp.ki.WHISPER_OF_TIDES)
+        player:addTitle(dsp.title.HEIR_OF_THE_GREAT_WATER)
+        player:messageSpecial(ID.text.KEYITEM_OBTAINED, dsp.ki.WHISPER_OF_TIDES)
     end
-
-end;
+end

--- a/scripts/zones/Cloister_of_Tremors/bcnms/puppet_master.lua
+++ b/scripts/zones/Cloister_of_Tremors/bcnms/puppet_master.lua
@@ -3,52 +3,33 @@
 -- BCNM: The Puppet Master
 -- !pos -539 1 -493 209
 -----------------------------------
-
-require("scripts/globals/quests");
 require("scripts/globals/battlefield")
-
 -----------------------------------
 
 function onBattlefieldTick(battlefield, tick)
     dsp.battlefield.onBattlefieldTick(battlefield, tick)
 end
 
--- After registering the BCNM via bcnmRegister(bcnmid)
-function onBattlefieldRegister(player,battlefield)
-end;
+function onBattlefieldRegister(player, battlefield)
+end
 
--- Physically entering the BCNM via bcnmEnter(bcnmid)
-function onBattlefieldEnter(player,battlefield)
-end;
+function onBattlefieldEnter(player, battlefield)
+end
 
--- Leaving the BCNM by every mean possible, given by the LeaveCode
--- 1=Select Exit on circle
--- 2=Winning the BC
--- 3=Disconnected or warped out
--- 4=Losing the BC
--- via bcnmLeave(1) or bcnmLeave(2). LeaveCodes 3 and 4 are called
--- from the core when a player disconnects or the time limit is up, etc
-
-function onBattlefieldLeave(player,battlefield,leavecode)
--- print("leave code "..leavecode);
-
-    if leavecode == dsp.battlefield.leaveCode.WON then -- play end CS. Need time and battle id for record keeping + storage
+function onBattlefieldLeave(player, battlefield, leavecode)
+    if leavecode == dsp.battlefield.leaveCode.WON then
         local name, clearTime, partySize = battlefield:getRecord()
         player:startEvent(32001, battlefield:getArea(), clearTime, partySize, battlefield:getTimeInside(), 1, battlefield:getLocalVar("[cs]bit"), 2)
     elseif leavecode == dsp.battlefield.leaveCode.LOST then
-        player:startEvent(32002);
+        player:startEvent(32002)
     end
+end
 
-end;
+function onEventUpdate(player, csid, option)
+end
 
-function onEventUpdate(player,csid,option)
--- print("bc update csid "..csid.." and option "..option);
-end;
-
-function onEventFinish(player,csid,option)
--- print("bc finish csid "..csid.." and option "..option);
-
-    if (csid == 32001 and player:getVar("ThePuppetMasterProgress") == 2) then
-        player:setVar("ThePuppetMasterProgress",3);
-    end;
-end;
+function onEventFinish(player, csid, option)
+    if csid == 32001 and player:getVar("ThePuppetMasterProgress") == 2 then
+        player:setVar("ThePuppetMasterProgress", 3)
+    end
+end

--- a/scripts/zones/Cloister_of_Tremors/bcnms/sugar-coated_directive.lua
+++ b/scripts/zones/Cloister_of_Tremors/bcnms/sugar-coated_directive.lua
@@ -2,59 +2,36 @@
 -- Area: Cloister of Tremors
 -- BCNM: Sugar Coated Directive (ASA-4)
 ----------------------------------------
-
-require("scripts/globals/keyitems");
 require("scripts/globals/battlefield")
-require("scripts/globals/missions");
-
+require("scripts/globals/missions")
 ----------------------------------------
 
--- After registering the BCNM via bcnmRegister(bcnmid)
-function onBattlefieldRegister(player,battlefield)
-end;
 function onBattlefieldTick(battlefield, tick)
     dsp.battlefield.onBattlefieldTick(battlefield, tick)
 end
 
--- Physically entering the BCNM via bcnmEnter(bcnmid)
-function onBattlefieldEnter(player,battlefield)
-end;
+function onBattlefieldRegister(player, battlefield)
+end
 
--- Leaving the BCNM by every mean possible, given by the LeaveCode
--- 1=Select Exit on circle
--- 2=Winning the BC
--- 3=Disconnected or warped out
--- 4=Losing the BC
--- via bcnmLeave(1) or bcnmLeave(2). LeaveCodes 3 and 4 are called
--- from the core when a player disconnects or the time limit is up, etc
+function onBattlefieldEnter(player, battlefield)
+end
 
-function onBattlefieldLeave(player,battlefield,leavecode)
-    -- print("leave code "..leavecode);
-
-    if leavecode == dsp.battlefield.leaveCode.WON then -- play end CS. Need time and battle id for record keeping + storage
-
+function onBattlefieldLeave(player, battlefield, leavecode)
+    if leavecode == dsp.battlefield.leaveCode.WON then
         local name, clearTime, partySize = battlefield:getRecord()
-        if (player:hasCompletedMission(ASA,dsp.mission.id.asa.SUGAR_COATED_DIRECTIVE)) then
-            player:startEvent(32001, battlefield:getArea(), clearTime, partySize, battlefield:getTimeInside(), 1, battlefield:getLocalVar("[cs]bit"), 1)
-        else
-            player:startEvent(32001, battlefield:getArea(), clearTime, partySize, battlefield:getTimeInside(), 1, battlefield:getLocalVar("[cs]bit"), 0)
-        end
+        local arg8 = (player:hasCompletedMission(ASA, dsp.mission.id.asa.SUGAR_COATED_DIRECTIVE)) and 1 or 0
+        player:startEvent(32001, battlefield:getArea(), clearTime, partySize, battlefield:getTimeInside(), 1, battlefield:getLocalVar("[cs]bit"), arg8)
     elseif leavecode == dsp.battlefield.leaveCode.LOST then
-        player:startEvent(32002);
+        player:startEvent(32002)
     end
+end
 
-end;
+function onEventUpdate(player, csid, option)
+end
 
-function onEventUpdate(player,csid,option)
-    -- print("bc update csid "..csid.." and option "..option);
-end;
-
-function onEventFinish(player,csid,option)
-    -- print("bc finish csid "..csid.." and option "..option);
-
-    if (csid == 32001) then
-        player:addExp(400);
-        player:setVar("ASA4_Amber","1");
+function onEventFinish(player, csid, option)
+    if csid == 32001 then
+        player:addExp(400)
+        player:setVar("ASA4_Amber", "1")
     end
-
-end;
+end

--- a/scripts/zones/Cloister_of_Tremors/bcnms/trial-size_trial_by_earth.lua
+++ b/scripts/zones/Cloister_of_Tremors/bcnms/trial-size_trial_by_earth.lua
@@ -1,68 +1,48 @@
 -----------------------------------
 -- Area: Cloister of Tremors
 -- BCNM: Trial-size Trial by Earth
--- !pos -539 1 -493 209
 -----------------------------------
-
-require("scripts/globals/keyitems");
-require("scripts/globals/quests");
-local ID = require("scripts/zones/Cloister_of_Tremors/IDs");
+local ID = require("scripts/zones/Cloister_of_Tremors/IDs")
 require("scripts/globals/battlefield")
-
+require("scripts/globals/quests")
 -----------------------------------
 
 function onBattlefieldTick(battlefield, tick)
     dsp.battlefield.onBattlefieldTick(battlefield, tick)
 end
 
--- After registering the BCNM via bcnmRegister(bcnmid)
-function onBattlefieldRegister(player,battlefield)
-end;
+function onBattlefieldRegister(player, battlefield)
+end
 
--- Physically entering the BCNM via bcnmEnter(bcnmid)
-function onBattlefieldEnter(player,battlefield)
-end;
+function onBattlefieldEnter(player, battlefield)
+end
 
--- Leaving the BCNM by every mean possible, given by the LeaveCode
--- 1=Select Exit on circle
--- 2=Winning the BC
--- 3=Disconnected or warped out
--- 4=Losing the BC
--- via bcnmLeave(1) or bcnmLeave(2). LeaveCodes 3 and 4 are called
--- from the core when a player disconnects or the time limit is up, etc
-
-function onBattlefieldLeave(player,battlefield,leavecode)
--- print("leave code "..leavecode);
-
-    if leavecode == dsp.battlefield.leaveCode.WON then -- play end CS. Need time and battle id for record keeping + storage
+function onBattlefieldLeave(player, battlefield, leavecode)
+    if leavecode == dsp.battlefield.leaveCode.WON then
         local name, clearTime, partySize = battlefield:getRecord()
-        player:startEvent(32001, battlefield:getArea(), clearTime, partySize, battlefield:getTimeInside(), 1, battlefield:getLocalVar("[cs]bit"), 0)
+        local arg8 = (player:getQuestStatus(BASTOK, dsp.quest.id.otherAreas.TRIAL_SIZE_TRIAL_BY_EARTH) == QUEST_COMPLETED) and 1 or 0
+        player:startEvent(32001, battlefield:getArea(), clearTime, partySize, battlefield:getTimeInside(), 1, battlefield:getLocalVar("[cs]bit"), arg8)
     elseif leavecode == dsp.battlefield.leaveCode.LOST then
-        player:setVar("TrialSizeEarth_date",tonumber(os.date("%j"))); -- If you loose, you need to wait 1 real day
-        player:startEvent(32002);
+        player:setVar("TrialSizeEarth_date", tonumber(os.date("%j"))) -- If you lose, you need to wait 1 real day
+        player:startEvent(32002)
     end
+end
 
-end;
+function onEventUpdate(player, csid, option)
+end
 
-function onEventUpdate(player,csid,option)
--- print("bc update csid "..csid.." and option "..option);
-end;
-
-function onEventFinish(player,csid,option)
--- print("bc finish csid "..csid.." and option "..option);
-
-    if (csid == 32001) then
-        if (player:hasSpell(299) == false) then
-            player:addSpell(299); -- Titan
-            player:messageSpecial(ID.text.TITAN_UNLOCKED,0,0,1);
+function onEventFinish(player, csid, option)
+    if csid == 32001 then
+        if not player:hasSpell(299) then
+            player:addSpell(299)
+            player:messageSpecial(ID.text.TITAN_UNLOCKED, 0, 0, 1)
         end
-        if (player:hasItem(4181) == false) then
-            player:addItem(4181);
-            player:messageSpecial(ID.text.ITEM_OBTAINED,4181); -- Scroll of instant warp
+        if not player:hasItem(4181) then
+            player:addItem(4181) -- Scroll of instant warp
+            player:messageSpecial(ID.text.ITEM_OBTAINED, 4181)
         end
-        player:setVar("TrialSizeEarth_date", 0);
-        player:addFame(BASTOK,30);
-        player:completeQuest(BASTOK,dsp.quest.id.bastok.TRIAL_SIZE_TRIAL_BY_EARTH);
+        player:setVar("TrialSizeEarth_date", 0)
+        player:addFame(BASTOK, 30)
+        player:completeQuest(BASTOK, dsp.quest.id.bastok.TRIAL_SIZE_TRIAL_BY_EARTH)
     end
-
-end;
+end

--- a/scripts/zones/Cloister_of_Tremors/bcnms/trial_by_earth.lua
+++ b/scripts/zones/Cloister_of_Tremors/bcnms/trial_by_earth.lua
@@ -1,63 +1,42 @@
 -----------------------------------
 -- Area: Cloister of Tremors
 -- BCNM: Trial by Earth
--- !pos -539 1 -493 209
 -----------------------------------
-
-require("scripts/globals/keyitems");
-require("scripts/globals/quests");
-local ID = require("scripts/zones/Cloister_of_Tremors/IDs");
+local ID = require("scripts/zones/Cloister_of_Tremors/IDs")
 require("scripts/globals/battlefield")
-
+require("scripts/globals/keyitems")
+require("scripts/globals/quests")
+require("scripts/globals/titles")
 -----------------------------------
 
 function onBattlefieldTick(battlefield, tick)
     dsp.battlefield.onBattlefieldTick(battlefield, tick)
 end
 
--- After registering the BCNM via bcnmRegister(bcnmid)
-function onBattlefieldRegister(player,battlefield)
-end;
+function onBattlefieldRegister(player, battlefield)
+end
 
--- Physically entering the BCNM via bcnmEnter(bcnmid)
-function onBattlefieldEnter(player,battlefield)
-end;
+function onBattlefieldEnter(player, battlefield)
+end
 
--- Leaving the BCNM by every mean possible, given by the LeaveCode
--- 1=Select Exit on circle
--- 2=Winning the BC
--- 3=Disconnected or warped out
--- 4=Losing the BC
--- via bcnmLeave(1) or bcnmLeave(2). LeaveCodes 3 and 4 are called
--- from the core when a player disconnects or the time limit is up, etc
-
-function onBattlefieldLeave(player,battlefield,leavecode)
--- print("leave code "..leavecode);
-
-    if leavecode == dsp.battlefield.leaveCode.WON then -- play end CS. Need time and battle id for record keeping + storage
+function onBattlefieldLeave(player, battlefield, leavecode)
+    if leavecode == dsp.battlefield.leaveCode.WON then
         local name, clearTime, partySize = battlefield:getRecord()
-        if (player:hasCompletedQuest(BASTOK,dsp.quest.id.bastok.TRIAL_BY_EARTH)) then
-            player:startEvent(32001, battlefield:getArea(), clearTime, partySize, battlefield:getTimeInside(), 1, battlefield:getLocalVar("[cs]bit"), 1)
-        else
-            player:startEvent(32001, battlefield:getArea(), clearTime, partySize, battlefield:getTimeInside(), 1, battlefield:getLocalVar("[cs]bit"), 0)
-        end
+        local arg8 = (player:hasCompletedQuest(BASTOK, dsp.quest.id.bastok.TRIAL_BY_EARTH)) and 1 or 0
+        player:startEvent(32001, battlefield:getArea(), clearTime, partySize, battlefield:getTimeInside(), 1, battlefield:getLocalVar("[cs]bit"), arg8)
     elseif leavecode == dsp.battlefield.leaveCode.LOST then
-        player:startEvent(32002);
+        player:startEvent(32002)
     end
+end
 
-end;
+function onEventUpdate(player, csid, option)
+end
 
-function onEventUpdate(player,csid,option)
--- print("bc update csid "..csid.." and option "..option);
-end;
-
-function onEventFinish(player,csid,option)
--- print("bc finish csid "..csid.." and option "..option);
-
-    if (csid == 32001) then
-        player:delKeyItem(dsp.ki.TUNING_FORK_OF_EARTH);
-        player:addKeyItem(dsp.ki.WHISPER_OF_TREMORS);
-        player:messageSpecial(ID.text.KEYITEM_OBTAINED,dsp.ki.WHISPER_OF_TREMORS);
+function onEventFinish(player, csid, option)
+    if csid == 32001 then
+        player:delKeyItem(dsp.ki.TUNING_FORK_OF_EARTH)
+        player:addKeyItem(dsp.ki.WHISPER_OF_TREMORS)
+        player:addTitle(dsp.title.HEIR_OF_THE_GREAT_EARTH)
+        player:messageSpecial(ID.text.KEYITEM_OBTAINED, dsp.ki.WHISPER_OF_TREMORS)
     end
-
-end;
+end

--- a/scripts/zones/Empyreal_Paradox/bcnms/dawn.lua
+++ b/scripts/zones/Empyreal_Paradox/bcnms/dawn.lua
@@ -1,6 +1,6 @@
 -----------------------------------
 -- Area: Empyreal_Paradox
--- Name: dawn
+-- Name: Dawn
 -- instance 1 Promathia !pos -520 -119 524
 -- instance 2 Promathia !pos 521 -0.500 517
 -- instance 3 Promathia !pos -519 120 -520
@@ -12,76 +12,50 @@ require("scripts/globals/missions")
 require("scripts/globals/titles")
 -----------------------------------
 
--- EXAMPLE SCRIPT
--- 
--- What should go here:
--- giving key items, playing ENDING cutscenes
---
--- What should NOT go here:
--- Handling of "battlefield" status, spawning of monsters,
--- putting loot into treasure pool, 
--- enforcing ANY rules (SJ/number of people/etc), moving
--- chars around, playing entrance CSes (entrance CSes go in bcnm.lua)
-
--- After registering the BCNM via bcnmRegister(bcnmid)
 function onBattlefieldTick(battlefield, tick)
     dsp.battlefield.onBattlefieldTick(battlefield, tick)
 end
 
+function onBattlefieldRegister(player, battlefield)
+    local baseID = ID.mob.PROMATHIA_OFFSET + (battlefield:getArea() - 1) * 2
+    local pos = GetMobByID(baseID):getSpawnPos()
 
-function onBattlefieldRegister(player,battlefield)
-    local baseID = 16924673 + (battlefield:getArea() - 1) * 2
-    local pos = GetMobByID(baseID):getSpawnPos();
-    local prishe = battlefield:insertEntity(14166, true);
-    prishe:setSpawn(pos.x - 6, pos.y, pos.z - 21.5, 192);
-    prishe:spawn();
+    local prishe = battlefield:insertEntity(14166, true)
+    prishe:setSpawn(pos.x - 6, pos.y, pos.z - 21.5, 192)
+    prishe:spawn()
 
-    local selhteus = battlefield:insertEntity(14167, true);
-    selhteus:setSpawn(pos.x + 10, pos.y, pos.z - 17.5, 172);
-    selhteus:spawn();
-end;
+    local selhteus = battlefield:insertEntity(14167, true)
+    selhteus:setSpawn(pos.x + 10, pos.y, pos.z - 17.5, 172)
+    selhteus:spawn()
+end
 
--- Physically entering the BCNM via bcnmEnter(bcnmid)
-function onBattlefieldEnter(player,battlefield)
-end;
+function onBattlefieldEnter(player, battlefield)
+end
 
 function onBattlefieldDestroy(battlefield)
-end;
+end
 
--- Leaving the BCNM by every mean possible, given by the LeaveCode
--- 1=Select Exit on circle
--- 2=Winning the BC
--- 3=Disconnected or warped out
--- 4=Losing the BC
--- via bcnmLeave(1) or bcnmLeave(2). LeaveCodes 3 and 4 are called
--- from the core when a player disconnects or the time limit is up, etc
-
-function onBattlefieldLeave(player,battlefield,leavecode)
-
-    if leavecode == dsp.battlefield.leaveCode.WON then -- play end CS. Need time and battle id for record keeping + storage
-
+function onBattlefieldLeave(player, battlefield, leavecode)
+    if leavecode == dsp.battlefield.leaveCode.WON then
         local name, clearTime, partySize = battlefield:getRecord()
         player:startEvent(6)
     elseif leavecode == dsp.battlefield.leaveCode.LOST then
         player:startEvent(32002)
     end
-    --printf("leavecode: %u",leavecode)
-
 end
 
-function onEventUpdate(player,csid,option)
-    -- print("bc update csid "..csid.." and option "..option)
+function onEventUpdate(player, csid, option)
 end
 
-function onEventFinish(player,csid,option)
-    if csid== 6 then
-        player:setPos(539,0,-593,192)
+function onEventFinish(player, csid, option)
+    if csid == 6 then
+        player:setPos(539, 0, -593, 192)
         player:addTitle(dsp.title.AVERTER_OF_THE_APOCALYPSE)
         player:startEvent(3)
-        if (player:getCurrentMission(COP) == dsp.mission.id.cop.DAWN and player:getVar("PromathiaStatus") == 2) then
+        if player:getCurrentMission(COP) == dsp.mission.id.cop.DAWN and player:getVar("PromathiaStatus") == 2 then
             player:addKeyItem(dsp.ki.TEAR_OF_ALTANA)
             player:messageSpecial(ID.text.KEYITEM_OBTAINED, dsp.ki.TEAR_OF_ALTANA)
-            player:setVar("Promathia_kill_day", tonumber(os.date("%j")));
+            player:setVar("Promathia_kill_day", tonumber(os.date("%j")))
             player:setVar("PromathiaStatus", 3)
         end
     end

--- a/scripts/zones/Full_Moon_Fountain/bcnms/moon_reading.lua
+++ b/scripts/zones/Full_Moon_Fountain/bcnms/moon_reading.lua
@@ -1,58 +1,40 @@
 -----------------------------------
 -- Area: Full Moon Mountain
--- Name: Windurst Mission 9-2
+-- Name: Windurst Mission 9-2 Moon Reading
 -----------------------------------
+require("scripts/globals/battlefield")
 require("scripts/globals/missions")
 -----------------------------------
 
--- After registering the BCNM via bcnmRegister(bcnmid)
+function onBattlefieldTick(battlefield, tick)
+    dsp.battlefield.onBattlefieldTick(battlefield, tick)
+end
 
+function onBcnmRegister(player, instance)
+end
 
-function onBcnmRegister(player,instance)
-end;
+function onBcnmEnter(player, instance)
+end
 
-
-
-
--- Physically entering the BCNM via bcnmEnter(bcnmid)
-function onBcnmEnter(player,instance)
-end;
-
--- Leaving the BCNM by every mean possible, given by the LeaveCode
--- 1=Select Exit on circle
--- 2=Winning the BC
--- 3=Disconnected or warped out
--- 4=Losing the BC
--- via bcnmLeave(1) or bcnmLeave(2). LeaveCodes 3 and 4 are called
--- from the core when a player disconnects or the time limit is up, etc
-
-function onBcnmLeave(player,instance,leavecode)
-    --print("leave code "..leavecode);
-    local currentMission = player:getCurrentMission(WINDURST);
-    if (leavecode == 2) then
-        --printf("win");
-        if (currentMission == dsp.mission.id.windurst.MOON_READING) then
-            player:startEvent(32001,1,1,1,instance:getTimeInside(),1,0,0);
-        else
-            player:startEvent(32001,1,1,1,instance:getTimeInside(),1,0,1);
-        end
-    elseif (leavecode == 4) then
-        player:startEvent(32002);
+function onBcnmLeave(player, instance, leavecode)
+    if leavecode == dsp.battlefield.leaveCode.WON then
+        local name, clearTime, partySize = battlefield:getRecord()
+        local arg8 = (player:getCurrentMission(WINDURST) ~= dsp.mission.id.windurst.MOON_READING) and 1 or 0
+        player:startEvent(32001, battlefield:getArea(), clearTime, partySize, battlefield:getTimeInside(), 1, battlefield:getLocalVar("[cs]bit"), arg8)
+    elseif leavecode == dsp.battlefield.leaveCode.LOST then
+        player:startEvent(32002)
     end
-end;
+end
 
-function onEventUpdate(player,csid,option)
-    --print("bc update csid "..csid.." and option "..option);
-end;
-    
-function onEventFinish(player,csid,option)
-    --print("bc finish csid "..csid.." and option "..option);
-    local currentMission = player:getCurrentMission(WINDURST);
-    local MissionStatus = player:getVar("MissionStatus");
+function onEventUpdate(player, csid, option)
+end
 
-    if (csid == 32001) then
-        if (currentMission == dsp.mission.id.windurst.MOON_READING and MissionStatus == 2) then
-            player:setVar("MissionStatus",3);
-        end
+function onEventFinish(player, csid, option)
+    if
+        csid == 32001 and
+        player:getCurrentMission(WINDURST) == dsp.mission.id.windurst.MOON_READING and
+        player:getVar("MissionStatus") == 2
+    then
+        player:setVar("MissionStatus", 3)
     end
-end;
+end

--- a/scripts/zones/Full_Moon_Fountain/bcnms/moonlit_path.lua
+++ b/scripts/zones/Full_Moon_Fountain/bcnms/moonlit_path.lua
@@ -2,68 +2,39 @@
 -- Area: Full Moon Fountain
 -- Name: The Moonlit Path
 -----------------------------------
-require("scripts/globals/keyitems");
-require("scripts/globals/battlefield")
-require("scripts/globals/missions");
 local ID = require("scripts/zones/Full_Moon_Fountain/IDs")
-
+require("scripts/globals/battlefield")
+require("scripts/globals/keyitems")
+require("scripts/globals/quests")
 -----------------------------------
 
--- What should go here:
--- giving key items, playing ENDING cutscenes
---
--- What should NOT go here:
--- Handling of "battlefield" status, spawning of monsters,
--- putting loot into treasure pool,
--- enforcing ANY rules (SJ/number of people/etc), moving
--- chars around, playing entrance CSes (entrance CSes go in bcnm.lua)
-
--- After registering the BCNM via bcnmRegister(bcnmid)
-function onBattlefieldRegister(player,battlefield)
-end;
 function onBattlefieldTick(battlefield, tick)
     dsp.battlefield.onBattlefieldTick(battlefield, tick)
 end
 
--- Physically entering the BCNM via bcnmEnter(bcnmid)
-function onBattlefieldEnter(player,battlefield)
-end;
+function onBattlefieldRegister(player, battlefield)
+end
 
--- Leaving the BCNM by every mean possible, given by the LeaveCode
--- 1=Select Exit on circle
--- 2=Winning the BC
--- 3=Disconnected or warped out
--- 4=Losing the BC
--- via bcnmLeave(1) or bcnmLeave(2). LeaveCodes 3 and 4 are called
--- from the core when a player disconnects or the time limit is up, etc
+function onBattlefieldEnter(player, battlefield)
+end
 
-function onBattlefieldLeave(player,battlefield,leavecode)
--- print("leave code "..leavecode);
-    moonlitPath = player:getQuestStatus(WINDURST,dsp.quest.id.windurst.THE_MOONLIT_PATH)
-
-    if leavecode == dsp.battlefield.leaveCode.WON then -- play end CS. Need time and battle id for record keeping + storage
-
+function onBattlefieldLeave(player, battlefield, leavecode)
+    if leavecode == dsp.battlefield.leaveCode.WON then
         local name, clearTime, partySize = battlefield:getRecord()
-        if (moonlitPath == QUEST_COMPLETED) then
-            player:startEvent(32001, battlefield:getArea(), clearTime, partySize, battlefield:getTimeInside(), 1, battlefield:getLocalVar("[cs]bit"), 1)
-        else
-            player:startEvent(32001, battlefield:getArea(), clearTime, partySize, battlefield:getTimeInside(), 1, battlefield:getLocalVar("[cs]bit"), 0)
-        end
+        local arg8 = (player:getQuestStatus(WINDURST, dsp.quest.id.windurst.THE_MOONLIT_PATH) == QUEST_COMPLETED) and 1 or 0
+        player:startEvent(32001, battlefield:getArea(), clearTime, partySize, battlefield:getTimeInside(), 1, battlefield:getLocalVar("[cs]bit"), arg8)
     elseif leavecode == dsp.battlefield.leaveCode.LOST then
-        player:startEvent(32002);
+        player:startEvent(32002)
     end
-end;
+end
 
-function onEventUpdate(player,csid,option)
--- print("bc update csid "..csid.." and option "..option);
-end;
+function onEventUpdate(player, csid, option)
+end
 
-function onEventFinish(player,csid,option)
--- print("bc finish csid "..csid.." and option "..option);
-
-    if (csid == 32001) then
-        player:delKeyItem(dsp.ki.MOON_BAUBLE);
-        player:addKeyItem(dsp.ki.WHISPER_OF_THE_MOON);
-        player:messageSpecial(ID.text.KEYITEM_OBTAINED,dsp.ki.WHISPER_OF_THE_MOON);
+function onEventFinish(player, csid, option)
+    if csid == 32001 then
+        player:delKeyItem(dsp.ki.MOON_BAUBLE)
+        player:addKeyItem(dsp.ki.WHISPER_OF_THE_MOON)
+        player:messageSpecial(ID.text.KEYITEM_OBTAINED, dsp.ki.WHISPER_OF_THE_MOON)
     end
-end;
+end

--- a/scripts/zones/Jade_Sepulcher/bcnms/puppet_in_peril.lua
+++ b/scripts/zones/Jade_Sepulcher/bcnms/puppet_in_peril.lua
@@ -3,56 +3,36 @@
 -- BCNM: TOAU-29 Puppet in Peril
 -----------------------------------
 require("scripts/globals/battlefield")
-require("scripts/globals/keyitems");
+require("scripts/globals/missions")
 ----------------------------------------
 
--- After registering the BCNM via bcnmRegister(bcnmid)
-function onBattlefieldRegister(player,battlefield)
-end;
 function onBattlefieldTick(battlefield, tick)
     dsp.battlefield.onBattlefieldTick(battlefield, tick)
 end
 
--- Physically entering the BCNM via bcnmEnter(bcnmid)
-function onBattlefieldEnter(player,battlefield)
-end;
+function onBattlefieldRegister(player, battlefield)
+end
 
--- Leaving the BCNM by every mean possible, given by the LeaveCode
--- 1=Select Exit on circle
--- 2=Winning the BC
--- 3=Disconnected or warped out
--- 4=Losing the BC
--- via bcnmLeave(1) or bcnmLeave(2). LeaveCodes 3 and 4 are called
--- from the core when a player disconnects or the time limit is up, etc
+function onBattlefieldEnter(player, battlefield)
+end
 
-function onBattlefieldLeave(player,battlefield,leavecode)
-    -- print("leave code "..leavecode);
-
-    if leavecode == dsp.battlefield.leaveCode.WON then -- play end CS. Need time and battle id for record keeping + storage
-
+function onBattlefieldLeave(player, battlefield, leavecode)
+    if leavecode == dsp.battlefield.leaveCode.WON then
         local name, clearTime, partySize = battlefield:getRecord()
-        if (player:hasCompletedMission(TOAU,dsp.mission.id.toau.PUPPET_IN_PERIL)) then
-            player:startEvent(32001, battlefield:getArea(), clearTime, partySize, battlefield:getTimeInside(), 1, battlefield:getLocalVar("[cs]bit"), 1)
-        else
-            player:startEvent(32001, battlefield:getArea(), clearTime, partySize, battlefield:getTimeInside(), 1, battlefield:getLocalVar("[cs]bit"), 0)
-        end
+        local arg8 = (player:hasCompletedMission(TOAU, dsp.mission.id.toau.PUPPET_IN_PERIL)) and 1 or 0
+        player:startEvent(32001, battlefield:getArea(), clearTime, partySize, battlefield:getTimeInside(), 1, battlefield:getLocalVar("[cs]bit"), arg8)
     elseif leavecode == dsp.battlefield.leaveCode.LOST then
-        player:startEvent(32002);
+        player:startEvent(32002)
     end
+end
 
-end;
+function onEventUpdate(player, csid, option)
+end
 
-function onEventUpdate(player,csid,option)
-    -- print("bc update csid "..csid.." and option "..option);
-end;
-
-function onEventFinish(player,csid,option)
-    -- print("bc finish csid "..csid.." and option "..option);
-
+function onEventFinish(player, csid, option)
     if csid == 32001 and player:getCurrentMission(TOAU) == dsp.mission.id.toau.PUPPET_IN_PERIL then
-        player:completeMission(TOAU,dsp.mission.id.toau.PUPPET_IN_PERIL);
-        player:setVar("AhtUrganStatus",0);
-        player:addMission(TOAU,dsp.mission.id.toau.PREVALENCE_OF_PIRATES);
+        player:completeMission(TOAU, dsp.mission.id.toau.PUPPET_IN_PERIL)
+        player:addMission(TOAU, dsp.mission.id.toau.PREVALENCE_OF_PIRATES)
+        player:setVar("AhtUrganStatus", 0)
     end
-
-end;
+end

--- a/scripts/zones/LaLoff_Amphitheater/bcnms/ark_angels_1.lua
+++ b/scripts/zones/LaLoff_Amphitheater/bcnms/ark_angels_1.lua
@@ -2,81 +2,51 @@
 -- Area: LaLoff Amphitheater
 -- Name: Ark Angels 1 (Hume)
 -----------------------------------
+local ID = require("scripts/zones/LaLoff_Amphitheater/IDs")
 require("scripts/globals/battlefield")
-local ID = require("scripts/zones/LaLoff_Amphitheater/IDs");
-require("scripts/globals/missions");
-require("scripts/globals/keyitems");
+require("scripts/globals/keyitems")
+require("scripts/globals/missions")
 -----------------------------------
 
--- Death cutscenes:
-
--- player:startEvent(32001, battlefield:getArea(), clearTime, partySize, battlefield:getTimeInside(), 1, battlefield:getLocalVar("[cs]bit"), 0) -- Hume
--- player:startEvent(32001, battlefield:getArea(), clearTime, partySize, battlefield:getTimeInside(), 1, battlefield:getLocalVar("[cs]bit"), 0) -- taru
--- player:startEvent(32001, battlefield:getArea(), clearTime, partySize, battlefield:getTimeInside(), 1, battlefield:getLocalVar("[cs]bit"), 0) -- mithra
--- player:startEvent(32001, battlefield:getArea(), clearTime, partySize, battlefield:getTimeInside(), 1, battlefield:getLocalVar("[cs]bit"), 0) -- elvan
--- player:startEvent(32001, battlefield:getArea(), clearTime, partySize, battlefield:getTimeInside(), 1, battlefield:getLocalVar("[cs]bit"), 0) -- galka
--- player:startEvent(32001, battlefield:getArea(), clearTime, partySize, battlefield:getTimeInside(), 1, battlefield:getLocalVar("[cs]bit"), 0) -- divine might
--- player:startEvent(32001, battlefield:getArea(), clearTime, partySize, battlefield:getTimeInside(), 1, battlefield:getLocalVar("[cs]bit"), 0) -- skip ending cs
-
-
--- After registering the BCNM via bcnmRegister(bcnmid)
-function onBattlefieldRegister(player,battlefield)
-end;
 function onBattlefieldTick(battlefield, tick)
     dsp.battlefield.onBattlefieldTick(battlefield, tick)
 end
 
--- Physically entering the BCNM via bcnmEnter(bcnmid)
-function onBattlefieldEnter(player,battlefield)
-end;
+function onBattlefieldRegister(player, battlefield)
+end
 
--- Leaving the BCNM by every mean possible, given by the LeaveCode
--- 1=Select Exit on circle
--- 2=Winning the BC
--- 3=Disconnected or warped out
--- 4=Losing the BC
--- via bcnmLeave(1) or bcnmLeave(2). LeaveCodes 3 and 4 are called
--- from the core when a player disconnects or the time limit is up, etc
+function onBattlefieldEnter(player, battlefield)
+end
 
-function onBattlefieldLeave(player,battlefield,leavecode)
---print("leave code "..leavecode);
-
-    if leavecode == dsp.battlefield.leaveCode.WON then -- play end CS. Need time and battle id for record keeping + storage
+function onBattlefieldLeave(player, battlefield, leavecode)
+    if leavecode == dsp.battlefield.leaveCode.WON then
         local name, clearTime, partySize = battlefield:getRecord()
-        local record = battlefield:getRecord();
-        local clearTime = record.clearTime;
-
-        if (player:hasCompletedMission(ZILART,dsp.mission.id.zilart.ARK_ANGELS)) then
-            player:startEvent(32001, battlefield:getArea(), clearTime, partySize, battlefield:getTimeInside(), 180, battlefield:getLocalVar("[cs]bit"), 1)        -- winning CS (allow player to skip)
-        else
-            player:startEvent(32001, battlefield:getArea(), clearTime, partySize, battlefield:getTimeInside(), 180, battlefield:getLocalVar("[cs]bit"), 0)        -- winning CS (allow player to skip)
-        end
-
+        local arg8 = (player:hasCompletedMission(ZILART, dsp.mission.id.zilart.ARK_ANGELS)) and 1 or 0
+        player:startEvent(32001, battlefield:getArea(), clearTime, partySize, battlefield:getTimeInside(), 180, battlefield:getLocalVar("[cs]bit"), arg8)
     elseif leavecode == dsp.battlefield.leaveCode.LOST then
-        player:startEvent(32002, 0, 0, 0, 0, 0, battlefield:getArea(), 180);    -- player lost
+        player:startEvent(32002, 0, 0, 0, 0, 0, battlefield:getArea(), 180)
     end
-end;
+end
 
-function onEventUpdate(player,csid,option)
-    -- print("bc update csid "..csid.." and option "..option);
+function onEventUpdate(player, csid, option)
+end
 
-end;
-
-function onEventFinish(player,csid,option)
-    -- print("bc finish csid "..csid.." and option "..option);
-
-    local AAKeyitems = (player:hasKeyItem(dsp.ki.SHARD_OF_ARROGANCE) and player:hasKeyItem(dsp.ki.SHARD_OF_COWARDICE)
-        and player:hasKeyItem(dsp.ki.SHARD_OF_ENVY) and player:hasKeyItem(dsp.ki.SHARD_OF_RAGE));
-
-    if (csid == 32001) then
-        if (player:getCurrentMission(ZILART) == dsp.mission.id.zilart.ARK_ANGELS and player:getVar("ZilartStatus") == 1) then
-            player:addKeyItem(dsp.ki.SHARD_OF_APATHY);
-            player:messageSpecial(ID.text.KEYITEM_OBTAINED,dsp.ki.SHARD_OF_APATHY);
-            if (AAKeyitems == true) then
-                player:completeMission(ZILART,dsp.mission.id.zilart.ARK_ANGELS);
-                player:addMission(ZILART,dsp.mission.id.zilart.THE_SEALED_SHRINE);
-                player:setVar("ZilartStatus",0);
+function onEventFinish(player, csid, option)
+    if csid == 32001 then
+        if player:getCurrentMission(ZILART) == dsp.mission.id.zilart.ARK_ANGELS and player:getVar("ZilartStatus") == 1 then
+            player:addKeyItem(dsp.ki.SHARD_OF_APATHY)
+            player:messageSpecial(ID.text.KEYITEM_OBTAINED, dsp.ki.SHARD_OF_APATHY)
+            if
+                player:hasKeyItem(dsp.ki.SHARD_OF_APATHY) and
+                player:hasKeyItem(dsp.ki.SHARD_OF_ARROGANCE) and
+                player:hasKeyItem(dsp.ki.SHARD_OF_COWARDICE) and
+                player:hasKeyItem(dsp.ki.SHARD_OF_ENVY) and
+                player:hasKeyItem(dsp.ki.SHARD_OF_RAGE)
+            then
+                player:completeMission(ZILART, dsp.mission.id.zilart.ARK_ANGELS)
+                player:addMission(ZILART, dsp.mission.id.zilart.THE_SEALED_SHRINE)
+                player:setVar("ZilartStatus", 0)
             end
         end
     end
-end;
+end

--- a/scripts/zones/LaLoff_Amphitheater/bcnms/ark_angels_2.lua
+++ b/scripts/zones/LaLoff_Amphitheater/bcnms/ark_angels_2.lua
@@ -2,81 +2,51 @@
 -- Area: LaLoff Amphitheater
 -- Name: Ark Angels 2 (Tarutaru)
 -----------------------------------
+local ID = require("scripts/zones/LaLoff_Amphitheater/IDs")
 require("scripts/globals/battlefield")
-local ID = require("scripts/zones/LaLoff_Amphitheater/IDs");
-require("scripts/globals/missions");
-require("scripts/globals/keyitems");
+require("scripts/globals/keyitems")
+require("scripts/globals/missions")
 -----------------------------------
 
--- Death cutscenes:
-
--- player:startEvent(32001, battlefield:getArea(), clearTime, partySize, battlefield:getTimeInside(), 1, battlefield:getLocalVar("[cs]bit"), 0) -- Hume
--- player:startEvent(32001, battlefield:getArea(), clearTime, partySize, battlefield:getTimeInside(), 1, battlefield:getLocalVar("[cs]bit"), 0) -- taru
--- player:startEvent(32001, battlefield:getArea(), clearTime, partySize, battlefield:getTimeInside(), 1, battlefield:getLocalVar("[cs]bit"), 0) -- mithra
--- player:startEvent(32001, battlefield:getArea(), clearTime, partySize, battlefield:getTimeInside(), 1, battlefield:getLocalVar("[cs]bit"), 0) -- elvan
--- player:startEvent(32001, battlefield:getArea(), clearTime, partySize, battlefield:getTimeInside(), 1, battlefield:getLocalVar("[cs]bit"), 0) -- galka
--- player:startEvent(32001, battlefield:getArea(), clearTime, partySize, battlefield:getTimeInside(), 1, battlefield:getLocalVar("[cs]bit"), 0) -- divine might
--- player:startEvent(32001, battlefield:getArea(), clearTime, partySize, battlefield:getTimeInside(), 1, battlefield:getLocalVar("[cs]bit"), 0) -- skip ending cs
-
-
--- After registering the BCNM via bcnmRegister(bcnmid)
-function onBattlefieldRegister(player,battlefield)
-end;
 function onBattlefieldTick(battlefield, tick)
     dsp.battlefield.onBattlefieldTick(battlefield, tick)
 end
 
--- Physically entering the BCNM via bcnmEnter(bcnmid)
-function onBattlefieldEnter(player,battlefield)
-end;
+function onBattlefieldRegister(player, battlefield)
+end
 
--- Leaving the BCNM by every mean possible, given by the LeaveCode
--- 1=Select Exit on circle
--- 2=Winning the BC
--- 3=Disconnected or warped out
--- 4=Losing the BC
--- via bcnmLeave(1) or bcnmLeave(2). LeaveCodes 3 and 4 are called
--- from the core when a player disconnects or the time limit is up, etc
+function onBattlefieldEnter(player, battlefield)
+end
 
-function onBattlefieldLeave(player,battlefield,leavecode)
---print("leave code "..leavecode);
-
-    if leavecode == dsp.battlefield.leaveCode.WON then -- play end CS. Need time and battle id for record keeping + storage
+function onBattlefieldLeave(player, battlefield, leavecode)
+    if leavecode == dsp.battlefield.leaveCode.WON then
         local name, clearTime, partySize = battlefield:getRecord()
-        local record = battlefield:getRecord();
-        local clearTime = record.clearTime;
-
-        if (player:hasCompletedMission(ZILART,dsp.mission.id.zilart.ARK_ANGELS)) then
-            player:startEvent(32001, battlefield:getArea(), clearTime, partySize, battlefield:getTimeInside(), 180, battlefield:getLocalVar("[cs]bit"), 1)        -- winning CS (allow player to skip)
-        else
-            player:startEvent(32001, battlefield:getArea(), clearTime, partySize, battlefield:getTimeInside(), 180, battlefield:getLocalVar("[cs]bit"), 0)        -- winning CS (allow player to skip)
-        end
-
+        local arg8 = (player:hasCompletedMission(ZILART, dsp.mission.id.zilart.ARK_ANGELS)) and 1 or 0
+        player:startEvent(32001, battlefield:getArea(), clearTime, partySize, battlefield:getTimeInside(), 180, battlefield:getLocalVar("[cs]bit"), arg8)
     elseif leavecode == dsp.battlefield.leaveCode.LOST then
-        player:startEvent(32002, 0, 0, 0, 0, 0, battlefield:getArea(), 180);    -- player lost
+        player:startEvent(32002, 0, 0, 0, 0, 0, battlefield:getArea(), 180)
     end
-end;
+end
 
-function onEventUpdate(player,csid,option)
-    -- print("bc update csid "..csid.." and option "..option);
+function onEventUpdate(player, csid, option)
+end
 
-end;
-
-function onEventFinish(player,csid,option)
-    -- print("bc finish csid "..csid.." and option "..option);
-
-    local AAKeyitems = (player:hasKeyItem(dsp.ki.SHARD_OF_APATHY) and player:hasKeyItem(dsp.ki.SHARD_OF_ARROGANCE)
-        and player:hasKeyItem(dsp.ki.SHARD_OF_ENVY) and player:hasKeyItem(dsp.ki.SHARD_OF_RAGE));
-
-    if (csid == 32001) then
-        if (player:getCurrentMission(ZILART) == dsp.mission.id.zilart.ARK_ANGELS  and player:getVar("ZilartStatus") == 1) then
-            player:addKeyItem(dsp.ki.SHARD_OF_COWARDICE);
-            player:messageSpecial(ID.text.KEYITEM_OBTAINED,dsp.ki.SHARD_OF_COWARDICE);
-            if (AAKeyitems == true) then
-                player:completeMission(ZILART,dsp.mission.id.zilart.ARK_ANGELS);
-                player:addMission(ZILART,dsp.mission.id.zilart.THE_SEALED_SHRINE);
-                player:setVar("ZilartStatus",0);
+function onEventFinish(player, csid, option)
+    if csid == 32001 then
+        if player:getCurrentMission(ZILART) == dsp.mission.id.zilart.ARK_ANGELS and player:getVar("ZilartStatus") == 1 then
+            player:addKeyItem(dsp.ki.SHARD_OF_COWARDICE)
+            player:messageSpecial(ID.text.KEYITEM_OBTAINED, dsp.ki.SHARD_OF_COWARDICE)
+            if
+                player:hasKeyItem(dsp.ki.SHARD_OF_APATHY) and
+                player:hasKeyItem(dsp.ki.SHARD_OF_ARROGANCE) and
+                player:hasKeyItem(dsp.ki.SHARD_OF_COWARDICE) and
+                player:hasKeyItem(dsp.ki.SHARD_OF_ENVY) and
+                player:hasKeyItem(dsp.ki.SHARD_OF_RAGE)
+            then
+                player:completeMission(ZILART, dsp.mission.id.zilart.ARK_ANGELS)
+                player:addMission(ZILART, dsp.mission.id.zilart.THE_SEALED_SHRINE)
+                player:setVar("ZilartStatus", 0)
             end
         end
     end
-end;
+end

--- a/scripts/zones/LaLoff_Amphitheater/bcnms/ark_angels_3.lua
+++ b/scripts/zones/LaLoff_Amphitheater/bcnms/ark_angels_3.lua
@@ -2,81 +2,51 @@
 -- Area: LaLoff Amphitheater
 -- Name: Ark Angels 3 (Mithra)
 -----------------------------------
+local ID = require("scripts/zones/LaLoff_Amphitheater/IDs")
 require("scripts/globals/battlefield")
-local ID = require("scripts/zones/LaLoff_Amphitheater/IDs");
-require("scripts/globals/missions");
-require("scripts/globals/keyitems");
+require("scripts/globals/keyitems")
+require("scripts/globals/missions")
 -----------------------------------
 
--- Death cutscenes:
-
--- player:startEvent(32001, battlefield:getArea(), clearTime, partySize, battlefield:getTimeInside(), 1, battlefield:getLocalVar("[cs]bit"), 0) -- Hume
--- player:startEvent(32001, battlefield:getArea(), clearTime, partySize, battlefield:getTimeInside(), 1, battlefield:getLocalVar("[cs]bit"), 0) -- taru
--- player:startEvent(32001, battlefield:getArea(), clearTime, partySize, battlefield:getTimeInside(), 1, battlefield:getLocalVar("[cs]bit"), 0) -- mithra
--- player:startEvent(32001, battlefield:getArea(), clearTime, partySize, battlefield:getTimeInside(), 1, battlefield:getLocalVar("[cs]bit"), 0) -- elvan
--- player:startEvent(32001, battlefield:getArea(), clearTime, partySize, battlefield:getTimeInside(), 1, battlefield:getLocalVar("[cs]bit"), 0) -- galka
--- player:startEvent(32001, battlefield:getArea(), clearTime, partySize, battlefield:getTimeInside(), 1, battlefield:getLocalVar("[cs]bit"), 0) -- divine might
--- player:startEvent(32001, battlefield:getArea(), clearTime, partySize, battlefield:getTimeInside(), 1, battlefield:getLocalVar("[cs]bit"), 0) -- skip ending cs
-
-
--- After registering the BCNM via bcnmRegister(bcnmid)
-function onBattlefieldRegister(player,battlefield)
-end;
 function onBattlefieldTick(battlefield, tick)
     dsp.battlefield.onBattlefieldTick(battlefield, tick)
 end
 
--- Physically entering the BCNM via bcnmEnter(bcnmid)
-function onBattlefieldEnter(player,battlefield)
-end;
+function onBattlefieldRegister(player, battlefield)
+end
 
--- Leaving the BCNM by every mean possible, given by the LeaveCode
--- 1=Select Exit on circle
--- 2=Winning the BC
--- 3=Disconnected or warped out
--- 4=Losing the BC
--- via bcnmLeave(1) or bcnmLeave(2). LeaveCodes 3 and 4 are called
--- from the core when a player disconnects or the time limit is up, etc
+function onBattlefieldEnter(player, battlefield)
+end
 
-function onBattlefieldLeave(player,battlefield,leavecode)
---print("leave code "..leavecode);
-
-    if leavecode == dsp.battlefield.leaveCode.WON then -- play end CS. Need time and battle id for record keeping + storage
+function onBattlefieldLeave(player, battlefield, leavecode)
+    if leavecode == dsp.battlefield.leaveCode.WON then
         local name, clearTime, partySize = battlefield:getRecord()
-        local record = battlefield:getRecord();
-        local clearTime = record.clearTime;
-
-        if (player:hasCompletedMission(ZILART,dsp.mission.id.zilart.ARK_ANGELS)) then
-            player:startEvent(32001, battlefield:getArea(), clearTime, partySize, battlefield:getTimeInside(), 180, battlefield:getLocalVar("[cs]bit"), 1)        -- winning CS (allow player to skip)
-        else
-            player:startEvent(32001, battlefield:getArea(), clearTime, partySize, battlefield:getTimeInside(), 180, battlefield:getLocalVar("[cs]bit"), 0)        -- winning CS (allow player to skip)
-        end
-
+        local arg8 = (player:hasCompletedMission(ZILART, dsp.mission.id.zilart.ARK_ANGELS)) and 1 or 0
+        player:startEvent(32001, battlefield:getArea(), clearTime, partySize, battlefield:getTimeInside(), 180, battlefield:getLocalVar("[cs]bit"), arg8)
     elseif leavecode == dsp.battlefield.leaveCode.LOST then
-        player:startEvent(32002, 0, 0, 0, 0, 0, battlefield:getArea(), 180);    -- player lost
+        player:startEvent(32002, 0, 0, 0, 0, 0, battlefield:getArea(), 180)
     end
-end;
+end
 
-function onEventUpdate(player,csid,option)
-    -- print("bc update csid "..csid.." and option "..option);
+function onEventUpdate(player, csid, option)
+end
 
-end;
-
-function onEventFinish(player,csid,option)
-    -- print("bc finish csid "..csid.." and option "..option);
-
-    local AAKeyitems = (player:hasKeyItem(dsp.ki.SHARD_OF_APATHY) and player:hasKeyItem(dsp.ki.SHARD_OF_ARROGANCE)
-        and player:hasKeyItem(dsp.ki.SHARD_OF_COWARDICE) and player:hasKeyItem(dsp.ki.SHARD_OF_RAGE));
-
-    if (csid == 32001) then
-        if (player:getCurrentMission(ZILART) == dsp.mission.id.zilart.ARK_ANGELS  and player:getVar("ZilartStatus") == 1) then
-            player:addKeyItem(dsp.ki.SHARD_OF_ENVY);
-            player:messageSpecial(ID.text.KEYITEM_OBTAINED,dsp.ki.SHARD_OF_ENVY);
-            if (AAKeyitems == true) then
-                player:completeMission(ZILART,dsp.mission.id.zilart.ARK_ANGELS);
-                player:addMission(ZILART,dsp.mission.id.zilart.THE_SEALED_SHRINE);
-                player:setVar("ZilartStatus",0);
+function onEventFinish(player, csid, option)
+    if csid == 32001 then
+        if player:getCurrentMission(ZILART) == dsp.mission.id.zilart.ARK_ANGELS and player:getVar("ZilartStatus") == 1 then
+            player:addKeyItem(dsp.ki.SHARD_OF_ENVY)
+            player:messageSpecial(ID.text.KEYITEM_OBTAINED, dsp.ki.SHARD_OF_ENVY)
+            if
+                player:hasKeyItem(dsp.ki.SHARD_OF_APATHY) and
+                player:hasKeyItem(dsp.ki.SHARD_OF_ARROGANCE) and
+                player:hasKeyItem(dsp.ki.SHARD_OF_COWARDICE) and
+                player:hasKeyItem(dsp.ki.SHARD_OF_ENVY) and
+                player:hasKeyItem(dsp.ki.SHARD_OF_RAGE)
+            then
+                player:completeMission(ZILART, dsp.mission.id.zilart.ARK_ANGELS)
+                player:addMission(ZILART, dsp.mission.id.zilart.THE_SEALED_SHRINE)
+                player:setVar("ZilartStatus", 0)
             end
         end
     end
-end;
+end

--- a/scripts/zones/LaLoff_Amphitheater/bcnms/ark_angels_4.lua
+++ b/scripts/zones/LaLoff_Amphitheater/bcnms/ark_angels_4.lua
@@ -2,90 +2,51 @@
 -- Area: LaLoff Amphitheater
 -- Name: Ark Angels 4 (Elvaan)
 -----------------------------------
+local ID = require("scripts/zones/LaLoff_Amphitheater/IDs")
 require("scripts/globals/battlefield")
-local ID = require("scripts/zones/LaLoff_Amphitheater/IDs");
-require("scripts/globals/missions");
-require("scripts/globals/keyitems");
+require("scripts/globals/keyitems")
+require("scripts/globals/missions")
 -----------------------------------
 
--- Death cutscenes:
-
--- player:startEvent(32001, battlefield:getArea(), clearTime, partySize, battlefield:getTimeInside(), 1, battlefield:getLocalVar("[cs]bit"), 0) -- Hume
--- player:startEvent(32001, battlefield:getArea(), clearTime, partySize, battlefield:getTimeInside(), 1, battlefield:getLocalVar("[cs]bit"), 0) -- taru
--- player:startEvent(32001, battlefield:getArea(), clearTime, partySize, battlefield:getTimeInside(), 1, battlefield:getLocalVar("[cs]bit"), 0) -- mithra
--- player:startEvent(32001, battlefield:getArea(), clearTime, partySize, battlefield:getTimeInside(), 1, battlefield:getLocalVar("[cs]bit"), 0) -- elvan
--- player:startEvent(32001, battlefield:getArea(), clearTime, partySize, battlefield:getTimeInside(), 1, battlefield:getLocalVar("[cs]bit"), 0) -- galka
--- player:startEvent(32001, battlefield:getArea(), clearTime, partySize, battlefield:getTimeInside(), 1, battlefield:getLocalVar("[cs]bit"), 0) -- divine might
--- player:startEvent(32001, battlefield:getArea(), clearTime, partySize, battlefield:getTimeInside(), 1, battlefield:getLocalVar("[cs]bit"), 0) -- skip ending cs
-
-
--- After registering the BCNM via bcnmRegister(bcnmid)
-function onBattlefieldRegister(player,battlefield)
-end;
 function onBattlefieldTick(battlefield, tick)
     dsp.battlefield.onBattlefieldTick(battlefield, tick)
 end
 
--- Physically entering the BCNM via bcnmEnter(bcnmid)
-function onBattlefieldEnter(player,battlefield)
-end;
+function onBattlefieldRegister(player, battlefield)
+end
 
--- Leaving the BCNM by every mean possible, given by the LeaveCode
--- 1=Select Exit on circle
--- 2=Winning the BC
--- 3=Disconnected or warped out
--- 4=Losing the BC
--- via bcnmLeave(1) or bcnmLeave(2). LeaveCodes 3 and 4 are called
--- from the core when a player disconnects or the time limit is up, etc
+function onBattlefieldEnter(player, battlefield)
+end
 
-function onBattlefieldLeave(player,battlefield,leavecode)
---print("leave code "..leavecode);
-
-    if leavecode == dsp.battlefield.leaveCode.WON then -- play end CS. Need time and battle id for record keeping + storage
+function onBattlefieldLeave(player, battlefield, leavecode)
+    if leavecode == dsp.battlefield.leaveCode.WON then
         local name, clearTime, partySize = battlefield:getRecord()
-        local record = battlefield:getRecord();
-        local clearTime = record.clearTime;
-
-        if (player:hasCompletedMission(ZILART,dsp.mission.id.zilart.ARK_ANGELS)) then
-            player:startEvent(32001, battlefield:getArea(), clearTime, partySize, battlefield:getTimeInside(), 180, battlefield:getLocalVar("[cs]bit"), 1)        -- winning CS (allow player to skip)
-        else
-            player:startEvent(32001, battlefield:getArea(), clearTime, partySize, battlefield:getTimeInside(), 180, battlefield:getLocalVar("[cs]bit"), 0)        -- winning CS (allow player to skip)
-        end
-
+        local arg8 = (player:hasCompletedMission(ZILART, dsp.mission.id.zilart.ARK_ANGELS)) and 1 or 0
+        player:startEvent(32001, battlefield:getArea(), clearTime, partySize, battlefield:getTimeInside(), 180, battlefield:getLocalVar("[cs]bit"), arg8)
     elseif leavecode == dsp.battlefield.leaveCode.LOST then
-        player:startEvent(32002, 0, 0, 0, 0, 0, battlefield:getArea(), 180);    -- player lost
+        player:startEvent(32002, 0, 0, 0, 0, 0, battlefield:getArea(), 180)
     end
-end;
+end
 
-function onEventUpdate(player,csid,option)
-    -- print("bc update csid "..csid.." and option "..option);
+function onEventUpdate(player, csid, option)
+end
 
-end;
-
-function onEventFinish(player,csid,option)
-    -- print("bc finish csid "..csid.." and option "..option);
-
-    local AAKeyitems = (player:hasKeyItem(dsp.ki.SHARD_OF_APATHY) and player:hasKeyItem(dsp.ki.SHARD_OF_COWARDICE)
-        and player:hasKeyItem(dsp.ki.SHARD_OF_ENVY) and player:hasKeyItem(dsp.ki.SHARD_OF_RAGE));
-
-    if (csid == 32001) then
-        if (player:getCurrentMission(ZILART) == dsp.mission.id.zilart.ARK_ANGELS  and player:getVar("ZilartStatus") == 1) then
-            player:addKeyItem(dsp.ki.SHARD_OF_ARROGANCE);
-            player:messageSpecial(ID.text.KEYITEM_OBTAINED,dsp.ki.SHARD_OF_ARROGANCE);
-            if (AAKeyitems == true) then
-                player:completeMission(ZILART,dsp.mission.id.zilart.ARK_ANGELS);
-                player:addMission(ZILART,dsp.mission.id.zilart.THE_SEALED_SHRINE);
-                player:setVar("ZilartStatus",0);
+function onEventFinish(player, csid, option)
+    if csid == 32001 then
+        if player:getCurrentMission(ZILART) == dsp.mission.id.zilart.ARK_ANGELS and player:getVar("ZilartStatus") == 1 then
+            player:addKeyItem(dsp.ki.SHARD_OF_ARROGANCE)
+            player:messageSpecial(ID.text.KEYITEM_OBTAINED, dsp.ki.SHARD_OF_ARROGANCE)
+            if
+                player:hasKeyItem(dsp.ki.SHARD_OF_APATHY) and
+                player:hasKeyItem(dsp.ki.SHARD_OF_ARROGANCE) and
+                player:hasKeyItem(dsp.ki.SHARD_OF_COWARDICE) and
+                player:hasKeyItem(dsp.ki.SHARD_OF_ENVY) and
+                player:hasKeyItem(dsp.ki.SHARD_OF_RAGE)
+            then
+                player:completeMission(ZILART, dsp.mission.id.zilart.ARK_ANGELS)
+                player:addMission(ZILART, dsp.mission.id.zilart.THE_SEALED_SHRINE)
+                player:setVar("ZilartStatus", 0)
             end
         end
     end
-
-    local AAKeyitems = (player:hasKeyItem(dsp.ki.SHARD_OF_APATHY) and player:hasKeyItem(dsp.ki.SHARD_OF_ARROGANCE)
-        and player:hasKeyItem(dsp.ki.SHARD_OF_COWARDICE) and player:hasKeyItem(dsp.ki.SHARD_OF_ENVY)
-        and player:hasKeyItem(dsp.ki.SHARD_OF_RAGE));
-    if (AAKeyitems == true) then
-        player:completeMission(ZILART,dsp.mission.id.zilart.ARK_ANGELS);
-        player:addMission(ZILART,dsp.mission.id.zilart.THE_SEALED_SHRINE);
-        player:setVar("ZilartStatus",0);
-    end
-end;
+end

--- a/scripts/zones/LaLoff_Amphitheater/bcnms/ark_angels_5.lua
+++ b/scripts/zones/LaLoff_Amphitheater/bcnms/ark_angels_5.lua
@@ -2,85 +2,51 @@
 -- Area: LaLoff Amphitheater
 -- Name: Ark Angels 5 (Galka)
 -----------------------------------
+local ID = require("scripts/zones/LaLoff_Amphitheater/IDs")
 require("scripts/globals/battlefield")
-local ID = require("scripts/zones/LaLoff_Amphitheater/IDs");
-require("scripts/globals/missions");
-require("scripts/globals/keyitems");
+require("scripts/globals/keyitems")
+require("scripts/globals/missions")
 -----------------------------------
 
--- Death cutscenes:
-
--- player:startEvent(32001, battlefield:getArea(), clearTime, partySize, battlefield:getTimeInside(), 1, battlefield:getLocalVar("[cs]bit"), 0) -- Hume
--- player:startEvent(32001, battlefield:getArea(), clearTime, partySize, battlefield:getTimeInside(), 1, battlefield:getLocalVar("[cs]bit"), 0) -- taru
--- player:startEvent(32001, battlefield:getArea(), clearTime, partySize, battlefield:getTimeInside(), 1, battlefield:getLocalVar("[cs]bit"), 0) -- mithra
--- player:startEvent(32001, battlefield:getArea(), clearTime, partySize, battlefield:getTimeInside(), 1, battlefield:getLocalVar("[cs]bit"), 0) -- elvan
--- player:startEvent(32001, battlefield:getArea(), clearTime, partySize, battlefield:getTimeInside(), 1, battlefield:getLocalVar("[cs]bit"), 0) -- galka
--- player:startEvent(32001, battlefield:getArea(), clearTime, partySize, battlefield:getTimeInside(), 1, battlefield:getLocalVar("[cs]bit"), 0) -- divine might
--- player:startEvent(32001, battlefield:getArea(), clearTime, partySize, battlefield:getTimeInside(), 1, battlefield:getLocalVar("[cs]bit"), 0) -- skip ending cs
-
-
--- After registering the BCNM via bcnmRegister(bcnmid)
-function onBattlefieldRegister(player,battlefield)
-end;
 function onBattlefieldTick(battlefield, tick)
     dsp.battlefield.onBattlefieldTick(battlefield, tick)
 end
 
--- Physically entering the BCNM via bcnmEnter(bcnmid)
-function onBattlefieldEnter(player,battlefield)
-end;
+function onBattlefieldRegister(player, battlefield)
+end
 
--- Leaving the BCNM by every mean possible, given by the LeaveCode
--- 1=Select Exit on circle
--- 2=Winning the BC
--- 3=Disconnected or warped out
--- 4=Losing the BC
--- via bcnmLeave(1) or bcnmLeave(2). LeaveCodes 3 and 4 are called
--- from the core when a player disconnects or the time limit is up, etc
+function onBattlefieldEnter(player, battlefield)
+end
 
-function onBattlefieldLeave(player,battlefield,leavecode)
---print("leave code "..leavecode);
-
-    if leavecode == dsp.battlefield.leaveCode.WON then -- play end CS. Need time and battle id for record keeping + storage
+function onBattlefieldLeave(player, battlefield, leavecode)
+    if leavecode == dsp.battlefield.leaveCode.WON then
         local name, clearTime, partySize = battlefield:getRecord()
-        local record = battlefield:getRecord();
-        local clearTime = record.clearTime;
-
-        if (player:hasCompletedMission(ZILART,dsp.mission.id.zilart.ARK_ANGELS)) then
-            player:startEvent(32001, battlefield:getArea(), clearTime, partySize, battlefield:getTimeInside(), 180, battlefield:getLocalVar("[cs]bit"), 1)        -- winning CS (allow player to skip)
-        else
-            player:startEvent(32001, battlefield:getArea(), clearTime, partySize, battlefield:getTimeInside(), 180, battlefield:getLocalVar("[cs]bit"), 0)        -- winning CS (allow player to skip)
-        end
-
+        local arg8 = (player:hasCompletedMission(ZILART, dsp.mission.id.zilart.ARK_ANGELS)) and 1 or 0
+        player:startEvent(32001, battlefield:getArea(), clearTime, partySize, battlefield:getTimeInside(), 180, battlefield:getLocalVar("[cs]bit"), arg8)
     elseif leavecode == dsp.battlefield.leaveCode.LOST then
-        player:startEvent(32002, 0, 0, 0, 0, 0, battlefield:getArea(), 180);    -- player lost
+        player:startEvent(32002, 0, 0, 0, 0, 0, battlefield:getArea(), 180)
     end
-end;
+end
 
-function onEventUpdate(player,csid,option)
-    -- print("bc update csid "..csid.." and option "..option);
+function onEventUpdate(player, csid, option)
+end
 
-end;
-
-function onEventFinish(player,csid,option)
-    -- print("bc finish csid "..csid.." and option "..option);
- 
-    local AAKeyitems = (player:hasKeyItem(dsp.ki.SHARD_OF_APATHY) and player:hasKeyItem(dsp.ki.SHARD_OF_ARROGANCE)
-        and player:hasKeyItem(dsp.ki.SHARD_OF_COWARDICE) and player:hasKeyItem(dsp.ki.SHARD_OF_ENVY));
-
-    if (csid == 32001) then
-        if (player:getCurrentMission(ZILART) == dsp.mission.id.zilart.ARK_ANGELS  and player:getVar("ZilartStatus") == 1) then
-            player:addKeyItem(dsp.ki.SHARD_OF_RAGE);
-            player:messageSpecial(ID.text.KEYITEM_OBTAINED,dsp.ki.SHARD_OF_RAGE);
-            if (AAKeyitems == true) then
-                player:completeMission(ZILART,dsp.mission.id.zilart.ARK_ANGELS);
-                player:addMission(ZILART,dsp.mission.id.zilart.THE_SEALED_SHRINE);
-                player:setVar("ZilartStatus",0);
+function onEventFinish(player, csid, option)
+    if csid == 32001 then
+        if player:getCurrentMission(ZILART) == dsp.mission.id.zilart.ARK_ANGELS and player:getVar("ZilartStatus") == 1 then
+            player:addKeyItem(dsp.ki.SHARD_OF_RAGE)
+            player:messageSpecial(ID.text.KEYITEM_OBTAINED, dsp.ki.SHARD_OF_RAGE)
+            if
+                player:hasKeyItem(dsp.ki.SHARD_OF_APATHY) and
+                player:hasKeyItem(dsp.ki.SHARD_OF_ARROGANCE) and
+                player:hasKeyItem(dsp.ki.SHARD_OF_COWARDICE) and
+                player:hasKeyItem(dsp.ki.SHARD_OF_ENVY) and
+                player:hasKeyItem(dsp.ki.SHARD_OF_RAGE)
+            then
+                player:completeMission(ZILART, dsp.mission.id.zilart.ARK_ANGELS)
+                player:addMission(ZILART, dsp.mission.id.zilart.THE_SEALED_SHRINE)
+                player:setVar("ZilartStatus", 0)
             end
         end
     end
-
-    local AAKeyitems = (player:hasKeyItem(dsp.ki.SHARD_OF_APATHY) and player:hasKeyItem(dsp.ki.SHARD_OF_ARROGANCE)
-        and player:hasKeyItem(dsp.ki.SHARD_OF_COWARDICE) and player:hasKeyItem(dsp.ki.SHARD_OF_ENVY)
-        and player:hasKeyItem(dsp.ki.SHARD_OF_RAGE));
-end;
+end

--- a/scripts/zones/LaLoff_Amphitheater/bcnms/divine_might.lua
+++ b/scripts/zones/LaLoff_Amphitheater/bcnms/divine_might.lua
@@ -1,94 +1,60 @@
 -----------------------------------
 -- Area: LaLoff Amphitheater
 -- Name: Divine Might
+--[[ caps:
+    7d01, 0, 529, 1, 950, 180, 6, 0, 0 --Neo AA HM
+    7d01, 0, 1400, 5, 1400, 180, 11, 0, 0  --Neo DM
+    7d01, 1, 405, 1, 1599, 180, 7, 0, 0 -- Neo AA TT
+    7d01, 1, 378, 3, 903, 180, 8, 0, 0 -- Neo AA MR
+    7d02, 0, 80, 1, 512, 4, 4, 180 -- Neo DM (lose)
+]]
 -----------------------------------
+local ID = require("scripts/zones/LaLoff_Amphitheater/IDs")
 require("scripts/globals/battlefield")
-local ID = require("scripts/zones/LaLoff_Amphitheater/IDs");
-require("scripts/globals/missions");
-require("scripts/globals/quests");
-require("scripts/globals/keyitems");
+require("scripts/globals/keyitems")
+require("scripts/globals/missions")
+require("scripts/globals/quests")
 -----------------------------------
 
--- Death cutscenes:
-
--- player:startEvent(32001, battlefield:getArea(), clearTime, partySize, battlefield:getTimeInside(), 1, battlefield:getLocalVar("[cs]bit"), 0) -- Hume
--- player:startEvent(32001, battlefield:getArea(), clearTime, partySize, battlefield:getTimeInside(), 1, battlefield:getLocalVar("[cs]bit"), 0) -- taru
--- player:startEvent(32001, battlefield:getArea(), clearTime, partySize, battlefield:getTimeInside(), 1, battlefield:getLocalVar("[cs]bit"), 0) -- mithra
--- player:startEvent(32001, battlefield:getArea(), clearTime, partySize, battlefield:getTimeInside(), 1, battlefield:getLocalVar("[cs]bit"), 0) -- elvan
--- player:startEvent(32001, battlefield:getArea(), clearTime, partySize, battlefield:getTimeInside(), 1, battlefield:getLocalVar("[cs]bit"), 0) -- galka
--- player:startEvent(32001, battlefield:getArea(), clearTime, partySize, battlefield:getTimeInside(), 1, battlefield:getLocalVar("[cs]bit"), 0) -- divine might
--- player:startEvent(32001, battlefield:getArea(), clearTime, partySize, battlefield:getTimeInside(), 1, battlefield:getLocalVar("[cs]bit"), 0) -- skip ending cs
-
-
--- After registering the BCNM via bcnmRegister(bcnmid)
-function onBattlefieldRegister(player,battlefield)
-end;
 function onBattlefieldTick(battlefield, tick)
     dsp.battlefield.onBattlefieldTick(battlefield, tick)
 end
 
--- Physically entering the BCNM via bcnmEnter(bcnmid)
-function onBattlefieldEnter(player,battlefield)
+function onBattlefieldRegister(player, battlefield)
+end
+
+function onBattlefieldEnter(player, battlefield)
     player:startEvent(32001, battlefield:getArea(), clearTime, partySize, battlefield:getTimeInside(), 1, battlefield:getLocalVar("[cs]bit"), 1)
-end;
+end
 
--- Leaving the BCNM by every mean possible, given by the LeaveCode
--- 1=Select Exit on circle
--- 2=Winning the BC
--- 3=Disconnected or warped out
--- 4=Losing the BC
--- via bcnmLeave(1) or bcnmLeave(2). LeaveCodes 3 and 4 are called
--- from the core when a player disconnects or the time limit is up, etc
-
-function onBattlefieldLeave(player,battlefield,leavecode)
---print("leave code "..leavecode);
-
-    if leavecode == dsp.battlefield.leaveCode.WON then -- play end CS. Need time and battle id for record keeping + storage
+function onBattlefieldLeave(player, battlefield, leavecode)
+    if leavecode == dsp.battlefield.leaveCode.WON then
         local name, clearTime, partySize = battlefield:getRecord()
-        local record = battlefield:getRecord();
-        local clearTime = record.clearTime;
-
-        if (player:hasCompletedMission(ZILART,dsp.mission.id.zilart.ARK_ANGELS)) then
-            player:startEvent(32001, battlefield:getArea(), clearTime, partySize, battlefield:getTimeInside(), 180, battlefield:getLocalVar("[cs]bit"), 1)        -- winning CS (allow player to skip)
-        else
-            player:startEvent(32001, battlefield:getArea(), clearTime, partySize, battlefield:getTimeInside(), 180, battlefield:getLocalVar("[cs]bit"), 0)        -- winning CS (allow player to skip)
-        end
-
-    --[[ caps:
-        7d01, 0, 529, 1, 950, 180, 6, 0, 0 --Neo AA HM
-        7d01, 0, 1400, 5, 1400, 180, 11, 0, 0  --Neo DM
-        7d01, 1, 405, 1, 1599, 180, 7, 0, 0 -- Neo AA TT
-        7d01, 1, 378, 3, 903, 180, 8, 0, 0 -- Neo AA MR
-        7d02, 0, 80, 1, 512, 4, 4, 180 -- Neo DM (lose)
-    ]]
-
+        local arg8 = (player:hasCompletedMission(ZILART, dsp.mission.id.zilart.ARK_ANGELS)) and 1 or 0
+        player:startEvent(32001, battlefield:getArea(), clearTime, partySize, battlefield:getTimeInside(), 180, battlefield:getLocalVar("[cs]bit"), arg8)
     elseif leavecode == dsp.battlefield.leaveCode.LOST then
-        player:startEvent(32002, 0, 0, 0, 0, 0, battlefield:getArea(), 180);    -- player lost
+        player:startEvent(32002, 0, 0, 0, 0, 0, battlefield:getArea(), 180)
     end
-end;
+end
 
-function onEventUpdate(player,csid,option)
-    -- print("bc update csid "..csid.." and option "..option);
+function onEventUpdate(player, csid, option)
+end
 
-end;
-
-function onEventFinish(player,csid,option)
-    -- print("bc finish csid "..csid.." and option "..option);
-
-    if (csid == 32001) then
-        if (player:getQuestStatus(OUTLANDS,dsp.quest.id.outlands.DIVINE_MIGHT) == QUEST_ACCEPTED) then
-            player:setVar("DivineMight",2); -- Used to use 2 to track completion, so that's preserved to maintain compatibility
-            for i=dsp.ki.SHARD_OF_APATHY, dsp.ki.SHARD_OF_RAGE do
-                player:addKeyItem(i);
-                player:messageSpecial(ID.text.KEYITEM_OBTAINED,i);
+function onEventFinish(player, csid, option)
+    if csid == 32001 then
+        if player:getQuestStatus(OUTLANDS, dsp.quest.id.outlands.DIVINE_MIGHT) == QUEST_ACCEPTED then
+            player:setVar("DivineMight", 2) -- Used to use 2 to track completion, so that's preserved to maintain compatibility
+            for i = dsp.ki.SHARD_OF_APATHY, dsp.ki.SHARD_OF_RAGE do
+                player:addKeyItem(i)
+                player:messageSpecial(ID.text.KEYITEM_OBTAINED, i)
             end
-            if (player:getCurrentMission(ZILART) == dsp.mission.id.zilart.ARK_ANGELS) then
-                player:completeMission(ZILART,dsp.mission.id.zilart.ARK_ANGELS);
-                player:addMission(ZILART,dsp.mission.id.zilart.THE_SEALED_SHRINE);
-                player:setVar("ZilartStatus",0);
+            if player:getCurrentMission(ZILART) == dsp.mission.id.zilart.ARK_ANGELS then
+                player:completeMission(ZILART, dsp.mission.id.zilart.ARK_ANGELS)
+                player:addMission(ZILART, dsp.mission.id.zilart.THE_SEALED_SHRINE)
+                player:setVar("ZilartStatus", 0)
             end
-        elseif (player:getQuestStatus(OUTLANDS,dsp.quest.id.outlands.DIVINE_MIGHT_REPEAT) == QUEST_ACCEPTED and player:hasKeyItem(dsp.ki.MOONLIGHT_ORE) == true) then
-            player:setVar("DivineMight",2);
+        elseif player:getQuestStatus(OUTLANDS, dsp.quest.id.outlands.DIVINE_MIGHT_REPEAT) == QUEST_ACCEPTED and player:hasKeyItem(dsp.ki.MOONLIGHT_ORE) then
+            player:setVar("DivineMight", 2)
         end
     end
-end;
+end

--- a/scripts/zones/Monarch_Linn/bcnms/ancient_vows.lua
+++ b/scripts/zones/Monarch_Linn/bcnms/ancient_vows.lua
@@ -2,64 +2,44 @@
 -- Area: Monarch Linn
 -- Name: Ancient Vows
 -----------------------------------
-
-require("scripts/globals/titles");
 require("scripts/globals/battlefield")
-require("scripts/globals/missions");
+require("scripts/globals/missions")
+require("scripts/globals/titles")
+-----------------------------------
 
--- After registering the BCNM via bcnmRegister(bcnmid)
-function onBattlefieldRegister(player,battlefield)
-
-end;
 function onBattlefieldTick(battlefield, tick)
     dsp.battlefield.onBattlefieldTick(battlefield, tick)
 end
 
--- Physically entering the BCNM via bcnmEnter(bcnmid)
-function onBattlefieldEnter(player,battlefield)
+function onBattlefieldRegister(player, battlefield)
+end
 
-end;
+function onBattlefieldEnter(player, battlefield)
+end
 
--- Leaving the BCNM by every mean possible, given by the LeaveCode
--- 1=Select Exit on circle
--- 2=Winning the BC
--- 3=Disconnected or warped out
--- 4=Losing the BC
--- via bcnmLeave(1) or bcnmLeave(2). LeaveCodes 3 and 4 are called
--- from the core when a player disconnects or the time limit is up, etc
-
-function onBattlefieldLeave(player,battlefield,leavecode)
-    -- printf("leavecode: %u",leavecode);
-    
-    if leavecode == dsp.battlefield.leaveCode.WON then -- play end CS. Need time and battle id for record keeping + storage
-    
+function onBattlefieldLeave(player, battlefield, leavecode)
+    if leavecode == dsp.battlefield.leaveCode.WON then
         local name, clearTime, partySize = battlefield:getRecord()
-        if (player:getCurrentMission(COP) == dsp.mission.id.cop.ANCIENT_VOWS and player:getVar("PromathiaStatus") == 2) then
-            player:startEvent(32001, battlefield:getArea(), clearTime, partySize, battlefield:getTimeInside(), 0, battlefield:getLocalVar("[cs]bit"), 0)
-        else
-            player:startEvent(32001, battlefield:getArea(), clearTime, partySize, battlefield:getTimeInside(), 0, battlefield:getLocalVar("[cs]bit"), 1)
-        end
+        local arg8 = (player:getCurrentMission(COP) ~= dsp.mission.id.cop.ANCIENT_VOWS or player:getVar("PromathiaStatus") ~= 2) and 1 or 0
+        player:startEvent(32001, battlefield:getArea(), clearTime, partySize, battlefield:getTimeInside(), 0, battlefield:getLocalVar("[cs]bit"), arg8)
     elseif leavecode == dsp.battlefield.leaveCode.LOST then
-        player:startEvent(32002);
+        player:startEvent(32002)
     end
-    
-end;
+end
 
-function onEventUpdate(player,csid,option)
--- print("bc update csid "..csid.." and option "..option);
-end;
-    
-function onEventFinish(player,csid,option)
+function onEventUpdate(player, csid, option)
+end
 
-    if (csid == 32001) then
-        player:addExp(1000);
-        player:addTitle(dsp.title.TAVNAZIAN_TRAVELER);
-        if (player:getCurrentMission(COP) == dsp.mission.id.cop.ANCIENT_VOWS and player:getVar("PromathiaStatus") == 2) then
-            player:setVar("VowsDone",1);
-            player:setVar("PromathiaStatus",0);
-            player:completeMission(COP,dsp.mission.id.cop.ANCIENT_VOWS);
-            player:addMission(COP,dsp.mission.id.cop.THE_CALL_OF_THE_WYRMKING);
-            player:setPos(694,-5.5,-619,74,107); -- To South Gustaberg
+function onEventFinish(player, csid, option)
+    if csid == 32001 then
+        player:addExp(1000)
+        player:addTitle(dsp.title.TAVNAZIAN_TRAVELER)
+        if player:getCurrentMission(COP) == dsp.mission.id.cop.ANCIENT_VOWS and player:getVar("PromathiaStatus") == 2 then
+            player:completeMission(COP, dsp.mission.id.cop.ANCIENT_VOWS)
+            player:addMission(COP, dsp.mission.id.cop.THE_CALL_OF_THE_WYRMKING)
+            player:setVar("VowsDone", 1)
+            player:setVar("PromathiaStatus", 0)
+            player:setPos(694, -5.5, -619, 74, 107) -- South Gustaberg
         end
     end
-end;
+end

--- a/scripts/zones/Monarch_Linn/bcnms/savage.lua
+++ b/scripts/zones/Monarch_Linn/bcnms/savage.lua
@@ -1,61 +1,41 @@
 -----------------------------------
 -- Area: Monarch Linn
--- Name: savage
+-- Name: The Savage
 -----------------------------------
 require("scripts/globals/battlefield")
-require("scripts/globals/missions");
-require("scripts/globals/titles");
+require("scripts/globals/missions")
+require("scripts/globals/titles")
 -----------------------------------
 
--- After registering the BCNM via bcnmRegister(bcnmid)
-function onBattlefieldRegister(player,battlefield)
-end;
 function onBattlefieldTick(battlefield, tick)
     dsp.battlefield.onBattlefieldTick(battlefield, tick)
 end
 
--- Physically entering the BCNM via bcnmEnter(bcnmid)
-function onBattlefieldEnter(player,battlefield)
+function onBattlefieldRegister(player, battlefield)
+end
 
-end;
+function onBattlefieldEnter(player, battlefield)
+end
 
--- Leaving the BCNM by every mean possible, given by the LeaveCode
--- 1=Select Exit on circle
--- 2=Winning the BC
--- 3=Disconnected or warped out
--- 4=Losing the BC
--- via bcnmLeave(1) or bcnmLeave(2). LeaveCodes 3 and 4 are called
--- from the core when a player disconnects or the time limit is up, etc
-
-function onBattlefieldLeave(player,battlefield,leavecode)
-    -- printf("leavecode: %u",leavecode);
-
-    if leavecode == dsp.battlefield.leaveCode.WON then -- play end CS. Need time and battle id for record keeping + storage
-
+function onBattlefieldLeave(player, battlefield, leavecode)
+    if leavecode == dsp.battlefield.leaveCode.WON then
         local name, clearTime, partySize = battlefield:getRecord()
-        if (player:getCurrentMission(COP) == dsp.mission.id.cop.THE_SAVAGE and player:getVar("PromathiaStatus") == 1) then
-            player:startEvent(32001, battlefield:getArea(), clearTime, partySize, battlefield:getTimeInside(), 1, battlefield:getLocalVar("[cs]bit"), 0)
-        else
-            player:startEvent(32001, battlefield:getArea(), clearTime, partySize, battlefield:getTimeInside(), 1, battlefield:getLocalVar("[cs]bit"), 1)
-        end
+        local arg8 = (player:getCurrentMission(COP) ~= dsp.mission.id.cop.THE_SAVAGE or player:getVar("PromathiaStatus") ~= 1) and 1 or 0
+        player:startEvent(32001, battlefield:getArea(), clearTime, partySize, battlefield:getTimeInside(), 1, battlefield:getLocalVar("[cs]bit"), arg8)
     elseif leavecode == dsp.battlefield.leaveCode.LOST then
-        player:startEvent(32002);
+        player:startEvent(32002)
     end
+end
 
-end;
+function onEventUpdate(player, csid, option)
+end
 
-function onEventUpdate(player,csid,option)
--- print("bc update csid "..csid.." and option "..option);
-end;
-
-function onEventFinish(player,csid,option)
-
-    if (csid == 32001) then
-        player:addExp(1500);
-        player:addTitle(dsp.title.MIST_MELTER);
-        if (player:getCurrentMission(COP) == dsp.mission.id.cop.THE_SAVAGE and player:getVar("PromathiaStatus") == 1) then
-            player:setVar("PromathiaStatus",2);
+function onEventFinish(player, csid, option)
+    if csid == 32001 then
+        if player:getCurrentMission(COP) == dsp.mission.id.cop.THE_SAVAGE and player:getVar("PromathiaStatus") == 1 then
+            player:setVar("PromathiaStatus", 2)
         end
+        player:addExp(1500)
+        player:addTitle(dsp.title.MIST_MELTER)
     end
-
-end;
+end

--- a/scripts/zones/Navukgo_Execution_Chamber/IDs.lua
+++ b/scripts/zones/Navukgo_Execution_Chamber/IDs.lua
@@ -26,6 +26,7 @@ zones[dsp.zone.NAVUKGO_EXECUTION_CHAMBER] =
     },
     mob =
     {
+        KARABABA_OFFSET = 17039401,
     },
     npc =
     {

--- a/scripts/zones/Navukgo_Execution_Chamber/bcnms/shield_of_diplomacy.lua
+++ b/scripts/zones/Navukgo_Execution_Chamber/bcnms/shield_of_diplomacy.lua
@@ -3,64 +3,42 @@
 -- BCNM: TOAU-22 Shield of Diplomacy
 -----------------------------------
 require("scripts/globals/battlefield")
-require("scripts/globals/keyitems");
+require("scripts/globals/missions")
 ----------------------------------------
 
--- After registering the BCNM via bcnmRegister(bcnmid)
 function onBattlefieldTick(battlefield, tick)
     dsp.battlefield.onBattlefieldTick(battlefield, tick)
 end
 
+function onBattlefieldRegister(player, battlefield)
+    local baseID = ID.mob.KARABABA_OFFSET + (battlefield:getArea() - 1) * 2
+    local pos = GetMobByID(baseID):getSpawnPos()
 
-function onBattlefieldRegister(player,battlefield)
-    local baseID = 17039401 + (battlefield:getArea() - 1) * 2
-    local pos = GetMobByID(baseID):getSpawnPos();
+    local karababa  = battlefield:insertEntity(2157, true)
+    karababa:setSpawn(pos.x, pos.y, pos.z, 0)
+    karababa:spawn()
+end
 
-    local karababa  = battlefield:insertEntity(2157, true);
-    karababa:setSpawn(pos.x, pos.y, pos.z, 0);
-    karababa:spawn();
-end;
+function onBattlefieldEnter(player, battlefield)
+end
 
--- Physically entering the BCNM via bcnmEnter(bcnmid)
-function onBattlefieldEnter(player,battlefield)
-end;
-
--- Leaving the BCNM by every mean possible, given by the LeaveCode
--- 1=Select Exit on circle
--- 2=Winning the BC
--- 3=Disconnected or warped out
--- 4=Losing the BC
--- via bcnmLeave(1) or bcnmLeave(2). LeaveCodes 3 and 4 are called
--- from the core when a player disconnects or the time limit is up, etc
-
-function onBattlefieldLeave(player,battlefield,leavecode)
-    -- print("leave code "..leavecode);
-
-    if leavecode == dsp.battlefield.leaveCode.WON then -- play end CS. Need time and battle id for record keeping + storage
-
+function onBattlefieldLeave(player, battlefield, leavecode)
+    if leavecode == dsp.battlefield.leaveCode.WON then
         local name, clearTime, partySize = battlefield:getRecord()
-        if (player:hasCompletedMission(TOAU,dsp.mission.id.toau.SHIELD_OF_DIPLOMACY)) then
-            player:startEvent(32001, battlefield:getArea(), clearTime, partySize, battlefield:getTimeInside(), 1, battlefield:getLocalVar("[cs]bit"), 1)
-        else
-            player:startEvent(32001, battlefield:getArea(), clearTime, partySize, battlefield:getTimeInside(), 1, battlefield:getLocalVar("[cs]bit"), 0)
-        end
+        local arg8 = (player:hasCompletedMission(TOAU, dsp.mission.id.toau.SHIELD_OF_DIPLOMACY)) and 1 or 0
+        player:startEvent(32001, battlefield:getArea(), clearTime, partySize, battlefield:getTimeInside(), 1, battlefield:getLocalVar("[cs]bit"), arg8)
     elseif leavecode == dsp.battlefield.leaveCode.LOST then
-        player:startEvent(32002);
+        player:startEvent(32002)
     end
+end
 
-end;
+function onEventUpdate(player, csid, option)
+end
 
-function onEventUpdate(player,csid,option)
-    -- print("bc update csid "..csid.." and option "..option);
-end;
-
-function onEventFinish(player,csid,option)
-    -- print("bc finish csid "..csid.." and option "..option);
-
+function onEventFinish(player, csid, option)
     if csid == 32001 and player:getCurrentMission(TOAU) == dsp.mission.id.toau.SHIELD_OF_DIPLOMACY then
-        player:completeMission(TOAU,dsp.mission.id.toau.SHIELD_OF_DIPLOMACY);
-        player:setVar("AhtUrganStatus",0);
-        player:addMission(TOAU,dsp.mission.id.toau.SOCIAL_GRACES);
+        player:completeMission(TOAU, dsp.mission.id.toau.SHIELD_OF_DIPLOMACY)
+        player:addMission(TOAU, dsp.mission.id.toau.SOCIAL_GRACES)
+        player:setVar("AhtUrganStatus", 0)
     end
-
-end;
+end

--- a/scripts/zones/Riverne-Site_B01/bcnms/storms_of_fate.lua
+++ b/scripts/zones/Riverne-Site_B01/bcnms/storms_of_fate.lua
@@ -3,69 +3,49 @@
 -- Name: Storms of Fate
 -- !pos 299 -123 345 146
 -----------------------------------
-
-require("scripts/globals/missions");
-local ID = require("scripts/zones/Riverne-Site_B01/IDs");
-require("scripts/globals/quests");
-require("scripts/globals/status");
-require("scripts/globals/bcnm");
+local ID = require("scripts/zones/Riverne-Site_B01/IDs")
 require("scripts/globals/battlefield")
+require("scripts/globals/keyitems")
+require("scripts/globals/settings")
+require("scripts/globals/quests")
+require("scripts/globals/status")
+require("scripts/globals/titles")
 -----------------------------------
 
 function onBattlefieldTick(battlefield, tick)
     dsp.battlefield.onBattlefieldTick(battlefield, tick)
 end
 
--- After registering the BCNM via bcnmRegister(bcnmid)
-function onBattlefieldRegister(player,battlefield)
-end;
+function onBattlefieldRegister(player, battlefield)
+end
 
--- Physically entering the BCNM via bcnmEnter(bcnmid)
-function onBattlefieldEnter(player,battlefield)
-    player:delStatusEffect(dsp.effect.LEVEL_RESTRICTION); -- can't be capped at 50 for this fight !
-end;
+function onBattlefieldEnter(player, battlefield)
+    player:delStatusEffect(dsp.effect.LEVEL_RESTRICTION) -- can't be capped at 50 for this fight !
+end
 
--- Leaving the BCNM by every mean possible, given by the LeaveCode
--- 1=Select Exit on circle
--- 2=Winning the BC
--- 3=Disconnected or warped out
--- 4=Losing the BC
--- via bcnmLeave(1) or bcnmLeave(2). LeaveCodes 3 and 4 are called
--- from the core when a player disconnects or the time limit is up, etc
-
-function onBattlefieldLeave(player,battlefield,leavecode)
--- print("leave code "..leavecode);
-
-    if leavecode == dsp.battlefield.leaveCode.WON then -- play end CS. Need time and battle id for record keeping + storage
+function onBattlefieldLeave(player, battlefield, leavecode)
+    if leavecode == dsp.battlefield.leaveCode.WON then
         local name, clearTime, partySize = battlefield:getRecord()
-        if (player:getQuestStatus(JEUNO,dsp.quest.id.jeuno.STORMS_OF_FATE) == QUEST_COMPLETED) then
-            player:startEvent(32001, battlefield:getArea(), clearTime, partySize, battlefield:getTimeInside(), 1, battlefield:getLocalVar("[cs]bit"), 1)
-        else
-            player:startEvent(32001, battlefield:getArea(), clearTime, partySize, battlefield:getTimeInside(), 1, battlefield:getLocalVar("[cs]bit"), 0)
-        end
+        local arg8 = (player:getQuestStatus(JEUNO, dsp.quest.id.jeuno.STORMS_OF_FATE) == QUEST_COMPLETED) and 1 or 0
+        player:startEvent(32001, battlefield:getArea(), clearTime, partySize, battlefield:getTimeInside(), 1, battlefield:getLocalVar("[cs]bit"), arg8)
     elseif leavecode == dsp.battlefield.leaveCode.LOST then
-        player:startEvent(32002);
+        player:startEvent(32002)
     end
+end
 
-end;
+function onEventUpdate(player, csid, option)
+end
 
-function onEventUpdate(player,csid,option)
--- print("bc update csid "..csid.." and option "..option);
-end;
-
-function onEventFinish(player,csid,option)
--- print("bc finish csid "..csid.." and option "..option);
-
-    if (csid == 32001) then
-        if (player:getQuestStatus(JEUNO,dsp.quest.id.jeuno.STORMS_OF_FATE) == QUEST_ACCEPTED and player:getVar('StormsOfFate') == 2) then
-            player:addKeyItem(dsp.ki.WHISPER_OF_THE_WYRMKING);
-            player:messageSpecial(ID.text.KEYITEM_OBTAINED,dsp.ki.WHISPER_OF_THE_WYRMKING);
-            player:setVar('StormsOfFate',3);
-            player:addTitle(dsp.title.CONQUEROR_OF_FATE);
-            if (ENABLE_COP_ZONE_CAP == 1) then -- restore level cap on exit if the setting is enabled
-                player:addStatusEffect(dsp.effect.LEVEL_RESTRICTION, 50, 0, 0);
-            end;
+function onEventFinish(player, csid, option)
+    if csid == 32001 then
+        if player:getQuestStatus(JEUNO, dsp.quest.id.jeuno.STORMS_OF_FATE) == QUEST_ACCEPTED and player:getVar('StormsOfFate') == 2 then
+            player:addKeyItem(dsp.ki.WHISPER_OF_THE_WYRMKING)
+            player:messageSpecial(ID.text.KEYITEM_OBTAINED, dsp.ki.WHISPER_OF_THE_WYRMKING)
+            player:setVar('StormsOfFate', 3)
+            player:addTitle(dsp.title.CONQUEROR_OF_FATE)
+        end
+        if ENABLE_COP_ZONE_CAP == 1 then
+            player:addStatusEffect(dsp.effect.LEVEL_RESTRICTION, 50, 0, 0)
         end
     end
-
-end;
+end

--- a/scripts/zones/Sealions_Den/bcnms/one_to_be_feared.lua
+++ b/scripts/zones/Sealions_Den/bcnms/one_to_be_feared.lua
@@ -1,60 +1,28 @@
 -----------------------------------
 -- Area: Sealion's Den
--- Name: one_to_be_feared
--- bcnmID : 992
+-- Name: One to be Feared
 -----------------------------------
-require("scripts/globals/missions")
 require("scripts/globals/battlefield")
+require("scripts/globals/missions")
 -----------------------------------
---battlefield 1   !pos -780 -103 -90
-          -- >     -231              = lieux de combat
---battlefield 2   !pos -140 -23 -450
-         --  >      -151             = lieux de combat
---battlefield 3   !pos 500  56  -810
-         --  >    640  -71   -206           = lieux de combat
 
-
-    --cs 0,battlefieldID= cs + teleportation     vers mamet
-    --cs 1,battlefieldID= cs + teleportation     vers ultima
-    --cs 2,battlefieldID= cs + teleportation     vers omega
-    --cs 7 leave l'insctance
-    -- cs 8 =>navire de guerre > retourner a tavnazia
-
-
--- After registering the BCNM via bcnmRegister(bcnmid)
-function onBattlefieldRegister(player,battlefield)
-end;
 function onBattlefieldTick(battlefield, tick)
     dsp.battlefield.onBattlefieldTick(battlefield, tick)
 end
 
--- Physically entering the BCNM via bcnmEnter(bcnmid)
-function onBattlefieldEnter(player,battlefield)
-end;
+function onBattlefieldRegister(player, battlefield)
+end
 
--- Leaving the BCNM by every mean possible, given by the LeaveCode
--- 1=Select Exit on circle
--- 2=Winning the BC
--- 3=Disconnected or warped out
--- 4=Losing the BC
--- via bcnmLeave(1) or bcnmLeave(2). LeaveCodes 3 and 4 are called
--- from the core when a player disconnects or the time limit is up, etc
+function onBattlefieldEnter(player, battlefield)
+end
 
-function onBattlefieldLeave(player,battlefield,leavecode)
-
-
-    if leavecode == dsp.battlefield.leaveCode.WON then -- play end CS. Need time and battle id for record keeping + storage
+function onBattlefieldLeave(player, battlefield, leavecode)
+    if leavecode == dsp.battlefield.leaveCode.WON then
         local name, clearTime, partySize = battlefield:getRecord()
-        if (player:getCurrentMission(COP) == dsp.mission.id.cop.ONE_TO_BE_FEARED and player:getVar("PromathiaStatus")==2) then
-            player:startEvent(32001, battlefield:getArea(), clearTime, partySize, battlefield:getTimeInside(), 1, battlefield:getLocalVar("[cs]bit"), 0)
-            player:setVar("PromathiaStatus",0)
-            player:completeMission(COP,dsp.mission.id.cop.ONE_TO_BE_FEARED)
-            player:addMission(COP,dsp.mission.id.cop.CHAINS_AND_BONDS)
-        else
-            player:startEvent(32001, battlefield:getArea(), clearTime, partySize, battlefield:getTimeInside(), 1, battlefield:getLocalVar("[cs]bit"), 1)
-        end
+        local arg8 = (player:getCurrentMission(COP) ~= dsp.mission.id.cop.ONE_TO_BE_FEARED or player:getVar("PromathiaStatus") ~= 2) and 1 or 0
+        player:startEvent(32001, battlefield:getArea(), clearTime, partySize, battlefield:getTimeInside(), 1, battlefield:getLocalVar("[cs]bit"), arg8)
     elseif leavecode == dsp.battlefield.leaveCode.LOST then
-           player:startEvent(32002)
+        player:startEvent(32002)
     end
 end
 
@@ -63,6 +31,11 @@ end
 
 function onEventFinish(player, csid, option)
     if csid == 32001 then
+        if player:getCurrentMission(COP) == dsp.mission.id.cop.ONE_TO_BE_FEARED and player:getVar("PromathiaStatus") == 2 then
+            player:completeMission(COP, dsp.mission.id.cop.ONE_TO_BE_FEARED)
+            player:addMission(COP, dsp.mission.id.cop.CHAINS_AND_BONDS)
+            player:setVar("PromathiaStatus", 0)
+        end
         player:addExp(1500)
         player:setPos(438, 0, -18, 11, 24) -- Lufaise
     end

--- a/scripts/zones/Sealions_Den/bcnms/warriors_path.lua
+++ b/scripts/zones/Sealions_Den/bcnms/warriors_path.lua
@@ -1,73 +1,44 @@
 -----------------------------------
 -- Area: Sealion's Den
--- Name: warriors_path
--- bcnmID : 993
+-- Name: The Warrior's Path
 -----------------------------------
-require("scripts/globals/titles");
 require("scripts/globals/battlefield")
-require("scripts/globals/keyitems");
-require("scripts/globals/missions");
+require("scripts/globals/missions")
+require("scripts/globals/titles")
 -----------------------------------
- --Tarutaru
---Tenzen                                                    group 860   3875
- --Makki-Chebukki (RNG) ,   16908311    16908315   16908319 group 853   2492
- --Kukki-Chebukki (BLM)     16908312    16908316   16908320 group 852   2293
- --Cherukiki (WHM).         16908313    16908317   16908321 group 851   710
 
---battlefield 1   !pos -780 -103 -90
-
---battlefield 2   !pos -140 -23 -450
-
---battlefield 3   !pos 500  56  -810
-
-
--- After registering the BCNM via bcnmRegister(bcnmid)
-function onBattlefieldRegister(player,battlefield)
-end;
 function onBattlefieldTick(battlefield, tick)
     dsp.battlefield.onBattlefieldTick(battlefield, tick)
 end
 
--- Physically entering the BCNM via bcnmEnter(bcnmid)
-function onBattlefieldEnter(player,battlefield)
-end;
+function onBattlefieldRegister(player, battlefield)
+end
 
--- Leaving the BCNM by every mean possible, given by the LeaveCode
--- 1=Select Exit on circle
--- 2=Winning the BC
--- 3=Disconnected or warped out
--- 4=Losing the BC
--- via bcnmLeave(1) or bcnmLeave(2). LeaveCodes 3 and 4 are called
--- from the core when a player disconnects or the time limit is up, etc
+function onBattlefieldEnter(player, battlefield)
+end
 
-function onBattlefieldLeave(player,battlefield,leavecode)
-
-
-    if leavecode == dsp.battlefield.leaveCode.WON then -- play end CS. Need time and battle id for record keeping + storage
+function onBattlefieldLeave(player, battlefield, leavecode)
+    if leavecode == dsp.battlefield.leaveCode.WON then
         local name, clearTime, partySize = battlefield:getRecord()
-        player:addExp(1000);
-        if (player:getCurrentMission(COP) == dsp.mission.id.cop.THE_WARRIOR_S_PATH) then
-            player:startEvent(32001, battlefield:getArea(), clearTime, partySize, battlefield:getTimeInside(), 1, battlefield:getLocalVar("[cs]bit"), 0)
-            player:setVar("PromathiaStatus",0);
-            player:completeMission(COP,dsp.mission.id.cop.THE_WARRIOR_S_PATH);
-            player:addMission(COP,dsp.mission.id.cop.GARDEN_OF_ANTIQUITY);
-        else
-            player:startEvent(32001, battlefield:getArea(), clearTime, partySize, battlefield:getTimeInside(), 1, battlefield:getLocalVar("[cs]bit"), 1)
-        end
+        local arg8 = (player:getCurrentMission(COP) ~= dsp.mission.id.cop.THE_WARRIOR_S_PATH) and 1 or 0
+        player:startEvent(32001, battlefield:getArea(), clearTime, partySize, battlefield:getTimeInside(), 1, battlefield:getLocalVar("[cs]bit"), arg8)
     elseif leavecode == dsp.battlefield.leaveCode.LOST then
-           player:startEvent(32002);
+        player:startEvent(32002)
     end
+end
 
-end;
+function onEventUpdate(player, csid, option)
+end
 
-function onEventUpdate(player,csid,option)
-    -- print("bc update csid "..csid.." and option "..option);
-end;
-
-function onEventFinish(player,csid,option)
-    -- print("bc finish csid "..csid.." and option "..option);
-    if (csid == 32001) then
-        player:setPos(-25,-1 ,-620 ,208 ,33);-- al'taieu
-        player:addTitle(dsp.title.THE_CHEBUKKIS_WORST_NIGHTMARE);
+function onEventFinish(player, csid, option)
+    if csid == 32001 then
+        if player:getCurrentMission(COP) == dsp.mission.id.cop.THE_WARRIOR_S_PATH then
+            player:completeMission(COP, dsp.mission.id.cop.THE_WARRIOR_S_PATH)
+            player:addMission(COP, dsp.mission.id.cop.GARDEN_OF_ANTIQUITY)
+            player:setVar("PromathiaStatus", 0)
+        end
+        player:addExp(1000)
+        player:addTitle(dsp.title.THE_CHEBUKKIS_WORST_NIGHTMARE)
+        player:setPos(-25, -1, -620, 208, 33) -- Al'Taieu
     end
-end;
+end

--- a/scripts/zones/Stellar_Fulcrum/bcnms/return_to_delkfutts_tower.lua
+++ b/scripts/zones/Stellar_Fulcrum/bcnms/return_to_delkfutts_tower.lua
@@ -1,68 +1,45 @@
 -----------------------------------
 -- Area: Stellar Fulcrum
--- Name: Mission 5-2
+-- Name: ZM8 Return to Delkfutt's Tower
 -- !pos -520 -4 17 179
 -----------------------------------
-
-require("scripts/globals/keyitems");
-require("scripts/globals/missions");
 require("scripts/globals/battlefield")
-
+require("scripts/globals/missions")
 -----------------------------------
 
 function onBattlefieldTick(battlefield, tick)
     dsp.battlefield.onBattlefieldTick(battlefield, tick)
 end
 
--- After registering the BCNM via bcnmRegister(bcnmid)
-function onBattlefieldRegister(player,battlefield)
-end;
+function onBattlefieldRegister(player, battlefield)
+end
 
--- Physically entering the BCNM via bcnmEnter(bcnmid)
-function onBattlefieldEnter(player,battlefield)
-end;
+function onBattlefieldEnter(player, battlefield)
+end
 
--- Leaving the BCNM by every mean possible, given by the LeaveCode
--- 1=Select Exit on circle
--- 2=Winning the BC
--- 3=Disconnected or warped out
--- 4=Losing the BC
--- via bcnmLeave(1) or bcnmLeave(2). LeaveCodes 3 and 4 are called
--- from the core when a player disconnects or the time limit is up, etc
-
-function onBattlefieldLeave(player,battlefield,leavecode)
--- print("leave code "..leavecode);
-
+function onBattlefieldLeave(player, battlefield, leavecode)
     if leavecode == dsp.battlefield.leaveCode.WON then -- play end CS. Need time and battle id for record keeping + storage
         local name, clearTime, partySize = battlefield:getRecord()
-        if (player:hasCompletedMission(ZILART,dsp.mission.id.zilart.RETURN_TO_DELKFUTTS_TOWER)) then
-            player:startEvent(32001, battlefield:getArea(), clearTime, partySize, battlefield:getTimeInside(), 1, battlefield:getLocalVar("[cs]bit"), 1)
-        else
-            player:startEvent(32001, battlefield:getArea(), clearTime, partySize, battlefield:getTimeInside(), 1, battlefield:getLocalVar("[cs]bit"), 0)
-        end
+        local arg8 = (player:hasCompletedMission(ZILART, dsp.mission.id.zilart.RETURN_TO_DELKFUTTS_TOWER)) and 1 or 0
+        player:startEvent(32001, battlefield:getArea(), clearTime, partySize, battlefield:getTimeInside(), 1, battlefield:getLocalVar("[cs]bit"), arg8)
     elseif leavecode == dsp.battlefield.leaveCode.LOST then
-        player:startEvent(32002);
+        player:startEvent(32002)
     end
+end
 
-end;
+function onEventUpdate(player, csid, option)
+end
 
-function onEventUpdate(player,csid,option)
--- print("bc update csid "..csid.." and option "..option);
-end;
-
-function onEventFinish(player,csid,option)
--- print("bc finish csid "..csid.." and option "..option);
-
-    if (csid == 32001) then
-        if (player:getCurrentMission(ZILART) == dsp.mission.id.zilart.RETURN_TO_DELKFUTTS_TOWER) then
-            player:completeMission(ZILART,dsp.mission.id.zilart.RETURN_TO_DELKFUTTS_TOWER);
-            player:addMission(ZILART,dsp.mission.id.zilart.ROMAEVE);
-            player:setVar("ZilartStatus",0);
+function onEventFinish(player, csid, option)
+    if csid == 32001 then
+        if player:getCurrentMission(ZILART) == dsp.mission.id.zilart.RETURN_TO_DELKFUTTS_TOWER then
+            player:completeMission(ZILART, dsp.mission.id.zilart.RETURN_TO_DELKFUTTS_TOWER)
+            player:addMission(ZILART, dsp.mission.id.zilart.ROMAEVE)
+            player:setVar("ZilartStatus", 0)
         end
         -- Play last CS if not skipped.
-        if (option == 1) then
-            player:startEvent(17);
+        if option == 1 then
+            player:startEvent(17)
         end
     end
-
-end;
+end

--- a/scripts/zones/Talacca_Cove/bcnms/legacy_of_the_lost.lua
+++ b/scripts/zones/Talacca_Cove/bcnms/legacy_of_the_lost.lua
@@ -2,61 +2,38 @@
 -- Area: Talacca Cove
 -- BCNM: TOAU-34 Legacy of the Lost
 -----------------------------------
-
-require("scripts/globals/keyitems");
 require("scripts/globals/battlefield")
-require("scripts/globals/missions");
-require("scripts/globals/titles");
-
+require("scripts/globals/missions")
+require("scripts/globals/titles")
 ----------------------------------------
 
--- After registering the BCNM via bcnmRegister(bcnmid)
-function onBattlefieldRegister(player,battlefield)
-end;
 function onBattlefieldTick(battlefield, tick)
     dsp.battlefield.onBattlefieldTick(battlefield, tick)
 end
 
--- Physically entering the BCNM via bcnmEnter(bcnmid)
-function onBattlefieldEnter(player,battlefield)
-end;
+function onBattlefieldRegister(player, battlefield)
+end
 
--- Leaving the BCNM by every mean possible, given by the LeaveCode
--- 1=Select Exit on circle
--- 2=Winning the BC
--- 3=Disconnected or warped out
--- 4=Losing the BC
--- via bcnmLeave(1) or bcnmLeave(2). LeaveCodes 3 and 4 are called
--- from the core when a player disconnects or the time limit is up, etc
+function onBattlefieldEnter(player, battlefield)
+end
 
-function onBattlefieldLeave(player,battlefield,leavecode)
-    -- print("leave code "..leavecode);
-
+function onBattlefieldLeave(player, battlefield, leavecode)
     if leavecode == dsp.battlefield.leaveCode.WON then -- play end CS. Need time and battle id for record keeping + storage
-
         local name, clearTime, partySize = battlefield:getRecord()
-        if (player:hasCompletedMission(TOAU,dsp.mission.id.toau.LEGACY_OF_THE_LOST)) then
-            player:startEvent(32001, battlefield:getArea(), clearTime, partySize, battlefield:getTimeInside(), 1, battlefield:getLocalVar("[cs]bit"), 1)
-        else
-            player:startEvent(32001, battlefield:getArea(), clearTime, partySize, battlefield:getTimeInside(), 1, battlefield:getLocalVar("[cs]bit"), 0)
-        end
+        local arg8 = (player:hasCompletedMission(TOAU, dsp.mission.id.toau.LEGACY_OF_THE_LOST)) and 1 or 0
+        player:startEvent(32001, battlefield:getArea(), clearTime, partySize, battlefield:getTimeInside(), 1, battlefield:getLocalVar("[cs]bit"), arg8)
     elseif leavecode == dsp.battlefield.leaveCode.LOST then
-        player:startEvent(32002);
+        player:startEvent(32002)
     end
+end
 
-end;
+function onEventUpdate(player, csid, option)
+end
 
-function onEventUpdate(player,csid,option)
-    -- print("bc update csid "..csid.." and option "..option);
-end;
-
-function onEventFinish(player,csid,option)
-    -- print("bc finish csid "..csid.." and option "..option);
-
-    if (csid == 32001) then
-        player:completeMission(TOAU,dsp.mission.id.toau.LEGACY_OF_THE_LOST);
-        player:setTitle(dsp.title.GESSHOS_MERCY);
-        player:addMission(TOAU,dsp.mission.id.toau.GAZE_OF_THE_SABOTEUR);
+function onEventFinish(player, csid, option)
+    if csid == 32001 and not player:hasCompletedMission(TOAU, dsp.mission.id.toau.LEGACY_OF_THE_LOST) then
+        player:completeMission(TOAU, dsp.mission.id.toau.LEGACY_OF_THE_LOST)
+        player:setTitle(dsp.title.GESSHOS_MERCY)
+        player:addMission(TOAU, dsp.mission.id.toau.GAZE_OF_THE_SABOTEUR)
     end
-
-end;
+end

--- a/scripts/zones/The_Celestial_Nexus/bcnms/celestial_nexus.lua
+++ b/scripts/zones/The_Celestial_Nexus/bcnms/celestial_nexus.lua
@@ -2,67 +2,42 @@
 -- Area: The Celestial Nexus
 -- Name: The Celestial Nexus (ZM16)
 -----------------------------------
-
-require("scripts/globals/titles");
-require("scripts/globals/missions");
 require("scripts/globals/battlefield")
-
+require("scripts/globals/missions")
+require("scripts/globals/titles")
 -----------------------------------
 
 function onBattlefieldTick(battlefield, tick)
     dsp.battlefield.onBattlefieldTick(battlefield, tick)
 end
 
--- After registering the BCNM via bcnmRegister(bcnmid)
-function onBattlefieldRegister(player,battlefield)
+function onBattlefieldRegister(player, battlefield)
+end
 
-end;
+function onBattlefieldEnter(player, battlefield)
+end
 
--- Physically entering the BCNM via bcnmEnter(bcnmid)
-function onBattlefieldEnter(player,battlefield)
-end;
-
--- Leaving the BCNM by every mean possible, given by the LeaveCode
--- 1=Select Exit on circle
--- 2=Winning the BC
--- 3=Disconnected or warped out
--- 4=Losing the BC
--- via bcnmLeave(1) or bcnmLeave(2). LeaveCodes 3 and 4 are called
--- from the core when a player disconnects or the time limit is up, etc
-
-function onBattlefieldLeave(player,battlefield,leavecode)
--- print("leave code "..leavecode);
-
-    if leavecode == dsp.battlefield.leaveCode.WON then -- play end CS. Need time and battle id for record keeping + storage
-
+function onBattlefieldLeave(player, battlefield, leavecode)
+    if leavecode == dsp.battlefield.leaveCode.WON then
         local name, clearTime, partySize = battlefield:getRecord()
-        if (player:hasCompletedMission(ZILART,dsp.mission.id.zilart.THE_CELESTIAL_NEXUS)) then
-            player:startEvent(32001, battlefield:getArea(), clearTime, partySize, battlefield:getTimeInside(), 1, battlefield:getLocalVar("[cs]bit"), 1)
-        else
-            player:startEvent(32001, battlefield:getArea(), clearTime, partySize, battlefield:getTimeInside(), 1, battlefield:getLocalVar("[cs]bit"), 0)
-        end
+        local arg8 = (player:hasCompletedMission(ZILART, dsp.mission.id.zilart.THE_CELESTIAL_NEXUS)) and 1 or 0
+        player:startEvent(32001, battlefield:getArea(), clearTime, partySize, battlefield:getTimeInside(), 1, battlefield:getLocalVar("[cs]bit"), arg8)
     elseif leavecode == dsp.battlefield.leaveCode.LOST then
-        player:startEvent(32002);
+        player:startEvent(32002)
     end
+end
 
-end;
+function onEventUpdate(player, csid, option)
+end
 
-function onEventUpdate(player,csid,option)
--- print("bc update csid "..csid.." and option "..option);
-end;
-
-function onEventFinish(player,csid,option)
--- print("bc finish csid "..csid.." and option "..option);
-
-    if (csid == 32001) then
-        if (player:getCurrentMission(ZILART) == dsp.mission.id.zilart.THE_CELESTIAL_NEXUS) then
-            player:completeMission(ZILART,dsp.mission.id.zilart.THE_CELESTIAL_NEXUS);
-            player:addMission(ZILART,dsp.mission.id.zilart.AWAKENING);
-            player:addTitle(dsp.title.BURIER_OF_THE_ILLUSION);
-            player:setVar("ZilartStatus",0);
+function onEventFinish(player, csid, option)
+    if csid == 32001 then
+        if player:getCurrentMission(ZILART) == dsp.mission.id.zilart.THE_CELESTIAL_NEXUS then
+            player:completeMission(ZILART, dsp.mission.id.zilart.THE_CELESTIAL_NEXUS)
+            player:addMission(ZILART, dsp.mission.id.zilart.AWAKENING)
+            player:addTitle(dsp.title.BURIER_OF_THE_ILLUSION)
+            player:setVar("ZilartStatus", 0)
         end
-        -- You will be transported to the Hall of the Gods
-        player:setPos(0,-18,137,64,251);
+        player:setPos(0, -18, 137, 64, 251) -- Hall of the Gods
     end
-
-end;
+end

--- a/scripts/zones/The_Garden_of_RuHmet/bcnms/when_angels_fall.lua
+++ b/scripts/zones/The_Garden_of_RuHmet/bcnms/when_angels_fall.lua
@@ -1,72 +1,39 @@
 -----------------------------------
 -- Area: The_Garden_of_RuHmet
--- Name: when_angels_fall
+-- Name: When Angels Fall
 -----------------------------------
-
-require("scripts/globals/titles");
 require("scripts/globals/battlefield")
-require("scripts/globals/keyitems");
-require("scripts/globals/quests");
-require("scripts/globals/missions");
-
+require("scripts/globals/missions")
 -----------------------------------
--- EXAMPLE SCRIPT
---
--- What should go here:
--- giving key items, playing ENDING cutscenes
---
--- What should NOT go here:
--- Handling of "battlefield" status, spawning of monsters,
--- putting loot into treasure pool,
--- enforcing ANY rules (SJ/number of people/etc), moving
--- chars around, playing entrance CSes (entrance CSes go in bcnm.lua)
 
--- After registering the BCNM via bcnmRegister(bcnmid)
-function onBattlefieldRegister(player,battlefield)
-end;
 function onBattlefieldTick(battlefield, tick)
     dsp.battlefield.onBattlefieldTick(battlefield, tick)
 end
 
--- Physically entering the BCNM via bcnmEnter(bcnmid)
-function onBattlefieldEnter(player,battlefield)
-end;
-
--- Leaving the BCNM by every mean possible, given by the LeaveCode
--- 1=Select Exit on circle
--- 2=Winning the BC
--- 3=Disconnected or warped out
--- 4=Losing the BC
--- via bcnmLeave(1) or bcnmLeave(2). LeaveCodes 3 and 4 are called
--- from the core when a player disconnects or the time limit is up, etc
-
-function onBattlefieldLeave(player,battlefield,leavecode)
-
-    if leavecode == dsp.battlefield.leaveCode.WON then -- play end CS. Need time and battle id for record keeping + storage
-
-        local name, clearTime, partySize = battlefield:getRecord()
-
-        if (player:getCurrentMission(COP) == dsp.mission.id.cop.WHEN_ANGELS_FALL and player:getVar("PromathiaStatus")==4) then
-            player:startEvent(32001, battlefield:getArea(), clearTime, partySize, battlefield:getTimeInside(), 0, battlefield:getLocalVar("[cs]bit"), 0)
-            player:setVar("PromathiaStatus",5);
-        else
-            player:startEvent(32001, battlefield:getArea(), clearTime, partySize, battlefield:getTimeInside(), 0, battlefield:getLocalVar("[cs]bit"), 1) --
-        end
-    elseif leavecode == dsp.battlefield.leaveCode.LOST then
-        player:startEvent(32002);
-    end
-    --printf("leavecode: %u",leavecode);
-
-end;
-
-function onEventUpdate(player,csid,option)
-    -- print("bc update csid "..csid.." and option "..option);
-end;
-
-function onEventFinish(player,csid,option)
--- print("bc finish csid "..csid.." and option "..option);
-  if (csid== 32001) then
-    player:setPos(420,0,445,192);
+function onBattlefieldRegister(player, battlefield)
 end
 
-end;
+function onBattlefieldEnter(player, battlefield)
+end
+
+function onBattlefieldLeave(player, battlefield, leavecode)
+    if leavecode == dsp.battlefield.leaveCode.WON then
+        local name, clearTime, partySize = battlefield:getRecord()
+        local arg8 = (player:getCurrentMission(COP) ~= dsp.mission.id.cop.WHEN_ANGELS_FALL or player:getVar("PromathiaStatus") ~= 4) and 1 or 0
+        player:startEvent(32001, battlefield:getArea(), clearTime, partySize, battlefield:getTimeInside(), 0, battlefield:getLocalVar("[cs]bit"), arg8)
+    elseif leavecode == dsp.battlefield.leaveCode.LOST then
+        player:startEvent(32002)
+    end
+end
+
+function onEventUpdate(player, csid, option)
+end
+
+function onEventFinish(player, csid, option)
+    if csid== 32001 then
+        if player:getCurrentMission(COP) == dsp.mission.id.cop.WHEN_ANGELS_FALL and player:getVar("PromathiaStatus") == 4 then
+            player:setVar("PromathiaStatus", 5)
+        end
+        player:setPos(420, 0, 445, 192)
+    end
+end

--- a/scripts/zones/Throne_Room/bcnms/shadow_lord_battle.lua
+++ b/scripts/zones/Throne_Room/bcnms/shadow_lord_battle.lua
@@ -3,64 +3,46 @@
 -- Name: Mission 5-2
 -- !pos -111 -6 0.1 165
 -----------------------------------
+local ID = require("scripts/zones/Throne_Room/IDs")
 require("scripts/globals/battlefield")
-local ID = require("scripts/zones/Throne_Room/IDs");
-require("scripts/globals/keyitems");
-require("scripts/globals/missions");
+require("scripts/globals/keyitems")
+require("scripts/globals/missions")
 -----------------------------------
 
 function onBattlefieldTick(battlefield, tick)
     dsp.battlefield.onBattlefieldTick(battlefield, tick)
 end
 
--- After registering the BCNM via bcnmRegister(bcnmid)
-function onBattlefieldRegister(player,battlefield)
-end;
+function onBattlefieldRegister(player, battlefield)
+end
 
--- Physically entering the BCNM via bcnmEnter(bcnmid)
-function onBattlefieldEnter(player,battlefield)
-end;
+function onBattlefieldEnter(player, battlefield)
+end
 
--- Leaving the BCNM by every mean possible, given by the LeaveCode
--- 1=Select Exit on circle
--- 2=Winning the BC
--- 3=Disconnected or warped out
--- 4=Losing the BC
--- via bcnmLeave(1) or bcnmLeave(2). LeaveCodes 3 and 4 are called
--- from the core when a player disconnects or the time limit is up, etc
-
-function onBattlefieldLeave(player,battlefield,leavecode)
-    -- print("leave code "..leavecode);
+function onBattlefieldLeave(player, battlefield, leavecode)
     if leavecode == dsp.battlefield.leaveCode.WON then -- play end CS. Need time and battle id for record keeping + storage
         local name, clearTime, partySize = battlefield:getRecord()
-        if (player:hasCompletedMission(player:getNation(),15)) then
-            player:startEvent(32001, battlefield:getArea(), clearTime, partySize, battlefield:getTimeInside(), 1, battlefield:getLocalVar("[cs]bit"), 1)
-        else
-            player:startEvent(32001, battlefield:getArea(), clearTime, partySize, battlefield:getTimeInside(), 1, battlefield:getLocalVar("[cs]bit"), 0)
-        end
+        local arg8 = player:hasCompletedMission(player:getNation(), 15) and 1 or 0
+        player:startEvent(32001, battlefield:getArea(), clearTime, partySize, battlefield:getTimeInside(), 1, battlefield:getLocalVar("[cs]bit"), arg8)
     elseif leavecode == dsp.battlefield.leaveCode.LOST then
-        player:startEvent(32002);
+        player:startEvent(32002)
     end
-end;
+end
 
-function onEventUpdate(player,csid,option)
-    -- print("bc update csid "..csid.." and option "..option);
-end;
+function onEventUpdate(player, csid, option)
+end
 
-function onEventFinish(player,csid,option)
-    -- print("bc finish csid "..csid.." and option "..option);
-    if csid == 32001 then
-        if (player:getCurrentMission(player:getNation()) == 15 and player:getVar("MissionStatus") == 3) then
-            if ((not player:hasCompletedMission(ZILART, dsp.mission.id.zilart.THE_NEW_FRONTIER)) and (player:getCurrentMission(ZILART) ~= dsp.mission.id.zilart.THE_NEW_FRONTIER)) then
-                -- Don't add missions we already completed..Players who change nation will hit this.
-                player:addMission(ZILART,dsp.mission.id.zilart.THE_NEW_FRONTIER);
-            end
-            player:startEvent(7);
+function onEventFinish(player, csid, option)
+    if csid == 32001 and player:getCurrentMission(player:getNation()) == 15 and player:getVar("MissionStatus") == 3 then
+        if player:getCurrentMission(ZILART) ~= dsp.mission.id.zilart.THE_NEW_FRONTIER and not player:hasCompletedMission(ZILART, dsp.mission.id.zilart.THE_NEW_FRONTIER) then
+            -- Don't add missions we already completed. Players who change nation will hit this.
+            player:addMission(ZILART, dsp.mission.id.zilart.THE_NEW_FRONTIER)
         end
+        player:startEvent(7)
     elseif csid == 7 then
-        player:addKeyItem(dsp.ki.SHADOW_FRAGMENT);
-        player:messageSpecial(ID.text.KEYITEM_OBTAINED,dsp.ki.SHADOW_FRAGMENT);
-        player:setVar("MissionStatus",4);
-        player:setPos(378, -12, -20, 125, 161);
+        player:addKeyItem(dsp.ki.SHADOW_FRAGMENT)
+        player:messageSpecial(ID.text.KEYITEM_OBTAINED, dsp.ki.SHADOW_FRAGMENT)
+        player:setVar("MissionStatus", 4)
+        player:setPos(378, -12, -20, 125, 161)
     end
-end;
+end

--- a/scripts/zones/Throne_Room/bcnms/where_two_paths_converge.lua
+++ b/scripts/zones/Throne_Room/bcnms/where_two_paths_converge.lua
@@ -1,54 +1,35 @@
 ------------------------------------
 -- Area: Throne Room
--- Name: Mission 9-2
+-- Name: Bastok Mission 9-2
 -- !pos -111 -6 0 165
 -----------------------------------
-require("scripts/globals/keyitems");
-require("scripts/globals/missions");
 require("scripts/globals/battlefield")
-
+require("scripts/globals/missions")
 -----------------------------------
 
 function onBattlefieldTick(battlefield, tick)
     dsp.battlefield.onBattlefieldTick(battlefield, tick)
 end
 
--- After registering the BCNM via bcnmRegister(bcnmid)
-function onBattlefieldRegister(player,battlefield)
-end;
+function onBattlefieldRegister(player, battlefield)
+end
 
--- Physically entering the BCNM via bcnmEnter(bcnmid)
-function onBattlefieldEnter(player,battlefield)
-end;
+function onBattlefieldEnter(player, battlefield)
+end
 
--- Leaving the BCNM by every mean possible, given by the LeaveCode
--- 1=Select Exit on circle
--- 2=Winning the BC
--- 3=Disconnected or warped out
--- 4=Losing the BC
--- via bcnmLeave(1) or bcnmLeave(2). LeaveCodes 3 and 4 are called
--- from the core when a player disconnects or the time limit is up, etc
-
-function onBattlefieldLeave(player,battlefield,leavecode)
-    -- print("leave code "..leavecode);
-
+function onBattlefieldLeave(player, battlefield, leavecode)
     if leavecode == dsp.battlefield.leaveCode.WON then
         local name, clearTime, partySize = battlefield:getRecord()
-        if (player:getCurrentMission(BASTOK) == dsp.mission.id.bastok.WHERE_TWO_PATHS_CONVERGE) then
-            player:startEvent(32001, battlefield:getArea(), clearTime, partySize, battlefield:getTimeInside(), 1, battlefield:getLocalVar("[cs]bit"), 0)
-        else
-            player:startEvent(32001, battlefield:getArea(), clearTime, partySize, battlefield:getTimeInside(), 1, battlefield:getLocalVar("[cs]bit"), 1)
-        end
+        local arg8 = (player:getCurrentMission(BASTOK) ~= dsp.mission.id.bastok.WHERE_TWO_PATHS_CONVERGE) and 1 or 0
+        player:startEvent(32001, battlefield:getArea(), clearTime, partySize, battlefield:getTimeInside(), 1, battlefield:getLocalVar("[cs]bit"), arg8)
     elseif leavecode == dsp.battlefield.leaveCode.LOST then
-        player:startEvent(32002);
+        player:startEvent(32002)
     end
-end;
+end
 
-function onEventUpdate(player,csid,option)
-    -- print("bc update csid "..csid.." and option "..option);
-end;
+function onEventUpdate(player, csid, option)
+end
 
-function onEventFinish(player,csid,option)
-    -- print("bc finish csid "..csid.." and option "..option);
-    player:setVar("BASTOK92",2); -- This should be MissionStatus..But all battlefields of same var need updated.
-end;
+function onEventFinish(player, csid, option)
+    player:setVar("BASTOK92", 2) -- This should be MissionStatus..But all battlefields of same var need updated.
+end


### PR DESCRIPTION
couple small fixes included:
* Trial by Element battlefields now award titles (before, only Ice did).
* Trial by Lightning now enforces the one-day wait on loss, like the other Trials.
* Moved mobIds into zones table.
* Moon Reading: record arguments are now passed into event.
