### PR TITLE
Removed custom setting for Limbus

### DIFF
--- a/scripts/globals/settings.lua
+++ b/scripts/globals/settings.lua
@@ -151,6 +151,3 @@ DIG_GRANT_BURROW = 0; -- Set to 1 to grant burrow ability
 DIG_GRANT_BORE = 0; -- Set to 1 to grant bore ability
 ENM_COOLDOWN = 120;  -- Number of hours before a player can obtain same KI for ENMs (default: 5 days)
 FORCE_SPAWN_QM_RESET_TIME = 300; -- Number of seconds the ??? remains hidden for after the despawning of the mob it force spawns.
-
--- LIMBUS
-BETWEEN_2COSMOCLEANSE_WAIT_TIME = 20; -- Hours before player can re-enter Limbus. Default is 20 hrs.

--- a/scripts/zones/Port_Jeuno/npcs/Sagheera.lua
+++ b/scripts/zones/Port_Jeuno/npcs/Sagheera.lua
@@ -256,7 +256,7 @@ local abcShop =
 local COSMO_READY = 2147483649 -- BITMASK for the purchase
 
 local function getCosmoCleanseTime(player)
-    local cosmoWaitTime = BETWEEN_2COSMOCLEANSE_WAIT_TIME * 60 * 60
+    local cosmoWaitTime = player:hasKeyItem(dsp.ki.RHAPSODY_IN_MAUVE) and 3600 or 72000
     local lastCosmoTime = player:getCharVar("Cosmo_Cleanse_TIME")
 
     if lastCosmoTime ~= 0 then


### PR DESCRIPTION
Default time between Limbus runs is 20 hours, added support for Rhapsody in Mauve to lower it to one hour.