### PR TITLE
Refactor the order of operations for how damage is applied from spells.

### DIFF
--- a/scripts/globals/bluemagic.lua
+++ b/scripts/globals/bluemagic.lua
@@ -216,12 +216,12 @@ function BlueMagicalSpell(caster, target, spell, params, statMod)
     local magicAttack = 1.0;
     local multTargetReduction = 1.0; -- TODO: Make this dynamically change, temp static till implemented.
     magicAttack = math.floor(D * multTargetReduction);
-    
+
     local rparams = {};
     rparams.diff = dStat;
     rparams.skillType = dsp.skill.BLUE_MAGIC;
     magicAttack = math.floor(magicAttack * applyResistance(caster, target, spell, rparams));
-    
+
     dmg = math.floor(addBonuses(caster, spell, target, magicAttack));
 
     caster:delStatusEffectSilent(dsp.effect.BURST_AFFINITY);
@@ -231,25 +231,25 @@ end;
 
 function BlueFinalAdjustments(caster, target, spell, dmg, params)
     if (dmg < 0) then
-        dmg = 0;
+        dmg = 0
     end
 
-    dmg = dmg * BLUE_POWER;
+    dmg = dmg * BLUE_POWER
 
-    dmg = dmg - target:getMod(dsp.mod.PHALANX);
+    dmg = dmg - target:getMod(dsp.mod.PHALANX)
     if (dmg < 0) then
-        dmg = 0;
+        dmg = 0
     end
 
     -- handling stoneskin
-    dmg = utils.stoneskin(target, dmg);
+    dmg = utils.stoneskin(target, dmg)
 
-    target:takeDamage(dmg, caster, dsp.attackType.PHYSICAL, params.dmgType or dsp.damageType.NONE);
-    target:updateEnmityFromDamage(caster,dmg);
-    target:handleAfflatusMiseryDamage(dmg);
+    target:takeSpellDamage(caster, spell, dmg, dsp.attackType.PHYSICAL, params.dmgType or dsp.damageType.NONE)
+    target:updateEnmityFromDamage(caster,dmg)
+    target:handleAfflatusMiseryDamage(dmg)
     -- TP has already been dealt with.
-    return dmg;
-end;
+    return dmg
+end
 
 ------------------------------
 -- Utility functions below ---

--- a/scripts/globals/magic.lua
+++ b/scripts/globals/magic.lua
@@ -635,66 +635,66 @@ end;
 
     -- handle multiple targets
     if (caster:isSpellAoE(spell:getID())) then
-        local total = spell:getTotalTargets();
+        local total = spell:getTotalTargets()
 
         if (total > 9) then
             -- ga spells on 10+ targets = 0.4
-            dmg = dmg * 0.4;
+            dmg = dmg * 0.4
         elseif (total > 1) then
             -- -ga spells on 2 to 9 targets = 0.9 - 0.05T where T = number of targets
-            dmg = dmg * (0.9 - 0.05 * total);
+            dmg = dmg * (0.9 - 0.05 * total)
         end
 
         -- kill shadows
-        -- target:delStatusEffect(dsp.effect.COPY_IMAGE);
-        -- target:delStatusEffect(dsp.effect.BLINK);
+        -- target:delStatusEffect(dsp.effect.COPY_IMAGE)
+        -- target:delStatusEffect(dsp.effect.BLINK)
     else
         -- this logic will eventually be moved here
-        -- dmg = utils.takeShadows(target, dmg, 1);
+        -- dmg = utils.takeShadows(target, dmg, 1)
 
         -- if (dmg == 0) then
-            -- spell:setMsg(dsp.msg.basic.SHADOW_ABSORB);
-            -- return 1;
+            -- spell:setMsg(dsp.msg.basic.SHADOW_ABSORB)
+            -- return 1
         -- end
     end
 
-    local skill = spell:getSkillType();
+    local skill = spell:getSkillType()
     if (skill == dsp.skill.ELEMENTAL_MAGIC) then
