### PR TITLE
Fix Ancient Vows CutScene order.

### DIFF
--- a/scripts/zones/Misareaux_Coast/npcs/Spatial_Displacement.lua
+++ b/scripts/zones/Misareaux_Coast/npcs/Spatial_Displacement.lua
@@ -14,7 +14,7 @@ function onTrigger(player,npc)
     if (player:hasCompletedMission(COP,dsp.mission.id.cop.SHELTERING_DOUBT)) then
         player:startEvent(551); -- Access to Sites A & B
     elseif (player:getCurrentMission(COP) == dsp.mission.id.cop.ANCIENT_VOWS and player:getCharVar("PromathiaStatus") == 1) then
-        player:startEvent(8);
+        player:setPos(732.55,-32.5,-506.544,90,30); -- Go to Riverne #A01 {R}
     else
         player:startEvent(550); -- Access to Site A Only
     end
@@ -26,10 +26,7 @@ end;
 
 function onEventFinish(player,csid,option)
 
-    if (csid == 8) then
-        player:setCharVar("PromathiaStatus",2);
-        player:setPos(732.55,-32.5,-506.544,90,30); -- Go to Riverne #A01 {R}
-    elseif ((csid == 551 or csid == 550) and option == 1) then
+    if ((csid == 551 or csid == 550) and option == 1) then
         player:setPos(732.55,-32.5,-506.544,90,30); -- Go to Riverne #A01 {R}
     elseif (csid == 551 and option == 2) then
         player:setPos(729.749,-20.319,407.153,90,29); -- Go to Riverne #B01 {R}

--- a/scripts/zones/Riverne-Site_A01/Zone.lua
+++ b/scripts/zones/Riverne-Site_A01/Zone.lua
@@ -18,8 +18,9 @@ end;
 
 function onZoneIn(player,prevZone)
     local cs = -1;
-
-    if (player:getXPos() == 0 and player:getYPos() == 0 and player:getZPos() == 0) then
+    if (player:getCurrentMission(COP) == dsp.mission.id.cop.ANCIENT_VOWS and player:getCharVar("PromathiaStatus") == 2) then
+        player:startEvent(100);
+    elseif (player:getXPos() == 0 and player:getYPos() == 0 and player:getZPos() == 0) then
         player:setPos(732.55,-32.5,-506.544,90); -- {R}
     end
 
@@ -39,4 +40,7 @@ function onEventUpdate(player,csid,option)
 end;
 
 function onEventFinish(player,csid,option)
+    if csid == 100 then
+        player:setCharVar("PromathiaStatus",2);
+    end
 end;


### PR DESCRIPTION
Remove incorrect cutscene when triggering Spatial Displacement. (CS
involved Tenzen)
Add trigger to zone player to RA01 when on Ancient Vows.
On ZoneIn to RA01 the correct cutscence plays.