### PR TITLE
 change amount values from uint8 to uint32 fixes issue #6282

### DIFF
--- a/src/map/trade_container.cpp
+++ b/src/map/trade_container.cpp
@@ -149,11 +149,11 @@ void CTradeContainer::setQuantity(uint8 slotID, uint32 quantity)
 	return;
 }
 
-bool CTradeContainer::setConfirmedStatus(uint8 slotID, uint8 amount)
+bool CTradeContainer::setConfirmedStatus(uint8 slotID, uint32 amount)
 {
     if (slotID < m_PItem.size() && m_PItem[slotID] && m_PItem[slotID]->getQuantity() >= amount)
 	{
-		m_confirmed[slotID] = std::min<uint8>(amount, m_PItem[slotID]->getQuantity());
+        m_confirmed[slotID] = std::min<uint32>(amount, m_PItem[slotID]->getQuantity());
         return true;
 	}
     return false;

--- a/src/map/trade_container.cpp
+++ b/src/map/trade_container.cpp
@@ -29,148 +29,148 @@
 
 CTradeContainer::CTradeContainer()
 {
-	Clean();
+    Clean();
 }
 
 CItem* CTradeContainer::getItem(uint8 slotID)
 {
     if (slotID < m_PItem.size())
-	{
-		return m_PItem[slotID];
-	}
-	return 0;
+    {
+        return m_PItem[slotID];
+    }
+    return 0;
 }
 
 uint16 CTradeContainer::getItemID(uint8 slotID)
 {
     if (slotID < m_PItem.size())
-	{
-		return m_itemID[slotID];
-	}
-	return 0;
+    {
+        return m_itemID[slotID];
+    }
+    return 0;
 }
 
 uint8 CTradeContainer::getInvSlotID(uint8 slotID)
 {
     if (slotID < m_PItem.size())
-	{
-		return m_slotID[slotID];
-	}
-	return 0xFF;
+    {
+        return m_slotID[slotID];
+    }
+    return 0xFF;
 }
 
 uint32 CTradeContainer::getQuantity(uint8 slotID)
 {
     if (slotID < m_PItem.size())
-	{
-		return m_quantity[slotID];
-	}
-	return 0;
+    {
+        return m_quantity[slotID];
+    }
+    return 0;
 }
 
 uint8 CTradeContainer::getConfirmedStatus(uint8 slotID)
 {
     if (slotID < m_PItem.size())
-	{
-		return m_confirmed[slotID];
-	}
-	return false;
+    {
+        return m_confirmed[slotID];
+    }
+    return false;
 }
 
 uint32 CTradeContainer::getItemQuantity(uint16 itemID)
 {
-	uint32 quantity = 0;
+    uint32 quantity = 0;
     for (uint8 slotID = 0; slotID < m_PItem.size(); ++slotID)
-	{
-		if( m_itemID[slotID] == itemID)
-		{
-			quantity += m_quantity[slotID];
-		}
-	}
-	return quantity;
+    {
+        if( m_itemID[slotID] == itemID)
+        {
+            quantity += m_quantity[slotID];
+        }
+    }
+    return quantity;
 }
 
-uint32 CTradeContainer::getTotalQuantity() 
+uint32 CTradeContainer::getTotalQuantity()
 {
-	uint32 quantity = 0;
+    uint32 quantity = 0;
     for (uint8 slotID = 0; slotID < m_PItem.size(); ++slotID)
-	{
-		quantity += (m_itemID[slotID] == 0xFFFF ? 1 : m_quantity[slotID]);
-	}
-	return quantity;
+    {
+        quantity += (m_itemID[slotID] == 0xFFFF ? 1 : m_quantity[slotID]);
+    }
+    return quantity;
 }
 
-uint8 CTradeContainer::getSlotCount() 
+uint8 CTradeContainer::getSlotCount()
 {
-	uint8 count = 0;
+    uint8 count = 0;
     for (uint8 slotID = 0; slotID < m_PItem.size(); ++slotID)
-	{
-		if (m_itemID[slotID] != 0)
-		{
-			count += 1;
-		}
-	}
-	return count;
+    {
+        if (m_itemID[slotID] != 0)
+        {
+            count += 1;
+        }
+    }
+    return count;
 }
 
 void CTradeContainer::setItem(uint8 slotID, CItem* item)
 {
     if (slotID < m_PItem.size())
-	{
-		m_PItem[slotID] = item;
-	}
-	return;
+    {
+        m_PItem[slotID] = item;
+    }
+    return;
 }
 
 void CTradeContainer::setItemID(uint8 slotID, uint16 itemID)
 {
     if (slotID < m_PItem.size())
-	{
-		m_itemID[slotID] = itemID;
-	}
-	return;
+    {
+        m_itemID[slotID] = itemID;
+    }
+    return;
 }
 
 void CTradeContainer::setInvSlotID(uint8 slotID, uint8 invSlotID)
 {
     if (slotID < m_PItem.size())
-	{
-		m_slotID[slotID] = invSlotID;
-	}
-	return;
+    {
+        m_slotID[slotID] = invSlotID;
+    }
+    return;
 }
 
 void CTradeContainer::setQuantity(uint8 slotID, uint32 quantity)
 {
     if (slotID < m_PItem.size())
-	{
-		m_quantity[slotID] = quantity;
-	}
-	return;
+    {
+        m_quantity[slotID] = quantity;
+    }
+    return;
 }
 
 bool CTradeContainer::setConfirmedStatus(uint8 slotID, uint32 amount)
 {
     if (slotID < m_PItem.size() && m_PItem[slotID] && m_PItem[slotID]->getQuantity() >= amount)
-	{
+    {
         m_confirmed[slotID] = std::min<uint32>(amount, m_PItem[slotID]->getQuantity());
         return true;
-	}
+    }
     return false;
 }
 
 void CTradeContainer::setItem(uint8 slotID, uint16 itemID, uint8 invSlotID, uint32 quantity, CItem* item)
 {
-	if (slotID < m_PItem.size())
-	{
-		m_ItemsCount += 1;
+    if (slotID < m_PItem.size())
+    {
+        m_ItemsCount += 1;
 
-		m_PItem[slotID] = item;
-		m_itemID[slotID] = itemID;
-		m_slotID[slotID] = invSlotID;
-		m_quantity[slotID] = quantity;
-	}
-	return;
+        m_PItem[slotID] = item;
+        m_itemID[slotID] = itemID;
+        m_slotID[slotID] = invSlotID;
+        m_quantity[slotID] = quantity;
+    }
+    return;
 }
 
 uint8 CTradeContainer::getSize()
@@ -189,22 +189,22 @@ void CTradeContainer::setSize(uint8 size)
 
 uint8 CTradeContainer::getItemsCount()
 {
-	return m_ItemsCount;
+    return m_ItemsCount;
 }
 
 void CTradeContainer::setItemsCount(uint8 count)
 {
-	m_ItemsCount = count;
+    m_ItemsCount = count;
 }
 
 uint8 CTradeContainer::getType()
 {
-	return m_type;
+    return m_type;
 }
 
 void CTradeContainer::setType(uint8 type)
 {
-	m_type = type;
+    m_type = type;
 }
 
 uint8 CTradeContainer::getCraftType()
@@ -226,9 +226,9 @@ void CTradeContainer::Clean()
             PItem->setReserve(0);
         }
     }