-        dmg = dmg * ELEMENTAL_POWER;
+        dmg = dmg * ELEMENTAL_POWER
     elseif (skill == dsp.skill.DARK_MAGIC) then
-        dmg = dmg * DARK_POWER;
+        dmg = dmg * DARK_POWER
     elseif (skill == dsp.skill.NINJUTSU) then
-        dmg = dmg * NINJUTSU_POWER;
+        dmg = dmg * NINJUTSU_POWER
     elseif (skill == dsp.skill.DIVINE_MAGIC) then
-        dmg = dmg * DIVINE_POWER;
+        dmg = dmg * DIVINE_POWER
     end
 
-    dmg = target:magicDmgTaken(dmg);
+    dmg = target:magicDmgTaken(dmg)
 
     if (dmg > 0) then
-        dmg = dmg - target:getMod(dsp.mod.PHALANX);
-        dmg = utils.clamp(dmg, 0, 99999);
+        dmg = dmg - target:getMod(dsp.mod.PHALANX)
+        dmg = utils.clamp(dmg, 0, 99999)
     end
 
     --handling stoneskin
-    dmg = utils.stoneskin(target, dmg);
-    dmg = utils.clamp(dmg, -99999, 99999);
+    dmg = utils.stoneskin(target, dmg)
+    dmg = utils.clamp(dmg, -99999, 99999)
 
     if (dmg < 0) then
-        dmg = target:addHP(-dmg);
-        spell:setMsg(dsp.msg.basic.MAGIC_RECOVERS_HP);
+        dmg = target:addHP(-dmg)
+        spell:setMsg(dsp.msg.basic.MAGIC_RECOVERS_HP)
     else
-        target:takeDamage(dmg, caster, dsp.attackType.MAGICAL, dsp.damageType.ELEMENTAL + spell:getElement());
-        target:handleAfflatusMiseryDamage(dmg);
-        target:updateEnmityFromDamage(caster,dmg);
+        target:takeSpellDamage(caster, spell, dmg, dsp.attackType.MAGICAL, dsp.damageType.ELEMENTAL + spell:getElement())
+        target:handleAfflatusMiseryDamage(dmg)
+        target:updateEnmityFromDamage(caster,dmg)
         -- Only add TP if the target is a mob
         if (target:getObjType() ~= dsp.objType.PC) then
-            target:addTP(100);
+            target:addTP(100)
         end
     end
 
-    return dmg;
- end;
+    return dmg
+ end
 
 function finalMagicNonSpellAdjustments(caster,target,ele,dmg)
     --Handles target's HP adjustment and returns SIGNED dmg (negative values on absorb)

--- a/scripts/globals/spells/bluemagic/self-destruct.lua
+++ b/scripts/globals/spells/bluemagic/self-destruct.lua
@@ -29,7 +29,7 @@ function onSpellCast(caster,target,spell)
     local damage = playerHP - 1
 
     if damage > 0 then
-        target:takeDamage(playerHP, caster, dsp.attackType.MAGICAL, dsp.damageType.FIRE)
+        target:takeSpellDamage(caster, spell, playerHP, dsp.attackType.MAGICAL, dsp.damageType.FIRE)
         caster:setHP(1)
         caster:delStatusEffect(dsp.effect.WEAKNESS)
         caster:addStatusEffect(dsp.effect.WEAKNESS,1,0,duration)

--- a/src/map/entities/battleentity.cpp
+++ b/src/map/entities/battleentity.cpp
@@ -1300,18 +1300,6 @@ void CBattleEntity::OnCastFinished(CMagicState& state, action_t& action)
             if (PSpell->getSkillType() == SKILLTYPE::SKILL_ENFEEBLING_MAGIC)
                 StatusEffectContainer->DelStatusEffect(EFFECT_SABOTEUR);
 
