### PR TITLE
Add config flag to dis/allow new accounts

### DIFF
--- a/conf/login_darkstar.conf
+++ b/conf/login_darkstar.conf
@@ -65,3 +65,7 @@ msg_server_ip: 127.0.0.1
 
 #Logging of user IP address to database (true/false)
 log_user_ip: false
+
+#New accounts may be created? (true/false)
+account_creation: true
+

--- a/src/login/login.cpp
+++ b/src/login/login.cpp
@@ -120,6 +120,11 @@ int32 do_init(int32 argc, char** argv)
 
     messageThread = std::thread(message_server_init);
     ShowStatus("The login-server is " CL_GREEN"ready" CL_RESET" to work...\n");
+ 
+    if(!login_config.account_creation)
+    {
+        ShowStatus("New account creation is " CL_RED"disabled" CL_RESET" in login_config.\n");
+    }
 
     bool attached = isatty(0);
 
@@ -440,6 +445,10 @@ void login_config_read(const char *key, const char *value)
     {
         login_config.log_user_ip = config_switch(value);
     }
+    else if (strcmp(key, "account_creation") == 0)
+    {
+        login_config.account_creation = config_switch(value);
+    }
     else
     {
         ShowWarning("Unknown setting '%s' with value '%s' in  login file\n", key, value);
@@ -490,6 +499,7 @@ void login_config_default()
     login_config.msg_server_ip = "127.0.0.1";
 
     login_config.log_user_ip = "false";
+    login_config.account_creation = "true";
 }
 
 void version_info_default()

--- a/src/login/login.h
+++ b/src/login/login.h
@@ -60,6 +60,7 @@ struct login_config_t
     uint16 msg_server_port;         // chat server port
     std::string msg_server_ip;      // chat server IP
     bool  log_user_ip;              // log user ip -> default false
+    bool  account_creation;         // allow new accounts to be created -> default true
 };
 
 struct version_info_t

--- a/src/login/login_auth.cpp
+++ b/src/login/login_auth.cpp
@@ -209,9 +209,20 @@ int32 login_parse(int32 fd)
         }
         break;
         case LOGIN_CREATE:
-            //looking for same login
             Sql_EscapeString(SqlHandle, escaped_name, name.c_str());
             Sql_EscapeString(SqlHandle, escaped_pass, password.c_str());
+
+           //check if account creation is disabled
+            if (!login_config.account_creation)
+            {
+                ShowWarning(CL_WHITE"login_parse" CL_RESET": New account attempt <" CL_WHITE"%s" CL_RESET"> but is disabled in config.\n", escaped_name);
+                session[fd]->wdata.resize(1);
+                ref<uint8>(session[fd]->wdata.data(), 0) = LOGIN_ERROR_CREATE;
+                do_close_login(sd, fd);
+                return 0;
+            }
+
+           //looking for same login
             if (Sql_Query(SqlHandle, "SELECT accounts.id FROM accounts WHERE accounts.login = '%s'", escaped_name) == SQL_ERROR)
             {
                 session[fd]->wdata.resize(1);


### PR DESCRIPTION
There are surely people hosting private servers for themselves or their friends who would prefer not have open registrations. True, the chance of someone port scanning you, finding your server, and logging in is minimal but most other server emulators offer an option to disable registration entirely. This PR adds that capability.

Adds new flag "account_creation" (true/false) in login_darkstar.conf file which permits new accounts to be created. Defaults to true. A one-line warning will also show at dsconnect startup if this flag is set False, as this could be a cause of issues or confusion if someone had done so inadvertently or had forgotten they'd done so.

**Considerations**:
If account creation is disabled, dsconnect will always return 0x04 ERROR_CREATE, which is visibly shown as "Username is taken" in xiloader. As xiloader only recognizes 4 status codes, this was the most suitable available. I considered adding a new 0x05 status to the xiloader code, but this would have no effect on existing installations and old versions or xiloader would show no feedback at all when attempting to create. Discussion on whether this function should use a new xiloader status code is welcomed.