### PR TITLE
Fix infinite loop failure in charutils::AddItem

### DIFF
--- a/src/map/lua/lua_baseentity.cpp
+++ b/src/map/lua/lua_baseentity.cpp
@@ -3481,6 +3481,7 @@ inline int32 CLuaBaseEntity::addItem(lua_State *L)
             else
             {
                 ShowWarning(CL_YELLOW"charplugin::AddItem: Item <%i> is not found in a database\n" CL_RESET, id);
+                break;
             }
         }
     }


### PR DESCRIPTION
Break out of add item loop if we have an invalid item (like when people add bad item ids like a fucking idiot)