-	m_type = 0;
+    m_type = 0;
     m_craftType = 0;
-	m_ItemsCount = 0;
+    m_ItemsCount = 0;
 
     m_PItem.clear();
     m_PItem.resize(CONTAINER_SIZE, nullptr);

--- a/src/map/trade_container.h
+++ b/src/map/trade_container.h
@@ -70,7 +70,7 @@ public:
 	void	setItemID(uint8 slotID, uint16 itemID);
 	void	setInvSlotID(uint8 slotID, uint8 invSlotID);
 	void	setQuantity(uint8 slotID, uint32 quantity);
-	bool	setConfirmedStatus(uint8 slotID, uint8 amount);
+    bool    setConfirmedStatus(uint8 slotID, uint32 amount);
 	void	setItem(uint8 slotID, uint16 itemID, uint8 invSlotID, uint32 quantity, CItem* item = nullptr);
     void    setSize(uint8 size);
 
@@ -86,7 +86,7 @@ private:
     std::vector<uint8>	    m_slotID;
     std::vector<uint16>	    m_itemID;
     std::vector<uint32>	    m_quantity;
-    std::vector<uint8>	    m_confirmed;
+    std::vector<uint32>     m_confirmed;
 };
 
 #endif

--- a/src/map/trade_container.h
+++ b/src/map/trade_container.h
@@ -27,13 +27,13 @@
 #include "../common/cbasetypes.h"
 #include <vector>
 
