### PR TITLE
Update modus_veritas.lua

### DIFF
--- a/scripts/globals/abilities/modus_veritas.lua
+++ b/scripts/globals/abilities/modus_veritas.lua
@@ -11,33 +11,33 @@ require("scripts/globals/magic")
 require("scripts/globals/msg")
 -----------------------------------
 
-function onAbilityCheck(player,target,ability)
-    return 0,0
+function onAbilityCheck(player, target, ability)
+    return 0, 0
 end
 
-function onUseAbility(player,target,ability)
+function onUseAbility(player, target, ability)
     local helix = target:getStatusEffect(dsp.effect.HELIX)
-    if (helix ~= nil) then
+    if helix ~= nil then
         local mvPower = helix:getSubPower()
-        local resist = applyResistanceAbility(player,target,dsp.magic.ele.NONE,dsp.skill.ELEMENTAL_MAGIC,0) -- seems reasonable...
+        local resist = applyResistanceAbility(player, target, dsp.magic.ele.NONE, dsp.skill.ELEMENTAL_MAGIC, 0) -- seems reasonable...
         -- Doesn't work against NMs apparently
-        if (mvPower > 0) or (resist < 0.25) or (target:isNM()) then -- Don't let Modus Veritas stack to prevent abuse
+        if mvPower > 0 or resist < 0.25 or target:isNM() then -- Don't let Modus Veritas stack to prevent abuse
             ability:setMsg(dsp.msg.basic.JA_MISS) --Miss
             return 0
         else
             -- Double power and halve remaining time
             local mvMerits = player:getMerit(dsp.merit.MODUS_VERITAS_DURATION)
             local durationMultiplier = 0.5 + (0.05 * mvMerits)
-            mvPower = mvPower +1
+            mvPower = mvPower + 1
             local helixPower = helix:getPower() * 2
             local duration = helix:getDuration()
-            local remaining = math.floor(helix:getTimeRemaining()/1000) -- from milliseconds
-			--print(string.format("helix original stats ... dot: %i, duration: %i, remaining: %i",helixPower/2,duration,remaining))
+            local remaining = math.floor(helix:getTimeRemaining() / 1000) -- from milliseconds
+            -- print(string.format("helix original dot stats: %i, duration: %i, remaining: %i", helixPower / 2, duration, remaining))
             duration = (duration-remaining) + math.floor(remaining * durationMultiplier)
-			--print(string.format("helix new stats ... dot: %i, remaining: %i",helixPower,duration))
+            -- print(string.format("helix new dot stats: %i, remaining: %i", helixPower, duration))
             helix:setSubPower(mvPower)
             helix:setPower(helixPower)
-            helix:setDuration(duration*1000) -- back to milliseconds
+            helix:setDuration(duration * 1000) -- back to milliseconds
         end
     else
         ability:setMsg(dsp.msg.basic.JA_NO_EFFECT_2) -- No effect

--- a/scripts/globals/abilities/modus_veritas.lua
+++ b/scripts/globals/abilities/modus_veritas.lua
@@ -31,11 +31,13 @@ function onUseAbility(player,target,ability)
             mvPower = mvPower +1
             local helixPower = helix:getPower() * 2
             local duration = helix:getDuration()
-            local remaining = helix:getTimeRemaining()
+            local remaining = math.floor(helix:getTimeRemaining()/1000) -- from milliseconds
+			--print(string.format("helix original stats ... dot: %i, duration: %i, remaining: %i",helixPower/2,duration,remaining))
             duration = (duration-remaining) + math.floor(remaining * durationMultiplier)
+			--print(string.format("helix new stats ... dot: %i, remaining: %i",helixPower,duration))
             helix:setSubPower(mvPower)
             helix:setPower(helixPower)
-            helix:setDuration(duration)
+            helix:setDuration(duration*1000) -- back to milliseconds
         end
     else
         ability:setMsg(dsp.msg.basic.JA_NO_EFFECT_2) -- No effect


### PR DESCRIPTION
lua spell functions "getTimeRemaining()" and "setDuration()" return and take arguments in milliseconds. original author wrote in assuming they were in seconds. net result was line 35's (duration-remaining) turning out to be a negative number (since remaining was an integer in the tens of thousands)... negative duration remaining meaning it'll last forever. simple fix here just converting to and from milliseconds/seconds for the calculations with some commented out print functions i used in testing for extra zazz