### PR TITLE
Adds MOD and logic to check for WS DEX +x%

### DIFF
--- a/scripts/globals/status.lua
+++ b/scripts/globals/status.lua
@@ -1517,6 +1517,7 @@ dsp.mod =
     -- Per https://www.bg-wiki.com/bg/Weapon_Skill_Damage we need all 3..
     ALL_WSDMG_FIRST_HIT             = 841, -- Generic (all Weaponskills) damage, first hit only.
     WS_NO_DEPLETE                   = 949, -- % chance a Weaponskill depletes no TP.
+    WS_DEX_BONUS                    = 957, -- % bonus to dex_wsc.
 
     -- Circle Abilities Extended Duration from AF/AF+1
     HOLY_CIRCLE_DURATION            = 857,
@@ -1541,9 +1542,9 @@ dsp.mod =
 
     -- The spares take care of finding the next ID to use so long as we don't forget to list IDs that have been freed up by refactoring.
     -- 570 - 825 used by WS DMG mods these are not spares.
-    -- SPARE = 957, -- stuff
     -- SPARE = 958, -- stuff
     -- SPARE = 959, -- stuff
+    -- SPARE = 960, -- stuff
 };
 
 dsp.latent =

--- a/scripts/globals/weaponskills.lua
+++ b/scripts/globals/weaponskills.lua
@@ -83,6 +83,11 @@ function calculateRawWSDmg(attacker, target, wsID, tp, action, wsParams, calcPar
         end
     end
 
+    -- Check for and apply WS_DEX_BONUS
+    if (attacker:getMod(dsp.mod.WS_DEX_BONUS) > 0) then
+        wsParams.dex_wsc = wsParams.dex_wsc + (attacker:getMod(dsp.mod.WS_DEX_BONUS)*.01)
+    end
+
     local wsMods = calcParams.fSTR +
         (attacker:getStat(dsp.mod.STR) * wsParams.str_wsc + attacker:getStat(dsp.mod.DEX) * wsParams.dex_wsc +
          attacker:getStat(dsp.mod.VIT) * wsParams.vit_wsc + attacker:getStat(dsp.mod.AGI) * wsParams.agi_wsc +
@@ -371,6 +376,11 @@ function doMagicWeaponskill(attacker, target, wsID, wsParams, tp, action, primar
 
     -- Magic-based WSes never miss, so we don't need to worry about calculating a miss, only if a shadow absorbed it.
     if not shadowAbsorb(target) then
+
+        -- Check for and apply WS_DEX_BONUS
+        if (attacker:getMod(dsp.mod.WS_DEX_BONUS) > 0) then
+             wsParams.dex_wsc = wsParams.dex_wsc + (attacker:getMod(dsp.mod.WS_DEX_BONUS) * 0.01)
+        end
 
         dmg = attacker:getMainLvl() + 2 + (attacker:getStat(dsp.mod.STR) * wsParams.str_wsc + attacker:getStat(dsp.mod.DEX) * wsParams.dex_wsc +
              attacker:getStat(dsp.mod.VIT) * wsParams.vit_wsc + attacker:getStat(dsp.mod.AGI) * wsParams.agi_wsc +

--- a/sql/item_mods.sql
+++ b/sql/item_mods.sql
@@ -27661,6 +27661,7 @@ INSERT INTO `item_mods` VALUES (22211,28,7);      -- Elan Strap +1: Magic Attack
 INSERT INTO `item_mods` VALUES (22212,2,70);      -- utu_grip HP+70
 INSERT INTO `item_mods` VALUES (22212,23,30);     -- Attack+30
 INSERT INTO `item_mods` VALUES (22212,25,30);     -- Accuracy+30
+INSERT INTO `item_mods` VALUES (22212,957,10);    -- Weaponskill DEX +10% (dex_wsc)
 INSERT INTO `item_mods` VALUES (22213,12,10);     -- enki_strap INT+10
 INSERT INTO `item_mods` VALUES (22213,13,10);     -- MND+10
 INSERT INTO `item_mods` VALUES (22213,30,10);     -- Magic Accuracy+10

--- a/src/map/modifier.h
+++ b/src/map/modifier.h
@@ -778,6 +778,7 @@ enum class Mod
     // Per https://www.bg-wiki.com/bg/Weapon_Skill_Damage we need all 3..
     ALL_WSDMG_FIRST_HIT       = 841, // Generic (all Weaponskills) damage, first hit only.
     WS_NO_DEPLETE             = 949, // % chance a Weaponskill depletes no TP.
+    WS_DEX_BONUS              = 957, // % bonus to dex_wsc.
 
     EXPERIENCE_RETAINED       = 914, // Experience points retained upon death (this is a percentage)
     CAPACITY_BONUS            = 915, // Capacity point bonus granted
@@ -787,9 +788,9 @@ enum class Mod
 
     // The spares take care of finding the next ID to use so long as we don't forget to list IDs that have been freed up by refactoring.
     // 570 through 825 used by WS DMG mods these are not spares.
-    // SPARE = 957, // stuff
     // SPARE = 958, // stuff
     // SPARE = 959, // stuff
+    // SPARE = 960, // stuff
 };
 
 //temporary workaround for using enum class as unordered_map key until compilers support it


### PR DESCRIPTION
While currently only present on one item (Utu Grip), added MOD and
logic to check and apply it. WS DEX +x% works by adding to the
dex_wsc value. Reference:

https://www.bg-wiki.com/bg/Utu_Grip

Applies to any WS (including ranged).