### PR TITLE
Tredecim Scythe

### DIFF
--- a/src/map/entities/battleentity.cpp
+++ b/src/map/entities/battleentity.cpp
@@ -1426,6 +1426,12 @@ bool CBattleEntity::OnAttack(CAttackState& state, action_t& action)
     actionList_t& list = action.getNewActionList();
 
     list.ActionTargetID = PTarget->id;
+    
+    bool tredecim = false;
+	if (this->objtype == TYPE_PC && (((CCharEntity*)this)->getEquip(SLOT_MAIN))->getID() == 18052)
+	{
+		tredecim = true;
+	}
 
     /////////////////////////////////////////////////////////////////////////
     //	Start of the attack loop.
@@ -1435,6 +1441,9 @@ bool CBattleEntity::OnAttack(CAttackState& state, action_t& action)
         actionTarget_t& actionTarget = list.getNewActionTarget();
         // Reference to the current swing.
         CAttack& attack = attackRound.GetCurrentAttack();
+        
+        if (tredecim)
+			(((CCharEntity*)this)->m_hitCounter)++;
 
         // Set the swing animation.
         actionTarget.animation = attack.GetAnimationID();
@@ -1514,7 +1523,11 @@ bool CBattleEntity::OnAttack(CAttackState& state, action_t& action)
             {
                 // Set this attack's critical flag.
                 attack.SetCritical(dsprand::GetRandomNumber(100) < battleutils::GetCritHitRate(this, PTarget, !attack.IsFirstSwing()));
-
+                if (tredecim && ((CCharEntity*)this)->m_hitCounter > 12)
+				{
+					((CCharEntity*)this)->m_hitCounter = 0;
+				    attack.SetCritical(true);
+				}
                 // Critical hit.
                 if (attack.IsCritical())
                 {

--- a/src/map/entities/charentity.h
+++ b/src/map/entities/charentity.h
@@ -296,6 +296,8 @@ public:
     bool              m_mentorUnlocked;
     uint32            m_moghouseID;
     uint16            m_moghancementID;
+    
+    uint8             m_hitCounter;                 // auto-attack it counter for Tredecim Scythe
 
     int8			  getShieldSize();
 

--- a/src/map/utils/charutils.cpp
+++ b/src/map/utils/charutils.cpp
@@ -773,6 +773,8 @@ namespace charutils
             memcpy(&PChar->teleport.survival, buf, (length > sizeof(PChar->teleport.survival) ? sizeof(PChar->teleport.survival) : length));
         }
 
+        PChar->m_hitCounter = 0;
+        
         PChar->PMeritPoints = new CMeritPoints(PChar);
         PChar->PMeritPoints->SetMeritPoints(meritPoints);
         PChar->PMeritPoints->SetLimitPoints(limitPoints);


### PR DESCRIPTION
the 13th hit guaranteed critical is not coded yet so here it is. wiki says it shouldnt count WS hits and this code follows that, this is just for autoattacks. wiki says it should save hit count when zoning but that will require adding an extra field within the database and i didn't want to clutter the database more to add "cross-zone memory" just seems unimportant. upon zoning the count is just set to 0.