### PR TITLE
Split ApplyMixins into 2 functions

### DIFF
--- a/src/map/lua/luautils.cpp
+++ b/src/map/lua/luautils.cpp
@@ -2307,6 +2307,66 @@ namespace luautils
 
         if (PMob->objtype == TYPE_MOB)
         {
+            lua_prepscript("scripts/zones/%s/mobs/%s.lua", PMob->loc.zone->GetName(), PMob->GetName());
+
+            lua_pushnil(LuaHandle);
+            lua_setglobal(LuaHandle, "mixins");
+            lua_pushnil(LuaHandle);
+            lua_setglobal(LuaHandle, "mixinOptions");
+
+            //remove any previous definition of the global "mixins"
+
+            auto ret = luaL_loadfile(LuaHandle, (const char*)File);
+            if (ret)
+            {
+                lua_pop(LuaHandle, 1);
+                return -1;
+            }
+
+            ret = lua_pcall(LuaHandle, 0, 0, 0);
+            if (ret)
+            {
+                ShowError("luautils::%s: %s\n", "applyMixins", lua_tostring(LuaHandle, -1));
+                lua_pop(LuaHandle, 1);
+                return -1;
+            }
+
+            //get the function "applyMixins"
+            lua_getglobal(LuaHandle, "applyMixins");
+            if (lua_isnil(LuaHandle, -1))
+            {
+                lua_pop(LuaHandle, 1);
+                return -1;
+            }
+
+            CLuaBaseEntity LuaMobEntity(PMob);
+            Lunar<CLuaBaseEntity>::push(LuaHandle, &LuaMobEntity);
+
+            //get the parameter "mixins"
+            lua_getglobal(LuaHandle, "mixins");
+            if (lua_isnil(LuaHandle, -1))
+            {
+                lua_pop(LuaHandle, 3);
+                return -1;
+            }
+            //get the parameter "mixinOptions" (optional)
+            lua_getglobal(LuaHandle, "mixinOptions");
+
+            if (lua_pcall(LuaHandle, 3, 0, 0))
+            {
+                ShowError("luautils::applyMixins: %s\n", lua_tostring(LuaHandle, -1));
+                lua_pop(LuaHandle, 1);
+            }
+        }
+        return 0;
+    }
+
+    int32 ApplyZoneMixins(CBaseEntity* PMob)
+    {
+        DSP_DEBUG_BREAK_IF(PMob == nullptr);
+
+        if (PMob->objtype == TYPE_MOB)
+        {
             if (PMob->objtype == TYPE_PET)
             {
                 CPetEntity* PPet = (CPetEntity*)PMob;
@@ -2418,57 +2478,6 @@ namespace luautils
                     lua_pop(LuaHandle, 1);
                 }
             }
-        }
-
-        lua_prepscript("scripts/zones/%s/mobs/%s.lua", PMob->loc.zone->GetName(), PMob->GetName());
-
-        lua_pushnil(LuaHandle);
-        lua_setglobal(LuaHandle, "mixins");
-        lua_pushnil(LuaHandle);
-        lua_setglobal(LuaHandle, "mixinOptions");
-
-        //remove any previous definition of the global "mixins"
-
-        auto ret = luaL_loadfile(LuaHandle, (const char*)File);
-        if (ret)
-        {
-            lua_pop(LuaHandle, 1);
-            return -1;
-        }
-
-        ret = lua_pcall(LuaHandle, 0, 0, 0);
-        if (ret)
-        {
-            ShowError("luautils::%s: %s\n", "applyMixins", lua_tostring(LuaHandle, -1));
-            lua_pop(LuaHandle, 1);
-            return -1;
-        }
-
-        //get the function "applyMixins"
-        lua_getglobal(LuaHandle, "applyMixins");
-        if (lua_isnil(LuaHandle, -1))
-        {
-            lua_pop(LuaHandle, 1);
-            return -1;
-        }
-
-        CLuaBaseEntity LuaMobEntity(PMob);
-        Lunar<CLuaBaseEntity>::push(LuaHandle, &LuaMobEntity);
-
-        //get the parameter "mixins"
-        lua_getglobal(LuaHandle, "mixins");
-        if (lua_isnil(LuaHandle, -1))
-        {
-            lua_pop(LuaHandle, 3);
-            return -1;
-        }
-        //get the parameter "mixinOptions" (optional)
-        lua_getglobal(LuaHandle, "mixinOptions");
-
-        if (lua_pcall(LuaHandle, 3, 0, 0))
-        {
-            ShowError("luautils::applyMixins: %s\n", lua_tostring(LuaHandle, -1));
-            lua_pop(LuaHandle, 1);
         }
         return 0;
     }

--- a/src/map/lua/luautils.h
+++ b/src/map/lua/luautils.h
@@ -221,6 +221,7 @@ namespace luautils
 
     int32 OnMobInitialize(CBaseEntity* PMob);                                     // Used for passive trait
     int32 ApplyMixins(CBaseEntity* PMob);
+    int32 ApplyZoneMixins(CBaseEntity* PMob);
     int32 OnMobSpawn(CBaseEntity* PMob);                                          // triggers on mob spawn
     int32 OnMobRoamAction(CBaseEntity* PMob);                                     // triggers when event mob is ready for a custom roam action
     int32 OnMobRoam(CBaseEntity* PMob);

--- a/src/map/utils/mobutils.cpp
+++ b/src/map/utils/mobutils.cpp
@@ -1310,6 +1310,7 @@ CMobEntity* InstantiateAlly(uint32 groupid, uint16 zoneID, CInstance* instance)
 
             luautils::OnMobInitialize(PMob);
             luautils::ApplyMixins(PMob);
+            luautils::ApplyZoneMixins(PMob);
 
             PMob->saveModifiers();
             PMob->saveMobModifiers();

--- a/src/map/utils/zoneutils.cpp
+++ b/src/map/utils/zoneutils.cpp
@@ -510,6 +510,7 @@ void LoadMOBList()
         {
             luautils::OnMobInitialize(PMob);
             luautils::ApplyMixins(PMob);
+            luautils::ApplyZoneMixins(PMob);
             PMob->saveModifiers();
             PMob->saveMobModifiers();
             PMob->m_AllowRespawn = PMob->m_SpawnType == SPAWNTYPE_NORMAL;


### PR DESCRIPTION
This adresses a problem that was raised around mixins not being applied after zone mixins are applied.
I think this would be the best course of action as this gives more control over when the zone mixins can be applied, i.e. not during instances.  