### PR TITLE
Claim updates

### DIFF
--- a/scripts/mixins/families/aern.lua
+++ b/scripts/mixins/families/aern.lua
@@ -11,34 +11,34 @@ g_mixins = g_mixins or {}
 g_mixins.families = g_mixins.families or {}
 
 g_mixins.families.aern = function(mob)
-    mob:addListener("DEATH", "AERN_DEATH", function(mob)
-        local reraises = mob:getLocalVar("AERN_RERAISE_MAX")
-        local curr_reraise = mob:getLocalVar("AERN_RERAISES")
-        if reraises == 0 then
-            if math.random() < 0.4 then
-                reraises = 1
-            end
-        end
-        if curr_reraise < reraises then
-            local dropid = mob:getDropID()
-            mob:setDropID(0)
-            local target = mob:getTarget()
-            local targetid = 0
-            if target then targetid = target:getShortID() end
-            mob:timer(12000, function(mob)
-                mob:setHP(mob:getMaxHP())
-                mob:setDropID(dropid)
-                mob:AnimationSub(3)
-                mob:setLocalVar("AERN_RERAISES", curr_reraise + 1)
-                mob:resetAI()
-                mob:stun(3000)
-                local new_target = mob:getEntity(targetid)
-                if new_target and mob:checkDistance(new_target) < 40 then
-                    mob:updateClaim(new_target)
-                    mob:updateEnmity(new_target)
+    mob:addListener("DEATH", "AERN_DEATH", function(mob, killer)
+        if killer then
+            local reraises = mob:getLocalVar("AERN_RERAISE_MAX")
+            local curr_reraise = mob:getLocalVar("AERN_RERAISES")
+            if reraises == 0 then
+                if math.random() < 0.4 then
+                    reraises = 1
                 end
-                mob:triggerListener("AERN_RERAISE", mob, curr_reraise + 1)
-            end)
+            end
+            if curr_reraise < reraises then
+                local dropid = mob:getDropID()
+                mob:setDropID(0)
+                local target = mob:getTarget()
+                if target then killer = target end
+                mob:timer(12000, function(mob)
+                    mob:setHP(mob:getMaxHP())
+                    mob:setDropID(dropid)
+                    mob:AnimationSub(3)
+                    mob:setLocalVar("AERN_RERAISES", curr_reraise + 1)
+                    mob:resetAI()
+                    mob:stun(3000)
+                    if mob:checkDistance(killer) < 40 then
+                        mob:updateClaim(killer)
+                        mob:updateEnmity(killer)
+                    end
+                    mob:triggerListener("AERN_RERAISE", mob, curr_reraise + 1)
+                end)
+            end
         end
     end)
 end

--- a/src/map/ai/states/ability_state.cpp
+++ b/src/map/ai/states/ability_state.cpp
@@ -85,15 +85,8 @@ void CAbilityState::ApplyEnmity()
             !(m_PAbility->getCE() == 0 && m_PAbility->getVE() == 0))
         {
             CMobEntity* mob = (CMobEntity*)PTarget;
-            if (!mob->CalledForHelp())
-            {
-                mob->m_OwnerID.id = m_PEntity->id;
-                mob->m_OwnerID.targid = m_PEntity->targid;
-            }
-            mob->updatemask |= UPDATE_STATUS;
+            battleutils::ClaimMob(mob, m_PEntity);
             mob->PEnmityContainer->UpdateEnmity(m_PEntity, m_PAbility->getCE(), m_PAbility->getVE(), false, m_PAbility->getID() == ABILITY_CHARM);
-            if (mob->m_HiPCLvl < m_PEntity->GetMLevel())
-                mob->m_HiPCLvl = m_PEntity->GetMLevel();
         }
     }
     else if (PTarget->allegiance == m_PEntity->allegiance)

