### PR TITLE
Fix various issues with linkshells

### DIFF
--- a/migrations/broken_linkshells.py
+++ b/migrations/broken_linkshells.py
@@ -1,0 +1,22 @@
+import array
+import mysql.connector
+
+def migration_name():
+	return "Adding broken column to linkshells table"
+
+def check_preconditions(cur):
+	return
+
+def needs_to_run(cur):
+	# Ensure broken column exists in linkshells
+	cur.execute("SHOW COLUMNS FROM linkshells LIKE 'broken'")
+	if not cur.fetchone():
+		return True
+	return False
+
+def migrate(cur, db):
+	try:
+		cur.execute("ALTER TABLE linkshells ADD COLUMN `broken` tinyint(1) unsigned NOT NULL DEFAULT 0;")
+		db.commit()
+	except mysql.connector.Error as err:
+		print("Something went wrong: {}".format(err))

--- a/migrations/migrate.py
+++ b/migrations/migrate.py
@@ -6,6 +6,7 @@ import unnamed_flags
 import char_unlock_table_columns
 import HP_masks_to_blobs
 import crystal_storage
+import broken_linkshells
 
 credentials = {}
 db = None
@@ -78,6 +79,7 @@ def run_all_migrations():
     run_migration(char_unlock_table_columns)
     run_migration(HP_masks_to_blobs)
     run_migration(crystal_storage)
+    run_migration(broken_linkshells)
     close()
 
     print("Finished running all migrations")

--- a/scripts/commands/breaklinkshell.lua
+++ b/scripts/commands/breaklinkshell.lua
@@ -1,0 +1,30 @@
+---------------------------------------------------------------------------------------------------
+-- func: breaklinkshell
+-- desc: Breaks a linkshell and all pearls/sacks
+---------------------------------------------------------------------------------------------------
+
+cmdprops =
+{
+    permission = 4,
+    parameters = "s"
+};
+
+function error(player, msg)
+    player:PrintToPlayer(msg);
+    player:PrintToPlayer("!breaklinkshell <linkshell name>");
+end;
+
+function onTrigger(player, target)
+
+    -- validate target
+    if not target then
+        error(player, "You must enter a linkshell name.");
+        return
+    end
+
+    if player:breakLinkshell(target) then
+        player:PrintToPlayer("Linkshell named \""..target.."\" has been broken!");
+    else
+        error(player, string.format("Linkshell named \"%s\" not found!", target))
+    end
+end

--- a/sql/linkshells.sql
+++ b/sql/linkshells.sql
@@ -34,5 +34,6 @@ CREATE TABLE IF NOT EXISTS `linkshells` (
   `message` BLOB NULL,
   `messagetime` int(10) unsigned NOT NULL DEFAULT '0',
   `postrights` tinyint(3) unsigned NOT NULL DEFAULT '0',
+  `broken` tinyint(1) unsigned NOT NULL DEFAULT '0',
   PRIMARY KEY (`linkshellid`)
 ) ENGINE=MyISAM  DEFAULT CHARSET=utf8 ROW_FORMAT=DYNAMIC AUTO_INCREMENT=1 ;

--- a/src/map/items/item_linkshell.cpp
+++ b/src/map/items/item_linkshell.cpp
@@ -49,7 +49,7 @@ void CItemLinkshell::SetLSID(uint32 lsid)
 
 LSTYPE CItemLinkshell::GetLSType()
 {
-    return (LSTYPE)(getID() - 0x200);
+    return ref<LSTYPE>(m_extra, 0x08);
 }
 
 lscolor_t CItemLinkshell::GetLSColor()
@@ -76,3 +76,9 @@ void CItemLinkshell::setSignature(int8* signature)
 {
     memcpy(m_extra + 0x09, signature, sizeof(m_extra) - 0x09);
 }
+
+void CItemLinkshell::SetLSType(LSTYPE value)
+{
+    ref<LSTYPE>(m_extra,0x08) = value;
+}
+

--- a/src/map/items/item_linkshell.h
+++ b/src/map/items/item_linkshell.h
@@ -42,8 +42,7 @@ enum LSTYPE : uint8
     LSTYPE_LINKSHELL,
     LSTYPE_PEARLSACK,
     LSTYPE_LINKPEARL,
-    LSTYPE_RIPPED_PERLSACK,
-    LSTYPE_BROKEN_LINKSHELL,
+    LSTYPE_BROKEN,
 };
 
 class CItemLinkshell : public CItem
@@ -61,6 +60,7 @@ public:
 	void		SetLSColor(uint16 color);	
     virtual const int8* getSignature();
     virtual void setSignature(int8* signature);
+    void        SetLSType(LSTYPE value);
 	
 private:
 

--- a/src/map/linkshell.cpp
+++ b/src/map/linkshell.cpp
@@ -33,6 +33,7 @@
 #include "packets/linkshell_equip.h"
 #include "packets/message_system.h"
 
+#include "utils/zoneutils.h"
 #include "utils/charutils.h"
 #include "conquest_system.h"
 #include "utils/itemutils.h"
@@ -69,6 +70,13 @@ void CLinkshell::setColor(uint16 color)
     m_color = color;
 }
 
