### PR TITLE
fix prime avatars sending error messages to game server (also Ouryu)

### DIFF
--- a/scripts/zones/Cloister_of_Flames/mobs/Ifrit_Prime.lua
+++ b/scripts/zones/Cloister_of_Flames/mobs/Ifrit_Prime.lua
@@ -1,42 +1,39 @@
 -----------------------------------
 -- Area: Cloister of Flames
 --  Mob: Ifrit Prime
--- Involved in Quest: Trial by Fire
+-- Involved in Quest: Trial by Fire, Trial Size Trial by Fire
 -- Involved in Mission: ASA-4 Sugar Coated Directive
 -----------------------------------
-require("scripts/globals/settings");
-require("scripts/globals/keyitems");
-require("scripts/globals/status");
+require("scripts/globals/settings")
+require("scripts/globals/keyitems")
+require("scripts/globals/status")
 -----------------------------------
-
-function onMobFight(mob, target)
-    local mobId = mob:getID();
-
-    -- ASA-4: Astral Flow Behavior - Guaranteed to Use At Least 5 times before killable, at specified intervals.
-    if (mob:getBattlefield():getBcnmID() == 547 and mob:getCurrentAction() == dsp.act.ATTACK) then
-        local astralFlows = mob:getLocalVar("astralflows");
-        if ((astralFlows == 0 and mob:getHPP() <= 80)
-        or (astralFlows == 1 and mob:getHPP() <= 60)
-        or (astralFlows == 2 and mob:getHPP() <= 40)
-        or (astralFlows == 3 and mob:getHPP() <= 20)
-        or (astralFlows == 4 and mob:getHPP() <= 1)) then
-            mob:setLocalVar("astralflows",astralFlows + 1);
-            mob:useMobAbility(848);
-            if (astralFlows >= 5) then
-                mob:setUnkillable(false);
-            end
-        end
-    end
-
-end;
 
 function onMobSpawn(mob)
     -- ASA-4: Avatar is Unkillable Until Its Used Astral Flow At Least 5 times At Specified Intervals
-    if (mob:getBattlefield():getBcnmID() == 547) then
-        mob:setLocalVar("astralflows","0");
-        mob:setUnkillable(true);
+    if mob:getBattlefieldID() == 547 then
+        mob:setLocalVar("astralflows", 0)
+        mob:setUnkillable(true)
     end
-end;
+end
+
+function onMobFight(mob, target)
+    -- ASA-4: Astral Flow Behavior - Guaranteed to Use At Least 5 times before killable, at specified intervals.
+    if mob:getBattlefieldID() == 547 and mob:getCurrentAction() == dsp.act.ATTACK then
+        local astralFlows = mob:getLocalVar("astralflows")
+        if (astralFlows == 0 and mob:getHPP() <= 80)
+        or (astralFlows == 1 and mob:getHPP() <= 60)
+        or (astralFlows == 2 and mob:getHPP() <= 40)
+        or (astralFlows == 3 and mob:getHPP() <= 20)
+        or (astralFlows == 4 and mob:getHPP() <= 1) then
+            mob:setLocalVar("astralflows", astralFlows + 1)
+            mob:useMobAbility(848)
+            if astralFlows >= 5 then
+                mob:setUnkillable(false)
+            end
+        end
+    end
+end
 
 function onMobDeath(mob, player, isKiller)
-end;
+end

--- a/scripts/zones/Cloister_of_Frost/mobs/Shiva_Prime.lua
+++ b/scripts/zones/Cloister_of_Frost/mobs/Shiva_Prime.lua
@@ -1,42 +1,39 @@
 -----------------------------------
 -- Area: Cloister of Frost
 --  Mob: Shiva Prime
--- Involved in Quest: Trial by Ice
+-- Involved in Quest: Trial by Ice, Trial Size Trial by Ice
 -- Involved in Mission: ASA-4 Sugar Coated Directive
 -----------------------------------
-require("scripts/globals/settings");
-require("scripts/globals/keyitems");
-require("scripts/globals/status");
+require("scripts/globals/keyitems")
+require("scripts/globals/settings")
+require("scripts/globals/status")
 -----------------------------------
