### PR TITLE
Fix True Will NM kill requirements

### DIFF
--- a/scripts/zones/Yhoator_Jungle/mobs/Kappa_Akuso.lua
+++ b/scripts/zones/Yhoator_Jungle/mobs/Kappa_Akuso.lua
@@ -12,9 +12,7 @@ function onMobInitialize(mob)
 end
 
 function onMobDeath(mob, player, isKiller)
-    if player:getQuestStatus(OUTLANDS,dsp.quest.id.outlands.TRUE_WILL) == QUEST_ACCEPTED then 
-        if KAPPA_BIWA:isDead() and KAPPA_BONZE:isDead() then
-            player:addCharVar("trueWillKilledNM", 1)
-        end
+    if player:getQuestStatus(OUTLANDS, dsp.quest.id.outlands.TRUE_WILL) == QUEST_ACCEPTED then 
+        player:addCharVar("trueWillKilledNM", 1)
     end
 end

--- a/scripts/zones/Yhoator_Jungle/mobs/Kappa_Biwa.lua
+++ b/scripts/zones/Yhoator_Jungle/mobs/Kappa_Biwa.lua
@@ -12,9 +12,7 @@ function onMobInitialize(mob)
 end
 
 function onMobDeath(mob, player, isKiller)
-    if player:getQuestStatus(OUTLANDS,dsp.quest.id.outlands.TRUE_WILL) == QUEST_ACCEPTED then
-        if KAPPA_AKUSO:isDead() and KAPPA_BONZE:isDead() then
-            player:addCharVar("trueWillKilledNM", 1)
-        end
+    if player:getQuestStatus(OUTLANDS, dsp.quest.id.outlands.TRUE_WILL) == QUEST_ACCEPTED then
+        player:addCharVar("trueWillKilledNM", 1)
     end
 end

--- a/scripts/zones/Yhoator_Jungle/mobs/Kappa_Bonze.lua
+++ b/scripts/zones/Yhoator_Jungle/mobs/Kappa_Bonze.lua
@@ -12,9 +12,7 @@ function onMobInitialize(mob)
 end
 
 function onMobDeath(mob, player, isKiller)
-    if player:getQuestStatus(OUTLANDS,dsp.quest.id.outlands.TRUE_WILL) == QUEST_ACCEPTED then
-        if KAPPA_AKUSO:isDead() and KAPPA_BIWA:isDead() then
-            player:addCharVar("trueWillKilledNM", 1)
-        end
+    if player:getQuestStatus(OUTLANDS, dsp.quest.id.outlands.TRUE_WILL) == QUEST_ACCEPTED then
+        player:addCharVar("trueWillKilledNM", 1)
     end
 end

--- a/scripts/zones/Yhoator_Jungle/npcs/qm3.lua
+++ b/scripts/zones/Yhoator_Jungle/npcs/qm3.lua
@@ -14,13 +14,12 @@ function onTrade(player,npc,trade)
 end
 
 function onTrigger(player,npc)
-    if player:getQuestStatus(OUTLANDS,dsp.quest.id.outlands.TRUE_WILL) == QUEST_ACCEPTED and not player:hasKeyItem(dsp.ki.OLD_TRICK_BOX) then
+    if player:getQuestStatus(OUTLANDS, dsp.quest.id.outlands.TRUE_WILL) == QUEST_ACCEPTED and not player:hasKeyItem(dsp.ki.OLD_TRICK_BOX) then
         if player:getCharVar("trueWillKilledNM") > 0 then
-            player:addKeyItem(dsp.ki.OLD_TRICK_BOX)
-            player:messageSpecial(ID.text.KEYITEM_OBTAINED,dsp.ki.OLD_TRICK_BOX)
+            npcUtil.giveKeyItem(player, dsp.ki.OLD_TRICK_BOX)
             player:setCharVar("trueWillKilledNM", 0)
         else
-            npcUtil.popFromQM(player, npc, {ID.mob.KAPPA_AKUSO, ID.mob.KAPPA_BONZE, ID.mob.KAPPA_BIWA})
+            npcUtil.popFromQM(player, npc, {ID.mob.KAPPA_AKUSO, ID.mob.KAPPA_BONZE, ID.mob.KAPPA_BIWA}, { hide = 0 })
         end
     else
         player:messageSpecial(ID.text.NOTHING_OUT_OF_ORDINARY)


### PR DESCRIPTION
The code that used to be here was checking if a nil value is dead in each NM script. It was impossible to complete the quest.

Also, made it retail accurate. If you're clever enough, you can kill only 1 NM and despawn the other two and still complete the quest. popFromQM does most of the heavy lifting for checking to make sure the mobs are despawned before attempting to spawn them again, etc.