### PR TITLE
Updating counter rate cap to be in line with retail

### DIFF
--- a/src/map/attack.cpp
+++ b/src/map/attack.cpp
@@ -433,7 +433,7 @@ bool CAttack::CheckCounter()
         seiganChance = std::clamp<uint16>(seiganChance, 0, 100);
         seiganChance /= 4;
     }
-    if ((dsprand::GetRandomNumber(100) < (m_victim->getMod(Mod::COUNTER) + meritCounter) || dsprand::GetRandomNumber(100) < seiganChance) &&
+    if ((dsprand::GetRandomNumber(100) < std::clamp<uint16>(m_victim->getMod(Mod::COUNTER) + meritCounter, 0, 80) || dsprand::GetRandomNumber(100) < seiganChance) &&
         isFaceing(m_victim->loc.p, m_attacker->loc.p, 40) && dsprand::GetRandomNumber(100) < battleutils::GetHitRate(m_victim, m_attacker))
     {
         m_isCountered = true;


### PR DESCRIPTION
Pretty simple change.

If you check the references on [the bg-wiki counter page](https://www.bg-wiki.com/bg/Counter), there has been quite a bit of testing that puts the counter cap at 80%. When this code was written so-so long ago, it was created with no cap, essentially giving you a hit-rate capped counter rate if you stacked enough +counter gear and have counterstance up. This PR should fix that and bring it in line with what is expected.

The line became rather long, but there isn't a pretty way to fix that and it still be easily understandable. If that's an issue let me know and I can break it at the `OR`.