### PR TITLE
Nagi - Augments Mijin Gakure

### DIFF
--- a/scripts/globals/abilities/mijin_gakure.lua
+++ b/scripts/globals/abilities/mijin_gakure.lua
@@ -25,6 +25,10 @@ function onUseAbility(player,target,ability)
     target:takeDamage(dmg, player, dsp.attackType.SPECIAL, dsp.damageType.ELEMENTAL)
 
     player:setLocalVar("MijinGakure", 1)
+    if (player:getMod(dsp.mod.MIJIN_NAGI) > 0) then
+        player:delStatusEffect(dsp.effect.RERAISE)
+        player:addStatusEffect(dsp.effect.RERAISE,1,0,3600)
+    end
     player:setHP(0)
     return dmg
 end

--- a/scripts/globals/abilities/mijin_gakure.lua
+++ b/scripts/globals/abilities/mijin_gakure.lua
@@ -25,9 +25,8 @@ function onUseAbility(player,target,ability)
     target:takeDamage(dmg, player, dsp.attackType.SPECIAL, dsp.damageType.ELEMENTAL)
 
     player:setLocalVar("MijinGakure", 1)
-    if (player:getMod(dsp.mod.MIJIN_NAGI) > 0) then
-        player:delStatusEffect(dsp.effect.RERAISE)
-        player:addStatusEffect(dsp.effect.RERAISE,1,0,3600)
+    if (player:getMod(dsp.mod.MIJIN_RERAISE) > 0) then
+        player:sendReraise(1)
     end
     player:setHP(0)
     return dmg

--- a/scripts/globals/abilities/mijin_gakure.lua
+++ b/scripts/globals/abilities/mijin_gakure.lua
@@ -25,9 +25,6 @@ function onUseAbility(player,target,ability)
     target:takeDamage(dmg, player, dsp.attackType.SPECIAL, dsp.damageType.ELEMENTAL)
 
     player:setLocalVar("MijinGakure", 1)
-    if (player:getMod(dsp.mod.MIJIN_RERAISE) > 0) then
-        player:sendReraise(1)
-    end
     player:setHP(0)
     return dmg
 end

--- a/scripts/globals/status.lua
+++ b/scripts/globals/status.lua
@@ -1538,12 +1538,13 @@ dsp.mod =
     BERSERK_DURATION                = 954, -- Berserk Duration
     AGGRESSOR_DURATION              = 955, -- Aggressor Duration
     DEFENDER_DURATION               = 956, -- Defender Duration
+    MIJIN_NAGI                      = 957, -- Nagi - Reraise no weakness full HP
 
     -- The spares take care of finding the next ID to use so long as we don't forget to list IDs that have been freed up by refactoring.
     -- 570 - 825 used by WS DMG mods these are not spares.
-    -- SPARE = 957, -- stuff
     -- SPARE = 958, -- stuff
     -- SPARE = 959, -- stuff
+    -- SPARE = 960, -- stuff
 };
 
 dsp.latent =

--- a/scripts/globals/status.lua
+++ b/scripts/globals/status.lua
@@ -1105,7 +1105,7 @@ dsp.mod =
     DEATHRES                        = 255,
     AFTERMATH                       = 256,
     PARALYZE                        = 257,
-    MIJIN_GAKURE                    = 258,
+    MIJIN_RERAISE                   = 258,
     DUAL_WIELD                      = 259,
     DOUBLE_ATTACK                   = 288,
     SUBTLE_BLOW                     = 289,
@@ -1538,13 +1538,12 @@ dsp.mod =
     BERSERK_DURATION                = 954, -- Berserk Duration
     AGGRESSOR_DURATION              = 955, -- Aggressor Duration
     DEFENDER_DURATION               = 956, -- Defender Duration
-    MIJIN_NAGI                      = 957, -- Nagi - Reraise no weakness full HP
 
     -- The spares take care of finding the next ID to use so long as we don't forget to list IDs that have been freed up by refactoring.
     -- 570 - 825 used by WS DMG mods these are not spares.