-
-function onMobFight(mob, target)
-    local mobId = mob:getID();
-
-    -- ASA-4: Astral Flow Behavior - Guaranteed to Use At Least 5 times before killable, at specified intervals.
-    if (mob:getBattlefield():getBcnmID() == 484 and mob:getCurrentAction() == dsp.act.ATTACK) then
-        local astralFlows = mob:getLocalVar("astralflows");
-        if ((astralFlows == 0 and mob:getHPP() <= 80)
-        or (astralFlows == 1 and mob:getHPP() <= 60)
-        or (astralFlows == 2 and mob:getHPP() <= 40)
-        or (astralFlows == 3 and mob:getHPP() <= 20)
-        or (astralFlows == 4 and mob:getHPP() <= 1)) then
-            mob:setLocalVar("astralflows",astralFlows + 1);
-            mob:useMobAbility(884);
-            if (astralFlows >= 5) then
-                mob:setUnkillable(false);
-            end
-        end
-    end
-
-end;
 
 function onMobSpawn(mob)
     -- ASA-4: Avatar is Unkillable Until Its Used Astral Flow At Least 5 times At Specified Intervals
-    if (mob:getBattlefield():getBcnmID() == 484) then
-        mob:setLocalVar("astralflows",0);
-        mob:setUnkillable(true);
+    if mob:getBattlefieldID() == 484 then
+        mob:setLocalVar("astralflows", 0)
+        mob:setUnkillable(true)
     end
-end;
+end
+
+function onMobFight(mob, target)
+    -- ASA-4: Astral Flow Behavior - Guaranteed to Use At Least 5 times before killable, at specified intervals.
+    if mob:getBattlefieldID() == 484 and mob:getCurrentAction() == dsp.act.ATTACK then
+        local astralFlows = mob:getLocalVar("astralflows")
+        if (astralFlows == 0 and mob:getHPP() <= 80)
+        or (astralFlows == 1 and mob:getHPP() <= 60)
+        or (astralFlows == 2 and mob:getHPP() <= 40)
+        or (astralFlows == 3 and mob:getHPP() <= 20)
+        or (astralFlows == 4 and mob:getHPP() <= 1) then
+            mob:setLocalVar("astralflows", astralFlows + 1)
+            mob:useMobAbility(884)
+            if astralFlows >= 5 then
+                mob:setUnkillable(false)
+            end
+        end
+    end
+end
 
 function onMobDeath(mob, player, isKiller)
-end;
+end

--- a/scripts/zones/Cloister_of_Gales/mobs/Garuda_Prime.lua
+++ b/scripts/zones/Cloister_of_Gales/mobs/Garuda_Prime.lua
@@ -1,73 +1,39 @@
 -----------------------------------
 -- Area: Cloister of Gales
 --  Mob: Garuda Prime
--- Involved in Quest: Trial by Wind
+-- Involved in Quest: Trial by Wind, Trial Size Trial by Wind
 -- Involved in Mission: ASA-4 Sugar Coated Directive
 -----------------------------------
-local ID = require("scripts/zones/Cloister_of_Gales/IDs")
-require("scripts/globals/settings");
-require("scripts/globals/keyitems");
-require("scripts/globals/status");
+require("scripts/globals/keyitems")
+require("scripts/globals/settings")
+require("scripts/globals/status")
 -----------------------------------
-
-function onMobFight(mob, target)
-    local mobId = mob:getID();
-
-    -- ASA-4: Astral Flow Behavior - Guaranteed to Use At Least 5 times before killable, at specified intervals.
-    if (mob:getBattlefield():getBcnmID() == 420 and mob:getCurrentAction() == dsp.act.ATTACK) then
-        local astralFlows = mob:getLocalVar("astralflows");
-        if ((astralFlows == 0 and mob:getHPP() <= 80)
-        or (astralFlows == 1 and mob:getHPP() <= 60)
-        or (astralFlows == 2 and mob:getHPP() <= 40)
-        or (astralFlows == 3 and mob:getHPP() <= 20)
-        or (astralFlows == 4 and mob:getHPP() <= 1)) then
-            mob:setLocalVar("astralflows",astralFlows + 1);
-            mob:useMobAbility(875);
-            if (astralFlows >= 5) then
-                mob:setUnkillable(false);
-            end
-        end
-    end
-
-end;
 
 function onMobSpawn(mob)
     -- ASA-4: Avatar is Unkillable Until Its Used Astral Flow At Least 5 times At Specified Intervals
-    if (mob:getBattlefield():getBcnmID() == 420) then
-        mob:setLocalVar("astralflows",0);
-        mob:setUnkillable(true);
+    if mob:getBattlefieldID() == 420 then
+        mob:setLocalVar("astralflows", 0)
+        mob:setUnkillable(true)
     end
