### PR TITLE
No reward for True Will if any of the NMs are still up

### DIFF
--- a/scripts/zones/Yhoator_Jungle/mobs/Kappa_Akuso.lua
+++ b/scripts/zones/Yhoator_Jungle/mobs/Kappa_Akuso.lua
@@ -3,6 +3,7 @@
 --   NM: Kappa Akuso
 -- Involved in Quest: True will
 -----------------------------------
+local ID = require("scripts/zones/Yhoator_Jungle/IDs")
 mixins = {require("scripts/mixins/job_special")}
 require("scripts/globals/quests")
 -----------------------------------
@@ -12,7 +13,10 @@ function onMobInitialize(mob)
 end
 
 function onMobDeath(mob, player, isKiller)
-    if player:getQuestStatus(OUTLANDS, dsp.quest.id.outlands.TRUE_WILL) == QUEST_ACCEPTED then 
-        player:addCharVar("trueWillKilledNM", 1)
+    if player:getQuestStatus(OUTLANDS, dsp.quest.id.outlands.TRUE_WILL) == QUEST_ACCEPTED then
+        local lastNM = not (GetMobByID(ID.mob.KAPPA_BONZE):isAlive() or GetMobByID(ID.mob.KAPPA_BIWA):isAlive())
+        if lastNM then -- Only count the kill for the last alive/spawned NM dying
+            player:addCharVar("trueWillKilledNM", 1)
+        end
     end
 end

--- a/scripts/zones/Yhoator_Jungle/mobs/Kappa_Biwa.lua
+++ b/scripts/zones/Yhoator_Jungle/mobs/Kappa_Biwa.lua
@@ -3,6 +3,7 @@
 --   NM: Kappa Biwa
 -- Involved in Quest: True will
 -----------------------------------
+local ID = require("scripts/zones/Yhoator_Jungle/IDs")
 mixins = {require("scripts/mixins/job_special")}
 require("scripts/globals/quests")
 -----------------------------------
@@ -13,6 +14,9 @@ end
 
 function onMobDeath(mob, player, isKiller)
     if player:getQuestStatus(OUTLANDS, dsp.quest.id.outlands.TRUE_WILL) == QUEST_ACCEPTED then
-        player:addCharVar("trueWillKilledNM", 1)
+        local lastNM = not (GetMobByID(ID.mob.KAPPA_AKUSO):isAlive() or GetMobByID(ID.mob.KAPPA_BONZE):isAlive())
+        if lastNM then -- Only count the kill for the last alive/spawned NM dying
+            player:addCharVar("trueWillKilledNM", 1)
+        end
     end
 end

--- a/scripts/zones/Yhoator_Jungle/mobs/Kappa_Bonze.lua
+++ b/scripts/zones/Yhoator_Jungle/mobs/Kappa_Bonze.lua
@@ -3,6 +3,7 @@
 --   NM: Kappa Bonze
 -- Involved in Quest: True will
 -----------------------------------
+local ID = require("scripts/zones/Yhoator_Jungle/IDs")
 mixins = {require("scripts/mixins/job_special")}
 require("scripts/globals/quests")
 -----------------------------------
@@ -13,6 +14,9 @@ end
 
 function onMobDeath(mob, player, isKiller)
     if player:getQuestStatus(OUTLANDS, dsp.quest.id.outlands.TRUE_WILL) == QUEST_ACCEPTED then
-        player:addCharVar("trueWillKilledNM", 1)
+        local lastNM = not (GetMobByID(ID.mob.KAPPA_AKUSO):isAlive() or GetMobByID(ID.mob.KAPPA_BIWA):isAlive())
+        if lastNM then -- Only count the kill for the last alive/spawned NM dying
+            player:addCharVar("trueWillKilledNM", 1)
+        end
     end
 end

--- a/scripts/zones/Yhoator_Jungle/npcs/qm3.lua
+++ b/scripts/zones/Yhoator_Jungle/npcs/qm3.lua
@@ -15,7 +15,8 @@ end
 
 function onTrigger(player,npc)
     if player:getQuestStatus(OUTLANDS, dsp.quest.id.outlands.TRUE_WILL) == QUEST_ACCEPTED and not player:hasKeyItem(dsp.ki.OLD_TRICK_BOX) then
-        if player:getCharVar("trueWillKilledNM") > 0 then
+        local mobsStillUp = GetMobByID(ID.mob.KAPPA_AKUSO):isSpawned() or GetMobByID(ID.mob.KAPPA_BONZE):isSpawned() or GetMobByID(ID.mob.KAPPA_BIWA)
+        if not mobsStillUp and player:getCharVar("trueWillKilledNM") > 0 then
             npcUtil.giveKeyItem(player, dsp.ki.OLD_TRICK_BOX)
             player:setCharVar("trueWillKilledNM", 0)
         else

--- a/scripts/zones/Yhoator_Jungle/npcs/qm3.lua
+++ b/scripts/zones/Yhoator_Jungle/npcs/qm3.lua
@@ -15,8 +15,7 @@ end
 
 function onTrigger(player,npc)
     if player:getQuestStatus(OUTLANDS, dsp.quest.id.outlands.TRUE_WILL) == QUEST_ACCEPTED and not player:hasKeyItem(dsp.ki.OLD_TRICK_BOX) then
-        local mobsStillUp = GetMobByID(ID.mob.KAPPA_AKUSO):isSpawned() or GetMobByID(ID.mob.KAPPA_BONZE):isSpawned() or GetMobByID(ID.mob.KAPPA_BIWA)
-        if not mobsStillUp and player:getCharVar("trueWillKilledNM") > 0 then
+        if player:getCharVar("trueWillKilledNM") > 0 then
             npcUtil.giveKeyItem(player, dsp.ki.OLD_TRICK_BOX)
             player:setCharVar("trueWillKilledNM", 0)
         else


### PR DESCRIPTION
So I forgot to check to make sure no NMs were up before allowing the player to grab the reward. Now it correctly checks that you killed at least one of them and the rest have despawned