### PR TITLE
fix Expertise daysPassed capitalization and sign

### DIFF
--- a/scripts/zones/Selbina/npcs/Valgeir.lua
+++ b/scripts/zones/Selbina/npcs/Valgeir.lua
@@ -28,7 +28,7 @@ function onTrigger(player,npc)
             player:startEvent(104)
         elseif expertiseStat == 2 then
             local daysPassed = VanadielDayOfTheYear() - player:getVar("QuestExpertiseDayStarted_var")
-            local hoursLeft  = 24 - VanadielHour() + (Dayspassed * 24) + player:getVar("QuestExpertiseHourStarted_var")
+            local hoursLeft  = 24 - VanadielHour() - (daysPassed * 24) + player:getVar("QuestExpertiseHourStarted_var")
 
             if hoursLeft < 0 then -- done waiting
                 player:startEvent(105)


### PR DESCRIPTION
The variable "daysPassed" had inconsistent capitalization causing an error and the daysPassed*24 was being added to the time left instead of being subtracted.