-end;
+end
+
+function onMobFight(mob, target)
+    -- ASA-4: Astral Flow Behavior - Guaranteed to Use At Least 5 times before killable, at specified intervals.
+    if mob:getBattlefieldID() == 420 and mob:getCurrentAction() == dsp.act.ATTACK then
+        local astralFlows = mob:getLocalVar("astralflows")
+        if (astralFlows == 0 and mob:getHPP() <= 80)
+        or (astralFlows == 1 and mob:getHPP() <= 60)
+        or (astralFlows == 2 and mob:getHPP() <= 40)
+        or (astralFlows == 3 and mob:getHPP() <= 20)
+        or (astralFlows == 4 and mob:getHPP() <= 1) then
+            mob:setLocalVar("astralflows", astralFlows + 1)
+            mob:useMobAbility(875)
+            if astralFlows >= 5 then
+                mob:setUnkillable(false)
+            end
+        end
+    end
+end
 
 function onMobDeath(mob, player, isKiller)
-    if (mob:getBattlefield():getBcnmID() ~= 420) then
-        player:setCharVar("BCNM_Killed",1);
-        record = 300;
-        partyMembers = 6;
-        pZone = player:getZone();
-
-        player:startEvent(32001,0,record,0,(os.time() - player:getCharVar("BCNM_Timer")),partyMembers,0,0);
-    end
-end;
-
-function onEventUpdate(player,csid,option)
-    -- printf("onUpdate CSID: %u",csid);
-    -- printf("onUpdate RESULT: %u",option);
-
-    if (csid == 32001) then
-        player:delStatusEffect(dsp.effect.BATTLEFIELD);
-    end
-
-end;
-
-function onEventFinish(player,csid,option)
-    -- printf("onFinish CSID: %u",csid);
-    -- printf("onFinish RESULT: %u",option);
-
-    if (csid == 32001) then
-        player:delKeyItem(dsp.ki.TUNING_FORK_OF_WIND);
-        player:addKeyItem(dsp.ki.WHISPER_OF_GALES);
-        player:messageSpecial(ID.text.KEYITEM_OBTAINED,dsp.ki.WHISPER_OF_GALES);
-    end
-
-end;
+end

--- a/scripts/zones/Cloister_of_Storms/mobs/Ramuh_Prime.lua
+++ b/scripts/zones/Cloister_of_Storms/mobs/Ramuh_Prime.lua
@@ -1,52 +1,39 @@
 -----------------------------------
 -- Area: Cloister of Storms
 --  Mob: Ramuh Prime
--- Involved in Quest: Trial by Lightning
+-- Involved in Quest: Trial by Lightning, Trial Size Trial by Lightning
 -- Involved in Mission: ASA-4 Sugar Coated Directive
 -----------------------------------
-require("scripts/globals/settings");
-require("scripts/globals/keyitems");
-require("scripts/globals/status");
+require("scripts/globals/keyitems")
+require("scripts/globals/settings")
+require("scripts/globals/status")
 -----------------------------------
-
-function onMobFight(mob, target)
-    local mobId = mob:getID();
-
-    -- ASA-4: Astral Flow Behavior - Guaranteed to Use At Least 5 times before killable, at specified intervals.
-    if (mob:getBattlefield():getBcnmID() == 452 and mob:getCurrentAction() == dsp.act.ATTACK) then
-        local astralFlows = mob:getLocalVar("astralflows");
-        if ((astralFlows == 0 and mob:getHPP() <= 80)
-        or (astralFlows == 1 and mob:getHPP() <= 60)
-        or (astralFlows == 2 and mob:getHPP() <= 40)
-        or (astralFlows == 3 and mob:getHPP() <= 20)
-        or (astralFlows == 4 and mob:getHPP() <= 1)) then
-            mob:setLocalVar("astralflows",astralFlows + 1);
-            mob:useMobAbility(893);
-            if (astralFlows >= 5) then
-                mob:setUnkillable(false);
-            end
-        end
-    end
-
-end;
 
 function onMobSpawn(mob)
     -- ASA-4: Avatar is Unkillable Until Its Used Astral Flow At Least 5 times At Specified Intervals
-    if (mob:getBattlefield():getBcnmID() == 452) then
-        mob:setLocalVar("astralflows","0");
-        mob:setUnkillable(true);
+    if mob:getBattlefieldID() == 452 then
+        mob:setLocalVar("astralflows", 0)
+        mob:setUnkillable(true)
     end
