### PR TITLE
Link pthread on linux platforms (Fixes #6421)

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -22,7 +22,7 @@ LIBS_ALL                += -lzmq
 
 ## Add Architecture-specific stuff
 if DARKSTAR_ARCH_LINUX
-LIBS_ALL                += -ldl
+LIBS_ALL                += -ldl -lpthread
 endif
 
 if DARKSTAR_ARCH_SOLARIS


### PR DESCRIPTION
@jefferyrlc couldn't compile on Manjaro linux without adding `-lpthread` to `LIBS_ALL` in `Makefile.am`. I didn't need to specify that for the OSX build, and the Windows build also probably doesn't need it, so this PR adds that lib only to the target `DARKSTAR_ARCH_LINUX `. 

Result should be the same 🤞 