### PR TITLE
Save inifinite duration status effects

### DIFF
--- a/src/map/status_effect_container.cpp
+++ b/src/map/status_effect_container.cpp
@@ -1375,7 +1375,7 @@ void CStatusEffectContainer::SaveStatusEffects(bool logout)
         auto realduration = std::chrono::milliseconds(PStatusEffect->GetDuration()) +
             PStatusEffect->GetStartTime() - server_clock::now();
 
-        if (realduration > 0s)
+        if (realduration > 0s || PStatusEffect->GetDuration() == 0)
         {
             const char* Query = "INSERT INTO char_effects (charid, effectid, icon, power, tick, duration, subid, subpower, tier, flags, timestamp) VALUES(%u,%u,%u,%u,%u,%u,%u,%u,%u,%u,%u);";
 


### PR DESCRIPTION
Adds a check for 0 (infinite) duration when saving status effects. Fixes #6310