--- a/src/map/ai/states/magic_state.cpp
+++ b/src/map/ai/states/magic_state.cpp
@@ -310,20 +310,8 @@ void CMagicState::ApplyEnmity(CBattleEntity* PTarget, int ce, int ve)
 
                 if (!(m_PSpell->isHeal()) || m_PSpell->tookEffect())  //can't claim mob with cure unless it does damage
                 {
-                    if (m_PEntity->objtype == TYPE_PC || (m_PEntity->PMaster && m_PEntity->PMaster->objtype == TYPE_PC))
-                    {
-                        auto claimer = m_PEntity->objtype == TYPE_PC ? m_PEntity : m_PEntity->PMaster;
-
-                        if (!mob->CalledForHelp())
-                        {
-                            mob->m_OwnerID.id = claimer->id;
-                            mob->m_OwnerID.targid = claimer->targid;
-                        }
-                        mob->updatemask |= UPDATE_STATUS;
-                    }
+                    battleutils::ClaimMob(PTarget, m_PEntity);
                     mob->PEnmityContainer->UpdateEnmity(m_PEntity, ce, ve);
-                    if (mob->m_HiPCLvl < m_PEntity->GetMLevel())
-                        mob->m_HiPCLvl = m_PEntity->GetMLevel();
                     enmityApplied = true;
                 }
             }

--- a/src/map/entities/charentity.h
+++ b/src/map/entities/charentity.h
@@ -215,6 +215,7 @@ public:
     CAutomatonEntity*       PAutomaton;                     // Automaton statistics
 
     std::vector<CTrustEntity*> PTrusts; // Active trusts
+    CBattleEntity*	PClaimedMob;
 
 
     // Эти миссии не нуждаются в списке пройденных, т.к. клиент автоматически

--- a/src/map/entities/mobentity.cpp
+++ b/src/map/entities/mobentity.cpp
@@ -669,17 +669,7 @@ void CMobEntity::OnMobSkillFinished(CMobSkillState& state, action_t& action)
             PTarget->PAI->EventHandler.triggerListener("WEAPONSKILL_TAKE", PTarget, this, PSkill->getID(), state.GetSpentTP(), &action);
         }
 
-        if (objtype == TYPE_PET && PMaster && PMaster->objtype == TYPE_PC )
-        {
-            auto mob = dynamic_cast<CMobEntity *>(PTarget);
-            if (mob && !mob->CalledForHelp())
-            {
-                mob->m_OwnerID.id = PMaster->id;
-                mob->m_OwnerID.targid = PMaster->targid;
-                mob->updatemask |= UPDATE_STATUS; //This can go here because we only wanna call the updatemask if this happens
-            }
-        }
-
+        battleutils::ClaimMob(PTarget, this);
         if (msg == 0)
         {
             msg = PSkill->getMsg();
@@ -733,6 +723,11 @@ void CMobEntity::OnMobSkillFinished(CMobSkillState& state, action_t& action)
             }
         }
         PTarget->StatusEffectContainer->DelStatusEffectsByFlag(EFFECTFLAG_DETECTABLE);
+    }
+    PTarget = static_cast<CBattleEntity*>(state.GetTarget());
+    if (PTarget->health.hp > 0)
+    {
+        battleutils::ClaimMob(PTarget, this);
     }
 }
 
@@ -1027,6 +1022,7 @@ void CMobEntity::Die()
                 loc.zone->PushPacket(this, CHAR_INRANGE, new CMessageBasicPacket(this, this, 0, 0, MSGBASIC_FALLS_TO_GROUND));
 
             DistributeRewards();
+            m_OwnerID.clean();
         }
     }));
     if (PMaster && PMaster->PPet == this && PMaster->objtype == TYPE_PC)