+    -- SPARE = 957, -- stuff
     -- SPARE = 958, -- stuff
     -- SPARE = 959, -- stuff
-    -- SPARE = 960, -- stuff
 };
 
 dsp.latent =

--- a/sql/item_mods.sql
+++ b/sql/item_mods.sql
@@ -23427,7 +23427,7 @@ INSERT INTO `item_mods` VALUES (19003,27,10);   -- Nagi 75 - Enmity+10
 INSERT INTO `item_mods` VALUES (19003,30,10);   -- Magic Accuracy+10
 INSERT INTO `item_mods` VALUES (19003,256,29);  -- Aftermath
 INSERT INTO `item_mods` VALUES (19003,355,138); -- Blade: Kamu
-INSERT INTO `item_mods` VALUES (19003,957,1);   -- Augments Mijin Gakure
+INSERT INTO `item_mods` VALUES (19003,258,1);   -- Augments Mijin Gakure
 INSERT INTO `item_mods` VALUES (19004,256,29);  -- Ryunohige 75 - Aftermath
 INSERT INTO `item_mods` VALUES (19004,355,122); -- Drakesbane
 INSERT INTO `item_mods` VALUES (19004,828,1);   -- Augments jump attacks
@@ -23582,7 +23582,7 @@ INSERT INTO `item_mods` VALUES (19072,27,15);   -- Nagi 80 - Emnity +15
 INSERT INTO `item_mods` VALUES (19072,30,15);   -- Magic Accuracy +15
 INSERT INTO `item_mods` VALUES (19072,256,34);  -- Aftermath
 INSERT INTO `item_mods` VALUES (19072,355,138); -- Blade: Kamu
-INSERT INTO `item_mods` VALUES (19072,957,1);   -- Augments Mijin Gakure
+INSERT INTO `item_mods` VALUES (19072,258,1);   -- Augments Mijin Gakure
 INSERT INTO `item_mods` VALUES (19073,256,34); -- Ryunohige 80 - Aftermath
 INSERT INTO `item_mods` VALUES (19073,355,122); -- Drakesbane
 INSERT INTO `item_mods` VALUES (19073,362,12);  -- Augments Jump attacks II (Jump +12.5% Attack, rounded)
@@ -23662,7 +23662,7 @@ INSERT INTO `item_mods` VALUES (19092,27,20);   -- Nagi 85 - Enmity+20
 INSERT INTO `item_mods` VALUES (19092,30,20);   -- Magic Accuracy+20
 INSERT INTO `item_mods` VALUES (19092,256,34);  -- Aftermath
 INSERT INTO `item_mods` VALUES (19092,355,138); -- Blade: Kamu
-INSERT INTO `item_mods` VALUES (19092,957,1);   -- Augments Mijin Gakure
+INSERT INTO `item_mods` VALUES (19092,258,1);   -- Augments Mijin Gakure
 INSERT INTO `item_mods` VALUES (19093,256,34);  -- Ryunohige 85 - Aftermath
 INSERT INTO `item_mods` VALUES (19093,355,122); -- Drakesbane
 INSERT INTO `item_mods` VALUES (19093,362,20);  -- Augments Jump Attacks III (Attack+20%)
@@ -24125,7 +24125,7 @@ INSERT INTO `item_mods` VALUES (19624,30,25);   -- Magic Accuracy+25
 INSERT INTO `item_mods` VALUES (19624,256,34);  -- Aftermath
 INSERT INTO `item_mods` VALUES (19624,355,138); -- Blade: Kamu
 INSERT INTO `item_mods` VALUES (19624,708,15);  -- Blade: Kamu WS DMG +15%
