### PR TITLE
Added afterZoneIn and style guide fix

### DIFF
--- a/scripts/zones/Metalworks/Zone.lua
+++ b/scripts/zones/Metalworks/Zone.lua
@@ -5,28 +5,36 @@
 -----------------------------------
 local ID = require("scripts/zones/Metalworks/IDs")
 require("scripts/globals/conquest")
+require("scripts/globals/keyitems")
 -----------------------------------
 
 function onInitialize(zone)
-end;
+end
 
 function onZoneIn(player,prevZone)
-    local cs = -1;
-    if (player:getXPos() == 0 and player:getYPos() == 0 and player:getZPos() == 0) then
-        player:setPos(-9.168,0,0.001,128);
+    local cs = -1
+    if player:getXPos() == 0 and player:getYPos() == 0 and player:getZPos() == 0 then
+        player:setPos(-9.168,0,0.001,128)
     end
-    return cs;
-end;
+    return cs
+end
+
+function afterZoneIn(player)
+    if player:hasKeyItem(dsp.ki.MESSAGE_TO_JEUNO_BASTOK) then
+        player:ChangeMusic(0,161)   --  Despair
+        player:ChangeMusic(1,161)   --  Despair
+    end
+end
 
 function onConquestUpdate(zone, updatetype)
     dsp.conq.onConquestUpdate(zone, updatetype)
-end;
+end
 
 function onRegionEnter(player,region)
-end;
+end
 
 function onEventUpdate(player,csid,option)
-end;
+end
 
 function onEventFinish(player,csid,option)
-end;
+end


### PR DESCRIPTION
This zone has to change music while holding key item MESSAGE TO JEUNO (BASTOK)
Unfortunately this cannot be done in onZoneIn, tried it and music will stay the default.
If added to on afterZoneIn, this will work but will make the default metalwork music 
be heard for about .5 seconds before switching to correct one.
Besides this, went ahead and removed semicolons and parenthesis in if statements
according to style guide preference.