+void CLinkshell::setPostRights(uint8 postrights)
+{
+    m_postRights = postrights;
+    Sql_Query(SqlHandle, "UPDATE linkshells SET postrights = %u WHERE linkshellid = %d;",
+        postrights, m_id);
+}
+
 const int8* CLinkshell::getName()
 {
     return (const int8*)m_name.c_str();
@@ -90,7 +98,10 @@ void CLinkshell::setMessage(const int8* message, const int8* poster)
     int8 packetData[8] {};
     ref<uint32>(packetData, 0) = m_id;
     ref<uint32>(packetData, 4) = 0;
-    message::send(MSG_CHAT_LINKSHELL, packetData, sizeof packetData, new CLinkshellMessagePacket(poster, message, (const int8*)m_name.c_str(), std::numeric_limits<uint32>::min(), true));
+    if (strlen((const char*)message) != 0)
+    {
+        message::send(MSG_CHAT_LINKSHELL, packetData, sizeof packetData, new CLinkshellMessagePacket(poster, message, (const int8*)m_name.c_str(), std::numeric_limits<uint32>::min(), true));
+    }
 }
 
 /************************************************************************
@@ -181,28 +192,32 @@ void CLinkshell::ChangeMemberRank(int8* MemberName, uint8 toSack)
                         return;
                     newShellItem->setQuantity(1);
                     memcpy(newShellItem->m_extra, PItemLinkshell->m_extra, 24);
+                    newShellItem->SetLSType(newId == 514 ? LSTYPE_PEARLSACK : LSTYPE_LINKPEARL);
                     newShellItem->setSubType(ITEM_LOCKED);
+                    uint8 LocationID = PItemLinkshell->getLocationID();
                     uint8 SlotID = PItemLinkshell->getSlotID();
                     delete PItemLinkshell;
                     PItemLinkshell = newShellItem;
+                    char extra[sizeof(PItemLinkshell->m_extra) * 2 + 1];
+                    Sql_EscapeStringLen(SqlHandle, extra, (const char*)PItemLinkshell->m_extra, sizeof(PItemLinkshell->m_extra));
 
-                    PMember->getStorage(LOC_INVENTORY)->InsertItem(PItemLinkshell, SlotID);
-                    const char* Query = "UPDATE char_inventory SET itemid = %u WHERE charid = %u AND location = %u AND slot = %u LIMIT 1";
-                    Sql_Query(SqlHandle, Query, PItemLinkshell->getID(), PMember->id, LOC_INVENTORY, SlotID);
+                    PMember->getStorage(LocationID)->InsertItem(PItemLinkshell, SlotID);
+                    const char* Query = "UPDATE char_inventory SET itemid = %u, extra = '%s' WHERE charid = %u AND location = %u AND slot = %u LIMIT 1";
+                    Sql_Query(SqlHandle, Query, PItemLinkshell->getID(), extra, PMember->id, LocationID, SlotID);
                     if (lsID == 1)
                     {
                         Sql_Query(SqlHandle, "UPDATE accounts_sessions SET linkshellid1 = %u , linkshellrank1 = %u WHERE charid = %u",
-                            m_id, PItemLinkshell->GetLSType(), PMember->id);
+                            m_id, static_cast<uint8>(PItemLinkshell->GetLSType()), PMember->id);
                     }
                     else if (lsID == 2)
                     {
                         Sql_Query(SqlHandle, "UPDATE accounts_sessions SET linkshellid2 = %u , linkshellrank2 = %u WHERE charid = %u",
-                            m_id, PItemLinkshell->GetLSType(), PMember->id);
+                            m_id, static_cast<uint8>(PItemLinkshell->GetLSType()), PMember->id);
                     }
 
                     PMember->pushPacket(new CInventoryAssignPacket(PItemLinkshell, INV_NORMAL));
                     PMember->pushPacket(new CLinkshellEquipPacket(PMember, lsID));
-                    PMember->pushPacket(new CInventoryItemPacket(PItemLinkshell, LOC_INVENTORY, SlotID));
+                    PMember->pushPacket(new CInventoryItemPacket(PItemLinkshell, LocationID, SlotID));
                 }
 	        
                 charutils::SaveCharStats(PMember);
@@ -218,12 +233,14 @@ void CLinkshell::ChangeMemberRank(int8* MemberName, uint8 toSack)
 
 /************************************************************************
 *                                                                       *
-*  Удаление персонажа из Linkshell по имени (ломаем все его Linkshells) *
+* Remove a character from Linkshell by name. Breaks all pearls/sacks if *
+* kicked by shell holder, otherwise equipped pearl only.                *
 *                                                                       *
 ************************************************************************/
 