-INSERT INTO `item_mods` VALUES (19624,957,1);   -- Augments Mijin Gakure
+INSERT INTO `item_mods` VALUES (19624,258,1);   -- Augments Mijin Gakure
 INSERT INTO `item_mods` VALUES (19625,256,34);  -- Ryunohige 90 - Aftermath
 INSERT INTO `item_mods` VALUES (19625,355,122); -- Drakesbane
 INSERT INTO `item_mods` VALUES (19625,362,30);  -- Augments "Jump" attacks IV (Attack+30%)
@@ -24270,7 +24270,7 @@ INSERT INTO `item_mods` VALUES (19722,30,25);   -- Magic Accuracy+25
 INSERT INTO `item_mods` VALUES (19722,256,39);  -- Aftermath
 INSERT INTO `item_mods` VALUES (19722,355,138); -- Blade: Kamu
 INSERT INTO `item_mods` VALUES (19722,708,15);  -- Blade: Kamu WS DMG +15%
-INSERT INTO `item_mods` VALUES (19722,957,1);   -- Augments Mijin Gakure
+INSERT INTO `item_mods` VALUES (19722,258,1);   -- Augments Mijin Gakure
 INSERT INTO `item_mods` VALUES (19723,256,39);  -- Ryunohige 95 - Aftermath
 INSERT INTO `item_mods` VALUES (19723,355,122); -- Drakesbane
 INSERT INTO `item_mods` VALUES (19723,362,30);  -- Augments "Jump" attacks IV (Attack+30%)
@@ -24589,7 +24589,7 @@ INSERT INTO `item_mods` VALUES (19831,30,30);   -- Magic Accuracy+30
 INSERT INTO `item_mods` VALUES (19831,256,39);  -- Aftermath
 INSERT INTO `item_mods` VALUES (19831,355,138); -- Blade: Kamu
 INSERT INTO `item_mods` VALUES (19831,708,30);  -- Blade: Kamu WS DMG +30%
-INSERT INTO `item_mods` VALUES (19831,957,1);   -- Augments Mijin Gakure
+INSERT INTO `item_mods` VALUES (19831,258,1);   -- Augments Mijin Gakure
 INSERT INTO `item_mods` VALUES (19832,256,39);  -- Ryunohige 99 - Aftermath
 INSERT INTO `item_mods` VALUES (19832,355,122); -- Drakesbane
 INSERT INTO `item_mods` VALUES (19832,362,35);  -- Augments jump attacks V (Attack+35%)
@@ -24833,7 +24833,7 @@ INSERT INTO `item_mods` VALUES (19960,30,30);   -- Magic Accuracy+30
 INSERT INTO `item_mods` VALUES (19960,256,39);  -- Aftermath
 INSERT INTO `item_mods` VALUES (19960,355,138); -- Blade: Kamu
 INSERT INTO `item_mods` VALUES (19960,708,30);  -- Blade: Kamu WS DMG +30%
-INSERT INTO `item_mods` VALUES (19960,957,1);   -- Augments Mijin Gakure
+INSERT INTO `item_mods` VALUES (19960,258,1);   -- Augments Mijin Gakure
 INSERT INTO `item_mods` VALUES (19961,256,39);  -- Ryunohige 99 AG - Aftermath
 INSERT INTO `item_mods` VALUES (19961,355,122); -- Drakesbane
 INSERT INTO `item_mods` VALUES (19961,362,35);  -- Augments jump attacks V (Attack+35%)
@@ -25592,13 +25592,13 @@ INSERT INTO `item_mods` VALUES (20972,30,30);   -- Magic Accuracy+30
 INSERT INTO `item_mods` VALUES (20972,256,39);  -- Aftermath
 INSERT INTO `item_mods` VALUES (20972,355,138); -- Blade: Kamu
 INSERT INTO `item_mods` VALUES (20972,708,30);  -- Blade: Kamu WS DMG +30%
