### PR TITLE
Fix some crash issues in Dawn BCNM

### DIFF
--- a/src/map/ai/states/magic_state.cpp
+++ b/src/map/ai/states/magic_state.cpp
@@ -60,6 +60,11 @@ CMagicState::CMagicState(CBattleEntity* PEntity, uint16 targid, SpellID spellid,
         throw CStateInitException(std::move(m_errorMsg));
     }
 
+    if (PTarget->objtype != TYPE_PC && (m_PSpell->getZoneMisc() & MISC_TRACTOR) != 0)
+    {
+        throw CStateInitException(std::make_unique<CMessageBasicPacket>(m_PEntity, m_PEntity, 0, 0, MSGBASIC_CANNOT_ON_THAT_TARG));
+    }
+
     auto errorMsg = luautils::OnMagicCastingCheck(m_PEntity, PTarget, GetSpell());
     if (errorMsg)
     {

--- a/src/map/entities/charentity.cpp
+++ b/src/map/entities/charentity.cpp
@@ -1631,7 +1631,10 @@ CBattleEntity* CCharEntity::IsValidTarget(uint16 targid, uint16 validTargetFlags
         }
         else if (static_cast<CCharEntity*>(this)->IsMobOwner(PTarget))
         {
-            return PTarget;
+            if (PTarget->isAlive() || (validTargetFlags & TARGET_PLAYER_DEAD) != 0)
+                return PTarget;
+            else
+                errMsg = std::make_unique<CMessageBasicPacket>(this, this, 0, 0, MSGBASIC_CANNOT_ON_THAT_TARG);
         }
         else
         {

--- a/src/map/entities/charentity.cpp
+++ b/src/map/entities/charentity.cpp
@@ -1632,9 +1632,13 @@ CBattleEntity* CCharEntity::IsValidTarget(uint16 targid, uint16 validTargetFlags
         else if (static_cast<CCharEntity*>(this)->IsMobOwner(PTarget))
         {
             if (PTarget->isAlive() || (validTargetFlags & TARGET_PLAYER_DEAD) != 0)
+            {
                 return PTarget;
+            }
             else
+            {
                 errMsg = std::make_unique<CMessageBasicPacket>(this, this, 0, 0, MSGBASIC_CANNOT_ON_THAT_TARG);
+            }
         }
         else
         {


### PR DESCRIPTION
This adds a check that the target is alive or the spell is meant for a dead target when targeting a mob with a spell. Normally this isn't a problem because mobs are untargetable when they die, but Prishe lets you raise her when she dies in this BCNM, so you can crash the client by casting cure or protect on her if she dies. This also adds a check so that tractor can only be cast on a player, fixing a server crash in the same situation.