### PR TITLE
Add mission / quest NATION.MISSION / AREA.QUEST table references

### DIFF
--- a/scripts/globals/missions.lua
+++ b/scripts/globals/missions.lua
@@ -640,6 +640,20 @@ dsp.mission.id =
     [dsp.mission.area[dsp.mission.log_id.CAMPAIGN]] = {},
 }
 
+-- Additional optional uppercase references to the mission ID tables (assigned by reference)
+dsp.mission.id.SANDORIA = dsp.mission.id.sandoria
+dsp.mission.id.BASTOK   = dsp.mission.id.bastok
+dsp.mission.id.WINDURST = dsp.mission.id.windurst
+dsp.mission.id.ZILART   = dsp.mission.id.zilart
+dsp.mission.id.COP      = dsp.mission.id.cop
+dsp.mission.id.TOAU     = dsp.mission.id.toau
+dsp.mission.id.WOTG     = dsp.mission.id.wotg
+dsp.mission.id.ACP      = dsp.mission.id.acp
+dsp.mission.id.AMK      = dsp.mission.id.amk
+dsp.mission.id.ASA      = dsp.mission.id.asa
+dsp.mission.id.SOA      = dsp.mission.id.soa
+dsp.mission.id.ROV      = dsp.mission.id.rov
+
 -- Assault and Campaign IDs deliberately left out of mission table
 -- due to their nature not being the same as other missions,
 -- and to allow the content the freedom to develop systems

--- a/scripts/globals/quests.lua
+++ b/scripts/globals/quests.lua
@@ -1196,3 +1196,16 @@ dsp.quest.id =
         BOOST_KAMIHR_DRIFTS             = 95,
     }
 }
+
+-- Additional optional uppercase references to the quest ID tables (assigned by reference)
+dsp.quest.id.SANDORIA    = dsp.quest.id.sandoria
+dsp.quest.id.BASTOK      = dsp.quest.id.bastok
+dsp.quest.id.WINDURST    = dsp.quest.id.windurst
+dsp.quest.id.JEUNO       = dsp.quest.id.jeuno
+dsp.quest.id.OTHER_AREAS = dsp.quest.id.otherAreas
+dsp.quest.id.OUTLANDS    = dsp.quest.id.outlands
+dsp.quest.id.AHT_URHGAN  = dsp.quest.id.ahtUrhgan
+dsp.quest.id.CRYSTAL_WAR = dsp.quest.id.crystalWar
+dsp.quest.id.ABYSSEA     = dsp.quest.id.abyssea
+dsp.quest.id.ADOULIN     = dsp.quest.id.adoulin
+dsp.quest.id.COALITION   = dsp.quest.id.coalition


### PR DESCRIPTION
`I was about to muse on the PR that since lua tables are by reference, if we wanted NATION.MISSION to also be a valid option, could assign dsp.mission.id.NATION = dsp.mission.id.nation in the global without losing any real performance (since we wouldn't be creating a second copy in memory)`