### PR TITLE
Added Lycopodium NPCs and their teleports

### DIFF
--- a/scripts/zones/Batallia_Downs/IDs.lua
+++ b/scripts/zones/Batallia_Downs/IDs.lua
@@ -20,6 +20,7 @@ zones[dsp.zone.BATALLIA_DOWNS] =
         FISHING_MESSAGE_OFFSET  = 7230, -- You can't fish here.
         DIG_THROW_AWAY          = 7243, -- You dig up <item>, but your inventory is full. You regretfully throw the <item> away.
         FIND_NOTHING            = 7245, -- You dig and you dig, but find nothing.
+        SPARKLING_LIGHT         = 7339, -- The ground is sparkling with a strange light.
         REGIME_REGISTERED       = 9981, -- New training regime registered!
         COMMON_SENSE_SURVIVAL   = 12834 -- It appears that you have arrived at a new survival guide provided by the Adventurers' Mutual Aid Network. Common sense dictates that you should now be able to teleport here from similar tomes throughout the world.
     },

--- a/scripts/zones/Batallia_Downs/npcs/Lyco_Sparkles.lua
+++ b/scripts/zones/Batallia_Downs/npcs/Lyco_Sparkles.lua
@@ -1,0 +1,37 @@
+-----------------------------------
+-- Area: Batallia Downs
+--  NPC:
+-- !pos -366.262 -16.000 325.967 105
+-----------------------------------
+local ID = require("scripts/zones/Batallia_Downs/IDs")
+require("scripts/globals/npc_util")
+-----------------------------------
+
+function onTrade(player, npc, trade)
+    if player:getMaskBit(player:getVar("LycopodiumTeleport_Mask"),1) then
+        local validFlowers = {948, 949, 956, 957, 958, 959, 1120, 1410, 1411, 1413, 1725, 2554}
+        for i = 1, #validFlowers do
+            if npcUtil.tradeHasExactly(trade, validFlowers[i]) then
+                player:startEvent(101)
+                break
+            end
+        end
+    end
+end
+
+function onTrigger(player, npc)
+    if player:getMaskBit(player:getVar("LycopodiumTeleport_Mask"),1) then
+        player:startEvent(100)
+    else
+        player:messageSpecial(ID.text.SPARKLING_LIGHT)
+    end
+end
+
+function onEventUpdate(player, csid, option)
+end
+
+function onEventFinish(player, csid, option)
+    if csid == 101 then
+        player:confirmTrade()
+    end
+end

--- a/scripts/zones/Batallia_Downs_[S]/IDs.lua
+++ b/scripts/zones/Batallia_Downs_[S]/IDs.lua
@@ -14,6 +14,7 @@ zones[dsp.zone.BATALLIA_DOWNS_S] =
         ITEM_OBTAINED           = 6388, -- Obtained: <item>.
         GIL_OBTAINED            = 6389, -- Obtained <number> gil.
         KEYITEM_OBTAINED        = 6391, -- Obtained key item: <keyitem>.
+        LYCOPODIUM_ENTRANCED    = 7056, -- The lycopodium is entranced by a sparkling light...≺Prompt≻
         FISHING_MESSAGE_OFFSET  = 7069, -- You can't fish here.
         COMMON_SENSE_SURVIVAL   = 9583  -- It appears that you have arrived at a new survival guide provided by the Servicemen's Mutual Aid Network. Common sense dictates that you should now be able to teleport here from similar tomes throughout the world.
     },

--- a/scripts/zones/Batallia_Downs_[S]/npcs/Lycopodium.lua
+++ b/scripts/zones/Batallia_Downs_[S]/npcs/Lycopodium.lua
@@ -1,0 +1,29 @@
+-----------------------------------
+-- Area: Batallia Downs [S]
+--  NPC: Lycopodium
+-- !pos -366.425 -22.127 324.666 84
+-----------------------------------
+local ID = require("scripts/zones/Batallia_Downs_[S]/IDs")
+require("scripts/globals/npc_util")
+-----------------------------------
+
+function onTrade(player, npc, trade)
+end
+
+function onTrigger(player, npc)
+    if player:getMaskBit(player:getVar("LycopodiumTeleport_Mask"),1) then
+        player:messageSpecial(ID.text.LYCOPODIUM_ENTRANCED)
+    else
+        player:messageSpecial(ID.text.LYCOPODIUM_ENTRANCED)
+        player:startEvent(202)
+    end
+end
+
+function onEventUpdate(player, csid, option)
+end
+
+function onEventFinish(player, csid, option)
+    if csid == 202 then
+        player:setMaskBit(player:getVar("LycopodiumTeleport_Mask"), "LycopodiumTeleport_Mask", 1, true)
+    end
+end

