### PR TITLE
Fix AH 7-item limit not being enforced correctly

### DIFF
--- a/src/map/packet_system.cpp
+++ b/src/map/packet_system.cpp
@@ -2348,7 +2348,20 @@ void SmallPacket0x04E(map_session_data_t* session, CCharEntity* PChar, CBasicPac
                 return;
             }
 
-            if (PChar->m_ah_history.size() >= 7)
+            // Get the current number of items the player has for sale
+            const char* Query = "SELECT COUNT(*) FROM auction_house WHERE seller = %u AND sale=0;";
+
+            int32 ret = Sql_Query(SqlHandle, Query, PChar->id);
+            uint8 numListings = 0;
+
+            if (ret != SQL_ERROR && Sql_NumRows(SqlHandle) != 0)
+            {
+                Sql_NextRow(SqlHandle);
+                numListings = (int32)Sql_GetIntData(SqlHandle, 0);
+		// ShowDebug(CL_CYAN"%s has %d outstanding listings before placing this one." CL_RESET, PChar->GetName(), numListings);
+            }
+
+            if (numListings >= 7)
             {
                 // ShowDebug(CL_CYAN"%s already has 7 items on the AH\n" CL_RESET,PChar->GetName());
                 PChar->pushPacket(new CAuctionHousePacket(action, 197, 0, 0)); // Failed to place up
@@ -2374,7 +2387,7 @@ void SmallPacket0x04E(map_session_data_t* session, CCharEntity* PChar, CBasicPac
             charutils::UpdateItem(PChar, LOC_INVENTORY, 0, -(int32)auctionFee); // Deduct AH fee
 
             PChar->pushPacket(new CAuctionHousePacket(action, 1, 0, 0)); // Merchandise put up on auction msg
-            PChar->pushPacket(new CAuctionHousePacket(0x0C, (uint8)PChar->m_ah_history.size(), PChar)); // Inform history of slot
+            PChar->pushPacket(new CAuctionHousePacket(0x0C, numListings, PChar)); // Inform history of slot
         }
     }
     break;


### PR DESCRIPTION
AH listing count is now checked at every sale,
and not just the cached value from the last time
player viewed their Sale History.

As previously discussed, the limit is enforced on the client so there's no reason to make it a configurable value.

Fixes #2673