### PR TITLE
Charm Fix

### DIFF
--- a/src/map/utils/battleutils.cpp
+++ b/src/map/utils/battleutils.cpp
@@ -4068,10 +4068,10 @@ namespace battleutils
         }
 
         // FIXME: Level and CHR ratios are complete guesses
-        const float levelRatio = (targetLvl - charmerBSTlevel) / 100.f;
+        const float levelRatio = (charmerBSTlevel - targetLvl) / 100.f;
         charmChance *= (1.f + levelRatio);
 
-        const float chrRatio = (PTarget->CHR() - PCharmer->CHR()) / 100.f;
+        const float chrRatio = (PCharmer->CHR() - PTarget->CHR()) / 100.f;
         charmChance *= (1.f + chrRatio);
 
         // Retail doesn't take light/apollo into account for Gauge

--- a/src/map/utils/battleutils.cpp
+++ b/src/map/utils/battleutils.cpp
@@ -3872,7 +3872,7 @@ namespace battleutils
                 CharmTime = 1800000;
                 break;
 
-            case EMobDifficulty::IncredibyEasyPrey:
+            case EMobDifficulty::IncrediblyEasyPrey:
             case EMobDifficulty::EasyPrey:
                 CharmTime = 1200000;
                 break;
@@ -4030,7 +4030,7 @@ namespace battleutils
         case EMobDifficulty::TooWeak:
             charmChance = 90.f;
             break;
-        case EMobDifficulty::IncredibyEasyPrey:
+        case EMobDifficulty::IncrediblyEasyPrey:
         case EMobDifficulty::EasyPrey:
             charmChance = 75.f;
             break;
@@ -4383,7 +4383,7 @@ namespace battleutils
             switch (mobCheck)
             {
             case EMobDifficulty::TooWeak:
-            case EMobDifficulty::IncredibyEasyPrey:
+            case EMobDifficulty::IncrediblyEasyPrey:
                 BindBreakChance = 10;
                 break;
 

--- a/src/map/utils/charutils.cpp
+++ b/src/map/utils/charutils.cpp
@@ -3092,7 +3092,7 @@ namespace charutils
         if (baseExp >= 200) return EMobDifficulty::EvenMatch;
         if (baseExp >= 160) return EMobDifficulty::DecentChallenge;
         if (baseExp >= 60) return EMobDifficulty::EasyPrey;
-        if (baseExp >= 14) return EMobDifficulty::IncredibyEasyPrey;
+        if (baseExp >= 14) return EMobDifficulty::IncrediblyEasyPrey;
 
         return EMobDifficulty::TooWeak;
     }

--- a/src/map/utils/charutils.h
+++ b/src/map/utils/charutils.h
@@ -42,7 +42,7 @@ class CAbility;
 enum class EMobDifficulty : uint8
 {
     TooWeak = 0,
-    IncredibyEasyPrey,
+    IncrediblyEasyPrey,
     EasyPrey,
     DecentChallenge,
     EvenMatch,


### PR DESCRIPTION
Fixed charm level and charisma ratio calculations. They were backwards.
Also fixed IncrediblyEasyPrey typo.