-end;
+end
+
+function onMobFight(mob, target)
+    -- ASA-4: Astral Flow Behavior - Guaranteed to Use At Least 5 times before killable, at specified intervals.
+    if mob:getBattlefieldID() == 452 and mob:getCurrentAction() == dsp.act.ATTACK then
+        local astralFlows = mob:getLocalVar("astralflows")
+        if (astralFlows == 0 and mob:getHPP() <= 80)
+        or (astralFlows == 1 and mob:getHPP() <= 60)
+        or (astralFlows == 2 and mob:getHPP() <= 40)
+        or (astralFlows == 3 and mob:getHPP() <= 20)
+        or (astralFlows == 4 and mob:getHPP() <= 1) then
+            mob:setLocalVar("astralflows", astralFlows + 1)
+            mob:useMobAbility(893)
+            if astralFlows >= 5 then
+                mob:setUnkillable(false)
+            end
+        end
+    end
+end
 
 function onMobDeath(mob, player, isKiller)
-end;
-
-function onEventUpdate(player,csid,option)
-    -- printf("onUpdate CSID: %u",csid);
-    -- printf("onUpdate RESULT: %u",option);
-end;
-
-function onEventFinish(player,csid,option)
-    -- printf("onFinish CSID: %u",csid);
-    -- printf("onFinish RESULT: %u",option);
-end;
+end

--- a/scripts/zones/Cloister_of_Tides/mobs/Leviathan_Prime.lua
+++ b/scripts/zones/Cloister_of_Tides/mobs/Leviathan_Prime.lua
@@ -4,39 +4,36 @@
 -- Involved in Quest: Trial by Water, Trial Size Trial by Water
 -- Involved in Mission: ASA-4 Sugar Coated Directive
 -----------------------------------
-require("scripts/globals/settings");
-require("scripts/globals/keyitems");
-require("scripts/globals/status");
+require("scripts/globals/keyitems")
+require("scripts/globals/settings")
+require("scripts/globals/status")
 -----------------------------------
-
-function onMobFight(mob, target)
-    local mobId = mob:getID();
-
-    -- ASA-4: Astral Flow Behavior - Guaranteed to Use At Least 5 times before killable, at specified intervals.
-    if (mob:getBattlefield():getBcnmID() == 611 and mob:getCurrentAction() == dsp.act.ATTACK) then
-        local astralFlows = mob:getLocalVar("astralflows");
-        if ((astralFlows == 0 and mob:getHPP() <= 80)
-        or (astralFlows == 1 and mob:getHPP() <= 60)
-        or (astralFlows == 2 and mob:getHPP() <= 40)
-        or (astralFlows == 3 and mob:getHPP() <= 20)
-        or (astralFlows == 4 and mob:getHPP() <= 1)) then
-            mob:setLocalVar("astralflows",astralFlows + 1);
-            mob:useMobAbility(866);
-            if (astralFlows >= 5) then
-                mob:setUnkillable(false);
-            end
-        end
-    end
-
-end;
 
 function onMobSpawn(mob)
     -- ASA-4: Avatar is Unkillable Until Its Used Astral Flow At Least 5 times At Specified Intervals
-    if (mob:getBattlefield():getBcnmID() == 611) then
-        mob:setLocalVar("astralflows","0");
-        mob:setUnkillable(true);
+    if mob:getBattlefieldID() == 611 then
+        mob:setLocalVar("astralflows", 0)
+        mob:setUnkillable(true)
     end
-end;
+end
+
+function onMobFight(mob, target)
+    -- ASA-4: Astral Flow Behavior - Guaranteed to Use At Least 5 times before killable, at specified intervals.
+    if mob:getBattlefieldID() == 611 and mob:getCurrentAction() == dsp.act.ATTACK then
+        local astralFlows = mob:getLocalVar("astralflows")
+        if (astralFlows == 0 and mob:getHPP() <= 80)
+        or (astralFlows == 1 and mob:getHPP() <= 60)
+        or (astralFlows == 2 and mob:getHPP() <= 40)
+        or (astralFlows == 3 and mob:getHPP() <= 20)
+        or (astralFlows == 4 and mob:getHPP() <= 1) then
+            mob:setLocalVar("astralflows", astralFlows + 1)
+            mob:useMobAbility(866)
+            if astralFlows >= 5 then
+                mob:setUnkillable(false)
+            end
+        end
+    end
+end
 
 function onMobDeath(mob, player, isKiller)
-end;
+end

--- a/scripts/zones/Cloister_of_Tremors/mobs/Titan_Prime.lua
+++ b/scripts/zones/Cloister_of_Tremors/mobs/Titan_Prime.lua
@@ -1,72 +1,39 @@
 -----------------------------------
 -- Area: Cloister of Tremors
 --  Mob: Titan Prime
--- Involved in Quest: Trial by Earth
+-- Involved in Quest: Trial by Earth, Trial Size Trial by Earth
 -- Involved in Mission: ASA-4 Sugar Coated Directive
 -----------------------------------