--- a/scripts/zones/Garlaige_Citadel/IDs.lua
+++ b/scripts/zones/Garlaige_Citadel/IDs.lua
@@ -21,6 +21,7 @@ zones[dsp.zone.GARLAIGE_CITADEL] =
         DEVICE_NOT_WORKING      = 7233, -- The device is not working.
         SYS_OVERLOAD            = 7242, -- Warning! Sys...verload! Enterin...fety mode. ID eras...d.
         YOU_LOST_THE            = 7247, -- You lost the <item>.
+        SPARKLING_LIGHT         = 7259, -- The ground is sparkling with a strange light.
         A_GATE_OF_STURDY_STEEL  = 7271, -- A gate of sturdy steel.
         OPEN_WITH_THE_RIGHT_KEY = 7277, -- You might be able to open it with the right key.
         BANISHING_GATES         = 7286, -- The first banishing gate begins to open...

--- a/scripts/zones/Garlaige_Citadel/npcs/Lyco_Sparkles.lua
+++ b/scripts/zones/Garlaige_Citadel/npcs/Lyco_Sparkles.lua
@@ -1,0 +1,37 @@
+-----------------------------------
+-- Area: Garlaige Citadel
+--  NPC: Lycopodium Teleport
+-- !pos -176.759 -1.249 71.511 200
+-----------------------------------
+local ID = require("scripts/zones/Garlaige_Citadel/IDs")
+require("scripts/globals/npc_util")
+-----------------------------------
+
+function onTrade(player, npc, trade)
+    if player:getMaskBit(player:getVar("LycopodiumTeleport_Mask"),0) then
+        local validFlowers = {948, 949, 956, 957, 958, 959, 1120, 1410, 1411, 1413, 1725, 2554}
+        for i = 1, #validFlowers do
+            if npcUtil.tradeHasExactly(trade, validFlowers[i]) then
+                player:startEvent(101)
+                break
+            end
+        end
+    end
+end
+
+function onTrigger(player, npc)
+    if player:getMaskBit(player:getVar("LycopodiumTeleport_Mask"),0) then
+        player:startEvent(100)
+    else
+        player:messageSpecial(ID.text.SPARKLING_LIGHT)
+    end
+end
+
+function onEventUpdate(player, csid, option)
+end
+
+function onEventFinish(player, csid, option)
+    if csid == 101 then
+        player:confirmTrade()
+    end
+end

--- a/scripts/zones/Garlaige_Citadel_[S]/IDs.lua
+++ b/scripts/zones/Garlaige_Citadel_[S]/IDs.lua
@@ -14,7 +14,8 @@ zones[dsp.zone.GARLAIGE_CITADEL_S] =
         ITEM_OBTAINED           = 6388, -- Obtained: <item>.
         GIL_OBTAINED            = 6389, -- Obtained <number> gil.
         KEYITEM_OBTAINED        = 6391, -- Obtained key item: <keyitem>.
