### PR TITLE
Survival guide Z coordinate fix for Crawlers Nest

### DIFF
--- a/scripts/globals/survival_guide_map.lua
+++ b/scripts/globals/survival_guide_map.lua
@@ -252,7 +252,7 @@ survivalGuides =
         groupIndex = 23,
         posX = 364,
         posY = -32,
-        posZ = 23,
+        posZ = -23,
         posRot = 64
     },
     [39] =


### PR DESCRIPTION
When using a survival guide to warp to the crawler's nest, the Z coordinate is causing the player to spawn into the crawler's nest outside of the tunneled area where the survival guide is located. The correct Z coordinate has been inputted and tested to spawn in directly at the survival guide. Most likely a typo, easily fixed.