### PR TITLE
Remove duplicate refill stat group in Dyna-Qufim. (add mobid to message)

### DIFF
--- a/scripts/zones/Dynamis-Qufim/IDs.lua
+++ b/scripts/zones/Dynamis-Qufim/IDs.lua
@@ -67,11 +67,6 @@ zones[dsp.zone.DYNAMIS_QUFIM] =
                 {mob = 16945212, eye = dynamis.eye.GREEN},
             },
             {
-                {mob = 16945200, eye = dynamis.eye.RED  }, -- Adamantking_Effigy
-                {mob = 16945201, eye = dynamis.eye.BLUE },
-                {mob = 16945202, eye = dynamis.eye.GREEN},
-            },
-            {
                 {mob = 16945220, eye = dynamis.eye.RED  }, -- Manifest_Icon
                 {mob = 16945221, eye = dynamis.eye.BLUE },
                 {mob = 16945222, eye = dynamis.eye.GREEN},

--- a/src/map/lua/lua_baseentity.cpp
+++ b/src/map/lua/lua_baseentity.cpp
@@ -12529,7 +12529,7 @@ inline int32 CLuaBaseEntity::spawn(lua_State* L)
         }
         else
         {
-            ShowDebug(CL_CYAN"SpawnMob: <%s> is already spawned\n" CL_RESET, PMob->GetName());
+            ShowDebug(CL_CYAN"SpawnMob: %u <%s> is already spawned\n" CL_RESET, PMob->id, PMob->GetName());
         }
     }
     return 0;

--- a/src/map/lua/luautils.cpp
+++ b/src/map/lua/luautils.cpp
@@ -873,7 +873,7 @@ namespace luautils
                     }
                     else
                     {
-                        ShowDebug(CL_CYAN"SpawnMob: <%s> is already spawned\n" CL_RESET, PMob->GetName());
+                        ShowDebug(CL_CYAN"SpawnMob: %u <%s> is already spawned\n" CL_RESET, PMob->id, PMob->GetName());
                     }
                 }
                 lua_getglobal(L, CLuaBaseEntity::className);


### PR DESCRIPTION
Removed duplicate refill statue group in Dyna Qufim

Also, added mobid to message when we attempt to spawn an already-spawned mob.  This was useful to help track down the problem.