### PR TITLE
Fix Shantotto weaponskill trade cs

### DIFF
--- a/scripts/zones/Windurst_Walls/npcs/Shantotto.lua
+++ b/scripts/zones/Windurst_Walls/npcs/Shantotto.lua
@@ -19,7 +19,11 @@ function onTrade(player,npc,trade)
     local count = trade:getItemCount()
 
     if wsQuestEvent ~= nil then
-        player:startEvent(wsQuestEvent)
+        if wsQuestEvent == 448 then
+            player:startEvent(wsQuestEvent, nil, nil, dsp.keyItem.ANNALS_OF_TRUTH)
+        else
+            player:startEvent(wsQuestEvent)
+        end
 
     -- Curses Foiled Again!
     elseif (player:getQuestStatus(WINDURST,dsp.quest.id.windurst.CURSES_FOILED_AGAIN_1) == QUEST_ACCEPTED) then


### PR DESCRIPTION
When playing with the fiance, he noticed that there was something missing on his retribution weaponskill quest trade chat with Shantotto.

Shantotto CS 448 needs to also pass nil nil keyitem, otherwise message will be blank.