-INSERT INTO `item_mods` VALUES (20972,957,1);   -- Augments Mijin Gakure
+INSERT INTO `item_mods` VALUES (20972,258,1);   -- Augments Mijin Gakure
 INSERT INTO `item_mods` VALUES (20973,27,30);   -- Nagi 119 AG - Enmity+30
 INSERT INTO `item_mods` VALUES (20973,30,30);   -- Magic Accuracy+30
 INSERT INTO `item_mods` VALUES (20973,256,39);  -- Aftermath
 INSERT INTO `item_mods` VALUES (20973,355,138); -- Blade: Kamu
 INSERT INTO `item_mods` VALUES (20973,708,30);  -- Blade: Kamu WS DMG +30%
-INSERT INTO `item_mods` VALUES (20973,957,1);   -- Augments Mijin Gakure
+INSERT INTO `item_mods` VALUES (20973,258,1);   -- Augments Mijin Gakure
 INSERT INTO `item_mods` VALUES (20974,11,20);   -- Kannagi 119 - AGI+20
 INSERT INTO `item_mods` VALUES (20974,256,44);  -- Aftermath
 INSERT INTO `item_mods` VALUES (20974,355,140); -- Blade: Hi
@@ -27040,7 +27040,7 @@ INSERT INTO `item_mods` VALUES (21907,256,39);    -- Aftermath
 INSERT INTO `item_mods` VALUES (21907,311,186);   -- Magic Damage+186
 INSERT INTO `item_mods` VALUES (21907,355,138);   -- Blade: Kamu
 INSERT INTO `item_mods` VALUES (21907,708,30);    -- Blade: Kamu WS DMG +30%
-INSERT INTO `item_mods` VALUES (21907,957,1);     -- Augments Mijin Gakure
+INSERT INTO `item_mods` VALUES (21907,258,1);     -- Augments Mijin Gakure
 INSERT INTO `item_mods` VALUES (21908,11,50);     -- Kannagi 119 III - AGI +50
 INSERT INTO `item_mods` VALUES (21908,256,45);    -- Aftermath
 INSERT INTO `item_mods` VALUES (21908,311,186);   -- Magic Damage+186

--- a/sql/item_mods.sql
+++ b/sql/item_mods.sql
@@ -23427,6 +23427,7 @@ INSERT INTO `item_mods` VALUES (19003,27,10);   -- Nagi 75 - Enmity+10
 INSERT INTO `item_mods` VALUES (19003,30,10);   -- Magic Accuracy+10
 INSERT INTO `item_mods` VALUES (19003,256,29);  -- Aftermath
 INSERT INTO `item_mods` VALUES (19003,355,138); -- Blade: Kamu
+INSERT INTO `item_mods` VALUES (19003,957,1);   -- Augments Mijin Gakure
 INSERT INTO `item_mods` VALUES (19004,256,29);  -- Ryunohige 75 - Aftermath
 INSERT INTO `item_mods` VALUES (19004,355,122); -- Drakesbane
 INSERT INTO `item_mods` VALUES (19004,828,1);   -- Augments jump attacks
@@ -23581,6 +23582,7 @@ INSERT INTO `item_mods` VALUES (19072,27,15);   -- Nagi 80 - Emnity +15
 INSERT INTO `item_mods` VALUES (19072,30,15);   -- Magic Accuracy +15
 INSERT INTO `item_mods` VALUES (19072,256,34);  -- Aftermath
 INSERT INTO `item_mods` VALUES (19072,355,138); -- Blade: Kamu
+INSERT INTO `item_mods` VALUES (19072,957,1);   -- Augments Mijin Gakure
 INSERT INTO `item_mods` VALUES (19073,256,34); -- Ryunohige 80 - Aftermath
 INSERT INTO `item_mods` VALUES (19073,355,122); -- Drakesbane
 INSERT INTO `item_mods` VALUES (19073,362,12);  -- Augments Jump attacks II (Jump +12.5% Attack, rounded)
