### PR TITLE
C++: Added code to make sure pets claim on spells

### DIFF
--- a/src/map/ai/states/magic_state.cpp
+++ b/src/map/ai/states/magic_state.cpp
@@ -305,12 +305,14 @@ void CMagicState::ApplyEnmity(CBattleEntity* PTarget, int ce, int ve)
 
                 if (!(m_PSpell->isHeal()) || m_PSpell->tookEffect())  //can't claim mob with cure unless it does damage
                 {
-                    if (m_PEntity->objtype == TYPE_PC)
+                    if (m_PEntity->objtype == TYPE_PC || (m_PEntity->PMaster && m_PEntity->PMaster->objtype == TYPE_PC))
                     {
+                        auto claimer = m_PEntity->objtype == TYPE_PC ? m_PEntity : m_PEntity->PMaster;
+
                         if (!mob->CalledForHelp())
                         {
-                            mob->m_OwnerID.id = m_PEntity->id;
-                            mob->m_OwnerID.targid = m_PEntity->targid;
+                            mob->m_OwnerID.id = claimer->id;
+                            mob->m_OwnerID.targid = claimer->targid;
                         }
                         mob->updatemask |= UPDATE_STATUS;
                     }

--- a/src/map/entities/mobentity.cpp
+++ b/src/map/entities/mobentity.cpp
@@ -669,6 +669,17 @@ void CMobEntity::OnMobSkillFinished(CMobSkillState& state, action_t& action)
             PTarget->PAI->EventHandler.triggerListener("WEAPONSKILL_TAKE", PTarget, this, PSkill->getID(), state.GetSpentTP(), &action);
         }
 
+        if (objtype == TYPE_PET && PMaster && PMaster->objtype == TYPE_PC )
+        {
+            auto mob = dynamic_cast<CMobEntity *>(PTarget);
+            if (mob && !mob->CalledForHelp())
+            {
+                mob->m_OwnerID.id = PMaster->id;
+                mob->m_OwnerID.targid = PMaster->targid;
+                mob->updatemask |= UPDATE_STATUS; //This can go here because we only wanna call the updatemask if this happens
+            }
+        }
+
         if (msg == 0)
         {
             msg = PSkill->getMsg();


### PR DESCRIPTION
I swapped the order of the checkcallforhelp and checkplayer.
The reason for this is that the checkplayer change needs to be two
parts now.

Checks if its called for help, then if the caster of a spell was
a player, and if it is a player, it behaves like it used to.
Then checks to see if the caster was not a player, was it a pet
whose master was a player. In this case, it sets owner and targid
to the master.