-#define CONTAINER_SIZE			17	
-#define TRADE_CONTAINER_SIZE	 8
+#define CONTAINER_SIZE          17
+#define TRADE_CONTAINER_SIZE     8
 
 /************************************************************************
-*																		*
-*																		*
-*																		*
+*                                                                       *
+*                                                                       *
+*                                                                       *
 ************************************************************************/
 
 enum CRAFT_TYPE
@@ -48,44 +48,44 @@ class CTradeContainer
 {
 public:
 
-	CTradeContainer();
+    CTradeContainer();
 
-	uint8	getType();
+    uint8   getType();
     uint8   getCraftType();
-	uint8	getItemsCount();
-	uint8	getSlotCount();									// количество занятых ячеек
-	uint32	getTotalQuantity();								// общее количество предметов (gil считаются за 1)
-	CItem*	getItem(uint8 slotID);
-	uint16	getItemID(uint8 slotID);						
-	uint8	getInvSlotID(uint8 slotID);
-	uint32	getQuantity(uint8 slotID);						// количество предметов в ячейке
-	uint8	getConfirmedStatus(uint8 slotID);
-	uint32	getItemQuantity(uint16 itemID);					// количество предметов одного типа
+    uint8   getItemsCount();
+    uint8   getSlotCount();                                 // количество занятых ячеек
+    uint32  getTotalQuantity();                             // общее количество предметов (gil считаются за 1)
+    CItem*  getItem(uint8 slotID);
+    uint16  getItemID(uint8 slotID);
+    uint8   getInvSlotID(uint8 slotID);
+    uint32  getQuantity(uint8 slotID);                      // количество предметов в ячейке
+    uint8   getConfirmedStatus(uint8 slotID);
+    uint32  getItemQuantity(uint16 itemID);                 // количество предметов одного типа
     uint8   getSize();
 
-	void	setType(uint8 type);
+    void    setType(uint8 type);
     void    setCraftType(uint8 craftType);
-	void	setItemsCount(uint8 count);
-	void	setItem(uint8 slotID, CItem* item);
-	void	setItemID(uint8 slotID, uint16 itemID);
-	void	setInvSlotID(uint8 slotID, uint8 invSlotID);
-	void	setQuantity(uint8 slotID, uint32 quantity);
+    void    setItemsCount(uint8 count);
+    void    setItem(uint8 slotID, CItem* item);
+    void    setItemID(uint8 slotID, uint16 itemID);
+    void    setInvSlotID(uint8 slotID, uint8 invSlotID);
+    void    setQuantity(uint8 slotID, uint32 quantity);
     bool    setConfirmedStatus(uint8 slotID, uint32 amount);
-	void	setItem(uint8 slotID, uint16 itemID, uint8 invSlotID, uint32 quantity, CItem* item = nullptr);
+    void    setItem(uint8 slotID, uint16 itemID, uint8 invSlotID, uint32 quantity, CItem* item = nullptr);
     void    setSize(uint8 size);
 
-	void	Clean();										// отчищаем контейнер
+    void    Clean();                                        // отчищаем контейнер
 
 private:
 
-	uint8	m_type;											// тип контейнера (тип кристалла, нация магазина и т.д.)
+    uint8   m_type;                                         // тип контейнера (тип кристалла, нация магазина и т.д.)
     uint8   m_craftType;                                    // The craft synthesis type (CRAFT_TYPE)
-	uint8	m_ItemsCount;									// количество предметов в контейнере (устанавливаем самостоятельно)
+    uint8   m_ItemsCount;                                   // количество предметов в контейнере (устанавливаем самостоятельно)
 
-	std::vector<CItem*>     m_PItem;
-    std::vector<uint8>	    m_slotID;
-    std::vector<uint16>	    m_itemID;
-    std::vector<uint32>	    m_quantity;
+    std::vector<CItem*>     m_PItem;
+    std::vector<uint8>      m_slotID;
+    std::vector<uint16>     m_itemID;
+    std::vector<uint32>     m_quantity;
     std::vector<uint32>     m_confirmed;
 };
 


### PR DESCRIPTION
It was only using 1 byte so amounts greater than 255 weren't supported. This is a problem if the trade contained gil when confirmTrade was being used.