### PR TITLE
Fix for Dynamis Mask check in Xarcabard

### DIFF
--- a/scripts/zones/Xarcabard/Zone.lua
+++ b/scripts/zones/Xarcabard/Zone.lua
@@ -27,7 +27,7 @@ function onZoneIn(player, prevZone)
         player:setPos(-136.287, -23.268, 137.302, 91)
     end
 
-    if not player:hasKeyItem(dsp.ki.VIAL_OF_SHROUDED_SAND) and player:getRank() >= 6 and player:getMainLvl() >= 65 and player:getCharVar("Dynamis_Status") == 0 then
+    if not player:hasKeyItem(dsp.ki.VIAL_OF_SHROUDED_SAND) and player:getRank() >= 6 and player:getMainLvl() >= 65 and bit.band(player:getCharVar("Dynamis_Status"), 1) == 0 then
         player:setCharVar("Dynamis_Status", 1)
         cs = 13
     elseif triggerLightCutscene(player) then -- Quest: I Can Hear A Rainbow


### PR DESCRIPTION
* Check specific flag of the dynamis mask instead of the entire mask like a jerk

Dynamis_Status can change if you click on Trail Markings or other Dynamis NPCs prior to getting the cutscene in Xarcabard. This caused the cutscene to never happen when the player became level and mission eligible to receive the cutscene. Checking the specific bit fixes it.