### PR TITLE
Removed custom settings for Homepoints

### DIFF
--- a/scripts/globals/homepoint.lua
+++ b/scripts/globals/homepoint.lua
@@ -147,7 +147,7 @@ local selection =
 local travelType = dsp.teleport.type.HOMEPOINT
 
 local function getCost (from, to, key)
-    
+
     if HPs[from].group == HPs[to].group and HPs[to].group ~= 0 then
         return 0
     else
@@ -173,17 +173,6 @@ local function goToHP(player, choice, index)
 end
 
 dsp.homepoint.onTrigger = function(player, csid, index)
-
-    if HOMEPOINT_HEAL == 1 then -- Settings.lua Homepoint Heal enabled
-        player:addHP(player:getMaxHP())
-        player:addMP(player:getMaxMP())
-    end
-
-    if not HOMEPOINT_TELEPORT == 1 then -- Settings.lua Homepoints disabled
-        player:startEvent(csid, 0, 0, 0, 0, 0, player:getGil(), 4095, index)
-        return
-    end
-
     local hpBit  = index % 32
     local hpSet  = math.floor(index / 32)
     local menu   = player:getTeleportMenu(travelType)

--- a/scripts/globals/settings.lua
+++ b/scripts/globals/settings.lua
@@ -136,7 +136,6 @@ HALLOWEEN_2005 = 0; -- Set to 1 to Enable the 2005 version of Harvest Festival, 
 HALLOWEEN_YEAR_ROUND = 0; -- Set to 1 to have Harvest Festival initialize outside of normal times.
 
 -- MISC
-HOMEPOINT_HEAL = 0; --Set to 1 if you want Home Points to heal you like in single-player Final Fantasy games.
 RIVERNE_PORTERS = 120; -- Time in seconds that Unstable Displacements in Cape Riverne stay open after trading a scale.
 LANTERNS_STAY_LIT = 1200; -- time in seconds that lanterns in the Den of Rancor stay lit.
 ENABLE_COP_ZONE_CAP = 1; -- enable or disable lvl cap
@@ -144,7 +143,6 @@ TIMEZONE_OFFSET = 9.0; -- Offset from UTC used to determine when "JP Midnight" i
 ALLOW_MULTIPLE_EXP_RINGS = 0; -- Set to 1 to remove ownership restrictions on the Chariot/Empress/Emperor Band trio.
 BYPASS_EXP_RING_ONE_PER_WEEK = 0; -- -- Set to 1 to bypass the limit of one ring per Conquest Tally Week.
 NUMBER_OF_DM_EARRINGS = 1; -- Number of earrings players can simultaneously own from Divine Might before scripts start blocking them (Default: 1)
-HOMEPOINT_TELEPORT = 0; -- Enables the homepoint teleport system
 DIG_ABUNDANCE_BONUS = 0; -- Increase chance of digging up an item (450  = item digup chance +45)
 DIG_FATIGUE = 1; -- Set to 0 to disable Dig Fatigue
 DIG_GRANT_BURROW = 0; -- Set to 1 to grant burrow ability


### PR DESCRIPTION
Homepoint will always be enabled, per-retail, and no option to heal the player,