-        COMMON_SENSE_SURVIVAL   = 8879  -- It appears that you have arrived at a new survival guide provided by the Servicemen's Mutual Aid Network. Common sense dictates that you should now be able to teleport here from similar tomes throughout the world.
+        COMMON_SENSE_SURVIVAL   = 8879,  -- It appears that you have arrived at a new survival guide provided by the Servicemen's Mutual Aid Network. Common sense dictates that you should now be able to teleport here from similar tomes throughout the world.
+        LYCOPODIUM_ENTRANCED    = 7056 -- The lycopodium is entranced by a sparkling light...≺Prompt≻
     },
     mob =
     {

--- a/scripts/zones/Garlaige_Citadel_[S]/npcs/Lycopodium.lua
+++ b/scripts/zones/Garlaige_Citadel_[S]/npcs/Lycopodium.lua
@@ -1,0 +1,29 @@
+-----------------------------------
+-- Area: Garlaige Citadel [S]
+--  NPC: Lycopodium
+-- !pos -96.753 -1.000 -167.332 164
+-----------------------------------
+local ID = require("scripts/zones/Garlaige_Citadel_[S]/IDs")
+require("scripts/globals/npc_util")
+-----------------------------------
+
+function onTrade(player, npc, trade)
+end
+
+function onTrigger(player, npc)
+    if player:getMaskBit(player:getVar("LycopodiumTeleport_Mask"),0) then
+        player:messageSpecial(ID.text.LYCOPODIUM_ENTRANCED)
+    else
+        player:messageSpecial(ID.text.LYCOPODIUM_ENTRANCED)
+        player:startEvent(30)
+    end
+end
+
+function onEventUpdate(player, csid, option)
+end
+
+function onEventFinish(player, csid, option)
+    if csid == 30 then
+        player:setMaskBit(player:getVar("LycopodiumTeleport_Mask"), "LycopodiumTeleport_Mask", 0, true)
+    end
+end

--- a/scripts/zones/North_Gustaberg/IDs.lua
+++ b/scripts/zones/North_Gustaberg/IDs.lua
@@ -24,6 +24,7 @@ zones[dsp.zone.NORTH_GUSTABERG] =
         FISHING_MESSAGE_OFFSET        = 7230, -- You can't fish here.
         DIG_THROW_AWAY                = 7243, -- You dig up <item>, but your inventory is full. You regretfully throw the <item> away.
         FIND_NOTHING                  = 7245, -- You dig and you dig, but find nothing.
+        SPARKLING_LIGHT               = 7374, -- The ground is sparkling with a strange light.
         SHINING_OBJECT_SLIPS_AWAY     = 7438, -- The shining object slips through your fingers and is washed further down the stream.
         REACH_WATER_FROM_HERE         = 7445, -- You can reach the water from here.
         CONQUEST                      = 7481, -- You've earned conquest points!

--- a/scripts/zones/North_Gustaberg/npcs/Lyco_Sparkles_0.lua
+++ b/scripts/zones/North_Gustaberg/npcs/Lyco_Sparkles_0.lua
@@ -1,0 +1,37 @@
+-----------------------------------
+-- Area: North Gustaberg
+--  NPC: Lycopodium Teleport 0
+-- !pos -281.182 40.113 263.102 106
+-----------------------------------
+local ID = require("scripts/zones/North_Gustaberg/IDs")
+require("scripts/globals/npc_util")
+-----------------------------------
+
+function onTrade(player, npc, trade)
+    if player:getMaskBit(player:getVar("LycopodiumTeleport_Mask"),2) then
+        local validFlowers = {948, 949, 956, 957, 958, 959, 1120, 1410, 1411, 1413, 1725, 2554}
+        for i = 1, #validFlowers do
+            if npcUtil.tradeHasExactly(trade, validFlowers[i]) then
+                player:startEvent(264)
+                break
+            end
+        end
+    end
+end
+
+function onTrigger(player, npc)
+    if player:getMaskBit(player:getVar("LycopodiumTeleport_Mask"),2) then
+        player:startEvent(263)
+    else
+        player:messageSpecial(ID.text.SPARKLING_LIGHT)
+    end
+end
+
+function onEventUpdate(player, csid, option)
+end
+
+function onEventFinish(player, csid, option)
+    if csid == 264 then
+        player:confirmTrade()
+    end
+end

--- a/scripts/zones/North_Gustaberg/npcs/Lyco_Sparkles_1.lua
+++ b/scripts/zones/North_Gustaberg/npcs/Lyco_Sparkles_1.lua
@@ -1,0 +1,36 @@
+-----------------------------------
+-- Area: North Gustaberg
+--  NPC: Lycopodium Teleport 1
+-- !pos -258.186 -3.231 204.774 106
+-----------------------------------
+local ID = require("scripts/zones/North_Gustaberg/IDs")
+require("scripts/globals/npc_util")
+-----------------------------------
+
+function onTrade(player, npc, trade)
+    if player:getMaskBit(player:getVar("LycopodiumTeleport_Mask"),2) then
+        local validFlowers = {948, 949, 956, 957, 958, 959, 1120, 1410, 1411, 1413, 1725, 2554}
+        for i = 1, #validFlowers do
+            if npcUtil.tradeHasExactly(trade, validFlowers[i]) then
+                player:startEvent(265)
+                break
+            end
+        end
+    end
+end
+function onTrigger(player, npc)
+    if player:getMaskBit(player:getVar("LycopodiumTeleport_Mask"),2) then
+        player:startEvent(263)
+    else
+        player:messageSpecial(ID.text.SPARKLING_LIGHT)
+    end
+end
+
+function onEventUpdate(player, csid, option)
+end
+
+function onEventFinish(player, csid, option)
+    if csid == 265 then
+        player:confirmTrade()
+    end
+end

--- a/scripts/zones/North_Gustaberg_[S]/IDs.lua
+++ b/scripts/zones/North_Gustaberg_[S]/IDs.lua
@@ -14,6 +14,7 @@ zones[dsp.zone.NORTH_GUSTABERG_S] =
         ITEM_OBTAINED           = 6388, -- Obtained: <item>.
         GIL_OBTAINED            = 6389, -- Obtained <number> gil.
         KEYITEM_OBTAINED        = 6391, -- Obtained key item: <keyitem>.
+        LYCOPODIUM_ENTRANCED    = 7056, -- The lycopodium is entranced by a sparkling light...≺Prompt≻
         FISHING_MESSAGE_OFFSET  = 7355, -- You can't fish here.
         MINING_IS_POSSIBLE_HERE = 7544, -- Mining is possible here if you have <item>.
         COMMON_SENSE_SURVIVAL   = 9076  -- It appears that you have arrived at a new survival guide provided by the Servicemen's Mutual Aid Network. Common sense dictates that you should now be able to teleport here from similar tomes throughout the world.

--- a/scripts/zones/North_Gustaberg_[S]/npcs/Lycopodium.lua
+++ b/scripts/zones/North_Gustaberg_[S]/npcs/Lycopodium.lua
@@ -1,0 +1,29 @@
+-----------------------------------
+-- Area: North Gustaberg [S]
+--  NPC: Lycopodium
+-- !pos -275.953 12.333 262.368 88
+-----------------------------------
+local ID = require("scripts/zones/Garlaige_Citadel_[S]/IDs")
+require("scripts/globals/npc_util")
+-----------------------------------
+
+function onTrade(player, npc, trade)
+end
+
+function onTrigger(player, npc)
+    if player:getMaskBit(player:getVar("LycopodiumTeleport_Mask"),2) then
+        player:messageSpecial(ID.text.LYCOPODIUM_ENTRANCED)
+    else
+        player:messageSpecial(ID.text.LYCOPODIUM_ENTRANCED)
+        player:startEvent(113)
+    end
+end
+
+function onEventUpdate(player, csid, option)
+end
+
+function onEventFinish(player, csid, option)
+    if csid == 113 then
+        player:setMaskBit(player:getVar("LycopodiumTeleport_Mask"), "LycopodiumTeleport_Mask", 2, true)
+    end
+end


### PR DESCRIPTION
Added logic for Lycopodiums in past and for blank points in present
that allow teleport after trading specific flowers.

Fixed spawn point in npc_list.sql, there was one posted as apocalypse
but there was no script for it as it was an unnamed npc without logic.
The correct one is named relic and it already has a valid relic.lua and
valid location in sql file.

Submitting this as a draft to go through the trial by fire, once IBM
merges his change, I will update it with the new charvar function
name he changed it to.

(Left NPC name field blank as that's their valid name, wasn't sure
if I shoulda just deleted the field but left it empty so it matches the
name-in-game.