### PR TITLE
BCNM allies and multi-phase fights

### DIFF
--- a/scripts/globals/bcnm.lua
+++ b/scripts/globals/bcnm.lua
@@ -488,7 +488,7 @@ function checkReqs(player, npc, bfid, registrant)
         [ 103] = function() return ( mjob == dsp.job.SMN and mlvl >= 66                                                                                                     ) end, -- Quest: Shattering Stars (SMN LB5)
         [ 128] = function() return ( roz == mi.zilart.THE_TEMPLE_OF_UGGALEPIH                                                                                               ) end, -- ZM4: The Temple of Uggalepih
         [ 160] = function() return ( nat == 15 and natStat == 3                                                                                                             ) end, -- Mission 5-2
-        [ 161] = function() return ( basty == mi.bastok.WHERE_TWO_PATHS_CONVERGE and player:getCharVar("BASTOK92") == 1                                                     ) end, -- Basty 9-2: Where Two Paths Converge
+        [ 161] = function() return ( basty == mi.bastok.WHERE_TWO_PATHS_CONVERGE and natStat == 1                                                                           ) end, -- Basty 9-2: Where Two Paths Converge
         [ 163] = function() return ( mjob == dsp.job.SCH and mlvl >= 66                                                                                                     ) end, -- Quest: Survival of the Wisest (SCH LB5)
         [ 192] = function() return ( roz == mi.zilart.THROUGH_THE_QUICKSAND_CAVES                                                                                           ) end, -- ZM6: Through the Quicksand Caves
         [ 194] = function() return ( mjob == dsp.job.SAM and mlvl >= 66                                                                                                     ) end, -- Quest: Shattering Stars (SAM LB5)