@@ -23660,6 +23662,7 @@ INSERT INTO `item_mods` VALUES (19092,27,20);   -- Nagi 85 - Enmity+20
 INSERT INTO `item_mods` VALUES (19092,30,20);   -- Magic Accuracy+20
 INSERT INTO `item_mods` VALUES (19092,256,34);  -- Aftermath
 INSERT INTO `item_mods` VALUES (19092,355,138); -- Blade: Kamu
+INSERT INTO `item_mods` VALUES (19092,957,1);   -- Augments Mijin Gakure
 INSERT INTO `item_mods` VALUES (19093,256,34);  -- Ryunohige 85 - Aftermath
 INSERT INTO `item_mods` VALUES (19093,355,122); -- Drakesbane
 INSERT INTO `item_mods` VALUES (19093,362,20);  -- Augments Jump Attacks III (Attack+20%)
@@ -24122,6 +24125,7 @@ INSERT INTO `item_mods` VALUES (19624,30,25);   -- Magic Accuracy+25
 INSERT INTO `item_mods` VALUES (19624,256,34);  -- Aftermath
 INSERT INTO `item_mods` VALUES (19624,355,138); -- Blade: Kamu
 INSERT INTO `item_mods` VALUES (19624,708,15);  -- Blade: Kamu WS DMG +15%
+INSERT INTO `item_mods` VALUES (19624,957,1);   -- Augments Mijin Gakure
 INSERT INTO `item_mods` VALUES (19625,256,34);  -- Ryunohige 90 - Aftermath
 INSERT INTO `item_mods` VALUES (19625,355,122); -- Drakesbane
 INSERT INTO `item_mods` VALUES (19625,362,30);  -- Augments "Jump" attacks IV (Attack+30%)
@@ -24266,6 +24270,7 @@ INSERT INTO `item_mods` VALUES (19722,30,25);   -- Magic Accuracy+25
 INSERT INTO `item_mods` VALUES (19722,256,39);  -- Aftermath
 INSERT INTO `item_mods` VALUES (19722,355,138); -- Blade: Kamu
 INSERT INTO `item_mods` VALUES (19722,708,15);  -- Blade: Kamu WS DMG +15%
+INSERT INTO `item_mods` VALUES (19722,957,1);   -- Augments Mijin Gakure
 INSERT INTO `item_mods` VALUES (19723,256,39);  -- Ryunohige 95 - Aftermath
 INSERT INTO `item_mods` VALUES (19723,355,122); -- Drakesbane
 INSERT INTO `item_mods` VALUES (19723,362,30);  -- Augments "Jump" attacks IV (Attack+30%)
@@ -24584,6 +24589,7 @@ INSERT INTO `item_mods` VALUES (19831,30,30);   -- Magic Accuracy+30
 INSERT INTO `item_mods` VALUES (19831,256,39);  -- Aftermath
 INSERT INTO `item_mods` VALUES (19831,355,138); -- Blade: Kamu
 INSERT INTO `item_mods` VALUES (19831,708,30);  -- Blade: Kamu WS DMG +30%
+INSERT INTO `item_mods` VALUES (19831,957,1);   -- Augments Mijin Gakure
 INSERT INTO `item_mods` VALUES (19832,256,39);  -- Ryunohige 99 - Aftermath
 INSERT INTO `item_mods` VALUES (19832,355,122); -- Drakesbane
 INSERT INTO `item_mods` VALUES (19832,362,35);  -- Augments jump attacks V (Attack+35%)
@@ -24827,6 +24833,7 @@ INSERT INTO `item_mods` VALUES (19960,30,30);   -- Magic Accuracy+30
 INSERT INTO `item_mods` VALUES (19960,256,39);  -- Aftermath
 INSERT INTO `item_mods` VALUES (19960,355,138); -- Blade: Kamu
 INSERT INTO `item_mods` VALUES (19960,708,30);  -- Blade: Kamu WS DMG +30%
