### PR TITLE
Remove hard-coded entity IDs from luas that are not IDs.lua

### DIFF
--- a/scripts/zones/Beadeaux/Zone.lua
+++ b/scripts/zones/Beadeaux/Zone.lua
@@ -16,12 +16,12 @@ require("scripts/globals/zone")
 
 function onInitialize(zone)
     -- The Afflictor System (RegionID, X, Radius, Z)
-    zone:registerRegion(1, -163, 10, -137, 0,0,0) -- 17379798 The Afflictor
-    zone:registerRegion(2, -209, 10, -131, 0,0,0) -- 17379799 The Afflictor
-    zone:registerRegion(3, -140, 10,   20, 0,0,0) -- 17379800 The Afflictor
-    zone:registerRegion(4,  261, 10,  140, 0,0,0) -- 17379801 The Afflictor
-    zone:registerRegion(5,  340, 10,  100, 0,0,0) -- 17379802 The Afflictor
-    zone:registerRegion(6,  380, 10,   60, 0,0,0) -- 17379803 The Afflictor
+    zone:registerRegion(1, -163, 10, -137, 0,0,0)
+    zone:registerRegion(2, -209, 10, -131, 0,0,0)
+    zone:registerRegion(3, -140, 10,   20, 0,0,0)
+    zone:registerRegion(4,  261, 10,  140, 0,0,0)
+    zone:registerRegion(5,  340, 10,  100, 0,0,0)
+    zone:registerRegion(6,  380, 10,   60, 0,0,0)
 
     dsp.treasure.initZone(zone)
 end

--- a/scripts/zones/Beadeaux/Zone.lua
+++ b/scripts/zones/Beadeaux/Zone.lua
@@ -15,7 +15,7 @@ require("scripts/globals/zone")
 -----------------------------------
 
 function onInitialize(zone)
-    -- The Afflictor System (RegionID, X, Radius, Z)
+    -- Regions 1-6 are for the Afflictor System (RegionID, X, Radius, Z)
     zone:registerRegion(1, -163, 10, -137, 0,0,0)
     zone:registerRegion(2, -209, 10, -131, 0,0,0)
     zone:registerRegion(3, -140, 10,   20, 0,0,0)

--- a/scripts/zones/Fort_Ghelsba/npcs/@3x0.lua
+++ b/scripts/zones/Fort_Ghelsba/npcs/@3x0.lua
@@ -2,22 +2,22 @@
 -- Area: Fort Ghelsba
 --  NPC: Elevator Platform
 -- !pos  6.912 -52.135 97.998 141
