### PR TITLE
Fix COP 6-4 Airship Fight

### DIFF
--- a/scripts/zones/Sealions_Den/npcs/Airship_Door.lua
+++ b/scripts/zones/Sealions_Den/npcs/Airship_Door.lua
@@ -35,6 +35,7 @@ end
 function onEventFinish(player, csid, option)
     if csid == 32003 and option >= 100 and option <= 102 then
         local inst = option - 99
+        player:setCharVar("bcnm_instanceid", inst)
         player:startEvent(player:getLocalVar("[OTBF]cs"), inst)
     end
 end


### PR DESCRIPTION
Add missing var player:setCharVar("bcnm_instanceid", inst) to Airship Door so you can progress through COP 6-4