--- a/scripts/globals/bcnm.lua
+++ b/scripts/globals/bcnm.lua
@@ -307,7 +307,7 @@ local battlefields = {
 
     [170] = {               -- FULL MOON FOUNTAIN
         { 0,  224,    0},   -- The Moonlit Path (Quest)
-     -- { 1,  225,    0},   -- Moon Reading (Windy 9-2)
+        { 1,  225,    0},   -- Moon Reading (Windy 9-2)
      -- { 2,  226,    0},   -- Waking the Beast (Quest)
      -- { 3,  227,    0},   -- Battaru Royale (ASA10)
      -- { 4,    ?,    0},   -- *The Moonlit Path (HTMBF)
@@ -495,7 +495,7 @@ function checkReqs(player, npc, bfid, registrant)
         [ 195] = function() return ( mjob == dsp.job.NIN and mlvl >= 66                                                                                                     ) end, -- Quest: Shattering Stars (NIN LB5)
         [ 196] = function() return ( mjob == dsp.job.DRG and mlvl >= 66                                                                                                     ) end, -- Quest: Shattering Stars (DRG LB5)
         [ 224] = function() return ( player:hasKeyItem(dsp.ki.MOON_BAUBLE)                                                                                                  ) end, -- Quest: The Moonlit Path
-        [ 225] = function() return ( windy == mi.windurst.MOON_READING and player:getCharVar("WINDURST92") == 2                                                             ) end, -- Windy 9-2: Moon Reading
+        [ 225] = function() return ( windy == mi.windurst.MOON_READING and natStat == 2                                                                                     ) end, -- Windy 9-2: Moon Reading
         [ 256] = function() return ( roz == mi.zilart.RETURN_TO_DELKFUTTS_TOWER and rozStat == 3                                                                            ) end, -- ZM8: Return to Delkfutt's Tower
         [ 288] = function() return ( roz == mi.zilart.ARK_ANGELS and rozStat == 1 and npcid == getZM14Offset(0) and not player:hasKeyItem(dsp.ki.SHARD_OF_APATHY)           ) end, -- ZM14: Ark Angels (Hume)
         [ 289] = function() return ( roz == mi.zilart.ARK_ANGELS and rozStat == 1 and npcid == getZM14Offset(1) and not player:hasKeyItem(dsp.ki.SHARD_OF_COWARDICE)        ) end, -- ZM14: Ark Angels (Tarutaru)

--- a/scripts/globals/mobskills/seal_of_quiescence.lua
+++ b/scripts/globals/mobskills/seal_of_quiescence.lua
@@ -4,10 +4,11 @@
 require("scripts/globals/monstertpmoves")
 require("scripts/globals/settings")
 require("scripts/globals/status")
+local ID = require("scripts/zones/Empyreal_Paradox/IDs")
 ---------------------------------------------
 
 function onMobSkillCheck(target,mob,skill)
-    mob:showText(mob, PROMATHIA_TEXT + 6)
+    mob:showText(mob, ID.text.PROMATHIA_TEXT + 6)
     return 0
 end
 

--- a/scripts/globals/mobskills/winds_of_oblivion.lua
+++ b/scripts/globals/mobskills/winds_of_oblivion.lua
@@ -4,10 +4,11 @@
 require("scripts/globals/monstertpmoves")
 require("scripts/globals/settings")
 require("scripts/globals/status")
+local ID = require("scripts/zones/Empyreal_Paradox/IDs")
 ---------------------------------------------
 
 function onMobSkillCheck(target,mob,skill)
-    mob:showText(mob, PROMATHIA_TEXT + 6)
+    mob:showText(mob, ID.text.PROMATHIA_TEXT + 6)
     return 0
 end
 

--- a/scripts/globals/spells/raise.lua
+++ b/scripts/globals/spells/raise.lua
@@ -16,6 +16,9 @@ function onSpellCast(caster,target,spell)
         if (target:getName() == "Prishe") then
             -- CoP 8-4 Prishe
             target:setLocalVar("Raise", 1)
+            target:entityAnimationPacket("sp00")
+            target:addHP(target:getMaxHP())
+            target:addMP(target:getMaxMP())
         end
     end
     spell:setMsg(dsp.msg.basic.MAGIC_CASTS_ON)

--- a/scripts/globals/spells/raise_ii.lua
+++ b/scripts/globals/spells/raise_ii.lua
@@ -16,6 +16,9 @@ function onSpellCast(caster,target,spell)
         if (target:getName() == "Prishe") then
             -- CoP 8-4 Prishe
             target:setLocalVar("Raise", 1)
+            target:entityAnimationPacket("sp00")
+            target:addHP(target:getMaxHP())
+            target:addMP(target:getMaxMP())
         end
     end
     spell:setMsg(dsp.msg.basic.MAGIC_CASTS_ON)

--- a/scripts/globals/spells/raise_iii.lua
+++ b/scripts/globals/spells/raise_iii.lua
@@ -16,6 +16,9 @@ function onSpellCast(caster,target,spell)
         if (target:getName() == "Prishe") then
             -- CoP 8-4 Prishe
             target:setLocalVar("Raise", 1)
+            target:entityAnimationPacket("sp00")
+            target:addHP(target:getMaxHP())
+            target:addMP(target:getMaxMP())
         end
     end
     spell:setMsg(dsp.msg.basic.MAGIC_CASTS_ON)

--- a/scripts/zones/Empyreal_Paradox/bcnms/dawn.lua
+++ b/scripts/zones/Empyreal_Paradox/bcnms/dawn.lua
@@ -12,21 +12,26 @@ require("scripts/globals/missions")
 require("scripts/globals/titles")
 -----------------------------------
 
+function onBattlefieldInitialise(battlefield)
+    battlefield:setLocalVar("loot", 1)
+    battlefield:setLocalVar("lootSpawned", 1)
+    local baseID = ID.mob.PROMATHIA_OFFSET + (battlefield:getArea() - 1) * 2
+    local pos = GetMobByID(baseID):getSpawnPos()
+
+    local prishe = battlefield:insertEntity(14166, true, true)
+    prishe:setSpawn(pos.x - 6, pos.y, pos.z - 21.5, 192)
+    prishe:spawn()
+
+    local selhteus = battlefield:insertEntity(14167, true, true)
+    selhteus:setSpawn(pos.x + 10, pos.y, pos.z - 17.5, 172)
+    selhteus:spawn()
+end
+
 function onBattlefieldTick(battlefield, tick)
     dsp.battlefield.onBattlefieldTick(battlefield, tick)
 end
 
 function onBattlefieldRegister(player, battlefield)
-    local baseID = ID.mob.PROMATHIA_OFFSET + (battlefield:getArea() - 1) * 2
-    local pos = GetMobByID(baseID):getSpawnPos()
-
-    local prishe = battlefield:insertEntity(14166, true)
-    prishe:setSpawn(pos.x - 6, pos.y, pos.z - 21.5, 192)
-    prishe:spawn()
-
-    local selhteus = battlefield:insertEntity(14167, true)
-    selhteus:setSpawn(pos.x + 10, pos.y, pos.z - 17.5, 172)
-    selhteus:spawn()
 end
 
 function onBattlefieldEnter(player, battlefield)

--- a/scripts/zones/Empyreal_Paradox/mobs/Prishe.lua
+++ b/scripts/zones/Empyreal_Paradox/mobs/Prishe.lua
@@ -12,7 +12,7 @@ function onMobInitialize(mob)
 end
 
 function onMobRoam(mob)
-    local promathia = ID.mob.PROMATHIA_OFFSET + (mob:getBattlefield():getBattlefieldNumber() - 1) * 2
+    local promathia = ID.mob.PROMATHIA_OFFSET + (mob:getBattlefield():getArea() - 1) * 2
     local wait = mob:getLocalVar("wait")
     local ready = mob:getLocalVar("ready")
 
@@ -40,11 +40,8 @@ function onMobEngaged(mob, target)
 end
 
 function onMobFight(mob, target)
-    if (mob:getHPP() == 0 and mob:getLocalVar("Raise") == 1) then
-        mob:entityAnimationPacket("sp00")
+    if (mob:getLocalVar("Raise") == 1) then
         mob:messageText(mob, ID.text.PRISHE_TEXT + 3)
-        mob:addHP(mob:getMaxHP())
-        mob:addMP(mob:getMaxMP())
         mob:setLocalVar("Raise", 0)
         mob:stun(3000)
     elseif (mob:getHPP() < 70 and mob:getLocalVar("HF") == 0) then

--- a/scripts/zones/Empyreal_Paradox/mobs/Prishe.lua
+++ b/scripts/zones/Empyreal_Paradox/mobs/Prishe.lua
@@ -16,8 +16,8 @@ function onMobRoam(mob)
     local wait = mob:getLocalVar("wait")
     local ready = mob:getLocalVar("ready")
 
-    if (ready == 0 and wait > 240) then
-        if (GetMobByID(promathia):getCurrentAction() ~= dsp.act.NONE) then
+    if ready == 0 and wait > 240 then
+        if GetMobByID(promathia):getCurrentAction() ~= dsp.act.NONE then
             mob:entityAnimationPacket("prov")
             mob:messageText(mob, ID.text.PRISHE_TEXT)
         else
@@ -27,7 +27,7 @@ function onMobRoam(mob)
         end
         mob:setLocalVar("ready", promathia)
         mob:setLocalVar("wait", 0)
-    elseif (ready > 0) then
+    elseif ready > 0 then
         mob:addEnmity(GetMobByID(ready), 0, 1)
     else
         mob:setLocalVar("wait", wait + 3)
@@ -40,15 +40,15 @@ function onMobEngaged(mob, target)
 end
 
 function onMobFight(mob, target)
-    if (mob:getLocalVar("Raise") == 1) then
+    if mob:getLocalVar("Raise") == 1 then
         mob:messageText(mob, ID.text.PRISHE_TEXT + 3)
         mob:setLocalVar("Raise", 0)
         mob:stun(3000)
-    elseif (mob:getHPP() < 70 and mob:getLocalVar("HF") == 0) then
+    elseif mob:getHPP() < 70 and mob:getLocalVar("HF") == 0 then
         mob:useMobAbility(dsp.jsa.HUNDRED_FISTS_PRISHE)
         mob:messageText(mob, ID.text.PRISHE_TEXT + 6)
         mob:setLocalVar("HF", 1)
-    elseif (mob:getHPP() < 30 and mob:getLocalVar("Bene") == 0) then
+    elseif mob:getHPP() < 30 and mob:getLocalVar("Bene") == 0 then
         mob:useMobAbility(dsp.jsa.BENEDICTION_PRISHE)
         mob:messageText(mob, ID.text.PRISHE_TEXT + 7)
         mob:setLocalVar("Bene", 1)

--- a/scripts/zones/Empyreal_Paradox/mobs/Promathia.lua
+++ b/scripts/zones/Empyreal_Paradox/mobs/Promathia.lua
@@ -51,7 +51,7 @@ end;
 
 function onMobDeath(mob, player, isKiller)
     local battlefield = player:getBattlefield();
-    player:startEvent(32004, battlefield:getBattlefieldNumber());
+    player:startEvent(32004, battlefield:getArea());
 end;
 
 function onEventUpdate(player,csid,option)

--- a/scripts/zones/Empyreal_Paradox/mobs/Promathia.lua
+++ b/scripts/zones/Empyreal_Paradox/mobs/Promathia.lua
@@ -3,73 +3,72 @@
 --  Mob: Promathia
 -- Note: Phase 1
 -----------------------------------
-local ID = require("scripts/zones/Empyreal_Paradox/IDs");
-require("scripts/globals/status");
-require("scripts/globals/titles");
+local ID = require("scripts/zones/Empyreal_Paradox/IDs")
+require("scripts/globals/status")
+require("scripts/globals/titles")
 -----------------------------------
 
 function onMobInitialize(mob)
-    mob:addMod(dsp.mod.REGAIN, 50);
-    mob:addMod(dsp.mod.UFASTCAST,50);
-end;
+    mob:addMod(dsp.mod.REGAIN, 50)
+    mob:addMod(dsp.mod.UFASTCAST,50)
+end
 
-function onMobEngaged(mob,target)
-    local bcnmAllies = mob:getBattlefield():getAllies();
+function onMobEngaged(mob, target)
+    local bcnmAllies = mob:getBattlefield():getAllies()
     for i,v in pairs(bcnmAllies) do
-        if (v:getName() == "Prishe") then
+        if v:getName() == "Prishe" then
             if not v:getTarget() then
-                v:entityAnimationPacket("prov");
-                v:showText(v, ID.text.PRISHE_TEXT);
-                v:setLocalVar("ready", mob:getID());
+                v:entityAnimationPacket("prov")
+                v:showText(v, ID.text.PRISHE_TEXT)
+                v:setLocalVar("ready", mob:getID())
             end
         else
-            v:addEnmity(mob,0,1);
+            v:addEnmity(mob,0,1)
         end
     end
-end;
+end
 
-function onMobFight(mob,target)
-    if (mob:AnimationSub() == 3 and not mob:hasStatusEffect(dsp.effect.STUN)) then
-        mob:AnimationSub(0);
-        mob:stun(1500);
+function onMobFight(mob, target)
+    if mob:AnimationSub() == 3 and not mob:hasStatusEffect(dsp.effect.STUN) then
+        mob:AnimationSub(0)
+        mob:stun(1500)
     end
 
-    local bcnmAllies = mob:getBattlefield():getAllies();
+    local bcnmAllies = mob:getBattlefield():getAllies()
     for i,v in pairs(bcnmAllies) do
         if not v:getTarget() then
-            v:addEnmity(mob,0,1);
+            v:addEnmity(mob,0,1)
         end
     end
-
-end;
+end
 
 function onSpellPrecast(mob, spell)
-    if (spell:getID() == 219) then
-        spell:setMPCost(1);
+    if spell:getID() == 219 then
+        spell:setMPCost(1)
     end
-end;
+end
 
 function onMobDeath(mob, player, isKiller)
-    local battlefield = player:getBattlefield();
-    player:startEvent(32004, battlefield:getArea());
-end;
+    local battlefield = player:getBattlefield()
+    player:startEvent(32004, battlefield:getArea())
+end
 
-function onEventUpdate(player,csid,option)
+function onEventUpdate(player, csid, option)
     -- printf("updateCSID: %u",csid);
-end;
+end
 
-function onEventFinish(player,csid,option,target)
+function onEventFinish(player, csid, option, target)
     -- printf("finishCSID: %u",csid);
 
-    if (csid == 32004) then
-        DespawnMob(target:getID());
-        mob = SpawnMob(target:getID()+1);
-        local bcnmAllies = mob:getBattlefield():getAllies();
+    if csid == 32004 then
+        DespawnMob(target:getID())
+        mob = SpawnMob(target:getID()+1)
+        local bcnmAllies = mob:getBattlefield():getAllies()
         for i,v in pairs(bcnmAllies) do
-            v:resetLocalVars();
-            local spawn = v:getSpawnPos();
-            v:setPos(spawn.x, spawn.y, spawn.z, spawn.rot);
+            v:resetLocalVars()
+            local spawn = v:getSpawnPos()
+            v:setPos(spawn.x, spawn.y, spawn.z, spawn.rot)
         end
     end
 
-end;
+end

--- a/scripts/zones/Empyreal_Paradox/mobs/Promathia_2.lua
+++ b/scripts/zones/Empyreal_Paradox/mobs/Promathia_2.lua
@@ -68,4 +68,5 @@ function onMagicCastingCheck(mob, target, spell)
 end;
 
 function onMobDeath(mob, player, isKiller)
+    mob:getBattlefield():setLocalVar("loot", 0)
 end;

--- a/scripts/zones/Empyreal_Paradox/mobs/Promathia_2.lua
+++ b/scripts/zones/Empyreal_Paradox/mobs/Promathia_2.lua
@@ -3,70 +3,70 @@
 --  Mob: Promathia
 -- Note: Phase 2
 -----------------------------------
-local ID = require("scripts/zones/Empyreal_Paradox/IDs");
-require("scripts/globals/status");
-require("scripts/globals/titles");
-require("scripts/globals/magic");
+local ID = require("scripts/zones/Empyreal_Paradox/IDs")
+require("scripts/globals/status")
+require("scripts/globals/titles")
+require("scripts/globals/magic")
 -----------------------------------
 
 function onMobInitialize(mob)
-    mob:addMod(dsp.mod.REGAIN, 50);
-    mob:addMod(dsp.mod.UFASTCAST,50);
-end;
+    mob:addMod(dsp.mod.REGAIN, 50)
+    mob:addMod(dsp.mod.UFASTCAST,50)
+end
 
-function onMobEngaged(mob,target)
-    local bcnmAllies = mob:getBattlefield():getAllies();
+function onMobEngaged(mob, target)
+    local bcnmAllies = mob:getBattlefield():getAllies()
     for i,v in pairs(bcnmAllies) do
-        if (v:getName() == "Prishe") then
+        if v:getName() == "Prishe" then
             if not v:getTarget() then
-                v:entityAnimationPacket("prov");
-                v:showText(v, ID.text.PRISHE_TEXT + 1);
-                v:setLocalVar("ready", mob:getID());
+                v:entityAnimationPacket("prov")
+                v:showText(v, ID.text.PRISHE_TEXT + 1)
+                v:setLocalVar("ready", mob:getID())
             end
         else
-            v:addEnmity(mob,0,1);
+            v:addEnmity(mob,0,1)
         end
     end
-end;
+end
 
-function onMobFight(mob,target)
-    if (mob:AnimationSub() == 3 and not mob:hasStatusEffect(dsp.effect.STUN)) then
-        mob:AnimationSub(0);
+function onMobFight(mob, target)
+    if mob:AnimationSub() == 3 and not mob:hasStatusEffect(dsp.effect.STUN) then
+        mob:AnimationSub(0)
         mob:stun(1500);
-    elseif (mob:AnimationSub() == 2 and not mob:hasStatusEffect(dsp.effect.MAGIC_SHIELD)) then
-        mob:AnimationSub(0);
-    elseif (mob:AnimationSub() == 1 and not mob:hasStatusEffect(dsp.effect.PHYSICAL_SHIELD)) then
-        mob:AnimationSub(0);
+    elseif mob:AnimationSub() == 2 and not mob:hasStatusEffect(dsp.effect.MAGIC_SHIELD) then
+        mob:AnimationSub(0)
+    elseif mob:AnimationSub() == 1 and not mob:hasStatusEffect(dsp.effect.PHYSICAL_SHIELD) then
+        mob:AnimationSub(0)
     end
 
-    local bcnmAllies = mob:getBattlefield():getAllies();
+    local bcnmAllies = mob:getBattlefield():getAllies()
     for i,v in pairs(bcnmAllies) do
         if not v:getTarget() then
-            v:addEnmity(mob,0,1);
+            v:addEnmity(mob,0,1)
         end
     end
-end;
+end
 
 function onSpellPrecast(mob, spell)
-    if (spell:getID() == 218) then
-        spell:setAoE(dsp.magic.aoe.RADIAL);
-        spell:setFlag(dsp.magic.spellFlag.HIT_ALL);
-        spell:setRadius(30);
-        spell:setAnimation(280);
-        spell:setMPCost(1);
-    elseif (spell:getID() == 219) then
-        spell:setMPCost(1);
+    if spell:getID() == 218 then
+        spell:setAoE(dsp.magic.aoe.RADIAL)
+        spell:setFlag(dsp.magic.spellFlag.HIT_ALL)
+        spell:setRadius(30)
+        spell:setAnimation(280)
+        spell:setMPCost(1)
+    elseif spell:getID() == 219 then
+        spell:setMPCost(1)
     end
-end;
+end
 
 function onMagicCastingCheck(mob, target, spell)
     if math.random() > 0.75 then
-        return 219;
+        return 219
     else
-        return 218;
+        return 218
     end
-end;
+end
 
 function onMobDeath(mob, player, isKiller)
     mob:getBattlefield():setLocalVar("loot", 0)
-end;
+end

--- a/scripts/zones/Empyreal_Paradox/mobs/Selhteus.lua
+++ b/scripts/zones/Empyreal_Paradox/mobs/Selhteus.lua
@@ -3,36 +3,36 @@
 --  Mob: Selh'teus
 -- Chains of Promathia 8-4 BCNM Fight
 -----------------------------------
-require("scripts/globals/status");
-require("scripts/globals/magic");
-local ID = require("scripts/zones/Empyreal_Paradox/IDs");
+require("scripts/globals/status")
+require("scripts/globals/magic")
+local ID = require("scripts/zones/Empyreal_Paradox/IDs")
 -----------------------------------
 
 function onMobInitialize(mob)
-    mob:addMod(dsp.mod.REGAIN, 50);
-    mob:SetAutoAttackEnabled(false);
-end;
+    mob:addMod(dsp.mod.REGAIN, 50)
+    mob:SetAutoAttackEnabled(false)
+end
 
 function onMobFight(mob, target)
-    if (target:getTarget():getID() ~= mob:getID()) then
-        local targetPos = target:getPos();
-        local radians = (256 - targetPos.rot) * (math.pi / 128);
-        mob:pathTo(targetPos.x + math.cos(radians) * 16, targetPos.y, targetPos.z + math.sin(radians) * 16);
+    if target:getTarget():getID() ~= mob:getID() then
+        local targetPos = target:getPos()
+        local radians = (256 - targetPos.rot) * (math.pi / 128)
+        mob:pathTo(targetPos.x + math.cos(radians) * 16, targetPos.y, targetPos.z + math.sin(radians) * 16)
     end
-    local lanceTime = mob:getLocalVar("lanceTime");
-    local lanceOut = mob:getLocalVar("lanceOut");
-    local rejuv = mob:getLocalVar("rejuv");
-    if (mob:getHPP() < 30 and rejuv == 0 and target:getFamily() == 478) then
-        mob:messageText(mob, ID.text.SELHTEUS_TEXT + 2);
-        mob:useMobAbility(1509);
-        mob:setLocalVar("rejuv", 1);
+    local lanceTime = mob:getLocalVar("lanceTime")
+    local lanceOut = mob:getLocalVar("lanceOut")
+    local rejuv = mob:getLocalVar("rejuv")
+    if mob:getHPP() < 30 and rejuv == 0 and target:getFamily() == 478 then
+        mob:messageText(mob, ID.text.SELHTEUS_TEXT + 2)
+        mob:useMobAbility(1509)
+        mob:setLocalVar("rejuv", 1)
     elseif lanceTime + 50 < mob:getBattleTime() and lanceOut == 0 then
-        mob:entityAnimationPacket("sp00");
-        mob:setLocalVar("lanceOut", 1);
+        mob:entityAnimationPacket("sp00")
+        mob:setLocalVar("lanceOut", 1)
     end
-end;
+end
 
 function onMobDeath(mob, player, isKiller)
-    mob:messageText(mob, ID.text.SELHTEUS_TEXT);
-    mob:getBattlefield():lose();
-end;
+    mob:messageText(mob, ID.text.SELHTEUS_TEXT)
+    mob:getBattlefield():lose()
+end

--- a/scripts/zones/Full_Moon_Fountain/Zone.lua
+++ b/scripts/zones/Full_Moon_Fountain/Zone.lua
@@ -52,7 +52,7 @@ function onEventFinish(player,csid,option)
     elseif (csid == 32004) then
         local battlefield = player:getBattlefield();
         if (battlefield) then
-            local inst = battlefield:getBattlefieldNumber();
+            local inst = battlefield:getArea();
             local instOffset = ID.mob.MOON_READING_OFFSET + (6 * (inst - 1));
             local allyPos =
             {
@@ -69,7 +69,7 @@ function onEventFinish(player,csid,option)
             -- spawn Ajido-Marujido and set ally positions
             local allies = battlefield:getAllies();
             if (#allies == 0) then
-                local ajido = battlefield:insertAlly(14184);
+                local ajido = battlefield:insertEntity(14184, true, true);
                 ajido:setSpawn(allyPos[inst].ajidoPos);
                 ajido:spawn();
             end

--- a/scripts/zones/Full_Moon_Fountain/Zone.lua
+++ b/scripts/zones/Full_Moon_Fountain/Zone.lua
@@ -11,49 +11,49 @@ require("scripts/globals/titles")
 -----------------------------------
 
 function onInitialize(zone)
-end;
+end
 
-function onZoneIn(player,prevZone)
-    local cs = -1;
-    if (player:getXPos() == 0 and player:getYPos() == 0 and player:getZPos() == 0) then
-        player:setPos(-260.136,2.09,-325.702,188);
+function onZoneIn(player, prevZone)
+    local cs = -1
+    if player:getXPos() == 0 and player:getYPos() == 0 and player:getZPos() == 0 then
+        player:setPos(-260.136,2.09,-325.702,188)
     end
-    if (player:getCurrentMission(WINDURST) == dsp.mission.id.windurst.FULL_MOON_FOUNTAIN and player:getCharVar("MissionStatus") == 3) then
-        cs = 50;
-    elseif (player:getCurrentMission(WINDURST) == dsp.mission.id.windurst.DOLL_OF_THE_DEAD and player:getCharVar("MissionStatus") == 7) then
-        cs = 61;
+    if player:getCurrentMission(WINDURST) == dsp.mission.id.windurst.FULL_MOON_FOUNTAIN and player:getCharVar("MissionStatus") == 3 then
+        cs = 50
+    elseif player:getCurrentMission(WINDURST) == dsp.mission.id.windurst.DOLL_OF_THE_DEAD and player:getCharVar("MissionStatus") == 7 then
+        cs = 61
     end
-    return cs;
-end;
+    return cs
+end
 
 function afterZoneIn(player)
-    player:entityVisualPacket("kilk");
-    player:entityVisualPacket("izum");
-    player:entityVisualPacket("hast");
-end;
+    player:entityVisualPacket("kilk")
+    player:entityVisualPacket("izum")
+    player:entityVisualPacket("hast")
+end
 
 function onConquestUpdate(zone, updatetype)
     dsp.conq.onConquestUpdate(zone, updatetype)
-end;
+end
 
-function onRegionEnter(player,region)
-end;
+function onRegionEnter(player, region)
+end
 
-function onEventUpdate(player,csid,option)
-end;
+function onEventUpdate(player, csid, option)
+end
 
-function onEventFinish(player,csid,option)
+function onEventFinish(player, csid, option)
 
-    if (csid == 50) then
-        finishMissionTimeline(player,3,csid,option);
-    elseif (csid == 61) then
-        player:addTitle(dsp.title.GUIDING_STAR);
-        finishMissionTimeline(player,3,csid,option);
-    elseif (csid == 32004) then
-        local battlefield = player:getBattlefield();
-        if (battlefield) then
-            local inst = battlefield:getArea();
-            local instOffset = ID.mob.MOON_READING_OFFSET + (6 * (inst - 1));
+    if csid == 50 then
+        finishMissionTimeline(player, 3, csid, option)
+    elseif csid == 61 then
+        player:addTitle(dsp.title.GUIDING_STAR)
+        finishMissionTimeline(player, 3, csid, option)
+    elseif csid == 32004 then
+        local battlefield = player:getBattlefield()
+        if battlefield then
+            local inst = battlefield:getArea()
+            local instOffset = ID.mob.MOON_READING_OFFSET + (6 * (inst - 1))
             local allyPos =
             {
                 [1] = { ajidoPos = {340.117,   48.752, -383.747, 64}, playerPos = { 340.220,  48.557, -386.114, 190} },
@@ -63,17 +63,17 @@ function onEventFinish(player,csid,option)
             
             -- spawn Yali and Yatzlwurm
             for i = instOffset + 4, instOffset + 5 do
-                SpawnMob(i);
+                SpawnMob(i)
             end
             
             -- spawn Ajido-Marujido and set ally positions
-            local allies = battlefield:getAllies();
-            if (#allies == 0) then
-                local ajido = battlefield:insertEntity(14184, true, true);
-                ajido:setSpawn(allyPos[inst].ajidoPos);
-                ajido:spawn();
+            local allies = battlefield:getAllies()
+            if #allies == 0 then
+                local ajido = battlefield:insertEntity(14184, true, true)
+                ajido:setSpawn(allyPos[inst].ajidoPos)
+                ajido:spawn()
             end
-            player:setPos(allyPos[inst].playerPos);
+            player:setPos(allyPos[inst].playerPos)
         end
     end
-end;
+end

--- a/scripts/zones/Full_Moon_Fountain/bcnms/moon_reading.lua
+++ b/scripts/zones/Full_Moon_Fountain/bcnms/moon_reading.lua
@@ -15,7 +15,7 @@ function onBattlefieldInitialise(battlefield)
     battlefield:setLocalVar("lootSpawned", 1)
 end
 
-function onBattlefieldLeave(player,battlefield,leavecode)
+function onBattlefieldLeave(player, battlefield, leavecode)
     if leavecode == dsp.battlefield.leaveCode.WON then
         local name, clearTime, partySize = battlefield:getRecord()
         local arg8 = (player:getCurrentMission(WINDURST) ~= dsp.mission.id.windurst.MOON_READING) and 1 or 0

--- a/scripts/zones/Full_Moon_Fountain/bcnms/moon_reading.lua
+++ b/scripts/zones/Full_Moon_Fountain/bcnms/moon_reading.lua
@@ -10,13 +10,12 @@ function onBattlefieldTick(battlefield, tick)
     dsp.battlefield.onBattlefieldTick(battlefield, tick)
 end
 
-function onBcnmRegister(player, instance)
+function onBattlefieldInitialise(battlefield)
+    battlefield:setLocalVar("loot", 1)
+    battlefield:setLocalVar("lootSpawned", 1)
 end
 
-function onBcnmEnter(player, instance)
-end
-
-function onBcnmLeave(player, instance, leavecode)
+function onBattlefieldLeave(player,battlefield,leavecode)
     if leavecode == dsp.battlefield.leaveCode.WON then
         local name, clearTime, partySize = battlefield:getRecord()
         local arg8 = (player:getCurrentMission(WINDURST) ~= dsp.mission.id.windurst.MOON_READING) and 1 or 0

--- a/scripts/zones/Full_Moon_Fountain/mobs/Ace_of_Batons.lua
+++ b/scripts/zones/Full_Moon_Fountain/mobs/Ace_of_Batons.lua
@@ -7,19 +7,19 @@ local ID = require("scripts/zones/Full_Moon_Fountain/IDs")
 -----------------------------------
 
 function allMoonMobsDead(player)
-    local inst = player:getBattlefield():getBattlefieldNumber();
-    local instOffset = ID.mob.MOON_READING_OFFSET + (6 * (inst - 1));
+    local inst = player:getBattlefield():getArea()
+    local instOffset = ID.mob.MOON_READING_OFFSET + (6 * (inst - 1))
     for i = instOffset, instOffset + 3 do
-        if (not GetMobByID(i):isDead()) then
-            return false;
+        if not GetMobByID(i):isDead() then
+            return false
         end
     end
-    return true;
-end;
+    return true
+end
 
 function onMobDeath(mob, player, isKiller)
-    if (allMoonMobsDead(player)) then
-        player:release(); -- prevents event collision if player kills multiple remaining mobs with an AOE move/spell
-        player:startEvent(32004,1,0,1,0,1);
+    if allMoonMobsDead(player) then
+        player:release() -- prevents event collision if player kills multiple remaining mobs with an AOE move/spell
+        player:startEvent(32004,1,0,1,0,1)
     end
-end;
+end

--- a/scripts/zones/Full_Moon_Fountain/mobs/Ace_of_Coins.lua
+++ b/scripts/zones/Full_Moon_Fountain/mobs/Ace_of_Coins.lua
@@ -7,19 +7,19 @@ local ID = require("scripts/zones/Full_Moon_Fountain/IDs")
 -----------------------------------
 
 function allMoonMobsDead(player)
-    local inst = player:getBattlefield():getBattlefieldNumber();
-    local instOffset = ID.mob.MOON_READING_OFFSET + (6 * (inst - 1));
+    local inst = player:getBattlefield():getArea()
+    local instOffset = ID.mob.MOON_READING_OFFSET + (6 * (inst - 1))
     for i = instOffset, instOffset + 3 do
-        if (not GetMobByID(i):isDead()) then
-            return false;
+        if not GetMobByID(i):isDead() then
+            return false
         end
     end
-    return true;
-end;
+    return true
+end
 
 function onMobDeath(mob, player, isKiller)
-    if (allMoonMobsDead(player)) then
-        player:release(); -- prevents event collision if player kills multiple remaining mobs with an AOE move/spell
-        player:startEvent(32004,1,0,1,0,1);
+    if allMoonMobsDead(player) then
+        player:release() -- prevents event collision if player kills multiple remaining mobs with an AOE move/spell
+        player:startEvent(32004,1,0,1,0,1)
     end
-end;
+end

--- a/scripts/zones/Full_Moon_Fountain/mobs/Ace_of_Cups.lua
+++ b/scripts/zones/Full_Moon_Fountain/mobs/Ace_of_Cups.lua
@@ -7,19 +7,19 @@ local ID = require("scripts/zones/Full_Moon_Fountain/IDs")
 -----------------------------------
 
 function allMoonMobsDead(player)
-    local inst = player:getBattlefield():getBattlefieldNumber();
-    local instOffset = ID.mob.MOON_READING_OFFSET + (6 * (inst - 1));
+    local inst = player:getBattlefield():getArea()
+    local instOffset = ID.mob.MOON_READING_OFFSET + (6 * (inst - 1))
     for i = instOffset, instOffset + 3 do
-        if (not GetMobByID(i):isDead()) then
-            return false;
+        if not GetMobByID(i):isDead() then
+            return false
         end
     end
-    return true;
-end;
+    return true
+end
 
 function onMobDeath(mob, player, isKiller)
-    if (allMoonMobsDead(player)) then
-        player:release(); -- prevents event collision if player kills multiple remaining mobs with an AOE move/spell
-        player:startEvent(32004,1,0,1,0,1);
+    if allMoonMobsDead(player) then
+        player:release() -- prevents event collision if player kills multiple remaining mobs with an AOE move/spell
+        player:startEvent(32004,1,0,1,0,1)
     end
-end;
+end

--- a/scripts/zones/Full_Moon_Fountain/mobs/Ace_of_Swords.lua
+++ b/scripts/zones/Full_Moon_Fountain/mobs/Ace_of_Swords.lua
@@ -7,19 +7,19 @@ local ID = require("scripts/zones/Full_Moon_Fountain/IDs")
 -----------------------------------
 
 function allMoonMobsDead(player)
-    local inst = player:getBattlefield():getBattlefieldNumber();
-    local instOffset = ID.mob.MOON_READING_OFFSET + (6 * (inst - 1));
+    local inst = player:getBattlefield():getArea()
+    local instOffset = ID.mob.MOON_READING_OFFSET + (6 * (inst - 1))
     for i = instOffset, instOffset + 3 do
-        if (not GetMobByID(i):isDead()) then
-            return false;
+        if not GetMobByID(i):isDead() then
+            return false
         end
     end
-    return true;
-end;
+    return true
+end
 
 function onMobDeath(mob, player, isKiller)
-    if (allMoonMobsDead(player)) then
-        player:release(); -- prevents event collision if player kills multiple remaining mobs with an AOE move/spell
-        player:startEvent(32004,1,0,1,0,1);
+    if allMoonMobsDead(player) then
+        player:release() -- prevents event collision if player kills multiple remaining mobs with an AOE move/spell
+        player:startEvent(32004,1,0,1,0,1)
     end
-end;
+end

--- a/scripts/zones/Full_Moon_Fountain/mobs/Ajido-Marujido.lua
+++ b/scripts/zones/Full_Moon_Fountain/mobs/Ajido-Marujido.lua
@@ -11,7 +11,7 @@ require("scripts/globals/magic")
 function onMobInitialize(mob)
     mob:setMod(dsp.mod.REFRESH, 1)
     mob:setMobMod(dsp.mobMod.TELEPORT_CD, 30)
-end;
+end
 
 function onMobSpawn(mob)
     mob:addListener("MAGIC_START", "MAGIC_MSG", function(mob, spell, action)
@@ -29,7 +29,7 @@ function onMobRoam(mob)
     local wait = mob:getLocalVar("wait")
     if wait > 40 then
         -- pick a random living target from the two enemies
-        local inst = mob:getBattlefield():getBattlefieldNumber()
+        local inst = mob:getBattlefield():getArea()
         local instOffset = ID.mob.MOON_READING_OFFSET + (6 * (inst - 1))
         local target = GetMobByID(instOffset + math.random(4,5))
         if not target:isDead() then

--- a/scripts/zones/Full_Moon_Fountain/mobs/Tatzlwurm.lua
+++ b/scripts/zones/Full_Moon_Fountain/mobs/Tatzlwurm.lua
@@ -3,7 +3,13 @@
 --  Mob: Tatzlwurm
 -- Windurst Mission 9-2
 -----------------------------------
-require("scripts/globals/status");
+require("scripts/globals/status")
+local ID = require("scripts/zones/Full_Moon_Fountain/IDs")
 
 function onMobDeath(mob, player, isKiller)
-end;
+    local inst = mob:getBattlefield():getArea()
+    local instOffset = ID.mob.MOON_READING_OFFSET + (6 * (inst - 1))
+    if GetMobByID(instOffset + 4):isDead() and GetMobByID(instOffset + 5):isDead() then
+        mob:getBattlefield():setLocalVar("loot", 0)
+    end
+end

--- a/scripts/zones/Full_Moon_Fountain/mobs/Yali.lua
+++ b/scripts/zones/Full_Moon_Fountain/mobs/Yali.lua
@@ -3,11 +3,17 @@
 --  Mob: Yali
 -- Windurst Mission 9-2
 -----------------------------------
-require("scripts/globals/status");
+require("scripts/globals/status")
+local ID = require("scripts/zones/Full_Moon_Fountain/IDs")
 
 function onMobInitialize(mob)
-    mob:setSpellList(135);
-end;
+    mob:setSpellList(135)
+end
 
 function onMobDeath(mob, player, isKiller)
-end;
+    local inst = mob:getBattlefield():getArea()
+    local instOffset = ID.mob.MOON_READING_OFFSET + (6 * (inst - 1))
+    if GetMobByID(instOffset + 4):isDead() and GetMobByID(instOffset + 5):isDead() then
+        mob:getBattlefield():setLocalVar("loot", 0)
+    end
+end

--- a/scripts/zones/Metalworks/npcs/Iron_Eater.lua
+++ b/scripts/zones/Metalworks/npcs/Iron_Eater.lua
@@ -31,9 +31,9 @@ function onTrigger(player,npc)
         player:startEvent(wsQuestEvent)
     elseif (currentMission == dsp.mission.id.bastok.THE_FOUR_MUSKETEERS and missionStatus == 0) then -- Four Musketeers
         player:startEvent(715)
-    elseif (currentMission == dsp.mission.id.bastok.WHERE_TWO_PATHS_CONVERGE and player:getCharVar("BASTOK92") == 0) then
+    elseif (currentMission == dsp.mission.id.bastok.WHERE_TWO_PATHS_CONVERGE and player:getCharVar("MissionStatus") == 0) then
         player:startEvent(780)
-    elseif (currentMission == dsp.mission.id.bastok.WHERE_TWO_PATHS_CONVERGE and player:getCharVar("BASTOK92") == 2) then
+    elseif (currentMission == dsp.mission.id.bastok.WHERE_TWO_PATHS_CONVERGE and player:getCharVar("MissionStatus") == 2) then
         player:startEvent(782)
     elseif (player:getCharVar("Flagbastok") == 1) then
         if (player:getFreeSlotsCount() == 0) then
@@ -66,7 +66,7 @@ function onEventFinish(player,csid,option)
     if (csid == 715 and option == 0) then
         player:setCharVar("MissionStatus",1)
     elseif (csid == 780) then
-        player:setCharVar("BASTOK92", 1)
+        player:setCharVar("MissionStatus", 1)
     elseif (csid == 767 and option == 0) then
         player:setCharVar("MissionStatus", 1)
     elseif (csid == 768) then
@@ -79,7 +79,7 @@ function onEventFinish(player,csid,option)
             player:addItem(182)
             player:messageSpecial(ID.text.ITEM_OBTAINED,182)
         end
-        player:setCharVar("BASTOK92",0)
+        player:setCharVar("MissionStatus",0)
         player:completeMission(BASTOK,dsp.mission.id.bastok.WHERE_TWO_PATHS_CONVERGE)
         player:setRank(10)
         player:addGil(GIL_RATE*100000)

--- a/scripts/zones/Navukgo_Execution_Chamber/bcnms/shield_of_diplomacy.lua
+++ b/scripts/zones/Navukgo_Execution_Chamber/bcnms/shield_of_diplomacy.lua
@@ -4,18 +4,17 @@
 -----------------------------------
 require("scripts/globals/battlefield")
 require("scripts/globals/missions")
+local ID = require("scripts/zones/Navukgo_Execution_Chamber/IDs")
 ----------------------------------------
 
 function onBattlefieldTick(battlefield, tick)
     dsp.battlefield.onBattlefieldTick(battlefield, tick)
 end
 
-function onBattlefieldRegister(player, battlefield)
-    local baseID = ID.mob.KARABABA_OFFSET + (battlefield:getArea() - 1) * 2
-    local pos = GetMobByID(baseID):getSpawnPos()
+function onBattlefieldInitialise(battlefield)
 
-    local karababa  = battlefield:insertEntity(2157, true)
-    karababa:setSpawn(pos.x, pos.y, pos.z, 0)
+    local karababa  = battlefield:insertEntity(2157, true, true)
+    karababa:setSpawn(360.937,-116.5,376.937, 0)
     karababa:spawn()
 end
 

--- a/scripts/zones/Navukgo_Execution_Chamber/mobs/Karababa.lua
+++ b/scripts/zones/Navukgo_Execution_Chamber/mobs/Karababa.lua
@@ -2,61 +2,57 @@
 -- Area: Navukgo Execution Chamber
 --  Mob: Karababa
 -----------------------------------
-require("scripts/globals/status");
-local ID = require("scripts/zones/Navukgo_Execution_Chamber/IDs");
+require("scripts/globals/status")
+local ID = require("scripts/zones/Navukgo_Execution_Chamber/IDs")
 -----------------------------------
 
 function onMobFight(mob,target)
-    local warp = mob:getLocalVar("warp");
-
-    if (mob:getHPP() <= 50 and mob:getLocalVar("powerup") == 0) then
-        target:showText(mob,ID.text.KARABABA_ENOUGH);
-        target:showText(mob,ID.text.KARABABA_ROUGH);
-        mob:addStatusEffect(dsp.effect.MAGIC_ATK_BOOST,15,0,1800);
-        mob:setLocalVar("powerup",1);
-    elseif (mob:getHPP() <= 20 and warp == 0) then
-        mob:setLocalVar("warp",1);
+    local warp = mob:getLocalVar("warp")
+    local wait = mob:getLocalVar("wait")
+    if mob:getLocalVar("warp") == 2 and wait < os.time() then
+        mob:getBattlefield():lose()
     end
-end;
+    if mob:getHPP() <= 50 and mob:getLocalVar("powerup") == 0 then
+        target:showText(mob,ID.text.KARABABA_ENOUGH)
+        target:showText(mob,ID.text.KARABABA_ROUGH)
+        mob:addStatusEffect(dsp.effect.MAGIC_ATK_BOOST,15,0,1800)
+        mob:setLocalVar("powerup",1)
+    elseif mob:getHPP() <= 20 and warp == 0 then
+        mob:setLocalVar("warp",1)
+    end
+end
 
 function onMonsterMagicPrepare(mob, target)
-    local powerup = mob:getLocalVar("powerup");
+    local powerup = mob:getLocalVar("powerup")
     local rnd = math.random(1, 6)
-    local warp = mob:getLocalVar("warp");
+    local warp = mob:getLocalVar("warp")
 
-    if (warp == 1) then
-        mob:showText(mob,ID.text.KARABABA_QUIT);
-        mob:setLocalVar("warp",2);
-        return 261;
-    elseif (mob:getLocalVar("warp") == 2) then
-        mob:getBattlefield():lose();
-        return -1;
-    elseif (rnd == 1) then
-        mob:showText(mob,ID.text.KARABARA_FIRE);
-        return 205 - powerup;
-    elseif (rnd == 2) then
-        mob:showText(mob,ID.text.KARABARA_ICE);
-        return 207 - powerup;
-    elseif (rnd == 3) then
-        mob:showText(mob,ID.text.KARABARA_WIND);
-        return 209 - powerup;
-    elseif (rnd == 4) then
-        mob:showText(mob,ID.text.KARABARA_EARTH);
-        return 211 - powerup;
-    elseif (rnd == 5) then
-        mob:showText(mob,ID.text.KARABARA_LIGHTNING);
-        return 213 - powerup;
-    elseif (rnd == 6) then
-        mob:showText(mob,ID.text.KARABARA_WATER);
-        return 215 - powerup;
+    if warp == 1 then
+        mob:showText(mob,ID.text.KARABABA_QUIT)
+        mob:setLocalVar("warp",2)
+        mob:setLocalVar("wait", os.time()+8)
+        return 261
+    elseif rnd == 1 then
+        mob:showText(mob,ID.text.KARABARA_FIRE)
+        return 205 - powerup
+    elseif rnd == 2 then
+        mob:showText(mob,ID.text.KARABARA_ICE)
+        return 207 - powerup
+    elseif rnd == 3 then
+        mob:showText(mob,ID.text.KARABARA_WIND)
+        return 209 - powerup
+    elseif rnd == 4 then
+        mob:showText(mob,ID.text.KARABARA_EARTH)
+        return 211 - powerup
+    elseif rnd == 5 then
+        mob:showText(mob,ID.text.KARABARA_LIGHTNING)
+        return 213 - powerup
+    elseif rnd == 6 then
+        mob:showText(mob,ID.text.KARABARA_WATER)
+        return 215 - powerup
     end
-
-end;
-
-function onMobDespawn(mob, player, isKiller)
-    mob:getBattlefield():lose();
-end;
+end
 
 function onMobDeath(mob, player, isKiller)
-    mob:getBattlefield():lose();
-end;
+    mob:getBattlefield():lose()
+end

--- a/scripts/zones/Navukgo_Execution_Chamber/mobs/Khimaira_13.lua
+++ b/scripts/zones/Navukgo_Execution_Chamber/mobs/Khimaira_13.lua
@@ -2,25 +2,26 @@
 -- Area: Navukgo Execution Chamber
 --  Mob: Khimaira 13
 -----------------------------------
-require("scripts/globals/allyassist");
------------------------------------
 
-function onMobFight(mob,target)
-    local assist = mob:getLocalVar("assist");
-
-    if (assist == 0) then
-        dsp.ally.startAssist(mob);
-        mob:setLocalVar("assist", 1);
+function onMobEngaged(mob, target)
+    local bcnmAllies = mob:getBattlefield():getAllies()
+    for i,v in pairs(bcnmAllies) do
+        if v:getName() == "Karababa" then
+            v:addEnmity(mob,0,1)
+        end
     end
-end;
+end
+
+function onMobFight(mob, target)
+end
 
 function onMobDeath(mob, player, isKiller)
-end;
+end
 
-function onEventUpdate(player,csid,option)
+function onEventUpdate(player, csid, option)
     -- printf("updateCSID: %u",csid);
-end;
+end
 
-function onEventFinish(player,csid,option,target)
+function onEventFinish(player, csid, option, target)
     -- printf("finishCSID: %u",csid);
-end;
+end

--- a/scripts/zones/QuBia_Arena/Zone.lua
+++ b/scripts/zones/QuBia_Arena/Zone.lua
@@ -32,7 +32,7 @@ function onEventFinish(player,csid,option)
     if (csid == 32004) then
         local battlefield = player:getBattlefield();
         if (battlefield) then
-            local inst = battlefield:getBattlefieldNumber();
+            local inst = battlefield:getArea();
             local instOffset = ID.mob.HEIR_TO_THE_LIGHT_OFFSET + (14 * (inst-1));
             local allyPos =
             {
@@ -49,7 +49,7 @@ function onEventFinish(player,csid,option)
             -- spawn trion and set ally positions
             local allies = battlefield:getAllies();
             if (#allies == 0) then
-                local trion = battlefield:insertAlly(14183);
+                local trion = battlefield:insertEntity(14183, true, true);
                 trion:setSpawn(allyPos[inst].trionPos);
                 trion:spawn();
             end

--- a/scripts/zones/QuBia_Arena/Zone.lua
+++ b/scripts/zones/QuBia_Arena/Zone.lua
@@ -8,32 +8,32 @@ require("scripts/globals/conquest")
 -----------------------------------
 
 function onInitialize(zone)
-end;
+end
 
 function onZoneIn(player,prevZone)
-    local cs = -1;
-    if (player:getXPos() == 0 and player:getYPos() == 0 and player:getZPos() == 0) then
-        player:setPos(-241.046,-25.86,19.991,0);
+    local cs = -1
+    if player:getXPos() == 0 and player:getYPos() == 0 and player:getZPos() == 0 then
+        player:setPos(-241.046,-25.86,19.991,0)
     end
-    return cs;
-end;
+    return cs
+end
 
 function onConquestUpdate(zone, updatetype)
     dsp.conq.onConquestUpdate(zone, updatetype)
-end;
+end
 
-function onRegionEnter(player,region)
-end;
+function onRegionEnter(player, region)
+end
 
-function onEventUpdate(player,csid,option)
-end;
+function onEventUpdate(player, csid, option)
+end
 
-function onEventFinish(player,csid,option)
-    if (csid == 32004) then
-        local battlefield = player:getBattlefield();
-        if (battlefield) then
-            local inst = battlefield:getArea();
-            local instOffset = ID.mob.HEIR_TO_THE_LIGHT_OFFSET + (14 * (inst-1));
+function onEventFinish(player, csid, option)
+    if csid == 32004 then
+        local battlefield = player:getBattlefield()
+        if battlefield then
+            local inst = battlefield:getArea()
+            local instOffset = ID.mob.HEIR_TO_THE_LIGHT_OFFSET + (14 * (inst-1))
             local allyPos =
             {
                 [1] = { trionPos = {-403, -201,  413, 58}, playerPos = {-400, -201,  419, 61} },
@@ -43,17 +43,17 @@ function onEventFinish(player,csid,option)
             
             -- spawn Warlord Rojnoj and its right and left hands.
             for i = instOffset + 0, instOffset + 2 do
-                SpawnMob(i);
+                SpawnMob(i)
             end
 
             -- spawn trion and set ally positions
-            local allies = battlefield:getAllies();
-            if (#allies == 0) then
-                local trion = battlefield:insertEntity(14183, true, true);
-                trion:setSpawn(allyPos[inst].trionPos);
-                trion:spawn();
+            local allies = battlefield:getAllies()
+            if #allies == 0 then
+                local trion = battlefield:insertEntity(14183, true, true)
+                trion:setSpawn(allyPos[inst].trionPos)
+                trion:spawn()
             end
-            player:setPos(allyPos[inst].playerPos);
+            player:setPos(allyPos[inst].playerPos)
         end
     end
-end;
+end

--- a/scripts/zones/QuBia_Arena/bcnms/heir_to_the_light.lua
+++ b/scripts/zones/QuBia_Arena/bcnms/heir_to_the_light.lua
@@ -10,6 +10,11 @@ function onBattlefieldTick(battlefield, tick)
     dsp.battlefield.onBattlefieldTick(battlefield, tick)
 end
 
+function onBattlefieldInitialise(battlefield)
+    battlefield:setLocalVar("loot", 1)
+    battlefield:setLocalVar("lootSpawned", 1)
+end
+
 function onBattlefieldRegister(player, battlefield)
 end
 

--- a/scripts/zones/QuBia_Arena/mobs/Death_Clan_Destroyer.lua
+++ b/scripts/zones/QuBia_Arena/mobs/Death_Clan_Destroyer.lua
@@ -10,7 +10,7 @@ function onMobInitialize(mob)
 end;
 
 function allHeirMobsDead(player)
-    local inst = player:getBattlefield():getBattlefieldNumber();
+    local inst = player:getBattlefield():getArea();
     local instOffset = ID.mob.HEIR_TO_THE_LIGHT_OFFSET + (14 * (inst-1));
     for i = instOffset + 3, instOffset + 13 do
         if (not GetMobByID(i):isDead()) then
@@ -21,7 +21,7 @@ function allHeirMobsDead(player)
 end;
 
 function onMobFight(mob,target)
-    local inst = mob:getBattlefield():getBattlefieldNumber();
+    local inst = mob:getBattlefield():getArea();
     local instOffset = ID.mob.HEIR_TO_THE_LIGHT_OFFSET + (14 * (inst-1));
     mob:setMP(9999);
 

--- a/scripts/zones/QuBia_Arena/mobs/Death_Clan_Destroyer.lua
+++ b/scripts/zones/QuBia_Arena/mobs/Death_Clan_Destroyer.lua
@@ -2,50 +2,50 @@
 -- Area: QuBia_Arena
 --  Mob: Death Clan Destroyer
 -----------------------------------
-local ID = require("scripts/zones/QuBia_Arena/IDs");
-require("scripts/globals/status");
+local ID = require("scripts/zones/QuBia_Arena/IDs")
+require("scripts/globals/status")
 
 function onMobInitialize(mob)
-    mob:setMobMod(dsp.mobMod.HP_STANDBACK, 60);
-end;
+    mob:setMobMod(dsp.mobMod.HP_STANDBACK, 60)
+end
 
 function allHeirMobsDead(player)
-    local inst = player:getBattlefield():getArea();
-    local instOffset = ID.mob.HEIR_TO_THE_LIGHT_OFFSET + (14 * (inst-1));
+    local inst = player:getBattlefield():getArea()
+    local instOffset = ID.mob.HEIR_TO_THE_LIGHT_OFFSET + (14 * (inst-1))
     for i = instOffset + 3, instOffset + 13 do
-        if (not GetMobByID(i):isDead()) then
-            return false;
+        if not GetMobByID(i):isDead() then
+            return false
         end
     end
-    return true;
-end;
+    return true
+end
 
-function onMobFight(mob,target)
-    local inst = mob:getBattlefield():getArea();
-    local instOffset = ID.mob.HEIR_TO_THE_LIGHT_OFFSET + (14 * (inst-1));
-    mob:setMP(9999);
+function onMobFight(mob, target)
+    local inst = mob:getBattlefield():getArea()
+    local instOffset = ID.mob.HEIR_TO_THE_LIGHT_OFFSET + (14 * (inst-1))
+    mob:setMP(9999)
 
     -- queue curaga II on any sleeping ally
     for i = instOffset + 3, instOffset + 12 do
-        if (GetMobByID(i):getCurrentAction() == dsp.act.SLEEP) then
-            if (mob:actionQueueEmpty()) then
-                if (mob:getLocalVar("cooldown") == 0) then
-                    mob:castSpell(8, GetMobByID(i));
-                    mob:setLocalVar("cooldown", 20);
+        if GetMobByID(i):getCurrentAction() == dsp.act.SLEEP then
+            if mob:actionQueueEmpty() then
+                if mob:getLocalVar("cooldown") == 0 then
+                    mob:castSpell(8, GetMobByID(i))
+                    mob:setLocalVar("cooldown", 20)
                 end
             else
-                mob:setLocalVar("cooldown",20);
+                mob:setLocalVar("cooldown",20)
             end
         end
     end
-    if (mob:getLocalVar("cooldown") > 0) then
-        mob:setLocalVar("cooldown", mob:getLocalVar("cooldown") - 1);
+    if mob:getLocalVar("cooldown") > 0 then
+        mob:setLocalVar("cooldown", mob:getLocalVar("cooldown") - 1)
     end
-end;
+end
 
 function onMobDeath(mob, player, isKiller)
-    if (allHeirMobsDead(player)) then
-        player:release(); -- prevents event collision if player kills multiple remaining mobs with an AOE move/spell
-        player:startEvent(32004,0,0,4);
+    if allHeirMobsDead(player) then
+        player:release() -- prevents event collision if player kills multiple remaining mobs with an AOE move/spell
+        player:startEvent(32004,0,0,4)
     end
-end;
+end

--- a/scripts/zones/QuBia_Arena/mobs/Rallbrog_of_Clan_Death.lua
+++ b/scripts/zones/QuBia_Arena/mobs/Rallbrog_of_Clan_Death.lua
@@ -6,7 +6,7 @@
 local ID = require("scripts/zones/QuBia_Arena/IDs");
 
 function allHeirMobsDead(player)
-    local inst = player:getBattlefield():getBattlefieldNumber();
+    local inst = player:getBattlefield():getArea();
     local instOffset = ID.mob.HEIR_TO_THE_LIGHT_OFFSET + (14 * (inst-1));
     for i = instOffset + 3, instOffset + 13 do
         if (not GetMobByID(i):isDead()) then

--- a/scripts/zones/QuBia_Arena/mobs/Rallbrog_of_Clan_Death.lua
+++ b/scripts/zones/QuBia_Arena/mobs/Rallbrog_of_Clan_Death.lua
@@ -3,22 +3,22 @@
 --  Mob: Rallbrog of Clan Death
 -- Mission 9-2 SANDO
 -----------------------------------
-local ID = require("scripts/zones/QuBia_Arena/IDs");
+local ID = require("scripts/zones/QuBia_Arena/IDs")
 
 function allHeirMobsDead(player)
-    local inst = player:getBattlefield():getArea();
-    local instOffset = ID.mob.HEIR_TO_THE_LIGHT_OFFSET + (14 * (inst-1));
+    local inst = player:getBattlefield():getArea()
+    local instOffset = ID.mob.HEIR_TO_THE_LIGHT_OFFSET + (14 * (inst-1))
     for i = instOffset + 3, instOffset + 13 do
-        if (not GetMobByID(i):isDead()) then
-            return false;
+        if not GetMobByID(i):isDead() then
+            return false
         end
     end
-    return true;
-end;
+    return true
+end
 
 function onMobDeath(mob, player, isKiller)
-    if (allHeirMobsDead(player)) then
-        player:release(); -- prevents event collision if player kills multiple remaining mobs with an AOE move/spell
-        player:startEvent(32004,0,0,4);
+    if allHeirMobsDead(player) then
+        player:release() -- prevents event collision if player kills multiple remaining mobs with an AOE move/spell
+        player:startEvent(32004,0,0,4)
     end
-end;
+end

--- a/scripts/zones/QuBia_Arena/mobs/Rojgnojs_Left_Hand.lua
+++ b/scripts/zones/QuBia_Arena/mobs/Rojgnojs_Left_Hand.lua
@@ -5,10 +5,18 @@
 -----------------------------------
 mixins = {require("scripts/mixins/job_special")};
 require("scripts/globals/status");
+local ID = require("scripts/zones/QuBia_Arena/IDs");
 
 function onMobInitialize(mob)
     mob:addMod(dsp.mod.SLEEPRES,50);
 end;
 
 function onMobDeath(mob, player, isKiller)
+    local inst = mob:getBattlefield():getArea()
+    local instOffset = ID.mob.HEIR_TO_THE_LIGHT_OFFSET + (14 * (inst-1));
+    if GetMobByID(instOffset + 0):isDead() and GetMobByID(instOffset + 1):isDead()
+        and GetMobByID(instOffset + 2):isDead()
+    then
+        mob:getBattlefield():setLocalVar("loot", 0)
+    end
 end;

--- a/scripts/zones/QuBia_Arena/mobs/Rojgnojs_Left_Hand.lua
+++ b/scripts/zones/QuBia_Arena/mobs/Rojgnojs_Left_Hand.lua
@@ -3,20 +3,20 @@
 --  Mob: Rojgnoj's Left Hand
 -- Mission 9-2 SANDO
 -----------------------------------
-mixins = {require("scripts/mixins/job_special")};
-require("scripts/globals/status");
-local ID = require("scripts/zones/QuBia_Arena/IDs");
+mixins = {require("scripts/mixins/job_special")}
+require("scripts/globals/status")
+local ID = require("scripts/zones/QuBia_Arena/IDs")
 
 function onMobInitialize(mob)
-    mob:addMod(dsp.mod.SLEEPRES,50);
-end;
+    mob:addMod(dsp.mod.SLEEPRES,50)
+end
 
 function onMobDeath(mob, player, isKiller)
     local inst = mob:getBattlefield():getArea()
-    local instOffset = ID.mob.HEIR_TO_THE_LIGHT_OFFSET + (14 * (inst-1));
+    local instOffset = ID.mob.HEIR_TO_THE_LIGHT_OFFSET + (14 * (inst-1))
     if GetMobByID(instOffset + 0):isDead() and GetMobByID(instOffset + 1):isDead()
         and GetMobByID(instOffset + 2):isDead()
     then
         mob:getBattlefield():setLocalVar("loot", 0)
     end
-end;
+end

--- a/scripts/zones/QuBia_Arena/mobs/Rojgnojs_Right_Hand.lua
+++ b/scripts/zones/QuBia_Arena/mobs/Rojgnojs_Right_Hand.lua
@@ -5,10 +5,18 @@
 -----------------------------------
 mixins = {require("scripts/mixins/job_special")};
 require("scripts/globals/status");
+local ID = require("scripts/zones/QuBia_Arena/IDs");
 
 function onMobInitialize(mob)
     mob:addMod(dsp.mod.SLEEPRES,50);
 end;
 
 function onMobDeath(mob, player, isKiller)
+    local inst = mob:getBattlefield():getArea()
+    local instOffset = ID.mob.HEIR_TO_THE_LIGHT_OFFSET + (14 * (inst-1));
+    if GetMobByID(instOffset + 0):isDead() and GetMobByID(instOffset + 1):isDead()
+        and GetMobByID(instOffset + 2):isDead()
+    then
+        mob:getBattlefield():setLocalVar("loot", 0)
+    end
 end;

--- a/scripts/zones/QuBia_Arena/mobs/Rojgnojs_Right_Hand.lua
+++ b/scripts/zones/QuBia_Arena/mobs/Rojgnojs_Right_Hand.lua
@@ -3,20 +3,20 @@
 --  Mob: Rojgnoj's Right Hand
 -- Mission 9-2 SANDO
 -----------------------------------
-mixins = {require("scripts/mixins/job_special")};
-require("scripts/globals/status");
-local ID = require("scripts/zones/QuBia_Arena/IDs");
+mixins = {require("scripts/mixins/job_special")}
+require("scripts/globals/status")
+local ID = require("scripts/zones/QuBia_Arena/IDs")
 
 function onMobInitialize(mob)
-    mob:addMod(dsp.mod.SLEEPRES,50);
-end;
+    mob:addMod(dsp.mod.SLEEPRES,50)
+end
 
 function onMobDeath(mob, player, isKiller)
     local inst = mob:getBattlefield():getArea()
-    local instOffset = ID.mob.HEIR_TO_THE_LIGHT_OFFSET + (14 * (inst-1));
+    local instOffset = ID.mob.HEIR_TO_THE_LIGHT_OFFSET + (14 * (inst-1))
     if GetMobByID(instOffset + 0):isDead() and GetMobByID(instOffset + 1):isDead()
         and GetMobByID(instOffset + 2):isDead()
     then
         mob:getBattlefield():setLocalVar("loot", 0)
     end
-end;
+end

--- a/scripts/zones/QuBia_Arena/mobs/Trion.lua
+++ b/scripts/zones/QuBia_Arena/mobs/Trion.lua
@@ -3,49 +3,49 @@
 --  Mob: Trion
 -- Ally during San d'Oria Mission 9-2
 -----------------------------------
-local ID = require("scripts/zones/QuBia_Arena/IDs");
-require("scripts/globals/status");
+local ID = require("scripts/zones/QuBia_Arena/IDs")
+require("scripts/globals/status")
 -----------------------------------
 
 function onMobInitialize(mob)
-    mob:addMod(dsp.mod.REGAIN, 30);
-end;
+    mob:addMod(dsp.mod.REGAIN, 30)
+end
 
 function onMobSpawn(mob)
     mob:addListener("WEAPONSKILL_STATE_ENTER", "WS_START_MSG", function(mob, skillID)
         -- Red Lotus Blade
-        if (skillID == 968) then
-            mob:showText(mob,ID.text.RLB_PREPARE);
+        if skillID == 968 then
+            mob:showText(mob,ID.text.RLB_PREPARE)
         -- Flat Blade
-        elseif (skillID == 969) then
-            mob:showText(mob,ID.text.FLAT_PREPARE);
+        elseif skillID == 969 then
+            mob:showText(mob,ID.text.FLAT_PREPARE)
         -- Savage Blade
-        elseif (skillID == 970) then
-            mob:showText(mob,ID.text.SAVAGE_PREPARE);
+        elseif skillID == 970 then
+            mob:showText(mob,ID.text.SAVAGE_PREPARE)
         end
-    end);
-end;
+    end)
+end
 
 function onMobDisengage(mob)
-    mob:setLocalVar("wait", 0);
-end;
+    mob:setLocalVar("wait", 0)
+end
 
 function onMobRoam(mob)
-    local wait = mob:getLocalVar("wait");
-    if (wait > 40) then
+    local wait = mob:getLocalVar("wait")
+    if wait > 40 then
         -- pick a random living target from the three enemies
-        local inst = mob:getBattlefield():getArea();
-        local instOffset = ID.mob.HEIR_TO_THE_LIGHT_OFFSET + (14 * (inst-1));
-        local target = GetMobByID(instOffset + math.random(0,2));
-        if (not target:isDead()) then
-            mob:addEnmity(target,0,1);
-            mob:setLocalVar("wait", 0);
+        local inst = mob:getBattlefield():getArea()
+        local instOffset = ID.mob.HEIR_TO_THE_LIGHT_OFFSET + (14 * (inst-1))
+        local target = GetMobByID(instOffset + math.random(0,2))
+        if not target:isDead() then
+            mob:addEnmity(target,0,1)
+            mob:setLocalVar("wait", 0)
         end
     else
-        mob:setLocalVar("wait", wait+3);
+        mob:setLocalVar("wait", wait+3)
     end
-end;
+end
 
 function onMobDeath(mob, player, isKiller)
-    mob:getBattlefield():lose();
-end;
+    mob:getBattlefield():lose()
+end

--- a/scripts/zones/QuBia_Arena/mobs/Trion.lua
+++ b/scripts/zones/QuBia_Arena/mobs/Trion.lua
@@ -34,7 +34,7 @@ function onMobRoam(mob)
     local wait = mob:getLocalVar("wait");
     if (wait > 40) then
         -- pick a random living target from the three enemies
-        local inst = mob:getBattlefield():getBattlefieldNumber();
+        local inst = mob:getBattlefield():getArea();
         local instOffset = ID.mob.HEIR_TO_THE_LIGHT_OFFSET + (14 * (inst-1));
         local target = GetMobByID(instOffset + math.random(0,2));
         if (not target:isDead()) then

--- a/scripts/zones/QuBia_Arena/mobs/Vangknok_of_Clan_Death.lua
+++ b/scripts/zones/QuBia_Arena/mobs/Vangknok_of_Clan_Death.lua
@@ -6,7 +6,7 @@
 local ID = require("scripts/zones/QuBia_Arena/IDs");
 
 function allHeirMobsDead(player)
-    local inst = player:getBattlefield():getBattlefieldNumber();
+    local inst = player:getBattlefield():getArea();
     local instOffset = ID.mob.HEIR_TO_THE_LIGHT_OFFSET + (14 * (inst-1));
     for i = instOffset + 3, instOffset + 13 do
         if (not GetMobByID(i):isDead()) then

--- a/scripts/zones/QuBia_Arena/mobs/Vangknok_of_Clan_Death.lua
+++ b/scripts/zones/QuBia_Arena/mobs/Vangknok_of_Clan_Death.lua
@@ -3,22 +3,22 @@
 --  Mob: Vangknok of Clan Death
 -- Mission 9-2 SANDO
 -----------------------------------
-local ID = require("scripts/zones/QuBia_Arena/IDs");
+local ID = require("scripts/zones/QuBia_Arena/IDs")
 
 function allHeirMobsDead(player)
-    local inst = player:getBattlefield():getArea();
-    local instOffset = ID.mob.HEIR_TO_THE_LIGHT_OFFSET + (14 * (inst-1));
+    local inst = player:getBattlefield():getArea()
+    local instOffset = ID.mob.HEIR_TO_THE_LIGHT_OFFSET + (14 * (inst-1))
     for i = instOffset + 3, instOffset + 13 do
-        if (not GetMobByID(i):isDead()) then
-            return false;
+        if not GetMobByID(i):isDead() then
+            return false
         end
     end
-    return true;
-end;
+    return true
+end
 
 function onMobDeath(mob, player, isKiller)
-    if (allHeirMobsDead(player)) then
-        player:release(); -- prevents event collision if player kills multiple remaining mobs with an AOE move/spell
-        player:startEvent(32004,0,0,4);
+    if allHeirMobsDead(player) then
+        player:release() -- prevents event collision if player kills multiple remaining mobs with an AOE move/spell
+        player:startEvent(32004,0,0,4)
     end
-end;
+end

--- a/scripts/zones/QuBia_Arena/mobs/Warlord_Rojgnoj.lua
+++ b/scripts/zones/QuBia_Arena/mobs/Warlord_Rojgnoj.lua
@@ -5,10 +5,18 @@
 -----------------------------------
 mixins = {require("scripts/mixins/job_special")};
 require("scripts/globals/status");
+local ID = require("scripts/zones/QuBia_Arena/IDs");
 
 function onMobInitialize(mob)
     mob:addMod(dsp.mod.SLEEPRES,50);
 end;
 
 function onMobDeath(mob, player, isKiller)
+    local inst = mob:getBattlefield():getArea()
+    local instOffset = ID.mob.HEIR_TO_THE_LIGHT_OFFSET + (14 * (inst-1));
+    if GetMobByID(instOffset + 0):isDead() and GetMobByID(instOffset + 1):isDead()
+        and GetMobByID(instOffset + 2):isDead()
+    then
+        mob:getBattlefield():setLocalVar("loot", 0)
+    end
 end;

--- a/scripts/zones/QuBia_Arena/mobs/Warlord_Rojgnoj.lua
+++ b/scripts/zones/QuBia_Arena/mobs/Warlord_Rojgnoj.lua
@@ -3,20 +3,20 @@
 --  Mob: Warlord Rojgnoj
 -- Mission 9-2 SANDO
 -----------------------------------
-mixins = {require("scripts/mixins/job_special")};
-require("scripts/globals/status");
-local ID = require("scripts/zones/QuBia_Arena/IDs");
+mixins = {require("scripts/mixins/job_special")}
+require("scripts/globals/status")
+local ID = require("scripts/zones/QuBia_Arena/IDs")
 
 function onMobInitialize(mob)
-    mob:addMod(dsp.mod.SLEEPRES,50);
-end;
+    mob:addMod(dsp.mod.SLEEPRES,50)
+end
 
 function onMobDeath(mob, player, isKiller)
     local inst = mob:getBattlefield():getArea()
-    local instOffset = ID.mob.HEIR_TO_THE_LIGHT_OFFSET + (14 * (inst-1));
+    local instOffset = ID.mob.HEIR_TO_THE_LIGHT_OFFSET + (14 * (inst-1))
     if GetMobByID(instOffset + 0):isDead() and GetMobByID(instOffset + 1):isDead()
         and GetMobByID(instOffset + 2):isDead()
     then
         mob:getBattlefield():setLocalVar("loot", 0)
     end
-end;
+end

--- a/scripts/zones/QuBia_Arena/mobs/Worgbut_of_Clan_Death.lua
+++ b/scripts/zones/QuBia_Arena/mobs/Worgbut_of_Clan_Death.lua
@@ -6,7 +6,7 @@
 local ID = require("scripts/zones/QuBia_Arena/IDs");
 
 function allHeirMobsDead(player)
-    local inst = player:getBattlefield():getBattlefieldNumber();
+    local inst = player:getBattlefield():getArea();
     local instOffset = ID.mob.HEIR_TO_THE_LIGHT_OFFSET + (14 * (inst-1));
     for i = instOffset + 3, instOffset + 13 do
         if (not GetMobByID(i):isDead()) then

--- a/scripts/zones/QuBia_Arena/mobs/Worgbut_of_Clan_Death.lua
+++ b/scripts/zones/QuBia_Arena/mobs/Worgbut_of_Clan_Death.lua
@@ -3,22 +3,22 @@
 --  Mob: Worgbut of Clan Death
 -- Mission 9-2 SANDO
 -----------------------------------
-local ID = require("scripts/zones/QuBia_Arena/IDs");
+local ID = require("scripts/zones/QuBia_Arena/IDs")
 
 function allHeirMobsDead(player)
-    local inst = player:getBattlefield():getArea();
-    local instOffset = ID.mob.HEIR_TO_THE_LIGHT_OFFSET + (14 * (inst-1));
+    local inst = player:getBattlefield():getArea()
+    local instOffset = ID.mob.HEIR_TO_THE_LIGHT_OFFSET + (14 * (inst-1))
     for i = instOffset + 3, instOffset + 13 do
-        if (not GetMobByID(i):isDead()) then
-            return false;
+        if not GetMobByID(i):isDead() then
+            return false
         end
     end
-    return true;
-end;
+    return true
+end
 
 function onMobDeath(mob, player, isKiller)
-    if (allHeirMobsDead(player)) then
-        player:release(); -- prevents event collision if player kills multiple remaining mobs with an AOE move/spell
-        player:startEvent(32004,0,0,4);
+    if allHeirMobsDead(player) then
+        player:release() -- prevents event collision if player kills multiple remaining mobs with an AOE move/spell
+        player:startEvent(32004,0,0,4)
     end
-end;
+end

--- a/scripts/zones/QuBia_Arena/mobs/Yukvok_of_Clan_Death.lua
+++ b/scripts/zones/QuBia_Arena/mobs/Yukvok_of_Clan_Death.lua
@@ -3,24 +3,24 @@
 --  Mob: Yukvok of Clan Death
 -- Mission 9-2 SANDO
 -----------------------------------
-local ID = require("scripts/zones/QuBia_Arena/IDs");
-mixins = {require("scripts/mixins/job_special")};
+local ID = require("scripts/zones/QuBia_Arena/IDs")
+mixins = {require("scripts/mixins/job_special")}
 -----------------------------------
 
 function allHeirMobsDead(player)
-    local inst = player:getBattlefield():getArea();
-    local instOffset = ID.mob.HEIR_TO_THE_LIGHT_OFFSET + (14 * (inst-1));
+    local inst = player:getBattlefield():getArea()
+    local instOffset = ID.mob.HEIR_TO_THE_LIGHT_OFFSET + (14 * (inst-1))
     for i = instOffset + 3, instOffset + 13 do
-        if (not GetMobByID(i):isDead()) then
-            return false;
+        if not GetMobByID(i):isDead() then
+            return false
         end
     end
-    return true;
-end;
+    return true
+end
 
 function onMobDeath(mob, player, isKiller)
-    if (allHeirMobsDead(player)) then
-        player:release(); -- prevents event collision if player kills multiple remaining mobs with an AOE move/spell
-        player:startEvent(32004,0,0,4);
+    if allHeirMobsDead(player) then
+        player:release() -- prevents event collision if player kills multiple remaining mobs with an AOE move/spell
+        player:startEvent(32004,0,0,4)
     end
-end;
+end

--- a/scripts/zones/QuBia_Arena/mobs/Yukvok_of_Clan_Death.lua
+++ b/scripts/zones/QuBia_Arena/mobs/Yukvok_of_Clan_Death.lua
@@ -8,7 +8,7 @@ mixins = {require("scripts/mixins/job_special")};
 -----------------------------------
 
 function allHeirMobsDead(player)
-    local inst = player:getBattlefield():getBattlefieldNumber();
+    local inst = player:getBattlefield():getArea();
     local instOffset = ID.mob.HEIR_TO_THE_LIGHT_OFFSET + (14 * (inst-1));
     for i = instOffset + 3, instOffset + 13 do
         if (not GetMobByID(i):isDead()) then

--- a/scripts/zones/Sealions_Den/bcnms/one_to_be_feared.lua
+++ b/scripts/zones/Sealions_Den/bcnms/one_to_be_feared.lua
@@ -10,6 +10,11 @@ function onBattlefieldTick(battlefield, tick)
     dsp.battlefield.onBattlefieldTick(battlefield, tick)
 end
 
+function onBattlefieldInitialise(battlefield)
+    battlefield:setLocalVar("loot", 1)
+    battlefield:setLocalVar("lootSpawned", 1)
+end
+
 function onBattlefieldRegister(player, battlefield)
 end
 

--- a/scripts/zones/Sealions_Den/mobs/Ultima.lua
+++ b/scripts/zones/Sealions_Den/mobs/Ultima.lua
@@ -25,6 +25,7 @@ function onAdditionalEffect(mob, target, damage)
 end
 
 function onMobDeath(mob, player, isKiller)
+    mob:getBattlefield():setLocalVar("loot", 0)
     player:addTitle(dsp.title.ULTIMA_UNDERTAKER)
     player:setLocalVar("[OTBF]cs", 0)
 end

--- a/scripts/zones/The_Celestial_Nexus/bcnms/celestial_nexus.lua
+++ b/scripts/zones/The_Celestial_Nexus/bcnms/celestial_nexus.lua
@@ -11,6 +11,11 @@ function onBattlefieldTick(battlefield, tick)
     dsp.battlefield.onBattlefieldTick(battlefield, tick)
 end
 
+function onBattlefieldInitialise(battlefield)
+    battlefield:setLocalVar("loot", 1)
+    battlefield:setLocalVar("lootSpawned", 1)
+end
+
 function onBattlefieldRegister(player, battlefield)
 end
 

--- a/scripts/zones/The_Celestial_Nexus/mobs/Ealdnarche.lua
+++ b/scripts/zones/The_Celestial_Nexus/mobs/Ealdnarche.lua
@@ -49,7 +49,7 @@ function onMobDeath(mob, player, isKiller)
     DespawnMob(mob:getID()+3);
     DespawnMob(mob:getID()+4);
     local battlefield = player:getBattlefield();
-    player:startEvent(32004, battlefield:getBattlefieldNumber());
+    player:startEvent(32004, battlefield:getArea());
 end;
 
 function onEventUpdate(player,csid,option)

--- a/scripts/zones/The_Celestial_Nexus/mobs/Ealdnarche_2.lua
+++ b/scripts/zones/The_Celestial_Nexus/mobs/Ealdnarche_2.lua
@@ -3,22 +3,23 @@
 --  Mob: Eald'narche (Phase 2)
 -- Zilart Mission 16 BCNM Fight
 -----------------------------------
-require("scripts/globals/titles");
-require("scripts/globals/status");
-require("scripts/globals/magic");
+require("scripts/globals/titles")
+require("scripts/globals/status")
+require("scripts/globals/magic")
 -----------------------------------
 
 function onMobInitialize(mob)
     -- 60% fast cast, -75% physical damage taken, 10tp/tick regain, no standback
-    mob:addMod(dsp.mod.UFASTCAST, 60);
-    mob:addMod(dsp.mod.UDMGPHYS, -75);
-    mob:addMod(dsp.mod.REGAIN, 100);
-    mob:setMobMod(dsp.mobMod.HP_STANDBACK,-1);
-end;
+    mob:addMod(dsp.mod.UFASTCAST, 60)
+    mob:addMod(dsp.mod.UDMGPHYS, -75)
+    mob:addMod(dsp.mod.REGAIN, 100)
+    mob:setMobMod(dsp.mobMod.HP_STANDBACK,-1)
+end
 
 function onMobSpawn(mob)
-    mob:setMobMod(dsp.mobMod.GA_CHANCE,25);
-end;
+    mob:setMobMod(dsp.mobMod.GA_CHANCE,25)
+end
 
 function onMobDeath(mob, player, isKiller)
-end;
+    mob:getBattlefield():setLocalVar("loot", 0)
+end

--- a/scripts/zones/Throne_Room/bcnms/shadow_lord_battle.lua
+++ b/scripts/zones/Throne_Room/bcnms/shadow_lord_battle.lua
@@ -13,6 +13,11 @@ function onBattlefieldTick(battlefield, tick)
     dsp.battlefield.onBattlefieldTick(battlefield, tick)
 end
 
+function onBattlefieldInitialise(battlefield)
+    battlefield:setLocalVar("loot", 1)
+    battlefield:setLocalVar("lootSpawned", 1)
+end
+
 function onBattlefieldRegister(player, battlefield)
 end
 

--- a/scripts/zones/Throne_Room/bcnms/where_two_paths_converge.lua
+++ b/scripts/zones/Throne_Room/bcnms/where_two_paths_converge.lua
@@ -11,6 +11,11 @@ function onBattlefieldTick(battlefield, tick)
     dsp.battlefield.onBattlefieldTick(battlefield, tick)
 end
 
+function onBattlefieldInitialise(battlefield)
+    battlefield:setLocalVar("loot", 1)
+    battlefield:setLocalVar("lootSpawned", 1)
+end
+
 function onBattlefieldRegister(player, battlefield)
 end
 
@@ -31,5 +36,5 @@ function onEventUpdate(player, csid, option)
 end
 
 function onEventFinish(player, csid, option)
-    player:setCharVar("BASTOK92", 2) -- This should be MissionStatus..But all battlefields of same var need updated.
+    player:setCharVar("MissionStatus", 2) -- This should be MissionStatus..But all battlefields of same var need updated.
 end

--- a/scripts/zones/Throne_Room/mobs/Shadow_Lord.lua
+++ b/scripts/zones/Throne_Room/mobs/Shadow_Lord.lua
@@ -74,6 +74,7 @@ function onMobDeath(mob, player, isKiller)
         player:startEvent(32004);
         player:setCharVar("mobid",mob:getID());
     else
+        mob:getBattlefield():setLocalVar("loot", 0)
         player:addTitle(dsp.title.SHADOW_BANISHER);
     end
     -- reset everything on death

--- a/scripts/zones/Throne_Room/mobs/Volker.lua
+++ b/scripts/zones/Throne_Room/mobs/Volker.lua
@@ -25,7 +25,7 @@ function onMobRoam(mob)
     local wait = mob:getLocalVar("wait");
     local ready = mob:getLocalVar("ready");
     if (ready == 0 and wait > 40) then
-        local baseID = ID.mob.ZEID_BCNM_OFFSET + (mob:getBattlefield():getBattlefieldNumber() - 1) * 4;
+        local baseID = ID.mob.ZEID_BCNM_OFFSET + (mob:getBattlefield():getArea() - 1) * 4;
         mob:setLocalVar("ready", bit.band(baseID, 0xFFF));
         mob:setLocalVar("wait", 0);
     elseif (ready > 0) then

--- a/scripts/zones/Throne_Room/mobs/Volker.lua
+++ b/scripts/zones/Throne_Room/mobs/Volker.lua
@@ -3,38 +3,38 @@
 --  Mob: Volker
 -- Ally during Bastok Mission 9-2
 -----------------------------------
-local ID = require("scripts/zones/Throne_Room/IDs");
-require("scripts/globals/status");
+local ID = require("scripts/zones/Throne_Room/IDs")
+require("scripts/globals/status")
 
 function onMobSpawn(mob)
     mob:addListener("WEAPONSKILL_STATE_ENTER", "WS_START_MSG", function(mob, skillID)
         -- Red Lotus Blade
-        if (skillID == 973) then
-            mob:showText(mob,ID.text.NO_HIDE_AWAY);
+        if skillID == 973 then
+            mob:showText(mob,ID.text.NO_HIDE_AWAY)
         -- Spirits Within
-        elseif (skillID == 974) then
-            mob:showText(mob,ID.text.YOUR_ANSWER);
+        elseif skillID == 974 then
+            mob:showText(mob,ID.text.YOUR_ANSWER)
         -- Vorpal Blade
-        elseif (skillID == 975) then
-            mob:showText(mob,ID.text.CANT_UNDERSTAND);
+        elseif skillID == 975 then
+            mob:showText(mob,ID.text.CANT_UNDERSTAND)
         end
-    end);
-end;
+    end)
+end
 
 function onMobRoam(mob)
-    local wait = mob:getLocalVar("wait");
-    local ready = mob:getLocalVar("ready");
-    if (ready == 0 and wait > 40) then
-        local baseID = ID.mob.ZEID_BCNM_OFFSET + (mob:getBattlefield():getArea() - 1) * 4;
-        mob:setLocalVar("ready", bit.band(baseID, 0xFFF));
-        mob:setLocalVar("wait", 0);
-    elseif (ready > 0) then
-        mob:addEnmity(GetMobByID(ready + bit.lshift(mob:getZoneID(), 12) + 0x1000000),0,1);
+    local wait = mob:getLocalVar("wait")
+    local ready = mob:getLocalVar("ready")
+    if ready == 0 and wait > 40 then
+        local baseID = ID.mob.ZEID_BCNM_OFFSET + (mob:getBattlefield():getArea() - 1) * 4
+        mob:setLocalVar("ready", bit.band(baseID, 0xFFF))
+        mob:setLocalVar("wait", 0)
+    elseif ready > 0 then
+        mob:addEnmity(GetMobByID(ready + bit.lshift(mob:getZoneID(), 12) + 0x1000000),0,1)
     else
-        mob:setLocalVar("wait", wait+3);
+        mob:setLocalVar("wait", wait+3)
     end
-end;
+end
 
 function onMobDeath(mob, player, isKiller)
-    mob:getBattlefield():lose();
-end;
+    mob:getBattlefield():lose()
+end

--- a/scripts/zones/Throne_Room/mobs/Zeid.lua
+++ b/scripts/zones/Throne_Room/mobs/Zeid.lua
@@ -3,20 +3,20 @@
 --  Mob: Zeid
 -- Mission 9-2 BASTOK BCNM Fight
 -----------------------------------
-local ID = require("scripts/zones/Throne_Room/IDs");
+local ID = require("scripts/zones/Throne_Room/IDs")
 
 function onMobDeath(mob, player, isKiller)
-    player:startEvent(32004,3,3,1,3,3,3,3,3);
-end;
+    player:startEvent(32004,3,3,1,3,3,3,3,3)
+end
 
 function onEventUpdate(player,csid,option)
-end;
+end
 
 function onEventFinish(player,csid,option)
-    if (csid == 32004) then
+    if csid == 32004 then
 
         local bfid = player:getBattlefield():getArea()
-        local zeidId = ID.mob.ZEID_BCNM_OFFSET + (bfid - 1) * 4;
+        local zeidId = ID.mob.ZEID_BCNM_OFFSET + (bfid - 1) * 4
         local playerCoords =
         {
             [1] = {-443      , -167 , -239     , 127},
@@ -28,12 +28,12 @@ function onEventFinish(player,csid,option)
             [1] = {-450      , -167 , -239     , 125},
             [2] = {-769.949  , -407 , -478.991 , 125},
             [3] = {-1089.787 , -647 , -718.976 , 125},
-        };
+        }
         
-        SpawnMob(zeidId);
+        SpawnMob(zeidId)
         local volker = player:getBattlefield():insertEntity(14182, true, true)
-        player:setPos(unpack(playerCoords[bfid]));
-        volker:setSpawn(unpack(volkerCoords[bfid]));
-        volker:spawn();
+        player:setPos(unpack(playerCoords[bfid]))
+        volker:setSpawn(unpack(volkerCoords[bfid]))
+        volker:spawn()
     end
-end;
+end

--- a/scripts/zones/Throne_Room/mobs/Zeid.lua
+++ b/scripts/zones/Throne_Room/mobs/Zeid.lua
@@ -15,7 +15,7 @@ end;
 function onEventFinish(player,csid,option)
     if (csid == 32004) then
 
-        local bfid = player:getCharVar("bcnm_instanceid");
+        local bfid = player:getBattlefield():getArea()
         local zeidId = ID.mob.ZEID_BCNM_OFFSET + (bfid - 1) * 4;
         local playerCoords =
         {
@@ -31,7 +31,7 @@ function onEventFinish(player,csid,option)
         };
         
         SpawnMob(zeidId);
-        local volker = player:getBattlefield():insertAlly(14182)
+        local volker = player:getBattlefield():insertEntity(14182, true, true)
         player:setPos(unpack(playerCoords[bfid]));
         volker:setSpawn(unpack(volkerCoords[bfid]));
         volker:spawn();

--- a/scripts/zones/Throne_Room/mobs/Zeid_2.lua
+++ b/scripts/zones/Throne_Room/mobs/Zeid_2.lua
@@ -3,11 +3,11 @@
 --  Mob: Zeid (Phase 2)
 -- Mission 9-2 BASTOK BCNM Fight
 -----------------------------------
-mixins = {require("scripts/mixins/job_special")};
-require("scripts/globals/monstertpmoves");
-require("scripts/globals/settings");
-require("scripts/globals/titles");
-require("scripts/globals/status");
+mixins = {require("scripts/mixins/job_special")}
+require("scripts/globals/monstertpmoves")
+require("scripts/globals/settings")
+require("scripts/globals/titles")
+require("scripts/globals/status")
 -----------------------------------
 
 function onMobSpawn(mob)
@@ -17,20 +17,20 @@ function onMobSpawn(mob)
             {id = dsp.jsa.BLOOD_WEAPON, hpp = math.random(20, 50)},
         },
     })
-end;
+end
 
 function onMobFight(mob, target)
-    local zeid = mob:getID();
-    local shadow1 = GetMobByID(zeid + 1);
-    local shadow2 = GetMobByID(zeid + 2);
+    local zeid = mob:getID()
+    local shadow1 = GetMobByID(zeid + 1)
+    local shadow2 = GetMobByID(zeid + 2)
 
-    if (mob:getHPP() <= 77 and mob:getTP() >= 1000 and shadow1:isDead() and shadow2:isDead()) then
-        mob:useMobAbility(984);
+    if mob:getHPP() <= 77 and mob:getTP() >= 1000 and shadow1:isDead() and shadow2:isDead() then
+        mob:useMobAbility(984)
     end
-end;
+end
 
 function onMobDeath(mob, player, isKiller)
     mob:getBattlefield():setLocalVar("loot", 0)
-    DespawnMob(mob:getID()+1);
-    DespawnMob(mob:getID()+2);
-end;
+    DespawnMob(mob:getID()+1)
+    DespawnMob(mob:getID()+2)
+end

--- a/scripts/zones/Throne_Room/mobs/Zeid_2.lua
+++ b/scripts/zones/Throne_Room/mobs/Zeid_2.lua
@@ -30,6 +30,7 @@ function onMobFight(mob, target)
 end;
 
 function onMobDeath(mob, player, isKiller)
+    mob:getBattlefield():setLocalVar("loot", 0)
     DespawnMob(mob:getID()+1);
     DespawnMob(mob:getID()+2);
 end;

--- a/sql/bcnm_battlefield.sql
+++ b/sql/bcnm_battlefield.sql
@@ -1147,7 +1147,6 @@ INSERT INTO `bcnm_battlefield` VALUES (1092,1,17010729,0);
 INSERT INTO `bcnm_battlefield` VALUES (1092,1,17010730,0);
 INSERT INTO `bcnm_battlefield` VALUES (1092,1,17010731,0);
 INSERT INTO `bcnm_battlefield` VALUES (1124,1,17039400,3); -- shield_of_diplomacy
-INSERT INTO `bcnm_battlefield` VALUES (1124,1,17039401,0);
 INSERT INTO `bcnm_battlefield` VALUES (1156,1,17051694,3); -- puppet_in_peril
 
 -- //////////////////////////////////////////////////////////////

--- a/sql/mob_groups.sql
+++ b/sql/mob_groups.sql
@@ -2645,7 +2645,7 @@ INSERT INTO `mob_groups` VALUES (2153,4336,63,'Whyjham',0,0,0,0,0,81,83,0);
 INSERT INTO `mob_groups` VALUES (2154,4465,63,'Yanshaal',1,0,0,0,0,1,1,0);
 INSERT INTO `mob_groups` VALUES (10633,5872,63,'Qiqirn_Mine',0,128,0,0,0,75,75,0);
 INSERT INTO `mob_groups` VALUES (1,2221,64,'Khimaira_13',0,128,0,0,0,75,75,0);
-INSERT INTO `mob_groups` VALUES (2,2189,64,'Karababa',0,128,0,1000,1000,75,75,1);
+INSERT INTO `mob_groups` VALUES (2157,2189,64,'Karababa',0,128,0,1000,1000,75,75,1);
 INSERT INTO `mob_groups` VALUES (2156,2063,64,'Immortal_Flan',0,128,0,0,0,50,50,0);
 INSERT INTO `mob_groups` VALUES (2159,3219,64,'Pudding_Master',0,128,0,0,0,50,50,0);
 INSERT INTO `mob_groups` VALUES (2160,3582,64,'Shamarhaan',0,128,0,0,0,75,75,0);

--- a/src/map/lua/lua_battlefield.cpp
+++ b/src/map/lua/lua_battlefield.cpp
@@ -386,7 +386,7 @@ inline int32 CLuaBattlefield::insertEntity(lua_State* L)
     DSP_DEBUG_BREAK_IF(m_PLuaBattlefield == nullptr);
     DSP_DEBUG_BREAK_IF(lua_isnil(L, 1));
 
-    auto PLuaEntity = Lunar<CLuaBaseEntity>::check(L, 1);
+    auto PLuaEntity = !lua_isnumber(L, 1) ? Lunar<CLuaBaseEntity>::check(L, 1) : nullptr;
     auto PEntity = PLuaEntity ? PLuaEntity->GetBaseEntity() : nullptr;
 
     auto targid = PEntity ? PEntity->targid : lua_tointeger(L, 1);
@@ -402,7 +402,7 @@ inline int32 CLuaBattlefield::insertEntity(lua_State* L)
 
     if (PEntity)
     {
-        m_PLuaBattlefield->InsertEntity(PEntity, inBattlefield, conditions);
+        m_PLuaBattlefield->InsertEntity(PEntity, inBattlefield, conditions, ally);
 
         lua_getglobal(L, CLuaBaseEntity::className);
         lua_pushstring(L, "new");

--- a/src/map/utils/mobutils.cpp
+++ b/src/map/utils/mobutils.cpp
@@ -1183,7 +1183,7 @@ void AddCustomMods(CMobEntity* PMob)
 CMobEntity* InstantiateAlly(uint32 groupid, uint16 zoneID, CInstance* instance)
 {
     const char* Query =
-        "SELECT zoneid, name, \
+        "SELECT zoneid, mob_groups.name, \
         respawntime, spawntype, dropid, mob_groups.HP, mob_groups.MP, minLevel, maxLevel, \
         modelid, mJob, sJob, cmbSkill, cmbDmgMult, cmbDelay, behavior, links, mobType, immunity, \
         systemid, mobsize, speed, \


### PR DESCRIPTION
This fixes some errors trying to spawn allies into a battlefield and updates some renamed BCNM functions.
This includes:
Prishe and Selh'teus in Dawn
Ajido-Marujido in Moon Reading
Karababa in Shield of Diplomacy
Trion in The Heir to the Light
Volker in Where Two Paths Converge

Also addressed is an issue where multi-phase fights will trigger win conditions if the target mob isn't spawned at the start.
These fights are:
Dawn
Moon Reading
The Heir to the Light
Where Two Paths Converge
One to be Feared
The Celestial Nexus
Shadow Lord

Fight logic wasn't checked other than spawning allies and stopping fights from ending prematurely. Allies currently will cause a crash just like pets until that is fixed. Working fine with #6212 with the only exception being the client (not server) crashes if you try to cure a dead Prishe.