--- 17354992  @3x0  Elevator platform
--- 17354993  _3x3  Elevator stationary lower door
--- 17354994  _3x4  Elevator stationary upper door
--- 17354995  _3xb  Elevator moving lower door
--- 17354996  _3xa  Elevator moving upper door
--- 17354997  _3x0  bigwinch
--- 17354998  _3x1  Elevator Lever 1
--- 17354999  _3x2  Elevator Lever 2
--- 17355000  _3x5  winch1 (lever's gear)
--- 17355001  _3x6  winch2 (lever's gear)
+-- @3x0  Elevator platform
+-- _3x3  Elevator stationary lower door
+-- _3x4  Elevator stationary upper door
+-- _3xb  Elevator moving lower door
+-- _3xa  Elevator moving upper door
+-- _3x0  bigwinch
+-- _3x1  Elevator Lever 1
+-- _3x2  Elevator Lever 2
+-- _3x5  winch1 (lever's gear)
+-- _3x6  winch2 (lever's gear)
 -- ALL THAT FOR ONE PLATFORM.
 -----------------------------------
 require("scripts/globals/status")
 -----------------------------------
 
-function onSpawn(npc) 
+function onSpawn(npc)
     local elevator =
     {
         id = dsp.elevator.FORT_GHELSBA_LIFT,
@@ -28,5 +28,5 @@ function onSpawn(npc)
     }
 
     npc:setElevator(elevator.id, elevator.lowerDoor, elevator.upperDoor, elevator.elevator, elevator.reversedAnimations)
-    
+
 end

--- a/scripts/zones/Labyrinth_of_Onzozo/mobs/Megapod_Megalops.lua
+++ b/scripts/zones/Labyrinth_of_Onzozo/mobs/Megapod_Megalops.lua
@@ -1,12 +1,12 @@
 -----------------------------------
 -- Area: Labyrinth of Onzozo
 --  Mob: Megapod Megalops
---   ID: 17649861
 -- Note: Popped by qm1
 -- !pos 115 14.68 164.1 213
 -- Involved in Quest: Bugi Soden
 -----------------------------------
 require("scripts/globals/wsquest")
+require("scripts/globals/status")
 -----------------------------------
 
 function onMobInitialize(mob)

--- a/scripts/zones/Metalworks/npcs/@6l0.lua
+++ b/scripts/zones/Metalworks/npcs/@6l0.lua
@@ -1,10 +1,10 @@
 -----------------------------------
 -- Area: Metalworks
 --  NPC: North side Elevator platform
--- 17748035  @6l0  North Elevator Platform    -56.006 -13.100 12.014
--- 17748039  _6lu  North Upper Elevator Door  -53.126 -12.098 12.040
--- 17748040  _6lv  North Lower Elevator Door  -58.850 0.000 12.002
--- 17748061  _6lk  North Elevator Winch       -55.911 -14.221 11.958
+-- @6l0  North Elevator Platform    -56.006 -13.100 12.014
+-- _6lu  North Upper Elevator Door  -53.126 -12.098 12.040
+-- _6lv  North Lower Elevator Door  -58.850 0.000 12.002
+-- _6lk  North Elevator Winch       -55.911 -14.221 11.958
 -----------------------------------
 require("scripts/globals/status")
 -----------------------------------

--- a/scripts/zones/Metalworks/npcs/@6l1.lua
+++ b/scripts/zones/Metalworks/npcs/@6l1.lua
@@ -1,10 +1,10 @@
 -----------------------------------
 -- Area: Metalworks
 --  NPC: South side Elevator platform
--- 17748036  _6ls  South Upper Elevator Door  -53.126 -12.098 -11.875
--- 17748037  _6lt  South Lower Elevator Door  -58.850 0.000 -11.914
--- 17748038  @6l1  South Elevator Platform    -55.978 -13.100 -12.020
--- 17748060  _6lj  South Elevator Winch       -56.126 -14.221 -11.988
+-- _6ls  South Upper Elevator Door  -53.126 -12.098 -11.875
+-- _6lt  South Lower Elevator Door  -58.850 0.000 -11.914
+-- @6l1  South Elevator Platform    -55.978 -13.100 -12.020
+-- _6lj  South Elevator Winch       -56.126 -14.221 -11.988
 -----------------------------------
 require("scripts/globals/status")
 -----------------------------------

--- a/scripts/zones/Quicksand_Caves/Zone.lua
+++ b/scripts/zones/Quicksand_Caves/Zone.lua
@@ -14,19 +14,19 @@ require("scripts/globals/status")
 
 function onInitialize(zone)
     -- Weight Door System (RegionID, X, Radius, Z)
-    zone:registerRegion(1, -15, 5, -60, 0,0,0);   -- 17629679 Door
-    zone:registerRegion(3, 15, 5,-180, 0,0,0);    -- 17629681 Door
-    zone:registerRegion(5, -580, 5,-420, 0,0,0);  -- 17629683 Door
-    zone:registerRegion(7, -700, 5,-420, 0,0,0);  -- 17629685 Door
-    zone:registerRegion(9, -700, 5,-380, 0,0,0);  -- 17629687 Door
-    zone:registerRegion(11, -780, 5,-460, 0,0,0); -- 17629689 Door
-    zone:registerRegion(13, -820, 5,-380, 0,0,0); -- 17629691 Door
-    zone:registerRegion(15, -260, 5, 740, 0,0,0); -- 17629693 Door
-    zone:registerRegion(17, -340, 5, 660, 0,0,0); -- 17629695 Door
-    zone:registerRegion(19, -420, 5, 740, 0,0,0); -- 17629697 Door
-    zone:registerRegion(21, -340, 5, 820, 0,0,0); -- 17629699 Door
-    zone:registerRegion(23, -409, 5, 800, 0,0,0); -- 17629701 Door
-    zone:registerRegion(25, -400, 5, 670, 0,0,0); -- 17629703 Door
+    zone:registerRegion(1, -15, 5, -60, 0,0,0);
+    zone:registerRegion(3, 15, 5,-180, 0,0,0);
+    zone:registerRegion(5, -580, 5,-420, 0,0,0);
+    zone:registerRegion(7, -700, 5,-420, 0,0,0);
+    zone:registerRegion(9, -700, 5,-380, 0,0,0);
+    zone:registerRegion(11, -780, 5,-460, 0,0,0);
+    zone:registerRegion(13, -820, 5,-380, 0,0,0);
+    zone:registerRegion(15, -260, 5, 740, 0,0,0);
+    zone:registerRegion(17, -340, 5, 660, 0,0,0);
+    zone:registerRegion(19, -420, 5, 740, 0,0,0);
+    zone:registerRegion(21, -340, 5, 820, 0,0,0);
+    zone:registerRegion(23, -409, 5, 800, 0,0,0);
+    zone:registerRegion(25, -400, 5, 670, 0,0,0);
 
     -- Hole in the Sand
     zone:registerRegion(30,495,-9,-817,497,-7,-815); -- E-11 (Map 2)

--- a/scripts/zones/Temple_of_Uggalepih/mobs/Yallery_Brown.lua
+++ b/scripts/zones/Temple_of_Uggalepih/mobs/Yallery_Brown.lua
@@ -1,7 +1,6 @@
 -----------------------------------
 -- Area: Temple of Uggalepih (159)
 --   NM: Yallery Brown
---   ID: 17428817
 -- Note: Popped by qm9
 -- Involved in Quest: Axe The Competition
 -- !pos 220 -8.11 205.38 159

--- a/scripts/zones/Western_Altepa_Desert/npcs/Peddlestox.lua
+++ b/scripts/zones/Western_Altepa_Desert/npcs/Peddlestox.lua
@@ -1,13 +1,12 @@
 -----------------------------------
 -- Area: Western Altepa Desert
 --  NPC: Peddlestox
---   ID: 17289769
 -- !pos 512.374 0.019 10.57 125
------------------------------------
--- Active on EARTHSDAY in this zone. To test on off-days, use:
--- !exec GetNPCByID(17289769):setStatus(dsp.status.NORMAL)
+-- Active on EARTHSDAY in this zone. To test on off-days, setStatus(dsp.status.NORMAL)
 -----------------------------------
 local ID = require("scripts/zones/Western_Altepa_Desert/IDs")
+require("scripts/globals/beastmentreasure")
+-----------------------------------
 
 function onTrigger(player)
     dsp.bmt.handleNpcOnTrigger(player,ID.npc.BEASTMEN_TREASURE)

--- a/scripts/zones/Western_Altepa_Desert/npcs/qm10.lua
+++ b/scripts/zones/Western_Altepa_Desert/npcs/qm10.lua
@@ -1,10 +1,11 @@
 -----------------------------------
 -- Area: Western Altepa Desert
 --  NPC: ??? (Beastmen Treasure qm10/chest7)
---   ID: 17289779
 -- !pos -670.697 -8.438 -677.751 125
 -----------------------------------
 local ID = require("scripts/zones/Western_Altepa_Desert/IDs")
+require("scripts/globals/beastmentreasure")
+-----------------------------------
 
 function onTrigger(player,npc)
     dsp.bmt.handleQmOnTrigger(player,npc,ID.text.SOMETHING_IS_BURIED_HERE,ID.text.NOTHING_OUT_OF_ORDINARY,ID.npc.BEASTMEN_TREASURE)

--- a/scripts/zones/Western_Altepa_Desert/npcs/qm3.lua
+++ b/scripts/zones/Western_Altepa_Desert/npcs/qm3.lua
@@ -1,10 +1,11 @@
 -----------------------------------
 -- Area: Western Altepa Desert
 --  NPC: ??? (Beastmen Treasure qm3/chest0)
---   ID: 17289772
 -- !pos -197.901 -0.733 357.648 125
 -----------------------------------
 local ID = require("scripts/zones/Western_Altepa_Desert/IDs")
+require("scripts/globals/beastmentreasure")
+-----------------------------------
 
 function onTrigger(player,npc)
     dsp.bmt.handleQmOnTrigger(player,npc,ID.text.SOMETHING_IS_BURIED_HERE,ID.text.NOTHING_OUT_OF_ORDINARY,ID.npc.BEASTMEN_TREASURE)

--- a/scripts/zones/Western_Altepa_Desert/npcs/qm4.lua
+++ b/scripts/zones/Western_Altepa_Desert/npcs/qm4.lua
@@ -1,10 +1,11 @@
 -----------------------------------
 -- Area: Western Altepa Desert
 --  NPC: ??? (Beastmen Treasure qm4/chest1)
---   ID: 17289773
 -- !pos -113.454 -4.459 -58.319 125
 -----------------------------------
 local ID = require("scripts/zones/Western_Altepa_Desert/IDs")
+require("scripts/globals/beastmentreasure")
+-----------------------------------
 
 function onTrigger(player,npc)
     dsp.bmt.handleQmOnTrigger(player,npc,ID.text.SOMETHING_IS_BURIED_HERE,ID.text.NOTHING_OUT_OF_ORDINARY,ID.npc.BEASTMEN_TREASURE)

--- a/scripts/zones/Western_Altepa_Desert/npcs/qm5.lua
+++ b/scripts/zones/Western_Altepa_Desert/npcs/qm5.lua
@@ -1,10 +1,11 @@
 -----------------------------------
 -- Area: Western Altepa Desert
 --  NPC: ??? (Beastmen Treasure qm5/chest2)
---   ID: 17289774
 -- !pos 3.302 -0.302 -250.435 125
 -----------------------------------
 local ID = require("scripts/zones/Western_Altepa_Desert/IDs")
+require("scripts/globals/beastmentreasure")
+-----------------------------------
 
 function onTrigger(player,npc)
     dsp.bmt.handleQmOnTrigger(player,npc,ID.text.SOMETHING_IS_BURIED_HERE,ID.text.NOTHING_OUT_OF_ORDINARY,ID.npc.BEASTMEN_TREASURE)

--- a/scripts/zones/Western_Altepa_Desert/npcs/qm6.lua
+++ b/scripts/zones/Western_Altepa_Desert/npcs/qm6.lua
@@ -1,10 +1,11 @@
 -----------------------------------
 -- Area: Western Altepa Desert
 --  NPC: ??? (Beastmen Treasure qm6/chest3)
---   ID: 17289775
 -- !pos -476.967 0.159 17.835 125
 -----------------------------------
 local ID = require("scripts/zones/Western_Altepa_Desert/IDs")
+require("scripts/globals/beastmentreasure")
+-----------------------------------
 
 function onTrigger(player,npc)
     dsp.bmt.handleQmOnTrigger(player,npc,ID.text.SOMETHING_IS_BURIED_HERE,ID.text.NOTHING_OUT_OF_ORDINARY,ID.npc.BEASTMEN_TREASURE)

--- a/scripts/zones/Western_Altepa_Desert/npcs/qm7.lua
+++ b/scripts/zones/Western_Altepa_Desert/npcs/qm7.lua
@@ -1,10 +1,11 @@
 -----------------------------------
 -- Area: Western Altepa Desert
 --  NPC: ??? (Beastmen Treasure qm7/chest4)
---   ID: 17289776
 -- !pos -454.701 -3.465 -286.864 125
 -----------------------------------
 local ID = require("scripts/zones/Western_Altepa_Desert/IDs")
+require("scripts/globals/beastmentreasure")
+-----------------------------------
 
 function onTrigger(player,npc)
     dsp.bmt.handleQmOnTrigger(player,npc,ID.text.SOMETHING_IS_BURIED_HERE,ID.text.NOTHING_OUT_OF_ORDINARY,ID.npc.BEASTMEN_TREASURE)

--- a/scripts/zones/Western_Altepa_Desert/npcs/qm8.lua
+++ b/scripts/zones/Western_Altepa_Desert/npcs/qm8.lua
@@ -1,10 +1,11 @@
 -----------------------------------
 -- Area: Western Altepa Desert
 --  NPC: ??? (Beastmen Treasure qm8/chest5)
---   ID: 17289777
 -- !pos -223.055 -0.085 -672.207 125
 -----------------------------------
 local ID = require("scripts/zones/Western_Altepa_Desert/IDs")
+require("scripts/globals/beastmentreasure")
+-----------------------------------
 
 function onTrigger(player,npc)
     dsp.bmt.handleQmOnTrigger(player,npc,ID.text.SOMETHING_IS_BURIED_HERE,ID.text.NOTHING_OUT_OF_ORDINARY,ID.npc.BEASTMEN_TREASURE)

--- a/scripts/zones/Western_Altepa_Desert/npcs/qm9.lua
+++ b/scripts/zones/Western_Altepa_Desert/npcs/qm9.lua
@@ -1,10 +1,11 @@
 -----------------------------------
 -- Area: Western Altepa Desert
 --  NPC: ??? (Beastmen Treasure qm9/chest6)
---   ID: 17289778
 -- !pos -631.524 0.046 -336.254 125
 -----------------------------------
 local ID = require("scripts/zones/Western_Altepa_Desert/IDs")
+require("scripts/globals/beastmentreasure")
+-----------------------------------
 
 function onTrigger(player,npc)
     dsp.bmt.handleQmOnTrigger(player,npc,ID.text.SOMETHING_IS_BURIED_HERE,ID.text.NOTHING_OUT_OF_ORDINARY,ID.npc.BEASTMEN_TREASURE)

--- a/scripts/zones/Yhoator_Jungle/npcs/Peddlestox.lua
+++ b/scripts/zones/Yhoator_Jungle/npcs/Peddlestox.lua
@@ -1,13 +1,12 @@
 -----------------------------------
 -- Area: Yhoator Jungle
 --  NPC: Peddlestox
---   ID: 17285685
 -- !pos -499.914 1.470 -109.039 124
------------------------------------
--- Active on LIGHTNINGDAY in this zone. To test on off-days, use:
--- !exec GetNPCByID(17285685):setStatus(dsp.status.NORMAL)
+-- Active on LIGHTNINGDAY in this zone. To test on off-days, setStatus(dsp.status.NORMAL)
 -----------------------------------
 local ID = require("scripts/zones/Yhoator_Jungle/IDs")
+require("scripts/globals/beastmentreasure")
+-----------------------------------
 
 function onTrigger(player)
     dsp.bmt.handleNpcOnTrigger(player,ID.npc.BEASTMEN_TREASURE)

--- a/scripts/zones/Yhoator_Jungle/npcs/qm10.lua
+++ b/scripts/zones/Yhoator_Jungle/npcs/qm10.lua
@@ -1,10 +1,11 @@
 -----------------------------------
 -- Area: Yhoator Jungle
 --  NPC: ??? (Beastmen Treasure qm10/chest6)
---   ID: 17285693
 -- !pos 16.069 -0.86 -393.843 124
 -----------------------------------
 local ID = require("scripts/zones/Yhoator_Jungle/IDs")
+require("scripts/globals/beastmentreasure")
+-----------------------------------
 
 function onTrigger(player,npc)
     dsp.bmt.handleQmOnTrigger(player,npc,ID.text.SOMETHING_IS_BURIED_HERE,ID.text.NOTHING_OUT_OF_ORDINARY,ID.npc.BEASTMEN_TREASURE)

--- a/scripts/zones/Yhoator_Jungle/npcs/qm11.lua
+++ b/scripts/zones/Yhoator_Jungle/npcs/qm11.lua
@@ -1,10 +1,11 @@
 -----------------------------------
 -- Area: Yhoator Jungle
 --  NPC: ??? (Beastmen Treasure qm11/chest7)
---   ID: 17285694
 -- !pos -255.358 -0.558 -405.178 124
 -----------------------------------
 local ID = require("scripts/zones/Yhoator_Jungle/IDs")
+require("scripts/globals/beastmentreasure")
+-----------------------------------
 
 function onTrigger(player,npc)
     dsp.bmt.handleQmOnTrigger(player,npc,ID.text.SOMETHING_IS_BURIED_HERE,ID.text.NOTHING_OUT_OF_ORDINARY,ID.npc.BEASTMEN_TREASURE)

--- a/scripts/zones/Yhoator_Jungle/npcs/qm4.lua
+++ b/scripts/zones/Yhoator_Jungle/npcs/qm4.lua
@@ -1,10 +1,11 @@
 -----------------------------------
 -- Area: Yhoator Jungle
 --  NPC: ??? (Beastmen Treasure qm4/chest0)
---   ID: 17285695
 -- !pos -149.929 -1.148 56.761 124
 -----------------------------------
 local ID = require("scripts/zones/Yhoator_Jungle/IDs")
+require("scripts/globals/beastmentreasure")
+-----------------------------------
 
 function onTrigger(player,npc)
     dsp.bmt.handleQmOnTrigger(player,npc,ID.text.SOMETHING_IS_BURIED_HERE,ID.text.NOTHING_OUT_OF_ORDINARY,ID.npc.BEASTMEN_TREASURE)

--- a/scripts/zones/Yhoator_Jungle/npcs/qm5.lua
+++ b/scripts/zones/Yhoator_Jungle/npcs/qm5.lua
@@ -1,10 +1,11 @@
 -----------------------------------
 -- Area: Yhoator Jungle
 --  NPC: ??? (Beastmen Treasure qm5/chest1)
---   ID: 17285688
 -- !pos 80.52 -1.312 200.147 124
 -----------------------------------
 local ID = require("scripts/zones/Yhoator_Jungle/IDs")
+require("scripts/globals/beastmentreasure")
+-----------------------------------
 
 function onTrigger(player,npc)
     dsp.bmt.handleQmOnTrigger(player,npc,ID.text.SOMETHING_IS_BURIED_HERE,ID.text.NOTHING_OUT_OF_ORDINARY,ID.npc.BEASTMEN_TREASURE)

--- a/scripts/zones/Yhoator_Jungle/npcs/qm6.lua
+++ b/scripts/zones/Yhoator_Jungle/npcs/qm6.lua
@@ -1,10 +1,11 @@
 -----------------------------------
 -- Area: Yhoator Jungle
 --  NPC: ??? (Beastmen Treasure qm6/chest2)
---   ID: 17285689
 -- !pos 198.65 -0.783 58.046 124
 -----------------------------------
 local ID = require("scripts/zones/Yhoator_Jungle/IDs")
+require("scripts/globals/beastmentreasure")
+-----------------------------------
 
 function onTrigger(player,npc)
     dsp.bmt.handleQmOnTrigger(player,npc,ID.text.SOMETHING_IS_BURIED_HERE,ID.text.NOTHING_OUT_OF_ORDINARY,ID.npc.BEASTMEN_TREASURE)

--- a/scripts/zones/Yhoator_Jungle/npcs/qm7.lua
+++ b/scripts/zones/Yhoator_Jungle/npcs/qm7.lua
@@ -1,10 +1,11 @@
 -----------------------------------
 -- Area: Yhoator Jungle
 --  NPC: ??? (Beastmen Treasure qm7/chest3)
---   ID: 17285690
 -- !pos 205.932 -1.097 -174.886 124
 -----------------------------------
 local ID = require("scripts/zones/Yhoator_Jungle/IDs")
+require("scripts/globals/beastmentreasure")
+-----------------------------------
 
 function onTrigger(player,npc)
     dsp.bmt.handleQmOnTrigger(player,npc,ID.text.SOMETHING_IS_BURIED_HERE,ID.text.NOTHING_OUT_OF_ORDINARY,ID.npc.BEASTMEN_TREASURE)

--- a/scripts/zones/Yhoator_Jungle/npcs/qm8.lua
+++ b/scripts/zones/Yhoator_Jungle/npcs/qm8.lua
@@ -1,10 +1,11 @@
 -----------------------------------
 -- Area: Yhoator Jungle
 --  NPC: ??? (Beastmen Treasure qm8/chest4)
---   ID: 17285691
 -- !pos 525.239 -1.224 -394.046 124
 -----------------------------------
 local ID = require("scripts/zones/Yhoator_Jungle/IDs")
+require("scripts/globals/beastmentreasure")
+-----------------------------------
 
 function onTrigger(player,npc)
     dsp.bmt.handleQmOnTrigger(player,npc,ID.text.SOMETHING_IS_BURIED_HERE,ID.text.NOTHING_OUT_OF_ORDINARY,ID.npc.BEASTMEN_TREASURE)

--- a/scripts/zones/Yhoator_Jungle/npcs/qm9.lua
+++ b/scripts/zones/Yhoator_Jungle/npcs/qm9.lua
@@ -1,10 +1,11 @@
 -----------------------------------
 -- Area: Yhoator Jungle
 --  NPC: ??? (Beastmen Treasure qm9/chest5)
---   ID: 17285692
 -- !pos 240.341 -0.826 -402.532 124
 -----------------------------------
 local ID = require("scripts/zones/Yhoator_Jungle/IDs")
+require("scripts/globals/beastmentreasure")
+-----------------------------------
 
 function onTrigger(player,npc)
     dsp.bmt.handleQmOnTrigger(player,npc,ID.text.SOMETHING_IS_BURIED_HERE,ID.text.NOTHING_OUT_OF_ORDINARY,ID.npc.BEASTMEN_TREASURE)

--- a/scripts/zones/Yuhtunga_Jungle/npcs/Peddlestox.lua
+++ b/scripts/zones/Yuhtunga_Jungle/npcs/Peddlestox.lua
@@ -1,13 +1,12 @@
 -----------------------------------
 -- Area: Yuhtunga Jungle
 --  NPC: Peddlestox
---   ID: 17281639
 -- !pos -103.286 0.6 434.866 123
------------------------------------
--- Active on WINDSDAY in this zone. To test on off-days, use:
--- !exec GetNPCByID(17281639):setStatus(dsp.status.NORMAL)
+-- Active on WINDSDAY in this zone. To test on off-days, setStatus(dsp.status.NORMAL)
 -----------------------------------
 local ID = require("scripts/zones/Yuhtunga_Jungle/IDs")
+require("scripts/globals/beastmentreasure")
+-----------------------------------
 
 function onTrigger(player)
     dsp.bmt.handleNpcOnTrigger(player,ID.npc.BEASTMEN_TREASURE)

--- a/scripts/zones/Yuhtunga_Jungle/npcs/qm10.lua
+++ b/scripts/zones/Yuhtunga_Jungle/npcs/qm10.lua
@@ -1,10 +1,11 @@
 -----------------------------------
 -- Area: Yuhtunga Jungle
 --  NPC: ??? (Beastmen Treasure qm10/chest7)
---   ID: 17281649
 -- !pos 369.795 4.0 201.805 123
 -----------------------------------
 local ID = require("scripts/zones/Yuhtunga_Jungle/IDs")
+require("scripts/globals/beastmentreasure")
+-----------------------------------
 
 function onTrigger(player,npc)
     dsp.bmt.handleQmOnTrigger(player,npc,ID.text.SOMETHING_IS_BURIED_HERE,ID.text.NOTHING_OUT_OF_ORDINARY,ID.npc.BEASTMEN_TREASURE)

--- a/scripts/zones/Yuhtunga_Jungle/npcs/qm3.lua
+++ b/scripts/zones/Yuhtunga_Jungle/npcs/qm3.lua
@@ -1,10 +1,11 @@
 -----------------------------------
 -- Area: Yuhtunga Jungle
 --  NPC: ??? (Beastmen Treasure qm3/chest0)
---   ID: 17281642
 -- !pos 83.726 -1.212 448.329 123
 -----------------------------------
 local ID = require("scripts/zones/Yuhtunga_Jungle/IDs")
+require("scripts/globals/beastmentreasure")
+-----------------------------------
 
 function onTrigger(player,npc)
     dsp.bmt.handleQmOnTrigger(player,npc,ID.text.SOMETHING_IS_BURIED_HERE,ID.text.NOTHING_OUT_OF_ORDINARY,ID.npc.BEASTMEN_TREASURE)

--- a/scripts/zones/Yuhtunga_Jungle/npcs/qm4.lua
+++ b/scripts/zones/Yuhtunga_Jungle/npcs/qm4.lua
@@ -1,10 +1,11 @@
 -----------------------------------
 -- Area: Yuhtunga Jungle
 --  NPC: ??? (Beastmen Treasure qm4/chest1)
---   ID: 17281643
 -- !pos -114.254 -3.981 -125.471 123
 -----------------------------------
 local ID = require("scripts/zones/Yuhtunga_Jungle/IDs")
+require("scripts/globals/beastmentreasure")
+-----------------------------------
 
 function onTrigger(player,npc)
     dsp.bmt.handleQmOnTrigger(player,npc,ID.text.SOMETHING_IS_BURIED_HERE,ID.text.NOTHING_OUT_OF_ORDINARY,ID.npc.BEASTMEN_TREASURE)

--- a/scripts/zones/Yuhtunga_Jungle/npcs/qm5.lua
+++ b/scripts/zones/Yuhtunga_Jungle/npcs/qm5.lua
@@ -1,10 +1,11 @@
 -----------------------------------
 -- Area: Yuhtunga Jungle
 --  NPC: ??? (Beastmen Treasure qm5/chest2)
---   ID: 17281644
 -- !pos -300.823 6.558 9.208 123
 -----------------------------------
 local ID = require("scripts/zones/Yuhtunga_Jungle/IDs")
+require("scripts/globals/beastmentreasure")
+-----------------------------------
 
 function onTrigger(player,npc)
     dsp.bmt.handleQmOnTrigger(player,npc,ID.text.SOMETHING_IS_BURIED_HERE,ID.text.NOTHING_OUT_OF_ORDINARY,ID.npc.BEASTMEN_TREASURE)

--- a/scripts/zones/Yuhtunga_Jungle/npcs/qm6.lua
+++ b/scripts/zones/Yuhtunga_Jungle/npcs/qm6.lua
@@ -1,10 +1,11 @@
 -----------------------------------
 -- Area: Yuhtunga Jungle
 --  NPC: ??? (Beastmen Treasure qm6/chest3)
---   ID: 17281645
 -- !pos -539.311 -0.168 203.151 123
 -----------------------------------
 local ID = require("scripts/zones/Yuhtunga_Jungle/IDs")
+require("scripts/globals/beastmentreasure")
+-----------------------------------
 
 function onTrigger(player,npc)
     dsp.bmt.handleQmOnTrigger(player,npc,ID.text.SOMETHING_IS_BURIED_HERE,ID.text.NOTHING_OUT_OF_ORDINARY,ID.npc.BEASTMEN_TREASURE)

--- a/scripts/zones/Yuhtunga_Jungle/npcs/qm7.lua
+++ b/scripts/zones/Yuhtunga_Jungle/npcs/qm7.lua
@@ -1,10 +1,11 @@
 -----------------------------------
 -- Area: Yuhtunga Jungle
 --  NPC: ??? (Beastmen Treasure qm7/chest4)
---   ID: 17281646
 -- !pos -577.734 -0.706 -82.563 123
 -----------------------------------
 local ID = require("scripts/zones/Yuhtunga_Jungle/IDs")
+require("scripts/globals/beastmentreasure")
+-----------------------------------
 
 function onTrigger(player,npc)
     dsp.bmt.handleQmOnTrigger(player,npc,ID.text.SOMETHING_IS_BURIED_HERE,ID.text.NOTHING_OUT_OF_ORDINARY,ID.npc.BEASTMEN_TREASURE)

--- a/scripts/zones/Yuhtunga_Jungle/npcs/qm8.lua
+++ b/scripts/zones/Yuhtunga_Jungle/npcs/qm8.lua
@@ -1,10 +1,11 @@
 -----------------------------------
 -- Area: Yuhtunga Jungle
 --  NPC: ??? (Beastmen Treasure qm8/chest5)
---   ID: 17281647
 -- !pos -361.835 15.695 -399.517 123
 -----------------------------------
 local ID = require("scripts/zones/Yuhtunga_Jungle/IDs")
+require("scripts/globals/beastmentreasure")
+-----------------------------------
 
 function onTrigger(player,npc)
     dsp.bmt.handleQmOnTrigger(player,npc,ID.text.SOMETHING_IS_BURIED_HERE,ID.text.NOTHING_OUT_OF_ORDINARY,ID.npc.BEASTMEN_TREASURE)

--- a/scripts/zones/Yuhtunga_Jungle/npcs/qm9.lua
+++ b/scripts/zones/Yuhtunga_Jungle/npcs/qm9.lua
@@ -1,10 +1,11 @@
 -----------------------------------
 -- Area: Yuhtunga Jungle
 --  NPC: ??? (Beastmen Treasure qm9/chest6)
---   ID: 17281648
 -- !pos -294.827 -1.53 -453.237 123
 -----------------------------------
 local ID = require("scripts/zones/Yuhtunga_Jungle/IDs")
+require("scripts/globals/beastmentreasure")
+-----------------------------------
 
 function onTrigger(player,npc)
     dsp.bmt.handleQmOnTrigger(player,npc,ID.text.SOMETHING_IS_BURIED_HERE,ID.text.NOTHING_OUT_OF_ORDINARY,ID.npc.BEASTMEN_TREASURE)


### PR DESCRIPTION
Let's keep NPC IDs only in the IDs.lua files in each zone.  The IDs can shift over time, and I only keep in sync the IDs.lua files when doing client updates.

(Note: There are still lots of hard-coded IDs in Dynamis, Limbus, and Abyssea.  And a couple in Ilrusi Atoll.  Will get to those eventually.)