-local ID = require("scripts/zones/Cloister_of_Tremors/IDs")
-require("scripts/globals/settings");
-require("scripts/globals/keyitems");
-require("scripts/globals/status");
+require("scripts/globals/keyitems")
+require("scripts/globals/settings")
+require("scripts/globals/status")
 -----------------------------------
-
-function onMobFight(mob, target)
-    local mobId = mob:getID();
-
-    -- ASA-4: Astral Flow Behavior - Guaranteed to Use At Least 5 times before killable, at specified intervals.
-    if (mob:getBattlefield():getBcnmID() == 580 and mob:getCurrentAction() == dsp.act.ATTACK) then
-        local astralFlows = mob:getLocalVar("astralflows");
-        if ((astralFlows == 0 and mob:getHPP() <= 80)
-        or (astralFlows == 1 and mob:getHPP() <= 60)
-        or (astralFlows == 2 and mob:getHPP() <= 40)
-        or (astralFlows == 3 and mob:getHPP() <= 20)
-        or (astralFlows == 4 and mob:getHPP() <= 1)) then
-            mob:setLocalVar("astralflows",astralFlows + 1);
-            mob:useMobAbility(857);
-            if (astralFlows >= 5) then
-                mob:setUnkillable(false);
-            end
-        end
-    end
-end;
 
 function onMobSpawn(mob)
     -- ASA-4: Avatar is Unkillable Until Its Used Astral Flow At Least 5 times At Specified Intervals
-    if (mob:getBattlefield():getBcnmID() == 580) then
-        mob:setLocalVar("astralflows",0);
-        mob:setUnkillable(true);
+    if mob:getBattlefieldID() == 580 then
+        mob:setLocalVar("astralflows", 0)
+        mob:setUnkillable(true)
     end
-end;
+end
+
+function onMobFight(mob, target)
+    -- ASA-4: Astral Flow Behavior - Guaranteed to Use At Least 5 times before killable, at specified intervals.
+    if mob:getBattlefieldID() == 580 and mob:getCurrentAction() == dsp.act.ATTACK then
+        local astralFlows = mob:getLocalVar("astralflows")
+        if (astralFlows == 0 and mob:getHPP() <= 80)
+        or (astralFlows == 1 and mob:getHPP() <= 60)
+        or (astralFlows == 2 and mob:getHPP() <= 40)
+        or (astralFlows == 3 and mob:getHPP() <= 20)
+        or (astralFlows == 4 and mob:getHPP() <= 1) then
+            mob:setLocalVar("astralflows", astralFlows + 1)
+            mob:useMobAbility(857)
+            if astralFlows >= 5 then
+                mob:setUnkillable(false)
+            end
+        end
+    end
+end
 
 function onMobDeath(mob, player, isKiller)
-    if (mob:getBattlefield():getBcnmID()~= 580) then
-        player:setCharVar("BCNM_Killed",1);
-        record = 300;
-        partyMembers = 6;
-        pZone = player:getZone();
-
-        player:startEvent(32001,0,record,0,(os.time() - player:getCharVar("BCNM_Timer")),partyMembers,0,0);
-    end
-end;
-
-function onEventUpdate(player,csid,option)
-    -- printf("onUpdate CSID: %u",csid);
-    -- printf("onUpdate RESULT: %u",option);
-
-    if (csid == 32001) then
-        player:delStatusEffect(dsp.effect.BATTLEFIELD);
-    end
-
-end;
-
-function onEventFinish(player,csid,option)
-    -- printf("onFinish CSID: %u",csid);
-    -- printf("onFinish RESULT: %u",option);
-
-    if (csid == 32001) then
-        player:delKeyItem(dsp.ki.TUNING_FORK_OF_EARTH);
-        player:addKeyItem(dsp.ki.WHISPER_OF_TREMORS);
-        player:messageSpecial(ID.text.KEYITEM_OBTAINED,dsp.ki.WHISPER_OF_TREMORS);
-    end
-
-end;
+end

--- a/scripts/zones/Monarch_Linn/mobs/Ouryu.lua
+++ b/scripts/zones/Monarch_Linn/mobs/Ouryu.lua
@@ -13,7 +13,7 @@ end;
 function onMobFight(mob,target)
 
     local bf = mob:getBattlefield()
-    if bf:getBcnmID() == 961 and mob:getHPP() < 30 then
+    if bf:getID() == 961 and mob:getHPP() < 30 then
         bf:win()
         return
     end


### PR DESCRIPTION
Replaced all references to no-longer-exists binding getBcnmID().
Cleaned up no-longer-needed event code from Prime Avatar mob luas.

Fixes #6274 and the second half of #6271 