+INSERT INTO `item_mods` VALUES (19960,957,1);   -- Augments Mijin Gakure
 INSERT INTO `item_mods` VALUES (19961,256,39);  -- Ryunohige 99 AG - Aftermath
 INSERT INTO `item_mods` VALUES (19961,355,122); -- Drakesbane
 INSERT INTO `item_mods` VALUES (19961,362,35);  -- Augments jump attacks V (Attack+35%)
@@ -25585,11 +25592,13 @@ INSERT INTO `item_mods` VALUES (20972,30,30);   -- Magic Accuracy+30
 INSERT INTO `item_mods` VALUES (20972,256,39);  -- Aftermath
 INSERT INTO `item_mods` VALUES (20972,355,138); -- Blade: Kamu
 INSERT INTO `item_mods` VALUES (20972,708,30);  -- Blade: Kamu WS DMG +30%
+INSERT INTO `item_mods` VALUES (20972,957,1);   -- Augments Mijin Gakure
 INSERT INTO `item_mods` VALUES (20973,27,30);   -- Nagi 119 AG - Enmity+30
 INSERT INTO `item_mods` VALUES (20973,30,30);   -- Magic Accuracy+30
 INSERT INTO `item_mods` VALUES (20973,256,39);  -- Aftermath
 INSERT INTO `item_mods` VALUES (20973,355,138); -- Blade: Kamu
 INSERT INTO `item_mods` VALUES (20973,708,30);  -- Blade: Kamu WS DMG +30%
+INSERT INTO `item_mods` VALUES (20973,957,1);   -- Augments Mijin Gakure
 INSERT INTO `item_mods` VALUES (20974,11,20);   -- Kannagi 119 - AGI+20
 INSERT INTO `item_mods` VALUES (20974,256,44);  -- Aftermath
 INSERT INTO `item_mods` VALUES (20974,355,140); -- Blade: Hi
@@ -27031,6 +27040,7 @@ INSERT INTO `item_mods` VALUES (21907,256,39);    -- Aftermath
 INSERT INTO `item_mods` VALUES (21907,311,186);   -- Magic Damage+186
 INSERT INTO `item_mods` VALUES (21907,355,138);   -- Blade: Kamu
 INSERT INTO `item_mods` VALUES (21907,708,30);    -- Blade: Kamu WS DMG +30%
+INSERT INTO `item_mods` VALUES (21907,957,1);     -- Augments Mijin Gakure
 INSERT INTO `item_mods` VALUES (21908,11,50);     -- Kannagi 119 III - AGI +50
 INSERT INTO `item_mods` VALUES (21908,256,45);    -- Aftermath
 INSERT INTO `item_mods` VALUES (21908,311,186);   -- Magic Damage+186

--- a/src/map/entities/charentity.cpp
+++ b/src/map/entities/charentity.cpp
@@ -1492,7 +1492,7 @@ void CCharEntity::OnRaise()
 
         list.ActionTargetID = id;
         // Check for Nagi equipped (MOD) and Mijin Gakure was used.
