### PR TITLE
Alliance hate mobmod

### DIFF
--- a/scripts/globals/status.lua
+++ b/scripts/globals/status.lua
@@ -2216,7 +2216,8 @@ dsp.mobMod =
     CHARMABLE           = 64, -- mob is charmable
     NO_MOVE             = 65, -- Mob will not be able to move
     MULTI_HIT           = 66, -- Mob will have as many swings as defined.
-    NO_AGGRO            = 67  -- If set, mob cannot aggro until unset.
+    NO_AGGRO            = 67, -- If set, mob cannot aggro until unset.
+    ALLI_HATE           = 68  -- Range around target to add alliance member to enmity list.
 }
 
 ------------------------------------

--- a/src/map/entities/mobentity.cpp
+++ b/src/map/entities/mobentity.cpp
@@ -950,6 +950,23 @@ void CMobEntity::OnEngage(CAttackState& state)
 {
     CBattleEntity::OnEngage(state);
     luautils::OnMobEngaged(this, state.GetTarget());
+    unsigned int range = this->getMobMod(MOBMOD_ALLI_HATE);
+    if (range != 0)
+    {
+        CBaseEntity* PTarget = state.GetTarget();
+        if (PTarget->objtype == TYPE_PET)
+            PTarget = ((CPetEntity*)PTarget)->PMaster;
+        if (PTarget->objtype == TYPE_PC)
+        {
+            ((CCharEntity*)PTarget)->ForAlliance([this, PTarget, range](CBattleEntity* PMember)
+            {
+                auto currentDistance = distance(PMember->loc.p, PTarget->loc.p);
+                if (currentDistance < range)
+                    this->PEnmityContainer->AddBaseEnmity(PMember);
+            });
+            this->PEnmityContainer->UpdateEnmity((CBattleEntity*)PTarget, 0, 1); // Set VE so target doesn't change
+        }
+    }
 
     static_cast<CMobController*>(PAI->GetController())->TapDeaggroTime();
 }

--- a/src/map/entities/mobentity.cpp
+++ b/src/map/entities/mobentity.cpp
@@ -954,8 +954,12 @@ void CMobEntity::OnEngage(CAttackState& state)
     if (range != 0)
     {
         CBaseEntity* PTarget = state.GetTarget();
+        CBaseEntity* PPet = nullptr;
         if (PTarget->objtype == TYPE_PET)
+        {
+            PPet = state.GetTarget();
             PTarget = ((CPetEntity*)PTarget)->PMaster;
+        }
         if (PTarget->objtype == TYPE_PC)
         {
             ((CCharEntity*)PTarget)->ForAlliance([this, PTarget, range](CBattleEntity* PMember)
@@ -964,7 +968,7 @@ void CMobEntity::OnEngage(CAttackState& state)
                 if (currentDistance < range)
                     this->PEnmityContainer->AddBaseEnmity(PMember);
             });
-            this->PEnmityContainer->UpdateEnmity((CBattleEntity*)PTarget, 0, 1); // Set VE so target doesn't change
+            this->PEnmityContainer->UpdateEnmity((PPet ? (CBattleEntity*)PPet : (CBattleEntity*)PTarget), 0, 1); // Set VE so target doesn't change
         }
     }
 

--- a/src/map/mob_modifier.h
+++ b/src/map/mob_modifier.h
@@ -96,7 +96,8 @@ enum MOBMODIFIER : int
     MOBMOD_CHARMABLE          = 64, // mob is charmable
     MOBMOD_NO_MOVE            = 65, // Mob will not be able to move
     MOBMOD_MULTI_HIT          = 66, // Mob will have as many swings as defined.
-    MOBMOD_NO_AGGRO           = 67  // If set, mob cannot aggro until unset.
+    MOBMOD_NO_AGGRO           = 67, // If set, mob cannot aggro until unset.
+    MOBMOD_ALLI_HATE          = 68  // Range around target to add alliance member to enmity list.
 };
 
 #endif


### PR DESCRIPTION
Adds alliance members within mobmod ALLI_HATE range of player to mob enmity list when mob engages.

It's unsigned so you can set to -1 for zone-wide alliance hate, or something small like 5 to [only add members close to the puller](https://www.bg-wiki.com/bg/Category:Dynamis_-_Divergence#Basics).