-void CLinkshell::RemoveMemberByName(int8* MemberName)
+void CLinkshell::RemoveMemberByName(int8* MemberName, uint8 kickerRank)
 {
+    uint32 lsid = m_id;
 	for (uint32 i = 0; i < members.size(); ++i) 
 	{
 		if (strcmp((const char*)MemberName, (const char*)members.at(i)->GetName()) == 0)
@@ -234,7 +251,7 @@ void CLinkshell::RemoveMemberByName(int8* MemberName)
             SLOTTYPE slot = SLOT_LINK1;
             int lsNum = 1;
 
-            if (!PItemLinkshell || (PItemLinkshell->GetLSID() != this->getID()))
+            if (!PItemLinkshell || (PItemLinkshell->GetLSID() != lsid))
             {
                 PItemLinkshell = (CItemLinkshell*)PMember->getEquip(SLOT_LINK2);
                 slot = SLOT_LINK2;
@@ -258,24 +275,30 @@ void CLinkshell::RemoveMemberByName(int8* MemberName)
                 PMember->pushPacket(new CLinkshellEquipPacket(PMember,lsNum));
             }
 
-			CItemContainer* Inventory = PMember->getStorage(LOC_INVENTORY);
-            for (uint8 SlotID = 0; SlotID < Inventory->GetSize(); ++SlotID)
+            for (uint8 LocationID = 0; LocationID < MAX_CONTAINER_ID; ++LocationID)
             {
-                    CItemLinkshell* PItemLinkshell = (CItemLinkshell*)Inventory->GetItem(SlotID);
-
-					if (PItemLinkshell != nullptr && PItemLinkshell->isType(ITEM_LINKSHELL) && PItemLinkshell->GetLSID() == m_id)
-		            {
-                        const char* Query = "UPDATE char_inventory SET itemid = (itemid+2) WHERE charid = %u AND location = %u AND slot = %u LIMIT 1";
-
-                        Sql_Query(SqlHandle, Query, PMember->id, LOC_INVENTORY, SlotID);
-
-                        PItemLinkshell->SetLSID(0);
-                        PItemLinkshell->setID(PItemLinkshell->getID() + 2);
-
-                        PMember->pushPacket(new CInventoryItemPacket(PItemLinkshell, LOC_INVENTORY, SlotID));
-		            }
+                CItemContainer* Inventory = PMember->getStorage(LocationID);
+                for (uint8 SlotID = 0; SlotID < Inventory->GetSize(); ++SlotID)
+                {
+                    CItemLinkshell* newPItemLinkshell = (CItemLinkshell*)Inventory->GetItem(SlotID);
+                    if (newPItemLinkshell != nullptr && newPItemLinkshell->isType(ITEM_LINKSHELL) && newPItemLinkshell->GetLSID() == lsid)
+                    {
+                        if (kickerRank == LSTYPE_LINKSHELL || newPItemLinkshell == PItemLinkshell)
+                        {
+                            if (newPItemLinkshell->GetLSType() != LSTYPE_LINKSHELL)
+                            {
+                                newPItemLinkshell->SetLSType(LSTYPE_BROKEN);
+                                char extra[sizeof(newPItemLinkshell->m_extra) * 2 + 1];
+                                Sql_EscapeStringLen(SqlHandle, extra, (const char*)newPItemLinkshell->m_extra, sizeof(newPItemLinkshell->m_extra));
+                                const char* Query = "UPDATE char_inventory SET extra = '%s' WHERE charid = %u AND location = %u AND slot = %u LIMIT 1";
+                                Sql_Query(SqlHandle, Query, extra, PMember->id, LocationID, SlotID);
+                                PMember->pushPacket(new CInventoryItemPacket(newPItemLinkshell, LocationID, SlotID));
+                            }
+                        }
+                    }
+                }
             }
-	        
+
             charutils::SaveCharStats(PMember);
             charutils::SaveCharEquip(PMember);
 
@@ -285,6 +308,33 @@ void CLinkshell::RemoveMemberByName(int8* MemberName)
 			return;
 		} 
 	}
