### PR TITLE
[Quest Rewrite] Implement returning events based on specific eventType priority

### DIFF
--- a/scripts/commands/reloadquest.lua
+++ b/scripts/commands/reloadquest.lua
@@ -18,7 +18,7 @@ end
 function onTrigger(player, logId, quest_string)
     -- validate logId
     if type(logId) == "string" then
-        logId = dsp.quest.log_id[string.upper(logId)]
+        logId = dsp.quest.log[string.upper(logId)]
     end
     local area = dsp.quest.area[logId]
     if logId == nil or area == nil then
@@ -41,17 +41,17 @@ function onTrigger(player, logId, quest_string)
     local quest_filename = 'scripts/quests/'
     local area_dirs =
     {
-        [dsp.quest.log_id.SANDORIA]    = 'sandoria',
-        [dsp.quest.log_id.BASTOK]      = 'bastok',
-        [dsp.quest.log_id.WINDURST]    = 'windurst',
-        [dsp.quest.log_id.JEUNO]       = 'jeuno',
-        [dsp.quest.log_id.OTHER_AREAS] = 'other_areas',
-        [dsp.quest.log_id.OUTLANDS]    = 'outlands',
-        [dsp.quest.log_id.AHT_URHGAN]  = 'aht_urhgan',
-        [dsp.quest.log_id.CRYSTAL_WAR] = 'crystal_war',
-        [dsp.quest.log_id.ABYSSEA]     = 'abyssea',
-        [dsp.quest.log_id.ADOULIN]     = 'adoulin',
-        [dsp.quest.log_id.COALITION]   = 'coalition'
+        [dsp.quest.log.SANDORIA]    = 'sandoria',
+        [dsp.quest.log.BASTOK]      = 'bastok',
+        [dsp.quest.log.WINDURST]    = 'windurst',
+        [dsp.quest.log.JEUNO]       = 'jeuno',
+        [dsp.quest.log.OTHER_AREAS] = 'other_areas',
+        [dsp.quest.log.OUTLANDS]    = 'outlands',
+        [dsp.quest.log.AHT_URHGAN]  = 'aht_urhgan',
+        [dsp.quest.log.CRYSTAL_WAR] = 'crystal_war',
+        [dsp.quest.log.ABYSSEA]     = 'abyssea',
+        [dsp.quest.log.ADOULIN]     = 'adoulin',
+        [dsp.quest.log.COALITION]   = 'coalition'
     }
     local quest_filename = quest_filename .. area_dirs[logId] .. '/' .. string.lower(quest_string)
 

--- a/scripts/commands/resetquest.lua
+++ b/scripts/commands/resetquest.lua
@@ -60,13 +60,19 @@ function onTrigger(player,logId,questId,target)
         targ:delQuest(logId, questId) -- Delete quest status
         targ:setVar(quest.vars.stage, 0) -- Reset stage var
         if quest.vars.additional then -- Purge any additional quest vars
-            for name, var in pairs(quest.vars.additional) do 
-                handleQuestVar(targ, quest, name, 0, "resetquest: ", nil)
+            for name, var in pairs(quest.vars.additional) do
+                quest.setVar(targ, name, 0, "resetquest: ")
             end
         end
         if quest.temporary and quest.temporary.key_items then -- Delete any temporary key items
             for _, ki in pairs(quest.temporary.key_items) do
                 player:delKeyItem(ki)
+            end
+        end
+        -- Clear all char_vars from having seen dsp.quest.eventType.ONCE type events
+        if quest.temporary and quest.temporary.seen_events then
+            for _, seen_event in pairs(quest.temporary.seen_events) do
+                player:setVar('[QE][Z'.. seen_event[1] ..']'.. seen_event[2], 0)
             end
         end
 

--- a/scripts/globals/quests.lua
+++ b/scripts/globals/quests.lua
@@ -20,7 +20,7 @@ QUEST_COMPLETED = 2;
 
 -- These integers are the ones used by the client
 -- to diffierentiate different quest log update packets
