### PR TITLE
Move battlefield capacity check to correct place.

### DIFF
--- a/scripts/globals/bcnm.lua
+++ b/scripts/globals/bcnm.lua
@@ -739,7 +739,7 @@ function findBattlefields(player, npc, itemId)
         return 0
     end
     for k, v in pairs(zbfs) do
-        if v[3] == itemId and checkReqs(player, npc, v[2], true) then
+        if v[3] == itemId and checkReqs(player, npc, v[2], true) and not player:battlefieldAtCapacity(v[2]) then
             mask = bit.bor(mask,math.pow(2,v[1]))
         end
     end
@@ -826,8 +826,7 @@ function TradeBCNM(player, npc, trade, onUpdate)
 
     -- open menu of valid battlefields
     local validBattlefields = findBattlefields(player, npc, itemId)
-    local battlefieldId = getBattlefieldIdByBit(player, validBattlefields)
-    if validBattlefields ~= 0 and not player:battlefieldAtCapacity(battlefieldId) then
+    if validBattlefields ~= 0 then
         if not onUpdate then
             player:startEvent(32000, 0, 0, 0, validBattlefields, 0, 0, 0, 0)
         end
@@ -842,7 +841,6 @@ end
 -----------------------------------------------
 
 function EventTriggerBCNM(player, npc)
-
     -- player is in battlefield and clicks to leave
     if player:getBattlefield() then
         player:startEvent(32003)
@@ -851,9 +849,9 @@ function EventTriggerBCNM(player, npc)
     -- player wants to register a new battlefield
     elseif not player:hasStatusEffect(dsp.effect.BATTLEFIELD) then
         local mask = findBattlefields(player, npc, 0)
+
         -- mask = 268435455 -- uncomment to open menu with all possible battlefields
-        local battlefieldId = getBattlefieldIdByBit(player, mask)
-        if mask ~= 0 and not player:battlefieldAtCapacity(battlefieldId) then
+        if mask ~= 0 then
             player:startEvent(32000, 0, 0, 0, mask, 0, 0, 0, 0)
             return true
         end


### PR DESCRIPTION
getBattlefieldIdByBit is being passed a mask instead of a single battlefield bit, which is then being passed into battlefieldAtCapacity. This fix moves battlefieldAtCapacity to the correct place in findBattlefields and each battlefield is checked individually.