+}
+
+/************************************************************************
+*                                                                       *
+*  Break and unequip all affiliated pearlsacks and linkpearls           *
+*                                                                       *
+************************************************************************/
+
+void CLinkshell::BreakLinkshell(int8* lsname, bool gm)
+{
+    uint32 lsid = m_id;
+    int8 signature[21];
+    DecodeStringLinkshell(lsname, signature);
+    
+    // break logged in and equipped members
+	while (members.size() > 0) 
+	{
+        RemoveMemberByName((int8*)members.at(0)->GetName(), LSTYPE_LINKSHELL);
+    }
+    // set the linkshell as broken
+    Sql_Query(SqlHandle, "UPDATE linkshells SET broken = 1 WHERE linkshellid = %u LIMIT 1", lsid);
+    // unequip any offline members
+    Sql_Query(SqlHandle, "DELETE char_equip FROM char_equip INNER JOIN char_inventory \
+        ON char_inventory.slot = char_equip.slotid \
+        AND char_inventory.location = char_equip.containerid \
+        WHERE STRCMP('%s', char_inventory.signature) = 0 \
+        AND (char_inventory.itemid = 513 OR char_inventory.itemid = 514 OR char_inventory.itemid = 515)", signature);
 }
 
 /************************************************************************
@@ -304,10 +354,12 @@ void CLinkshell::PushPacket(uint32 senderID, CBasicPacket* packet)
             CBasicPacket* newPacket = new CBasicPacket(*packet);
             if (members.at(i)->PLinkshell2 == this)
             {
-                if (newPacket->id() == CChatMessagePacket::id) {
+                if (newPacket->id() == CChatMessagePacket::id)
+                {
                     newPacket->ref<uint8>(0x04) = MESSAGE_LINKSHELL2;
                 }
-                else if (newPacket->id() == CLinkshellMessagePacket::id) {
+                else if (newPacket->id() == CLinkshellMessagePacket::id)
+                {
                     newPacket->ref<uint8>(0x05) |= 0x40;
                 }
             }
@@ -346,7 +398,7 @@ namespace linkshell
 
     CLinkshell* LoadLinkshell(uint32 id)
     {
-	    int32 ret = Sql_Query(SqlHandle, "SELECT linkshellid, color, name FROM linkshells WHERE linkshellid = %d", id);
+	    int32 ret = Sql_Query(SqlHandle, "SELECT linkshellid, color, name, postrights FROM linkshells WHERE linkshellid = %d", id);
 
 	    if( ret != SQL_ERROR && Sql_NumRows(SqlHandle) != 0 && Sql_NextRow(SqlHandle) == SQL_SUCCESS)
 	    {
@@ -356,11 +408,32 @@ namespace linkshell
             int8 EncodedName[16];
             EncodeStringLinkshell(Sql_GetData(SqlHandle,2), EncodedName);
             PLinkshell->setName(EncodedName);
+            if (Sql_GetUIntData(SqlHandle,3) < LSTYPE_LINKSHELL || Sql_GetUIntData(SqlHandle,3) > LSTYPE_LINKPEARL)
+            {
+                PLinkshell->setPostRights(LSTYPE_PEARLSACK);
+            }
+            else
+            {
+                PLinkshell->m_postRights = Sql_GetUIntData(SqlHandle,3);
+            }
             LinkshellList[id] = std::move(PLinkshell);
-
             return LinkshellList[id].get();
 	    }
         return nullptr;
+    }
+
+    /************************************************************************
+    *                                                                       *
+    *  Unloads a loaded linkshell, only used after all members are removed  *
+    *                                                                       *
+    ************************************************************************/
+
+    void UnloadLinkshell(uint32 id)
+    {
+        if (auto PLinkshell = LinkshellList.find(id); PLinkshell != LinkshellList.end())
+        {
+            LinkshellList.erase(id);
+        }
     }
 
     /************************************************************************
@@ -439,7 +512,7 @@ namespace linkshell
     {
         if (IsValidLinkshellName(name))
         {
-		    if (Sql_Query(SqlHandle, "INSERT INTO linkshells (name, color) VALUES ('%s', %u)", name, color) != SQL_ERROR)
+		    if (Sql_Query(SqlHandle, "INSERT INTO linkshells (name, color, postrights) VALUES ('%s', %u, %u)", name, color, static_cast<uint8>(LSTYPE_PEARLSACK)) != SQL_ERROR)
             {
                 return LoadLinkshell((uint32)Sql_LastInsertId(SqlHandle))->getID();
             }

--- a/src/map/linkshell.h
+++ b/src/map/linkshell.h
@@ -47,8 +47,10 @@ public:
 
     uint32      getID();
     uint16      getColor();
+    uint8       getPostRights();
 
     void        setColor(uint16 color);
+    void        setPostRights(uint8 postrights); // Updates lsmes privilege and writes to db
 
     const int8* getName();
 	void		setName(int8* name);
@@ -57,13 +59,15 @@ public:
     void        AddMember(CCharEntity* PChar,int8 type, uint8 lsNum);
     bool        DelMember(CCharEntity* PChar);
 
-    void        RemoveMemberByName(int8* MemberName);
+    void        BreakLinkshell(int8* lsname, bool gm);
+    void        RemoveMemberByName(int8* MemberName, uint8 kickerRank);
 	void		ChangeMemberRank(int8* MemberName, uint8 toSack);
 
     void        PushPacket(uint32 senderID, CBasicPacket* packet);
     void        PushLinkshellMessage(CCharEntity* PChar, bool ls1);
 
     std::vector<CCharEntity*> members; // список участников linkshell
+    uint8       m_postRights;
 
 private:
 
@@ -82,6 +86,7 @@ private:
 namespace linkshell
 {
     CLinkshell* LoadLinkshell(uint32 id);
+    void UnloadLinkshell(uint32 id);
 
     bool AddOnlineMember(CCharEntity* PChar, CItemLinkshell* PItemLinkshell, uint8 lsNum);
     bool DelOnlineMember(CCharEntity* PChar, CItemLinkshell* PItemLinkshell);

--- a/src/map/lua/lua_baseentity.cpp
+++ b/src/map/lua/lua_baseentity.cpp
@@ -45,6 +45,7 @@
 #include "../instance.h"
 #include "../item_container.h"
 #include "../latent_effect_container.h"
+#include "../linkshell.h"
 #include "../map.h"
 #include "../message.h"
 #include "../mob_modifier.h"
@@ -3830,6 +3831,44 @@ inline int32 CLuaBaseEntity::getCurrentGPItem(lua_State* L)
     lua_pushinteger(L, GPItem.second);
 
     return 2;
+}
+
+/************************************************************************
+*  Function: breakLinkshell()
+*  Purpose : Breaks linkshell and all pearls/sacks
+*  Example : player:breakLinkshell(LSname)
+*  Notes   : Used by GMs to break a linkshell
+************************************************************************/
+
+inline int32 CLuaBaseEntity::breakLinkshell(lua_State* L)
+{
+    DSP_DEBUG_BREAK_IF(lua_isnil(L, 1) || !lua_isstring(L, 1));
+
+    auto lsname = lua_tostring(L, 1);
+    bool found = false;
+
+    int32 ret = Sql_Query(SqlHandle, "SELECT broken, linkshellid FROM linkshells WHERE name = '%s'", lsname);
+	if( ret != SQL_ERROR && Sql_NumRows(SqlHandle) != 0 && Sql_NextRow(SqlHandle) == SQL_SUCCESS)
+    {
+        uint8 broken = Sql_GetUIntData(SqlHandle,0);
+        if (broken)
+        {
+            lua_pushboolean(L, true);
+            return 1;
+        }
+        uint32 lsid = Sql_GetUIntData(SqlHandle,1);
+        CLinkshell* PLinkshell = linkshell::GetLinkshell(lsid);
+        if (!PLinkshell)
+            PLinkshell = linkshell::LoadLinkshell(lsid);
+        int8 EncodedName[16];
+        EncodeStringLinkshell((int8*)lsname, EncodedName);
+        PLinkshell->BreakLinkshell(EncodedName, true);
+        linkshell::UnloadLinkshell(lsid);
+        found = true;
+    }
+
+    lua_pushboolean(L, found);
+    return 1;
 }
 
 /************************************************************************
@@ -14086,6 +14125,7 @@ Lunar<CLuaBaseEntity>::Register_t CLuaBaseEntity::methods[] =
     LUNAR_DECLARE_METHOD(CLuaBaseEntity,createShop),
     LUNAR_DECLARE_METHOD(CLuaBaseEntity,addShopItem),
     LUNAR_DECLARE_METHOD(CLuaBaseEntity,getCurrentGPItem),
+    LUNAR_DECLARE_METHOD(CLuaBaseEntity,breakLinkshell),
 
     // Trading
     LUNAR_DECLARE_METHOD(CLuaBaseEntity,getContainerSize),

--- a/src/map/lua/lua_baseentity.h
+++ b/src/map/lua/lua_baseentity.h
@@ -194,6 +194,7 @@ public:
     int32 createShop(lua_State*);            // Prepare the container for work of shop ??
     int32 addShopItem(lua_State*);           // Adds item to shop container (16 max)
     int32 getCurrentGPItem(lua_State*);      // Gets current GP item id and max points
+    int32 breakLinkshell(lua_State*);        // Breaks all pearls/sacks
 
     // Trading
     int32 getContainerSize(lua_State*);      // Gets the current capacity of a container

--- a/src/map/message.cpp
+++ b/src/map/message.cpp
@@ -369,18 +369,18 @@ namespace message
             {
                 uint8 kickerRank = ref<uint8>((uint8*)extra->data(), 28);
                 CItemLinkshell* targetLS = (CItemLinkshell*)PChar->getEquip(SLOT_LINK1);
-                if (kickerRank == LSTYPE_LINKSHELL || (kickerRank == LSTYPE_PEARLSACK && targetLS && targetLS->GetLSType() == LSTYPE_LINKPEARL))
+                if (targetLS && (kickerRank == LSTYPE_LINKSHELL || (kickerRank == LSTYPE_PEARLSACK && targetLS->GetLSType() == LSTYPE_LINKPEARL)))
                 {
-                    PChar->PLinkshell1->RemoveMemberByName((int8*)extra->data() + 4);
+                    PChar->PLinkshell1->RemoveMemberByName((int8*)extra->data() + 4, (targetLS->GetLSType() == LSTYPE_LINKSHELL ? LSTYPE_PEARLSACK : kickerRank));
                 }
             }
             else if (PChar && PChar->PLinkshell2 && PChar->PLinkshell2->getID() == ref<uint32>((uint8*)extra->data(), 24))
             {
                 uint8 kickerRank = ref<uint8>((uint8*)extra->data(), 28);
                 CItemLinkshell* targetLS = (CItemLinkshell*)PChar->getEquip(SLOT_LINK2);
-                if (kickerRank == LSTYPE_LINKSHELL || (kickerRank == LSTYPE_PEARLSACK && targetLS && targetLS->GetLSType() == LSTYPE_LINKPEARL))
+                if (targetLS && (kickerRank == LSTYPE_LINKSHELL || (kickerRank == LSTYPE_PEARLSACK && targetLS->GetLSType() == LSTYPE_LINKPEARL)))
                 {
-                    PChar->PLinkshell2->RemoveMemberByName((int8*)extra->data() + 4);
+                    PChar->PLinkshell2->RemoveMemberByName((int8*)extra->data() + 4, kickerRank);
                 }
             }
             break;

--- a/src/map/packet_system.cpp
+++ b/src/map/packet_system.cpp
@@ -940,10 +940,22 @@ void SmallPacket0x028(map_session_data_t* session, CCharEntity* PChar, CBasicPac
     if (PItem != nullptr && !PItem->isSubType(ITEM_LOCKED))
     {
         uint16 ItemID = PItem->getID();
+        // Break linkshell if the main shell was disposed of.
+        CItemLinkshell* ItemLinkshell = dynamic_cast<CItemLinkshell*>(PItem);
+        if (ItemLinkshell && ItemLinkshell->GetLSType() == LSTYPE_LINKSHELL)
+        {
+            uint32 lsid = ItemLinkshell->GetLSID();
+            CLinkshell* PLinkshell = linkshell::GetLinkshell(lsid);
+            if (!PLinkshell)
+            {
+                PLinkshell = linkshell::LoadLinkshell(lsid);
+            }
+            PLinkshell->BreakLinkshell((int8*)PLinkshell->getName(), false);
+            linkshell::UnloadLinkshell(lsid);
+        }
 
         if (charutils::UpdateItem(PChar, container, slotID, -quantity) != 0)
         {
-            // TODO: Break linkshell if the main shell was disposed of.
             // ShowNotice(CL_CYAN"Player %s DROPPING itemID %u (quantity: %u)\n" CL_RESET, PChar->GetName(), ItemID, quantity);
             PChar->pushPacket(new CMessageStandardPacket(nullptr, ItemID, quantity, MsgStd::ThrowAway));
             PChar->pushPacket(new CInventoryFinishPacket());
@@ -2490,7 +2502,10 @@ void SmallPacket0x050(map_session_data_t* session, CCharEntity* PChar, CBasicPac
     uint8 containerID = data.ref<uint8>(0x06);     // container id
 
     if (containerID != LOC_INVENTORY && containerID != LOC_WARDROBE && containerID != LOC_WARDROBE2 && containerID != LOC_WARDROBE3 && containerID != LOC_WARDROBE4)
-        return;
+        if (equipSlotID != 16 && equipSlotID != 17)
+            return;
+        else if (containerID != LOC_MOGSATCHEL && containerID != LOC_MOGSACK && containerID != LOC_MOGCASE)
+            return;
 
     charutils::EquipItem(PChar, slotID, equipSlotID, containerID); //current
     charutils::SaveCharEquip(PChar);
@@ -4296,6 +4311,7 @@ void SmallPacket0x0C3(map_session_data_t* session, CCharEntity* PChar, CBasicPac
         {
             PItemLinkPearl->setQuantity(1);
             memcpy(PItemLinkPearl->m_extra, PItemLinkshell->m_extra, 24);
+            PItemLinkPearl->SetLSType(LSTYPE_LINKPEARL);
             charutils::AddItem(PChar, LOC_INVENTORY, PItemLinkPearl);
         }
     }
@@ -4311,10 +4327,10 @@ void SmallPacket0x0C3(map_session_data_t* session, CCharEntity* PChar, CBasicPac
 void SmallPacket0x0C4(map_session_data_t* session, CCharEntity* PChar, CBasicPacket data)
 {
     uint8 SlotID = data.ref<uint8>(0x06);
+    uint8 LocationID = data.ref<uint8>(0x07);
     uint8 action = data.ref<uint8>(0x08);
     uint8 lsNum = data.ref<uint8>(0x1B);
-
-    CItemLinkshell* PItemLinkshell = (CItemLinkshell*)PChar->getStorage(LOC_INVENTORY)->GetItem(SlotID);
+    CItemLinkshell* PItemLinkshell = (CItemLinkshell*)PChar->getStorage(LocationID)->GetItem(SlotID);
 
     if (PItemLinkshell != nullptr && PItemLinkshell->isType(ITEM_LINKSHELL))
     {
@@ -4338,8 +4354,9 @@ void SmallPacket0x0C4(map_session_data_t* session, CCharEntity* PChar, CBasicPac
                 if (PItemLinkshell == nullptr)
                     return;
                 PItemLinkshell->setQuantity(1);
-                PChar->getStorage(LOC_INVENTORY)->InsertItem(PItemLinkshell, SlotID);
+                PChar->getStorage(LocationID)->InsertItem(PItemLinkshell, SlotID);
                 PItemLinkshell->SetLSID(LinkshellID);
+                PItemLinkshell->SetLSType(LSTYPE_LINKSHELL);
                 PItemLinkshell->setSignature(EncodedName); //because apparently the format from the packet isn't right, and is missing terminators
                 PItemLinkshell->SetLSColor(LinkshellColor);
 
@@ -4351,7 +4368,7 @@ void SmallPacket0x0C4(map_session_data_t* session, CCharEntity* PChar, CBasicPac
                 if (Sql_Query(SqlHandle, Query, DecodedName, extra, PChar->id, SlotID) != SQL_ERROR &&
                     Sql_AffectedRows(SqlHandle) != 0)
                 {
-                    PChar->pushPacket(new CInventoryItemPacket(PItemLinkshell, LOC_INVENTORY, SlotID));
+                    PChar->pushPacket(new CInventoryItemPacket(PItemLinkshell, LocationID, SlotID));
                 }
             }
             else
@@ -4393,9 +4410,22 @@ void SmallPacket0x0C4(map_session_data_t* session, CCharEntity* PChar, CBasicPac
             break;
             case 1: // equip linkshell
             {
-                if (PItemLinkshell->GetLSID() == 0) // linkshell no exists, item is unusable
+                auto ret = Sql_Query(SqlHandle, "SELECT broken FROM linkshells WHERE linkshellid = %u LIMIT 1", PItemLinkshell->GetLSID());
+                if (ret != SQL_ERROR && Sql_NumRows(SqlHandle) != 0 && Sql_NextRow(SqlHandle) == SQL_SUCCESS && Sql_GetUIntData(SqlHandle, 0) == 1)
+                { // if the linkshell has been broken, break the item
+                    PItemLinkshell->SetLSType(LSTYPE_BROKEN);
+                    char extra[sizeof(PItemLinkshell->m_extra) * 2 + 1];
+                    Sql_EscapeStringLen(SqlHandle, extra, (const char*)PItemLinkshell->m_extra, sizeof(PItemLinkshell->m_extra));
+                    const char* Query = "UPDATE char_inventory SET extra = '%s' WHERE charid = %u AND location = %u AND slot = %u LIMIT 1";
+                    Sql_Query(SqlHandle, Query, extra, PChar->id, PItemLinkshell->getLocationID(), PItemLinkshell->getSlotID());
+                    PChar->pushPacket(new CInventoryItemPacket(PItemLinkshell, PItemLinkshell->getLocationID(), PItemLinkshell->getSlotID()));
+                    PChar->pushPacket(new CInventoryFinishPacket());
+                    PChar->pushPacket(new CMessageSystemPacket(0, 0, 110)); // That linkshell group no longer exists. This item is unusable.
+                    return;
+                }
+                if (PItemLinkshell->GetLSID() == 0)
                 {
-                    PChar->pushPacket(new CMessageSystemPacket(0, 0, 110));
+                    PChar->pushPacket(new CMessageSystemPacket(0, 0, 110)); // That linkshell group no longer exists. This item is unusable.
                     return;
                 }
                 if (OldLinkshell != nullptr) // switching linkshell group
@@ -4415,7 +4445,7 @@ void SmallPacket0x0C4(map_session_data_t* session, CCharEntity* PChar, CBasicPac
                 PItemLinkshell->setSubType(ITEM_LOCKED);
 
                 PChar->equip[slot] = SlotID;
-                PChar->equipLoc[slot] = LOC_INVENTORY;
+                PChar->equipLoc[slot] = LocationID;
                 if (lsNum == 1)
                 {
                     PChar->nameflags.flags |= FLAG_LINKSHELL;
@@ -4430,7 +4460,7 @@ void SmallPacket0x0C4(map_session_data_t* session, CCharEntity* PChar, CBasicPac
             charutils::SaveCharEquip(PChar);
 
             PChar->pushPacket(new CLinkshellEquipPacket(PChar, lsNum));
-            PChar->pushPacket(new CInventoryItemPacket(PItemLinkshell, LOC_INVENTORY, SlotID));
+            PChar->pushPacket(new CInventoryItemPacket(PItemLinkshell, LocationID, SlotID));
         }
         PChar->pushPacket(new CInventoryFinishPacket());
         PChar->pushPacket(new CCharUpdatePacket(PChar));
@@ -4876,15 +4906,29 @@ void SmallPacket0x0E2(map_session_data_t* session, CCharEntity* PChar, CBasicPac
     {
         switch (data.ref<uint8>(0x04) & 0xF0)
         {
-        case 0x20: // Establish right to change the message..
+        case 0x20: // Establish right to change the message.
         {
-            // TODO: ....
+            if (PItemLinkshell->GetLSType() == LSTYPE_LINKSHELL)
+            {
+                switch (data.ref<uint8>(0x05))
+                {
+                case 0x00:
+                    PChar->PLinkshell1->setPostRights(LSTYPE_LINKSHELL);
+                break;
+                case 0x04:
+                    PChar->PLinkshell1->setPostRights(LSTYPE_PEARLSACK);
+                break;
+                case 0x08:
+                    PChar->PLinkshell1->setPostRights(LSTYPE_LINKPEARL);
+                break;
+                }
+                return;     
+            }
         }
         break;
         case 0x40: // Change Message
         {
-            if (PItemLinkshell->GetLSType() == LSTYPE_LINKSHELL ||
-                PItemLinkshell->GetLSType() == LSTYPE_PEARLSACK)
+            if (static_cast<uint8>(PItemLinkshell->GetLSType()) <= PChar->PLinkshell1->m_postRights)
             {
                 PChar->PLinkshell1->setMessage(data[16], PChar->GetName());
                 return;
@@ -4893,7 +4937,7 @@ void SmallPacket0x0E2(map_session_data_t* session, CCharEntity* PChar, CBasicPac
         break;
         }
     }
-    PChar->pushPacket(new CLinkshellMessagePacket(nullptr, nullptr, nullptr, 0, 1)); // you are not authorized to this action
+    PChar->pushPacket(new CMessageSystemPacket(0, 0, 158)); // You do not have access to those linkshell commands.
     return;
 }
 

--- a/src/map/packets/linkshell_equip.cpp
+++ b/src/map/packets/linkshell_equip.cpp
@@ -36,7 +36,13 @@ CLinkshellEquipPacket::CLinkshellEquipPacket(CCharEntity* PChar, uint8 number)
 
     ref<uint8>(0x04) = number;
     if (number == 1)
+    {
         ref<uint8>(0x05) = PChar->equip[SLOT_LINK1];
+        ref<uint8>(0x06) = PChar->equipLoc[SLOT_LINK1];
+    }
     else
+    {
         ref<uint8>(0x05) = PChar->equip[SLOT_LINK2];
+        ref<uint8>(0x06) = PChar->equipLoc[SLOT_LINK2];
+    }
 }

--- a/src/map/utils/charutils.cpp
+++ b/src/map/utils/charutils.cpp
@@ -911,6 +911,10 @@ namespace charutils
 
                     if (PItem->isType(ITEM_LINKSHELL))
                     {
+                        if (static_cast<CItemLinkshell*>(PItem)->GetLSType() == 0)
+                        {
+                            static_cast<CItemLinkshell*>(PItem)->SetLSType((LSTYPE)(PItem->getID() - 0x200));
+                        }
                         int8 EncodedString[16];
                         EncodeStringLinkshell(Sql_GetData(SqlHandle, 5), EncodedString);
                         PItem->setSignature(EncodedString);
@@ -996,13 +1000,14 @@ namespace charutils
                 {
                     uint8 SlotID = Sql_GetUIntData(SqlHandle, 0);
                     uint8 equipSlot = Sql_GetUIntData(SqlHandle, 1);
-                    CItem* PItem = PChar->getStorage(LOC_INVENTORY)->GetItem(SlotID);
+                    uint8 LocationID = Sql_GetUIntData(SqlHandle, 2);
+                    CItem* PItem = PChar->getStorage(LocationID)->GetItem(SlotID);
 
                     if ((PItem != nullptr) && PItem->isType(ITEM_LINKSHELL))
                     {
                         PItem->setSubType(ITEM_LOCKED);
                         PChar->equip[equipSlot] = SlotID;
-                        PChar->equipLoc[equipSlot] = LOC_INVENTORY;
+                        PChar->equipLoc[equipSlot] = LocationID;
                         if (equipSlot == SLOT_LINK1)
                             PLinkshell1 = (CItemLinkshell*)PItem;
                         else if (equipSlot == SLOT_LINK2)
@@ -1136,7 +1141,7 @@ namespace charutils
             PItem->setSubType(ITEM_LOCKED);
 
             PChar->nameflags.flags |= FLAG_LINKSHELL;
-            PChar->pushPacket(new CInventoryItemPacket(PItem, LOC_INVENTORY, PChar->equip[SLOT_LINK1]));
+            PChar->pushPacket(new CInventoryItemPacket(PItem, PChar->equipLoc[SLOT_LINK1], PChar->equip[SLOT_LINK1]));
             PChar->pushPacket(new CInventoryAssignPacket(PItem, INV_LINKSHELL));
             PChar->pushPacket(new CLinkshellEquipPacket(PChar, 1));
         }
@@ -1150,7 +1155,7 @@ namespace charutils
         {
             PItem->setSubType(ITEM_LOCKED);
 
-            PChar->pushPacket(new CInventoryItemPacket(PItem, LOC_INVENTORY, PChar->equip[SLOT_LINK2]));
+            PChar->pushPacket(new CInventoryItemPacket(PItem, PChar->equipLoc[SLOT_LINK2], PChar->equip[SLOT_LINK2]));
             PChar->pushPacket(new CInventoryAssignPacket(PItem, INV_LINKSHELL));
             PChar->pushPacket(new CLinkshellEquipPacket(PChar, 2));
         }


### PR DESCRIPTION
This adds several features to make linkshells match retail behavior. The biggest change is using the 9th byte of a linkshell items extra data to hold the linkshell type, rather than using an offset of the item id as is currently done (this appears to be how retail does it). Also added is the ability to change /lsmes privilege level to LS holder only, pearlsack holders, or everyone. These changes should require no input to existing shells for compatibility. Breaking the linkshell group has also been added. This will kick and break the pearls/sacks of all equipped members, then set the linkshell as broken in the database. Any offline or unequipped members will receive a message when they next try equipping which will then break the item. There has been a !breaklinkshell command added for GMs to break any linkshell group. ***This change DOES require that you add a column to the linkshells table.***

* break linkshell and all pearls/sacks by dropping linkshell or with gm command
* pearlsack kick breaks equipped pearl, linkshell kick breaks all pearls/sacks in all inventories
* lsmes privilege (/lsmes level ls, /lsmes level ps, /lsmes level all, /lsmes clear)
* equipable from any local inventory (inventory, satchel, sack, case)

Fixes pretty much everything in #2569 except trading pearls.