-            // Remove effects from damage
-            if (PSpell->canTargetEnemy() && actionTarget.param > 0 && PSpell->dealsDamage())
-            {
-                PTarget->StatusEffectContainer->DelStatusEffectsByFlag(EFFECTFLAG_DAMAGE);
-                // Check for bind breaking
-                battleutils::BindBreakCheck(this, PTarget);
-
-                // Do we get TP for damaging spells?
-                int16 tp = battleutils::CalculateSpellTP(this, PSpell);
-                addTP(tp);
-            }
-
             if (msg == 0)
             {
                 msg = PSpell->getMessage();

--- a/src/map/lua/lua_baseentity.cpp
+++ b/src/map/lua/lua_baseentity.cpp
@@ -11758,6 +11758,33 @@ int32 CLuaBaseEntity::takeWeaponskillDamage(lua_State* L)
 }
 
 /************************************************************************
+*  Function: int32 TakeSpellDamage()
+*  Purpose : Calls Battle Utils to calculate final spell damage against a foe
+*  Example : target:takeSpellDamage(caster, spell, finaldmg, attackType, damageType)
+*  Notes   : Global function of same name in bluemagic.lua, calls this member function from within
+************************************************************************/
+
+int32 CLuaBaseEntity::takeSpellDamage(lua_State* L)
+{
+    DSP_DEBUG_BREAK_IF(m_PBaseEntity == nullptr);
+    DSP_DEBUG_BREAK_IF(lua_isnil(L, 1) || !lua_isuserdata(L, 1));
+    DSP_DEBUG_BREAK_IF(lua_isnil(L, 2) || !lua_isuserdata(L, 2));
+    DSP_DEBUG_BREAK_IF(lua_isnil(L, 3) || !lua_isnumber(L, 3));
+    DSP_DEBUG_BREAK_IF(lua_isnil(L, 3) || !lua_isnumber(L, 4));
+    DSP_DEBUG_BREAK_IF(lua_isnil(L, 3) || !lua_isnumber(L, 5));
+
+
+    auto PChar = static_cast<CCharEntity*>(Lunar<CLuaBaseEntity>::check(L, 1)->m_PBaseEntity);
+    auto PSpell = Lunar<CLuaSpell>::check(L, 2)->GetSpell();
+    auto damage = (int32)lua_tointeger(L, 3);
+    ATTACKTYPE attackType = (ATTACKTYPE)lua_tointeger(L, 4);
+    DAMAGETYPE damageType = (DAMAGETYPE)lua_tointeger(L, 5);
+
+    lua_pushinteger(L, (lua_Integer)battleutils::TakeSpellDamage(static_cast<CBattleEntity*>(m_PBaseEntity), PChar, PSpell, damage, attackType, damageType));
+    return 1;
+}
+
+/************************************************************************
 *  Function: spawnPet()
 *  Purpose : Spawns a pet if a few correct conditions are met
 *  Example : caster:spawnPet(PET_CARBUNCLE)
@@ -14439,6 +14466,7 @@ Lunar<CLuaBaseEntity>::Register_t CLuaBaseEntity::methods[] =
     LUNAR_DECLARE_METHOD(CLuaBaseEntity,getWSSkillchainProp),
 
     LUNAR_DECLARE_METHOD(CLuaBaseEntity,takeWeaponskillDamage),
+    LUNAR_DECLARE_METHOD(CLuaBaseEntity,takeSpellDamage),
 
     // Pets and Automations
     LUNAR_DECLARE_METHOD(CLuaBaseEntity,spawnPet),

--- a/src/map/lua/lua_baseentity.h
+++ b/src/map/lua/lua_baseentity.h
@@ -573,6 +573,7 @@ public:
     int32 getWSSkillchainProp(lua_State* L);    // returns weapon skill's skillchain properties (up to 3)
 
     int32 takeWeaponskillDamage(lua_State* L);
+    int32 takeSpellDamage(lua_State* L);
 
     // Pets and Automations
     int32 spawnPet(lua_State*);              // Calls Pet

--- a/src/map/utils/battleutils.cpp
+++ b/src/map/utils/battleutils.cpp
@@ -2185,6 +2185,32 @@ namespace battleutils
         return damage;
     }
 
+
+    /************************************************************************
+    *                                                                       *
+    *  Handles Damage from Spells (dmg type reductions calced in lua)       *
+    *                                                                       *
+    ************************************************************************/
+
+    int32 TakeSpellDamage(CBattleEntity* PDefender, CCharEntity* PAttacker, CSpell* PSpell, int32 damage, ATTACKTYPE attackType, DAMAGETYPE damageType)
+    {
+        PDefender->takeDamage(damage, PAttacker, attackType, damageType);
+
+        // Remove effects from damage
+        if (PSpell->canTargetEnemy() && damage > 0 && PSpell->dealsDamage())
+        {
+            PDefender->StatusEffectContainer->DelStatusEffectsByFlag(EFFECTFLAG_DAMAGE);
+            // Check for bind breaking
+            BindBreakCheck(PAttacker, PDefender);
+
+            // Do we get TP for damaging spells?
+            int16 tp = battleutils::CalculateSpellTP(PAttacker, PSpell);
+            PAttacker->addTP(tp);
+        }
+
+        return damage;
+    }
+
     /************************************************************************
     *                                                                       *
     *  Calculate Probability attack will hit (20% min cap - 95% max cap)    *

--- a/src/map/utils/battleutils.h
+++ b/src/map/utils/battleutils.h
@@ -150,6 +150,7 @@ namespace battleutils
     int32               TakePhysicalDamage(CBattleEntity* PAttacker, CBattleEntity* PDefender, PHYSICAL_ATTACK_TYPE physicalAttackType, int32 damage, bool isBlocked, uint8 slot, uint16 tpMultiplier, CBattleEntity* taChar, bool giveTPtoVictim, bool giveTPtoAttacker, bool isCounter = false);
     int32               TakeWeaponskillDamage(CCharEntity* PAttacker, CBattleEntity* PDefender, int32 damage, ATTACKTYPE attackType, DAMAGETYPE damageType, uint8 slot, bool primary, float tpMultiplier, uint16 bonusTP, float targetTPMultiplier);
     int32               TakeSkillchainDamage(CBattleEntity* PAttacker, CBattleEntity* PDefender, int32 lastSkillDamage, CBattleEntity* taChar);
+    int32               TakeSpellDamage(CBattleEntity* PDefender, CCharEntity* PAttacker, CSpell* PSpell, int32 damage, ATTACKTYPE attackType, DAMAGETYPE damageType);
 
     bool                TryInterruptSpell(CBattleEntity* PAttacker, CBattleEntity* PDefender, CSpell* PSpell);
     float               GetRangedDamageRatio(CBattleEntity* PAttacker, CBattleEntity* PDefender, bool isCritical);


### PR DESCRIPTION
This primarily refactors the order of operations such that any magic
spell that deals damage now handles the effects from the damage
immediately after.

This is necessary as a prerequisite for implementing spells like
Pinecone Bomb, which reapply a sleep effect after the damage has been
applied.

The prior implementation would apply the damage and then apply the sleep
all in the Lua code before returning back to
CBattleEntity::OnCastFinished(), which would then remove the sleep since
damage was taken.

After this refactor the damage and debuff behavior from the damage all
occur on the Lua side. That way Lua scripts for spells can reapply
sleeps and have it function properly.

This was modeled after how TakeWeaponskillDamage() was implemented to
achieve a similar order of operations.

NOTE: I tested manually by sleeping mobs and applying the various types of
spells to verify that sleep is canceled correctly. Also tested a pinecone_bomb
script (not included in this PR) to verify that re-applying sleep would work.

I also audited every Lua script that includes a spell that deals damage to
cover all possible code paths.