### PR TITLE
Fix compilation error on mac, missing import.

### DIFF
--- a/src/map/battlefield.h
+++ b/src/map/battlefield.h
@@ -27,6 +27,7 @@ This file is part of DarkStar-server source code.
 #include <set>
 #include <functional>
 #include <memory>
+#include <vector>
 
 #include "../common/cbasetypes.h"
 #include "../common/mmo.h"


### PR DESCRIPTION
Undeclared definition of a template type would not build for me on Mac.

Error:

```
In file included from src/map/battlefield.cpp:24:
src/map/battlefield.h:176:35: error: implicit instantiation of undefined
      template 'std::__1::vector<BattlefieldMob_t,
      std::__1::allocator<BattlefieldMob_t> >'
    std::vector<BattlefieldMob_t> m_RequiredEnemyList;
                                  ^
```

This is remedied by `#include <vector>` explicitly.