### PR TITLE
Set Unarmed Default Skill to 1, not 0

### DIFF
--- a/src/map/utils/charutils.cpp
+++ b/src/map/utils/charutils.cpp
@@ -2310,7 +2310,7 @@ namespace charutils
 
         //add in melee ws
         PItem = dynamic_cast<CItemWeapon*>(PChar->getEquip(SLOT_MAIN));
-        uint8 skill = PItem ? PItem->getSkillType() : 0;
+        uint8 skill = PItem ? PItem->getSkillType() : 1;
         auto& WeaponSkillList = battleutils::GetWeaponSkills(skill);
         for (auto&& PSkill : WeaponSkillList)
         {

--- a/src/map/utils/charutils.cpp
+++ b/src/map/utils/charutils.cpp
@@ -2310,7 +2310,7 @@ namespace charutils
 
         //add in melee ws
         PItem = dynamic_cast<CItemWeapon*>(PChar->getEquip(SLOT_MAIN));
-        uint8 skill = PItem ? PItem->getSkillType() : 1;
+        uint8 skill = PItem ? PItem->getSkillType() : SKILL_HAND_TO_HAND;
         auto& WeaponSkillList = battleutils::GetWeaponSkills(skill);
         for (auto&& PSkill : WeaponSkillList)
         {


### PR DESCRIPTION
In response to issue #6264 , while unarmed, PItem initializes to null and therefore initializes skill to a default of 0. Since H2H weapon skills are Type ID 1, the for loop has nothing to iterate over within the global weapon skill list. 