### PR TITLE
Fixed order of cutscenes

### DIFF
--- a/scripts/zones/Bastok_Markets/Zone.lua
+++ b/scripts/zones/Bastok_Markets/Zone.lua
@@ -17,22 +17,20 @@ end
 function onZoneIn(player,prevZone)
     local cs = -1
 
-    -- SOA 1-1 Optional CS
-    if 
-        ENABLE_SOA and 
-        player:getCurrentMission(SOA) == dsp.mission.id.soa.RUMORS_FROM_THE_WEST and 
-        player:getCharVar("SOA_1_CS2") == 0 
-    then
-        cs = 22
-    end
-
     -- FIRST LOGIN (START CS)
-    if (player:getPlaytime(false) == 0) then
-        if (OPENING_CUTSCENE_ENABLE == 1) then
-            --cs = 0
-        end
+    if player:getPlaytime(false) == 0 and OPENING_CUTSCENE_ENABLE == 1 then
+        --cs = 0
         player:setPos(-280,-12,-91,15)
         player:setHomePoint()
+    end
+
+    -- SOA 1-1 Optional CS
+    if
+        ENABLE_SOA == 1 and
+        player:getCurrentMission(SOA) == dsp.mission.id.soa.RUMORS_FROM_THE_WEST and
+        player:getCharVar("SOA_1_CS2") == 0
+    then
+        cs = 22
     end
 
     -- MOG HOUSE EXIT

--- a/scripts/zones/Northern_San_dOria/Zone.lua
+++ b/scripts/zones/Northern_San_dOria/Zone.lua
@@ -28,23 +28,22 @@ function onZoneIn(player,prevZone)
     local MissionStatus = player:getCharVar("MissionStatus")
     local cs = -1
 
+    -- FIRST LOGIN (START CS)
+    if player:getPlaytime(false) == 0 and OPENING_CUTSCENE_ENABLE == 1 then
+        cs = 535
+        player:setPos(0,0,-11,191)
+        player:setHomePoint()
+    end
+
     -- SOA 1-1 Optional CS
-    if 
-        ENABLE_SOA and 
-        player:getCurrentMission(SOA) == dsp.mission.id.soa.RUMORS_FROM_THE_WEST and 
-        player:getCharVar("SOA_1_CS1") == 0 
+    if
+        ENABLE_SOA == 1 and
+        player:getCurrentMission(SOA) == dsp.mission.id.soa.RUMORS_FROM_THE_WEST and
+        player:getCharVar("SOA_1_CS1") == 0
     then
         cs = 878
     end
 
-    -- FIRST LOGIN (START CS)
-    if (player:getPlaytime(false) == 0) then
-        if (OPENING_CUTSCENE_ENABLE == 1) then
-            cs = 535
-        end
-        player:setPos(0,0,-11,191)
-        player:setHomePoint()
-    end
     -- MOG HOUSE EXIT
     if (player:getXPos() == 0 and player:getYPos() == 0 and player:getZPos() == 0) then
         player:setPos(130,-0.2,-3,160)

--- a/scripts/zones/Windurst_Woods/Zone.lua
+++ b/scripts/zones/Windurst_Woods/Zone.lua
@@ -19,22 +19,20 @@ end
 function onZoneIn(player,prevZone)
     local cs = -1
 
-    -- SOA 1-1 Optional CS
-    if 
-        ENABLE_SOA and 
-        player:getCurrentMission(SOA) == dsp.mission.id.soa.RUMORS_FROM_THE_WEST and 
-        player:getCharVar("SOA_1_CS3") == 0 
-    then
-        cs = 839
-    end
-
     -- FIRST LOGIN (START CS)
-    if player:getPlaytime(false) == 0 then
-        if OPENING_CUTSCENE_ENABLE == 1 then
-            cs = 367
-        end
+    if player:getPlaytime(false) == 0 and OPENING_CUTSCENE_ENABLE == 1 then
+        cs = 367
         player:setPos(0,0,-50,0)
         player:setHomePoint()
+    end
+
+    -- SOA 1-1 Optional CS
+    if
+        ENABLE_SOA == 1 and
+        player:getCurrentMission(SOA) == dsp.mission.id.soa.RUMORS_FROM_THE_WEST and
+        player:getCharVar("SOA_1_CS3") == 0
+    then
+        cs = 839
     end
 
     -- MOG HOUSE EXIT


### PR DESCRIPTION
Opening cutscene should always have top priority.

Also fixed check for ENABLE_SOA, have to check the actual value as lua will return true so long as the variable exists.