-dsp.quest.log_id =
+dsp.quest.log =
 {
     SANDORIA    =  0,
     BASTOK      =  1,
@@ -40,21 +40,21 @@ dsp.quest.log_id =
 -- These areas are keyed by the area's quest log ID to facilitate
 -- fetching the area's quests.
 -- Ex: If all you have is a quest log ID, you can pull all
--- quest IDs for that area by: dsp.quest.id[dsp.quest.area[log_id]]
+-- quest IDs for that area by: dsp.quest.id[dsp.quest.area[log]]
 -- These can also be tied into quest file directories later.
 dsp.quest.area =
 {
-    [dsp.quest.log_id.SANDORIA]    = 'sandoria',
-    [dsp.quest.log_id.BASTOK]      = 'bastok',
-    [dsp.quest.log_id.WINDURST]    = 'windurst',
-    [dsp.quest.log_id.JEUNO]       = 'jeuno',
-    [dsp.quest.log_id.OTHER_AREAS] = 'otherAreas',
-    [dsp.quest.log_id.OUTLANDS]    = 'outlands',
-    [dsp.quest.log_id.AHT_URHGAN]  = 'ahtUrhgan',
-    [dsp.quest.log_id.CRYSTAL_WAR] = 'crystalWar',
-    [dsp.quest.log_id.ABYSSEA]     = 'abyssea',
-    [dsp.quest.log_id.ADOULIN]     = 'adoulin',
-    [dsp.quest.log_id.COALITION]   = 'coalition'
+    [dsp.quest.log.SANDORIA]    = 'sandoria',
+    [dsp.quest.log.BASTOK]      = 'bastok',
+    [dsp.quest.log.WINDURST]    = 'windurst',
+    [dsp.quest.log.JEUNO]       = 'jeuno',
+    [dsp.quest.log.OTHER_AREAS] = 'otherAreas',
+    [dsp.quest.log.OUTLANDS]    = 'outlands',
+    [dsp.quest.log.AHT_URHGAN]  = 'ahtUrhgan',
+    [dsp.quest.log.CRYSTAL_WAR] = 'crystalWar',
+    [dsp.quest.log.ABYSSEA]     = 'abyssea',
+    [dsp.quest.log.ADOULIN]     = 'adoulin',
+    [dsp.quest.log.COALITION]   = 'coalition'
 }
 
 -----------------------------------
@@ -66,7 +66,7 @@ dsp.quest.id =
     -----------------------------------
     --  San d'Oria
     -----------------------------------
-    [dsp.quest.area[dsp.quest.log_id.SANDORIA]] =
+    [dsp.quest.area[dsp.quest.log.SANDORIA]] =
     {
         A_SENTRY_S_PERIL                = 0,  -- ± --
         WATER_OF_THE_CHEVAL             = 1,  -- ± --
@@ -154,7 +154,7 @@ dsp.quest.id =
     -----------------------------------
     --  Bastok
     -----------------------------------
-    [dsp.quest.area[dsp.quest.log_id.BASTOK]] =
+    [dsp.quest.area[dsp.quest.log.BASTOK]] =
     {
         THE_SIREN_S_TEAR                = 0,  -- ± --
         BEAUTY_AND_THE_GALKA            = 1,  -- ± --
@@ -252,7 +252,7 @@ dsp.quest.id =
     -----------------------------------
     --  Windurst
     -----------------------------------
-    [dsp.quest.area[dsp.quest.log_id.WINDURST]] =
+    [dsp.quest.area[dsp.quest.log.WINDURST]] =
     {
         HAT_IN_HAND                     = 0,  -- + --
         A_FEATHER_IN_ONE_S_CAP          = 1,  -- + --
@@ -348,7 +348,7 @@ dsp.quest.id =
     -----------------------------------
     --  Jeuno
     -----------------------------------
-    [dsp.quest.area[dsp.quest.log_id.JEUNO]] =
+    [dsp.quest.area[dsp.quest.log.JEUNO]] =
     {
         CREST_OF_DAVOI                  = 0,  -- + --
         SAVE_MY_SISTER                  = 1,  -- + --
@@ -499,7 +499,7 @@ dsp.quest.id =
     -----------------------------------
     --  Other Areas
     -----------------------------------
-    [dsp.quest.area[dsp.quest.log_id.OTHER_AREAS]] =
+    [dsp.quest.area[dsp.quest.log.OTHER_AREAS]] =
     {
         RYCHARDE_THE_CHEF               = 0,  -- + --
         WAY_OF_THE_COOK                 = 1,  -- + --
@@ -572,7 +572,7 @@ dsp.quest.id =
     -----------------------------------
     --  Outlands
     -----------------------------------
-    [dsp.quest.area[dsp.quest.log_id.OUTLANDS]] =
+    [dsp.quest.area[dsp.quest.log.OUTLANDS]] =
     {
         -- Kazham (1-15)
         THE_FIREBLOOM_TREE              = 1,
@@ -644,7 +644,7 @@ dsp.quest.id =
     -----------------------------------
     --  Aht Urhgan
     -----------------------------------
-    [dsp.quest.area[dsp.quest.log_id.AHT_URHGAN]] =
+    [dsp.quest.area[dsp.quest.log.AHT_URHGAN]] =
     {
         KEEPING_NOTES                   = 0,
         ARTS_AND_CRAFTS                 = 1,
@@ -702,7 +702,7 @@ dsp.quest.id =
     -----------------------------------
     --  Crystal War
     -----------------------------------
-    [dsp.quest.area[dsp.quest.log_id.CRYSTAL_WAR]] =
+    [dsp.quest.area[dsp.quest.log.CRYSTAL_WAR]] =
     {
         LOST_IN_TRANSLOCATION            = 0,
         MESSAGE_ON_THE_WINDS             = 1,
@@ -801,7 +801,7 @@ dsp.quest.id =
     -----------------------------------
     --  Abyssea
     -----------------------------------
-    [dsp.quest.area[dsp.quest.log_id.ABYSSEA]] =
+    [dsp.quest.area[dsp.quest.log.ABYSSEA]] =
     {
         -- For some reason these did not match dat file order,
         -- had to adjust IDs >120 after using @addquest
@@ -1002,7 +1002,7 @@ dsp.quest.id =
     -----------------------------------
     --  Adoulin
     -----------------------------------
-    [dsp.quest.area[dsp.quest.log_id.ADOULIN]] =
+    [dsp.quest.area[dsp.quest.log.ADOULIN]] =
     {
         -- These also do not match the DAT file order, had
         -- discrepencies and swapped orders from the start.
@@ -1108,7 +1108,7 @@ dsp.quest.id =
     -----------------------------------
     --  Coalition
     -----------------------------------
-    [dsp.quest.area[dsp.quest.log_id.COALITION]] =
+    [dsp.quest.area[dsp.quest.log.COALITION]] =
     {
         -- Also slightly incongruent with DAT file order
         PROCURE_CEIZAK_BATTLEGROUNDS    = 0,
@@ -1239,17 +1239,17 @@ dsp.quest.string = buildQuestStringTable(dsp.quest.id)
 -- Quest objects inside these tables will be loaded/reloaded as required by NPC scripts and GM commands
 dsp.quest.object =
 {
-    [dsp.quest.area[dsp.quest.log_id.SANDORIA]] = {},
-    [dsp.quest.area[dsp.quest.log_id.BASTOK]] = {},
-    [dsp.quest.area[dsp.quest.log_id.WINDURST]] = {},
-    [dsp.quest.area[dsp.quest.log_id.JEUNO]] = {},
-    [dsp.quest.area[dsp.quest.log_id.OTHER_AREAS]] = {},
-    [dsp.quest.area[dsp.quest.log_id.OUTLANDS]] = {},
-    [dsp.quest.area[dsp.quest.log_id.AHT_URHGAN]] = {},
-    [dsp.quest.area[dsp.quest.log_id.CRYSTAL_WAR]] = {},
-    [dsp.quest.area[dsp.quest.log_id.ABYSSEA]] = {},
-    [dsp.quest.area[dsp.quest.log_id.ADOULIN]] = {},
-    [dsp.quest.area[dsp.quest.log_id.COALITION]] = {}
+    [dsp.quest.area[dsp.quest.log.SANDORIA]] = {},
+    [dsp.quest.area[dsp.quest.log.BASTOK]] = {},
+    [dsp.quest.area[dsp.quest.log.WINDURST]] = {},
+    [dsp.quest.area[dsp.quest.log.JEUNO]] = {},
+    [dsp.quest.area[dsp.quest.log.OTHER_AREAS]] = {},
+    [dsp.quest.area[dsp.quest.log.OUTLANDS]] = {},
+    [dsp.quest.area[dsp.quest.log.AHT_URHGAN]] = {},
+    [dsp.quest.area[dsp.quest.log.CRYSTAL_WAR]] = {},
+    [dsp.quest.area[dsp.quest.log.ABYSSEA]] = {},
+    [dsp.quest.area[dsp.quest.log.ADOULIN]] = {},
+    [dsp.quest.area[dsp.quest.log.COALITION]] = {}
 }
 
 -----------------------------------
@@ -1261,6 +1261,7 @@ dsp.quest.stage =
     STAGE0   =  0, STAGE1  =  1, STAGE2  =  2, STAGE3   =  3, STAGE4   =  4,
     STAGE5   =  5, STAGE6  =  6, STAGE7  =  7, STAGE8   =  8, STAGE9   =  9,
     STAGE10  = 10, STAGE11 = 11, STAGE12 = 12, STAGE13  = 13, STAGE14  = 14,
+    COMPLETE = 255
 }
 
 dsp.quest.fame =
@@ -1345,7 +1346,7 @@ dsp.quest.newQuest = function()
         end
 
         if not var then
-            ret.message = " unable to find "..varname.." for quest: "..quest.name.." (log_id: "..quest.log_id..")"
+            ret.message = " unable to find "..varname.." for quest: "..quest.name.." (log: "..quest.log..")"
         else
             if vartype == dsp.quest.var.CHAR then
                 if get then
@@ -1415,7 +1416,14 @@ dsp.quest.newQuest = function()
     ---------------------------------------------------------------
     this.getStage = function(entity)
         local message = this.string_key.. ".getStage -> "
-        return this.getVar(entity, this.vars.stage, message)
+        local stage = this.getVar(entity, this.vars.stage, message)
+        if stage > 0 then
+            return stage
+        elseif player:getQuestStatus(this.log, this.quest_id) == dsp.quest.status.COMPLETED then
+            return dsp.quest.stage.COMPLETE
+        else
+            return 0
+        end
     end
 
     -- Advances the player's current quest stage by 1
@@ -1430,16 +1438,16 @@ dsp.quest.newQuest = function()
     -- Returns true if the player meets all the listed quest requirements
     ---------------------------------------------------------------
     this.checkRequirements = function(player)
-        local questStatusCheck = player:getQuestStatus(this.log_id, this.quest_id)
+        local questStatusCheck = player:getQuestStatus(this.log, this.quest_id)
 
         if questStatusCheck == dsp.quest.status.AVAILABLE
         or (questStatusCheck == dsp.quest.status.COMPLETED and this.repeatable) then
             -- Check all required quests
             if this.requirements.quests then
                 for i, requiredQuest in ipairs(this.requirements.quests) do
-                    local requiredQuestStatus = player:getQuestStatus(requiredQuest.log_id, requiredQuest.quest_id)
+                    local requiredQuestStatus = player:getQuestStatus(requiredQuest.log, requiredQuest.quest_id)
                     if requiredQuest.stage then
-                        local quest = dsp.quest.getQuest(requiredQuest.log_id, requiredQuest.quest_id)
+                        local quest = dsp.quest.getQuest(requiredQuest.log, requiredQuest.quest_id)
                         if quest then
                             if quest.getStage(player) < requiredQuest.stage then
                                 return false
@@ -1494,7 +1502,7 @@ dsp.quest.newQuest = function()
     -- Adds a quest to the player's log and sets their stage to 1
     ---------------------------------------------------------------
     this.begin = function(player)
-        player:addQuest(this.log_id, this.quest_id)
+        player:addQuest(this.log, this.quest_id)
         return this.advanceStage(player)
     end
 
@@ -1517,8 +1525,7 @@ dsp.quest.newQuest = function()
     ---------------------------------------------------------------
     this.startEvent = function(player, event, params)
         if not params then params = {} end
-        player:startEvent(event, params[1], params[2], params[3], params[4],
-                                 params[5], params[6], params[7], params[8])
+        player:startEvent(event, unpack(params))
         return true
     end
 
@@ -1531,7 +1538,6 @@ dsp.quest.newQuest = function()
         if npcUtil.giveItem(player, item, silent_fail) then
             return true
         else
-            this.holdItem(player, item)
             return false
         end
     end
@@ -1678,7 +1684,7 @@ dsp.quest.newQuest = function()
                     end
                 end
 
-                rewards_given = npcUtil.completeQuest(player, this.log_id, this.quest_id, reward_set)
+                rewards_given = npcUtil.completeQuest(player, this.log, this.quest_id, reward_set)
                 if not rewards_given then
                     error(player, message.. "Unable to give quest rewards.")
                 end
@@ -1786,17 +1792,17 @@ dsp.quest.getQuest = function(area_log_id, quest_id)
                 local quest_filename = 'scripts/quests/'
                 local area_dirs =
                 {
-                    [dsp.quest.log_id.SANDORIA]    = 'sandoria',
-                    [dsp.quest.log_id.BASTOK]      = 'bastok',
-                    [dsp.quest.log_id.WINDURST]    = 'windurst',
-                    [dsp.quest.log_id.JEUNO]       = 'jeuno',
-                    [dsp.quest.log_id.OTHER_AREAS] = 'other_areas',
-                    [dsp.quest.log_id.OUTLANDS]    = 'outlands',
-                    [dsp.quest.log_id.AHT_URHGAN]  = 'aht_urhgan',
-                    [dsp.quest.log_id.CRYSTAL_WAR] = 'crystal_war',
-                    [dsp.quest.log_id.ABYSSEA]     = 'abyssea',
-                    [dsp.quest.log_id.ADOULIN]     = 'adoulin',
-                    [dsp.quest.log_id.COALITION]   = 'coalition'
+                    [dsp.quest.log.SANDORIA]    = 'sandoria',
+                    [dsp.quest.log.BASTOK]      = 'bastok',
+                    [dsp.quest.log.WINDURST]    = 'windurst',
+                    [dsp.quest.log.JEUNO]       = 'jeuno',
+                    [dsp.quest.log.OTHER_AREAS] = 'other_areas',
+                    [dsp.quest.log.OUTLANDS]    = 'outlands',
+                    [dsp.quest.log.AHT_URHGAN]  = 'aht_urhgan',
+                    [dsp.quest.log.CRYSTAL_WAR] = 'crystal_war',
+                    [dsp.quest.log.ABYSSEA]     = 'abyssea',
+                    [dsp.quest.log.ADOULIN]     = 'adoulin',
+                    [dsp.quest.log.COALITION]   = 'coalition'
                 }
                 quest_filename = quest_filename .. area_dirs[area_log_id] .. '/' .. string.lower(quest_string)
                 local quest = require(quest_filename)

--- a/scripts/quests/adoulin/a_certain_substitute_patrolman.lua
+++ b/scripts/quests/adoulin/a_certain_substitute_patrolman.lua
@@ -4,12 +4,12 @@ require("scripts/globals/quests")
 local thisQuest = dsp.quest.newQuest()
 
 thisQuest.name = "A Certain Substitute Patrolman"
-thisQuest.log_id = dsp.quest.log_id.ADOULIN
+thisQuest.log = dsp.quest.log.ADOULIN
 thisQuest.quest_id = dsp.quest.id.adoulin.A_CERTAIN_SUBSTITUTE_PATROLMAN
 thisQuest.string_key = dsp.quest.string.adoulin[thisQuest.quest_id]
 
 thisQuest.repeatable = false
-thisQuest.var_prefix = "[Q]["..thisQuest.log_id.."]["..thisQuest.quest_id.."]"
+thisQuest.var_prefix = "[Q]["..thisQuest.log.."]["..thisQuest.quest_id.."]"
 thisQuest.vars =
 {
     stage = thisQuest.var_prefix,

--- a/scripts/quests/adoulin/fertile_ground.lua
+++ b/scripts/quests/adoulin/fertile_ground.lua
@@ -4,12 +4,12 @@ require("scripts/globals/quests")
 local thisQuest = dsp.quest.newQuest()
 
 thisQuest.name = "Fertile Ground"
-thisQuest.log_id = dsp.quest.log_id.ADOULIN
+thisQuest.log = dsp.quest.log.ADOULIN
 thisQuest.quest_id = dsp.quest.id.adoulin.FERTILE_GROUND
 thisQuest.string_key = dsp.quest.string.adoulin[thisQuest.quest_id]
 
 thisQuest.repeatable = false
-thisQuest.var_prefix = "[Q]["..thisQuest.log_id.."]["..thisQuest.quest_id.."]"
+thisQuest.var_prefix = "[Q]["..thisQuest.log.."]["..thisQuest.quest_id.."]"
 thisQuest.vars =
 {
     stage = thisQuest.var_prefix,
@@ -21,7 +21,7 @@ thisQuest.requirements =
     quests =
     {
         {
-            log_id = dsp.quest.log_id.ADOULIN,
+            log = dsp.quest.log.ADOULIN,
             quest_id = dsp.quest.id.adoulin.THE_OLD_MAN_AND_THE_HARPOON
         }
     },

--- a/scripts/quests/adoulin/the_old_man_and_the_harpoon.lua
+++ b/scripts/quests/adoulin/the_old_man_and_the_harpoon.lua
@@ -4,12 +4,12 @@ require("scripts/globals/quests")
 local thisQuest = dsp.quest.newQuest()
 
 thisQuest.name = "The Old Man and the Harpoon"
-thisQuest.log_id = dsp.quest.log_id.ADOULIN
+thisQuest.log = dsp.quest.log.ADOULIN
 thisQuest.quest_id = dsp.quest.id.adoulin.THE_OLD_MAN_AND_THE_HARPOON
 thisQuest.string_key = dsp.quest.string.adoulin[thisQuest.quest_id]
 
 thisQuest.repeatable = false
-thisQuest.var_prefix = "[Q]["..thisQuest.log_id.."]["..thisQuest.quest_id.."]"
+thisQuest.var_prefix = "[Q]["..thisQuest.log.."]["..thisQuest.quest_id.."]"
 thisQuest.vars =
 {
     stage = thisQuest.var_prefix,

--- a/scripts/quests/adoulin/the_old_man_and_the_harpoon.lua
+++ b/scripts/quests/adoulin/the_old_man_and_the_harpoon.lua
@@ -45,7 +45,11 @@ thisQuest.rewards =
 thisQuest.temporary =
 {
     items = {},
-    key_items = {dsp.ki.BROKEN_HARPOON, dsp.ki.EXTRAVAGANT_HARPOON}
+    key_items = {dsp.ki.BROKEN_HARPOON, dsp.ki.EXTRAVAGANT_HARPOON},
+    --seen_events =
+    --{
+        --{dsp.zone.WESTERN_ADOULIN, 2541}
+    --}
 }
 
 -----------------------------------

--- a/scripts/quests/adoulin/wayward_waypoints.lua
+++ b/scripts/quests/adoulin/wayward_waypoints.lua
@@ -4,12 +4,12 @@ require("scripts/globals/quests")
 local thisQuest = dsp.quest.newQuest()
 
 thisQuest.name = "Wayward Waypoints"
-thisQuest.log_id = dsp.quest.log_id.ADOULIN
+thisQuest.log = dsp.quest.log.ADOULIN
 thisQuest.quest_id = dsp.quest.id.adoulin.WAYWARD_WAYPOINTS
 thisQuest.string_key = dsp.quest.string.adoulin[thisQuest.quest_id]
 
 thisQuest.repeatable = false
-thisQuest.var_prefix = "[Q]["..thisQuest.log_id.."]["..thisQuest.quest_id.."]"
+thisQuest.var_prefix = "[Q]["..thisQuest.log.."]["..thisQuest.quest_id.."]"
 thisQuest.vars =
 {
     stage = thisQuest.var_prefix,
@@ -25,7 +25,7 @@ thisQuest.requirements =
     quests =
     { 
         {
-            log_id = dsp.quest.log_id.ADOULIN,
+            log = dsp.quest.log.ADOULIN,
             quest_id = dsp.quest.id.adoulin.MEGALOMANIAC
         } 
     },

--- a/scripts/quests/sandoria/lure_of_the_wildcat.lua
+++ b/scripts/quests/sandoria/lure_of_the_wildcat.lua
@@ -3,7 +3,7 @@ require("scripts/globals/zone")
 
 local this_quest = {}
 local name = "LURE_OF_THE_WILDCAT"
-local logid = dsp.quest.log_id.SANDORIA
+local logid = dsp.quest.log.SANDORIA
 local id = dsp.quest.id.sandoria.LURE_OF_THE_WILDCAT
 
 this_quest.id = id

--- a/scripts/quests/sandoria/the_brugaire_consortium.lua
+++ b/scripts/quests/sandoria/the_brugaire_consortium.lua
@@ -3,12 +3,12 @@ require("scripts/globals/quests")
 local thisQuest = dsp.quest.newQuest()
 
 thisQuest.name = "The Brugaire Consortium"
-thisQuest.log_id = dsp.quest.log_id.SANDORIA
+thisQuest.log = dsp.quest.log.SANDORIA
 thisQuest.quest_id = dsp.quest.id.sandoria.THE_BRUGAIRE_CONSORTIUM
 thisQuest.string_key = dsp.quest.string.sandoria[thisQuest.quest_id]
 
 thisQuest.repeatable = false
-thisQuest.var_prefix = "[Q]["..thisQuest.log_id.."]["..thisQuest.quest_id.."]"
+thisQuest.var_prefix = "[Q]["..thisQuest.log.."]["..thisQuest.quest_id.."]"
 thisQuest.vars =
 {
     stage = thisQuest.var_prefix,


### PR DESCRIPTION
### **The problem (can skip if you've seen my ramblings about Halver on Discord):**
- Missions are more important than quests.
- Sometimes NPCs will have mission/quest-specific "flavor" dialogue in response to your current progress
- If we choose the first event in a quest list that the player qualifies for, it would sometimes be these "worthless" flavor events, instead of events that progress other missions/quests
- The above is not retail behavior. And neither would be choosing each qualified event once in a looping fashion.

Take Halver, for example, when you've started San d'Oria Mission 5-2, The Shadow Lord, and have also not yet completed the quest "Fit for a Prince". This is the retail behavior for how Halver chooses events in response to your onTrigger:

1. When you enter, you are on stage X of San d'Oria 5-2. You go in, talk to Halver, and San d'Oria  5-2 takes priority, plays a CS, and advances you straight to stage X+1.
2. While on Stage X+1, Halver has dialogue telling you where Trion is
3. However, that dialogue _won't_ be given to you until after you deal with Fit for a Prince for that zone: every time you speak to Halver, he will offer you the quest, and then keep offering it to you until you accept it
4. Once you have Fit for a Prince accepted, Halver won't do any of his flavor dialogue ("Trion is in his chambers") for Sandy 5-2 Stage X+1. Instead he'll remind you of the girl you're looking for, and give you the chance to give up.
5. Once you've given up, _then_ he'll give you his Sandy 5-2 flavor dialogue because you're on stage X+1 - that Trion is in his chamber.

When NPCs are scripted in a linear fashion with all their quest and mission logic in long if-else chains, this behavior can be scripted relatively trivially. But with quest logic separated into their own files and completely agnostic of each other, making sure the right event is chosen is more difficult.

### The solution:
Implement a system that lets the scripter define what kind of priority an event should have, making the `involvedQuests` object choose the _best_ qualifying event to be seen, rather than just the first. Or, this PR!

On an `involvedQuests` check, a "rolling" check will be done, keeping track of the "highest event type" event as the entire list is checked. Each event is checked against appropriate tracking variables (almost all of them not-Lua-local) - which are automatically updated by the quest system itself - to ensure that the event is only chosen under conditions where it "should" be, like "once per zone" or "every other time the player talks to the NPC".

| eventType | description|
| --- | --- |
| NEVER | The event will never be chosen, even if the player meets the conditions for it. As a nice side effect, this can be used to disable entire quests by just changing the quest's "starting" event to `eventType.NEVER` |
| DEFAULT | Will be chosen if no other qualifying onTrigger takes precedence. This is "default dialogue" or "flavor dialogue". This would Halver's event about Trion being in his chambers. |
| CYCLE | Shares being chosen among other events of `eventType.CYCLE`. Each event of this type that the player qualifies for will be chosen in succession across multiple onTriggers, looping back to the first event when the player has seen them all once. If the player only qualifies for one `CYCLE` event, that event will be chosen repeatedly unless overridden by a "higher priority" eventType. |
| TOGGLE | The event is chosen once, not chosen on the next onTrigger, but is chosen again on the onTrigger after that. Repeats this on/off behavior. NPCs who do things like only offer their quest _every other_ time the player talks to them (like shop NPCs) would use this |
| ZONE | Only chosen one time for each time the player zones. One-time-per-zone reminders, like some of Cid's quests, would make use of this, as would NPCs that only offer their quest once and don't offer again until the player zones (like Zalsuhm) |
| ONCE | Only chooses the event once, "ever". However, **this should not be used if an event is merely advancing a quest's stage**. It should only be used for events that _do not_ advance a stage, but for some reason, only play once. So if you're using this, chances are you're doing something wrong. <br /><br />This uses a char_var to remember that the player has seen the event. _But don't freak out - when a quest is completed, the char_var is cleared_. Of course, to make sure the var is cleared, quests that utilize this behavior (which in reality would be _very, very_ few) need to define a table in their quest file for them. Defining this table before using this eventType isn't strictly enforced  by code at the moment, but _could_ be if there's concern over one of these slipping past code review. |
| ALWAYS | This overrides all other eventTypes, and would best be used for events which start or advance a quest. Examples of these would be talking to Halver to start a mission, or him constantly offering you Fit for a Prince. While `eventType.ALWAYS` events are the highest "event type priority", the quest system does not select same-level events after an event of that level is tracked as the current selection; so if the player qualifies for multiple `ALWAYS` (starting mission and a quest), the event chosen will be the one listed first in the `involvedQuests` table (hopefully the mission). |

Declaring one of these types is simple when using the (now required) `quest.StartEvent()` method!
`thisQuest.startEvent(player, id, {params}, dsp.quest.eventType.ZONE)`
See? Easy peasy.

"But what if I don't feel like defining an eventType?!"
That's cool too, the event wrapper automatically assigns events without defined types to be `dsp.quest.eventType.DEFAULT`:
`thisQuest.startEvent(player, id)`

Oh, and I apparently did a commit on my branch to change `log_id` to just `log`. I was probably planning on changing `quest_id` to just `id` as well, but that can be done later.

edit: And I guess put in some logic for `dsp.quest.stage.COMPLETE` usage. This is meant for a NPC's default dialogue changing after you complete a quest/mission: "Thank you for saving my baby, I'll never forget it!"

### Future Quest Rewrite Plans
- Merge master into quest_rewrite and bring it up to date again
- Python quest variable migration system
- Various bits and bobs, like the aforementioned shortening of references, and maybe another method or two for bitmasks

(It would be quite nice if quest_rewrite was merged into master before December...!)