--- a/src/map/utils/battleutils.cpp
+++ b/src/map/utils/battleutils.cpp
@@ -4072,8 +4072,8 @@ namespace battleutils
             if (PAttacker->objtype != TYPE_PC)
             {
                 if (PAttacker->PMaster != nullptr && PAttacker->PMaster->objtype == TYPE_PC)
-                {
-                    PAttacker = PAttacker->PMaster; // claim by master
+                { // claim by master
+                    PAttacker = PAttacker->PMaster;
                 }
                 else
                 {
@@ -4084,6 +4084,13 @@ namespace battleutils
             if (PAttacker)
             {
                 CCharEntity* attacker = (CCharEntity*)PAttacker;
+                if (attacker->PClaimedMob && attacker->PClaimedMob != PDefender
+                    && attacker->PClaimedMob->health.hp > 0 && attacker->PClaimedMob->m_OwnerID.id == attacker->id)
+                { // unclaim any other living mobs owned by attacker
+                    attacker->PClaimedMob->m_OwnerID.clean();
+                    attacker->PClaimedMob->updatemask |= UPDATE_STATUS;
+                    attacker->PClaimedMob = nullptr;
+                }
                 if (mob->m_HiPCLvl < PAttacker->GetMLevel())
                 {
                     mob->m_HiPCLvl = PAttacker->GetMLevel();
@@ -4107,16 +4114,6 @@ namespace battleutils
                                 mob->m_OwnerID.targid = PAttacker->targid;
                                 if (PDefender->health.hp > 0)
                                 { // ignore killing blow
-                                    PAttacker->ForAlliance([&PAttacker, &PDefender](CBattleEntity* PMember2){
-                                        CCharEntity* member = (CCharEntity*)PMember2;
-                                        if (member->getZone() == PAttacker->getZone() && member->PClaimedMob && member->PClaimedMob != PDefender
-                                            && member->PClaimedMob->health.hp > 0 && member->PClaimedMob->m_OwnerID.id == member->id)
-                                        { // unclaim any other living mobs owned by alliance members in zone
-                                            member->PClaimedMob->m_OwnerID.clean();
-                                            member->PClaimedMob->updatemask |= UPDATE_STATUS;
-                                            member->PClaimedMob = nullptr;
-                                        }
-                                    });
                                     mob->updatemask |= UPDATE_STATUS;
                                     attacker->PClaimedMob = PDefender;
                                 }

--- a/src/map/zone_entities.cpp
+++ b/src/map/zone_entities.cpp
@@ -288,6 +288,8 @@ void CZoneEntities::DecreaseZoneCounter(CCharEntity* PChar)
     DSP_DEBUG_BREAK_IF(PChar == nullptr);
     DSP_DEBUG_BREAK_IF(PChar->loc.zone != m_zone);
 
+    PChar->PClaimedMob = nullptr;
+
     //remove pets
     if (PChar->PPet != nullptr)
     {


### PR DESCRIPTION
Add a var to char entity to keep track of currently claimed mob and centralized all places that currently set claim/owner to battleutils::ClaimMob.
* For battleutils::ClaimMob to claim successfully, someone from the attacking players alliance must be top of the hate list.
* A killing blow does not cause anything to go unclaimed.
* When a mob is claimed, any mob owned by the attacker will go unclaimed.
* Claiming a mob or attacking a claimed mob will update the players claimed mob var and unclaim anything owned by that player. Each action performed on a mob updates the actual owner.
* The claimed mob var is cleared on load, zone, disengage, mob or player death, when the player is charmed, when the mob is charmed, and when a claiming action is performed.
* When current owner disengage, is charmed, or dies, will try to pass claim to alliance member, otherwise will go unclaimed. For the claim to pass, the member must have performed at least 1 claiming action on the mob and must not have done anything (like disengage) to clear their claimed mob var.
* Clean mob owner after exp/loot is distributed to deal with an issue with Aern reraising causing problems. Also refactored Aern mixin to work correctly with these changes. Aern will now reraise claimed and unclaim anything else that may have been claimed in the mean time.
* Popped mobs using entity:updateClaim will likewise unclaim any mobs owned by the popping players party. In cases where multiple mobs pop from a qm, only 1 will pop claimed.
* All aoe spells, abilities, and weaponskills end with claim being on targeted mob.

Issues:
#2109 functionality based mostly on these comments
#4240 point 2
#3923 claim issue
#3876
#2789
#1738
#1900