-        if ((m_hasRaise == 1) && (GetLocalVar("MijinGakure") != 0) && (getMod(Mod::MIJIN_NAGI) != 0))
+        if (GetLocalVar("MijinGakure") != 0 && getMod(Mod::MIJIN_RERAISE) != 0)
         {
             actionTarget.animation = 511;
             hpReturned = (uint16)(GetMaxHP());

--- a/src/map/entities/charentity.cpp
+++ b/src/map/entities/charentity.cpp
@@ -1491,7 +1491,7 @@ void CCharEntity::OnRaise()
         auto& actionTarget = list.getNewActionTarget();
 
         list.ActionTargetID = id;
-        // Check for Nagi equipped (MOD) and Mijin Gakure was used.
+        // Mijin Gakure used with MIJIN_RERAISE MOD
         if (GetLocalVar("MijinGakure") != 0 && getMod(Mod::MIJIN_RERAISE) != 0)
         {
             actionTarget.animation = 511;
@@ -1678,6 +1678,10 @@ void CCharEntity::Die(duration _duration)
 
     if (this->getMod(Mod::RERAISE_III) > 0)
         m_hasRaise = 3;
+    // MIJIN_RERAISE checks
+    if (m_hasRaise == 0 && this->getMod(Mod::MIJIN_RERAISE) > 0)
+        m_hasRaise = 1;
+
     CBattleEntity::Die();
 }
 

--- a/src/map/entities/charentity.cpp
+++ b/src/map/entities/charentity.cpp
@@ -1491,7 +1491,13 @@ void CCharEntity::OnRaise()
         auto& actionTarget = list.getNewActionTarget();
 
         list.ActionTargetID = id;
-        if (m_hasRaise == 1)
+        // Check for Nagi equipped (MOD) and Mijin Gakure was used.
+        if ((m_hasRaise == 1) && (GetLocalVar("MijinGakure") != 0) && (getMod(Mod::MIJIN_NAGI) != 0))
+        {
+            actionTarget.animation = 511;
+            hpReturned = (uint16)(GetMaxHP());
+        }
+        else if (m_hasRaise == 1)
         {
             actionTarget.animation = 511;
             hpReturned = (uint16)((GetLocalVar("MijinGakure") != 0) ? GetMaxHP() * 0.5 : GetMaxHP() * 0.1);

--- a/src/map/modifier.h
+++ b/src/map/modifier.h
@@ -289,8 +289,7 @@ enum class Mod
     DEATHRES                  = 255, // Used by gear and ATMA that give resistance to instance KO
 
     PARALYZE                  = 257, // Paralyze -- percent chance to proc
-    MIJIN_GAKURE              = 258, // Tracks whether or not you used this ability to die.
-    MIJIN_NAGI                = 957, // Nagi Buff - Reraise no weakness full HP
+    MIJIN_RERAISE             = 258, // Augments Mijin Gakure
     DUAL_WIELD                = 259, // Percent reduction in dual wield delay.
 
     // Warrior
@@ -788,9 +787,9 @@ enum class Mod
 
     // The spares take care of finding the next ID to use so long as we don't forget to list IDs that have been freed up by refactoring.
     // 570 through 825 used by WS DMG mods these are not spares.
+    // SPARE = 957, // stuff
     // SPARE = 958, // stuff
     // SPARE = 959, // stuff
-    // SPARE = 960, // stuff
 };
 
 //temporary workaround for using enum class as unordered_map key until compilers support it

--- a/src/map/modifier.h
+++ b/src/map/modifier.h
@@ -290,6 +290,7 @@ enum class Mod
 
     PARALYZE                  = 257, // Paralyze -- percent chance to proc
     MIJIN_GAKURE              = 258, // Tracks whether or not you used this ability to die.
+    MIJIN_NAGI                = 957, // Nagi Buff - Reraise no weakness full HP
     DUAL_WIELD                = 259, // Percent reduction in dual wield delay.
 
     // Warrior
@@ -787,9 +788,9 @@ enum class Mod
 
     // The spares take care of finding the next ID to use so long as we don't forget to list IDs that have been freed up by refactoring.
     // 570 through 825 used by WS DMG mods these are not spares.
-    // SPARE = 957, // stuff
     // SPARE = 958, // stuff
     // SPARE = 959, // stuff
+    // SPARE = 960, // stuff
 };
 
 //temporary workaround for using enum class as unordered_map key until compilers support it


### PR DESCRIPTION
modifier.h and status.lua: Adds MOD 957 MIJIN_NAGI

item_mods.sql:  Adds MOD 957 with value of 1 to all variants of Nagi with
'Augments "Mijin Gakure"' text.

abilities/mijin_gakure.lua: Adds check for MIJIN_NAGI > 0 and remove any
existing reraise and apply a reraise effect if so.

map/entities/charentity.cpp: Adds a step to check if Mijin Gakure was
used AND a Nagi is equipped, when processing reraise.