### PR TITLE
Fix the Pet Crashing in Battlefield

### DIFF
--- a/src/map/battlefield.cpp
+++ b/src/map/battlefield.cpp
@@ -467,6 +467,7 @@ bool CBattlefield::RemoveEntity(CBaseEntity* PEntity, uint8 leavecode)
                 {
                     m_AllyList.erase(std::remove_if(m_AllyList.begin(), m_AllyList.end(), check), m_AllyList.end());
                 }
+                PEntity->status = STATUS_DISAPPEAR;
                 return found;
             }
             else

--- a/src/map/battlefield.cpp
+++ b/src/map/battlefield.cpp
@@ -463,9 +463,10 @@ bool CBattlefield::RemoveEntity(CBaseEntity* PEntity, uint8 leavecode)
                 if (static_cast<CPetEntity*>(PEntity)->isAlive() && PEntity->PAI->IsSpawned())
                     static_cast<CPetEntity*>(PEntity)->Die();
 
-                m_AllyList.erase(std::remove_if(m_AllyList.begin(), m_AllyList.end(), check), m_AllyList.end());
-                GetZone()->DeletePET(PEntity);
-                delete PEntity;
+                if (m_AllyList.size() > 0)
+                {
+                    m_AllyList.erase(std::remove_if(m_AllyList.begin(), m_AllyList.end(), check), m_AllyList.end());
+                }
                 return found;
             }
             else


### PR DESCRIPTION
Fix the Pet Crashing in Battlefield. Removed a few delete calls that were causing a delete loop